### PR TITLE
[v1.18] Keep non-serving terminating backends

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1360,12 +1360,18 @@ Cilium's eBPF kube-proxy replacement supports graceful termination of service
 endpoint pods. The Cilium agent detects such terminating Pod events, and
 increments the metric ``k8s_terminating_endpoints_events_total``.
 
-When Cilium agent receives a Kubernetes update event for a terminating endpoint,
-the datapath state for the endpoint is removed such that it won't service new
-connections, but the endpoint's active connections are able to terminate
-gracefully. The endpoint state is fully removed when the agent receives
-a Kubernetes delete event for the endpoint. The `Kubernetes
-pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
+When Cilium agent receives a Kubernetes update event that marks an endpoint as
+terminating Cilium will retain the datapath state necessary for existing connections.
+The terminating endpoint will be used as fallback for new connections only if
+1) no active endpoints exist for the service and 2) terminating endpoint has condition ``serving``
+(e.g. pod is still passing `readinessProbes <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes>`_).
+
+If ``publishNotReadyAddresses`` is set on the Service the endpoints received by Cilium
+may have both the ``ready`` and ``terminating`` conditions set. In this case Cilium follows
+kube-proxy and uses these for new connections, ignoring the ``terminating`` condition.
+
+The endpoint state is fully removed when the agent receives a Kubernetes delete
+event for the endpoint. The `Kubernetes pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
 documentation contains more background on the behavior and configuration using ``terminationGracePeriodSeconds``.
 There are some special cases, like zero disruption during rolling updates, that require to be able to send traffic
 to Terminating Pods that are still Serving traffic during the Terminating period, the Kubernetes blog

