### PR TITLE
Remove mention of Umbrella Chart in Helm value `namespaceOverride` description

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2889,7 +2889,7 @@
      - string
      - ``"cilium"``
    * - :spelling:ignore:`namespaceOverride`
-     - namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets.
+     - namespaceOverride allows to override the destination namespace for Cilium resources.
      - string
      - ``""``
    * - :spelling:ignore:`nat.mapStatsEntries`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -772,7 +772,7 @@ contributors across the globe, there is almost always someone available to help.
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent daemonset name. |
-| namespaceOverride | string | `""` | namespaceOverride allows to override the destination namespace for Cilium resources. This property allows to use Cilium as part of an Umbrella Chart with different targets. |
+| namespaceOverride | string | `""` | namespaceOverride allows to override the destination namespace for Cilium resources. |
 | nat.mapStatsEntries | int | `32` | Number of the top-k SNAT map connections to track in Cilium statedb. |
 | nat.mapStatsInterval | string | `"30s"` | Interval between how often SNAT map is counted for stats. |
 | nat46x64Gateway | object | `{"enabled":false}` | Configure standalone NAT46/NAT64 gateway |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -6,7 +6,6 @@
 # type: [null, string]
 # @schema
 # -- namespaceOverride allows to override the destination namespace for Cilium resources.
-# This property allows to use Cilium as part of an Umbrella Chart with different targets.
 namespaceOverride: ""
 # @schema
 # type: [null, object]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3,7 +3,6 @@
 # type: [null, string]
 # @schema
 # -- namespaceOverride allows to override the destination namespace for Cilium resources.
-# This property allows to use Cilium as part of an Umbrella Chart with different targets.
 namespaceOverride: ""
 # @schema
 # type: [null, object]


### PR DESCRIPTION
The Umbrella Chart is no longer used and the description for Helm value `namespaceOverride` should no longer reference it.

cc: @fgiloux 