### PR TITLE
hive: prefer injected job.Group over job.Registry

### DIFF
--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -36,8 +36,7 @@ type syncHostIPsParams struct {
 	cell.In
 
 	Logger        *slog.Logger
-	Jobs          job.Registry
-	Health        cell.Health
+	JobGroup      job.Group
 	DB            *statedb.DB
 	Config        *option.DaemonConfig
 	NodeAddresses statedb.Table[tables.NodeAddress]
@@ -60,7 +59,7 @@ func (s *syncHostIPs) StartAndWaitFirst(ctx context.Context) error {
 	}
 }
 
-func newSyncHostIPs(lc cell.Lifecycle, p syncHostIPsParams) *syncHostIPs {
+func newSyncHostIPs(p syncHostIPsParams) *syncHostIPs {
 	s := &syncHostIPs{
 		params:     p,
 		start:      make(chan struct{}),
@@ -72,8 +71,7 @@ func newSyncHostIPs(lc cell.Lifecycle, p syncHostIPsParams) *syncHostIPs {
 		return s
 	}
 
-	g := p.Jobs.NewGroup(p.Health, lc)
-	g.Add(job.OneShot("sync-hostips", s.loop))
+	p.JobGroup.Add(job.OneShot("sync-hostips", s.loop))
 
 	return s
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -102,8 +102,7 @@ type orchestratorParams struct {
 	DirectRoutingDevice tables.DirectRoutingDevice
 	LocalNodeStore      *node.LocalNodeStore
 	NodeDiscovery       *nodediscovery.NodeDiscovery
-	JobRegistry         job.Registry
-	Health              cell.Health
+	JobGroup            job.Group
 	Lifecycle           cell.Lifecycle
 	EndpointManager     endpointmanager.EndpointManager
 	ConfigPromise       promise.Promise[*option.DaemonConfig]
@@ -148,8 +147,7 @@ func newOrchestrator(params orchestratorParams) *orchestrator {
 		},
 	})
 
-	group := params.JobRegistry.NewGroup(params.Health, params.Lifecycle)
-	group.Add(job.OneShot("reinitialize", o.reconciler, job.WithShutdown()))
+	params.JobGroup.Add(job.OneShot("reinitialize", o.reconciler, job.WithShutdown()))
 
 	return o
 }

--- a/pkg/k8s/synced/cell.go
+++ b/pkg/k8s/synced/cell.go
@@ -86,9 +86,7 @@ type syncCRDsPromiseParams struct {
 
 	Logger *slog.Logger
 
-	Lifecycle     cell.Lifecycle
-	Jobs          job.Registry
-	Health        cell.Health
+	JobGroup      job.Group
 	Clientset     client.Clientset
 	Resources     *Resources
 	APIGroups     *APIGroups
@@ -103,8 +101,7 @@ func newCRDSyncPromise(params syncCRDsPromiseParams) promise.Promise[CRDSync] {
 		return crdSyncPromise
 	}
 
-	g := params.Jobs.NewGroup(params.Health, params.Lifecycle)
-	g.Add(job.OneShot("sync-crds", func(ctx context.Context, health cell.Health) error {
+	params.JobGroup.Add(job.OneShot("sync-crds", func(ctx context.Context, health cell.Health) error {
 		err := SyncCRDs(ctx, params.Logger, params.Clientset, params.ResourceNames, params.Resources, params.APIGroups, params.Config)
 		if err != nil {
 			crdSyncResolver.Reject(err)

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -49,20 +49,16 @@ func newFixture(t testing.TB) *fixture {
 	var (
 		tbl    statedb.RWTable[*tables.L2AnnounceEntry]
 		db     *statedb.DB
-		jr     job.Registry
 		jg     job.Group
-		h      cell.Health
 		logger = hivetest.Logger(t)
 	)
 
 	hive.New(
 		cell.Provide(tables.NewL2AnnounceTable),
-		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], h_ cell.Health, j job.Registry, jg_ job.Group) {
+		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], jg_ job.Group) {
 			db = d
 			tbl = t
-			jr = j
 			jg = jg_
-			h = h_
 		}),
 	).Populate(logger)
 
@@ -86,13 +82,10 @@ func newFixture(t testing.TB) *fixture {
 		JobGroup:        jg,
 	}
 
-	lc := hivetest.Lifecycle(t)
-
 	// Setting stores normally happens in .run which we bypass for testing purposes
 	announcer := NewL2Announcer(params)
 	announcer.policyStore = fakePolicyStore
 	announcer.svcStore = fakeSvcStore
-	announcer.params.JobGroup = jr.NewGroup(h, lc)
 	announcer.scopedGroup = announcer.params.JobGroup.Scoped("leader-election")
 
 	return &fixture{


### PR DESCRIPTION
Except for some special cases it's preferred that modules depend on `job.Group` rather than `job.Registry` and creating a new `job.Group` from it via `NewGroup`. The reason is that the Cilium Hive integration provides a `job.Group` to modules that is already scoped (logger, pprof, ...) (https://github.com/cilium/cilium/blob/main/pkg/hive/hive.go#L157-L162).

Therefore, this commit changes the usages of `job.Registry` to use `job.Group` instead.

Related to: https://github.com/cilium/cilium/pull/42762 (`hive: add metrics for hive jobs (total, errors, duration)`)