### PR TITLE
Policy: properly reference-count L4Policies

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -237,6 +237,9 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 		return nil
 	}
 
+	// Release our claim on the SelectorPolicy
+	defer selectorPolicy.Done()
+
 	// Add new redirects before Consume() so that all required proxy ports are available for it.
 	var desiredRedirects map[string]uint16
 	err = e.rlockAlive()

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -219,7 +219,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 
 	var selectorPolicy policy.SelectorPolicy
-	selectorPolicy, result.policyRevision, err = e.policyRepo.GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats, e.GetID())
+	selectorPolicy, result.policyRevision, err = e.policyRepo.GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
 	if err != nil {
 		e.getLogger().Warn("Failed to calculate SelectorPolicy", logfields.Error, err)
 		return err

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -705,6 +705,9 @@ func (sp *testSelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, poli
 	}
 }
 
+func (sp *testSelectorPolicy) Done() {
+}
+
 // createSelectorCache creates a common selector cache setup used by both DNS and non-DNS policies
 func (sp *testSelectorPolicy) createSelectorCache() (policy.CachedSelector, *policy.SelectorCache) {
 	dnsServerIdentity := destIdentity

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -93,7 +93,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 // Returns whether the cache was updated, or an error.
 //
 // Must be called with repo.Mutex held for reading.
-func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
+func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity) (*selectorPolicy, bool, error) {
 	cip := cache.lookupOrCreate(identity)
 
 	// As long as UpdatePolicy() is triggered from endpoint
@@ -123,7 +123,7 @@ func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, e
 	// There is now an outstanding reference to this policy, so increment the counter
 	selPolicy.L4Policy.acquire()
 
-	cip.setPolicy(selPolicy, endpointID)
+	cip.setPolicy(selPolicy)
 
 	return selPolicy, true, nil
 }
@@ -207,7 +207,7 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 // the endpoint that initiated the old selector policy detach. Since detach
 // can trigger endpoint regenerations of all it users, this ensures
 // that endpoints do not continuously update themselves.
-func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) {
+func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy) {
 	policy.L4Policy.acquire()
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -68,10 +68,10 @@ func TestCacheManagement(t *testing.T) {
 	require.True(t, removed)
 
 	// Insert identity twice. Should be the same policy.
-	policy1, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
+	policy1, updated, err := cache.updateSelectorPolicy(identity)
 	require.NoError(t, err)
 	require.True(t, updated)
-	policy2, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
+	policy2, updated, err := cache.updateSelectorPolicy(identity)
 	require.NoError(t, err)
 	require.False(t, updated)
 	// must be same pointer
@@ -90,13 +90,13 @@ func TestCacheManagement(t *testing.T) {
 	ep3.SetIdentity(1234, true)
 	identity3 := ep3.GetSecurityIdentity()
 	require.NotEqual(t, identity, identity3)
-	policy1, _, _ = cache.updateSelectorPolicy(identity, ep1.Id)
+	policy1, _, _ = cache.updateSelectorPolicy(identity)
 	require.NotNil(t, policy1)
-	policy3, _, _ := cache.updateSelectorPolicy(identity3, ep3.Id)
+	policy3, _, _ := cache.updateSelectorPolicy(identity3)
 	require.NotNil(t, policy3)
 	require.NotSame(t, policy3, policy1)
 	_ = cache.delete(identity)
-	_, updated, _ = cache.updateSelectorPolicy(identity3, ep3.Id)
+	_, updated, _ = cache.updateSelectorPolicy(identity3)
 	require.False(t, updated)
 }
 
@@ -109,26 +109,26 @@ func TestCachePopulation(t *testing.T) {
 	require.Equal(t, identity1, ep2.GetSecurityIdentity())
 
 	// Calculate the policy and observe that it's cached
-	policy1, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy1, updated, err := cache.updateSelectorPolicy(identity1)
 	require.NoError(t, err)
 	require.True(t, updated)
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, updated, err = cache.updateSelectorPolicy(identity1)
 	require.NoError(t, err)
 	require.False(t, updated)
-	policy2, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy2, _, _ := cache.updateSelectorPolicy(identity1)
 	require.NotNil(t, policy2)
 	require.Same(t, policy1, policy2)
 
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	_, updated, _ = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, updated, _ = cache.updateSelectorPolicy(identity1)
 	require.True(t, updated)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint(t)
 	ep3.SetIdentity(1234, true)
-	policy3, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	policy3, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity())
 	require.NoError(t, err)
 	require.True(t, updated)
 
@@ -164,7 +164,7 @@ func TestPolicyLifecycle(t *testing.T) {
 	require.Len(t, repo.selectorCache.selectors, 1)
 
 	regen := func(id *identity.Identity) (*selectorPolicy, *EndpointPolicy) {
-		spi, _, err := repo.GetSelectorPolicy(id, 0, &dummyPolicyStats{}, owner.GetID())
+		spi, _, err := repo.GetSelectorPolicy(id, 0, &dummyPolicyStats{})
 		require.NoError(t, err)
 		sp := spi.(*selectorPolicy)
 
@@ -515,7 +515,7 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // distillEndpointPolicy distills the policy repository into an EndpointPolicy
 // Caller is responsible for Ready() & Detach() when done with the policy
 func (d *policyDistillery) distillEndpointPolicy(logger *slog.Logger, owner PolicyOwner, identity *identity.Identity) (*EndpointPolicy, error) {
-	sp, _, err := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{}, owner.GetID())
+	sp, _, err := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate policy: %w", err)
 	}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -276,7 +276,6 @@ func (td *testData) policyMapEquals(t *testing.T, expectedIn, expectedOut L4Poli
 
 	selPolicy, err := td.repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer selPolicy.detach(true, 0)
 
 	// Distill Selector policy to Endpoint Policy
 	epPolicy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, nil)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -411,6 +411,10 @@ func (p *testPolicyContextType) PolicyTrace(format string, a ...any) {
 	p.logger.Info(fmt.Sprintf(format, a...))
 }
 
+func (p *testPolicyContextType) GetL4Policy() *L4Policy {
+	return nil
+}
+
 // Tests in this file:
 //
 // How to read this table:

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -355,7 +355,7 @@ func TestJSONMarshal(t *testing.T) {
 		})},
 	}
 
