### PR TITLE
maps/lxcmap: use `netip.Addr`

### DIFF
--- a/cilium-dbg/cmd/bpf_endpoint_delete.go
+++ b/cilium-dbg/cmd/bpf_endpoint_delete.go
@@ -4,7 +4,7 @@
 package cmd
 
 import (
-	"net"
+	"net/netip"
 
 	"github.com/spf13/cobra"
 
@@ -23,12 +23,12 @@ var bpfEndpointDeleteCmd = &cobra.Command{
 			Fatalf("Please specify the endpoint to delete")
 		}
 
-		ip := net.ParseIP(args[0])
-		if ip == nil {
-			Fatalf("Unable to parse IP '%s'", args[0])
+		addr, err := netip.ParseAddr(args[0])
+		if err != nil {
+			Fatalf("Unable to parse IP '%s': %v", args[0], err)
 		}
 
-		if err := lxcmap.DeleteEntry(ip); err != nil {
+		if err := lxcmap.DeleteEntry(addr); err != nil {
 			Fatalf("Unable to delete endpoint entry: %s", err)
 		}
 	},

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 	"os"
 	"slices"
 	"sync"
@@ -348,7 +348,7 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 	}
 
 	var (
-		existingEndpoints map[string]lxcmap.EndpointInfo
+		existingEndpoints map[netip.Addr]lxcmap.EndpointInfo
 		err               error
 	)
 
@@ -388,8 +388,8 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 		r.restoreState.restored = append(r.restoreState.restored, ep)
 
 		if existingEndpoints != nil {
-			delete(existingEndpoints, ep.GetIPv4Address())
-			delete(existingEndpoints, ep.GetIPv6Address())
+			delete(existingEndpoints, ep.IPv4Address())
+			delete(existingEndpoints, ep.IPv6Address())
 		}
 	}
 
@@ -399,10 +399,13 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 		logfields.Failed, failed,
 	)
 
