### PR TITLE
pkg/aws,pkg/alibabacloud: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/alibabacloud/utils/utils_test.go
+++ b/pkg/alibabacloud/utils/utils_test.go
@@ -4,10 +4,10 @@
 package utils
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetENIIndexFromTags(t *testing.T) {
@@ -61,9 +61,8 @@ func TestFillTagWithENIIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FillTagWithENIIndex(tt.args.tags, tt.args.index); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FillTagWithENIIndex() = %v, want %v", got, tt.want)
-			}
+			got := FillTagWithENIIndex(tt.args.tags, tt.args.index)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/aws/ec2/ec2_test.go
+++ b/pkg/aws/ec2/ec2_test.go
@@ -4,13 +4,13 @@
 package ec2
 
 import (
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
 )
 
 type Filters []ec2_types.Filter
@@ -94,9 +94,7 @@ func TestNewSubnetsFilters(t *testing.T) {
 			got := NewSubnetsFilters(tt.args.tags, tt.args.ids)
 			sort.Sort(Filters(got))
 			sort.Sort(Filters(tt.want))
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewSubnetsFilters() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -141,9 +139,7 @@ func TestNewTagsFilters(t *testing.T) {
 			got := NewTagsFilter(tt.args.tags)
 			sort.Sort(Filters(got))
 			sort.Sort(Filters(tt.want))
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewTagsFilter() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 3 usages of `reflect.DeepEqual` across two packages:

- `pkg/aws/ec2/ec2_test.go` (2 usages)
- `pkg/alibabacloud/utils/utils_test.go` (1 usage)

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/aws/ec2/... -v
PASS
ok  	github.com/cilium/cilium/pkg/aws/ec2	0.013s

$ go test ./pkg/alibabacloud/utils/... -v
PASS
ok  	github.com/cilium/cilium/pkg/alibabacloud/utils	0.004s
```

## Follow-up

This is an incremental change affecting two small packages. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42186
- #42322

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/aws and pkg/alibabacloud tests for better error messages
```