### PR TITLE
Support RTA_VIA in route reconciler

### DIFF
--- a/pkg/datapath/linux/route/reconciler/scripttest/testdata/manager.txtar
+++ b/pkg/datapath/linux/route/reconciler/scripttest/testdata/manager.txtar
@@ -48,6 +48,7 @@ table: 2000
 prefix: "10.2.3.4/32"
 adminDistance: 101
 device: veth0
+nexthop: fe80::1
 
 -- route2.yaml --
 table: 2000
@@ -57,12 +58,12 @@ device: veth1
 
 -- desired-routes-both.table --
 Owner    Table   Prefix        Priority   AD    Selected   Nexthop   Src    Device      MTU    Scope      Type  
-owner1   2000    10.2.3.4/32   none       101   false      none      none   veth0 (2)   none   universe   unspec
+owner1   2000    10.2.3.4/32   none       101   false      fe80::1   none   veth0 (2)   none   universe   unspec
 owner2   2000    10.2.3.4/32   none       100   true       none      none   veth1 (3)   none   universe   unspec
 -- desired-routes-owner1.table --
 Owner    Table   Prefix        Priority   AD    Selected   Nexthop   Src    Device      MTU    Scope      Type  
-owner1   2000    10.2.3.4/32   none       101   true       none      none   veth0 (2)   none   universe   unspec
+owner1   2000    10.2.3.4/32   none       101   true       fe80::1   none   veth0 (2)   none   universe   unspec
 -- route1.txt --
-10.2.3.4/32 dev veth0 scope universe table 2000
+10.2.3.4/32 via inet6 fe80::1 dev veth0 scope universe table 2000
 -- route2.txt --
 10.2.3.4/32 dev veth1 scope universe table 2000

--- a/pkg/testutils/scriptnet/scriptnet.go
+++ b/pkg/testutils/scriptnet/scriptnet.go
@@ -648,8 +648,22 @@ func routeListCmd(nsm *NetNSManager) script.Cmd {
 
 					fmt.Fprintf(&sb, "%s", route.Dst.String())
 
-					if route.Gw.Equal(net.IPv4zero) || route.Gw.Equal(net.IPv6zero) {
+					if len(route.Gw) != 0 {
 						fmt.Fprintf(&sb, " via %s", route.Gw)
+					} else if route.Via != nil {
+						switch nh := route.Via.(type) {
+						case *netlink.Via:
+							var family string
+							switch nh.Family() {
+							case netlink.FAMILY_V4:
+								family = "inet"
+							case netlink.FAMILY_V6:
+								family = "inet6"
+							default:
+								family = fmt.Sprintf("unknown(%d)", nh.Family())
+							}
+							fmt.Fprintf(&sb, " via %s %s", family, nh.Addr.String())
+						}
 					}
 
 					fmt.Fprintf(&sb, " dev %s scope %s", link.Attrs().Name, route.Scope)


### PR DESCRIPTION
Support RTA_VIA attribute which allows creating the route that has the prefix and the nexthop have different address families. Currently, it is possible to specify such a route by for example, setting IPv4 Dst and IPv6 Nexthop, but the route reconciliation will fail because it uses RTA_GATEWAY internally.

Like iproute2 does, we don't expose this to the DesiredRoute object explicitly and use it transparently when we find the address family of Dst and Nexthop are mismatching.

```release-note
Support RTA_VIA in route reconciler
```
