### PR TITLE
vendor: Bump to StateDB v0.5.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.0-20251021073839-03494cb6c4de
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.5.2
+	github.com/cilium/statedb v0.5.6
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.5.2 h1:NqolzqeChszirabHdu2hTt0OiyAcP7ydntG9majd9P0=
-github.com/cilium/statedb v0.5.2/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
+github.com/cilium/statedb v0.5.6 h1:qid1eoMlWAYi02qMHL9Ewdhtd+FCoTF6nGUrcBB36to=
+github.com/cilium/statedb v0.5.6/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -199,8 +199,11 @@ type WriteTxn struct {
 // tables to be used with the methods of [Writer]. The returned transaction MUST be
 // Abort()'ed or Commit()'ed.
 func (w *Writer) WriteTxn(extraTables ...statedb.TableMeta) WriteTxn {
+	if len(extraTables) == 0 {
+		return WriteTxn{w.db.WriteTxn(w.svcs, w.bes, w.fes)}
+	}
 	return WriteTxn{
-		w.db.WriteTxn(w.svcs, append(extraTables, w.bes, w.fes)...),
+		w.db.WriteTxn(append(extraTables, w.svcs, w.bes, w.fes)...),
 	}
 }
 

--- a/vendor/github.com/cilium/statedb/Makefile
+++ b/vendor/github.com/cilium/statedb/Makefile
@@ -6,7 +6,7 @@ build:
 	go build ./...
 
 test:
-	go test ./... -cover -vet=all -test.count 1
+	PART_VALIDATE=1 go test ./... -cover -vet=all -test.count 1
 
 test-race:
 	go test -race ./... -test.count 1

--- a/vendor/github.com/cilium/statedb/deletetracker.go
+++ b/vendor/github.com/cilium/statedb/deletetracker.go
@@ -59,7 +59,8 @@ func (dt *deleteTracker[Obj]) close() {
 	}
 
 	// Remove the delete tracker from the table.
-	txn := dt.db.WriteTxn(dt.table).getTxn()
+	wtxn := dt.db.WriteTxn(dt.table)
+	txn := wtxn.getTxn()
 	dt.db = nil
 	db := txn.db
 	table := txn.modifiedTables[dt.table.tablePos()]
@@ -67,7 +68,7 @@ func (dt *deleteTracker[Obj]) close() {
 		panic("BUG: Table missing from write transaction")
 	}
 	_, _, table.deleteTrackers = table.deleteTrackers.Delete([]byte(dt.trackerName))
-	txn.Commit()
+	wtxn.Commit()
 
 	db.metrics.DeleteTrackerCount(dt.table.Name(), table.deleteTrackers.Len())
 

--- a/vendor/github.com/cilium/statedb/part/cache.go
+++ b/vendor/github.com/cilium/statedb/part/cache.go
@@ -9,28 +9,48 @@ import (
 
 const nodeMutatedSize = 256 // must be power-of-two
 
-type nodeMutated struct {
-	ptrs [nodeMutatedSize]uintptr
+// nodeMutated is a probabilistic check for seeing if a node has
+// been cloned within a transaction and thus can be modified in-place
+// since it has not been seen outside. This significantly speeds up
+// writes within a single write transaction as inner nodes no longer
+// need to be cloned on every change, effectively making the immutable
+// radix tree perform as if it's a mutable one.
+//
+// Earlier versions of StateDB just used a map[*header[T]]struct{}, but
+// that was fairly costly and experiments showed that it's enough to most
+// of the time avoid the clone to perform well.
+//
+// The value for [nodeMutatedSize] is a balance between making Txn()
+// not too costly (due to e.g. clear()) and between giving a high likelyhood
+// that we mutate nodes in-place.
+type nodeMutated[T any] struct {
+	ptrs [nodeMutatedSize]*header[T]
 	used bool
 }
 
-func nodeMutatedSet[T any](nm *nodeMutated, ptr *header[T]) {
+func (nm *nodeMutated[T]) set(n *header[T]) {
 	if nm == nil {
 		return
 	}
-	ptrInt := uintptr(unsafe.Pointer(ptr))
-	nm.ptrs[slot(ptrInt)] = ptrInt
+	ptrInt := uintptr(unsafe.Pointer(n))
+	nm.ptrs[slot(ptrInt)] = n
 	nm.used = true
 }
 
-func nodeMutatedExists[T any](nm *nodeMutated, ptr *header[T]) bool {
+func (nm *nodeMutated[T]) exists(n *header[T]) bool {
 	if nm == nil {
 		return false
 	}
-	ptrInt := uintptr(unsafe.Pointer(ptr))
-	return nm.ptrs[slot(ptrInt)] == ptrInt
+	ptrInt := uintptr(unsafe.Pointer(n))
+	return nm.ptrs[slot(ptrInt)] == n
 }
 
+// slot returns the index in the [ptrs] array for a given pointer.
+// The Go spec allows objects to be moved so it may be that the same
+// instance of an object is assigned to a different memory location in
+// which case we'd no longer report that node as being in the cache.
+// This is fine though as we do compare the actual *header[T] pointers
+// and this is probabilistic anyway as this is a fixed size cache.
 func slot(p uintptr) int {
 	p >>= 4 // ignore low order bits
 	// use some relevant bits from the pointer
@@ -38,7 +58,7 @@ func slot(p uintptr) int {
 	return int(slot & (nodeMutatedSize - 1))
 }
 
-func (nm *nodeMutated) clear() {
+func (nm *nodeMutated[T]) clear() {
 	if nm == nil {
 		return
 	}

--- a/vendor/github.com/cilium/statedb/part/iterator.go
+++ b/vendor/github.com/cilium/statedb/part/iterator.go
@@ -64,9 +64,13 @@ func newIterator[T any](start *header[T]) *Iterator[T] {
 	return &Iterator[T]{[][]*header[T]{{start}}}
 }
 
-func prefixSearch[T any](root *header[T], prefix []byte) (*Iterator[T], <-chan struct{}) {
+func prefixSearch[T any](root *header[T], rootWatch <-chan struct{}, prefix []byte) (*Iterator[T], <-chan struct{}) {
+	if root == nil {
+		return newIterator[T](nil), rootWatch
+	}
+
 	this := root
-	watch := root.watch
+	watch := rootWatch
 	for {
 		// Does the node have part of the prefix we're looking for?
 		commonPrefix := this.prefix()[:min(len(prefix), int(this.prefixLen))]
@@ -118,6 +122,10 @@ func traverseToMin[T any](n *header[T], edges [][]*header[T]) [][]*header[T] {
 }
 
 func lowerbound[T any](start *header[T], key []byte) *Iterator[T] {
+	if start == nil {
+		return &Iterator[T]{nil}
+	}
+
 	// The starting edges to explore. This contains all larger nodes encountered
 	// on the path to the node larger or equal to the key.
 	edges := [][]*header[T]{}

--- a/vendor/github.com/cilium/statedb/part/set.go
+++ b/vendor/github.com/cilium/statedb/part/set.go
@@ -36,7 +36,7 @@ func NewSet[T any](values ...T) Set[T] {
 	for _, v := range values {
 		txn.Insert(s.toBytes(v), v)
 	}
-	s.tree = txn.CommitOnly()
+	s.tree = txn.Commit()
 	return s
 }
 
@@ -52,7 +52,7 @@ func (s Set[T]) Set(v T) Set[T] {
 	s.ensureTree()
 	txn := s.tree.Txn()
 	txn.Insert(s.toBytes(v), v)
-	s.tree = txn.CommitOnly() // As Set is passed by value we can just modify it.
+	s.tree = txn.Commit() // As Set is passed by value we can just modify it.
 	return s
 }
 
@@ -64,7 +64,7 @@ func (s Set[T]) Delete(v T) Set[T] {
 	}
 	txn := s.tree.Txn()
 	txn.Delete(s.toBytes(v))
-	s.tree = txn.CommitOnly()
+	s.tree = txn.Commit()
 	if s.tree.Len() == 0 {
 		s.tree = nil
 	}
@@ -102,7 +102,7 @@ func (s Set[T]) Union(s2 Set[T]) Set[T] {
 	for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
 		txn.Insert(k, v)
 	}
-	s.tree = txn.CommitOnly()
+	s.tree = txn.Commit()
 	return s
 }
 
@@ -118,7 +118,7 @@ func (s Set[T]) Difference(s2 Set[T]) Set[T] {
 	for k, _, ok := iter.Next(); ok; k, _, ok = iter.Next() {
 		txn.Delete(k)
 	}
-	s.tree = txn.CommitOnly()
+	s.tree = txn.Commit()
 	return s
 }
 
@@ -207,7 +207,7 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 		}
 		txn.Insert(s.toBytes(x), x)
 	}
-	s.tree = txn.CommitOnly()
+	s.tree = txn.Commit()
 	if s.tree.Len() == 0 {
 		s.tree = nil
 	}
@@ -243,7 +243,7 @@ func (s *Set[T]) UnmarshalYAML(value *yaml.Node) error {
 		}
 		txn.Insert(s.toBytes(v), v)
 	}
-	s.tree = txn.CommitOnly()
+	s.tree = txn.Commit()
 	return nil
 }
 

--- a/vendor/github.com/cilium/statedb/part/txn.go
+++ b/vendor/github.com/cilium/statedb/part/txn.go
@@ -5,12 +5,20 @@ package part
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"slices"
 )
 
 // Txn is a transaction against a tree. It allows doing efficient
 // modifications to a tree by caching and reusing cloned nodes.
 type Txn[T any] struct {
-	root *header[T]
+	root      *header[T]
+	oldRoot   *header[T]
+	rootWatch chan struct{}
+
+	dirty bool
+
 	opts options
 	size int // the number of objects in the tree
 
@@ -18,7 +26,7 @@ type Txn[T any] struct {
 	// that we can keep mutating without cloning them again.
 	// It is cleared if the transaction is cloned or iterated
 	// upon.
-	mutated *nodeMutated
+	mutated *nodeMutated[T]
 
 	// watches contains the channels of cloned nodes that should be closed
 	// when transaction is committed.
@@ -41,10 +49,10 @@ func (txn *Txn[T]) Clone() Ops[T] {
 	// further modifications in this transaction.
 	txn.mutated.clear()
 	return &Tree[T]{
-		opts: txn.opts,
-		root: txn.root,
-		size: txn.size,
-		txn:  nil,
+		opts:      txn.opts,
+		root:      txn.root,
+		rootWatch: txn.rootWatch,
+		size:      txn.size,
 	}
 }
 
@@ -60,11 +68,12 @@ func (txn *Txn[T]) Insert(key []byte, value T) (old T, hadOld bool) {
 // key changes again.
 func (txn *Txn[T]) InsertWatch(key []byte, value T) (old T, hadOld bool, watch <-chan struct{}) {
 	old, hadOld, watch, txn.root = txn.insert(txn.root, key, value)
+	validateTree(txn.root, nil, txn.watches)
 	if !hadOld {
 		txn.size++
 	}
 	if txn.opts.rootOnlyWatch() {
-		watch = txn.root.watch
+		watch = txn.rootWatch
 	}
 	return
 }
@@ -85,11 +94,12 @@ func (txn *Txn[T]) Modify(key []byte, mod func(T) T) (old T, hadOld bool) {
 // when the key changes again.
 func (txn *Txn[T]) ModifyWatch(key []byte, mod func(T) T) (old T, hadOld bool, watch <-chan struct{}) {
 	old, hadOld, watch, txn.root = txn.modify(txn.root, key, mod)
+	validateTree(txn.root, nil, txn.watches)
 	if !hadOld {
 		txn.size++
 	}
 	if txn.opts.rootOnlyWatch() {
-		watch = txn.root.watch
+		watch = txn.rootWatch
 	}
 	return
 }
@@ -98,6 +108,7 @@ func (txn *Txn[T]) ModifyWatch(key []byte, mod func(T) T) (old T, hadOld bool, w
 // Returns the old value if it exists.
 func (txn *Txn[T]) Delete(key []byte) (old T, hadOld bool) {
 	old, hadOld, txn.root = txn.delete(txn.root, key)
+	validateTree(txn.root, nil, txn.watches)
 	if hadOld {
 		txn.size--
 	}
@@ -108,7 +119,7 @@ func (txn *Txn[T]) Delete(key []byte) (old T, hadOld bool) {
 // Since this is the channel associated with the root, this closes
 // when there are any changes to the tree.
 func (txn *Txn[T]) RootWatch() <-chan struct{} {
-	return txn.root.watch
+	return txn.rootWatch
 }
 
 // Get fetches the value associated with the given key.
@@ -116,10 +127,7 @@ func (txn *Txn[T]) RootWatch() <-chan struct{} {
 // modification to the key) and boolean which is true if
 // value was found.
 func (txn *Txn[T]) Get(key []byte) (T, <-chan struct{}, bool) {
-	value, watch, ok := search(txn.root, key)
-	if txn.opts.rootOnlyWatch() {
-		watch = txn.root.watch
-	}
+	value, watch, ok := search(txn.root, txn.rootWatch, key)
 	return value, watch, ok
 }
 
@@ -128,11 +136,7 @@ func (txn *Txn[T]) Get(key []byte) (T, <-chan struct{}, bool) {
 // the given prefix are upserted or deleted.
 func (txn *Txn[T]) Prefix(key []byte) (*Iterator[T], <-chan struct{}) {
 	txn.mutated.clear()
-	iter, watch := prefixSearch(txn.root, key)
-	if txn.opts.rootOnlyWatch() {
-		watch = txn.root.watch
-	}
-	return iter, watch
+	return prefixSearch(txn.root, txn.rootWatch, key)
 }
 
 // LowerBound returns an iterator for all objects that have a
@@ -148,21 +152,33 @@ func (txn *Txn[T]) Iterator() *Iterator[T] {
 	return newIterator(txn.root)
 }
 
-// Commit the transaction and produce the new tree.
-func (txn *Txn[T]) Commit() *Tree[T] {
+// CommitAndNotify commits the transaction and notifies by
+// closing the watch channels of all modified nodes.
+func (txn *Txn[T]) CommitAndNotify() *Tree[T] {
 	txn.Notify()
-	return txn.CommitOnly()
+	return txn.Commit()
 }
 
-// CommitOnly the transaction, but do not close the
+// Commit the transaction, but do not close the
 // watch channels. Returns the new tree.
 // To close the watch channels call Notify(). You must call Notify() before
 // Tree.Txn().
-func (txn *Txn[T]) CommitOnly() *Tree[T] {
-	t := &Tree[T]{opts: txn.opts, root: txn.root, size: txn.size}
-	if !txn.opts.noCache() {
-		t.txn = txn
+func (txn *Txn[T]) Commit() *Tree[T] {
+	newRootWatch := txn.rootWatch
+	if txn.dirty {
+		newRootWatch = make(chan struct{})
+		validateTree(txn.oldRoot, nil, nil)
+		validateTree(txn.root, nil, txn.watches)
 	}
+	t := &Tree[T]{
+		opts:      txn.opts,
+		root:      txn.root,
+		rootWatch: newRootWatch,
+		size:      txn.size,
+	}
+	txn.mutated.clear()
+	// Store this txn in the tree to reuse the allocation next time.
+	t.prevTxn.Store(txn)
 	return t
 }
 
@@ -174,22 +190,37 @@ func (txn *Txn[T]) Notify() {
 		close(ch)
 	}
 	clear(txn.watches)
+	if !txn.dirty && len(txn.watches) > 0 {
+		panic("BUG: watch channels marked but txn not dirty")
+	}
+	if txn.dirty && txn.rootWatch != nil {
+		close(txn.rootWatch)
+		txn.rootWatch = nil
+	}
+	if !txn.opts.rootOnlyWatch() {
+		validateRemovedWatches(txn.oldRoot, txn.root)
+	}
 }
 
 // PrintTree to the standard output. For debugging.
 func (txn *Txn[T]) PrintTree() {
 	txn.root.printTree(0)
+	fmt.Printf("watches: ")
+	for watch := range txn.watches {
+		fmt.Printf("%p ", watch)
+	}
+	fmt.Println()
 }
 
 func (txn *Txn[T]) cloneNode(n *header[T]) *header[T] {
-	if nodeMutatedExists(txn.mutated, n) {
+	if txn.mutated.exists(n) {
 		return n
 	}
 	if n.watch != nil {
 		txn.watches[n.watch] = struct{}{}
 	}
-	n = n.clone(!txn.opts.rootOnlyWatch() || n == txn.root)
-	nodeMutatedSet(txn.mutated, n)
+	n = n.clone(!txn.opts.rootOnlyWatch())
+	txn.mutated.set(n)
 	return n
 }
 
@@ -198,7 +229,14 @@ func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, had
 }
 
 func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue T, hadOld bool, watch <-chan struct{}, newRoot *header[T]) {
+	txn.dirty = true
 	fullKey := key
+
+	if root == nil {
+		var zero T
+		leaf := newLeaf(txn.opts, key, fullKey, mod(zero))
+		return zero, false, leaf.watch, leaf.self()
+	}
 
 	// Start recursing from the root to find the insertion point.
 	// Point [thisp] to the root we're returning. It'll be replaced by a clone of the root when we recurse into it.
@@ -209,13 +247,14 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 	// it, we do it and return. If an existing node exists where the key should go, then
 	// we stop. 'this' points to that node, and 'thisp' to its memory location. It has
 	// not been cloned.
-	for !this.isLeaf() && bytes.HasPrefix(key, this.prefix()) {
-		// Prefix matched. Consume it and go further.
-		key = key[this.prefixLen:]
-		if len(key) == 0 {
-			// Our key matches this node or we reached a leaf node.
+	for len(key) > 0 && !this.isLeaf() && bytes.HasPrefix(key, this.prefix()) {
+		if len(key) == int(this.prefixLen) {
+			// Exact match
 			break
 		}
+
+		// Prefix matched. Consume it and go further.
+		key = key[this.prefixLen:]
 
 		child, idx := this.findIndex(key[0])
 		if child == nil {
@@ -225,8 +264,8 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 				if this.watch != nil {
 					txn.watches[this.watch] = struct{}{}
 				}
-				this = this.promote(!txn.opts.rootOnlyWatch() || this == root)
-				nodeMutatedSet(txn.mutated, this)
+				this = this.promote()
+				txn.mutated.set(this)
 			} else {
 				// Node is big enough, clone it so we can mutate it
 				this = txn.cloneNode(this)
@@ -254,7 +293,7 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 	// have been cloned.
 	//
 	// Check first if it's an exact match.
-	if len(key) == 0 || len(key) == len(common) && len(key) == int(this.prefixLen) {
+	if len(key) == len(common) && len(key) == int(this.prefixLen) {
 		this = txn.cloneNode(this)
 		*thisp = this
 		if leaf := this.getLeaf(); leaf != nil {
@@ -265,8 +304,8 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 				leaf = txn.cloneNode(leaf.self()).getLeaf()
 				this.setLeaf(leaf)
 			}
-			leaf.value = mod(oldValue)
 			watch = leaf.watch
+			leaf.value = mod(oldValue)
 		} else {
 			// Set the leaf
 			var zero T
@@ -288,7 +327,6 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 	} else {
 		this = txn.cloneNode(this)
 	}
-	*thisp = this
 	this.setPrefix(this.prefix()[len(common):])
 	key = key[len(common):]
 
@@ -318,14 +356,14 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 		newNode.setSize(1)
 
 	case this.key() < key[0]:
-		// target node has smaller key then new leaf
+		// target node has smaller key than new leaf
 		newNode.children[0] = this
 		newNode.keys[0] = this.key()
 		newNode.children[1] = newLeaf.self()
 		newNode.keys[1] = key[0]
 		newNode.setSize(2)
 	default:
-		// new leaf has smaller key then target node
+		// new leaf has smaller key than target node
 		newNode.children[0] = newLeaf.self()
 		newNode.keys[0] = key[0]
 		newNode.children[1] = this
@@ -333,6 +371,7 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 		newNode.setSize(2)
 	}
 	*thisp = newNode.self()
+	txn.mutated.set(newNode.self())
 
 	return
 }
@@ -345,6 +384,10 @@ type deleteParent[T any] struct {
 }
 
 func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool, newRoot *header[T]) {
+	if root == nil {
+		return
+	}
+
 	// Reuse the same slice in the transaction to hold the parents in order to avoid
 	// allocations. Pre-allocate 32 levels to cover most of the use-cases without
 	// reallocation.
@@ -381,6 +424,8 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 		}
 	}
 
+	txn.dirty = true
+
 	oldValue = leaf.value
 	hadOld = true
 
@@ -390,11 +435,26 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	}
 
 	if target == root {
-		// Target is the root, clear it.
-		if root.isLeaf() || newRoot.size() == 0 {
-			// Replace leaf or empty root with a node4
-			newRoot = newNode4[T]()
-		} else {
+		switch {
+		case root.isLeaf() || root.size() == 0:
+			if root.watch != nil {
+				txn.watches[root.watch] = struct{}{}
+			}
+			// Root is a leaf or node without children
+			newRoot = nil
+		case root.size() == 1:
+			if root.watch != nil {
+				txn.watches[root.watch] = struct{}{}
+			}
+			// Root is a non-leaf node with single child. We can replace
+			// the root with the child.
+			child := root.children()[0]
+			childClone := child.clone(false)
+			childClone.watch = child.watch
+			childClone.setPrefix(slices.Concat(root.prefix(), childClone.prefix()))
+			newRoot = childClone
+		default:
+			// Root is a non-leaf node with many children. Just drop the leaf.
 			newRoot = txn.cloneNode(root)
 			newRoot.setLeaf(nil)
 		}
@@ -406,7 +466,19 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	index := len(parents) - 1
 	this := &parents[index]
 	parent := &parents[index-1]
-	if this.node.size() > 0 {
+	if this.node.size() == 1 {
+		// The target node is not a leaf node and has only a single
+		// child. Shift the child up.
+		if this.node.watch != nil {
+			txn.watches[this.node.watch] = struct{}{}
+		}
+		child := this.node.children()[0]
+		childClone := child.clone(false)
+		childClone.watch = child.watch
+		childClone.setPrefix(slices.Concat(this.node.prefix(), childClone.prefix()))
+		parent.node = txn.cloneNode(parent.node)
+		parent.node.children()[this.index] = childClone
+	} else if this.node.size() > 0 {
 		// The target node is not a leaf node and has children.
 		// Drop the leaf.
 		this.node = txn.cloneNode(this.node)
@@ -416,6 +488,9 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	} else {
 		// The target node is a leaf node or a non-leaf node without any
 		// children. We can just drop it from the parent.
+		if this.node.watch != nil {
+			txn.watches[this.node.watch] = struct{}{}
+		}
 		parent.node = txn.removeChild(parent.node, this.index)
 	}
 	index--
@@ -424,8 +499,13 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	for index > 0 {
 		parent = &parents[index-1]
 		this = &parents[index]
-		parent.node = txn.cloneNode(parent.node)
-		parent.node.children()[this.index] = this.node
+		if this.node == nil {
+			// Node is gone, can remove it completely.
+			parent.node = txn.removeChild(parent.node, this.index)
+		} else {
+			parent.node = txn.cloneNode(parent.node)
+			parent.node.children()[this.index] = this.node
+		}
 		index--
 	}
 
@@ -433,12 +513,38 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	return
 }
 
-func (txn *Txn[T]) removeChild(parent *header[T], index int) *header[T] {
+func (txn *Txn[T]) removeChild(parent *header[T], index int) (newParent *header[T]) {
 	size := parent.size()
-	// Check if the node should be demoted.
 	switch {
+	case size == 2 && parent.getLeaf() == nil:
+		// Only one child remains and no leaf. Replace the node with the
+		// remaining child.
+		if parent.kind() != nodeKind4 {
+			panic("expected node4")
+		}
+		remainingIndex := 0
+		if index == 0 {
+			remainingIndex = 1
+		}
+
+		if parent.watch != nil {
+			txn.watches[parent.watch] = struct{}{}
+		}
+
+		child := parent.node4().children[remainingIndex]
+		// Clone for prefix adjustment, but leave watch alone.
+		// The node must not be marked as mutated since we didn't clone
+		// the watch.
+		childClone := child.clone(false)
+		childClone.watch = child.watch
+		childClone.setPrefix(slices.Concat(parent.prefix(), childClone.prefix()))
+		return childClone
+
 	case parent.kind() == nodeKind256 && size <= 49:
 		demoted := (&node48[T]{header: *parent}).self()
+		if parent.watch != nil {
+			demoted.watch = make(chan struct{})
+		}
 		demoted.setKind(nodeKind48)
 		demoted.setSize(size - 1)
 		n48 := demoted.node48()
@@ -450,9 +556,12 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) *header[T] {
 				children = append(children, n)
 			}
 		}
-		return demoted
+		newParent = demoted
 	case parent.kind() == nodeKind48 && size <= 17:
 		demoted := (&node16[T]{header: *parent}).self()
+		if parent.watch != nil {
+			demoted.watch = make(chan struct{})
+		}
 		demoted.setKind(nodeKind16)
 		demoted.setSize(size - 1)
 		n16 := demoted.node16()
@@ -465,9 +574,12 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) *header[T] {
 				idx++
 			}
 		}
-		return demoted
+		newParent = demoted
 	case parent.kind() == nodeKind16 && size <= 5:
 		demoted := (&node4[T]{header: *parent}).self()
+		if parent.watch != nil {
+			demoted.watch = make(chan struct{})
+		}
 		demoted.setKind(nodeKind4)
 		demoted.setSize(size - 1)
 		n16 := parent.node16()
@@ -481,10 +593,202 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) *header[T] {
 				idx++
 			}
 		}
-		return demoted
+		newParent = demoted
 	default:
-		parent = txn.cloneNode(parent)
-		parent.remove(index)
-		return parent
+		newParent = txn.cloneNode(parent)
+		newParent.remove(index)
+		return newParent
+	}
+	if parent.watch != nil {
+		txn.watches[parent.watch] = struct{}{}
+	}
+	txn.mutated.set(newParent)
+	return newParent
+}
+
+var runValidation = os.Getenv("PART_VALIDATE") != ""
+
+// validateTree checks that the resulting tree is well-formed and panics
+// if it is not.
+func validateTree[T any](node *header[T], parents []*header[T], watches map[chan struct{}]struct{}) {
+	if !runValidation {
+		return
+	}
+
+	if node == nil {
+		return
+	}
+	assert := func(b bool, f string, args ...any) {
+		if !b {
+			node.printTree(0)
+			panic(fmt.Sprintf(f, args...))
+		}
+	}
+
+	// A leaf node's key is the sum of all prefixes in path
+	if leaf := node.getLeaf(); leaf != nil {
+		var fullKey []byte
+		for _, p := range parents {
+			fullKey = append(fullKey, p.prefix()...)
+		}
+		fullKey = append(fullKey, node.prefix()...)
+
+		assert(bytes.Equal(leaf.fullKey(), fullKey),
+			"leaf's key does not match sum of prefixes, expected %x, got %x",
+			leaf.fullKey(), fullKey)
+
+		// If a leaf's watch channel is to be closed then parent's should be
+		// marked closed too. The case where node is a leaf is handled below.
+		if !node.isLeaf() {
+			if _, found := watches[leaf.watch]; found {
+				_, found := watches[node.watch]
+				assert(found, "node's watch channel not marked for closing when leaf is")
+			}
+		}
+	}
+
+	// Nodes without a leaf must have size 2 or greater.
+	assert(node.getLeaf() != nil || node.size() > 1,
+		"node with single child has no leaf")
+
+	// Node16 must have occupancy higher than 4
+	assert(node.kind() != nodeKind16 || node.size() > 4, "node16 has fewer children than 5")
+
+	// Node48 must have occupancy higher than 16
+	assert(node.kind() != nodeKind48 || node.size() > 16, "node48 has fewer children than 17")
+
+	// Node256 must have occupancy higher than 48
+	assert(node.kind() != nodeKind256 || node.size() > 48, "node256 has fewer children than 49")
+
+	// Nodes that have a watch channel that is to be closed must
+	// also have all their parent's watch channels to be closed.
+	if _, found := watches[node.watch]; found {
+		select {
+		case <-node.watch:
+			panic("node's watch channel marked for closing but is already closed!")
+		default:
+		}
+		for i, p := range parents {
+			_, found := watches[p.watch]
+			if !found {
+				p.printTree(0)
+				panic(fmt.Sprintf("parent %p (%d) watch channel (%p) not marked for closing (child %p, watch %p)", p, i, p.watch, node, node.watch))
+			}
+
+		}
+	}
+
+	// If a node's watch channel is closed then all the parents must be
+	// closed as well.
+	select {
+	case <-node.watch:
+		for _, p := range parents {
+			select {
+			case <-p.watch:
+			default:
+				p.printTree(0)
+				panic(fmt.Sprintf("parent watch channel (%p) not marked for closing (child %p)", p.watch, node.watch))
+			}
+		}
+	default:
+	}
+
+	parents = append(parents, node)
+
+	for _, child := range node.children() {
+		if child != nil {
+			validateTree(child, parents, watches)
+		}
+	}
+}
+
+func validateRemovedWatches[T any](oldRoot *header[T], newRoot *header[T]) {
+	if !runValidation {
+		return
+	}
+
+	// nodeStruct memoizes the structure for a node.
+	nodeStruct := map[*header[T]]string{}
+
+	// summarizeNodeStructure "lazily" summarizes the internal structure of a node,
+	// e.g. it's watch channel, size, leaf and children. The lazy construction speeds
+	// things up a lot as we only look at the structure in certain specific cases.
+	var summarizeNodeStructure func(node *header[T]) func() string
+	summarizeNodeStructure = func(node *header[T]) func() string {
+		if node == nil {
+			return func() string { return "" }
+		}
+		if s, found := nodeStruct[node]; found {
+			return func() string { return s }
+		}
+		return func() string {
+			var childS string
+			for _, child := range node.children() {
+				if child != nil {
+					childS += summarizeNodeStructure(child)()
+				}
+			}
+			var leafS string
+			if leaf := node.getLeaf(); leaf != nil && !node.isLeaf() {
+				leafS = summarizeNodeStructure(leaf.self())()
+			}
+			s := fmt.Sprintf("K:%d S:%d W:%p L:[%s] C:[%s]", node.kind(), node.size(), node.watch, leafS, childS)
+			nodeStruct[node] = s
+			return s
+		}
+	}
+
+	var collectWatches func(depth int, watches map[<-chan struct{}]func() string, node *header[T])
+	collectWatches = func(depth int, watches map[<-chan struct{}]func() string, node *header[T]) {
+		if node == nil {
+			return
+		}
+		if node.watch == nil {
+			panic("nil watch channel")
+		}
+		watches[node.watch] = summarizeNodeStructure(node)
+		if leaf := node.getLeaf(); leaf != nil && !node.isLeaf() {
+			watches[leaf.watch] = summarizeNodeStructure(leaf.self())
+		}
+		for _, child := range node.children() {
+			if child != nil {
+				collectWatches(depth+1, watches, child)
+			}
+		}
+	}
+
+	oldWatches := map[<-chan struct{}]func() string{}
+	collectWatches(0, oldWatches, oldRoot)
+	newWatches := map[<-chan struct{}]func() string{}
+	collectWatches(0, newWatches, newRoot)
+
+	// Check that any nodes that kept the old watch channel have exactly
+	// the same leaf and children structure.
+	for watch, oldDescFn := range oldWatches {
+		newDescFn, found := newWatches[watch]
+		if found {
+			oldDesc := oldDescFn()
+			newDesc := newDescFn()
+			if oldDesc != newDesc {
+				panic(fmt.Sprintf("node with retained watch channel has different structure:\nexpected: %s\n     got: %s", oldDesc, newDesc))
+			}
+		}
+
+	}
+
+	// Any nodes that are not part of the new tree must have their watch channels closed.
+	for watch := range newWatches {
+		delete(oldWatches, watch)
+	}
+
+	for watch, desc := range oldWatches {
+		select {
+		case <-watch:
+		default:
+			oldRoot.printTree(0)
+			fmt.Println("---")
+			newRoot.printTree(0)
+			panic(fmt.Sprintf("dropped watch channel %p not closed %s", watch, desc()))
+		}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -331,7 +331,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.5.2
+# github.com/cilium/statedb v0.5.6
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This bumps to StateDB v0.5.6.
See release notes at https://github.com/cilium/statedb/releases/tag/v0.5.6.

The main changes are optimizations to the adaptive radix tree structure and a fix to watch channels of demoted nodes that first appeared in v0.5.2 (was only present in cilium/cilium for a short time, so no need for release note or backports).
