### PR TITLE
fix:monitor: misaligned file indexing in metrics

### DIFF
--- a/pkg/monitor/api/files.go
+++ b/pkg/monitor/api/files.go
@@ -30,10 +30,10 @@ var files = map[uint8]string{
 	109: "local_delivery.h",
 	110: "trace.h",
 	111: "encap.h",
-	113: "host_firewall.h",
-	114: "nodeport_egress.h",
-	115: "ipv6.h",
-	116: "classifiers.h",
+	112: "host_firewall.h",
+	113: "nodeport_egress.h",
+	114: "ipv6.h",
+	115: "classifiers.h",
 
 	// @@ source files list end
 }


### PR DESCRIPTION
The file `pkg/monitor/api/files.go` should be kept in-sync with the correspondent file `bpf/lib/source_info.h` in the datapath. This way, during notification and while dumping the metrics map, we can correlate the event to the appropriate file (and line). However, due to indexes not being aligned, I was observing a strange update in the metrics map from the `host_firewall.h` file even when host firewall was not enabled. After some debugging, this turned out to be the culprit. Let's re-sync the indexes.