### PR TITLE
policy: fix selector policy leak and detachment issues

### DIFF
--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -169,7 +169,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	logger := hivetest.Logger(t)
 	model := newTestEndpointModel(12345, StateRegenerating)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil)
+	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, s.do.idmgr, nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
@@ -132,31 +133,32 @@ var (
 	}
 )
 
-func testNewPolicyRepository(t *testing.T, initialIDs []*identity.Identity) *policy.Repository {
+func testNewPolicyRepository(t *testing.T, initialIDs []*identity.Identity) (identitymanager.IDManager, *policy.Repository) {
 	idmap := identity.IdentityMap{}
 	for _, id := range initialIDs {
 		idmap[id.ID] = id.LabelArray
 	}
 	logger := hivetest.Logger(t)
-	repo := policy.NewPolicyRepository(logger, idmap, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, idmap, nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
 	repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
-	return repo
+	return idManager, repo
 }
 
 // validateNetworkPolicy takes a repository and validates
 // that the set of flows are allowed and denied as expected.
-func validateNetworkPolicy(t *testing.T, repo *policy.Repository, allowFlows, denyFlows []policy.Flow) {
+func validateNetworkPolicy(t *testing.T, repo *policy.Repository, identityManager identitymanager.IDManager, allowFlows, denyFlows []policy.Flow) {
 	t.Helper()
 	logger := hivetest.Logger(t)
 
 	for i, allow := range allowFlows {
-		verdict, _, _, err := policy.LookupFlow(logger, repo, allow, nil, nil)
+		verdict, _, _, err := policy.LookupFlow(logger, repo, identityManager, allow, nil, nil)
 		require.NoError(t, err, "Looking up allow flow %i failed", i)
 		require.Equal(t, api.Allowed, verdict, "Verdict for allow flow %d must match", i)
 	}
 
 	for i, allow := range denyFlows {
-		verdict, _, _, err := policy.LookupFlow(logger, repo, allow, nil, nil)
+		verdict, _, _, err := policy.LookupFlow(logger, repo, identityManager, allow, nil, nil)
 		require.NoError(t, err, "Looking up deny flow %i failed", i)
 		require.Equal(t, api.Denied, verdict, "Verdict for deny flow %d must match", i)
 	}
@@ -430,7 +432,7 @@ func TestParseNetworkPolicyMultipleSelectors(t *testing.T) {
 	np := slim_networkingv1.NetworkPolicy{}
 	err := json.Unmarshal(ex1, &np)
 	require.NoError(t, err)
-	repo := parseAndAddRules(t, &np)
+	idManager, repo := parseAndAddRules(t, &np)
 
 	allowedFlows := []policy.Flow{
 		flowAToB,
@@ -444,7 +446,7 @@ func TestParseNetworkPolicyMultipleSelectors(t *testing.T) {
 		flowAToOther,
 	}
 
-	validateNetworkPolicy(t, repo, allowedFlows, deniedFlows)
+	validateNetworkPolicy(t, repo, idManager, allowedFlows, deniedFlows)
 }
 
 func TestParseNetworkPolicyNoSelectors(t *testing.T) {
@@ -554,8 +556,9 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 	flowAToB81 := flowAToB
 	flowAToB81.Dport = 81
 
-	repo := parseAndAddRules(t, netPolicy)
+	idManager, repo := parseAndAddRules(t, netPolicy)
 	validateNetworkPolicy(t, repo,
+		idManager,
 		[]policy.Flow{
 			flowAToB,
 		}, []policy.Flow{
@@ -565,9 +568,9 @@ func TestParseNetworkPolicyEgress(t *testing.T) {
 		})
 }
 
-func parseAndAddRules(t *testing.T, ps ...*slim_networkingv1.NetworkPolicy) *policy.Repository {
+func parseAndAddRules(t *testing.T, ps ...*slim_networkingv1.NetworkPolicy) (identitymanager.IDManager, *policy.Repository) {
 	t.Helper()
-	repo := testNewPolicyRepository(t, allIDs)
+	idManager, repo := testNewPolicyRepository(t, allIDs)
 
 	for i, p := range ps {
 		if p.Name == "" {
@@ -582,11 +585,11 @@ func parseAndAddRules(t *testing.T, ps ...*slim_networkingv1.NetworkPolicy) *pol
 		_, id := repo.MustAddPolicyEntries(rules)
 		require.Equal(t, rev+1, id)
 	}
-	return repo
+	return idManager, repo
 }
 
 func TestParseNetworkPolicyEgressAllowAll(t *testing.T) {
-	repo := parseAndAddRules(t,
+	idManager, repo := parseAndAddRules(t,
 		// pod A: allow all egress
 		&slim_networkingv1.NetworkPolicy{Spec: slim_networkingv1.NetworkPolicySpec{
 			PodSelector: labelSelectorA,
@@ -603,7 +606,7 @@ func TestParseNetworkPolicyEgressAllowAll(t *testing.T) {
 		}},
 	)
 
-	validateNetworkPolicy(t, repo,
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			flowAToB,
 			flowAToC,
@@ -614,7 +617,7 @@ func TestParseNetworkPolicyEgressAllowAll(t *testing.T) {
 }
 
 func TestParseNetworkPolicyEgressL4AllowAll(t *testing.T) {
-	repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
+	idManager, repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
 		Spec: slim_networkingv1.NetworkPolicySpec{
 			PodSelector: labelSelectorA,
 			Egress: []slim_networkingv1.NetworkPolicyEgressRule{
@@ -628,14 +631,14 @@ func TestParseNetworkPolicyEgressL4AllowAll(t *testing.T) {
 	flowAToC90 := flowAToC
 	flowAToC90.Dport = 90
 
-	validateNetworkPolicy(t, repo,
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{flowAToC},
 		[]policy.Flow{flowAToC90})
 
 }
 
 func TestParseNetworkPolicyEgressL4PortRangeAllowAll(t *testing.T) {
-	repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
+	idManager, repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
 		Spec: slim_networkingv1.NetworkPolicySpec{
 			PodSelector: labelSelectorA,
 			Egress: []slim_networkingv1.NetworkPolicyEgressRule{
@@ -656,14 +659,14 @@ func TestParseNetworkPolicyEgressL4PortRangeAllowAll(t *testing.T) {
 		flow := flowAToC
 		flow.Dport = port
 
-		verdict, _, _, err := policy.LookupFlow(hivetest.Logger(t), repo, flow, nil, nil)
+		verdict, _, _, err := policy.LookupFlow(hivetest.Logger(t), repo, idManager, flow, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, expected, verdict, "Port %d", port)
 	}
 }
 
 func TestParseNetworkPolicyIngressAllowAll(t *testing.T) {
-	repo := parseAndAddRules(t,
+	idManager, repo := parseAndAddRules(t,
 		// pod a: deny all ingress
 		&slim_networkingv1.NetworkPolicy{Spec: slim_networkingv1.NetworkPolicySpec{
 			PodSelector: labelSelectorA,
@@ -686,7 +689,7 @@ func TestParseNetworkPolicyIngressAllowAll(t *testing.T) {
 			},
 		}})
 
-	validateNetworkPolicy(t, repo, []policy.Flow{
+	validateNetworkPolicy(t, repo, idManager, []policy.Flow{
 		flowAToB,
 		flowAToC,
 	}, []policy.Flow{
@@ -695,7 +698,7 @@ func TestParseNetworkPolicyIngressAllowAll(t *testing.T) {
 }
 
 func TestParseNetworkPolicyIngressL4AllowAll(t *testing.T) {
-	repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
+	idManager, repo := parseAndAddRules(t, &slim_networkingv1.NetworkPolicy{
 		Spec: slim_networkingv1.NetworkPolicySpec{
 			PodSelector: labelSelectorC,
 			Ingress: []slim_networkingv1.NetworkPolicyIngressRule{
@@ -709,7 +712,7 @@ func TestParseNetworkPolicyIngressL4AllowAll(t *testing.T) {
 	flowAToC90 := flowAToC
 	flowAToC90.Dport = 90
 
-	validateNetworkPolicy(t, repo,
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			flowAToC,
 		}, []policy.Flow{
@@ -814,8 +817,8 @@ func TestParseNetworkPolicyEmptyFrom(t *testing.T) {
 		},
 	}
 
-	repo := parseAndAddRules(t, netPolicy1)
-	validateNetworkPolicy(t, repo, []policy.Flow{
+	idManager, repo := parseAndAddRules(t, netPolicy1)
+	validateNetworkPolicy(t, repo, idManager, []policy.Flow{
 		flowBToA,
 		flowCToA,
 		flowOtherToA,
@@ -833,8 +836,8 @@ func TestParseNetworkPolicyDenyAll(t *testing.T) {
 		},
 	}
 
-	repo := parseAndAddRules(t, netPolicy1)
-	validateNetworkPolicy(t, repo,
+	idManager, repo := parseAndAddRules(t, netPolicy1)
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			flowAToOther,
 		},
@@ -911,9 +914,9 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	nsBob := makePod("nsBob", map[string]string{"role": "frontend"}, map[string]string{"user": "bob"})
 	nsSally := makePod("nsSally", map[string]string{"role": "frontend"}, map[string]string{"user": "sally"})
 
-	makeRepo := func(pol ...[]byte) *policy.Repository {
+	makeRepo := func(pol ...[]byte) (identitymanager.IDManager, *policy.Repository) {
 		t.Helper()
-		repo := testNewPolicyRepository(t, allIDs)
+		idManager, repo := testNewPolicyRepository(t, allIDs)
 
 		for i, p := range pol {
 			np := slim_networkingv1.NetworkPolicy{}
@@ -925,7 +928,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 
 			repo.MustAddPolicyEntries(rules)
 		}
-		return repo
+		return idManager, repo
 	}
 
 	// Example 1a: Only allow traffic from frontend pods on TCP port 6379 to
@@ -965,8 +968,8 @@ func TestNetworkPolicyExamples(t *testing.T) {
   }
 }`)
 
-	repo := makeRepo(ex1)
-	validateNetworkPolicy(t, repo,
+	idManager, repo := makeRepo(ex1)
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			tcpFlow(frontend, backend, 6379),
 		}, []policy.Flow{
@@ -1020,8 +1023,8 @@ func TestNetworkPolicyExamples(t *testing.T) {
 		  }
 		}`)
 
-	repo = makeRepo(ex1b)
-	validateNetworkPolicy(t, repo,
+	idManager, repo = makeRepo(ex1b)
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			// allows all from frontend
 			tcpFlow(frontend, backend, 6379),
@@ -1078,8 +1081,8 @@ func TestNetworkPolicyExamples(t *testing.T) {
 		  }
 		}`)
 
-	repo = makeRepo(ex2)
-	validateNetworkPolicy(t, repo,
+	idManager, repo = makeRepo(ex2)
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			// allows nsbob 443, rejects everything else
 			tcpFlow(nsBob, frontend, 443),
@@ -1107,8 +1110,8 @@ func TestNetworkPolicyExamples(t *testing.T) {
 		    ]
 		  }
 		}`)
-	repo = makeRepo(ex3)
-	validateNetworkPolicy(t, repo,
+	idManager, repo = makeRepo(ex3)
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			// allows all
 			tcpFlow(nsBob, frontend, 443),
@@ -1193,9 +1196,9 @@ func TestNetworkPolicyExamples(t *testing.T) {
 		  }
 		}`)
 
-	repo = makeRepo(ex4a, ex4b)
+	idManager, repo = makeRepo(ex4a, ex4b)
 
-	validateNetworkPolicy(t, repo,
+	validateNetworkPolicy(t, repo, idManager,
 		[]policy.Flow{
 			// allows all from bob
 			udpFlow(nsBob, frontend, 8080),
@@ -1325,11 +1328,11 @@ func TestNetworkPolicyExamples(t *testing.T) {
 		"environment": "prod",
 	})
 
-	repo = makeRepo(defaultDeny, ex5)
+	idManager, repo = makeRepo(defaultDeny, ex5)
 
 	// Policy allows FROM all namespaces with the desired labels
 	// TO pods with the desired labels
-	validateNetworkPolicy(t, repo, []policy.Flow{
+	validateNetworkPolicy(t, repo, idManager, []policy.Flow{
 		udpFlow(redisCacheProdOther, redisCacheProd, 8080),
 	}, []policy.Flow{
 		udpFlow(redisCacheDevOther, redisCacheProd, 8080),

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/cilium/cilium/pkg/container/versioned"
@@ -36,17 +37,21 @@ func newPolicyCache(repo *Repository, idmgr identitymanager.IDManager) *policyCa
 	return cache
 }
 
-// lookupOrCreate adds the specified Identity to the policy cache, with a reference
-// from the specified Endpoint, then returns the threadsafe copy of the policy.
-func (cache *policyCache) lookupOrCreate(identity *identityPkg.Identity) *cachedSelectorPolicy {
+// lookup is the same function as lookupLocked, except that it grabs the lock of the cache
+func (cache *policyCache) lookup(identity *identityPkg.Identity) (*cachedSelectorPolicy, bool) {
 	cache.Lock()
 	defer cache.Unlock()
+	return cache.lookupLocked(identity)
+}
+
+// lookupLocked returns the selector policy for the given identity. If the identity is not present in the cache it
+// will return nil and false
+func (cache *policyCache) lookupLocked(identity *identityPkg.Identity) (*cachedSelectorPolicy, bool) {
 	cip, ok := cache.policies[identity.ID]
 	if !ok {
-		cip = newCachedSelectorPolicy(identity)
-		cache.policies[identity.ID] = cip
+		return nil, false
 	}
-	return cip
+	return cip, true
 }
 
 // GetPolicySnapshot returns a snapshot of the current policy cache.
@@ -62,6 +67,18 @@ func (cache *policyCache) GetPolicySnapshot() map[identityPkg.NumericIdentity]Se
 		}
 	}
 	return snapshot
+}
+
+// insert adds the specified Identity to the policy cache
+func (cache *policyCache) insert(identity *identityPkg.Identity) *cachedSelectorPolicy {
+	cache.Lock()
+	defer cache.Unlock()
+	cip, ok := cache.lookupLocked(identity)
+	if !ok {
+		cip = newCachedSelectorPolicy(identity)
+		cache.policies[identity.ID] = cip
+	}
+	return cip
 }
 
 // delete forgets about any cached SelectorPolicy that this endpoint uses.
@@ -89,11 +106,17 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 // of themselves if the selector policy is created and initiates a regeneration trigger
 // on detach.
 //
-// Returns whether the cache was updated, or an error.
+// Returns whether the cache was updated, or an error. It will return an error if the
+// identity is not in use by any endpoint on the node. That can happen in cases where
+// an endpoint changed its identity during policy regeneration, where the regeneration
+// is still referring to the old identity.
 //
 // Must be called with repo.Mutex held for reading.
 func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
-	cip := cache.lookupOrCreate(identity)
+	cip, ok := cache.lookup(identity)
+	if !ok {
+		return nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
+	}
 
 	// As long as UpdatePolicy() is triggered from endpoint
 	// regeneration, it's possible for two endpoints with the
@@ -123,9 +146,10 @@ func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, e
 	return selPolicy, true, nil
 }
 
-// LocalEndpointIdentityAdded is not needed; we only care about local endpoint
-// deletion
+// LocalEndpointIdentityAdded creates a SelectorPolicy cache entry for the
+// specified Identity, without calculating any policy for it.
 func (cache *policyCache) LocalEndpointIdentityAdded(identity *identityPkg.Identity) {
+	cache.insert(identity)
 }
 
 // LocalEndpointIdentityRemoved deletes the cached SelectorPolicy for the

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -36,21 +37,13 @@ const (
 	AuthTypeDisabled   = types.AuthTypeDisabled
 )
 
-func setupTest(tb testing.TB) {
-	ep1 = testutils.NewTestEndpoint(tb)
-	ep2 = testutils.NewTestEndpoint(tb)
-}
-
-var (
-	ep1, ep2 testutils.TestEndpoint
-)
-
 func localIdentity(n uint32) identity.NumericIdentity {
 	return identity.NumericIdentity(n) | identity.IdentityScopeLocal
 }
 
 func TestCacheManagement(t *testing.T) {
-	setupTest(t)
+	ep1 := testutils.NewTestEndpoint(t)
+	ep2 := testutils.NewTestEndpoint(t)
 	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	cache := repo.policyCache
 	identity := ep1.GetSecurityIdentity()
@@ -60,22 +53,10 @@ func TestCacheManagement(t *testing.T) {
 	deleted := cache.delete(identity)
 	require.False(t, deleted)
 
-	// Insert directly to cache and delete the entry.
-	csp := cache.lookupOrCreate(identity)
-	require.NotNil(t, csp)
-	require.Nil(t, csp.getPolicy())
-	removed := cache.delete(identity)
-	require.True(t, removed)
-
 	// Insert identity twice. Should be the same policy.
-	policy1, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
-	require.NoError(t, err)
-	require.True(t, updated)
-	policy2, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
-	require.NoError(t, err)
-	require.False(t, updated)
-	// must be same pointer
-	require.Same(t, policy2, policy1)
+	policy1 := cache.insert(identity)
+	policy2 := cache.insert(identity)
+	require.Equal(t, policy2, policy1)
 
 	// Despite two insert calls, there is no reference tracking; any delete
 	// will clear the cache.
@@ -90,23 +71,26 @@ func TestCacheManagement(t *testing.T) {
 	ep3.SetIdentity(1234, true)
 	identity3 := ep3.GetSecurityIdentity()
 	require.NotEqual(t, identity, identity3)
-	policy1, _, _ = cache.updateSelectorPolicy(identity, ep1.Id)
-	require.NotNil(t, policy1)
-	policy3, _, _ := cache.updateSelectorPolicy(identity3, ep3.Id)
-	require.NotNil(t, policy3)
-	require.NotSame(t, policy3, policy1)
+	policy1 = cache.insert(identity)
+	policy3 := cache.insert(identity3)
+	require.NotEqual(t, policy3, policy1)
 	_ = cache.delete(identity)
-	_, updated, _ = cache.updateSelectorPolicy(identity3, ep3.Id)
-	require.False(t, updated)
+	policy3, ok := cache.lookup(identity3)
+	require.NotNil(t, policy3)
+	require.True(t, ok)
 }
 
 func TestCachePopulation(t *testing.T) {
+	ep1 := testutils.NewTestEndpoint(t)
+	ep2 := testutils.NewTestEndpoint(t)
+
 	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
 	repo.revision.Store(42)
 	cache := repo.policyCache
 
 	identity1 := ep1.GetSecurityIdentity()
 	require.Equal(t, identity1, ep2.GetSecurityIdentity())
+	cip1 := cache.insert(identity1)
 
 	// Calculate the policy and observe that it's cached
 	policy1, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
@@ -115,26 +99,61 @@ func TestCachePopulation(t *testing.T) {
 	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.False(t, updated)
-	policy2, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
-	require.NotNil(t, policy2)
-	require.Same(t, policy1, policy2)
+	policy3, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
+	require.NotNil(t, policy1)
+	require.Same(t, policy1, policy3)
+	cip2, ok := cache.lookup(identity1)
+	require.True(t, ok)
+	require.Same(t, cip1, cip2)
 
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	_, updated, _ = cache.updateSelectorPolicy(identity1, ep1.Id)
-	require.True(t, updated)
+	_, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	require.Error(t, err)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint(t)
 	ep3.SetIdentity(1234, true)
-	policy3, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	_, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	require.Error(t, err)
+
+	cache.insert(ep3.GetSecurityIdentity())
+	policy4, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+
+	// policy4 must be different from ep1, ep2
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.NotEqual(t, policy1, policy4)
+
+	// Insert endpoint with different identity and observe that the cache
+	// is different from ep1, ep2
+	policy5 := cache.insert(identity1)
+	idp1 := policy5.getPolicy()
+	require.Nil(t, idp1)
+
+	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
 	require.NoError(t, err)
 	require.True(t, updated)
 
-	// policy3 must be different from ep1, ep2
+	idp1 = policy5.getPolicy()
+	require.NotNil(t, idp1)
+
+	identity3 := ep3.GetSecurityIdentity()
+	policy6 := cache.insert(identity3)
+	require.NotEqual(t, policy5, policy6)
+	idp3, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
-	require.NotEqual(t, policy1, policy3)
+	require.False(t, updated)
+	require.Equal(t, idp1, idp3)
+
+	repo.revision.Store(43)
+	idp3, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
+	require.NoError(t, err)
+	require.True(t, updated)
+	idp1 = policy5.getPolicy()
+
+	require.NotEqual(t, idp1, idp3)
 }
 
 // Distillery integration tests
@@ -394,12 +413,15 @@ func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
 // allowing simple direct evaluation of L3 and L4 state into "MapState".
 type policyDistillery struct {
 	*Repository
-	log io.Writer
+	idMgr identitymanager.IDManager
+	log   io.Writer
 }
 
 func newPolicyDistillery(t testing.TB, selectorCache *SelectorCache) *policyDistillery {
+	idMgr := identitymanager.NewIDManager(hivetest.Logger(t))
 	ret := &policyDistillery{
-		Repository: NewPolicyRepository(hivetest.Logger(t), nil, nil, envoypolicy.NewEnvoyL7RulesTranslator(hivetest.Logger(t), certificatemanager.NewMockSecretManagerInline()), nil, testpolicy.NewPolicyMetricsNoop()),
+		Repository: NewPolicyRepository(hivetest.Logger(t), nil, nil, envoypolicy.NewEnvoyL7RulesTranslator(hivetest.Logger(t), certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		idMgr:      idMgr,
 	}
 	ret.selectorCache = selectorCache
 	return ret
@@ -409,6 +431,7 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 	return &policyDistillery{
 		Repository: d.Repository,
 		log:        w,
+		idMgr:      d.idMgr,
 	}
 }
 
@@ -661,6 +684,8 @@ func Test_MergeL3(t *testing.T) {
 			t.Run(fmt.Sprintf("permutation_%d-%d", tt.test, round), func(t *testing.T) {
 				logBuffer := new(bytes.Buffer)
 				repo = repo.WithLogBuffer(logBuffer)
+				repo.idMgr.Add(identity)
+				defer repo.idMgr.Remove(identity)
 				mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 				if err != nil {
 					t.Errorf("Policy resolution failure: %s", err)
@@ -1202,6 +1227,8 @@ func Test_MergeRules(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
+			repo.idMgr.Add(identity)
+			defer repo.idMgr.Remove(identity)
 			mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
@@ -1297,6 +1324,8 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
+			repo.idMgr.Add(identity)
+			defer repo.idMgr.Remove(identity)
 			mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
@@ -1343,6 +1372,8 @@ func Test_AllowAll(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
+			repo.idMgr.Add(identity)
+			defer repo.idMgr.Remove(identity)
 			mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
@@ -1761,6 +1792,8 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
+			repo.idMgr.Add(identity)
+			defer repo.idMgr.Remove(identity)
 			mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
@@ -1842,6 +1875,8 @@ func Test_Allowception(t *testing.T) {
 	}
 	logBuffer := new(bytes.Buffer)
 	repo = repo.WithLogBuffer(logBuffer)
+	repo.idMgr.Add(identity)
+	defer repo.idMgr.Remove(identity)
 	mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 	if err != nil {
 		t.Errorf("Policy resolution failure: %s", err)
@@ -1890,6 +1925,8 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
+			repo.idMgr.Add(identity)
+			defer repo.idMgr.Remove(identity)
 			mapstate, err := repo.distillPolicy(hivetest.Logger(t), DummyOwner{logger: hivetest.Logger(t)}, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
@@ -2015,6 +2052,9 @@ func Test_IncrementalFQDNDeletion(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
+
+			repo.idMgr.Add(fooIdentity)
+			defer repo.idMgr.Remove(fooIdentity)
 			epp, err := repo.distillEndpointPolicy(logger, DummyOwner{
 				logger: logger,
 			}, fooIdentity)
@@ -2180,7 +2220,7 @@ func TestEgressPortRangePrecedence(t *testing.T) {
 					if rt.isAllow {
 						verdict = api.Allowed
 					}
-					checkFlow(t, td.repo, flow, verdict)
+					checkFlow(t, td.repo, td.identityManager, flow, verdict)
 				}
 			}
 		})

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -264,8 +264,8 @@ func TestDeniesIngress(t *testing.T) {
 	flowCtoB := flowAToB
 	flowCtoB.From = idC
 
-	checkFlow(t, repo, flowAToB, api.Denied)
-	checkFlow(t, repo, flowCtoB, api.Allowed)
+	checkFlow(t, repo, td.identityManager, flowAToB, api.Denied)
+	checkFlow(t, repo, td.identityManager, flowCtoB, api.Allowed)
 }
 
 func TestDeniesEgress(t *testing.T) {
@@ -296,9 +296,9 @@ func TestDeniesEgress(t *testing.T) {
 	}
 	repo.mustAdd(rule1)
 
-	checkFlow(t, repo, flowAToB, api.Denied)
-	checkFlow(t, repo, flowAToC, api.Allowed)
-	checkFlow(t, repo, flowAToWorld80, api.Allowed)
+	checkFlow(t, repo, td.identityManager, flowAToB, api.Denied)
+	checkFlow(t, repo, td.identityManager, flowAToC, api.Allowed)
+	checkFlow(t, repo, td.identityManager, flowAToWorld80, api.Allowed)
 }
 
 func TestWildcardL3RulesIngressDeny(t *testing.T) {


### PR DESCRIPTION
***tl;dr*** This fixes a leak in the selector policy cache that can occur when an endpoint changes its identity. If the identity is changed during a regeneration, the identity can be removed from the selector policy cache.

This is effectively a revert of 36c9bba, but since it had some many conflict I ended up creating a separate commit instead of a revert. Some of the tests were seemingly plain wrong, so I need to spend some time trying to understand the actual intention behind them to make them better. I also like this approach with actually benefiting from the refcount better. If the refcount isn't good enough or has a quirk - its most likely a bug that should not be solved by directly upserting to the cache silently.

See commit message(s) for more details.

---

Fixes: 36c9bba ("policy/cache: simplify cache entry creation flow")

```release-note
Fix leak in the policy subsystem
```