--- a/api/v1/models/backend_address.go
+++ b/api/v1/models/backend_address.go
@@ -41,7 +41,7 @@ type BackendAddress struct {
 	Protocol string `json:"protocol,omitempty"`
 
 	// State of the backend for load-balancing service traffic
-	// Enum: ["active","terminating","quarantined","maintenance"]
+	// Enum: ["active","terminating","terminating-not-serving","quarantined","maintenance"]
 	State string `json:"state,omitempty"`
 
 	// Backend weight
@@ -82,7 +82,7 @@ var backendAddressTypeStatePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["active","terminating","quarantined","maintenance"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["active","terminating","terminating-not-serving","quarantined","maintenance"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -97,6 +97,9 @@ const (
 
 	// BackendAddressStateTerminating captures enum value "terminating"
 	BackendAddressStateTerminating string = "terminating"
+
+	// BackendAddressStateTerminatingDashNotDashServing captures enum value "terminating-not-serving"
+	BackendAddressStateTerminatingDashNotDashServing string = "terminating-not-serving"
 
 	// BackendAddressStateQuarantined captures enum value "quarantined"
 	BackendAddressStateQuarantined string = "quarantined"

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2924,6 +2924,7 @@ definitions:
         enum:
           - active
           - terminating
+          - terminating-not-serving
           - quarantined
           - maintenance
       preferred:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1824,6 +1824,7 @@ func init() {
           "enum": [
             "active",
             "terminating",
+            "terminating-not-serving",
             "quarantined",
             "maintenance"
           ]
@@ -7452,6 +7453,7 @@ func init() {
           "enum": [
             "active",
             "terminating",
+            "terminating-not-serving",
             "quarantined",
             "maintenance"
           ]

--- a/pkg/bgpv1/manager/reconciler/service.go
+++ b/pkg/bgpv1/manager/reconciler/service.go
@@ -158,7 +158,7 @@ endpointsLoop:
 		svcID := eps.ServiceName
 
 		for _, be := range eps.Backends {
-			if !be.Terminating && be.NodeName == localNodeName {
+			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can make unavailable to available.
 				if _, found := ls[svcID]; !found {

--- a/pkg/bgpv1/manager/reconciler/service_test.go
+++ b/pkg/bgpv1/manager/reconciler/service_test.go
@@ -122,7 +122,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -138,8 +139,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:    "node1",
-				Terminating: true,
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionTerminating,
 			},
 		},
 	}
@@ -155,7 +156,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -171,10 +173,12 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -190,7 +194,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -206,7 +211,8 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -222,10 +228,12 @@ func TestServiceReconcilerWithLoadBalancer(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -825,7 +833,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -841,7 +850,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -857,10 +867,12 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -876,7 +888,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -892,7 +905,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -908,7 +922,8 @@ func TestServiceReconcilerWithClusterIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
 				NodeName: "node2",
@@ -1468,7 +1483,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1484,7 +1500,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1500,10 +1517,12 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("10.0.0.2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1519,7 +1538,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1535,7 +1555,8 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -1551,10 +1572,12 @@ func TestServiceReconcilerWithExternalIP(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("fd00:10::1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 			cmtypes.MustParseAddrCluster("fd00:10::2"): {
-				NodeName: "node2",
+				NodeName:   "node2",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
@@ -2063,14 +2086,16 @@ func TestEPUpdateOnly(t *testing.T) {
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName: "node1",
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 			},
 		},
 	}
 	eps1IPv4LocalUpdated := eps1IPv4Local.DeepCopy()
 	eps1IPv4LocalUpdated.Backends = map[cmtypes.AddrCluster]*k8s.Backend{
 		cmtypes.MustParseAddrCluster("10.0.0.1"): {
-			NodeName: "node2",
+			NodeName:   "node2",
+			Conditions: k8s.BackendConditionReady | k8s.BackendConditionServing,
 		},
 	}
 

--- a/pkg/bgpv1/manager/reconcilerv2/service.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service.go
@@ -393,7 +393,7 @@ endpointsLoop:
 		}
 
 		for _, be := range eps.Backends {
-			if !be.Terminating && be.NodeName == localNodeName {
+			if !be.Conditions.IsTerminating() && be.NodeName == localNodeName {
 				// At least one endpoint is available on this node. We
 				// can add service to the local services set.
 				ls.Insert(svcKey)

--- a/pkg/bgpv1/manager/reconcilerv2/service_test.go
+++ b/pkg/bgpv1/manager/reconcilerv2/service_test.go
@@ -663,12 +663,12 @@ var (
 		},
 		Backends: map[cmtypes.AddrCluster]*k8s.Backend{
 			cmtypes.MustParseAddrCluster("10.0.0.1"): {
-				NodeName:    "node1",
-				Terminating: true,
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionTerminating,
 			},
 			cmtypes.MustParseAddrCluster("2001:db8:1000::1"): {
-				NodeName:    "node1",
-				Terminating: true,
+				NodeName:   "node1",
+				Conditions: k8s.BackendConditionTerminating,
 			},
 		},
 	}

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -98,7 +98,58 @@ func (in *Endpoints) DeepCopy() *Endpoints {
 	return out
 }
 
-// Backend contains all ports, terminating state, and the node name of a given backend
+// BackendCondition is a flag mirroring the endpoint Conditions.
+type BackendCondition uint8
+
+const (
+	// BackendConditionReady indicates that this endpoint is prepared to receive traffic,
+	// according to whatever system is managing the endpoint.
+	// More info: vendor/k8s.io/api/discovery/v1/types.go
+	// See also https://github.com/kubernetes/kubernetes/issues/108523
+	BackendConditionReady = 1 << iota
+
+	// BackendConditionServing indicates that this endpoint can serve new connections.
+	// It is meaningful to Cilium when the backend is terminating. If this condition is false
+	// then a terminating backend will not be used for new connections even as fallback
+	// when no active backends exist.
+	// More info: vendor/k8s.io/api/discovery/v1/types.go
+	// See also https://github.com/kubernetes/kubernetes/issues/108523 and
+	// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L76
+	BackendConditionServing
+
+	// Terminating indicates that the endpoint is getting terminated.
+	// It will not be used for new conditions unless 1) no active backends exist
+	// and 2) this backend is serving.
+	//
+	// If [publishNotReadyAddresses] is set on a service then a backend may be
+	// both terminating and ready in which case the terminating state is ignored.
+	//
+	// More info: vendor/k8s.io/api/discovery/v1/types.go
+	// See also https://github.com/kubernetes/kubernetes/issues/108523
+	BackendConditionTerminating
+)
+
+var backendConditions = [...]string{
+	BackendConditionReady:       "ready",
+	BackendConditionServing:     "serving",
+	BackendConditionTerminating: "terminating",
+}
+
+func (bc BackendCondition) String() string {
+	var flags []string
+	for mask, str := range backendConditions {
+		if str != "" && bc&BackendCondition(mask) != 0 {
+			flags = append(flags, str)
+		}
+	}
+	return strings.Join(flags, "+")
+}
+
+func (bc BackendCondition) IsReady() bool       { return bc&BackendConditionReady != 0 }
+func (bc BackendCondition) IsServing() bool     { return bc&BackendConditionServing != 0 }
+func (bc BackendCondition) IsTerminating() bool { return bc&BackendConditionTerminating != 0 }
+
+// Backend contains all ports, conditions, and the node name of a given backend
 //
 // +k8s:deepcopy-gen=true
 // +deepequal-gen=false
@@ -106,7 +157,7 @@ type Backend struct {
 	Ports         map[loadbalancer.L4Addr][]string
 	NodeName      string
 	Hostname      string
-	Terminating   bool
+	Conditions    BackendCondition
 	HintsForZones []string
 	Preferred     bool
 	Zone          string
@@ -116,7 +167,7 @@ func (b *Backend) DeepEqual(other *Backend) bool {
 	return maps.EqualFunc(b.Ports, other.Ports, slices.Equal) &&
 		b.NodeName == other.NodeName &&
 		b.Hostname == other.Hostname &&
-		b.Terminating == other.Terminating &&
+		b.Conditions == other.Conditions &&
 		slices.Equal(b.HintsForZones, other.HintsForZones) &&
 		b.Preferred == other.Preferred &&
 		b.Zone == other.Zone
@@ -240,6 +291,19 @@ func ParseEndpointSliceID(es endpointSlice) EndpointSliceID {
 	}
 }
 
+func ParseEndpointConditionsV1Beta1(conditions slim_discovery_v1beta1.EndpointConditions) (bc BackendCondition) {
+	if conditions.Ready == nil || *conditions.Ready {
+		bc |= BackendConditionReady
+	}
+	if conditions.Serving == nil || conditions.Serving != nil && *conditions.Serving {
+		bc |= BackendConditionServing
+	}
+	if conditions.Terminating != nil && *conditions.Terminating {
+		bc |= BackendConditionTerminating
+	}
+	return
+}
+
 // ParseEndpointSliceV1Beta1 parses a Kubernetes EndpointsSlice v1beta1 resource
 // It reads ready and terminating state of endpoints in the EndpointSlice to
 // return an EndpointSlice ID and a filtered list of Endpoints for service load-balancing.
@@ -260,35 +324,18 @@ func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) *Endpoi
 	}
 
 	for _, sub := range ep.Endpoints {
-		skipEndpoint := false
-		// ready indicates that this endpoint is prepared to receive traffic,
-		// according to whatever system is managing the endpoint. A nil value
-		// indicates an unknown state. In most cases consumers should interpret this
-		// unknown state as ready.
-		// More info: vendor/k8s.io/api/discovery/v1beta1/types.go
-		if sub.Conditions.Ready != nil && !*sub.Conditions.Ready {
-			skipEndpoint = true
-			// Terminating indicates that the endpoint is getting terminated. A
-			// nil values indicates an unknown state. Ready is never true when
-			// an endpoint is terminating. Propagate the terminating endpoint
-			// state so that we can gracefully remove those endpoints.
-			// More details : vendor/k8s.io/api/discovery/v1/types.go
-			if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
-				skipEndpoint = false
-			}
-		}
-		if skipEndpoint {
-			continue
-		}
+		conditions := ParseEndpointConditionsV1Beta1(sub.Conditions)
 		for _, addr := range sub.Addresses {
 			addrCluster, err := cmtypes.ParseAddrCluster(addr)
 			if err != nil {
 				continue
 			}
-
 			backend, ok := endpoints.Backends[addrCluster]
 			if !ok {
-				backend = &Backend{Ports: map[loadbalancer.L4Addr][]string{}}
+				backend = &Backend{
+					Ports:      map[loadbalancer.L4Addr][]string{},
+					Conditions: conditions,
+				}
 				endpoints.Backends[addrCluster] = backend
 				if nodeName, ok := sub.Topology[corev1.LabelHostname]; ok {
 					backend.NodeName = nodeName
@@ -296,8 +343,7 @@ func ParseEndpointSliceV1Beta1(ep *slim_discovery_v1beta1.EndpointSlice) *Endpoi
 				if sub.Hostname != nil {
 					backend.Hostname = *sub.Hostname
 				}
-				if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
-					backend.Terminating = true
+				if conditions.IsTerminating() {
 					metrics.TerminatingEndpointsEvents.Inc()
 				}
 				if zoneName, ok := sub.Topology[corev1.LabelTopologyZone]; ok {
@@ -343,6 +389,19 @@ func parseEndpointPortV1Beta1(port slim_discovery_v1beta1.EndpointPort) (name st
 
 const logfieldTerminating = "terminating"
 
+func ParseEndpointConditionsV1(conditions slim_discovery_v1.EndpointConditions) (bc BackendCondition) {
+	if conditions.Ready == nil || *conditions.Ready {
+		bc |= BackendConditionReady
+	}
+	if conditions.Serving == nil || conditions.Serving != nil && *conditions.Serving {
+		bc |= BackendConditionServing
+	}
+	if conditions.Terminating != nil && *conditions.Terminating {
+		bc |= BackendConditionTerminating
+	}
+	return
+}
+
 // ParseEndpointSliceV1 parses a Kubernetes EndpointSlice resource.
 // It reads ready and terminating state of endpoints in the EndpointSlice to
 // return an EndpointSlice ID and a filtered list of Endpoints for service load-balancing.
@@ -376,41 +435,10 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	}
 
 	for i, sub := range ep.Endpoints {
-		// ready indicates that this endpoint is prepared to receive traffic,
-		// according to whatever system is managing the endpoint. A nil value
-		// indicates an unknown state. In most cases consumers should interpret this
-		// unknown state as ready.
-		// More info: vendor/k8s.io/api/discovery/v1/types.go
-		isReady := sub.Conditions.Ready == nil || *sub.Conditions.Ready
-		// serving is identical to ready except that it is set regardless of the
-		// terminating state of endpoints. This condition should be set to true for
-		// a ready endpoint that is terminating. If nil, consumers should defer to
-		// the ready condition.
-		// More info: vendor/k8s.io/api/discovery/v1/types.go
-		isServing := (sub.Conditions.Serving == nil && isReady) || (sub.Conditions.Serving != nil && *sub.Conditions.Serving)
-		// Terminating indicates that the endpoint is getting terminated. A
-		// nil values indicates an unknown state. Ready is never true when
-		// an endpoint is terminating. Propagate the terminating endpoint
-		// state so that we can gracefully remove those endpoints.
-		// More info: vendor/k8s.io/api/discovery/v1/types.go
-		isTerminating := sub.Conditions.Terminating != nil && *sub.Conditions.Terminating
-
-		// if is not Ready allow endpoints that are Serving and Terminating
-		if !isReady {
-			// filter not Serving endpoints since those can not receive traffic
-			if !isServing {
-				logger.Debug(
-					"discarding Endpoint on EndpointSlice: not Serving",
-					logfields.Name, ep.Name,
-				)
-				continue
-			}
-		}
-
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Ports:       ports,
-			Terminating: !isReady && isServing && isTerminating,
+			Conditions: ParseEndpointConditionsV1(sub.Conditions),
+			Ports:      ports,
 		}
 
 		if sub.NodeName != nil {
@@ -453,7 +481,7 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 			endpoints.Backends[addrCluster] = backend
 		}
 
-		if backend.Terminating {
+		if backend.Conditions.IsTerminating() {
 			metrics.TerminatingEndpointsEvents.Inc()
 		}
 
@@ -462,7 +490,7 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 			logfields.Name, ep.Name,
 			logfields.Addresses, sub.Addresses,
 			logfields.Backend, backend,
-			logfieldTerminating, backend.Terminating,
+			logfieldTerminating, backend.Conditions.IsTerminating(),
 		)
 	}
 

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -435,9 +435,16 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	}
 
 	for i, sub := range ep.Endpoints {
+		conditions := ParseEndpointConditionsV1(sub.Conditions)
+		if conditions == 0 {
+			// Skip backends that have no conditions set as these are not ready to
+			// serve traffic.
+			continue
+		}
+
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Conditions: ParseEndpointConditionsV1(sub.Conditions),
+			Conditions: conditions,
 			Ports:      ports,
 		}
 

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -435,16 +435,9 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	}
 
 	for i, sub := range ep.Endpoints {
-		conditions := ParseEndpointConditionsV1(sub.Conditions)
-		if conditions == 0 {
-			// Skip backends that have no conditions set as these are not ready to
-			// serve traffic.
-			continue
-		}
-
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Conditions: conditions,
+			Conditions: ParseEndpointConditionsV1(sub.Conditions),
 			Ports:      ports,
 		}
 

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -642,8 +642,9 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
-					NodeName: nodeName,
-					Hostname: hostname,
+					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName:   nodeName,
+					Hostname:   hostname,
 				}
 				return svcEP
 			},
@@ -687,7 +688,8 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName:   nodeName,
 				}
 				return svcEP
 			},
@@ -736,13 +738,15 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName:   nodeName,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -799,13 +803,22 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					NodeName:   nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
+				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.3")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
+					},
+					Conditions: BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -855,13 +868,14 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Terminating: true,
+					Conditions: BackendConditionServing | BackendConditionTerminating,
 				}
 				return svcEP
 			},
@@ -916,14 +930,14 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Terminating: true,
+					Conditions: BackendConditionServing | BackendConditionTerminating,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Terminating: true,
+					Conditions: BackendConditionServing | BackendConditionTerminating,
 				}
 				return svcEP
 			},
