### PR TITLE
conformance-l7: optimize E2E testing by splitting L7 and L3/L4 tests

### DIFF
--- a/.github/actions/e2e/ipsec.yaml
+++ b/.github/actions/e2e/ipsec.yaml
@@ -6,6 +6,9 @@
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy - packets
+  # must be decrypted before L7 processing and re-encrypted for upstream connections
+  test-l7: 'true'
 - name: 'ipsec-2'
   kernel: '5.10'
   kube-proxy: 'iptables'
@@ -14,6 +17,8 @@
   encryption: 'ipsec'
   key-one: 'cbc-aes-sha256'
   key-two: 'cbc-aes-sha256'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy
+  test-l7: 'true'
 - name: 'ipsec-3'
   kernel: '5.10'
   kube-proxy: 'iptables'
@@ -24,6 +29,8 @@
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
   kvstore: 'true'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy
+  test-l7: 'true'
 - name: 'ipsec-4'
   kernel: '6.1'
   kube-proxy: 'iptables'
@@ -34,6 +41,8 @@
   key-one: 'cbc-aes-sha256'
   key-two: 'cbc-aes-sha256'
   kvstore: 'true'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy
+  test-l7: 'true'
 - name: 'ipsec-5'
   kernel: '6.6'
   kube-proxy: 'none'
@@ -44,6 +53,8 @@
   encryption: 'ipsec'
   key-one: 'cbc-aes-sha256'
   key-two: 'cbc-aes-sha256'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy
+  test-l7: 'true'
 - name: 'ipsec-6'
   kernel: '6.1'
   kube-proxy: 'none'
@@ -57,6 +68,8 @@
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
+  # L7 testing: IPsec encryption + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'
 - name: 'ipsec-7'
   kernel: '5.15'
   kube-proxy: 'iptables'
@@ -67,6 +80,8 @@
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
   skip-upgrade: 'true'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy
+  test-l7: 'true'
 - name: 'ipsec-8'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -79,6 +94,8 @@
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
+  # L7 testing: IPsec encryption + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'
 - name: 'ipsec-9'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -92,6 +109,8 @@
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
   skip-upgrade: 'true'
+  # L7 testing: IPsec encryption has complex interaction with L7 proxy
+  test-l7: 'true'
 - name: 'ipsec-10'
   kernel: '6.6'
   kube-proxy: 'none'
@@ -105,3 +124,5 @@
   key-two: 'cbc-aes-sha256'
   # no strict mode on v1.18
   skip-upgrade: 'true'
+  # L7 testing: IPsec strict mode especially critical - affects proxy traffic encryption
+  test-l7: 'true'

--- a/.github/actions/e2e/kube-proxy.yaml
+++ b/.github/actions/e2e/kube-proxy.yaml
@@ -5,6 +5,8 @@
   tunnel: 'vxlan'
   host-fw: 'true'
   misc: 'bpfClockProbe=false,cni.uninstall=false,tls.readSecretsOnlyFromSecretsNamespace=false,tls.secretSync.enabled=false'
+  # L7 testing: Basic VXLAN + host firewall - moderate interaction, test on schedule only
+  test-l7: 'false'
 - name: 'kube-proxy-2'
   kernel: '5.10'
   kube-proxy: 'iptables'
@@ -12,6 +14,8 @@
   tunnel: 'disabled'
   host-fw: 'true'
   misc: 'bpfClockProbe=false,cni.uninstall=false,tls.readSecretsOnlyFromSecretsNamespace=false,tls.secretSync.enabled=false'
+  # L7 testing: Disabled tunnel + host firewall - moderate interaction, test on schedule only
+  test-l7: 'false'
 - name: 'kube-proxy-3'
   kernel: '5.10'
   kube-proxy: 'iptables'
@@ -19,6 +23,8 @@
   tunnel: 'disabled'
   endpoint-routes: 'true'
   kvstore: 'true'
+  # L7 testing: Basic routing configuration without complex L7 dependencies - can skip
+  test-l7: 'false'
 - name: 'kube-proxy-4'
   kernel: '6.12'
   kube-proxy: 'iptables'
