### PR TITLE
ztunnel: add daemonset controller

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -499,6 +499,7 @@ Makefile* @cilium/build
 /operator/pkg/networkpolicy @cilium/sig-policy
 /operator/pkg/secretsync @cilium/envoy @cilium/sig-servicemesh
 /operator/pkg/workqueuemetrics @cilium/metrics
+/operator/pkg/ztunnel @cilium/ztunnel
 /pkg/act/ @cilium/sig-datapath @cilium/metrics
 /pkg/annotation @cilium/sig-k8s
 /pkg/alibabacloud/ @cilium/alibabacloud

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -60,6 +60,7 @@ cilium-operator-alibabacloud [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -41,6 +41,7 @@ cilium-operator-alibabacloud hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -64,6 +64,7 @@ cilium-operator-aws [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
       --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -41,6 +41,7 @@ cilium-operator-aws hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-operator-aws hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -63,6 +63,7 @@ cilium-operator-azure [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -41,6 +41,7 @@ cilium-operator-azure hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-operator-azure hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -59,6 +59,7 @@ cilium-operator-generic [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -41,6 +41,7 @@ cilium-operator-generic hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-operator-generic hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -69,6 +69,7 @@ cilium-operator [flags]
       --enable-node-selector-labels                          Enable use of node label based identity
       --enable-policy string                                 Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
       --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -41,6 +41,7 @@ cilium-operator hive [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -47,6 +47,7 @@ cilium-operator hive dot-graph [flags]
       --enable-lb-ipam                                       Enable LB IPAM (default true)
       --enable-node-ipam                                     Enable Node IPAM
       --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
       --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
       --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'

--- a/install/kubernetes/cilium/templates/cilium-operator/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/role.yaml
@@ -83,3 +83,35 @@ rules:
   - update
   - patch
 {{- end }}
+
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cilium-operator-ztunnel
+  namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+# ZTunnel DaemonSet management permissions
+# Note: These permissions must always be granted (not conditional on encryption.type)
+# because the controller needs to clean up stale DaemonSets when ztunnel is disabled.
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+{{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -77,3 +77,29 @@ subjects:
   name: {{ .Values.serviceAccounts.operator.name | quote }}
   namespace: {{ include "cilium.namespace" . }}
 {{- end }}
+
+{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cilium-operator-ztunnel
+  namespace: {{ include "cilium.namespace" . }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-ztunnel
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.operator.name | quote }}
+  namespace: {{ include "cilium.namespace" . }}
+{{- end }}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/networkpolicy"
 	"github.com/cilium/cilium/operator/pkg/nodeipam"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
+	"github.com/cilium/cilium/operator/pkg/ztunnel"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslicesync"
@@ -316,6 +317,10 @@ var (
 
 			// GC of stale node entries in the KVStore
 			nodesgc.Cell,
+
+			// Provides the ztunnel daemonset controller if ztunnel encryption
+			// is specified.
+			ztunnel.Cell,
 		),
 	)
 

--- a/operator/pkg/ztunnel/cell.go
+++ b/operator/pkg/ztunnel/cell.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ztunnel
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/yaml"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var DefaultConfig = Config{
+	EnableZTunnel: false,
+}
+
+type Config struct {
+	EnableZTunnel bool
+}
+
+func (c Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-ztunnel", false, "Use zTunnel as Cilium's encryption infrastructure")
+}
+
+// Cell manages the ztunnel DaemonSet, ensuring a ztunnel proxy runs on each
+// node in the cluster when ztunnel encryption is enabled.
+var Cell = cell.Module(
+	"ztunnel",
+	"ZTunnel DaemonSet Controller",
+
+	cell.Config(DefaultConfig),
+	cell.Invoke(newZTunnelController),
+)
+
+type controllerParams struct {
+	cell.In
+
+	Lifecycle      cell.Lifecycle
+	Logger         *slog.Logger
+	Clientset      k8sClient.Clientset
+	Config         Config
+	OperatorConfig *operatorOption.OperatorConfig
+}
+
+//go:embed ztunnel-daemonset.yaml
+var ztunnelDaemonSetYAML []byte
+
+// createDaemonSet parses the embedded YAML and returns a DaemonSet object
+func createDaemonSet(namespace string) (*appsv1.DaemonSet, error) {
+	var daemonSet appsv1.DaemonSet
+	if err := yaml.Unmarshal(ztunnelDaemonSetYAML, &daemonSet); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ztunnel DaemonSet YAML: %w", err)
+	}
+	daemonSet.Namespace = namespace
+	return &daemonSet, nil
+}
+
+func newZTunnelController(params controllerParams) error {
+	params.Logger.Info("Creating ZTunnel DaemonSet controller")
+
+	c := &controller{
+		client:         params.Clientset,
+		logger:         params.Logger,
+		config:         params.Config,
+		operatorConfig: params.OperatorConfig,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(_ cell.HookContext) error {
+			params.Logger.Info("Starting ztunnel DaemonSet controller")
+			go func() {
+				// must parse embedded yaml into a daemon set
+				ds, err := createDaemonSet(params.OperatorConfig.CiliumK8sNamespace)
+				if err != nil {
+					params.Logger.Error("Failed to create ztunnel DaemonSet",
+						logfields.Error, err)
+					return
+				}
+
+				if err := c.run(ctx, ds); err != nil {
+					params.Logger.Error("ZTunnel controller error",
+						logfields.Error, err)
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx cell.HookContext) error {
+			params.Logger.Info("Stopping ztunnel DaemonSet controller")
+			cancel()
+			return nil
+		},
+	})
+
+	return nil
+}

--- a/operator/pkg/ztunnel/controller.go
+++ b/operator/pkg/ztunnel/controller.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ztunnel
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	ztunnelDaemonSetName = "ztunnel-cilium"
+)
+
+// controller manages a ztunnel daemonset, ensuring a ztunnel proxy runs on each
+// node in the cluster.
+type controller struct {
+	client         k8sClient.Clientset
+	logger         *slog.Logger
+	config         Config
+	operatorConfig *operatorOption.OperatorConfig
+}
+
+// create will create the ztunnel daemonset.
+func (c *controller) create(ctx context.Context, ds *appsv1.DaemonSet, ns string) error {
+	_, err := c.client.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create ztunnel DaemonSet: %w", err)
+	}
+
+	c.logger.Info("Successfully created ztunnel DaemonSet")
+	return nil
+}
+
+// createIfNotExists ensures the ztunnel DaemonSet exists and creates it if it doesn't
+func (c *controller) createIfNotExists(ctx context.Context, ds *appsv1.DaemonSet, ns string) error {
+	// Check if DaemonSet already exists
+	_, err := c.client.AppsV1().DaemonSets(ns).Get(ctx, ztunnelDaemonSetName, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get ztunnel DaemonSet: %w", err)
+	}
+
+	return c.create(ctx, ds, ns)
+}
+
+// remove removes the ztunnel DaemonSet if it exists
+func (c *controller) remove(ctx context.Context, ns string) error {
+	// Check if DaemonSet exists
+	_, err := c.client.AppsV1().DaemonSets(ns).Get(ctx, ztunnelDaemonSetName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// DaemonSet doesn't exist, nothing to clean up
+		c.logger.Debug("ztunnel DaemonSet not found, nothing to clean up")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get ztunnel DaemonSet: %w", err)
+	}
+
+	// DaemonSet exists, delete it
+	err = c.client.AppsV1().DaemonSets(ns).Delete(ctx, ztunnelDaemonSetName, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete ztunnel DaemonSet: %w", err)
+	}
+
+	c.logger.Info("Successfully deleted ztunnel DaemonSet")
+	return nil
+}
+
+// run will launch a background reconciler for a ztunnel daemonset.
+//
+// if ztunnel is not enabled in the configuration any stale ztunnel daemonset
+// will be removed.
+//
+// if ztunnel is enabled an Informer which watches for deleted daemonsets will
+// be spawned.
+// if we detect a delete event for the ztunnel daemonset, we will recreate it.
+//
+// after the controller is launched we will ensure that the ztunnel daemonset
+// exists, creating it if it does not.
+func (c *controller) run(ctx context.Context, ds *appsv1.DaemonSet) error {
+	// we must know Cilium's namespace
+	if c.operatorConfig.CiliumK8sNamespace == "" {
+		return fmt.Errorf("cannot run ztunnel controller: CiliumK8sNamespace is not set")
+	}
+
+	// ztunnel may have been enabled, disabled, and the operator has restarted.
+	// therefore, cleanup stale ztunnel daemonset.
+	if !c.config.EnableZTunnel {
+		c.logger.Info("ztunnel encryption disabled, cleaning up DaemonSet if it exists")
+		return c.remove(ctx, c.operatorConfig.CiliumK8sNamespace)
+	}
+
+	// Set up watcher for DaemonSet events, if we catch a delete of the ztunnel
+	// daemonset, we will recreate it.
+	listWatcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return c.client.AppsV1().DaemonSets(c.operatorConfig.CiliumK8sNamespace).List(ctx, metav1.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("metadata.name", ztunnelDaemonSetName).String(),
+			})
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return c.client.AppsV1().DaemonSets(c.operatorConfig.CiliumK8sNamespace).Watch(ctx, metav1.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("metadata.name", ztunnelDaemonSetName).String(),
+			})
+		},
+	}
+
+	_, controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: listWatcher,
+		ObjectType:    &appsv1.DaemonSet{},
+		ResyncPeriod:  time.Minute * 5,
+		Handler: cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj any) {
+				oldDS, ok := oldObj.(*appsv1.DaemonSet)
+				if !ok {
+					return
+				}
+				newDS, ok := newObj.(*appsv1.DaemonSet)
+				if !ok {
+					return
+				}
+
+				// Only care about spec changes, not status
+				if oldDS.Generation == newDS.Generation {
+					return
+				}
+
+				c.logger.Warn("ztunnel DaemonSet spec modified externally and changes may be overwritten on operator restart")
+			},
+			DeleteFunc: func(obj any) {
+				// Check if the deleted object is our ztunnel DaemonSet
+				deletedDS, ok := obj.(*appsv1.DaemonSet)
+				if !ok {
+					tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+					if ok {
+						deletedDS, ok = tombstone.Obj.(*appsv1.DaemonSet)
+					}
+					if !ok {
+						c.logger.Debug("Received non-DaemonSet delete event")
+						return
+					}
+				}
+
+				if deletedDS.Name != ztunnelDaemonSetName || deletedDS.Namespace != c.operatorConfig.CiliumK8sNamespace {
+					c.logger.Debug(
+						"Deleted DaemonSet is not our ztunnel DaemonSet",
+						logfields.Name,
+						deletedDS.Name,
+						logfields.K8sNamespace,
+						deletedDS.Namespace)
+					return
+				}
+
+				// Our ztunnel DaemonSet was deleted, recreate it with createIfNotExists,
+				// just incase this is an out-of-order event and the daemonset was already
+				// recreated.
+				c.logger.Info("ztunnel DaemonSet was deleted, recreating...")
+				if err := c.createIfNotExists(ctx, ds, c.operatorConfig.CiliumK8sNamespace); err != nil {
+					c.logger.Error(
+						"Error recreating ztunnel DaemonSet after deletion", logfields.Error, err)
+				}
+			},
+		},
+	})
+
+	// Start the controller
+	go controller.RunWithContext(ctx)
+
+	// Initial reconciliation - ensure DaemonSet exists
+	if err := c.createIfNotExists(ctx, ds, c.operatorConfig.CiliumK8sNamespace); err != nil {
+		return fmt.Errorf("failed initial DaemonSet reconciliation: %w", err)
+	}
+
+	return nil
+}