@@ -959,6 +973,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.SCTP, 5555): {"sctp-test-svc"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -993,6 +1008,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -1210,8 +1226,9 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
-					NodeName: nodeName,
-					Hostname: hostname,
+					NodeName:   nodeName,
+					Hostname:   hostname,
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -1255,7 +1272,8 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					NodeName:   nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -1304,13 +1322,15 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					NodeName:   nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -1367,13 +1387,22 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
+					NodeName:   nodeName,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
+				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.3")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
+					},
+					Conditions: BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -1427,13 +1456,22 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					NodeName: nodeName,
+					NodeName:   nodeName,
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
+				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.3")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
+					},
+					Conditions: BackendConditionServing,
 				}
 				return svcEP
 			},
@@ -1479,12 +1517,19 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 			setupWanted: func() *Endpoints {
 				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
+				be := &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
+				// nil conditions means ready & serving
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = be
+				// endpoints that are terminating should be kept regardless of other conditions.
+				be = be.DeepCopy()
+				be.Conditions = BackendConditionTerminating
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = be
 				return svcEP
 			},
 		},
@@ -1534,13 +1579,14 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Terminating: true,
+					Conditions: BackendConditionServing | BackendConditionTerminating,
 				}
 				return svcEP
 			},
@@ -1587,6 +1633,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing | BackendConditionTerminating,
 				}
 				return svcEP
 			},
