### PR TITLE
helm: respect CA bundle configuration in kvstoremesh remote certificate

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -456,8 +456,17 @@ spec:
                 path: common-etcd-client.key
               - key: tls.crt
                 path: common-etcd-client.crt
+          {{- if not .Values.tls.caBundle.enabled }}
               - key: ca.crt
                 path: common-etcd-client-ca.crt
+          {{- else }}
+          - {{ .Values.tls.caBundle.useSecret | ternary "secret" "configMap" }}:
+              name: {{ .Values.tls.caBundle.name }}
+              optional: true
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: common-etcd-client-ca.crt
+          {{- end }}
       {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
       - configMap:
           defaultMode: 0400


### PR DESCRIPTION
The blamed commit added the `clustermesh-apiserver-remote-cert` secret as a projected volume to the clustermesh-apiserver pod, providing the client certificate and key normally used to authenticate with the etcd instance in remote clusters, as well as the CA used to validate the server certificate presented by the etcd instances. However, it missed respecting the CA bundle setting, incorrectly always using the CA from the secret itself. Let's get this fixed, aligning the behavior here with that of all the other clustermesh related secrets.

Fixes: bd5386019c2b ("kvstoremesh: add helm configuration")

<!-- Description of change -->

Fixes: #issue-number

```release-note
KVStoreMesh now correctly respects the CA bundle setting when validating remote cluster certificates
```
