### PR TITLE
bpf: untangle usage of common.h

### DIFF
--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -6,7 +6,6 @@
 #include <bpf/config/node.h>
 
 #include "lib/common.h"
-#include "lib/eps.h"
 #include "lib/nat.h"
 #include "lib/trace.h"
 #include "lib/policy_log.h"
@@ -27,21 +26,31 @@
 
 add_type(struct ipv4_ct_tuple);
 add_type(struct ipv6_ct_tuple);
+
+#include "lib/conntrack.h"
 add_type(struct ct_entry);
+
+#include "lib/eps.h"
+add_type(struct endpoint_key);
+add_type(struct endpoint_info);
 add_type(struct ipcache_key);
 add_type(struct remote_endpoint_info);
+
 add_type(struct lb4_key);
 add_type(struct lb4_service);
 add_type(struct lb4_backend);
 add_type(struct lb6_key);
 add_type(struct lb6_service);
 add_type(struct lb6_backend);
-add_type(struct endpoint_key);
-add_type(struct endpoint_info);
+
+#include "lib/metrics.h"
 add_type(struct metrics_key);
 add_type(struct metrics_value);
+
+#include "lib/policy.h"
 add_type(struct policy_key);
 add_type(struct policy_entry);
+
 add_type(struct ipv4_nat_entry);
 add_type(struct ipv6_nat_entry);
 add_type(struct trace_notify);
@@ -67,8 +76,11 @@ add_type(struct lb_affinity_val);
 add_type(struct lb_affinity_match);
 add_type(struct lb4_src_range_key);
 add_type(struct lb6_src_range_key);
+
+#include "lib/edt.h"
 add_type(struct edt_id);
 add_type(struct edt_info);
+
 add_type(struct egress_gw_policy_key);
 add_type(struct egress_gw_policy_entry);
 add_type(struct egress_gw_policy_key6);
@@ -82,9 +94,15 @@ add_type(struct srv6_policy_key6);
 add_type(struct trace_sock_notify);
 add_type(struct auth_key);
 add_type(struct auth_info);
+
+#include "lib/ipsec.h"
 add_type(struct encrypt_config);
+
 add_type(struct mcast_subscriber_v4);
+
+#include "lib/node.h"
 add_type(struct node_key);
 add_type(struct node_value);
+
 add_type(struct skip_lb4_key);
 add_type(struct skip_lb6_key);

--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -49,10 +49,13 @@ add_type(struct drop_notify);
 add_type(struct policy_verdict_notify);
 add_type(struct debug_msg);
 add_type(struct debug_capture_msg);
+
+#include "lib/sock.h"
 add_type(struct ipv4_revnat_tuple);
 add_type(struct ipv4_revnat_entry);
 add_type(struct ipv6_revnat_tuple);
 add_type(struct ipv6_revnat_entry);
+
 add_type(struct ipv4_frag_id);
 add_type(struct ipv4_frag_l4ports);
 add_type(struct ipv6_frag_id);

--- a/bpf/bpf_probes.c
+++ b/bpf/bpf_probes.c
@@ -7,7 +7,7 @@
 #include <node_config.h>
 #include <lib/static_data.h>
 
-#include "lib/common.h"
+#include "lib/socket.h"
 
 __section_entry
 int probe_fib_lookup_skip_neigh(struct __ctx_buff *ctx)

--- a/bpf/bpf_sock_term.c
+++ b/bpf/bpf_sock_term.c
@@ -8,7 +8,7 @@
 #include <lib/static_data.h>
 
 #include "bpf/compiler.h"