@@ -1602,19 +1649,11 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 							{
 								Conditions: slim_discovery_v1.EndpointConditions{
 									Ready:       func() *bool { a := false; return &a }(),
+									Serving:     func() *bool { a := false; return &a }(),
 									Terminating: func() *bool { a := true; return &a }(),
 								},
 								Addresses: []string{
 									"172.0.0.1",
-								},
-							},
-							{
-								Conditions: slim_discovery_v1.EndpointConditions{
-									Ready:       func() *bool { a := false; return &a }(),
-									Terminating: func() *bool { a := true; return &a }(),
-								},
-								Addresses: []string{
-									"172.0.0.2",
 								},
 							},
 						},
@@ -1635,6 +1674,13 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 			setupWanted: func() *Endpoints {
 				svcEP := newEmptyEndpoints()
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
+					},
+					Conditions: BackendConditionTerminating,
+				}
 				return svcEP
 			},
 		},
@@ -1684,20 +1730,15 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 			},
 			setupWanted: func() *Endpoints {
 				svcEP := newEmptyEndpoints()
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
+				be := &Backend{
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
 					},
-					Terminating: true,
+					Conditions: BackendConditionServing | BackendConditionTerminating,
 				}
-				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = &Backend{
-					Ports: map[loadbalancer.L4Addr][]string{
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
-						loadbalancer.NewL4Addr(loadbalancer.TCP, 8081): {"http-test-svc-2"},
-					},
-					Terminating: true,
-				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = be
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.2")] = be
 				return svcEP
 			},
 		},
