### PR TITLE
test:verifier: ensure output directory exists

### DIFF
--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -70,6 +70,10 @@ func TestPrivilegedVerifier(t *testing.T) {
 			t.Fatalf("Failed to set permissions on temporary directory %s: %v", resultDir, err)
 		}
 		flagResultDir = &resultDir
+	} else {
+		if err := os.Mkdir(*flagResultDir, 0755); err != nil && !os.IsExist(err) && !os.IsPermission(err) {
+			t.Fatalf("Failed to create directory %s with permissions: %v", *flagResultDir, err)
+		}
 	}
 
 	if err := rlimit.RemoveMemlock(); err != nil {


### PR DESCRIPTION
This commit simply makes sure that when providing an output directory
we create it before running the test. If the directory does not exist,
we were still running the tests and trying to dump results on it.
While the test per-se were successfully passing, the dumping of results
was failing due to the directory not being created.
    
Let's ignore errors when the directory already exists, or we cannot set
the desired permissions.