-	policy.Attach(td.testPolicyContext)
+	policy.Finalize(td.testPolicyContext)
 	model = policy.GetModel()
 	require.NotNil(t, model)
 

--- a/pkg/policy/lookup.go
+++ b/pkg/policy/lookup.go
@@ -77,7 +77,7 @@ func LookupFlow(logger *slog.Logger, repo PolicyRepository, flow Flow, srcEP, ds
 	dstEP.remoteEndpoint = srcEP
 
 	// Resolve and look up the flow as egress from the source
-	selPolSrc, _, err := repo.GetSelectorPolicy(flow.From, 0, &dummyPolicyStats{}, srcEP.ID)
+	selPolSrc, _, err := repo.GetSelectorPolicy(flow.From, 0, &dummyPolicyStats{})
 	if err != nil {
 		return api.Undecided, ingress, egress, fmt.Errorf("GetSelectorPolicy(from) failed: %w", err)
 	}
@@ -92,7 +92,7 @@ func LookupFlow(logger *slog.Logger, repo PolicyRepository, flow Flow, srcEP, ds
 	}
 
 	// Resolve ingress policy for destination
-	selPolDst, _, err := repo.GetSelectorPolicy(flow.To, 0, &dummyPolicyStats{}, dstEP.ID)
+	selPolDst, _, err := repo.GetSelectorPolicy(flow.To, 0, &dummyPolicyStats{})
 	if err != nil {
 		return api.Undecided, ingress, egress, fmt.Errorf("GetSelectorPolicy(to) failed: %w", err)
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2083,6 +2083,5 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()
-	p.detach(true, 0)
 	assert.Positive(t, n)
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -324,6 +324,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 		defaultDenyEgress:  hasEgressDefaultDeny,
 		traceEnabled:       option.Config.TracingEnabled(),
 		logger:             p.logger.With(logfields.Identity, securityIdentity.ID),
+		l4policy:           &calculatedPolicy.L4Policy,
 	}
 
 	if ingressEnabled {
@@ -345,7 +346,7 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 	}
 
 	// Make the calculated policy ready for incremental updates
-	calculatedPolicy.Attach(&policyCtx)
+	calculatedPolicy.Finalize(&policyCtx)
 
 	return calculatedPolicy, nil
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -43,7 +43,7 @@ type PolicyRepository interface {
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
-	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
+	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error)
 
 	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
 	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
@@ -470,7 +470,7 @@ func wildcardRule(lbls labels.LabelArray, ingress bool) *rule {
 //
 // Done() must be called on the returned SelectorPolicy, if supplied, to prevent
 // unnecessary garbage collection.
-func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error) {
+func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error) {
 	stats.WaitingForPolicyRepository().Start()
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
@@ -487,7 +487,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	stats.SelectorPolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
+	sp, updated, err := r.policyCache.updateSelectorPolicy(id)
 	stats.SelectorPolicyCalculation().EndError(err)
 
 	// If we hit cache, reset the statistics.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -467,6 +467,9 @@ func wildcardRule(lbls labels.LabelArray, ingress bool) *rule {
 // This is used to skip policy calculation when a certain revision delta is
 // known to not affect the given identity. Pass a skipRevision of 0 to force
 // calculation.
+//
+// Done() must be called on the returned SelectorPolicy, if supplied, to prevent
+// unnecessary garbage collection.
 func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error) {
 	stats.WaitingForPolicyRepository().Start()
 	r.mutex.RLock()

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -72,6 +72,8 @@ type PolicyContext interface {
 
 	GetLogger() *slog.Logger
 
+	GetL4Policy() *L4Policy
+
 	PolicyTrace(format string, a ...any)
 }
 
@@ -90,6 +92,8 @@ type policyContext struct {
 
 	logger       *slog.Logger
 	traceEnabled bool
+
+	l4policy *L4Policy
 }
 
 var _ PolicyContext = &policyContext{}
@@ -174,6 +178,10 @@ func (p *policyContext) PolicyTrace(format string, a ...any) {
 	p.logger.Info(fmt.Sprintf(format, a...))
 }
 
+func (p *policyContext) GetL4Policy() *L4Policy {
+	return p.l4policy
+}
+
 // SelectorPolicy represents a selectorPolicy, previously resolved from
 // the policy repository and ready to be distilled against a set of identities
 // to compute datapath-level policy configuration.
@@ -210,8 +218,8 @@ type selectorPolicy struct {
 	EgressPolicyEnabled bool
 }
 
-func (p *selectorPolicy) Attach(ctx PolicyContext) {
-	p.L4Policy.Attach(ctx)
+func (p *selectorPolicy) Finalize(ctx PolicyContext) {
+	p.L4Policy.Finalize(ctx)
 }
 
 // EndpointPolicy is a structure which contains the resolved policy across all

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -193,7 +193,6 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
-	ip.detach(true, 0)
 	b.Logf("Number of MapState entries: %d\n", owner.mapStateSize)
 }
 
@@ -205,7 +204,6 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	epPolicy := ip.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
 	n := epPolicy.policyMapState.Len()
 	epPolicy.Ready()
-	ip.detach(true, 0)
 	assert.Positive(t, n)
 }
 
@@ -612,7 +610,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
-	policy.SelectorPolicy.detach(true, 0)
+	policy.Detach(logger)
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.Nil(t, cachedSelectorTest)
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -201,8 +201,7 @@ func BenchmarkResolveCIDRPolicyRules(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		ip.detach(true, 0)
+		td.repo.resolvePolicyLocked(fooIdentity)
 	}
 }
 