@@ -1732,6 +1773,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
+					Conditions:    BackendConditionReady | BackendConditionServing,
 					HintsForZones: []string{"testing"},
 				}
 				return svcEP
@@ -1767,6 +1809,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					Ports: map[loadbalancer.L4Addr][]string{
 						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
 					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -382,12 +382,14 @@ const (
 // Valid transition states for a backend -
 // BackendStateActive -> BackendStateTerminating, BackendStateQuarantined, BackendStateMaintenance
 // BackendStateTerminating -> No valid state transition
+// BackendStateTerminatingNotServing -> No valid state transition
 // BackendStateQuarantined -> BackendStateActive, BackendStateTerminating
 // BackendStateMaintenance -> BackendStateActive
 //
 // Sources setting the states -
 // BackendStateActive - Kubernetes events, service API
 // BackendStateTerminating - Kubernetes events
+// BackendStateTerminatingNotServing - Kubernetes events
 // BackendStateQuarantined - service API
 // BackendStateMaintenance - service API
 const (
@@ -396,9 +398,15 @@ const (
 	// Backends in this state can be health-checked.
 	BackendStateActive BackendState = iota
 	// BackendStateTerminating refers to the terminating backend state so that
-	// it can be gracefully removed.
+	// it can be gracefully removed. Backend in this state can be used as a fallback
+	// if no active backends exist.
 	// Backends in this state won't be health-checked.
 	BackendStateTerminating
+	// BackendStateTerminatingNotServing refers to the terminating backend state
+	// for a backend that can be gracefully removed but cannot be used as fallback.
+	// Backends in this state won't be health-checked. In the BPF backend map this
+	// is the same as [BackendStateTerminating].
+	BackendStateTerminatingNotServing
 	// BackendStateQuarantined refers to the backend state when it's unreachable,
 	// and will not be selected for load-balancing traffic.
 	// Backends in this state can be health-checked.
@@ -429,7 +437,7 @@ func NewBackendFlags(state BackendState) BackendStateFlags {
 	switch state {
 	case BackendStateActive:
 		flags = BackendStateActiveFlag
-	case BackendStateTerminating:
+	case BackendStateTerminating, BackendStateTerminatingNotServing:
 		flags = BackendStateTerminatingFlag
 	case BackendStateQuarantined:
 		flags = BackendStateQuarantinedFlag
@@ -694,6 +702,8 @@ func (state BackendState) String() (string, error) {
 		return models.BackendAddressStateActive, nil
 	case BackendStateTerminating:
 		return models.BackendAddressStateTerminating, nil
+	case BackendStateTerminatingNotServing:
+		return models.BackendAddressStateTerminatingDashNotDashServing, nil
 	case BackendStateQuarantined:
 		return models.BackendAddressStateQuarantined, nil
 	case BackendStateMaintenance:

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -191,6 +191,12 @@ type bpfOpsParams struct {
 	NodeAddresses  statedb.Table[tables.NodeAddress]
 }
 
+const (
+	logfieldActiveCount      = "active-count"
+	logfieldTerminatingCount = "terminating-count"
+	logfieldInactiveCount    = "inactive-count"
+)
+
 func newBPFOps(p bpfOpsParams) *BPFOps {
 	ops := &BPFOps{
 		cfg:       p.Config,
@@ -881,7 +887,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 
 		if ops.needsUpdate(be.Address, be.Revision) {
 			ops.log.Debug("Update backend",
-				logfields.Backend, be,
+				logfields.Backend, be.BackendParams,
 				logfields.ID, beID,
 				logfields.Address, be.Address,
 			)
@@ -1024,7 +1030,10 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		logfields.Type, fe.Type,
 		logfields.ProxyRedirect, fe.Service.ProxyRedirect,
 		logfields.Address, fe.Address,
-		logfields.Count, backendCount)
+		logfields.Count, backendCount,
+		logfieldActiveCount, activeCount,
+		logfieldTerminatingCount, terminatingCount,
+		logfieldInactiveCount, inactiveCount)
 	if err := ops.upsertMaster(svcKey, svcVal, fe, activeCount, inactiveCount); err != nil {
 		return fmt.Errorf("upsert service master: %w", err)
 	}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -454,9 +454,9 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					// fully removed to avoid disrupting connections.
 					state = loadbalancer.BackendStateTerminating
 				default:
-					// In all other cases we mark the backend as quarantined. Existing connections
-					// are not disrupted until the backend is actually deleted.
-					state = loadbalancer.BackendStateQuarantined
+					// In all other cases we mark the backend to be in maintenance. This avoids disruptions
+					// to existing connections when a backend readiness is flapping.
+					state = loadbalancer.BackendStateMaintenance
 				}
 				be := loadbalancer.BackendParams{
 					Address:   l3n4Addr,

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -431,9 +431,32 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					}
 				}
 
-				state := loadbalancer.BackendStateActive
-				if be.Terminating {
+				var state loadbalancer.BackendState
+				switch {
+				case be.Conditions.IsReady():
+					// A backend that is ready (regardless of serving and terminating) is considered
+					// active. We may see backends that are ready+terminating if 'PublishNotReadyAddresses'
+					// is true. While it would be more logical to set this as terminating, we're following
+					// kube-proxy here and considering it as an active backend and not ignoring it even when
+					// other active backends are available.
+					//
+					// See also kube-proxy implementation at:
+					// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L61
+					state = loadbalancer.BackendStateActive
+				case be.Conditions.IsTerminating() && !be.Conditions.IsServing():
+					// A backend that is terminating and not serving should not be used for load-balancing
+					// even if it's the only backend. A terminating backend is kept in the BPF maps until
+					// fully removed to avoid disrupting connections.
+					state = loadbalancer.BackendStateTerminatingNotServing
+				case be.Conditions.IsTerminating():
+					// A backend that is terminating and serving can still be used for new connections
+					// when no active backends are available. A terminating backend is kept in the BPF maps until
+					// fully removed to avoid disrupting connections.
 					state = loadbalancer.BackendStateTerminating
+				default:
+					// In all other cases we mark the backend as quarantined. Existing connections
+					// are not disrupted until the backend is actually deleted.
+					state = loadbalancer.BackendStateQuarantined
 				}
 				be := loadbalancer.BackendParams{
 					Address:   l3n4Addr,

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -76,8 +76,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating3.expected lbmaps.actual
 
 # Set the first backend as not serving and second as ready+terminating .
-# First backend will be quarantined. Existing connections to
-# it won't be affected as it's still in the backends BPF map.
+# First backend will be removed.
 # The second backend will be just considered ready and its terminating
 # condition is ignored ("ready" overrides everything).
 cp endpointslice.yaml.tmpl endpointslice.yaml
@@ -146,7 +145,6 @@ Address                 Instances                                         NodeNa
 
 -- backends-terminating4.table --
 Address                 Instances                                         NodeName
-10.244.0.112:8081/TCP   test/graceful-term-svc [quarantined]              graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
@@ -267,10 +265,8 @@ SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCO
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 -- lbmaps-terminating4.expected --
-BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=quarantined
 BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
 MAGLEV: ID=1 INNER=[2(1021)]
 REV: ID=1 ADDR=10.96.116.33:8081
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
-SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -8,10 +8,12 @@ hive start
 
 # Start with two backends that are both active.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$TERM1' 'false' endpointslice.yaml
 replace '$READY1' 'true' endpointslice.yaml
-replace '$TERM2' 'false' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
 replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'true' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
 
 k8s/add service.yaml endpointslice.yaml
 db/cmp services services.table
@@ -25,10 +27,12 @@ lb/maps-dump lbmaps.actual
 # Set the first backend as terminating. The second backend
 # will now serve the traffic.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$TERM1' 'true' endpointslice.yaml
 replace '$READY1' 'false' endpointslice.yaml
-replace '$TERM2' 'false' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
 replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'true' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
 k8s/update endpointslice.yaml
 db/cmp backends backends-terminating1.table
 
@@ -40,10 +44,12 @@ lb/maps-dump lbmaps.actual
 # are now active backends the terminating backends are used
 # instead.
 cp endpointslice.yaml.tmpl endpointslice.yaml
-replace '$TERM1' 'true' endpointslice.yaml
 replace '$READY1' 'false' endpointslice.yaml
-replace '$TERM2' 'true' endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
 replace '$READY2' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+replace '$SERVING2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
 db/cmp frontends frontends-terminating2.table
 db/cmp backends backends-terminating2.table
@@ -51,6 +57,43 @@ db/cmp backends backends-terminating2.table
 # Check BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating2.expected lbmaps.actual
+
+# Set the second backend as terminating AND not serving.
+# This now won't be used as a fallback.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'true' endpointslice.yaml
+replace '$READY2' 'false' endpointslice.yaml
+replace '$SERVING2' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends-terminating3.table
+db/cmp backends backends-terminating3.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-terminating3.expected lbmaps.actual
+
+# Set the first backend as not serving and second as ready+terminating .
+# First backend will be quarantined. Existing connections to
+# it won't be affected as it's still in the backends BPF map.
+# The second backend will be just considered ready and its terminating
+# condition is ignored ("ready" overrides everything).
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$READY1' 'false' endpointslice.yaml
+replace '$SERVING1' 'false' endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'false' endpointslice.yaml
+replace '$TERM2' 'true' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends-terminating4.table
+db/cmp backends backends-terminating4.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-terminating4.expected lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice.yaml
@@ -73,6 +116,14 @@ Address                 Type        ServiceName              Status  Backends
 Address                 Type        ServiceName              Status  Backends
 10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
 
+-- frontends-terminating3.table --
+Address                 Type        ServiceName              Status  Backends
+10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
+
+-- frontends-terminating4.table --
+Address                 Type        ServiceName              Status  Backends
+10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
+
 -- backends.table --
 Address                 Instances                NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc   graceful-term-control-plane
@@ -87,6 +138,16 @@ Address                 Instances                              NodeName
 Address                 Instances                             NodeName
 10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc [terminating]  graceful-term-control-plane
+
+-- backends-terminating3.table --
+Address                 Instances                                         NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [terminating]              graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc [terminating-not-serving]  graceful-term-control-plane
+
+-- backends-terminating4.table --
+Address                 Instances                                         NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [quarantined]              graceful-term-control-plane
+10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
 apiVersion: v1
@@ -146,7 +207,7 @@ endpoints:
   - 10.244.0.112
   conditions:
     ready: $READY1
-    serving: true
+    serving: $SERVING1
     terminating: $TERM1
   nodeName: graceful-term-control-plane
   targetRef:
@@ -159,7 +220,7 @@ endpoints:
   - 10.244.0.113
   conditions:
     ready: $READY2
-    serving: true
+    serving: $SERVING2
     terminating: $TERM2
   nodeName: graceful-term-control-plane
   targetRef:
@@ -197,3 +258,19 @@ REV: ID=1 ADDR=10.96.116.33:8081
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- lbmaps-terminating3.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=terminating
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=terminating
+MAGLEV: ID=1 INNER=[1(1021)]
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- lbmaps-terminating4.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=quarantined
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
+MAGLEV: ID=1 INNER=[2(1021)]
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP

--- a/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
+++ b/pkg/loadbalancer/tests/testdata/graceful-termination.txtar
@@ -51,7 +51,7 @@ replace '$READY2' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
 replace '$SERVING2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating2.table
+db/cmp frontends frontends.table
 db/cmp backends backends-terminating2.table
 
 # Check BPF maps
@@ -68,7 +68,7 @@ replace '$READY2' 'false' endpointslice.yaml
 replace '$SERVING2' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating3.table
+db/cmp frontends frontends.table
 db/cmp backends backends-terminating3.table
 
 # Check BPF maps
@@ -76,7 +76,7 @@ lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating3.expected lbmaps.actual
 
 # Set the first backend as not serving and second as ready+terminating .
-# First backend will be removed.
+# First backend will be kept but in maintenance and not load-balanced..
 # The second backend will be just considered ready and its terminating
 # condition is ignored ("ready" overrides everything).
 cp endpointslice.yaml.tmpl endpointslice.yaml
@@ -87,12 +87,28 @@ replace '$READY2' 'true' endpointslice.yaml
 replace '$SERVING2' 'false' endpointslice.yaml
 replace '$TERM2' 'true' endpointslice.yaml
 k8s/update endpointslice.yaml
-db/cmp frontends frontends-terminating4.table
+db/cmp frontends frontends.table
 db/cmp backends backends-terminating4.table
 
 # Check BPF maps
 lb/maps-dump lbmaps.actual
 * cmp lbmaps-terminating4.expected lbmaps.actual
+
+# Set both ready&serving. First backend will be added back to services map.
+cp endpointslice.yaml.tmpl endpointslice.yaml
+replace '$READY1' 'true' endpointslice.yaml
+replace '$SERVING1' 'true' endpointslice.yaml
+replace '$TERM1' 'false' endpointslice.yaml
+replace '$READY2' 'true' endpointslice.yaml
+replace '$SERVING2' 'false' endpointslice.yaml
+replace '$TERM2' 'false' endpointslice.yaml
+k8s/update endpointslice.yaml
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Check BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-active.expected lbmaps.actual
 
 # Cleanup
 k8s/delete service.yaml endpointslice.yaml
@@ -109,18 +125,6 @@ test/graceful-term-svc   k8s      =8081      Cluster
 
 -- frontends.table --
 Address                 Type        ServiceName              Status  Backends                              
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating2.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating3.table --
-Address                 Type        ServiceName              Status  Backends
-10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
-
--- frontends-terminating4.table --
-Address                 Type        ServiceName              Status  Backends
 10.96.116.33:8081/TCP   ClusterIP   test/graceful-term-svc   Done    10.244.0.112:8081/TCP, 10.244.0.113:8081/TCP
 
 -- backends.table --
@@ -145,6 +149,7 @@ Address                 Instances                                         NodeNa
 
 -- backends-terminating4.table --
 Address                 Instances                                         NodeName
+10.244.0.112:8081/TCP   test/graceful-term-svc [maintenance]              graceful-term-control-plane
 10.244.0.113:8081/TCP   test/graceful-term-svc                            graceful-term-control-plane
 
 -- service.yaml --
@@ -265,6 +270,7 @@ SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCO
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
 -- lbmaps-terminating4.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=maintenance
 BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
 MAGLEV: ID=1 INNER=[2(1021)]
 REV: ID=1 ADDR=10.96.116.33:8081


### PR DESCRIPTION
This backports #40969, #41234 and #42170 to v1.18. This fixes losing connectivity to terminating endpoints that are marked unready due to pod readiness checks.

```release-note
Kubernetes endpoints that are terminating are retained in the backends BPF state regardless of the "serving" condition to avoid connection disruptions when a pod no longer signals readiness to process new connections.
```
