### PR TITLE
CODEOWNERS: Remove sig-k8s from Helm charts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -477,11 +477,11 @@ Makefile* @cilium/build
 /images/builder/update-cilium-builder-image.sh @cilium/github-sec
 /images/hubble-relay @cilium/sig-hubble
 /images/runtime/update-cilium-runtime-image.sh @cilium/github-sec
-/install/kubernetes/ @cilium/sig-k8s @cilium/helm
-/install/kubernetes/cilium/**/cilium-envoy @cilium/sig-k8s @cilium/helm @cilium/envoy @cilium/sig-servicemesh
-/install/kubernetes/cilium/**/spire @cilium/sig-k8s @cilium/helm @cilium/sig-servicemesh
-/install/kubernetes/cilium/templates/clustermesh* @cilium/sig-k8s @cilium/helm @cilium/sig-clustermesh
-/install/kubernetes/cilium/templates/hubble* @cilium/sig-k8s @cilium/helm @cilium/sig-hubble
+/install/kubernetes/ @cilium/helm
+/install/kubernetes/cilium/**/cilium-envoy @cilium/helm @cilium/envoy @cilium/sig-servicemesh
+/install/kubernetes/cilium/**/spire @cilium/helm @cilium/sig-servicemesh
+/install/kubernetes/cilium/templates/clustermesh* @cilium/helm @cilium/sig-clustermesh
+/install/kubernetes/cilium/templates/hubble* @cilium/helm @cilium/sig-hubble
 /LICENSE @cilium/contributing
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure


### PR DESCRIPTION
I propose to remove ownership of the Helm charts from `sig-k8s`. The `sig-k8s` team has a wide area of responsibilities. This leads to team members being pulled into many PRs. In the case of Helm changes (where most PRs often only add or update Helm values), the changes from a `sig-k8s` perspective are often trivial (e.g. adding a new configmap key or extending a volume mount), leading to the `sig-k8s` team often just rubber-stamping Helm PRs from a Kubernetes perspective. These kind of changes can be reviewed by the Helm team itself.

Therefore I propose to remove `sig-k8s` as a CODEOWNER from the Helm chart directory. If the Helm team does need input from `sig-k8s`, it can still request a `sig-k8s` review manually. But I do believe that the lack of a `sig-k8s` review does not need to block all Helm PRs by default.

To members of @cilium/helm and @cilium/sig-k8s: What do you think?