### PR TITLE
gh: ipsec-e2e: fix flaky connection disruptivity test

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -89,7 +89,6 @@ runs:
             --nodes-without-cilium \
             --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
             --helm-set=l2NeighDiscovery.enabled=true \
-            --helm-set-string=encryption.ipsec.keyRotationDuration="1m" \
             --set='${{ inputs.misc }}' \
             --set-string=extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
             --set-string=extraEnv[0].value=true \

--- a/.github/actions/ipsec-key-rotate/action.yaml
+++ b/.github/actions/ipsec-key-rotate/action.yaml
@@ -40,6 +40,8 @@ runs:
         ((exp_nb_keys/=2))
 
         # Wait until key rotation completes
+        # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
+        sleep $((4*60))
         while true; do
           keys_in_use=$(kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg encrypt status | awk '/Keys in use/ {print $NF}')
           if [[ $keys_in_use == $exp_nb_keys ]]; then

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -392,9 +392,7 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: ${{ env.job_name }}-${{ matrix.name }}-post-rotate
-          # Opt-out from `no-ipsec-xfrm-error`, seeing XfrmOutPolBlock errors.
-          tests: 'no-interrupted-connections'
-          extra-connectivity-test-flags: "${{ steps.vars-conn.outputs.connectivity_test_defaults }} --include-conn-disrupt-test"
+          extra-connectivity-test-flags: "${{ steps.vars-conn.outputs.connectivity_test_defaults }}"
 
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start


### PR DESCRIPTION
Roll back the change from https://github.com/cilium/cilium/pull/40032, and then remove the workaround from https://github.com/cilium/cilium/pull/42724 that is no longer required.