@@ -29,6 +35,8 @@
   local-redirect-policy: 'true'
   node-local-dns: 'true'
   skip-include-conn-disrupt-test-ns-traffic: 'true'
+  # L7 testing: Node local DNS requires DNS proxy testing
+  test-l7: 'true'
 - name: 'kube-proxy-5'
   kernel: '5.15'
   kube-proxy: 'iptables'
@@ -41,12 +49,16 @@
   local-redirect-policy: 'true'
   node-local-dns: 'true'
   kvstore: 'true'
+  # L7 testing: WireGuard encryption in kube-proxy mode - covered by wireguard.yaml, test on schedule only
+  test-l7: 'false'
 - name: 'kube-proxy-6'
   kernel: 'rhel8.10'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'vxlan'
   misc: 'policyCIDRMatchMode=nodes'
+  # L7 testing: Basic VXLAN configuration without complex L7 dependencies - can skip
+  test-l7: 'false'
 - name: 'kube-proxy-7'
   kernel: '6.12'
   kube-proxy: 'iptables'
@@ -57,3 +69,5 @@
   underlay: 'ipv6'
   encryption: 'wireguard'
   skip-upgrade: 'true'
+  # L7 testing: IPv6-only configuration - covered by other wireguard tests, can skip
+  test-l7: 'false'

--- a/.github/actions/e2e/lb.yaml
+++ b/.github/actions/e2e/lb.yaml
@@ -10,6 +10,8 @@
   egress-gateway: 'true'
   host-fw: 'true'
   ingress-controller: 'true'
+  # L7 testing: DSR load balancer mode + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'
 - name: 'lb-2'
   kernel: '6.1'
   kube-proxy: 'none'
@@ -23,6 +25,8 @@
   lb-acceleration: 'testing-only'
   ingress-controller: 'true'
   bgp-control-plane: 'true'
+  # L7 testing: SNAT load balancer mode + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'
 - name: 'lb-3'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -37,6 +41,8 @@
   local-redirect-policy: 'true'
   node-local-dns: 'true'
   misc: 'bpfClockProbe=false,cni.uninstall=false,tls.secretsBackend=k8s,tls.secretSync.enabled=true'
+  # L7 testing: SNAT load balancer + Ingress controller + node local DNS requires DNS proxy
+  test-l7: 'true'
 - name: 'lb-4'
   # Switch to 5.15 until https://github.com/cilium/cilium/issues/27642
   # has been resolved. https://github.com/cilium/cilium/pull/30837#issuecomment-1960897445
@@ -52,6 +58,8 @@
   egress-gateway: 'true'
   lb-acceleration: 'testing-only'
   ingress-controller: 'true'
+  # L7 testing: SNAT load balancer mode + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'
 - name: 'lb-5'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -62,3 +70,5 @@
   lb-mode: 'dsr'
   ingress-controller: 'true'
   misc: 'bpfClockProbe=false,cni.uninstall=false,tls.secretsBackend=k8s,tls.secretSync.enabled=true,tunnelProtocol=geneve,loadBalancer.dsrDispatch=geneve'
+  # L7 testing: DSR load balancer mode + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'

--- a/.github/actions/e2e/misc.yaml
+++ b/.github/actions/e2e/misc.yaml
@@ -9,6 +9,8 @@
   endpoint-routes: 'true'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: Ingress covered in lb.yaml, can skip
+  test-l7: 'false'
 - name: 'misc-2'
   kernel: '6.6'
   kube-proxy: 'none'
@@ -19,6 +21,8 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: Ingress covered in lb.yaml, can skip
+  test-l7: 'false'
 - name: 'misc-3'
   kernel: '6.6'
   kube-proxy: 'none'
@@ -29,6 +33,8 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: Ingress covered in lb.yaml, can skip
+  test-l7: 'false'
 - name: 'misc-4'
   kernel: '6.6'
   kube-proxy: 'none'
@@ -40,6 +46,8 @@
   endpoint-routes: 'true'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: Endpoint routes + Ingress, can skip
+  test-l7: 'false'
 - name: 'misc-5'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -50,6 +58,8 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: Duplicate of misc-3, can skip
