### PR TITLE
datapath: remove unused `ReinitializeXDP` method

### DIFF
--- a/pkg/datapath/fake/types/loader.go
+++ b/pkg/datapath/fake/types/loader.go
@@ -23,10 +23,6 @@ func (f *FakeLoader) ReloadDatapath(ctx context.Context, ep datapath.Endpoint, l
 	panic("implement me")
 }
 
-func (f *FakeLoader) ReinitializeXDP(ctx context.Context, lnc *datapath.LocalNodeConfiguration, extraCArgs []string) error {
-	panic("implement me")
-}
-
 func (f *FakeLoader) EndpointHash(cfg datapath.EndpointConfiguration, _ *datapath.LocalNodeConfiguration) (string, error) {
 	panic("implement me")
 }

--- a/pkg/datapath/fake/types/orchestrator.go
+++ b/pkg/datapath/fake/types/orchestrator.go
@@ -27,10 +27,6 @@ func (f *FakeOrchestrator) ReloadDatapath(ctx context.Context, ep datapath.Endpo
 	return "", nil
 }
 
-func (f *FakeOrchestrator) ReinitializeXDP(ctx context.Context, extraCArgs []string) error {
-	return nil
-}
-
 func (f *FakeOrchestrator) EndpointHash(cfg datapath.EndpointConfiguration) (string, error) {
 	return "", nil
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -305,7 +305,7 @@ func reinitializeWireguard(ctx context.Context, logger *slog.Logger, lnc *datapa
 	return
 }
 
-func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, lnc *datapath.LocalNodeConfiguration, extraCArgs []string, devices []string) error {
+func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, lnc *datapath.LocalNodeConfiguration, devices []string) error {
 	xdpConfig := lnc.XDPConfig
 	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpf.CiliumPath())
 	if xdpConfig.Disabled() {
@@ -320,7 +320,7 @@ func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, lnc *datapa
 			continue
 		}
 
-		if err := compileAndLoadXDPProg(ctx, logger, lnc, dev, xdpConfig.Mode(), extraCArgs); err != nil {
+		if err := compileAndLoadXDPProg(ctx, logger, lnc, dev, xdpConfig.Mode()); err != nil {
 			if option.Config.NodePortAcceleration == option.XDPModeBestEffort {
 				logger.Info("Failed to attach XDP program, ignoring due to best-effort mode",
 					logfields.Error, err,
@@ -333,17 +333,6 @@ func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, lnc *datapa
 	}
 
 	return nil
-}
-
-// ReinitializeXDP (re-)configures the XDP datapath only. This includes recompilation
-// and reinsertion of the object into the kernel as well as an atomic program replacement
-// at the XDP hook. extraCArgs can be passed-in in order to alter BPF code defines.
-func (l *loader) ReinitializeXDP(ctx context.Context, lnc *datapath.LocalNodeConfiguration, extraCArgs []string) error {
-	l.compilationLock.Lock()
-	defer l.compilationLock.Unlock()
-	devices := lnc.DeviceNames()
-
-	return reinitializeXDPLocked(ctx, l.logger, lnc, extraCArgs, devices)
 }
 
 func (l *loader) ReinitializeHostDev(ctx context.Context, mtu int) error {
@@ -479,8 +468,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 		}
 	}
 
-	extraArgs := []string{"-Dcapture_enabled=0"}
-	if err := reinitializeXDPLocked(ctx, l.logger, lnc, extraArgs, devices); err != nil {
+	if err := reinitializeXDPLocked(ctx, l.logger, lnc, devices); err != nil {
 		logging.Fatal(l.logger, "Failed to compile XDP program", logfields.Error, err)
 	}
 

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -102,21 +102,8 @@ func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, xdpDevs []string, xdpMo
 	}
 }
 
-// xdpCompileArgs derives compile arguments for bpf_xdp.c.
-func xdpCompileArgs(extraCArgs []string) ([]string, error) {
-	args := []string{}
-	copy(args, extraCArgs)
-
-	return args, nil
-}
-
 // compileAndLoadXDPProg compiles bpf_xdp.c for the given XDP device and loads it.
-func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger, lnc *datapath.LocalNodeConfiguration, xdpDev string, xdpMode xdp.Mode, extraCArgs []string) error {
-	args, err := xdpCompileArgs(extraCArgs)
-	if err != nil {
-		return fmt.Errorf("failed to derive XDP compile extra args: %w", err)
-	}
-
+func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger, lnc *datapath.LocalNodeConfiguration, xdpDev string, xdpMode xdp.Mode) error {
 	dirs := &directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
@@ -127,7 +114,6 @@ func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger, lnc *datapa
 		Source:     xdpProg,
 		Output:     xdpObj,
 		OutputType: outputObject,
-		Options:    args,
 	}
 
 	objPath, err := compile(ctx, logger, prog, dirs)

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -334,16 +334,6 @@ func (o *orchestrator) ReloadDatapath(ctx context.Context, ep datapath.Endpoint,
 	return o.params.Loader.ReloadDatapath(ctx, ep, o.latestLocalNodeConfig.Load(), stats)
 }
 
-func (o *orchestrator) ReinitializeXDP(ctx context.Context, extraCArgs []string) error {
-	select {
-	case <-o.dpInitialized:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
-	return o.params.Loader.ReinitializeXDP(ctx, o.latestLocalNodeConfig.Load(), extraCArgs)
-}
-
 func (o *orchestrator) EndpointHash(cfg datapath.EndpointConfiguration) (string, error) {
 	<-o.dpInitialized
 	return o.params.Loader.EndpointHash(cfg, o.latestLocalNodeConfig.Load())

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -20,7 +20,6 @@ type Loader interface {
 	HostDatapathInitialized() <-chan struct{}
 
 	ReloadDatapath(ctx context.Context, ep Endpoint, cfg *LocalNodeConfiguration, stats *metrics.SpanStat) (string, error)
-	ReinitializeXDP(ctx context.Context, cfg *LocalNodeConfiguration, extraCArgs []string) error
 	EndpointHash(cfg EndpointConfiguration, lnCfg *LocalNodeConfiguration) (string, error)
 	ReinitializeHostDev(ctx context.Context, mtu int) error
 	Reinitialize(ctx context.Context, cfg *LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr IptablesManager, p Proxy) error

--- a/pkg/datapath/types/orchestrator.go
+++ b/pkg/datapath/types/orchestrator.go
@@ -15,7 +15,6 @@ type Orchestrator interface {
 
 	DatapathInitialized() <-chan struct{}
 	ReloadDatapath(ctx context.Context, ep Endpoint, stats *metrics.SpanStat) (string, error)
-	ReinitializeXDP(ctx context.Context, extraCArgs []string) error
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration) error
 	Unload(ep Endpoint)


### PR DESCRIPTION
The `ReinitializeXDP` method of the orchestrator and thus also the loader is unused since commit 94e10ad3c416 ("treewide: Remove pcap recorder") removed its only caller. This also allows to drop the now always-empty `extraCArgs` argument to `reinitializeXDPLocked` and `compileAndLoadXDPProg`.