### PR TITLE
datapath: only handle ETH_P_ARP when IPv4 is enabled

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1130,7 +1130,6 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 identity,
 		 */
 		return send_drop_notify_error_with_exitcode_ext(ctx, identity, ret, ext_err,
 								CTX_ACT_OK, METRIC_INGRESS);
-#endif /* ENABLE_IPV4 */
 	case bpf_htons(ETH_P_ARP):
 		if (is_defined(ENABLE_ARP_PASSTHROUGH) ||
 		    is_defined(ENABLE_ARP_RESPONDER) ||
@@ -1155,6 +1154,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 identity,
 		}
 
 		fallthrough;
+#endif /* ENABLE_IPV4 */
 	default:
 		send_trace_notify(ctx, obs_point, identity, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor, proto);

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -540,7 +540,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_IDENTITY_MARK"] = "1"
 	}
 
-	if option.Config.EnableVTEP {
+	if option.Config.IPv4Enabled() && option.Config.EnableVTEP {
 		cDefinesMap["ENABLE_VTEP"] = "1"
 	}
 
@@ -831,7 +831,7 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, devices []strin
 		fmt.Fprintf(fw, "#define HOST_ENDPOINT 1\n")
 	}
 
-	if e.IsHost() || option.Config.DatapathMode != datapathOption.DatapathModeNetkit {
+	if option.Config.IPv4Enabled() && (e.IsHost() || option.Config.DatapathMode != datapathOption.DatapathModeNetkit) {
 		if e.RequireARPPassthrough() {
 			fmt.Fprint(fw, "#define ENABLE_ARP_PASSTHROUGH 1\n")
 		} else {


### PR DESCRIPTION
Wrapping ETH_P_ARP packet handling in ENABLE_IPV4 checks to ensure ARP packets are only processed when IPv4 is enabled. This prevents unnecessary ARP processing in IPv6-only configurations.

Fixes: #42589 

```release-note
Handling ETH_P_ARP only when IPv4 is enabled
```
