### PR TITLE
makefile: More reliable update-helm-values

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -101,6 +101,8 @@ HELM_DOCS_OUTPUT_DIR := $(HELM_DOCS_ROOT_PATH)/Documentation
 HELM_DOCS := $(DOCKER_CTR) $(HELM_TOOLBOX_IMAGE) helm-docs
 
 M2R := $(DOCKER_CTR) $(HELM_TOOLBOX_IMAGE) python3 /usr/bin/m2r2
+DOCKER_AWK := $(DOCKER_CTR) busybox awk
+DOCKER_SED := $(DOCKER_CTR) busybox sed
 
 .PHONY: update-helm-values FORCE
 $(HELM_VALUES): TMP_FILE_1 := helm-values.tmp
@@ -108,9 +110,9 @@ $(HELM_VALUES): TMP_FILE_2 := helm-values.awk
 $(HELM_VALUES): TMP_FILE_3 := helm-values.sed
 $(HELM_VALUES): FORCE
 	$(QUIET)$(HELM_DOCS) -d -c $(HELM_DOCS_CHARTS_DIR) -t $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE_1).tmpl > $(TMP_FILE_1)
-	$(QUIET)awk -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(TMP_FILE_1) > $(TMP_FILE_2)
+	$(QUIET)$(DOCKER_AWK) -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE_1) > $(TMP_FILE_2)
 	$(QUIET)$(M2R) --overwrite $(TMP_FILE_2)
-	$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\{1,\}\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
+	$(QUIET)$(DOCKER_SED) 's/^\(   \* - \)\([[:print:]]\{1,\}\)$$/\1:spelling:ignore:`\2`/' $(HELM_DOCS_OUTPUT_DIR)/$(HELM_VALUES) > $(TMP_FILE_3)
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 


### PR DESCRIPTION
On my system (MacOS), I cannot reliably run update-helm-values without it either deleting the entire content of `helm-values.rst` or writing a parts of it.

To make this more reliable across systems, use Docker to run awk and sed commands.

For me, this works 100% of the time now and I find myself un-stashing this change on pretty much all my PRs with Helm changes.

Note to reviewers: please add backport labels for all stable branches. Thanks!