--- a/operator/pkg/ztunnel/ztunnel-daemonset.yaml
+++ b/operator/pkg/ztunnel/ztunnel-daemonset.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ztunnel-cilium
+  labels:
+    app: ztunnel-cilium
+    app.kubernetes.io/name: ztunnel-cilium
+    app.kubernetes.io/managed-by: cilium-operator
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ztunnel
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: ztunnel
+    spec:
+      hostNetwork: true
+      containers:
+      - args:
+        - proxy
+        - ztunnel
+        env:
+        - name: XDS_ADDRESS
+          value: "https://localhost:15012"
+        - name: XDS_ROOT_CA
+          value: "/etc/ztunnel/bootstrap-root.crt"
+        - name: CA_ROOT_CA
+          value: "/etc/ztunnel/bootstrap-root.crt"
+        - name: CA_ADDRESS
+          value: "https://localhost:15012"
+        - name: ISTIO_META_DNS_CAPTURE
+          value: false
+        - name: INPOD_UDS
+          value: /var/run/cilium/ztunnel.sock
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: ISTIO_META_ENABLE_HBONE
+          value: "true"
+        image: docker.io/istio/ztunnel:1.28.0-distroless
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        stdin: false
+        stdinOnce: false
+        tty: false
+        readinessProbe:
+          initialDelaySeconds: 0
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
+            - NET_RAW
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: false
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/run/ztunnel
+          name: ztunnel-dir
+          readOnly: false
+        - mountPath: /etc/ztunnel
+          name: cilium-ztunnel-secrets
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      shareProcessNamespace: false
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: ztunnel-dir
+      - name: cilium-ztunnel-secrets
+        secret:
+          secretName: cilium-ztunnel-secrets
+          defaultMode: 420
+          items:
+            - key: bootstrap-root.crt
+              path: bootstrap-root.crt
+              mode: 420
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate


### PR DESCRIPTION
Add a controller in Cilium's operator to (re)deploy an opinionated
ztunnel instance which integrates with Cilium.

The daemonset details are embedded directly into Cilium and read from
memory when applying the manifest to kubernetes.

The manifest is opinionated and installs ztunnel with the necessary
configuration, environment variables, and volume mounts required to
integrate with Cilium successfully.

```release-note
ztunnel: add ztunnel daemonset controller
```