+  test-l7: 'false'
 - name: 'misc-6'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -61,6 +71,8 @@
   endpoint-routes: 'true'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: Duplicate of misc-4, can skip
+  test-l7: 'false'
 - name: 'misc-7'
   kernel: '5.15'
   kube-proxy: 'none'
@@ -72,3 +84,5 @@
   tunnel: 'vxlan'
   underlay: 'ipv6'
   skip-upgrade: 'true'
+  # L7 testing: Basic IPv6-only configuration, can skip
+  test-l7: 'false'

--- a/.github/actions/e2e/netkit.yaml
+++ b/.github/actions/e2e/netkit.yaml
@@ -8,6 +8,8 @@
   devices: '{eth0,eth1}'
   secondary-network: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit datapath mode - Ingress covered in other files, can skip
+  test-l7: 'false'
 - name: 'netkit-2'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit-l2,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
@@ -18,6 +20,8 @@
   devices: '{eth0,eth1}'
   secondary-network: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit-L2 datapath mode - Ingress covered in other files, can skip
+  test-l7: 'false'
 - name: 'netkit-3'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit'
@@ -28,6 +32,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
   kvstore: 'true'
+  # L7 testing: Netkit + VXLAN - basic tunnel, can skip
+  test-l7: 'false'
 - name: 'netkit-4'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit-l2'
@@ -37,6 +43,8 @@
   devices: '{eth0,eth1}'
   secondary-network: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit-L2 + VXLAN - basic tunnel, can skip
+  test-l7: 'false'
 - name: 'netkit-5'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit'
@@ -46,6 +54,8 @@
   devices: '{eth0,eth1}'
   secondary-network: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit + Geneve - basic tunnel, can skip
+  test-l7: 'false'
 - name: 'netkit-6'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit-l2'
@@ -55,6 +65,8 @@
   devices: '{eth0,eth1}'
   secondary-network: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit-L2 + Geneve - basic tunnel, can skip
+  test-l7: 'false'
 - name: 'netkit-7'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit'
@@ -66,6 +78,8 @@
   secondary-network: 'true'
   ingress-controller: 'true'
   host-fw: 'true'
+  # L7 testing: Netkit + host firewall - proxy traffic must traverse host firewall
+  test-l7: 'true'
 - name: 'netkit-8'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
@@ -78,6 +92,8 @@
   ciliumendpointslice: 'true'
   endpoint-routes: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit + CiliumEndpointSlice - can skip
+  test-l7: 'false'
 - name: 'netkit-9'
   kernel: '6.12'
   misc: 'bpf.datapathMode=netkit-l2,enableIPv4BIGTCP=true,enableIPv6BIGTCP=true'
@@ -90,3 +106,5 @@
   ciliumendpointslice: 'true'
   endpoint-routes: 'true'
   ingress-controller: 'true'
+  # L7 testing: Netkit-L2 + CiliumEndpointSlice - similar to netkit-8, can skip
+  test-l7: 'false'

--- a/.github/actions/e2e/wireguard.yaml
+++ b/.github/actions/e2e/wireguard.yaml
@@ -11,6 +11,8 @@
   endpoint-routes: 'true'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: WireGuard encryption + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'
 - name: 'wireguard-2'
   kernel: '6.1'
   kube-proxy: 'none'
@@ -26,6 +28,8 @@
   misc: 'socketLB.hostNamespaceOnly=true'
   local-redirect-policy: 'true'
   node-local-dns: 'true'
+  # L7 testing: WireGuard encryption + Ingress controller requires L7 proxy, node local DNS requires DNS proxy
+  test-l7: 'true'
 - name: 'wireguard-3'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -39,6 +43,8 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  # L7 testing: WireGuard strict mode + Ingress controller - critical for proxy traffic encryption
+  test-l7: 'true'
 - name: 'wireguard-4'
   kernel: '5.15'
   kube-proxy: 'none'
@@ -52,6 +58,8 @@
   host-fw: 'true'
   ciliumendpointslice: 'true'
   ingress-controller: 'true'
