### PR TITLE
Fix getDirFromXfrmMark helper

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -660,12 +660,14 @@ func getNodeIDAsHexFromXfrmMark(mark *netlink.XfrmMark) string {
 }
 
 func getDirFromXfrmMark(mark *netlink.XfrmMark) dir {
-	switch {
-	case mark == nil:
+	if mark == nil {
 		return dirUnspec
-	case mark.Value&linux_defaults.RouteMarkDecrypt != 0:
+	}
+	bitwiseResult := mark.Value & linux_defaults.RouteMarkMask
+	switch bitwiseResult {
+	case linux_defaults.RouteMarkDecrypt:
 		return dirIngress
-	case mark.Value&linux_defaults.RouteMarkEncrypt != 0:
+	case linux_defaults.RouteMarkEncrypt:
 		return dirEgress
 	}
 	return dirUnspec

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -646,3 +646,43 @@ func testUpdateExistingIPSecEndpoint(t *testing.T) {
 	_, err = a.UpsertIPsecEndpoint(params)
 	require.NoError(t, err)
 }
+
+func Test_getDirFromXfrmMark(t *testing.T) {
+	tests := []struct {
+		name string
+		mark *netlink.XfrmMark
+		want dir
+	}{
+		{
+			name: "Should return ingress for decrypt mark",
+			mark: &netlink.XfrmMark{
+				Value: 0xcb200d00,
+			},
+			want: dirIngress,
+		},
+		{
+			name: "Should return egress for encrypt mark",
+			mark: &netlink.XfrmMark{
+				Value: 0xcb200e00,
+			},
+			want: dirEgress,
+		},
+		{
+			name: "Should return unspec for nil mark",
+			mark: nil,
+			want: dirUnspec,
+		},
+		{
+			name: "Should return unspec for invalid mark",
+			mark: &netlink.XfrmMark{
+				Value: 0xcb200a1b,
+			},
+			want: dirUnspec,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, getDirFromXfrmMark(tt.mark), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
The `getDirFromXfrmMark` helper is always returning `dirIngress` because it is checking for non zero in the result of a bitwise & that will always return non zero regardless of the mark value passed in:

```
case mark.Value&linux_defaults.RouteMarkDecrypt != 0:
```

If the mark was egress `0xcb200e00` for example, the above will & against `0x00000d00` which gives a non zero result and returns `dirIngress` for an egress mark.

This commit updates the logic to mask out the encrypt/decrypt bits in the mark value and check them accordingly instead of testing for non zero.

```release-note
Fix a bug that would cause IPsec logs to incorrectly report the XFRM rules being processed as "Ingress" rules.
```

