### PR TITLE
cli: cleanups for pre-v1.15 removal

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -51,7 +51,6 @@ const (
 	configNameClusterID   = "cluster-id"
 	configNameClusterName = "cluster-name"
 
-	configNameTunnelLegacy         = "tunnel"
 	configNameTunnelProtocol       = "tunnel-protocol"
 	configNameRoutingMode          = "routing-mode"
 	configNameMaxConnectedClusters = "max-connected-clusters"

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -409,25 +409,23 @@ const (
 	// the reason why this exception is needed.
 
 	// errors
-	panicMessage                         = "panic:"
-	deadLockHeader                       = "POTENTIAL DEADLOCK:"                                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	RunInitFailed                        = "JoinEP: "                                             // from https://github.com/cilium/cilium/pull/5052
-	emptyBPFInitArg                      = "empty argument passed to bpf/init.sh"                 // from https://github.com/cilium/cilium/issues/10228
-	RemovingMapMsg                       = "Removing map to allow for property upgrade"           // from https://github.com/cilium/cilium/pull/10626
-	symbolSubstitution                   = "Skipping symbol substitution"                         //
-	uninitializedRegen                   = "Uninitialized regeneration level"                     // from https://github.com/cilium/cilium/pull/10949
-	unstableStat                         = "BUG: stat() has unstable behavior"                    // from https://github.com/cilium/cilium/pull/11028
-	removeInexistentID     stringMatcher = "removing identity not added to the identity manager!" // from https://github.com/cilium/cilium/issues/16419
-	missingIptablesWait                  = "Missing iptables wait arg (-w):"
-	localIDRestoreFail                   = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
-	routerIPMismatch                     = "Mismatch of router IPs found during restoration"
-	emptyIPNodeIDAlloc                   = "Attempt to allocate a node ID for an empty node IP address"
-	failedToListCRDs       stringMatcher = "the server could not find the requested resource" // cf. https://github.com/cilium/cilium/issues/16425
-	failedToUpdateLock     stringMatcher = "Failed to update lock:"
-	failedToReleaseLock    stringMatcher = "Failed to release lock:"
-	previouslyUsedCIDR     stringMatcher = "Unable to find identity of previously used CIDR"                           // from https://github.com/cilium/cilium/issues/26881
-	klogLeaderElectionFail stringMatcher = "error retrieving resource lock kube-system/cilium-operator-resource-lock:" // from: https://github.com/cilium/cilium/issues/31050
-	nilDetailsForService   stringMatcher = "retrieved nil details for Service"                                         // from: https://github.com/cilium/cilium/issues/35595
+	panicMessage                       = "panic:"
+	deadLockHeader                     = "POTENTIAL DEADLOCK:"                                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	RunInitFailed                      = "JoinEP: "                                             // from https://github.com/cilium/cilium/pull/5052
+	emptyBPFInitArg                    = "empty argument passed to bpf/init.sh"                 // from https://github.com/cilium/cilium/issues/10228
+	RemovingMapMsg                     = "Removing map to allow for property upgrade"           // from https://github.com/cilium/cilium/pull/10626
+	symbolSubstitution                 = "Skipping symbol substitution"                         //
+	uninitializedRegen                 = "Uninitialized regeneration level"                     // from https://github.com/cilium/cilium/pull/10949
+	unstableStat                       = "BUG: stat() has unstable behavior"                    // from https://github.com/cilium/cilium/pull/11028
+	removeInexistentID   stringMatcher = "removing identity not added to the identity manager!" // from https://github.com/cilium/cilium/issues/16419
+	missingIptablesWait                = "Missing iptables wait arg (-w):"
+	localIDRestoreFail                 = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
+	routerIPMismatch                   = "Mismatch of router IPs found during restoration"
+	emptyIPNodeIDAlloc                 = "Attempt to allocate a node ID for an empty node IP address"
+	failedToListCRDs     stringMatcher = "the server could not find the requested resource" // cf. https://github.com/cilium/cilium/issues/16425
+	failedToUpdateLock   stringMatcher = "Failed to update lock:"
+	failedToReleaseLock  stringMatcher = "Failed to release lock:"
+	nilDetailsForService stringMatcher = "retrieved nil details for Service" // from: https://github.com/cilium/cilium/issues/35595
 
 	// warnings
 	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.


### PR DESCRIPTION
Remove a bit of unused code that was left behind by
https://github.com/cilium/cilium/commit/8cd07122737522b0f8f7ada633ee1e3f07708e48 ("cli: require Cilium v1.15").