### PR TITLE
[v1.16] gh: bump RHEL8 testing to RHEL8.10

### DIFF
--- a/.github/actions/e2e/kernel-versions.yml
+++ b/.github/actions/e2e/kernel-versions.yml
@@ -1,6 +1,6 @@
 kernels:
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  rhel8.6: 'rhel8.6-20250812.093650'
+  rhel8.10: 'rhel8.10-20251031.120020'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   5.4: '5.4-20251031.120020'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -13,14 +13,14 @@ include:
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20250812.093650"
+    kernel: "rhel8.10-20251031.120020"
 
   - k8s-version: "1.28"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.28.15@sha256:a7c05c7ae043a0b8c818f5a06188bc2c4098f6cb59ca7d1856df00375d839251"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "rhel8.6-20250812.093650"
+    kernel: "rhel8.10-20251031.120020"
 
   - k8s-version: "1.27"
     ip-family: "dual"

--- a/.github/actions/ipsec/configs.yaml
+++ b/.github/actions/ipsec/configs.yaml
@@ -1,6 +1,6 @@
 - name: '1'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  kernel: 'rhel8.6'
+  kernel: 'rhel8.10'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'

--- a/.github/actions/resolve-kernel-version/action.yaml
+++ b/.github/actions/resolve-kernel-version/action.yaml
@@ -2,7 +2,7 @@ name: 'Resolve Kernel Version'
 description: 'Resolves short kernel version to full timestamped version'
 inputs:
   kernel:
-    description: 'Short kernel version (e.g., 5.10, 6.1, rhel8.6)'
+    description: 'Short kernel version (e.g., 5.10, 6.1, rhel8.10)'
     required: true
 outputs:
   full:

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -84,7 +84,7 @@ jobs:
         include:
           - kernel: '5.4'
             ci-kernel: '54'
-          - kernel: 'rhel8.6'
+          - kernel: 'rhel8.10'
             ci-kernel: '54'
           - kernel: '5.10'
             ci-kernel: '510'
@@ -117,7 +117,7 @@ jobs:
           KERNEL="${{ matrix.kernel }}"
           case "$KERNEL" in
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "rhel8.6") FULL_KERNEL="rhel8.6-20250812.093650" ;;
+            "rhel8.10") FULL_KERNEL="rhel8.10-20251031.120020" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "5.4") FULL_KERNEL="5.4-20251031.120020" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -102,7 +102,7 @@ jobs:
         include:
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8.6-20250812.093650'
+            kernel: 'rhel8.10-20251031.120020'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -249,7 +249,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: 'rhel8.6-20250812.093650'
+            kernel: 'rhel8.10-20251031.120020'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -20,7 +20,7 @@ When running Cilium using the container image ``cilium/cilium``, the host
 system must meet these requirements:
 
 - Hosts with either AMD64 or AArch64 architecture
-- `Linux kernel`_ >= 5.4 or equivalent (e.g., 4.18 on RHEL 8.6)
+- `Linux kernel`_ >= 5.4 or equivalent (e.g., 4.18 on RHEL 8.10)
 
 When running Cilium as a native process on your host (i.e. **not** running the
 ``cilium/cilium`` container image) these additional requirements must be met:
@@ -34,13 +34,13 @@ must be met:
 
 - :ref:`req_kvstore` etcd >= 3.1.0
 
-======================== ============================== ===================
-Requirement              Minimum Version                In cilium container
-======================== ============================== ===================
-`Linux kernel`_          >= 5.4 or >= 4.18 on RHEL 8.6  no
-Key-Value store (etcd)   >= 3.1.0                       no
-clang+LLVM               >= 17.0.6                      yes
-======================== ============================== ===================
+======================== =============================== ===================
+Requirement              Minimum Version                 In cilium container
+======================== =============================== ===================
+`Linux kernel`_          >= 5.4 or >= 4.18 on RHEL 8.10  no
+Key-Value store (etcd)   >= 3.1.0                        no
+clang+LLVM               >= 17.0.6                       yes
+======================== =============================== ===================
 
 Architecture Support
 ====================
@@ -144,7 +144,7 @@ subsystems which integrate with eBPF. Therefore, host systems are required to
 run a recent Linux kernel to run a Cilium agent. More recent kernels may
 provide additional eBPF functionality that Cilium will automatically detect and
 use on agent start. For this version of Cilium, it is recommended to use kernel
-5.4 or later (or equivalent such as 4.18 on RHEL8). For a list of features
+5.4 or later (or equivalent such as 4.18 on RHEL 8.10). For a list of features
 that require newer kernels, see :ref:`advanced_features`.
 
 In order for the eBPF feature to be enabled properly, the following kernel


### PR DESCRIPTION
Backport of
* [ ] #41639

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 41639
```

```release-note
Testing for RHEL8 compatibility now uses a RHEL8.10-compatible kernel (previously this was a RHEL8.6-compatible kernel).
```