### PR TITLE
update lrp helm value in tests

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -214,7 +214,7 @@ runs:
 
           LOCAL_REDIRECT_POLICY=""
           if [ "${{ inputs.local-redirect-policy }}" == "true" ]; then
-            LOCAL_REDIRECT_POLICY="--helm-set=localRedirectPolicy=true"
+            LOCAL_REDIRECT_POLICY="--helm-set=localRedirectPolicies.enabled=true"
           fi
 
           BGP_CONTROL_PLANE=""

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -308,7 +308,7 @@ jobs:
           if [[ "$ADV_FEAT" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
               --helm-set enableIPv4Masquerade=true \
-              --helm-set localRedirectPolicy=true \
+              --helm-set localRedirectPolicies.enabled=true \
               --helm-set egressGateway.enabled=true"
           fi
 


### PR DESCRIPTION
We have the new way to enable LRP in the [doc](https://docs.cilium.io/en/stable/network/kubernetes/local-redirect-policy/#prerequisites) like the following.

```
helm upgrade cilium cilium/cilium --version 1.18.3 \
  --namespace kube-system \
  --reuse-values \
  --set localRedirectPolicies.enabled=true
```
we still have the old way to enable LRP in the test. This PR is just moving from the old way to the new way to enable LRP. 

I have searched in the codebase and update all occurances that I can find.

```release-note
Move the deprecated LRP helm values  to the new way in tests
```