+  # L7 testing: WireGuard encryption + Ingress controller + host firewall - proxy traffic must traverse host firewall
+  test-l7: 'true'
 - name: 'wireguard-5'
   kernel: '6.12'
   kube-proxy: 'none'
@@ -64,3 +72,5 @@
   ingress-controller: 'true'
   encryption: 'wireguard'
   skip-upgrade: 'true'
+  # L7 testing: WireGuard encryption + Ingress controller requires L7 proxy for HTTP routing
+  test-l7: 'true'

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -12,6 +12,8 @@ triggers:
     - conformance-gateway-api.yaml
     - conformance-ginkgo.yaml
     - conformance-ingress.yaml
+    - conformance-l3-l4.yaml
+    - conformance-l7.yaml
     - conformance-kpr.yaml
     - conformance-multi-pool.yaml
     - conformance-race.yaml
@@ -19,7 +21,6 @@ triggers:
     - integration-test.yaml
     - tests-clustermesh-upgrade.yaml
     - tests-datapath-verifier.yaml
-    - tests-e2e-upgrade.yaml
     - hubble-cli-integration-test.yaml
   /ci-aks:
     workflows:
@@ -37,9 +38,6 @@ triggers:
   /ci-delegated-ipam:
     workflows:
     - conformance-delegated-ipam.yaml
-  /ci-e2e-upgrade:
-    workflows:
-    - tests-e2e-upgrade.yaml
   /ci-ipsec-upgrade:
     workflows:
     - tests-ipsec-upgrade.yaml
@@ -73,6 +71,12 @@ triggers:
   /ci-kubespray:
     workflows:
     - conformance-kubespray.yaml
+  /ci-l3-l4:
+    workflows:
+      - conformance-l3-l4.yaml
+  /ci-l7:
+    workflows:
+      - conformance-l7.yaml
   /ci-multi-pool:
     workflows:
     - conformance-multi-pool.yaml
@@ -143,6 +147,10 @@ workflows:
   conformance-kpr.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-kubespray.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  conformance-l3-l4.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  conformance-l7.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-multi-pool.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)

--- a/.github/workflows/conformance-l3-l4.yaml
+++ b/.github/workflows/conformance-l3-l4.yaml
@@ -1,0 +1,117 @@
+name: Conformance L3-L4 only (ci-l3-l4)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      base-SHA:
+        description: "SHA of the base branch (target branch of the PR)."
+        required: false
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
+concurrency:
+  # Structure:
+  # - Parent concurrency group name to avoid deadlock with child workflows
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    parent
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+
+  tests-e2e-upgrade:
+    name: E2E Upgrade with L3-L4 Tests
+    needs: wait-for-images
+    uses: ./.github/workflows/tests-e2e-upgrade.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: ${{ inputs.extra-args }}
+      UID: 1
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: [tests-e2e-upgrade]
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      success: ${{ needs.tests-e2e-upgrade.result == 'success' }}
+

--- a/.github/workflows/conformance-l7.yaml
+++ b/.github/workflows/conformance-l7.yaml
@@ -1,0 +1,118 @@
+name: Conformance L7-only (ci-l7)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      base-SHA:
+        description: "SHA of the base branch (target branch of the PR)."
+        required: false
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
+concurrency:
+  # Structure:
+  # - Parent concurrency group name to avoid deadlock with child workflows
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    parent
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+
+  tests-e2e-upgrade:
+    name: E2E Upgrade with L7 Tests
+    needs: wait-for-images
+    uses: ./.github/workflows/tests-e2e-upgrade.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: ${{ inputs.extra-args }}
+      test-l7-only: true
+      UID: 1
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: [tests-e2e-upgrade]
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      success: ${{ needs.tests-e2e-upgrade.result == 'success' }}
+

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -2,24 +2,45 @@ name: Cilium E2E Upgrade (ci-e2e-upgrade)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       PR-number:
         description: "Pull request number."
-        required: true
+        required: false
+        type: string
+      UID:
+        description: "A second number, to differentiate multiple runs of the same workflow by the same PR"
+        required: false
+        default: 1
+        type: number
       context-ref:
         description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
