### PR TITLE
endpoint: fix identity manager refCount issues causing leaks

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -223,7 +223,7 @@ func (ds *DaemonSuite) prepareEndpoint(t *testing.T, identity *identity.Identity
 		e.IPv6 = ProdIPv6Addr
 		e.IPv4 = ProdIPv4Addr
 	}
-	e.SetIdentity(identity, true)
+	e.SetIdentity(identity)
 
 	ready := e.SetState(endpoint.StateWaitingToRegenerate, "test")
 	require.True(t, ready)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2317,15 +2317,15 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 		logfields.IdentityNew, allocatedIdentity.StringID(),
 	)
 
-	e.SetIdentity(allocatedIdentity, false)
+	identityToRelease := e.SetIdentity(allocatedIdentity)
 
-	if oldIdentity != nil {
-		_, err := e.allocator.Release(context.Background(), oldIdentity, false)
+	if identityToRelease != nil {
+		_, err := e.allocator.Release(context.Background(), identityToRelease, false)
 		if err != nil {
 			scopedLog.Warn(
 				"Unable to release old endpoint identity",
 				logfields.Error, err,
-				logfields.IdentityOld, oldIdentity.ID,
+				logfields.IdentityOld, identityToRelease.ID,
 			)
 		}
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -266,6 +266,12 @@ type Endpoint struct {
 	// the endpoint's labels.
 	SecurityIdentity *identity.Identity `json:"SecLabel"`
 
+	// identitySet is used to keep track of whether the SecurityIdentity of an endpoint
+	// has been added to the identity manager. This is only false for new endpoints without an identity or
+	// on endpoints that have been restored. We do this to ensure we only remove it from
+	// the identity manager if we are sure it was added.
+	identitySet bool
+
 	// policyMapFactory is used to create endpoint policy maps
 	policyMapFactory policymap.Factory
 
@@ -1275,16 +1281,20 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	}
 
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
-		// Restored endpoint may be created with a reserved identity of 5
-		// (init), which is not registered in the identity manager and
-		// therefore doesn't need to be removed.
-		if e.SecurityIdentity.ID != identity.ReservedIdentityInit {
-			e.identityManager.Remove(e.SecurityIdentity)
-		}
+		if e.identitySet {
+			// Restored endpoint may be created with a reserved identity of 5
+			// (init), which is not registered in the identity manager and
+			// therefore doesn't need to be removed.
+			// If identity was never set, eg. if the endpoint was disconnecting when it was restored
+			// we have not yet added its identity - hence we should not remove it.
+			if e.SecurityIdentity.ID != identity.ReservedIdentityInit {
+				e.identityManager.Remove(e.SecurityIdentity)
+			}
 
-		_, err := e.allocator.Release(context.Background(), e.SecurityIdentity, false)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("unable to release identity: %w", err))
+			_, err := e.allocator.Release(context.Background(), e.SecurityIdentity, false)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("unable to release identity: %w", err))
+			}
 		}
 		e.removeNetworkPolicy()
 		e.SecurityIdentity = nil

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1107,14 +1107,16 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 	}
 
 	// Current security identity for endpoint is its old identity - delete its
-	// reference from global identity manager, add add a reference to the new
-	// identity for the endpoint.
-	if newEndpoint {
+	// reference from global identity manager, add a reference to the new
+	// identity for the endpoint. If the endpoint has never had its identitySet,
+	// we should note remove the old identity from the identity manager
+	if newEndpoint || !e.identitySet {
 		// TODO - GH-9354.
 		e.identityManager.Add(identity)
 	} else {
 		e.identityManager.RemoveOldAddNew(e.SecurityIdentity, identity)
 	}
+	e.identitySet = true
 	e.SecurityIdentity = identity
 	e.replaceIdentityLabels(labels.LabelSourceAny, identity.Labels)
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1099,8 +1099,11 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 
 // SetIdentity resets endpoint's policy identity to 'id'.
 // Caller triggers policy regeneration if needed.
+// If an identity was previously set and managed by the agent, it is
+// returned. If the endpoint was restored with an identity without having
+// executed SetIdentity during startup, the old identity is not returned.
 // Called with e.mutex Lock()ed
-func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool) {
+func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) (identityToRelease *identityPkg.Identity) {
 	oldIdentity := "no identity"
 	if e.SecurityIdentity != nil {
 		oldIdentity = e.SecurityIdentity.StringID()
@@ -1108,13 +1111,15 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 
 	// Current security identity for endpoint is its old identity - delete its
 	// reference from global identity manager, add a reference to the new
-	// identity for the endpoint. If the endpoint has never had its identitySet,
-	// we should note remove the old identity from the identity manager
-	if newEndpoint || !e.identitySet {
+	// identity for the endpoint. If the endpoint has never had its identity set,
+	// we should not remove the old identity from the identity manager
+	if e.identitySet {
+		// ensure we return the identity in case we remove it
+		identityToRelease = e.SecurityIdentity
+		e.identityManager.RemoveOldAddNew(e.SecurityIdentity, identity)
+	} else {
 		// TODO - GH-9354.
 		e.identityManager.Add(identity)
-	} else {
-		e.identityManager.RemoveOldAddNew(e.SecurityIdentity, identity)
 	}
 	e.identitySet = true
 	e.SecurityIdentity = identity
@@ -1145,6 +1150,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 	e.UpdateLogger(map[string]any{
 		logfields.Identity: identity.StringID(),
 	})
+	return identityToRelease
 }
 
 // UpdateNoTrackRules updates the NOTRACK iptable rules for this endpoint. If noTrackPort

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -179,7 +179,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 
 	epIdentity, _, err := s.mgr.AllocateIdentity(context.Background(), labelsBar.Labels(), true, identityBar)
 	require.NoError(t, err)
-	ep.SetIdentity(epIdentity, true)
+	ep.SetIdentity(epIdentity)
 
 	return ep
 }

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -400,8 +400,22 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 	}
 	// The identity of a freshly restored endpoint is incomplete due to some
 	// parts of the identity not being marshaled to JSON. Hence we must set
-	// the identity even if has not changed.
-	e.SetIdentity(id, true)
+	// the identity even if has not changed. This will also upsert the identity
+	// so that other parts of the system can correctly keep track of the identity.
+	identityToRelease := e.SetIdentity(id)
+
+	// If a separate goroutine has already set the identity we need to clear a reference
+	// to avoid leaking a ref.
+	if identityToRelease != nil {
+		_, err := e.allocator.Release(context.Background(), identityToRelease, false)
+		if err != nil {
+			e.getLogger().Warn(
+				"Unable to release old endpoint identity",
+				logfields.Error, err,
+				logfields.IdentityOld, identityToRelease.ID,
+			)
+		}
+	}
 	e.unlock()
 
 	return nil


### PR DESCRIPTION
This fixes a refCount issue in the identity manager in the case where an agent is restoring endpoints that are in the process of being stopped and cleaned up. In that case, the identity might never be added to the identity manger, but it will unconditionally be removed from it when its being cleaned up.

See the commit message for more information.

Keeping as a draft now to run tests. I'll add some better test cases here, and spend some time creating a repro so that its easier to reason about.


```release-note
Fix agent local identity leak 
```
