### PR TITLE
datapath: Fix error handling in orchestrator reinitialize

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -974,10 +974,10 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	const struct lb6_service *svc;
 	__u16 dst_port = ctx_dst_port(ctx);
 	__u8 protocol = ctx_protocol(ctx);
-	struct lb6_key key = {
+	struct lb6_key key __align_stack_8 = {
 		.dport		= dst_port,
 		.proto		= protocol,
-	}, orig_key;
+	}, orig_key __align_stack_8;
 	const struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -121,6 +122,9 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 
 	ds.hive = hive.New(
 		cell.Provide(
+			func() (_ statedbReconciler.Reconciler[*reconciler.DesiredRoute]) {
+				return nil
+			},
 			func(log *slog.Logger) (k8sClient.Clientset, k8sClient.Config) {
 				cs, _ := k8sFakeClient.NewFakeClientset(log)
 				cs.Disable()

--- a/pkg/datapath/linux/route/reconciler/cell.go
+++ b/pkg/datapath/linux/route/reconciler/cell.go
@@ -6,7 +6,6 @@ package reconciler
 import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
-	"github.com/cilium/statedb/reconciler"
 )
 
 var Cell = cell.Module(
@@ -14,7 +13,6 @@ var Cell = cell.Module(
 	"Reconciles desired routes to the Linux kernel routing table",
 	TableCell,
 	cell.Provide(registerReconciler),
-	cell.Invoke(func(r reconciler.Reconciler[*DesiredRoute]) {}),
 	cell.Invoke(desiredRouteRefresher),
 )
 

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/spf13/afero"
 
 	"github.com/cilium/cilium/pkg/cidr"
@@ -71,6 +72,9 @@ func newTestLoader(tb testing.TB) *loader {
 		Cell,
 
 		routeReconciler.TableCell,
+		cell.Provide(func() (_ statedbReconciler.Reconciler[*routeReconciler.DesiredRoute]) {
+			return nil
+		}),
 		cell.Provide(tables.NewDeviceTable), cell.Provide(statedb.RWTable[*tables.Device].ToTable),
 		cell.Provide(func() (
 			sysctl.Sysctl,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/hive/job"
 	cilium "github.com/cilium/proxy/go/cilium/api"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/completion"
@@ -32,6 +33,9 @@ func proxyForTest(t *testing.T, envoyIntegration *envoyProxyIntegration) *Proxy 
 	var drm *reconciler.DesiredRouteManager
 	hive.New(
 		reconciler.TableCell,
+		cell.Provide(func() (_ statedbReconciler.Reconciler[*reconciler.DesiredRoute]) {
+			return nil
+		}),
 		cell.Invoke(func(m *reconciler.DesiredRouteManager) {
 			drm = m
 		}),

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
+	statedbReconciler "github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd"
@@ -70,6 +71,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 
 		// Provide the mocked infrastructure and datapath components
 		cell.Provide(
+			func() (_ statedbReconciler.Reconciler[*reconciler.DesiredRoute]) { return nil },
 			func() k8sClient.Clientset { return clientset },
 			func() k8sClient.Config { return clientset.Config() },
 			func() *option.DaemonConfig { return option.Config },


### PR DESCRIPTION
Previously, when datapath reinitialization failed (e.g., when inserting IPv4 proxy routes), the error was accumulated but the orchestrator would continue executing. This caused two issues:

1. The orchestrator would store the failed local node configuration and mark the datapath as initialized even though initialization had failed
2. Endpoint regeneration would be triggered with an incomplete datapath configuration

This meant that after a reinitialization failure, the error would never be retried because the orchestrator thought everything was successful.

The fix ensures that if Loader.Reinitialize() fails, we return early without updating the local node configuration or triggering endpoint regeneration. This allows the retry mechanism to kick in and attempt reinitialization again after reinitRetryDuration (10 seconds).

Additionally, fix two bugs in the route reconciler:
- UpsertRouteWait() was returning nil instead of the actual error from UpsertRoute(), masking route insertion failures
- waitForReconciliation() timeout error formatting would panic if err was nil (using %w on nil error)

Fixes the issue where "Failed to reinitialize datapath... inserting ipv4 proxy route" errors would never recover.

Fixes: https://github.com/cilium/cilium/commit/c508c64fd6a34731f55e91e37ac1a7a4d8b3d171 ("pkg/datapath: Table based loader reconciliation")