### PR TITLE
k8s: remove input mutation in parseNetworkPolicyPeer

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -79,17 +79,21 @@ func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networking
 		return nil
 	}
 
+	// peer should not be nutated in this function
+
 	var retSel *api.EndpointSelector
+	podSelector := peer.PodSelector.DeepCopy()
+
 	// The PodSelector should only reflect to the configured cluster unless the selector
 	// explicitly targets another cluster already.
-	if clusterName != cmtypes.PolicyAnyCluster && !isPodSelectorSelectingCluster(peer.PodSelector) {
-		if peer.PodSelector == nil {
-			peer.PodSelector = &slim_metav1.LabelSelector{}
+	if clusterName != cmtypes.PolicyAnyCluster && !isPodSelectorSelectingCluster(podSelector) {
+		if podSelector == nil {
+			podSelector = &slim_metav1.LabelSelector{}
 		}
-		if peer.PodSelector.MatchLabels == nil {
-			peer.PodSelector.MatchLabels = map[string]slim_metav1.MatchLabelsValue{}
+		if podSelector.MatchLabels == nil {
+			podSelector.MatchLabels = map[string]slim_metav1.MatchLabelsValue{}
 		}
-		peer.PodSelector.MatchLabels[k8sConst.PolicyLabelCluster] = clusterName
+		podSelector.MatchLabels[k8sConst.PolicyLabelCluster] = clusterName
 	}
 
 	if peer.NamespaceSelector != nil {
@@ -123,10 +127,10 @@ func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networking
 			namespaceSelector.MatchExpressions = []slim_metav1.LabelSelectorRequirement{allowAllNamespacesRequirement}
 		}
 
-		selector := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, namespaceSelector, peer.PodSelector)
+		selector := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, namespaceSelector, podSelector)
 		retSel = &selector
-	} else if peer.PodSelector != nil {
-		podSelector := parsePodSelector(peer.PodSelector, namespace)
+	} else if podSelector != nil {
+		podSelector = parsePodSelector(podSelector, namespace)
 		selector := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector)
 		retSel = &selector
 	}


### PR DESCRIPTION
parseNetworkPolicyPeer should not mutate the peer argument. The addition for the option `policy-default-local-cluster` mistakenly added a such mutation and this commit fixes that.

Fixes: e80eea9 ("clustermesh: policy: add --policy-default-local-cluster")

Fixes: #42605

```release-note
policy: prevent incorrect mutation of network policy when using policy-default-local-cluster
```
