### PR TITLE
endpoint: cleanup: refactor endpoint params into structs.

### DIFF
--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -27,7 +27,19 @@ func TestWriteInformationalComments(t *testing.T) {
 	s := setupEndpointSuite(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	p := EndpointParams{
+		Logger:           logger,
+		EPBuildQueue:     &MockEndpointBuildQueue{},
+		Orchestrator:     s.orchestrator,
+		PolicyRepo:       s.repo,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		WgConfig:         fakeTypes.WireguardConfig{},
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+	}
+	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -47,7 +59,19 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 	s := setupEndpointSuite(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	e, err := NewEndpointFromChangeModel(b.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, &fakeTypes.IPsecConfig{}, nil, nil, nil)
+	p := EndpointParams{
+		Logger:           logger,
+		EPBuildQueue:     &MockEndpointBuildQueue{},
+		Orchestrator:     s.orchestrator,
+		PolicyRepo:       s.repo,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		WgConfig:         fakeTypes.WireguardConfig{},
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+	}
+	e, err := NewEndpointFromChangeModel(b.Context(), p, nil, nil, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))

--- a/pkg/endpoint/creator/cell.go
+++ b/pkg/endpoint/creator/cell.go
@@ -4,6 +4,9 @@
 package creator
 
 import (
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/ipcache"
+
 	"github.com/cilium/hive/cell"
 )
 
@@ -12,5 +15,8 @@ var Cell = cell.Module(
 	"endpoint-creator",
 	"API for creating and parsing Endpoints",
 
+	cell.ProvidePrivate(func(ipc *ipcache.IPCache) endpoint.NamedPortsGetter {
+		return ipc
+	}),
 	cell.Provide(newEndpointCreator),
 )

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -4,26 +4,19 @@
 package endpoint
 
 import (
-	"context"
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
-	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
-	"github.com/cilium/cilium/pkg/node"
-	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
 func TestGetCiliumEndpointStatus(t *testing.T) {
-	s := setupEndpointSuite(t)
-
-	e, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), nil, &models.EndpointChangeRequest{
+	p := createTestEndpointParams(t)
+	m := &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: "192.168.1.100",
 			IPV6: "f00d::a10:0:0:abcd",
@@ -40,7 +33,8 @@ func TestGetCiliumEndpointStatus(t *testing.T) {
 			"k8s:name=probe",
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
-	}, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}
+	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, m, nil)
 	require.NoError(t, err)
 
 	status := e.GetCiliumEndpointStatus()
@@ -65,9 +59,8 @@ func TestGetCiliumEndpointStatus(t *testing.T) {
 }
 
 func TestGetCiliumEndpointStatusWithServiceAccount(t *testing.T) {
-	s := setupEndpointSuite(t)
-
-	e, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, ctmap.NewFakeGCRunner(), nil, &models.EndpointChangeRequest{
+	p := createTestEndpointParams(t)
+	m := &models.EndpointChangeRequest{
 		Addressing: &models.AddressPair{
 			IPV4: "192.168.1.100",
 			IPV6: "f00d::a10:0:0:abcd",
@@ -84,7 +77,8 @@ func TestGetCiliumEndpointStatusWithServiceAccount(t *testing.T) {
 			"k8s:name=probe",
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
-	}, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}
+	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, m, nil)
 	require.NoError(t, err)
 
 	// Create a mock pod with ServiceAccount

--- a/pkg/endpoint/params.go
+++ b/pkg/endpoint/params.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"log/slog"
+
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/lxcmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/policy"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
+
+	"github.com/cilium/hive/cell"
+)
+
+// EndpointParams is used to pass the many dependencies required
+// to create an endpoint.
+type EndpointParams struct {
+	cell.In
+
+	Logger              *slog.Logger
+	EPBuildQueue        EndpointBuildQueue
+	Loader              datapath.Loader
+	Orchestrator        datapath.Orchestrator
+	CompilationLock     datapath.CompilationLock
+	BandwidthManager    datapath.BandwidthManager
+	IPTablesManager     datapath.IptablesManager
+	IdentityManager     identitymanager.IDManager
+	MonitorAgent        monitoragent.Agent
+	PolicyMapFactory    policymap.Factory
+	PolicyRepo          policy.PolicyRepository
+	Allocator           cache.IdentityAllocator
+	CTMapGC             ctmap.GCRunner
+	KVStoreSynchronizer *ipcache.IPIdentitySynchronizer
+	WgConfig            wgTypes.WireguardConfig
+	IPSecConfig         datapath.IPsecConfig
+	NamedPortsGetter    NamedPortsGetter
+	LxcMap              lxcmap.Map
+	LocalNodeStore      node.NodeGetter
+}

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -47,7 +47,17 @@ func TestMarkAndSweep(t *testing.T) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		model := newTestEndpointModel(int(id), endpoint.StateReady)
-		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+			NamedPortsGetter: testipcache.NewMockIPCache(),
+			Allocator:        testidentity.NewMockIdentityAllocator(nil),
+			CTMapGC:          ctmap.NewFakeGCRunner(),
+			WgConfig:         &fakeTypes.WireguardConfig{},
+			IPSecConfig:      fakeTypes.IPsecConfig{},
+			Logger:           logger,
+			IdentityManager:  identitymanager.NewIDManager(logger),
+			PolicyRepo:       s.repo,
+		}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 		require.NoError(t, err)
 
 		ep.Start(uint16(model.ID))

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -391,7 +391,17 @@ func TestLookup(t *testing.T) {
 			logger := hivetest.Logger(t)
 			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, tt.cm, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+					EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+					NamedPortsGetter: testipcache.NewMockIPCache(),
+					Allocator:        testidentity.NewMockIdentityAllocator(nil),
+					CTMapGC:          ctmap.NewFakeGCRunner(),
+					WgConfig:         &fakeTypes.WireguardConfig{},
+					IPSecConfig:      fakeTypes.IPsecConfig{},
+					Logger:           logger,
+					IdentityManager:  identitymanager.NewIDManager(logger),
+					PolicyRepo:       s.repo,
+				}, nil, &endpoint.FakeEndpointProxy{}, tt.cm, nil)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
 				err = mgr.expose(ep)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -416,7 +426,17 @@ func TestLookupCiliumID(t *testing.T) {
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		PolicyRepo:       s.repo,
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           logger,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -491,10 +511,20 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &apiv1.EndpointChangeRequest{
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           logger,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
-	}, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	}, nil)
 	require.NoError(t, err)
 	require.NoError(t, mgr.expose(ep))
 
