### PR TITLE
daemon: remove `startDaemon`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -379,6 +379,7 @@ Makefile* @cilium/build
 /daemon/cmd/bootstrap_statistics.go @cilium/metrics
 /daemon/cmd/policy* @cilium/sig-policy
 /daemon/cmd/cells*.go @cilium/sig-foundations
+/daemon/infraendpoints/ @cilium/sig-agent @cilium/endpoint
 /Documentation/ @cilium/docs-structure
 /Documentation/_static/ @cilium/docs-structure
 /Documentation/api.rst @cilium/sig-agent @cilium/docs-structure

--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -15,7 +15,6 @@ type bootstrapStatistics struct {
 	k8sInit     spanstat.SpanStat
 	restore     spanstat.SpanStat
 	healthCheck spanstat.SpanStat
-	ingressIPAM spanstat.SpanStat
 	cleanup     spanstat.SpanStat
 	bpfBase     spanstat.SpanStat
 	ipam        spanstat.SpanStat
@@ -48,7 +47,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"k8sInit":     &b.k8sInit,
 		"restore":     &b.restore,
 		"healthCheck": &b.healthCheck,
-		"ingressIPAM": &b.ingressIPAM,
 		"cleanup":     &b.cleanup,
 		"bpfBase":     &b.bpfBase,
 		"ipam":        &b.ipam,

--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -14,7 +14,6 @@ type bootstrapStatistics struct {
 	earlyInit   spanstat.SpanStat
 	k8sInit     spanstat.SpanStat
 	restore     spanstat.SpanStat
-	healthCheck spanstat.SpanStat
 	cleanup     spanstat.SpanStat
 	bpfBase     spanstat.SpanStat
 	ipam        spanstat.SpanStat
@@ -46,7 +45,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"earlyInit":   &b.earlyInit,
 		"k8sInit":     &b.k8sInit,
 		"restore":     &b.restore,
-		"healthCheck": &b.healthCheck,
 		"cleanup":     &b.cleanup,
 		"bpfBase":     &b.bpfBase,
 		"ipam":        &b.ipam,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/daemon/healthz"
+	"github.com/cilium/cilium/daemon/infraendpoints"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/daemon/restapi"
 	"github.com/cilium/cilium/pkg/api"
@@ -174,6 +175,9 @@ var (
 	ControlPlane = cell.Module(
 		"controlplane",
 		"Control Plane",
+
+		// IP allocation and creation of agents infrastructure endpoints (host, health & ingress)
+		infraendpoints.Cell,
 
 		// LocalNodeStore holds onto the information about the local node and allows
 		// observing changes to it.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -258,19 +258,14 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		}
 	}
 
+	// Launch the K8s watchers in parallel as we continue to process other
+	// daemon options.
 	// Some of the k8s watchers rely on option flags set above (specifically
 	// EnableBPFMasquerade), so we should only start them once the flag values
 	// are set.
-	if params.Clientset.IsEnabled() {
-		bootstrapStats.k8sInit.Start()
-
-		// Launch the K8s watchers in parallel as we continue to process other
-		// daemon options.
-		params.K8sWatcher.InitK8sSubsystem(ctx, params.CacheStatus)
-		bootstrapStats.k8sInit.End(true)
-	} else {
-		close(params.CacheStatus)
-	}
+	bootstrapStats.k8sInit.Start()
+	params.K8sWatcher.InitK8sSubsystem(ctx)
+	bootstrapStats.k8sInit.End(true)
 
 	bootstrapStats.cleanup.Start()
 	err = clearCiliumVeths(params.Logger)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cilium/cilium/daemon/infraendpoints"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
@@ -278,7 +279,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	// the Kubernetes or CiliumNode resource in the K8s subsystem from call
 	// k8s.WaitForNodeInformation(). These will be used later after starting
 	// IPAM initialization to finish off the `cilium_host` IP restoration.
-	var restoredRouterIPs restoredIPs
+	var restoredRouterIPs infraendpoints.RestoredIPs
 	restoredRouterIPs.IPv4FromK8s, restoredRouterIPs.IPv6FromK8s = node.GetInternalIPv4Router(params.Logger), node.GetIPv6Router(params.Logger)
 	// Fetch the router IPs from the filesystem in case they were set a priori
 	restoredRouterIPs.IPv4FromFS, restoredRouterIPs.IPv6FromFS = node.ExtractCiliumHostIPFromFS(params.Logger)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -400,6 +400,9 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		}
 	}
 
+	bootstrapStats.overall.End(true)
+	bootstrapStats.updateMetrics()
+
 	return nil
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -34,7 +34,6 @@ import (
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
-	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -1240,7 +1239,6 @@ type daemonParams struct {
 	Resources           agentK8s.Resources
 	K8sWatcher          *watchers.K8sWatcher
 	NodeHandler         datapath.NodeHandler
-	EndpointCreator     endpointcreator.EndpointCreator
 	EndpointManager     endpointmanager.EndpointManager
 	EndpointRestorer    *endpointRestorer
 	IdentityAllocator   identitycell.CachingIdentityAllocator
@@ -1354,15 +1352,6 @@ func daemonLegacyInitialization(params daemonParams) legacy.DaemonInitialization
 func startDaemon(ctx context.Context, params daemonParams) error {
 	if err := params.EndpointRestorer.InitRestore(ctx); err != nil {
 		return err
-	}
-
-	if params.EndpointManager.HostEndpointExists() {
-		params.EndpointManager.InitHostEndpointLabels(ctx)
-	} else {
-		params.Logger.Info("Creating host endpoint")
-		if err := params.EndpointCreator.AddHostEndpoint(ctx); err != nil {
-			return fmt.Errorf("unable to create host endpoint: %w", err)
-		}
 	}
 
 	if err := params.MonitorAgent.SendEvent(monitorAPI.MessageTypeAgent, monitorAPI.StartMessage(time.Now())); err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cilium/cilium/daemon/cmd/legacy"
+	"github.com/cilium/cilium/daemon/infraendpoints"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
@@ -1200,7 +1201,6 @@ var daemonCell = cell.Module(
 		promise.New[*option.DaemonConfig],
 		newSyncHostIPs,
 		newEndpointRestorer,
-		newInfraIPAllocator,
 	),
 	cell.Invoke(registerEndpointStateResolver),
 	cell.Invoke(func(_ legacy.DaemonInitialization) {}), // Force instantiation.
@@ -1265,7 +1265,7 @@ type daemonParams struct {
 	KPRConfig           kpr.KPRConfig
 	KPRInitializer      kprinitializer.KPRInitializer
 	HealthConfig        healthconfig.CiliumHealthConfig
-	InfraIPAllocator    *infraIPAllocator
+	InfraIPAllocator    infraendpoints.InfraIPAllocator
 }
 
 func daemonConfigInitialization(params daemonConfigParams) legacy.DaemonConfigInitialization {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1241,7 +1241,6 @@ type daemonParams struct {
 	LocalNodeStore      *node.LocalNodeStore
 	Resources           agentK8s.Resources
 	K8sWatcher          *watchers.K8sWatcher
-	CacheStatus         k8sSynced.CacheStatus
 	NodeHandler         datapath.NodeHandler
 	EndpointCreator     endpointcreator.EndpointCreator
 	EndpointManager     endpointmanager.EndpointManager

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1365,23 +1365,6 @@ func startDaemon(ctx context.Context, params daemonParams) error {
 		}
 	}
 
-	if params.DaemonConfig.EnableEnvoyConfig {
-		if !params.EndpointManager.IngressEndpointExists() {
-			// Creating Ingress Endpoint depends on the Ingress IPs having been
-			// allocated first. This happens earlier in the agent bootstrap.
-			if (params.DaemonConfig.EnableIPv4 && len(node.GetIngressIPv4(params.Logger)) == 0) ||
-				(option.Config.EnableIPv6 && len(node.GetIngressIPv6(params.Logger)) == 0) {
-				params.Logger.Warn("Ingress IPs are not available, skipping creation of the Ingress Endpoint: Policy enforcement on Cilium Ingress will not work as expected.")
-			} else {
-				params.Logger.Info("Creating ingress endpoint")
-				err := params.EndpointCreator.AddIngressEndpoint(ctx)
-				if err != nil {
-					return fmt.Errorf("unable to create ingress endpoint: %w", err)
-				}
-			}
-		}
-	}
-
 	if err := params.MonitorAgent.SendEvent(monitorAPI.MessageTypeAgent, monitorAPI.StartMessage(time.Now())); err != nil {
 		params.Logger.Warn("Failed to send agent start monitor message", logfields.Error, err)
 	}

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -662,9 +662,6 @@ func (r *endpointRestorer) InitRestore(ctx context.Context) error {
 		return fmt.Errorf("failed to wait for initial IPCache revision: %w", err)
 	}
 
-	bootstrapStats.restore.Start()
-	defer bootstrapStats.restore.End(true)
-
 	// When we regenerate restored endpoints, it is guaranteed that we have
 	// received the full list of policies present at the time the daemon
 	// is bootstrapped.

--- a/daemon/infraendpoints/cell.go
+++ b/daemon/infraendpoints/cell.go
@@ -14,4 +14,5 @@ var Cell = cell.Module(
 
 	cell.Provide(newInfraIPAllocator),
 	cell.Invoke(registerIngressEndpoint),
+	cell.Invoke(registerHostEndpoint),
 )

--- a/daemon/infraendpoints/cell.go
+++ b/daemon/infraendpoints/cell.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package infraendpoints
+
+import "github.com/cilium/hive/cell"
+
+// Cell is responsible to initialize the Cilium Agent "infrastructure"
+// (host, health, ingress) endpoints. This includes IP allocation and
+// setting up the endpoint.
+var Cell = cell.Module(
+	"agent-infra-endpoints",
+	"Cilium Agent infrastructure endpoints",
+
+	cell.Provide(newInfraIPAllocator),
+)

--- a/daemon/infraendpoints/cell.go
+++ b/daemon/infraendpoints/cell.go
@@ -13,4 +13,5 @@ var Cell = cell.Module(
 	"Cilium Agent infrastructure endpoints",
 
 	cell.Provide(newInfraIPAllocator),
+	cell.Invoke(registerIngressEndpoint),
 )

--- a/daemon/infraendpoints/host_endpoint.go
+++ b/daemon/infraendpoints/host_endpoint.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package infraendpoints
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+type hostEndpointParams struct {
+	cell.In
+
+	Logger *slog.Logger
+
+	JobGroup job.Group
+
+	EndpointCreator        endpointcreator.EndpointCreator
+	EndpointManager        endpointmanager.EndpointManager
+	EndpointRestorePromise promise.Promise[endpointstate.Restorer]
+}
+
+type hostEndpointCreator struct {
+	logger                 *slog.Logger
+	endpointCreator        endpointcreator.EndpointCreator
+	endpointManager        endpointmanager.EndpointManager
+	endpointRestorePromise promise.Promise[endpointstate.Restorer]
+}
+
+func registerHostEndpoint(params hostEndpointParams) {
+	creator := &hostEndpointCreator{
+		logger:                 params.Logger,
+		endpointCreator:        params.EndpointCreator,
+		endpointManager:        params.EndpointManager,
+		endpointRestorePromise: params.EndpointRestorePromise,
+	}
+
+	params.JobGroup.Add(job.OneShot("init-host-endpoint", creator.createHostEndpoint, job.WithShutdown()))
+}
+
+func (c *hostEndpointCreator) createHostEndpoint(ctx context.Context, health cell.Health) error {
+	health.OK("Wait for endpoint restoration")
+	r, err := c.endpointRestorePromise.Await(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for endpoint restorer promise: %w", err)
+	}
+
+	if err := r.WaitForEndpointRestoreWithoutRegeneration(ctx); err != nil {
+		return fmt.Errorf("failed to wait for endpoint restoration: %w", err)
+	}
+
+	health.OK("Start initialization")
+
+	if c.endpointManager.HostEndpointExists() {
+		c.logger.Info("Initializing labels on existing host endpoint")
+		c.endpointManager.InitHostEndpointLabels(ctx)
+		return nil
+	}
+
+	c.logger.Info("Creating host endpoint")
+	if err := c.endpointCreator.AddHostEndpoint(ctx); err != nil {
+		return fmt.Errorf("unable to create host endpoint: %w", err)
+	}
+
+	return nil
+}

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package infraendpoints
 
 import (
 	"fmt"

--- a/daemon/infraendpoints/ingress_endpoint.go
+++ b/daemon/infraendpoints/ingress_endpoint.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package infraendpoints
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+type ingressEndpointCreatorParams struct {
+	cell.In
+
+	Logger       *slog.Logger
+	DaemonConfig *option.DaemonConfig
+
+	JobGroup job.Group
+
+	EndpointCreator        endpointcreator.EndpointCreator
+	EndpointManager        endpointmanager.EndpointManager
+	EndpointRestorePromise promise.Promise[endpointstate.Restorer]
+}
+
+type ingressEndpointCreator struct {
+	logger                 *slog.Logger
+	endpointCreator        endpointcreator.EndpointCreator
+	endpointManager        endpointmanager.EndpointManager
+	endpointRestorePromise promise.Promise[endpointstate.Restorer]
+
+	ipv4Enabled bool
+	ipv6Enabled bool
+}
+
+func registerIngressEndpoint(params ingressEndpointCreatorParams) {
+	if !params.DaemonConfig.EnableEnvoyConfig {
+		return
+	}
+
+	creator := &ingressEndpointCreator{
+		logger:                 params.Logger,
+		endpointCreator:        params.EndpointCreator,
+		endpointManager:        params.EndpointManager,
+		endpointRestorePromise: params.EndpointRestorePromise,
+		ipv4Enabled:            params.DaemonConfig.IPv4Enabled(),
+		ipv6Enabled:            params.DaemonConfig.IPv6Enabled(),
+	}
+
+	params.JobGroup.Add(job.OneShot("init-ingress-endpoint", creator.createIngressEndpoint, job.WithShutdown()))
+}
+
+func (c *ingressEndpointCreator) createIngressEndpoint(ctx context.Context, health cell.Health) error {
+	health.OK("Wait for endpoint restoration")
+	r, err := c.endpointRestorePromise.Await(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for endpoint restorer promise: %w", err)
+	}
+
+	if err := r.WaitForEndpointRestoreWithoutRegeneration(ctx); err != nil {
+		return fmt.Errorf("failed to wait for endpoint restoration: %w", err)
+	}
+
+	health.OK("Start initialization")
+
+	if c.endpointManager.IngressEndpointExists() {
+		c.logger.Debug("Ingress endpoint already exists")
+		return nil
+	}
+
+	// Creating Ingress Endpoint depends on the Ingress IPs having been
+	// allocated first. This happens earlier in the agent bootstrap.
+	if (c.ipv4Enabled && len(node.GetIngressIPv4(c.logger)) == 0) ||
+		(c.ipv6Enabled && len(node.GetIngressIPv6(c.logger)) == 0) {
+		msg := "Ingress IPs are not available, skipping creation of the Ingress Endpoint: Policy enforcement on Cilium Ingress will not work as expected."
+		c.logger.Warn(msg)
+		health.Degraded(msg, nil)
+		return nil
+	}
+
+	c.logger.Info("Creating ingress endpoint")
+	if err := c.endpointCreator.AddIngressEndpoint(ctx); err != nil {
+		return fmt.Errorf("unable to create ingress endpoint: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/k8s/watchers/cell.go
+++ b/pkg/k8s/watchers/cell.go
@@ -45,6 +45,7 @@ type k8sWatcherParams struct {
 	Clientset         k8sClient.Clientset
 	K8sResourceSynced *k8sSynced.Resources
 	K8sAPIGroups      *k8sSynced.APIGroups
+	K8sCacheStatus    k8sSynced.CacheStatus
 	ResourceGroupsFn  ResourceGroupFunc
 
 	KVStoreClient kvstore.Client
@@ -61,6 +62,7 @@ func newK8sWatcher(params k8sWatcherParams) *K8sWatcher {
 		params.K8sCiliumEndpointsWatcher,
 		params.K8sEventReporter,
 		params.K8sResourceSynced,
+		params.K8sCacheStatus,
 		params.K8sAPIGroups,
 		params.AgentConfig,
 		params.KVStoreClient,


### PR DESCRIPTION
This PR removes the function `startDaemon` that is part of the legacy daemon initialization logic.

Please review the individual commits.