### PR TITLE
pkg/aws: move vpc filter logic to startup

### DIFF
--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -209,7 +209,7 @@ func TestGetSubnet(t *testing.T) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
 	metadataMockapi, _ := metadataMock.NewMetadataMock()
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
+	mngr, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -248,7 +248,7 @@ func TestFindSubnetByIDs(t *testing.T) {
 	api := ec2mock.NewAPI(subnets2, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
 	metadataMockapi, _ := metadataMock.NewMetadataMock()
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
+	mngr, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -288,7 +288,7 @@ func TestFindSubnetByTags(t *testing.T) {
 	api := ec2mock.NewAPI(subnets, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
 	metadataMockapi, _ := metadataMock.NewMetadataMock()
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
+	mngr, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 
@@ -326,7 +326,7 @@ func TestGetSecurityGroupByTags(t *testing.T) {
 	require.NotNil(t, api)
 
 	metadataMockapi, _ := metadataMock.NewMetadataMock()
-	mngr, err := NewInstancesManager(hivetest.Logger(t), api, metadataMockapi)
+	mngr, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
 

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -85,7 +85,7 @@ func TestGetNodeNames(t *testing.T) {
 	setup(t)
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
@@ -115,7 +115,7 @@ func TestNodeManagerGet(t *testing.T) {
 	setup(t)
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, false)
@@ -146,7 +146,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	const instanceID = "i-testNodeManagerDefaultAllocation-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -192,7 +192,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 
 	pdTestSubnet := *testSubnet
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{&pdTestSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -263,7 +263,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	const instanceID = "i-testNodeManagerDefaultAllocation-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -325,7 +325,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	const instanceID = "i-testNodeManagerMinAllocate20-1"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -383,7 +383,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	const instanceID = "i-testNodeManagerMinAllocateAndPreallocate-1"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -450,7 +450,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 
 	operatorOption.Config.ExcessIPReleaseDelay = 2
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -554,7 +554,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	const instanceID = "i-testNodeManagerDefaultAllocation-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -624,7 +624,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	const instanceID = "i-testNodeManagerExceedENICapacity-1"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -684,7 +684,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	}
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet, testSubnet2}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -750,7 +750,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	}
 
 	ec2api := ec2mock.NewAPI(subnets, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instancesManager, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instancesManager, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instancesManager)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instancesManager, k8sapi, metricsapi, 10, false, false)
@@ -821,7 +821,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
 	metricsMock := metricsmock.NewMockMetrics()
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -868,7 +868,7 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	const instanceID = "i-testInstanceBeenDeleted-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -929,7 +929,7 @@ func TestNodeManagerStaticIP(t *testing.T) {
 	const instanceID = "i-testNodeManagerStaticIP-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -975,7 +975,7 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	const instanceID = "i-testNodeManagerStaticIPAlreadyAssociated-0"
 
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
-	instances, err := NewInstancesManager(hivetest.Logger(t), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
@@ -1010,7 +1010,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{testSubnet1, testSubnet2, testSubnet3}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, routeTables)
 	ec2api.SetDelay(ec2mock.AllOperations, delay)
 	ec2api.SetLimiter(rateLimit, burst)
-	instances, err := NewInstancesManager(hivetest.Logger(b), ec2api, metadataMockapi)
+	instances, err := NewInstancesManager(b.Context(), hivetest.Logger(b), ec2api, metadataMockapi)
 	require.NoError(b, err)
 	require.NotNil(b, instances)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(b), instances, k8sapi, metricsapi, 10, false, false)

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -19,7 +19,7 @@ import (
 func TestGetMaximumAllocatableIPv4(t *testing.T) {
 	api := ec2mock.NewAPI(nil, nil, nil, nil)
 	metadataMock, _ := metadataMock.NewMetadataMock()
-	instances, err := NewInstancesManager(hivetest.Logger(t), api, metadataMock)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMock)
 	require.NoError(t, err)
 	n := &Node{
 		rootLogger: hivetest.Logger(t),
@@ -213,7 +213,7 @@ func TestIsPrefixDelegated(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			api := ec2mock.NewAPI(nil, nil, nil, nil)
 			metadataMock, _ := metadataMock.NewMetadataMock()
-			instances, err := NewInstancesManager(hivetest.Logger(t), api, metadataMock)
+			instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), api, metadataMock)
 			require.NoError(t, err)
 			n := &Node{
 				rootLogger: hivetest.Logger(t),

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -133,7 +133,7 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize metadata client: %w", err)
 	}
-	instances, err := eni.NewInstancesManager(a.rootLogger, a.client, imds)
+	instances, err := eni.NewInstancesManager(ctx, a.rootLogger, a.client, imds)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize ENI instances manager: %w", err)
 	}


### PR DESCRIPTION
We observed ENI IPAM flake in CI https://github.com/cilium/cilium/issues/42065 and we got https://github.com/cilium/cilium/pull/42066 as the workaround.

I looked into it and found the root cause of the issue, and here is the reason:

We have LRP test with KPR, and the cilium-operator pod is on the same node with lrp test pod. In that a few seconds lrp test, cilium operator was triggered to refresh the aws info through IMDS. Cilium operator get the info from the lrp backend pod for `404`, aws sdk think `404` is from aws and throw that error. Because we have kpr with socketlb, cilium operator follow the lrp config to rewrite `169.254.169.254` to our backend pod.

Let's move getting aws vpc id logic to start up since it doesn't change over the time and to prevent any possible conflicts for lrp config in the future.



```release-note
Move aws operator fetch vpc id logic to the start up
```
