### PR TITLE
feat(sdp): Dockerfile for standalone dns proxy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -666,6 +666,7 @@ Makefile* @cilium/build
 /SECURITY-INSIGHTS.yml @cilium/security
 /stable.txt @cilium/release-managers
 /standalone-dns-proxy/ @cilium/fqdn
+/standalone-dns-proxy/Makefile @cilium/build
 /test/ @cilium/ci-structure
 /test/Makefile* @cilium/ci-structure @cilium/build
 # Service handling tests

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SUBDIRS_CILIUM_CONTAINER := cilium-dbg daemon cilium-health bugtool hubble tools
 SUBDIR_OPERATOR_CONTAINER := operator
 SUBDIR_RELAY_CONTAINER := hubble-relay
 SUBDIR_CLUSTERMESH_APISERVER_CONTAINER := clustermesh-apiserver
+SUBDIR_STANDALONE_DNS_PROXY_CONTAINER := standalone-dns-proxy
 
 ifdef LIBNETWORK_PLUGIN
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-docker
@@ -80,6 +81,9 @@ build-container-hubble-relay:
 
 build-container-clustermesh-apiserver: ## Builds components required for the clustermesh-apiserver container.
 	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_CLUSTERMESH_APISERVER_CONTAINER) all
+ 
+build-container-standalone-dns-proxy: ## Builds components required for standalone dns proxy container.
+	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_STANDALONE_DNS_PROXY_CONTAINER) all
 
 $(SUBDIRS): force ## Execute default make target(make all) for the provided subdirectory.
 	@ $(MAKE) $(SUBMAKEOPTS) -C $@ all
@@ -237,6 +241,10 @@ install-container-binary-hubble-relay:
 
 install-container-binary-clustermesh-apiserver: ## Install binaries for all components required for the clustermesh-apiserver container.
 	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_CLUSTERMESH_APISERVER_CONTAINER) install-binary
+
+install-container-binary-standalone-dns-proxy: ## Install binaries for all components required for standalone-dns-proxy container.
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR_STANDALONE_DNS_PROXY_CONTAINER) install-binary
 
 # Workaround for not having git in the build environment
 # Touch the file only if needed
@@ -568,7 +576,8 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 	$(call print_help_line,"docker-operator-*-image","Build platform specific cilium-operator images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"dev-docker-operator-*-image-debug","Build platform specific cilium-operator debug images(alibabacloud, aws, azure, generic)")
 	$(call print_help_line,"docker-*-image-unstripped","Build unstripped version of above docker images(cilium, hubble-relay, operator etc.)")
-
+	$(call print_help_line,"docker-standalone-dns-proxy-image","Build standalone DNS proxy docker image")
+	
 .PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-kvstoremesh-api generate-hubble-api generate-sdp-api install licenses-all veryclean run_bpf_tests run-builder gateway-api-conformance
 force :;
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -134,6 +134,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-hubble-relay-image,images/hubble-rela
 # docker-clustermesh-apiserver-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-clustermesh-apiserver-image,images/clustermesh-apiserver/Dockerfile,clustermesh-apiserver,$(DOCKER_IMAGE_TAG),release))
 
+# docker-standalone-dns-proxy-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-standalone-dns-proxy-image,images/standalone-dns-proxy/Dockerfile,standalone-dns-proxy,$(DOCKER_IMAGE_TAG),release))
+
 # docker-operator-images.
 # We eat the ending of "operator" in to the stem ('%') to allow this pattern
 # to build also 'docker-operator-image', where the stem would be empty otherwise.
@@ -144,9 +147,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image-debug,images/operato
 #
 # docker-*-all targets are mainly used from the CI
 #
-docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all ## Build all Cilium related docker images.
+docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all docker-standalone-dns-proxy-image ## Build all Cilium related docker images.
 
-docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped ## Build all Cilium related unstripped docker images.
+docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped docker-standalone-dns-proxy-image-unstripped ## Build all Cilium related unstripped docker images.
 
 docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-alibabacloud-image docker-operator-generic-image ## Build all variants of cilium-operator images.
 

--- a/images/standalone-dns-proxy/Dockerfile
+++ b/images/standalone-dns-proxy/Dockerfile
@@ -1,0 +1,36 @@
+# check=error=true
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+ARG BASE_IMAGE=scratch
+ARG GOLANG_IMAGE=docker.io/library/golang:1.25.3@sha256:6bac879c5b77e0fc9c556a5ed8920e89dab1709bd510a854903509c828f67f96
+
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+# Represents the plataform where the build is happening, do not mix with
+# TARGETARCH
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} AS builder
+
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+# MODIFIERS are extra arguments to be passed to make at build time.
+ARG MODIFIERS
+
+WORKDIR /go/src/github.com/cilium/cilium
+
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    make GOARCH=${TARGETARCH} DESTDIR=/out/${TARGETOS}/${TARGETARCH} $(echo $MODIFIERS | tr -d '"') \
+    build-container-standalone-dns-proxy install-container-binary-standalone-dns-proxy
+
+FROM ${BASE_IMAGE} AS release
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/standalone-dns-proxy /usr/bin/standalone-dns-proxy
+ENTRYPOINT [ "/usr/bin/standalone-dns-proxy" ]

--- a/standalone-dns-proxy/.gitignore
+++ b/standalone-dns-proxy/.gitignore
@@ -1,0 +1,1 @@
+standalone-dns-proxy

--- a/standalone-dns-proxy/Makefile
+++ b/standalone-dns-proxy/Makefile
@@ -1,0 +1,28 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+.DEFAULT_GOAL := all
+
+ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
+
+include ${ROOT_DIR}/../Makefile.defs
+
+
+TARGET := standalone-dns-proxy
+
+.PHONY: all $(TARGET) clean install-binary
+
+all: $(TARGET)
+
+$(TARGET):
+	@$(ECHO_GO)
+	$(QUIET)$(GO_BUILD) -o $@
+
+clean:
+	@$(ECHO_CLEAN)
+	$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO_CLEAN)
+
+install-binary:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
Dockerfile for standalone dns proxy to create the container image for standalone dns proxy.

Note: There is still active development of standalone DNS proxy feature, this PR currently just helps in testing it locally on a kind cluster.

Fixes: https://github.com/cilium/cilium/issues/30984
Relevant PRs: https://github.com/cilium/cilium/pull/41507, #41548 , #39906 
CFP: https://github.com/cilium/design-cfps/pull/54

```release-note
feat(sdp): Dockerfile for standalone dns proxy
```