### PR TITLE
node: move local node sync cell from daemon/cmd to pkg/node/sync

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -70,6 +70,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/node/neighbordiscovery"
+	nodesync "github.com/cilium/cilium/pkg/node/sync"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
@@ -176,12 +177,7 @@ var (
 		// LocalNodeStore holds onto the information about the local node and allows
 		// observing changes to it.
 		node.LocalNodeStoreCell,
-
-		// Provide a newLocalNodeSynchronizer that is invoked when LocalNodeStore is started.
-		// This fills in the initial state before it is accessed by other sub-systems.
-		// Then, it takes care of keeping selected fields (e.g., labels, annotations)
-		// synchronized with the corresponding kubernetes object.
-		cell.Provide(newLocalNodeSynchronizer),
+		nodesync.LocalNodeSyncCell,
 
 		// Controller provides flags and configuration related
 		// to Controller management, concurrent control loops

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package sync
 
 import (
 	"context"
@@ -105,10 +105,11 @@ func (fln *fakeLocalNode) Store(context.Context) (resource.Store[*slim_corev1.No
 
 func TestLocalNodeSync(t *testing.T) {
 	var (
-		local = node.LocalNode{Node: types.Node{
-			Labels:      map[string]string{"ex": "label"},
-			Annotations: map[string]string{"ex": "annot"},
-		},
+		local = node.LocalNode{
+			Node: types.Node{
+				Labels:      map[string]string{"ex": "label"},
+				Annotations: map[string]string{"ex": "annot"},
+			},
 			Local: &node.LocalNodeInfo{},
 		}
 		fln  = newFakeLocalNode()


### PR DESCRIPTION
This commit moves the hive cell that provides the `LocalNodeSynchronizer` from the package `daemon/cmd` to `pkg/node/sync`.