### PR TITLE
ipsec: Fix detection logic for conflicting XFRM states

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -341,9 +341,6 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: ${{ env.job_name }}-${{ matrix.name }}-post-rotate
-          # Opt-out from `no-ipsec-xfrm-error`, seeing XfrmOutPolBlock errors.
-          tests: 'no-interrupted-connections'
-          extra-connectivity-test-flags: "--include-conn-disrupt-test"
 
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -489,7 +489,7 @@ func xfrmDeleteConflictingState(log *slog.Logger, states []netlink.XfrmState, ne
 	for _, s := range states {
 		if new.Spi == s.Spi && (new.Mark == nil) == (s.Mark == nil) &&
 			(new.Mark == nil || new.Mark.Value&new.Mark.Mask&s.Mark.Mask == s.Mark.Value) &&
-			xfrmIPEqual(new.Src, s.Src) && xfrmIPEqual(new.Dst, s.Dst) {
+			xfrmIPEqual(new.Dst, s.Dst) {
 			if err := xfrmStateCache.XfrmStateDel(&s); err != nil {
 				errs.Add(err)
 				continue


### PR DESCRIPTION
[ upstream commit 6897bf5e8119d9d1b02eb7c84f55b014babad3de ]

Function `xfrmDeleteConflictingState` aims to delete any XFRM states that conflict with the state we're trying to add. This is needed because the kernel will reject our XFRM state insertion if an existing state conflicts with it. XFRM states don't need to match 1:1 to conflict; unfortunately, the logic to reject conflicting states is a bit more complicated.

In the kernel, for our specific case (ESP), that logic is implemented in function [`__xfrm_state_lookup`](https://elixir.bootlin.com/linux/v6.16/source/net/xfrm/xfrm_state.c#L1174). The Cilium agent thus needs to replicate that logic to identify conflicting states and delete them before re-trying the insertion.

That logic was however not correctly replicated in the agent: in the kernel, `__xfrm_state_lookup` doesn't compare the source IP address to detect conflicts, whereas in the agent, we would. This pull request fixes it by removing the comparison of source IP addresses.