### PR TITLE
daemon: extract daemonconfig modification/validation code

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1228,7 +1228,8 @@ var daemonCell = cell.Module(
 type daemonConfigParams struct {
 	cell.In
 
-	CfgResolver promise.Resolver[*option.DaemonConfig]
+	CfgResolver  promise.Resolver[*option.DaemonConfig]
+	DaemonConfig *option.DaemonConfig
 
 	Logger    *slog.Logger
 	Lifecycle cell.Lifecycle
@@ -1246,6 +1247,7 @@ type daemonParams struct {
 
 	// Ensures that the legacy daemon config initialization is executed
 	legacy.DaemonConfigInitialization
+	DaemonConfig *option.DaemonConfig
 
 	Logger    *slog.Logger
 	Lifecycle cell.Lifecycle
@@ -1410,11 +1412,11 @@ func startDaemon(ctx context.Context, params daemonParams) error {
 		}
 	}
 
-	if option.Config.EnableEnvoyConfig {
+	if params.DaemonConfig.EnableEnvoyConfig {
 		if !params.EndpointManager.IngressEndpointExists() {
 			// Creating Ingress Endpoint depends on the Ingress IPs having been
 			// allocated first. This happens earlier in the agent bootstrap.
-			if (option.Config.EnableIPv4 && len(node.GetIngressIPv4(params.Logger)) == 0) ||
+			if (params.DaemonConfig.EnableIPv4 && len(node.GetIngressIPv4(params.Logger)) == 0) ||
 				(option.Config.EnableIPv6 && len(node.GetIngressIPv6(params.Logger)) == 0) {
 				params.Logger.Warn("Ingress IPs are not available, skipping creation of the Ingress Endpoint: Policy enforcement on Cilium Ingress will not work as expected.")
 			} else {

--- a/daemon/cmd/legacy/daemon_init.go
+++ b/daemon/cmd/legacy/daemon_init.go
@@ -8,3 +8,8 @@ package legacy
 // hook of any dependent cell. In detail, `newDaemon` has been called, but `startDaemon`
 // is likely going to run in parallel with the start hook of the dependent cell.
 type DaemonInitialization struct{}
+
+// DaemonConfigInitialization can be used to depend on the legacy DaemonConfig initialization and
+// validation where some properties are changed at runtime depending on other properties or the environment.
+// Note that this isn't the same as depending on the DaemonConfig itself (which doesn't await this initialization).
+type DaemonConfigInitialization struct{}

--- a/pkg/kpr/initializer/kube_proxy_replacement.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement.go
@@ -48,6 +48,23 @@ func (r *kprInitializer) InitKubeProxyReplacementOptions() error {
 	if !r.kprCfg.KubeProxyReplacement {
 		option.Config.EnableHostLegacyRouting = true
 	}
+
+	if !option.Config.EnableHostLegacyRouting {
+		msg := ""
+		switch {
+		// Non-BPF masquerade requires netfilter and hence CT.
+		case option.Config.IptablesMasqueradingEnabled():
+			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
+		// KPR=true is needed or we might rely on netfilter.
+		case !r.kprCfg.KubeProxyReplacement:
+			msg = fmt.Sprintf("BPF host routing requires %s.", option.KubeProxyReplacement)
+		}
+		if msg != "" {
+			option.Config.EnableHostLegacyRouting = true
+			r.logger.Info(fmt.Sprintf("%s Falling back to legacy host routing (%s=true).", msg, option.EnableHostLegacyRouting))
+		}
+	}
+
 	r.logger.Info("kube-proxy replacement starting with the following config",
 		logfields.KPRConfiguration, r.kprCfg)
 
@@ -242,22 +259,6 @@ func (r *kprInitializer) FinishKubeProxyReplacementInit(devices []*tables.Device
 	// of kube-proxy replacement. Otherwise, nothing else is needed.
 	if option.Config.EnableMKE && r.kprCfg.EnableSocketLB {
 		markHostExtension(r.logger)
-	}
-
-	if !option.Config.EnableHostLegacyRouting {
-		msg := ""
-		switch {
-		// Non-BPF masquerade requires netfilter and hence CT.
-		case option.Config.IptablesMasqueradingEnabled():
-			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
-		// KPR=true is needed or we might rely on netfilter.
-		case !r.kprCfg.KubeProxyReplacement:
-			msg = fmt.Sprintf("BPF host routing requires %s.", option.KubeProxyReplacement)
-		}
-		if msg != "" {
-			option.Config.EnableHostLegacyRouting = true
-			r.logger.Info(fmt.Sprintf("%s Falling back to legacy host routing (%s=true).", msg, option.EnableHostLegacyRouting))
-		}
 	}
 
 	if option.Config.NodePortNat46X64 && r.lbConfig.LBMode != loadbalancer.LBModeSNAT {

--- a/pkg/kpr/initializer/kube_proxy_replacement_test.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement_test.go
@@ -183,7 +183,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 			kprConfig{
 				expectedErrorRegex:         ".+with enable-bpf-masquerade.",
 				enableSocketLB:             true,
-				enableHostLegacyRouting:    false,
+				enableHostLegacyRouting:    true,
 				installNoConntrackIptRules: true,
 				enableIPv4Masquerade:       true,
 				enableSocketLBTracing:      true,


### PR DESCRIPTION
This PR splits the code that modifies & validates the global `DaemonConfig` at startup from the rest of the legacy daemon init code.

A follow up PR could be to split the `DaemonConfig` into 3 pieces

* static properties (loaded at runtime from the go flags / env vars) that don't change at runtime
* properties that are configured at startup (based on the environment or other config flags)
* dynamic properties that can be changed at runtime (e.g. via Cilium API)