### PR TITLE
bpf: align WireGuard/IPSec do_decrypt and trace ingressing encrypted packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1247,9 +1247,9 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	 * etc. on an encrypted packet.
 	 * In all other cases (packet doesn't need decryption or already
 	 * decrypted), we want to run all subsequent logic here. We therefore
-	 * ignore the return value from do_decrypt.
+	 * ignore the return value from ipsec_do_decrypt.
 	 */
-	ret = do_decrypt(ctx, proto);
+	ret = ipsec_do_decrypt(ctx, proto);
 	if (IS_ERR(ret))
 		goto drop_err;
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1237,8 +1237,12 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		goto drop_err;
 
-	if (ctx_is_decrypt(ctx))
+	if (ctx_is_decrypt(ctx)) {
+		send_trace_notify(ctx, TRACE_FROM_NETWORK, UNKNOWN_ID, UNKNOWN_ID,
+				  TRACE_EP_ID_UNKNOWN, ctx->ingress_ifindex,
+				  TRACE_REASON_ENCRYPTED, TRACE_PAYLOAD_LEN, proto);
 		return CTX_ACT_OK;
+	}
 #endif
 	ret = tcx_early_hook(ctx, proto);
 	if (ret != CTX_ACT_OK)

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -48,7 +48,7 @@ int cil_from_network(struct __ctx_buff *ctx)
 	if (!validate_ethertype(ctx, &proto))
 		goto out;
 
-	ret = do_decrypt(ctx, proto);
+	ret = ipsec_do_decrypt(ctx, proto);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_INGRESS);
 #endif
@@ -61,13 +61,13 @@ int cil_from_network(struct __ctx_buff *ctx)
  *    and marked with MARK_MAGIC_DECRYPT, IPSec mode only)
  *
  * 1. will be traced with TRACE_REASON_ENCRYPTED, because
- * do_decrypt marks them with MARK_MAGIC_DECRYPT.
+ * ipsec_do_decrypt marks them with MARK_MAGIC_DECRYPT.
  *
  * 2. will be traced without TRACE_REASON_ENCRYPTED, because
- * do_decrypt does't touch to mark.
+ * ipsec_do_decrypt does't touch to mark.
  *
  * 3. will be traced without TRACE_REASON_ENCRYPTED, because
- * do_decrypt clears the mark.
+ * ipsec_do_decrypt clears the mark.
  *
  * Note that 1. contains the ESP packets someone else generated.
  * In that case, we trace it as "encrypted", but it doesn't mean
@@ -80,7 +80,7 @@ int cil_from_network(struct __ctx_buff *ctx)
 	if (ctx_is_decrypt(ctx))
 		trace.reason = TRACE_REASON_ENCRYPTED;
 
-	/* Only possible redirect in here is the one in the do_decrypt
+	/* Only possible redirect in here is the one in the ipsec_do_decrypt
 	 * which redirects to cilium_host.
 	 */
 	if (ret == CTX_ACT_REDIRECT)

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -110,7 +110,7 @@ set_ipsec_encrypt(struct __ctx_buff *ctx,
 }
 
 static __always_inline int
-do_decrypt(struct __ctx_buff *ctx, __u16 proto)
+ipsec_do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 {
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
@@ -317,7 +317,7 @@ overlay_encrypt:
 }
 #else
 static __always_inline int
-do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
+ipsec_do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
 {
 	return CTX_ACT_OK;
 }

--- a/contrib/coccinelle/encrypt_agg.cocci
+++ b/contrib/coccinelle/encrypt_agg.cocci
@@ -14,7 +14,8 @@ cnt = 0
 
 
 @pass_monitor exists@
-expression e1, e2, e3, e4, e5, e6, e7;
+expression e1, e3, e4, e5, e6, e7;
+identifier e2 =~ "TRACE_TO_.*";
 identifier f;
 expression m != 0;
 position p;


### PR DESCRIPTION
This PR tries to align the Ingress logic to mark a WireGuard-encrypted packet to IPSec.
This has no functional impact wrt to main branch. In case of fragmentation, we're not tagging subsequent WG fragments (no L4 header), and this will not be fixed in this PR.
In addition, let's add an always skipped ingress trace for IPSec-encrypted packets coming from outside.

**EDIT**: This PR was initially thought to skip ingress processing for WG-encrypted pkts, similarly as we do for IPSec. As described in commit description `bpf: refactor ctx_is_wireguard to wg_do_decrypt`, we can't stop the ingress program, otherwise we wouldn't handle fragments: the 1st fragment with L4 header is recognized as WireGuard and skip directly to stack; the 2nd fragment goes through the ingress program, and will fail due to `First logical datagram fragment not found`.  I'm not sure whether we should mark also subsequent fragments, but that will not be part of this PR.