-        required: true
+        required: false
+        type: string
       SHA:
         description: "SHA under test (head of the PR branch)."
-        required: true
+        required: false
+        type: string
       base-SHA:
         description: "SHA of the base branch (target branch of the PR)."
         required: false
+        type: string
       extra-args:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
+        type: string
         default: '{}'
+      is-workflow-call:
+        description: "Distinguish if it's a workflow_call event."
+        required: false
+        type: boolean
+        default: true
+      test-l7-only:
+        description: "Run test configurations with L7-only tests."
+        required: false
+        type: boolean
+        default: false
+
   # Run every 8 hours
   schedule:
     - cron:  '0 5/8 * * *'
@@ -39,35 +60,29 @@ permissions:
 concurrency:
   # Structure:
   # - Workflow name
+  #   For workflow_call events, this is the name of the *parent* workflow.
   # - Event type
   # - A unique identifier depending on event type:
   #   - schedule: SHA
-  #   - workflow_dispatch: PR number
+  # The 'tests-e2e-upgrade' suffix added to schedule ensures that for workflow_call
+  # events it doesn't conflict with other potential parallel workflow_call done to
+  # other workflows from the same parent workflow. As otherwise the group name would
+  # be identical.
   #
   # This structure ensures a unique concurrency group name is generated for each
   # type of testing, such that re-runs will cancel the previous run.
   group: |
     ${{ github.workflow }}
+    tests-e2e-upgrade
     ${{ github.event_name }}
-    ${{
-      (github.event_name == 'schedule' && github.sha) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
-    }}
+    ${{ github.sha }}
+    ${{ inputs.UID }}
   cancel-in-progress: true
 
 env:
   test_concurrency: 5
 
 jobs:
-  echo-inputs:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    name: Echo Workflow Dispatch Inputs
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Echo Workflow Dispatch Inputs
-        run: |
-          echo '${{ tojson(inputs) }}'
-
   commit-status-start:
     name: Commit Status Start
     runs-on: ubuntu-24.04
@@ -103,7 +118,23 @@ jobs:
         id: generate-matrix
         run: |
           cd /tmp/generated/e2e
-          jq '[.[] | del(."key-one", ."key-two") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
+          # When test-l7-only is true: filter to only test-l7: true configs
+          # When test-l7-only is false (default):
+          #   - On schedule: include all configs (with L3/L4 AND L7)
+          #   - Otherwise: include only test-l7: false configs (L3/L4 only)
+          if [ "${{ inputs.test-l7-only }}" = "true" ]; then
+            jq '[.[] | select(.["test-l7"] == "true") | del(."key-one", ."key-two", ."test-l7") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
+            CONFIG_COUNT=$(jq 'length' matrix.json)
+            echo "::notice::Filtering matrix to test-l7: true configurations only (${CONFIG_COUNT} configs for L7-only testing)"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            jq '[.[] | del(."key-one", ."key-two", ."test-l7") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
+            CONFIG_COUNT=$(jq 'length' matrix.json)
+            echo "::notice::Including all configurations in matrix (${CONFIG_COUNT} configs - scheduled run with full test suite)"
+          else
+            jq '[.[] | select(.["test-l7"] != "true") | del(."key-one", ."key-two", ."test-l7") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
+            CONFIG_COUNT=$(jq 'length' matrix.json)
+            echo "::notice::Including only test-l7: false configurations (${CONFIG_COUNT} configs - L3/L4 testing only)"
+          fi
           echo "Generated matrix:"
           cat /tmp/generated/e2e/matrix.json
           echo "matrix=$(jq -c . < /tmp/generated/e2e/matrix.json)" >> $GITHUB_OUTPUT
@@ -170,11 +201,43 @@ jobs:
           CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh stable)
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
 
+          L7_FILTER="((dns)|(fqdn)|(l7)|(client-egress-tls-sni))"
+
+          SEQUENTIAL_CONNECTIVITY_TESTS="seq-.*,!pod-to-world.*"
           CONCURRENT_CONNECTIVITY_TESTS="!seq-.*"
           if [ "${{ matrix.ipv4 }}" == "false" ]; then
             CONCURRENT_CONNECTIVITY_TESTS="!(seq-.*|pod-to-world.*|pod-to-cidr)"
           fi
