### PR TITLE
Minor improvements around certificate validation in etcd/clustermesh troubleshoot commands

### DIFF
--- a/pkg/kvstore/etcd_debug.go
+++ b/pkg/kvstore/etcd_debug.go
@@ -297,7 +297,7 @@ func etcdDbgCerts(cfgfile string, cfg *client.Config, iw *indentedWriter) {
 
 			_, err = leaf.Verify(opts)
 			if err != nil {
-				iiw.Println("⚠️ Cannot verify certificate with the configured root CAs")
+				iiw.Println("⚠️ Cannot verify certificate with the configured root CAs: %s", err)
 			}
 		}
 	}

--- a/pkg/kvstore/etcd_debug.go
+++ b/pkg/kvstore/etcd_debug.go
@@ -293,6 +293,7 @@ func etcdDbgCerts(cfgfile string, cfg *client.Config, iw *indentedWriter) {
 			opts := x509.VerifyOptions{
 				Roots:         cfg.TLS.RootCAs,
 				Intermediates: intermediates,
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 			}
 
 			_, err = leaf.Verify(opts)


### PR DESCRIPTION
Please refer to the individual commit messages for additional details. Marking for backport to all stable branches given that it is an improvement to a troubleshooting tool.

(Checked a sysdump from three different runs using respectively helm, certgen and cert-manager for certificate generation --- validation completed successfully in all three).