### PR TITLE
ci: Enable `modernize` golangci-lint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - modernize
     - sloglint
     - staticcheck
     - testifylint
@@ -115,6 +116,12 @@ linters:
     gosec:
       includes:
         - G402
+    modernize:
+      disable: # TODO: remove each disabled rule and fix it
+        - omitzero
+        - rangeint
+        - stringsbuilder
+        - waitgroup
     govet:
       enable:
         - nilness

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -68,8 +68,7 @@ func readInput(t *testing.T, file string) []client.Object {
 	require.NoError(t, err)
 
 	var res []client.Object
-	objects := strings.Split(string(inputYaml), "---")
-	for _, o := range objects {
+	for o := range strings.SplitSeq(string(inputYaml), "---") {
 		o = strings.TrimSpace(o)
 		if o == "" {
 			continue

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -104,10 +104,8 @@ func (ms *MapSweeper) walk(path string, _ os.FileInfo, _ error) error {
 	}
 
 	for _, m := range mapPrefix {
-		if strings.HasPrefix(filename, m) {
-			if endpointID := strings.TrimPrefix(filename, m); endpointID != filename {
-				ms.deleteMapIfStale(path, filename, endpointID)
-			}
+		if endpointID, found := strings.CutPrefix(filename, m); found {
+			ms.deleteMapIfStale(path, filename, endpointID)
 		}
 	}
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -583,7 +583,7 @@ func (e *Endpoint) realizeBPFState(regenContext *regenerationContext) (err error
 
 	if datapathRegenCtxt.regenerationLevel > regeneration.RegenerateWithoutDatapath {
 		if e.Options.IsEnabled(option.Debug) {
-			debugFunc := func(format string, args ...interface{}) {
+			debugFunc := func(format string, args ...any) {
 				e.getLogger().Debug(fmt.Sprintf(format, args...))
 			}
 			ctx, cancel := context.WithCancel(regenContext.parentContext)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -817,7 +817,7 @@ func newTestEndpointModel(id int, state State) *models.EndpointChangeRequest {
 	return &models.EndpointChangeRequest{
 		ID:    int64(id),
 		State: ptr.To(models.EndpointState(state)),
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			PropertyFakeEndpoint: true,
 		},
 	}

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -76,7 +76,7 @@ func newTestEndpointModel(id int, state endpoint.State) *models.EndpointChangeRe
 	return &models.EndpointChangeRequest{
 		ID:    int64(id),
 		State: ptr.To(models.EndpointState(state)),
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			endpoint.PropertyFakeEndpoint: true,
 		},
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1647,7 +1647,7 @@ func newTestEndpointModel(id int, state endpoint.State) *models.EndpointChangeRe
 	return &models.EndpointChangeRequest{
 		ID:    int64(id),
 		State: ptr.To(models.EndpointState(state)),
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			endpoint.PropertyFakeEndpoint: true,
 		},
 	}

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -143,7 +143,7 @@ var decodeHooks = cell.DecodeHooks{
 		if from.Kind() != reflect.String {
 			return data, nil
 		}
-		if to != reflect.TypeOf(netip.Prefix{}) {
+		if to != reflect.TypeFor[netip.Prefix]() {
 			return data, nil
 		}
 		return netip.ParsePrefix(data.(string))

--- a/pkg/hubble/filters/cel_expression.go
+++ b/pkg/hubble/filters/cel_expression.go
@@ -24,7 +24,7 @@ var (
 
 	celTypes = cel.Types(&flowpb.Flow{})
 
-	goBoolType = reflect.TypeOf(false)
+	goBoolType = reflect.TypeFor[bool]()
 
 	celEnv *cel.Env
 )

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -159,14 +159,14 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 					} else {
 						logger.Warn(
 							"Unknown CiliumNode object type received",
-							logfields.Type, reflect.TypeOf(oldNode),
-							logfields.Object, oldNode,
+							logfields.Type, reflect.TypeOf(newNode), //nolint:modernize // newNode is any, can't use TypeFor
+							logfields.Object, newNode,
 						)
 					}
 				} else {
 					logger.Warn(
 						"Unknown CiliumNode object type received",
-						logfields.Type, reflect.TypeOf(oldNode),
+						logfields.Type, reflect.TypeOf(oldNode), //nolint:modernize // oldNode is any, can't use TypeFor
 						logfields.Object, oldNode,
 					)
 				}

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -68,11 +68,6 @@ var OperatorCell = cell.Module("operator-metrics", "Operator Metrics",
 // `github.com/cilium/cilium/pkg/metrics/metric.WithMetadata`
 // and `github.com/prometheus/client_golang/prometheus.Collector` interfaces.
 func Metric[S any](ctor func() S) cell.Cell {
-	var (
-		withMeta  pkgmetric.WithMetadata
-		collector prometheus.Collector
-	)
-
 	var nilOut S
 	outTyp := reflect.TypeOf(nilOut)
 	if outTyp.Kind() == reflect.Ptr {
@@ -95,8 +90,6 @@ func Metric[S any](ctor func() S) cell.Cell {
 		))
 	}
 
-	withMetaTyp := reflect.TypeOf(&withMeta).Elem()
-	collectorTyp := reflect.TypeOf(&collector).Elem()
 	for i := range outTyp.NumField() {
 		field := outTyp.Field(i)
 		if !field.IsExported() {
@@ -107,14 +100,14 @@ func Metric[S any](ctor func() S) cell.Cell {
 			))
 		}
 
-		if !field.Type.Implements(withMetaTyp) {
+		if !field.Type.Implements(reflect.TypeFor[pkgmetric.WithMetadata]()) {
 			panic(fmt.Errorf(
 				"The struct returned by the constructor passed to metrics.Metric has a field '%s', which is not metric.WithMetadata.",
 				field.Name,
 			))
 		}
 
-		if !field.Type.Implements(collectorTyp) {
+		if !field.Type.Implements(reflect.TypeFor[prometheus.Collector]()) {
 			panic(fmt.Errorf(
 				"The struct returned by the constructor passed to metrics.Metric has a field '%s', which is not prometheus.Collector.",
 				field.Name,

--- a/pkg/wal/wal_test.go
+++ b/pkg/wal/wal_test.go
@@ -190,10 +190,7 @@ type SmallReadsReader struct {
 }
 
 func (r *SmallReadsReader) Read(p []byte) (int, error) {
-	l := min(len(p), 8)
-	if l > len(r.data) {
-		l = len(r.data)
-	}
+	l := min(len(p), 8, len(r.data))
 
 	copy(p, r.data[:l])
 	r.data = r.data[l:]


### PR DESCRIPTION
Followup to #42525

This PR enables the new [`modernize`](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) golangci-lint linter that's available since golangci-lint [2.6.0](https://golangci-lint.run/docs/product/changelog/#260) (#42514).

This PR includes fixes for the following `modernize` analyzers that would currently be failing:
* `stringsseq`: Ranging over SplitSeq is more efficient
* `stringscutprefix`: HasPrefix + TrimPrefix can be simplified to CutPrefix
* `reflecttypefor`: reflect.TypeOf call can be simplified using TypeFor
* `any`: interface{} can be replaced by any
* `minmax`: if statement can be modernized using min

The following `modernize` analyzers are currently disabled as fixing them would cause a larger diff and should be done in separate PRs:
* `omitzero`
* `rangeint`
* `stringsbuilder`
* `waitgroup`