@@ -218,7 +217,6 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
-	ip.detach(true, 0)
 	b.Logf("Number of MapState entries: %d\n", owner.mapStateSize)
 }
 
@@ -228,8 +226,7 @@ func BenchmarkResolveL3IngressPolicyRules(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		ip.detach(true, 0)
+		td.repo.resolvePolicyLocked(fooIdentity)
 	}
 }
 
@@ -241,7 +238,6 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(hivetest.Logger(b), DummyOwner{logger: hivetest.Logger(b)}, nil)
 		policy.Ready()
-		ip.detach(true, 0)
 	}
 }
 
@@ -253,7 +249,6 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(hivetest.Logger(b), DummyOwner{logger: hivetest.Logger(b)}, nil)
 		policy.Ready()
-		ip.detach(true, 0)
 	}
 }
 
@@ -762,7 +757,7 @@ func TestMapStateWithIngress(t *testing.T) {
 
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
-	policy.SelectorPolicy.detach(true, 0)
+	policy.Detach(logger)
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.Nil(t, cachedSelectorTest)
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1685,7 +1685,6 @@ func TestIngressL4AllowAll(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idC)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
 
 	filter := pol.L4Policy.Ingress.PortRules.ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
@@ -1719,7 +1718,6 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idC)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
 
 	filter := pol.L4Policy.Ingress.PortRules.ExactLookup("port-80", 0, "TCP")
 	require.NotNil(t, filter)
@@ -1779,7 +1777,6 @@ func TestEgressL4AllowAll(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
 
 	t.Log(pol.L4Policy.Egress.PortRules)
 	filter := pol.L4Policy.Egress.PortRules.ExactLookup("80", 0, "TCP")
@@ -1821,7 +1818,6 @@ func TestEgressL4AllowWorld(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
 
 	filter := pol.L4Policy.Egress.PortRules.ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
@@ -1861,7 +1857,6 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
 
 	filter := pol.L4Policy.Egress.PortRules.ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)


### PR DESCRIPTION
This changes the lifecycle of an L4Policy, to ensure it is not disconnected from the SelectorCache too soon and thus stops receiving incremental updates.

Policies contain selectors, and those selectors are stored in the SelectorCache. If a selector learns of a new identity, it "pushes" that identity to all L4Policies. When an L4Policy is no longer needed, it needs to manually remove all its registered selectors.

Previously, we would forcibly disconnect a L4Policy from the SelectorCache as soon as it was no longer stored in the policyCache. This is wrong -- the policy may still be in use! This has caused a number of bugs in the past:

- https://github.com/cilium/cilium/pull/37910, in which force-computing policy may lead to an orphaned policy
- https://github.com/cilium/cilium/pull/42662, in which we incorrectly marked local identities as deleted

The fix is to only disconnect a policy when it has no users. However, we have to be careful, because an endpoint may have a reference to a policy, but be in the process of computing policy. The fix is to track both `users` and `references`, where the reference count is incremented by anything holding on to the L4Policy. The lifecycle is thus:

1. SelectorPolicy is inserted in to the cache: refcount 1, usercount 0
2. An endpoint consumes the policy: refcount 2, usercount 0
3. An endpoint computes the EndpointPolicy: refcount 1, usercount 1
4. The policy revision is bumped, and new policy begins to be calculated: refcount 0, usercount 1
5. The endpoint finishes applying the new policy, and the old one is released: refcount 0, usercount 0, and the policy may be detached.

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