+
+          # When test-l7-only is true: run ONLY L7 tests (exclude L3/L4 tests)
+          # When test-l7-only is false (default):
+          #   - On schedule: run full test suite (L3/L4 AND L7 tests together)
+          #   - Otherwise: exclude L7 tests (L3/L4 traffic only)
+          if [ "${{ inputs.test-l7-only }}" = "true" ]; then
+            # L7-only mode: run only L7 tests
+            SEQUENTIAL_CONNECTIVITY_TESTS="seq-.*${L7_FILTER},!pod-to-world.*"
+            CONCURRENT_CONNECTIVITY_TESTS="${CONCURRENT_CONNECTIVITY_TESTS},${L7_FILTER},no-unexpected-packet-drops,check-log-errors"
+            echo "::notice::Running L7-only tests ${L7_FILTER}"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            # Scheduled run: full test suite (L3/L4 AND L7)
+            echo "::notice::Running full test suite (L3/L4 AND L7 tests)"
+          else
+            # Default mode: L3/L4 tests only, exclude L7
+            SEQUENTIAL_CONNECTIVITY_TESTS="${SEQUENTIAL_CONNECTIVITY_TESTS},!${L7_FILTER}"
+            CONCURRENT_CONNECTIVITY_TESTS="${CONCURRENT_CONNECTIVITY_TESTS},!${L7_FILTER}"
+            echo "::notice::Excluding L7 tests - running L3/L4 traffic only"
+          fi
+
+          echo sequential_connectivity_tests=${SEQUENTIAL_CONNECTIVITY_TESTS} >> $GITHUB_OUTPUT
           echo concurrent_connectivity_tests=${CONCURRENT_CONNECTIVITY_TESTS} >> $GITHUB_OUTPUT
+
+          # Determine if proxy traffic check should be enabled
+          # Disable if: L7 tests are excluded OR ipv4 is explicitly false
+          ENABLE_PROXY_CHECK="true"
+          if [[ "${{ inputs.test-l7-only }}" != "true" || "${{ matrix.ipv4 }}" == "false" ]]; then
+            ENABLE_PROXY_CHECK="false"
+          fi
+          echo enable_proxy_check=${ENABLE_PROXY_CHECK} >> $GITHUB_OUTPUT
 
       - name: Resolve full kernel version
         id: kernel-version
@@ -435,13 +498,13 @@ jobs:
           # Enable the check for proxy traffic only if IPv4 is enabled.
           # Otherwise we will be skipping proxy tests and won't have DNS proxy traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
