### PR TITLE
daemon: Remove deprecated `egress-multi-home-ip-rule-compat` flag

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -351,6 +351,11 @@ Removed Options
 * The previously deprecated custom calls feature (``--enable-custom-calls``) has been removed.
 * The previously deprecated ``--enable-ipv4-egress-gateway`` flag has been removed. To enable the
   corresponding features, users must set ``--enable-egress-gateway=true``.
+* The previously deprecated ``--egress-multi-home-ip-rule-compat`` flag has been removed. If you are running ENI IPAM
+  mode and had this flag explicitly set to ``true``, please unset it and let Cilium v1.18 migrate your rules prior
+  to the upgrade to Cilium v1.19. Azure IPAM users are unaffected by this change, as Cilium continues to use
+  old-style IP rules with Azure IPAM.
+
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -54,9 +54,6 @@ type DaemonConfigurationStatus struct {
 	// Tailroom buffer margin on workload facing devices
 	DeviceTailroom int64 `json:"deviceTailroom,omitempty"`
 
-	// Configured compatibility mode for --egress-multi-home-ip-rule-compat
-	EgressMultiHomeIPRuleCompat bool `json:"egress-multi-home-ip-rule-compat,omitempty"`
-
 	// True if BBR is enabled only in the host network namespace
 	EnableBBRHostNamespaceOnly bool `json:"enableBBRHostNamespaceOnly,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2542,9 +2542,6 @@ definitions:
           ipv6:
             description: Status of masquerading for IPv6 traffic
             type: boolean
-      egress-multi-home-ip-rule-compat:
-        description: Configured compatibility mode for --egress-multi-home-ip-rule-compat
-        type: boolean
       installUplinkRoutesForDelegatedIPAM:
         description: |
           Install ingress/egress routes through uplink on host for Pods when working with

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2462,10 +2462,6 @@ func init() {
           "description": "Tailroom buffer margin on workload facing devices",
           "type": "integer"
         },
-        "egress-multi-home-ip-rule-compat": {
-          "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
-          "type": "boolean"
-        },
         "enableBBRHostNamespaceOnly": {
           "description": "True if BBR is enabled only in the host network namespace",
           "type": "boolean"
@@ -7886,10 +7882,6 @@ func init() {
         "deviceTailroom": {
           "description": "Tailroom buffer margin on workload facing devices",
           "type": "integer"
-        },
-        "egress-multi-home-ip-rule-compat": {
-          "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
-          "type": "boolean"
         },
         "enableBBRHostNamespaceOnly": {
           "description": "True if BBR is enabled only in the host network namespace",

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -730,11 +730,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Var(option.NewMapOptions(&option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache_v2=enabled_1024_1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
-	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,
-		"Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.")
-	flags.MarkDeprecated(option.EgressMultiHomeIPRuleCompat, "The feature will be removed in v1.19")
-	option.BindEnv(vp, option.EgressMultiHomeIPRuleCompat)
-
 	flags.Bool(option.InstallUplinkRoutesForDelegatedIPAM, false,
 		"Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin.")
 	option.BindEnv(vp, option.InstallUplinkRoutesForDelegatedIPAM)
@@ -1144,17 +1139,6 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 			"Auto-set option to `false` because it is redundant to per-endpoint routes",
 			logfields.Option, option.EnableLocalNodeRoute,
 			option.EnableEndpointRoutes, true,
-		)
-	}
-
-	if option.Config.IPAM == ipamOption.IPAMAzure {
-		option.Config.EgressMultiHomeIPRuleCompat = true
-		logger.Debug(
-			fmt.Sprintf("Auto-set %q to `true` because the Azure datapath has not been migrated over to a new scheme. "+
-				"A future version of Cilium will support a newer Azure datapath. "+
-				"Connectivity is not affected.",
-				option.EgressMultiHomeIPRuleCompat),
-			logfields.URL, "https://github.com/cilium/cilium/issues/14705",
 		)
 	}
 

--- a/daemon/cmd/ipam_infra_ip_allocation.go
+++ b/daemon/cmd/ipam_infra_ip_allocation.go
@@ -290,7 +290,6 @@ func (r *infraIPAllocator) allocateDatapathIPs(ctx context.Context, family types
 		if err = routingInfo.Configure(
 			result.IP,
 			r.mtuManager.GetDeviceMTU(),
-			option.Config.EgressMultiHomeIPRuleCompat,
 			true,
 		); err != nil {
 			return nil, fmt.Errorf("failed to configure router IP rules and routes: %w", err)
@@ -307,7 +306,6 @@ func (r *infraIPAllocator) allocateDatapathIPs(ctx context.Context, family types
 			for {
 				watchSet, err := routingInfo.ReconcileGatewayRoutes(
 					r.mtuManager.GetDeviceMTU(),
-					option.Config.EgressMultiHomeIPRuleCompat,
 					r.db.ReadTxn(),
 					r.routes,
 				)
@@ -469,7 +467,6 @@ func (r *infraIPAllocator) allocateIngressIPs() error {
 					if err := ingressRouting.Configure(
 						result.IP,
 						r.mtuManager.GetDeviceMTU(),
-						option.Config.EgressMultiHomeIPRuleCompat,
 						false,
 					); err != nil {
 						r.logger.Warn("Error while configuring ingress IP rules and routes.", logfields.Error, err)

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -402,7 +402,6 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 			IPV4: option.Config.EnableIPv4Masquerade,
 			IPV6: option.Config.EnableIPv6Masquerade,
 		},
-		EgressMultiHomeIPRuleCompat:         option.Config.EgressMultiHomeIPRuleCompat,
 		InstallUplinkRoutesForDelegatedIPAM: option.Config.InstallUplinkRoutesForDelegatedIPAM,
 		GROMaxSize:                          int64(h.bigTCPConfig.GetGROIPv6MaxSize()),
 		GSOMaxSize:                          int64(h.bigTCPConfig.GetGSOIPv6MaxSize()),

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -28,19 +28,22 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
+// useCompatEgressPriority determines whether to use the new or old style egress rule.
+// Old style rules are only used in Azure IPAM mode.
+func (info *RoutingInfo) useCompatEgressPriority() bool {
+	return info.IpamMode == ipamOption.IPAMAzure
+}
+
 // Configure sets up the rules and routes needed when running in ENI or
 // Azure IPAM mode.
 // These rules and routes direct egress traffic out of the interface and
-// ingress traffic back to the endpoint (`ip`). The compat flag controls which
-// egress priority to consider when deleting the egress rules (see
-// option.Config.EgressMultiHomeIPRuleCompat).
+// ingress traffic back to the endpoint (`ip`).
 //
 // ip: The endpoint IP address to direct traffic out / from interface.
 // info: The interface routing info used to create rules and routes.
 // mtu: The interface MTU.
-// compat: Whether to use the compat egress priority or not.
 // host: Whether the IP is a host IP and needs to be routed via the 'local' table
-func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) error {
+func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 	if ip == nil || (ip.To4() == nil && ip.To16() == nil) {
 		info.logger.Warn(
 			"Unable to configure rules and routes because IP is not a valid IP address",
@@ -88,14 +91,14 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 	}
 
 	var egressPriority, ifaceNum, tableID int
-	if compat {
+	if info.useCompatEgressPriority() {
 		egressPriority = linux_defaults.RulePriorityEgress
 		ifaceNum = ifindex
 	} else {
 		egressPriority = linux_defaults.RulePriorityEgressv2
 		ifaceNum = info.InterfaceNumber
 	}
-	tableID = computeTableIDFromIfaceNumber(compat, ifaceNum)
+	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
 
 	// The condition here should mirror the condition in Delete.
 	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
@@ -129,7 +132,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, compat bool, host bool) e
 	return info.installRoutes(ifindex, tableID)
 }
 
-func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, compat bool, rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
+func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {
 	set := statedb.NewWatchSet()
 
 	ifindex, err := retrieveIfIndexFromMAC(info.MasterIfMAC, mtu)
@@ -138,12 +141,12 @@ func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, compat bool, rx statedb
 	}
 
 	var ifaceNum, tableID int
-	if compat {
+	if info.useCompatEgressPriority() {
 		ifaceNum = ifindex
 	} else {
 		ifaceNum = info.InterfaceNumber
 	}
-	tableID = computeTableIDFromIfaceNumber(compat, ifaceNum)
+	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
 
 	// Get the desired routes.
 	gwRoutes := info.gatewayRoutes(ifindex, tableID)
@@ -242,9 +245,7 @@ func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
 
 // Delete removes the ingress and egress rules that control traffic for
 // endpoints. Note that the routes referenced by the rules are not deleted as
-// they can be reused when another endpoint is created on the same node. The
-// compat flag controls which egress priority to consider when deleting the
-// egress rules (see option.Config.EgressMultiHomeIPRuleCompat).
+// they can be reused when another endpoint is created on the same node.
 //
 // Note that one or more IPs may share the same route table, as identified by
 // the interface number of the corresponding device. This function only removes
@@ -261,7 +262,7 @@ func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
 // one egress rule. Deletion of any rule only proceeds if the rule matches
 // the IP & priority. In order to avoid leaving stale rules behind, all the
 // matching rules are removed.
-func Delete(logger *slog.Logger, ip netip.Addr, compat bool) error {
+func Delete(logger *slog.Logger, ip netip.Addr) error {
 	if !ip.Is4() && !ip.Is6() && !ip.IsValid() {
 		logger.Warn(
 			"Unable to delete rules because IP is not a valid IP address",
@@ -300,6 +301,7 @@ func Delete(logger *slog.Logger, ip netip.Addr, compat bool) error {
 		logfields.IPAddr, ipWithMask,
 	)
 
+	compat := option.Config.IPAM == ipamOption.IPAMAzure
 	priority := linux_defaults.RulePriorityEgressv2
 	if compat {
 		priority = linux_defaults.RulePriorityEgress

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -87,7 +87,7 @@ func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, ri := getFakes(t, ipamOption.IPAMENI, true, false)
-	err := ri.Configure(nil, 1500, false, false)
+	err := ri.Configure(nil, 1500, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "IP not compatible")
 }
@@ -96,7 +96,7 @@ func TestPrivilegedDeleteRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	ip := netip.Addr{}
-	err := Delete(hivetest.Logger(t), ip, false)
+	err := Delete(hivetest.Logger(t), ip)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "IP not compatible")
 }
@@ -175,7 +175,7 @@ func TestPrivilegedDelete(t *testing.T) {
 				defer ifaceCleanup()
 
 				ip := tt.preRun()
-				err := Delete(hivetest.Logger(t), ip, false)
+				err := Delete(hivetest.Logger(t), ip)
 				require.Equalf(t, tt.wantErr, (err != nil), "got error: %v", err)
 
 				return nil
@@ -209,7 +209,7 @@ func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int
 }
 
 func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
-	err := ri.Configure(ip.AsSlice(), mtu, false, false)
+	err := ri.Configure(ip.AsSlice(), mtu, false)
 	require.NoError(t, err)
 }
 
@@ -241,7 +241,7 @@ func verifyMasqueradeRules(t *testing.T, rules []netlink.Rule, ri RoutingInfo, i
 }
 
 func runDelete(t *testing.T, ip netip.Addr) {
-	err := Delete(hivetest.Logger(t), ip, false)
+	err := Delete(hivetest.Logger(t), ip)
 	require.NoError(t, err)
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2545,13 +2545,13 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		// ingress rule and multiple egress rules. If we find more rules than
 		// expected, we delete all rules referring to a per-ENI routing table ID.
 		if e.IPv4.IsValid() {
-			if err := linuxrouting.Delete(e.getLogger(), e.IPv4, option.Config.EgressMultiHomeIPRuleCompat); err != nil {
+			if err := linuxrouting.Delete(e.getLogger(), e.IPv4); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
 			}
 		}
 
 		if e.IPv6.IsValid() {
-			if err := linuxrouting.Delete(e.getLogger(), e.IPv6, option.Config.EgressMultiHomeIPRuleCompat); err != nil {
+			if err := linuxrouting.Delete(e.getLogger(), e.IPv6); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
 			}
 		}

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -357,7 +357,6 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		if err := routingConfig.Configure(
 			healthIP,
 			mtuConfig.GetDeviceMTU(),
-			option.Config.EgressMultiHomeIPRuleCompat,
 			false,
 		); err != nil {
 			return nil, fmt.Errorf("Error while configuring health endpoint rules and routes: %w", err)
@@ -381,5 +380,5 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 }
 
 type routingConfigurer interface {
-	Configure(ip net.IP, mtu int, compat bool, host bool) error
+	Configure(ip net.IP, mtu int, host bool) error
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -845,12 +845,11 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 
 				// For now, we can hardcode the interface number to a valid
 				// integer because it will not be used in the allocation result
-				// anyway. To elaborate, Azure IPAM mode automatically sets
-				// option.Config.EgressMultiHomeIPRuleCompat to true, meaning
-				// that the CNI will not use the interface number when creating
-				// the pod rules and routes. We are hardcoding simply to bypass
-				// the parsing errors when InterfaceNumber is empty. See
-				// https://github.com/cilium/cilium/issues/15496.
+				// anyway. Azure IPAM does not use the per-interface egress rule
+				// priority meaning that the CNI will not use the interface
+				// number when creating the pod rules and routes. We are hardcoding
+				// simply to bypass the parsing errors when InterfaceNumber
+				// is empty. See https://github.com/cilium/cilium/issues/15496.
 				//
 				// TODO: Once https://github.com/cilium/cilium/issues/14705 is
 				// resolved, then we don't need to hardcode this anymore.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -892,11 +892,6 @@ const (
 	// K8sEnableAPIDiscovery enables Kubernetes API discovery
 	K8sEnableAPIDiscovery = "enable-k8s-api-discovery"
 
-	// EgressMultiHomeIPRuleCompat instructs Cilium to use a new scheme to
-	// store rules and routes under ENI and Azure IPAM modes, if false.
-	// Otherwise, it will use the old scheme.
-	EgressMultiHomeIPRuleCompat = "egress-multi-home-ip-rule-compat"
-
 	// Install ingress/egress routes through uplink on host for Pods when working with
 	// delegated IPAM plugin.
 	InstallUplinkRoutesForDelegatedIPAM = "install-uplink-routes-for-delegated-ipam"
@@ -1756,11 +1751,6 @@ type DaemonConfig struct {
 	// This is only enabled for cilium-operator
 	K8sEnableLeasesFallbackDiscovery bool
 
-	// EgressMultiHomeIPRuleCompat instructs Cilium to use a new scheme to
-	// store rules and routes under ENI and Azure IPAM modes, if false.
-	// Otherwise, it will use the old scheme.
-	EgressMultiHomeIPRuleCompat bool
-
 	// Install ingress/egress routes through uplink on host for Pods when working with
 	// delegated IPAM plugin.
 	InstallUplinkRoutesForDelegatedIPAM bool
@@ -2618,7 +2608,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	default:
 		logging.Fatal(logger, "Invalid value for --%s: %s (must be 'icmp' or 'none')", PolicyDenyResponse, c.PolicyDenyResponse)
 	}
-	c.EgressMultiHomeIPRuleCompat = vp.GetBool(EgressMultiHomeIPRuleCompat)
 	c.InstallUplinkRoutesForDelegatedIPAM = vp.GetBool(InstallUplinkRoutesForDelegatedIPAM)
 
 	vlanBPFBypassIDs := vp.GetStringSlice(VLANBPFBypass)

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -241,7 +241,6 @@ func allocateIPsWithDelegatedPlugin(
 	}
 	// Interface number could not be determined from IPAM result for now.
 	// Set a static value zero before we have a proper solution.
-	// option.Config.EgressMultiHomeIPRuleCompat also needs to be set to true.
 	for _, ipConfig := range ipamResult.IPs {
 		ipNet := ipConfig.Address
 		if ipNet.IP.To4() != nil {

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -71,7 +71,6 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 	if err := routingInfo.Configure(
 		ipConfig.Address.IP,
 		int(conf.DeviceMTU),
-		conf.EgressMultiHomeIPRuleCompat,
 		false,
 	); err != nil {
 		return fmt.Errorf("unable to install ip rules and routes: %w", err)


### PR DESCRIPTION
See individual commits. Impact should be small. We do not expect users to explicitly have this enabled, as it was always set to false by default, except on Azure where it was forced to be set to true. The underlying behavior in Azure remains unchanged.

Ref:
- https://github.com/cilium/cilium/pull/39914
- https://github.com/cilium/cilium/pull/42618