### PR TITLE
pkg/datapath,pkg/container: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/container/bitlpm/cidr_test.go
+++ b/pkg/container/bitlpm/cidr_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"net/netip"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -200,9 +199,7 @@ func TestDescendants(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Descendants prefix %s, expected to get %v, but got: %v", pref.String(), expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes, "Descendants prefix %s", pref.String())
 		}
 	}
 }
@@ -322,9 +319,7 @@ func TestDescendantsShortestPrefixFirst(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("LPM Descendants prefix %s, expected to get %v, but got: %v", pref.String(), expectedRes, gotRes)
-			}
+			assert.Equal(t, expectedRes, gotRes, "LPM Descendants prefix %s", pref.String())
 		}
 	}
 }

--- a/pkg/datapath/iptables/reconciler_test.go
+++ b/pkg/datapath/iptables/reconciler_test.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"net"
 	"net/netip"
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -566,7 +565,7 @@ func assertIptablesState(current, expected desiredState) error {
 			expected.localNodeInfo, current.localNodeInfo)
 	}
 	if len(current.proxies) != 0 && len(expected.proxies) != 0 &&
-		!reflect.DeepEqual(current.proxies, expected.proxies) {
+		!assert.ObjectsAreEqual(expected.proxies, current.proxies) {
 		return fmt.Errorf("expected proxies info to be %v, found %v",
 			expected.proxies, current.proxies)
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 3 usages of `reflect.DeepEqual` across two packages:

- `pkg/datapath/iptables/reconciler_test.go` (1 usage)
- `pkg/container/bitlpm/cidr_test.go` (2 usages)

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/datapath/iptables -timeout 30s
ok  	github.com/cilium/cilium/pkg/datapath/iptables	4.069s

$ go test ./pkg/container/bitlpm/ -v -run "TestDescendants"
=== RUN   TestDescendants
--- PASS: TestDescendants (0.00s)
=== RUN   TestDescendantsShortestPrefixFirst
--- PASS: TestDescendantsShortestPrefixFirst (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/container/bitlpm	0.003s
```

## Follow-up

This is an incremental change affecting two small packages. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42186
- #42322
- #42768

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/datapath/iptables and pkg/container/bitlpm tests for better error messages
```
