### PR TITLE
Fix two file descriptor leaks

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -477,6 +477,7 @@ func (m *manager) restoreNodeCheckpoint() {
 		)
 		return
 	}
+	defer f.Close()
 
 	r := jsoniter.ConfigFastest.NewDecoder(bufio.NewReader(f))
 	var nodeCheckpoint []*nodeTypes.Node

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3337,6 +3337,7 @@ func (c *DaemonConfig) diffFromFile() error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	fi, err := f.Stat()
 	if err != nil {


### PR DESCRIPTION
Both the node check-pointing logic and the option-config diffing logic leaked a file descriptor.

Fixes: #42530

