### PR TITLE
[v1.18] ipam: fix TestNodeManagerAbortReleaseIPReassignment test

### DIFF
--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -673,6 +673,10 @@ func TestNodeManagerAbortReleaseIPReassignment(t *testing.T) {
 		return releasedIP != ""
 	}, 10*time.Second, time.Second)
 
+	// Actually run the IP maintenance process to mark the IP for release
+	err = node.MaintainIPPool(context.Background())
+	require.NoError(t, err)
+
 	node.PopulateIPReleaseStatus(node.resource)
 
 	node.mutex.Lock()


### PR DESCRIPTION
[ upstream commit ee1d78a7bf41ee22facfa1751a1ec3002f44f8c2 ]

[ backporter's notes: Part of this fix was already committed in the backport commit 7db716c7ee3106dc09044bbd11be38232e5bd8b9  as part of the conflict resolution, this makes the test actually look the same as in upstream ]