### PR TITLE
Clean up leftovers after fromRequires/toRequires removal

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -622,7 +622,7 @@ Makefile* @cilium/build
 /pkg/option @cilium/sig-agent @cilium/cli
 /pkg/pidfile @cilium/sig-agent
 /pkg/policy @cilium/sig-policy
-/pkg/policy/api/ @cilium/api
+/pkg/policy/api/ @cilium/api @cilium/sig-policy
 /pkg/policy/groups/aws/ @cilium/sig-policy @cilium/aws
 /pkg/policy/k8s @cilium/sig-policy
 /pkg/pprof @cilium/sig-foundations

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -83,11 +83,11 @@ func addClusterFilterByDefault(es *api.EndpointSelector, clusterName string) {
 // this is when translating selectors for CiliumClusterwideNetworkPolicy.
 // If a clusterName is provided then is is assumed that the selector is scoped to the local
 // cluster by default in a ClusterMesh environment.
-func getEndpointSelector(clusterName, namespace string, labelSelector *slim_metav1.LabelSelector, addK8sPrefix, matchesInit bool) api.EndpointSelector {
+func getEndpointSelector(clusterName, namespace string, labelSelector *slim_metav1.LabelSelector, matchesInit bool) api.EndpointSelector {
 	es := api.NewESFromK8sLabelSelector("", labelSelector)
 
 	// The k8s prefix must not be added to reserved labels.
-	if addK8sPrefix && es.HasKeyPrefix(labels.LabelSourceReservedKeyPrefix) {
+	if es.HasKeyPrefix(labels.LabelSourceReservedKeyPrefix) {
 		return es
 	}
 
@@ -129,7 +129,7 @@ func parseToCiliumIngressCommonRule(clusterName, namespace string, es api.Endpoi
 	if ing.FromEndpoints != nil {
 		retRule.FromEndpoints = make([]api.EndpointSelector, len(ing.FromEndpoints))
 		for j, ep := range ing.FromEndpoints {
-			retRule.FromEndpoints[j] = getEndpointSelector(clusterName, namespace, ep.LabelSelector, true, matchesInit)
+			retRule.FromEndpoints[j] = getEndpointSelector(clusterName, namespace, ep.LabelSelector, matchesInit)
 		}
 	}
 
@@ -213,7 +213,7 @@ func parseToCiliumEgressCommonRule(clusterName, namespace string, es api.Endpoin
 	if egr.ToEndpoints != nil {
 		retRule.ToEndpoints = make([]api.EndpointSelector, len(egr.ToEndpoints))
 		for j, ep := range egr.ToEndpoints {
-			endpointSelector := getEndpointSelector(clusterName, namespace, ep.LabelSelector, true, matchesInit)
+			endpointSelector := getEndpointSelector(clusterName, namespace, ep.LabelSelector, matchesInit)
 			endpointSelector.Generated = ep.Generated
 			retRule.ToEndpoints[j] = endpointSelector
 		}

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -344,25 +344,6 @@ func (n *EndpointSelector) IsWildcard() bool {
 		len(n.LabelSelector.MatchLabels)+len(n.LabelSelector.MatchExpressions) == 0
 }
 
-// ConvertToLabelSelectorRequirementSlice converts the MatchLabels and
-// MatchExpressions within the specified EndpointSelector into a list of
-// LabelSelectorRequirements.
-func (n *EndpointSelector) ConvertToLabelSelectorRequirementSlice() []slim_metav1.LabelSelectorRequirement {
-	requirements := make([]slim_metav1.LabelSelectorRequirement, 0, len(n.MatchExpressions)+len(n.MatchLabels))
-	// Append already existing match expressions.
-	requirements = append(requirements, n.MatchExpressions...)
-	// Convert each MatchLables to LabelSelectorRequirement.
-	for key, value := range n.MatchLabels {
-		requirementFromMatchLabels := slim_metav1.LabelSelectorRequirement{
-			Key:      key,
-			Operator: slim_metav1.LabelSelectorOpIn,
-			Values:   []string{value},
-		}
-		requirements = append(requirements, requirementFromMatchLabels)
-	}
-	return requirements
-}
-
 // Sanitize returns an error if the EndpointSelector's LabelSelector is invalid.
 // It also muatates all label selector keys into Cilium's internal representation.
 // Check documentation of `EndpointSelector.sanitized` for more details.


### PR DESCRIPTION
Remove/inline some unused code after #42615. Also assign `pkg/policy/api` to @cilium/sig-policy in addition to @cilium/api.

See commits for details.