-	for epIP, info := range existingEndpoints {
-		if ip := net.ParseIP(epIP); !info.IsHost() && ip != nil {
-			if err := lxcmap.DeleteEntry(ip); err != nil {
-				r.logger.Warn("Unable to delete obsolete endpoint from BPF map", logfields.Error, err)
+	for addr, info := range existingEndpoints {
+		if addr.IsValid() && !info.IsHost() {
+			if err := lxcmap.DeleteEntry(addr); err != nil {
+				r.logger.Warn("Unable to delete obsolete endpoint from BPF map",
+					logfields.IPAddr, addr,
+					logfields.Error, err,
+				)
 			} else {
 				r.logger.Debug(
 					"Removed outdated endpoint from endpoint map",

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
-	"go4.org/netipx"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -123,19 +122,17 @@ func (s *syncHostIPs) loop(ctx context.Context, health cell.Health) error {
 // changes were made.
 func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]) error {
 	type ipIDLabel struct {
-		identity.IPIdentityPair
-		labels.Labels
+		IP     netip.Addr
+		ID     identity.NumericIdentity
+		Labels labels.Labels
 	}
 	specialIdentities := make([]ipIDLabel, 0, 2)
 
-	addIdentity := func(ip net.IP, mask net.IPMask, id identity.NumericIdentity, labels labels.Labels) {
+	addIdentity := func(ip netip.Addr, id identity.NumericIdentity, labels labels.Labels) {
 		specialIdentities = append(specialIdentities, ipIDLabel{
-			identity.IPIdentityPair{
-				IP:   ip,
-				Mask: mask,
-				ID:   id,
-			},
-			labels,
+			IP:     ip,
+			ID:     id,
+			Labels: labels,
 		})
 	}
 
@@ -149,7 +146,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 		if option.Config.IsExcludedLocalAddress(addr.Addr) {
 			continue
 		}
-		addIdentity(addr.Addr.AsSlice(), nil, identity.ReservedIdentityHost, labels.LabelHost)
+		addIdentity(addr.Addr, identity.ReservedIdentityHost, labels.LabelHost)
 	}
 
 	if option.Config.EnableIPv6 {
@@ -159,7 +156,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			ipv6Ident = identity.ReservedIdentityWorld
 			ipv6Label = labels.LabelWorld
 		}
-		addIdentity(net.IPv6zero, net.CIDRMask(0, net.IPv6len*8), ipv6Ident, ipv6Label)
+		addIdentity(netip.IPv6Unspecified(), ipv6Ident, ipv6Label)
 	}
 
 	if option.Config.EnableIPv4 {
@@ -169,7 +166,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			ipv4Ident = identity.ReservedIdentityWorld
 			ipv4Label = labels.LabelWorld
 		}
-		addIdentity(net.IPv4zero, net.CIDRMask(0, net.IPv4len*8), ipv4Ident, ipv4Label)
+		addIdentity(netip.IPv4Unspecified(), ipv4Ident, ipv4Label)
 	}
 
 	existingEndpoints, err := lxcmap.DumpToMap()
@@ -181,7 +178,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 	for _, ipIDLblsPair := range specialIdentities {
 		isHost := ipIDLblsPair.ID == identity.ReservedIdentityHost
 		if isHost {
-			added, err := lxcmap.SyncHostEntry(ipIDLblsPair.IP)
+			added, err := lxcmap.SyncHostEntry(ipIDLblsPair.IP.AsSlice())
 			if err != nil {
 				return fmt.Errorf("Unable to add host entry to endpoint map: %w", err)
 			}
@@ -197,10 +194,10 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 
 		lbls := ipIDLblsPair.Labels
 		if ipIDLblsPair.ID.IsWorld() {
-			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(netipx.MustFromStdIP(ipIDLblsPair.IP), 0))
+			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(ipIDLblsPair.IP, 0))
 			s.params.IPCache.OverrideIdentity(p, lbls, source.Local, daemonResourceID)
 		} else {
-			p := cmtypes.NewLocalPrefixCluster(ippkg.IPToNetPrefix(ipIDLblsPair.IP))
+			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(ipIDLblsPair.IP, ipIDLblsPair.IP.BitLen()))
 			s.params.IPCache.UpsertMetadata(p, source.Local, daemonResourceID, lbls)
 		}
 	}

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
-	"net"
 	"net/netip"
 
 	"github.com/cilium/hive/cell"
@@ -18,7 +17,6 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/identity"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -178,7 +176,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 	for _, ipIDLblsPair := range specialIdentities {
 		isHost := ipIDLblsPair.ID == identity.ReservedIdentityHost
 		if isHost {
-			added, err := lxcmap.SyncHostEntry(ipIDLblsPair.IP.AsSlice())
+			added, err := lxcmap.SyncHostEntry(ipIDLblsPair.IP)
 			if err != nil {
 				return fmt.Errorf("Unable to add host entry to endpoint map: %w", err)
 			}
@@ -190,7 +188,7 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 			}
 		}
 
-		delete(existingEndpoints, ipIDLblsPair.IP.String())
+		delete(existingEndpoints, ipIDLblsPair.IP)
 
 		lbls := ipIDLblsPair.Labels
 		if ipIDLblsPair.ID.IsWorld() {
@@ -204,17 +202,17 @@ func (s *syncHostIPs) sync(addrs iter.Seq2[tables.NodeAddress, statedb.Revision]
 
 	// existingEndpoints is a map from endpoint IP to endpoint info. Referring
 	// to the key as host IP here because we only care about the host endpoint.
-	for hostIP, info := range existingEndpoints {
-		if ip := net.ParseIP(hostIP); info.IsHost() && ip != nil {
-			if err := lxcmap.DeleteEntry(ip); err != nil {
+	for addr, info := range existingEndpoints {
+		if addr.IsValid() && info.IsHost() {
+			if err := lxcmap.DeleteEntry(addr); err != nil {
 				return fmt.Errorf("unable to delete obsolete host IP: %w", err)
 			} else {
 				s.params.Logger.Debug(
 					"Removed outdated host IP from endpoint map",
-					logfields.IPAddr, hostIP,
+					logfields.IPAddr, addr,
 				)
 			}
-			p := cmtypes.NewLocalPrefixCluster(ippkg.IPToNetPrefix(ip))
+			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(addr, addr.BitLen()))
 			s.params.IPCache.RemoveMetadata(p, daemonResourceID, labels.LabelHost)
 		}
 	}

--- a/pkg/bpf/endpoint_test.go
+++ b/pkg/bpf/endpoint_test.go
@@ -4,7 +4,7 @@
 package bpf
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,17 +12,16 @@ import (
 
 func TestEndpointKeyToString(t *testing.T) {
 	tests := []struct {
-		ip string
+		addr netip.Addr
 	}{
-		{"0.0.0.0"},
-		{"192.0.2.3"},
-		{"::"},
-		{"fdff::ff"},
+		{netip.IPv4Unspecified()},
+		{netip.MustParseAddr("192.0.2.3")},
+		{netip.IPv6Unspecified()},
+		{netip.MustParseAddr("fdff::ff")},
 	}
 
 	for _, tt := range tests {
-		ip := net.ParseIP(tt.ip)
-		k := NewEndpointKey(ip, 0)
-		require.Equal(t, tt.ip, k.ToIP().String())
+		k := NewEndpointKey(tt.addr, 0)
+		require.Equal(t, tt.addr.String(), k.ToAddr().String())
 	}
 }


### PR DESCRIPTION
Avoid conversion from/to `net.IP` and parsing/converting IPs from/to strings when interacting with `maps/lxcmap`.

See commits for details.

For #24246