-#include "lib/common.h"
+#include "lib/endian.h"
 #include "lib/sock.h"
 #include "lib/sock_term.h"
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -285,10 +285,6 @@ struct srv6_policy_key6 {
 #define REASON_LB_REVNAT_DELETE		14
 #define REASON_MTU_ERROR_MSG			15
 
-/* Lookup scope for externalTrafficPolicy=Local */
-#define LB_LOOKUP_SCOPE_EXT	0
-#define LB_LOOKUP_SCOPE_INT	1
-
 /* Cilium metrics direction for dropping/forwarding packet */
 enum metric_dir {
 	METRIC_INGRESS = 1,
@@ -464,40 +460,6 @@ enum ct_status {
 	CT_RELATED,
 } __packed;
 
-/* Service flags (lb{4,6}_service->flags) */
-enum {
-	SVC_FLAG_EXTERNAL_IP     = (1 << 0),	/* External IPs */
-	SVC_FLAG_NODEPORT        = (1 << 1),	/* NodePort service */
-	SVC_FLAG_EXT_LOCAL_SCOPE = (1 << 2),	/* externalTrafficPolicy=Local */
-	SVC_FLAG_HOSTPORT        = (1 << 3),	/* hostPort forwarding */
-	SVC_FLAG_AFFINITY        = (1 << 4),	/* sessionAffinity=clientIP */
-	SVC_FLAG_LOADBALANCER    = (1 << 5),	/* LoadBalancer service */
-	SVC_FLAG_ROUTABLE        = (1 << 6),	/* Not a surrogate/ClusterIP entry */
-	SVC_FLAG_SOURCE_RANGE    = (1 << 7),	/* Check LoadBalancer source range */
-};
-
-/* Service flags (lb{4,6}_service->flags2) */
-enum {
-	SVC_FLAG_LOCALREDIRECT     = (1 << 0),	/* Local redirect service */
-	SVC_FLAG_NAT_46X64         = (1 << 1),	/* NAT-46/64 entry */
-	SVC_FLAG_L7_LOADBALANCER   = (1 << 2),	/* TPROXY redirect to local L7 load-balancer */
-	SVC_FLAG_LOOPBACK          = (1 << 3),	/* HostPort with a loopback hostIP */
-	SVC_FLAG_L7_DELEGATE       = (1 << 3),	/* If set then delegate unmodified to local L7 proxy */
-	SVC_FLAG_INT_LOCAL_SCOPE   = (1 << 4),	/* internalTrafficPolicy=Local */
-	SVC_FLAG_TWO_SCOPES        = (1 << 5),	/* Two sets of backends are used for external/internal connections */
-	SVC_FLAG_QUARANTINED       = (1 << 6),	/* Backend slot (key: backend_slot > 0) is quarantined */
-	SVC_FLAG_SOURCE_RANGE_DENY = (1 << 6),	/* Master slot: LoadBalancer source range check is inverted */
-	SVC_FLAG_FWD_MODE_DSR      = (1 << 7),	/* If bit is set, use DSR instead of SNAT in annotation mode */
-};
-
-/* Backend flags (lb{4,6}_backends->flags) */
-enum {
-	BE_STATE_ACTIVE		= 0,
-	BE_STATE_TERMINATING,
-	BE_STATE_QUARANTINED,
-	BE_STATE_MAINTENANCE,
-};
-
 struct ipv6_ct_tuple {
 	/* Address fields are reversed, i.e.,
 	 * these field names are correct for reply direction traffic.
@@ -527,16 +489,6 @@ struct ipv4_ct_tuple {
 	__u8		nexthdr;
 	__u8		flags;
 } __packed;
-
-/* We previously tolerated services with no specified L4 protocol (IPPROTO_ANY).
- *
- * This was deprecated, and we now re-purpose IPPROTO_ANY such that when combined with
- * a zero L4 Destination Port, we can encode a wild-card service entry. This informs
- * the data path to drop flows towards IPs we know about, but on services we don't.
- */
-#define IPPROTO_ANY	0
-#define LB_SVC_WILDCARD_PROTO IPPROTO_ANY
-#define LB_SVC_WILDCARD_DPORT 0
 
 struct lb6_key {
 	union v6addr address;	/* Service virtual IPv6 address */
@@ -593,9 +545,6 @@ struct lb4_key {
 	__u8 scope;		/* LB_LOOKUP_SCOPE_* for externalTrafficPolicy=Local */
 	__u8 pad[2];
 };
-
-#define LB_ALGORITHM_SHIFT	24
-#define AFFINITY_TIMEOUT_MASK	((1 << LB_ALGORITHM_SHIFT) - 1)
 
 struct lb4_service {
 	union {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -450,11 +450,6 @@ enum {
 	POLICY_MATCH_PROTO_ONLY = 6,
 };
 
-enum {
-	CAPTURE_INGRESS = 1,
-	CAPTURE_EGRESS = 2,
-};
-
 #ifndef BPF_F_PSEUDO_HDR
 # define BPF_F_PSEUDO_HDR                (1ULL << 4)
 #endif

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -38,6 +38,35 @@ enum ct_entry_type {
 	CT_ENTRY_SVC		= (1 << 2),
 };
 
+struct ct_state {
+	__u16 rev_nat_index;
+#ifdef USE_LOOPBACK_LB
+	__u16 loopback:1,
+#else
+	__u16 loopback_disabled:1,
+#endif
+	      node_port:1,
+	      dsr_internal:1,   /* DSR is k8s service related, cluster internal */
+	      syn:1,
+	      proxy_redirect:1,	/* Connection is redirected to a proxy */
+	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
+	      reserved1:1,	/* Was auth_required, not used in production anywhere */
+	      from_tunnel:1,	/* Connection is from tunnel */
+		  closing:1,
+	      reserved:7;
+	__u32 src_sec_id;
+	__u32 backend_id;	/* Backend ID in lb4_backends */
+};
+
+static __always_inline bool ct_state_is_from_l7lb(const struct ct_state *ct_state __maybe_unused)
+{
+#ifdef ENABLE_L7_LB
+	return ct_state->from_l7lb;
+#else
+	return false;
+#endif
+}
+
 struct ct_buffer4 {
 	struct ipv4_ct_tuple tuple;
 	struct ct_state ct_state;
@@ -53,6 +82,42 @@ struct ct_buffer6 {
 	int ret;
 	int l4_off;
 	fraginfo_t fraginfo;
+};
+
+struct ct_entry {
+	__u64 reserved0;	/* unused since v1.16 */
+	__u64 backend_id;
+	__u64 packets;
+	__u64 bytes;
+	__u32 lifetime;
+	__u16 rx_closing:1,
+	      tx_closing:1,
+	      reserved1:1,	/* unused since v1.12 */
+	      lb_loopback:1,
+	      seen_non_syn:1,
+	      node_port:1,
+	      proxy_redirect:1,	/* Connection is redirected to a proxy */
+	      dsr_internal:1,	/* DSR is k8s service related, cluster internal */
+	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
+	      reserved2:1,	/* unused since v1.14 */
+	      from_tunnel:1,	/* Connection is over tunnel */
+	      reserved3:5;
+	__u16 rev_nat_index;
+	__u16 reserved4;	/* unused since v1.18 */
+
+	/* *x_flags_seen represents the OR of all TCP flags seen for the
+	 * transmit/receive direction of this entry.
+	 */
+	__u8  tx_flags_seen;
+	__u8  rx_flags_seen;
+
+	__u32 src_sec_id; /* Used from userspace proxies, do not change offset! */
+
+	/* last_*x_report is a timestamp of the last time a monitor
+	 * notification was sent for the transmit/receive direction.
+	 */
+	__u32 last_tx_report;
+	__u32 last_rx_report;
 };
 
 static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags)

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -8,6 +8,27 @@
 #include "common.h"
 #include "time.h"
 
+#define DIRECTION_EGRESS 0
+#define DIRECTION_INGRESS 1
+
+struct edt_id {
+	__u32		id;
+	__u8		direction;
+	__u8		pad[3];
+};
+
+struct edt_info {
+	__u64		bps;
+	__u64		t_last;
+	union {
+		__u64	t_horizon_drop;
+		__u64	tokens;
+	};
+	__u32		prio;
+	__u32		pad_32;
+	__u64		pad[3];
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct edt_id);

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "dbg.h"
+#include "eps.h"
 #include "hash.h"
 #include "trace.h"
 

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -18,6 +18,11 @@
 /* We cap key index at 4 bits because mark value is used to map ctx to key */
 #define MAX_KEY_INDEX 15
 
+/* encrypt_config is the current encryption context on the node */
+struct encrypt_config {
+	__u8 encrypt_key;
+} __packed;
+
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, __u32);

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -7,6 +7,7 @@
 
 #include "eth.h"
 #include "dbg.h"
+#include "ipv6_core.h"
 #include "l4.h"
 #include "metrics.h"
 #include "ipfrag.h"

--- a/bpf/lib/ipv6_core.h
+++ b/bpf/lib/ipv6_core.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+union v6addr {
+	__u8 addr[16];
+	struct {
+		__u32 p1;
+		__u32 p2;
+		__u32 p3;
+		__u32 p4;
+	} p;
+#define p1 p.p1
+#define p2 p.p2
+#define p3 p.p3
+#define p4 p.p4
+	struct {
+		__u64 d1;
+		__u64 d2;
+	} d;
+#define d1 d.d1
+#define d2 d.d2
+} __packed;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -190,6 +190,57 @@ struct {
 	__uint(map_flags, CONDITIONAL_PREALLOC);
 } cilium_lb_affinity_match __section_maps_btf;
 
+/* Lookup scope for externalTrafficPolicy=Local */
+#define LB_LOOKUP_SCOPE_EXT	0
+#define LB_LOOKUP_SCOPE_INT	1
+
+/* Service flags (lb{4,6}_service->flags) */
+enum {
+	SVC_FLAG_EXTERNAL_IP     = (1 << 0),	/* External IPs */
+	SVC_FLAG_NODEPORT        = (1 << 1),	/* NodePort service */
+	SVC_FLAG_EXT_LOCAL_SCOPE = (1 << 2),	/* externalTrafficPolicy=Local */
+	SVC_FLAG_HOSTPORT        = (1 << 3),	/* hostPort forwarding */
+	SVC_FLAG_AFFINITY        = (1 << 4),	/* sessionAffinity=clientIP */
+	SVC_FLAG_LOADBALANCER    = (1 << 5),	/* LoadBalancer service */
+	SVC_FLAG_ROUTABLE        = (1 << 6),	/* Not a surrogate/ClusterIP entry */
+	SVC_FLAG_SOURCE_RANGE    = (1 << 7),	/* Check LoadBalancer source range */
+};
+
+/* Service flags (lb{4,6}_service->flags2) */
+enum {
+	SVC_FLAG_LOCALREDIRECT     = (1 << 0),	/* Local redirect service */
+	SVC_FLAG_NAT_46X64         = (1 << 1),	/* NAT-46/64 entry */
+	SVC_FLAG_L7_LOADBALANCER   = (1 << 2),	/* TPROXY redirect to local L7 load-balancer */
+	SVC_FLAG_LOOPBACK          = (1 << 3),	/* HostPort with a loopback hostIP */
+	SVC_FLAG_L7_DELEGATE       = (1 << 3),	/* If set then delegate unmodified to local L7 proxy */
+	SVC_FLAG_INT_LOCAL_SCOPE   = (1 << 4),	/* internalTrafficPolicy=Local */
+	SVC_FLAG_TWO_SCOPES        = (1 << 5),	/* Two sets of backends are used for external/internal connections */
+	SVC_FLAG_QUARANTINED       = (1 << 6),	/* Backend slot (key: backend_slot > 0) is quarantined */
+	SVC_FLAG_SOURCE_RANGE_DENY = (1 << 6),	/* Master slot: LoadBalancer source range check is inverted */
+	SVC_FLAG_FWD_MODE_DSR      = (1 << 7),	/* If bit is set, use DSR instead of SNAT in annotation mode */
+};
+
+/* Backend flags (lb{4,6}_backends->flags) */
+enum {
+	BE_STATE_ACTIVE		= 0,
+	BE_STATE_TERMINATING,
+	BE_STATE_QUARANTINED,
+	BE_STATE_MAINTENANCE,
+};
+
+/* We previously tolerated services with no specified L4 protocol (IPPROTO_ANY).
+ *
+ * This was deprecated, and we now re-purpose IPPROTO_ANY such that when combined with
+ * a zero L4 Destination Port, we can encode a wild-card service entry. This informs
+ * the data path to drop flows towards IPs we know about, but on services we don't.
+ */
+#define IPPROTO_ANY	0
+#define LB_SVC_WILDCARD_PROTO IPPROTO_ANY
+#define LB_SVC_WILDCARD_DPORT 0
+
+#define LB_ALGORITHM_SHIFT	24
+#define AFFINITY_TIMEOUT_MASK	((1 << LB_ALGORITHM_SHIFT) - 1)
+
 #ifdef LB_DEBUG
 #define cilium_dbg_lb cilium_dbg
 #else

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "dbg.h"
+#include "eps.h"
 #include "l3.h"
 #include "token_bucket.h"
 

--- a/bpf/lib/map_defs.h
+++ b/bpf/lib/map_defs.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <bpf/api.h>
+
+#ifdef PREALLOCATE_MAPS
+#define CONDITIONAL_PREALLOC 0
+#else
+#define CONDITIONAL_PREALLOC BPF_F_NO_PREALLOC
+#endif
+
+#ifdef NO_COMMON_MEM_MAPS
+#define LRU_MEM_FLAVOR BPF_F_NO_COMMON_LRU
+#else
+#define LRU_MEM_FLAVOR 0
+#endif

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -11,6 +11,20 @@
 #include "utils.h"
 #include "dbg.h"
 
+struct metrics_key {
+	__u8      reason;	/* 0: forwarded, >0 dropped */
+	__u8      dir:2,	/* 1: ingress 2: egress */
+		  pad:6;
+	__u16	  line;		/* __MAGIC_LINE__ */
+	__u8	  file;		/* __MAGIC_FILE__, needs to fit __id_for_file */
+	__u8	  reserved[3];	/* reserved for future extension */
+};
+
+struct metrics_value {
+	__u64	count;
+	__u64	bytes;
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 	__type(key, struct metrics_key);

--- a/bpf/lib/node.h
+++ b/bpf/lib/node.h
@@ -7,6 +7,29 @@
 #include <bpf/section.h>
 #include <bpf/loader.h>
 
+#include "eps.h"
+
+struct node_key {
+	__u16 pad1;
+	__u8 pad2;
+	__u8 family;
+	union {
+		struct {
+			__u32 ip4;
+			__u32 pad4;
+			__u32 pad5;
+			__u32 pad6;
+		};
+		union v6addr ip6;
+	};
+};
+
+struct node_value {
+	__u16 id;
+	__u8  spi;
+	__u8  pad;
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct node_key);

--- a/bpf/lib/sock.h
+++ b/bpf/lib/sock.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include "ipv6_core.h"
+#include "map_defs.h"
+
 static __always_inline __maybe_unused
 __sock_cookie sock_local_cookie(struct bpf_sock_addr *ctx)
 {
@@ -16,6 +19,19 @@ __sock_cookie sock_local_cookie(struct bpf_sock_addr *ctx)
 #endif
 }
 
+struct ipv4_revnat_tuple {
+	__sock_cookie cookie;
+	__be32 address;
+	__be16 port;
+	__u16 pad;
+};
+
+struct ipv4_revnat_entry {
+	__be32 address;
+	__be16 port;
+	__u16 rev_nat_index;
+};
+
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv4_revnat_tuple);
@@ -24,6 +40,19 @@ struct {
 	__uint(max_entries, LB4_REVERSE_NAT_SK_MAP_SIZE);
 	__uint(map_flags, LRU_MEM_FLAVOR);
 } cilium_lb4_reverse_sk __section_maps_btf;
+
+struct ipv6_revnat_tuple {
+	__sock_cookie cookie;
+	union v6addr address;
+	__be16 port;
+	__u16 pad;
+};
+
+struct ipv6_revnat_entry {
+	union v6addr address;
+	__be16 port;
+	__u16 rev_nat_index;
+};
 
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);

--- a/bpf/lib/socket.h
+++ b/bpf/lib/socket.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#ifndef AF_INET
+#define AF_INET 2
+#endif
+
+#ifndef AF_INET6
+#define AF_INET6 10
+#endif

--- a/bpf/tests/destroy_sock_socket_lb.c
+++ b/bpf/tests/destroy_sock_socket_lb.c
@@ -52,6 +52,9 @@ static __always_inline __sock_cookie mock_get_socket_cookie(void *ctx __maybe_un
 
 #define ENABLE_IPV4 1
 #define ENABLE_IPV6 1
+
+#include "lib/socket.h"
+
 #include "bpf_sock_term.c"
 
 const __sock_cookie no_match_cookie4 = 200;


### PR DESCRIPTION
Re-organize `common.h` a bit so that it's possible to build simple Cilium-related programs (like `bpf_sock_term` or `bpf_probes`) without including the whole world. I'd hope that with a bit more progress on this effort, we can also avoid the include in `bpf_alignchecker`.

Moving many of the map-related structs into their associated header should also help with better code ownership assignment.