### PR TITLE
workflows: consolidate AKS conformance test cleanup steps

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -369,21 +369,11 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }}-concurrent-clear (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
-      - name: Features tested
-        uses: ./.github/actions/feature-status
-        with:
-          title: "Summary of all features tested"
-          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1"
-
-      - name: Clean up Cilium
-        run: |
-          cilium uninstall --wait
-
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
         uses: ./.github/actions/post-logic
         with:
-          artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 2"
+          artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
           job_status: "${{ job.status }}"
           capture_features_tested: ${{ steps.run-tests.outcome != 'skipped' }}
 


### PR DESCRIPTION
Remove redundant "Features tested" and "Clean up Cilium" steps in favor of the unified post-logic action. The post-logic action already handles feature status reporting and cleanup when capture_features_tested is enabled.

Also remove the "- 2" suffix from artifacts_suffix as there's now only one artifact upload step per job.

Fixes: c73fac0d4f25 ("workflows/aks: Don't run tests twice when IPsec is enabled")