@@ -514,7 +544,17 @@ func TestLookupIPv4(t *testing.T) {
 
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(4, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           logger,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -667,7 +707,17 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+			NamedPortsGetter: testipcache.NewMockIPCache(),
+			Allocator:        testidentity.NewMockIdentityAllocator(nil),
+			CTMapGC:          ctmap.NewFakeGCRunner(),
+			WgConfig:         &fakeTypes.WireguardConfig{},
+			IPSecConfig:      fakeTypes.IPsecConfig{},
+			Logger:           logger,
+			IdentityManager:  identitymanager.NewIDManager(logger),
+			PolicyRepo:       s.repo,
+		}, nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		tt.preTestRun(ep)
 		args := tt.setupArgs()
@@ -710,9 +760,20 @@ func TestUpdateReferences(t *testing.T) {
 	}
 	for _, tt := range tests {
 		var err error
-		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, nil, nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, &tt.cm, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
-		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		logger := hivetest.Logger(t)
+		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+			NamedPortsGetter: testipcache.NewMockIPCache(),
+			Allocator:        testidentity.NewMockIdentityAllocator(nil),
+			CTMapGC:          ctmap.NewFakeGCRunner(),
+			WgConfig:         &fakeTypes.WireguardConfig{},
+			IPSecConfig:      fakeTypes.IPsecConfig{},
+			Logger:           logger,
+			IdentityManager:  identitymanager.NewIDManager(logger),
+			PolicyRepo:       s.repo,
+		}, nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
+		require.NoErrorf(t, err, "Test Name: %s", tt.name)
+		//logger := hivetest.Logger(t)
 		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 
 		err = mgr.expose(ep)
@@ -746,7 +807,17 @@ func TestRemove(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(7, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           logger,
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -806,7 +877,18 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter:    testipcache.NewMockIPCache(),
+		Allocator:           testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:             ctmap.NewFakeGCRunner(),
+		WgConfig:            &fakeTypes.WireguardConfig{},
+		IPSecConfig:         fakeTypes.IPsecConfig{},
+		Logger:              logger,
+		IdentityManager:     identitymanager.NewIDManager(logger),
+		PolicyRepo:          s.repo,
+		KVStoreSynchronizer: kvstoreSync,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -858,7 +940,18 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Add labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+				ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
+					NamedPortsGetter:    testipcache.NewMockIPCache(),
+					Allocator:           testidentity.NewMockIdentityAllocator(nil),
+					CTMapGC:             ctmap.NewFakeGCRunner(),
+					WgConfig:            &fakeTypes.WireguardConfig{},
+					IPSecConfig:         fakeTypes.IPsecConfig{},
+					Logger:              logger,
+					IdentityManager:     identitymanager.NewIDManager(logger),
+					PolicyRepo:          s.repo,
+					KVStoreSynchronizer: kvstoreSync,
+				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -889,7 +982,18 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+				ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
+					NamedPortsGetter:    testipcache.NewMockIPCache(),
+					Allocator:           testidentity.NewMockIdentityAllocator(nil),
+					CTMapGC:             ctmap.NewFakeGCRunner(),
+					WgConfig:            &fakeTypes.WireguardConfig{},
+					IPSecConfig:         fakeTypes.IPsecConfig{},
+					Logger:              logger,
+					IdentityManager:     identitymanager.NewIDManager(logger),
+					PolicyRepo:          s.repo,
+					KVStoreSynchronizer: kvstoreSync,
+				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -922,7 +1026,19 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+
+				ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
+					NamedPortsGetter:    testipcache.NewMockIPCache(),
+					Allocator:           testidentity.NewMockIdentityAllocator(nil),
+					CTMapGC:             ctmap.NewFakeGCRunner(),
+					WgConfig:            &fakeTypes.WireguardConfig{},
+					IPSecConfig:         fakeTypes.IPsecConfig{},
+					Logger:              logger,
+					IdentityManager:     identitymanager.NewIDManager(logger),
+					PolicyRepo:          s.repo,
+					KVStoreSynchronizer: kvstoreSync,
+				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 				ep.SetIsHost(true)
 				require.NoError(t, err)
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -170,7 +170,17 @@ func (s *DNSProxyTestSuite) LookupRegisteredEndpoint(ip netip.Addr) (*endpoint.E
 		return nil, false, fmt.Errorf("No EPs available when restoring")
 	}
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.TODO(), s.logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(s.logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           s.logger,
+		IdentityManager:  identitymanager.NewIDManager(s.logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	ep.Start(uint16(model.ID))
 	defer ep.Stop()
 	return ep, false, err
@@ -895,7 +905,17 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep1, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           hivetest.Logger(t),
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))
@@ -947,7 +967,17 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules for epID3
 	modelEP3 := newTestEndpointModel(int(epID3), endpoint.StateReady)
-	ep3, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, modelEP3, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep3, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           hivetest.Logger(t),
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep3.Start(uint16(modelEP3.ID))
@@ -1159,7 +1189,17 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 	// restore rules, set the mock to restoring state
 	s.restoring = true
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep1, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		WgConfig:         &fakeTypes.WireguardConfig{},
+		IPSecConfig:      fakeTypes.IPsecConfig{},
+		Logger:           hivetest.Logger(t),
+		IdentityManager:  identitymanager.NewIDManager(logger),
+		PolicyRepo:       s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -26,6 +26,12 @@ type LocalNodeSynchronizer interface {
 	WaitForNodeInformation(context.Context, *LocalNodeStore) error
 }
 
+// NodeGetter describes the behavior of a node store used for retrieving the
+// local node.
+type NodeGetter interface {
+	Get(ctx context.Context) (LocalNode, error)
+}
+
 // LocalNodeStoreCell provides the LocalNodeStore instance.
 // The LocalNodeStore is the canonical owner of `types.Node` for the local node and
 // provides a reactive API for observing and updating it.
@@ -62,7 +68,7 @@ type LocalNodeStore struct {
 	sync  LocalNodeSynchronizer
 }
 
-func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
+func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, NodeGetter, error) {
 	wtxn := params.DB.WriteTxn(params.Nodes)
 
 	// Register an initializer that'll mark the table initialized once we're done
@@ -127,7 +133,7 @@ func NewLocalNodeStore(params LocalNodeStoreParams) (*LocalNodeStore, error) {
 		},
 	})
 
-	return s, nil
+	return s, s, nil
 }
 
 // observeRatePerSecond sets the maximum number of [LocalNode] updates per second that


### PR DESCRIPTION
The various endpoint lifecycle commands are starting to get out of hand with the number of params being passed.

This cleans this up by refactoring things into some *Param types to cleanly pass these around.

