### PR TITLE
k8s: remove permissions for endpoints

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -40,7 +40,6 @@ rules:
   - namespaces
   - services
   - pods
-  - endpoints
   - nodes
 {{- if not $readSecretsOnlyFromSecretsNamespace }}
   - secrets

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -103,7 +103,6 @@ rules:
   resources:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
-  - endpoints
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -40,7 +40,6 @@ rules:
   - namespaces
   - services
   - pods
-  - endpoints
   - nodes
 {{- if $readSecretsOnlyFromSecretsNamespace }}
   - secrets


### PR DESCRIPTION
With deprecation of Endpoints in 1.33 k8s, we should also remove permission so we don't accidentally start using it again.

Related: #41083
Related: #40555

```release-note
k8s: remove permissions for list/get/watch of endpoints
```
