### PR TITLE
gh: conn-disrupt: fix XFRM error checks

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -37,7 +37,7 @@ runs:
         if [[ -n "${{ inputs.tests }}" ]]; then
           TEST_ARG="${{ inputs.tests }}"
         else
-          TEST_ARG="no-interrupted-connections"
+          TEST_ARG="no-interrupted-connections,no-ipsec-xfrm-error"
           EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
           if [[ "${{ inputs.skip-include-conn-disrupt-test-ns-traffic }}" != "true" ]]; then
             EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -392,7 +392,9 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: ${{ env.job_name }}-${{ matrix.name }}-post-rotate
-          extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+          # Opt-out from `no-ipsec-xfrm-error`, seeing XfrmOutPolBlock errors.
+          tests: 'no-interrupted-connections'
+          extra-connectivity-test-flags: "${{ steps.vars-conn.outputs.connectivity_test_defaults }} --include-conn-disrupt-test"
 
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start


### PR DESCRIPTION
XFRM error checking is supposed to occur before/after a conn-disrupt test. During the test-setup step we collect the initial XFRM errors, and the test-check step is meant to compare the new error count against the previously collected error count.

But this requires that we actually run the `no-ipsec-xfrm-error` test during conn-disrupt's test-check step.

Opt-out the ipsec-e2e workflow for now until the observed `XfrmOutPolBlock` errors are addressed.