### PR TITLE
[v1.16] gh: conn-disrupt: fix XFRM error checks

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -16,6 +16,10 @@ inputs:
     required: false
     default: 'false'
     description: 'Run full connectivity test suite'
+  tests:
+    required: false
+    default: ''
+    description: 'Select which connectivity tests to run'
 
 runs:
   using: composite
@@ -23,12 +27,17 @@ runs:
     - name: Perform Conn Disrupt Test
       shell: bash
       run: |
-        TEST_ARG="no-interrupted-connections"
+        if [[ -n "${{ inputs.tests }}" ]]; then
+          TEST_ARG="${{ inputs.tests }}"
+        else
+          TEST_ARG="no-interrupted-connections"
+          EXTRA_ARG="--include-conn-disrupt-test"
+        fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
+          EXTRA_ARG="--include-conn-disrupt-test"
         fi
         ${{ inputs.cilium-cli }} connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-          --include-conn-disrupt-test \
           --flush-ct \
           --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
           --sysdump-output-filename "cilium-sysdump-conn-disrupt-test-${{ inputs.job-name }}-<ts>" \
@@ -38,4 +47,5 @@ runs:
           --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
           --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
           --test "$TEST_ARG" \
-          --expected-xfrm-errors "+inbound_no_state"
+          --expected-xfrm-errors "+inbound_no_state" \
+          ${EXTRA_ARG}

--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -30,7 +30,7 @@ runs:
         if [[ -n "${{ inputs.tests }}" ]]; then
           TEST_ARG="${{ inputs.tests }}"
         else
-          TEST_ARG="no-interrupted-connections"
+          TEST_ARG="no-interrupted-connections,no-ipsec-xfrm-error"
           EXTRA_ARG="--include-conn-disrupt-test"
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -341,6 +341,9 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: ${{ env.job_name }}-${{ matrix.name }}-post-rotate
+          # Opt-out from `no-ipsec-xfrm-error`, seeing XfrmOutPolBlock errors.
+          tests: 'no-interrupted-connections'
+          extra-connectivity-test-flags: "--include-conn-disrupt-test"
 
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start


### PR DESCRIPTION
Backport of
* [ ] #42724

With an additional patch to introduce some missing infrastructure in the `conn-disrupt-test-check` action.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42724
```
