### PR TITLE
bpf/unused_maps.go: Fix unused map verification

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -126,7 +126,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 #endif /* ENABLE_LOCAL_REDIRECT_POLICY && ENABLE_SOCKET_LB_FULL */
 		ret = lb4_local(get_ct_map4(&tuple), ctx, ETH_HLEN, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				false, &cluster_id, ext_err, CONFIG(endpoint_netns_cookie));
+				false, &cluster_id, ext_err);
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {
@@ -202,7 +202,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 #endif /* ENABLE_LOCAL_REDIRECT_POLICY && ENABLE_SOCKET_LB_FULL */
 		ret = lb6_local(get_ct_map6(&tuple), ctx, ETH_HLEN, fraginfo,
 				l4_off, &key, &tuple, svc, &ct_state_new,
-				false, ext_err, CONFIG(endpoint_netns_cookie));
+				false, ext_err);
 
 		if (IS_ERR(ret)) {
 			if (ret == DROP_NO_SERVICE) {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1354,7 +1354,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 #endif
 	ret = lb6_local(get_ct_map6(tuple), ctx, l3_off, fraginfo, l4_off,
 			key, tuple, svc, &ct_state_svc,
-			nodeport_xlate6(svc, tuple), ext_err, 0);
+			nodeport_xlate6(svc, tuple), ext_err);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE) {
 			if (!CONFIG(enable_no_service_endpoints_routable))
@@ -2715,7 +2715,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 	} else {
 		ret = lb4_local(get_ct_map4(tuple), ctx, l3_off, fraginfo, l4_off,
 				key, tuple, svc, &ct_state_svc,
-				nodeport_xlate4(svc, tuple), &cluster_id, ext_err, 0);
+				nodeport_xlate4(svc, tuple), &cluster_id, ext_err);
 	}
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE) {

--- a/pkg/bpf/unused_maps.go
+++ b/pkg/bpf/unused_maps.go
@@ -49,6 +49,8 @@ func removeUnusedMaps(spec *ebpf.CollectionSpec, keep *set.Set[string], reach re
 		}
 	}
 
+	keepAlways := keep.Clone()
+
 	for name := range spec.Programs {
 		r, ok := reach[name]
 		if !ok {
@@ -88,7 +90,7 @@ func removeUnusedMaps(spec *ebpf.CollectionSpec, keep *set.Set[string], reach re
 		}
 	}
 
-	return keep, nil
+	return &keepAlways, nil
 }
 
 // verifyUnusedMaps makes sure that all Maps appearing in the Collection are


### PR DESCRIPTION
The `verifyUnusedMaps` function takes in a set of map names which it should ignore. This list is meant for maps which are intentionally unused in the bytecode such as maps for global variables or inner maps.

We need this same list inside `removeUnusedMaps` to avoid removing maps which are intentionally unused. So our solution is to generate the list in `removeUnusedMaps` and return it to the caller so it can be passed to `verifyUnusedMaps`.

The flaw is that we were internally also adding the names for maps which are reachable from programs. An error likely introduced during a refactor and missed during code review.

This effectively disables the unused map verification. Since any map we believe to be reachable is ignored and thus no error reported if the reachability analysis is incorrect.

This commit fixes the issue by making a copy of the `keep` set before adding maps from the reachability analysis to it, and returning that copy instead.