-          args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "${{ matrix.encryption }}"
+          args: ${{ steps.bpftrace-params.outputs.params }} "${{ steps.vars.outputs.enable_proxy_check }}" "${{ matrix.encryption }}"
 
       - name: Run sequential Cilium tests
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-sequential
-          tests: 'seq-.*,!pod-to-world.*'
+          tests: ${{ steps.vars.outputs.sequential_connectivity_tests }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Run concurrent Cilium tests
@@ -547,14 +610,14 @@ jobs:
         with:
           # enable the check for proxy traffic.
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
-          args: ${{ steps.bpftrace-params.outputs.params }} "${{ matrix.ipv4 != 'false' }}" "${{ matrix.encryption }}"
+          args: ${{ steps.bpftrace-params.outputs.params }} "${{ steps.vars.outputs.enable_proxy_check }}" "${{ matrix.encryption }}"
 
       - name: Run sequential Cilium tests
         if: ${{ matrix.skip-upgrade != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-sequential
-          tests: 'seq-.*,!pod-to-world.*'
+          tests: ${{ steps.vars.outputs.sequential_connectivity_tests }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Run concurrent Cilium tests
@@ -599,12 +662,12 @@ jobs:
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ matrix.name }}"
+          artifacts_suffix: "${{ matrix.name }}-${{ inputs.UID }}"
           job_status: "${{ job.status }}"
           capture_features_tested: false
 
   merge-upload-and-status:
-    if: ${{ always() }}
+    if: ${{ always() && !inputs.is-workflow-call }}
     name: Merge Upload and Status
     needs: setup-and-test
     uses: ./.github/workflows/common-post-jobs.yaml

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -31,6 +31,9 @@ var (
 	//go:embed manifests/client-egress-only-dns.yaml
 	clientEgressOnlyDNSPolicyYAML string
 
+	//go:embed manifests/client-egress-only-port-53.yaml
+	clientEgressOnlyPort53PolicyYAML string
+
 	//go:embed manifests/client-egress-to-fqdns.yaml
 	clientEgressToFQDNsPolicyYAML string
 
@@ -373,6 +376,7 @@ func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Par
 		"clientEgressL7HTTPExternalYAML":                             clientEgressL7HTTPExternalYAML,
 		"clientEgressNodeLocalDNSYAML":                               clientEgressNodeLocalDNSYAML,
 		"clientEgressOnlyDNSPolicyYAML":                              clientEgressOnlyDNSPolicyYAML,
+		"clientEgressOnlyPort53PolicyYAML":                           clientEgressOnlyPort53PolicyYAML,
 		"echoIngressFromCIDRYAML":                                    echoIngressFromCIDRYAML,
 		"denyCIDRPolicyYAML":                                         denyCIDRPolicyYAML,
 		"ingressfromSpecificNSYAML":                                  ingressfromSpecificNSYAML,

--- a/cilium-cli/connectivity/builder/manifests/client-egress-only-port-53.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-only-port-53.yaml
@@ -1,0 +1,44 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-only-port-53
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEndpoints:
+      - matchExpressions:
+          - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
+          - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
+          - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}" ] }
+# OpenShift  runs coreDNS in openshift-dns namespace and uses port 5353
+  - toPorts:
+    - ports:
+      - port: "5353"
+        protocol: UDP
+      - port: "5353"
+        protocol: TCP
+    toEndpoints:
+    - matchExpressions:
+      - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
+      - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}" ] }
+  # When node-local-dns is deployed with local IP,
+  # Cilium labels its ip as world.
+  # This change prevents failing the connectivity
+  # test for such environments.
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+    toEntities:
+    - world

--- a/cilium-cli/connectivity/builder/pod_to_ingress_service.go
+++ b/cilium-cli/connectivity/builder/pod_to_ingress_service.go
@@ -68,7 +68,7 @@ func (t podToIngressService) build(ct *check.ConnectivityTest, templates map[str
 		WithCiliumVersion(">1.17.1 || >1.16.7 <1.17.0 || >1.15.14 <1.16.0").
 		WithFeatureRequirements(features.RequireEnabled(features.IngressController)).
 		WithCiliumPolicy(denyIngressSourceEgressOtherNodePolicyYML).
-		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
+		WithCiliumPolicy(templates["clientEgressOnlyPort53PolicyYAML"]). // DNS resolution only
 		WithScenarios(tests.PodToIngress()).
 		WithExpectations(func(a *check.Action) (egress check.Result, ingress check.Result) {
 			if strings.Contains(a.Destination().Name(), "cilium-ingress-same-node") {

--- a/cilium-cli/connectivity/builder/policy_local_cluster.go
+++ b/cilium-cli/connectivity/builder/policy_local_cluster.go
@@ -19,7 +19,7 @@ type policyLocalCluster struct{}
 func (t policyLocalCluster) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("policy-local-cluster-egress", ct).
 		WithCiliumPolicy(clientEgressToEchoNoClusterPolicyYAML).
-		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
+		WithCiliumPolicy(templates["clientEgressOnlyPort53PolicyYAML"]).
 		WithScenarios(tests.PodToPod()).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {


### PR DESCRIPTION
This commit introduces a major optimization to the CI testing strategy by
separating L7 proxy tests from L3/L4 datapath tests, reducing PR test
times while maintaining comprehensive coverage through scheduled runs.

Previously, all 48 E2E upgrade configurations ran the full test suite
(both L3/L4 and L7 tests) on every PR, resulting in long CI times
(25-34 minutes per config) and redundant L7 testing on configs without
critical L7 interactions.

Thus, we are splitting the tests by adding a new workflow:
conformance-l7.yaml. This workflow will only run L7 tests and the
existing tests-e2e-upgrade.yaml will only run L3-L4 tests. On a schedule
basis, the tests-e2e-upgrade.yaml will continue to run as before,
covering L3-L4 and L7 tests.

The following table shows the summary of the test coverage for each
workflow and their respective times.

| Config Name | PR: conformance-l3-l4 | PR: conformance-l7 | Schedule: tests-e2e-upgrade | Old PR Time | New PR Time | Gain (%) |
|-------------|----------------------|--------------------|-----------------------------|-------------|-------------|----------|
| **ipsec-1** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 28m 4s | 17m 49s     | 37%      |
| **ipsec-2** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 26m 58s | 17m 34s     | 35%      |
| **ipsec-3** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 26m 29s | 17m 15s     | 35%      |
| **ipsec-4** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 27m 52s | 18m 44s     | 33%      |
| **ipsec-5** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 28m 18s | 20m 13s     | 29%      |
| **ipsec-6** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 30m 54s | 21m 8s      | 32%      |
| **ipsec-7** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 14m 54s | 11m 13s     | 25%      |
| **ipsec-8** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 28m 38s | 24m 56s     | 13%      |
| **ipsec-9** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 11m 3s | 7m 39s      | 31%      |
| **ipsec-10** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 15m 20s | 10m 46s     | 30%      |
| **wireguard-1** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 31m 5s | 21m 10s     | 32%      |
| **wireguard-2** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 34m 2s | 23m 25s     | 31%      |
| **wireguard-3** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 34m 31s | 27m 19s     | 21%      |
| **wireguard-4** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 30m 35s | 21m 8s      | 31%      |
| **wireguard-5** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 16m 35s | 12m 50s     | 23%      |
| **lb-1** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 28m 42s | 18m 36s     | 35%      |
| **lb-2** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 31m 14s | 18m 22s     | 41%      |
| **lb-3** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 30m 54s | 18m 36s     | 40%      |
| **lb-4** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 27m 15s | 19m 50s     | 27%      |
| **lb-5** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 26m 6s | 18m 41s     | 29%      |
| **kube-proxy-1** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 26m 10s | 20m 10s     | 23%      |
| **kube-proxy-2** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 26m 57s | 19m 49s     | 27%      |
| **kube-proxy-3** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 25m 21s | 19m 28s     | 23%      |
| **kube-proxy-4** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 29m 51s | 21m 9s      | 29%      |
| **kube-proxy-5** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 26m 5s | 20m 8s      | 23%      |
| **kube-proxy-6** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 25m 29s | 19m 0s      | 25%      |
| **kube-proxy-7** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 11m 28s | 10m 3s      | 12%      |
| **netkit-1** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 28m 28s | 22m 8s      | 22%      |
| **netkit-2** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 28m 32s | 20m 25s     | 28%      |
| **netkit-3** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 29m 23s | 21m 15s     | 28%      |
| **netkit-4** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 25m 35s | 22m 34s     | 12%      |
| **netkit-5** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 30m 33s | 23m 15s     | 24%      |
| **netkit-6** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 29m 29s | 25m 10s     | 15%      |
| **netkit-7** | ❌ Not Run | ✅ L7 Only | ✅ L3-L4-L7 | 29m 38s | 20m 18s     | 31%      |
| **netkit-8** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 29m 53s | 22m 46s     | 24%      |
| **netkit-9** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 29m 11s | 23m 0s      | 21%      |
| **misc-1** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 29m 11s | 22m 55s     | 21%      |
| **misc-2** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 31m 43s | 24m 52s     | 22%      |
| **misc-3** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 28m 55s | 24m 5s      | 17%      |
| **misc-4** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 31m 14s | 24m 53s     | 20%      |
| **misc-5** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 30m 48s | 23m 38s     | 23%      |
| **misc-6** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 31m 40s | 24m 38s     | 22%      |
| **misc-7** | ✅ L3-L4 Only | ❌ Not Run | ✅ L3-L4-L7 | 10m 18s | 9m 36s      | 7%       |
