### PR TITLE
policy: Add generic precedence support

### DIFF
--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -76,7 +76,7 @@ func TestPrivilegedPolicyMapDumpToSlice(t *testing.T) {
 
 	require.False(t, dump[0].PolicyEntry.AuthRequirement.IsExplicit())
 	require.Equal(t, policyTypes.AuthType(1), dump[0].PolicyEntry.AuthRequirement.AuthType())
-	require.Equal(t, policyTypes.ProxyPortPriority(42), dump[0].PolicyEntry.ProxyPortPriority)
+	require.Equal(t, policyTypes.Precedence(42), dump[0].PolicyEntry.Precedence)
 
 	// Special case: allow-all entry
 	barKey := newKey(0, 0, 0, 0, 0)
@@ -103,7 +103,7 @@ func TestPrivilegedDenyPolicyMapDumpToSlice(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 
 	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)
-	fooEntry := newDenyEntry(fooKey)
+	fooEntry := newDenyEntry(fooKey, 321)
 	err := testMap.Update(&fooKey, &fooEntry)
 	require.NoError(t, err)
 
@@ -116,7 +116,7 @@ func TestPrivilegedDenyPolicyMapDumpToSlice(t *testing.T) {
 
 	// Special case: deny-all entry
 	barKey := newKey(0, 0, 0, 0, 0)
-	barEntry := newDenyEntry(barKey)
+	barEntry := newDenyEntry(barKey, 0)
 	err = testMap.Update(&barKey, &barEntry)
 	require.NoError(t, err)
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1415,8 +1415,8 @@ var (
 	mapKeyL3WorldEgressIPv4   = EgressKey().WithIdentity(worldReservedIDIPv4)
 	mapKeyL3WorldEgressIPv6   = EgressKey().WithIdentity(worldReservedIDIPv6)
 
-	AllowEntry    = types.AllowEntry()
-	DenyEntry     = types.DenyEntry()
+	AllowEntry    = types.AllowEntry().WithLevel(0)
+	DenyEntry     = types.DenyEntry().WithLevel(0)
 	mapEntryDeny  = NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil})
 	mapEntryAllow = NewMapStateEntry(AllowEntry).withLabels(labels.LabelArrayList{nil})
 

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -84,7 +84,7 @@ func FuzzAccumulateMapChange(f *testing.F) {
 			proxyPort = 1
 		}
 		key := KeyForDirection(dir).WithPortProto(proto, port)
-		value := newMapStateEntry(NilRuleOrigin, proxyPort, 0, deny, NoAuthRequirement)
+		value := newMapStateEntry(0, NilRuleOrigin, proxyPort, 0, deny, NoAuthRequirement)
 		policyMaps := MapChanges{logger: slog.New(slog.DiscardHandler)}
 		policyMaps.AccumulateMapChanges(adds, deletes, []Key{key}, value)
 		policyMaps.SyncMapChanges(versioned.LatestTx)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1407,6 +1407,10 @@ const (
 	redirectRules
 	authRules
 
+	// if any of the precedenceFeatures is set, then we need to scan for policy overrides due to
+	// precedence differences between rules.
+	precedenceFeatures policyFeatures = denyRules | redirectRules
+
 	allFeatures policyFeatures = ^policyFeatures(0)
 )
 

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -403,8 +403,8 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA: &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -461,8 +461,8 @@ func TestL3L4AllowRuleWithByL3DenyAll(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorA: &PerSelectorPolicy{IsDeny: true},
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -714,8 +714,9 @@ func (ms *mapState) insertWithChanges(newKey Key, newEntry mapStateEntry, featur
 
 		// Bail if covered by a deny key or a key with a higher proxy port priority.
 		//
-		// This can be skipped if no rules have denies or proxy redirects
-		if features.contains(denyRules | redirectRules) {
+		// This can be skipped if no rules have proxy redirects, non-zero precedence,
+		// and there are no deny rules.
+		if features.contains(precedenceFeatures) {
 			for _, v := range ms.BroaderOrEqualKeys(newKey) {
 				if v.IsDeny() || v.ProxyPortPriority > newEntry.ProxyPortPriority {
 					return
@@ -725,8 +726,8 @@ func (ms *mapState) insertWithChanges(newKey Key, newEntry mapStateEntry, featur
 
 		// Delete covered allow entries with lower proxy port priority.
 		//
-		// This is only needed if the newEntry has a proxy port priority greater than zero.
-		if newEntry.ProxyPortPriority > 0 {
+		// This can be skipped if all rules have the same precedence
+		if features.contains(precedenceFeatures) {
 			for k, v := range ms.NarrowerOrEqualKeys(newKey) {
 				if !v.IsDeny() && v.ProxyPortPriority < newEntry.ProxyPortPriority {
 					ms.deleteKeyWithChanges(k, changes)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -326,7 +326,8 @@ func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
 		// auth type may be overridden by a covering key.
 		// This also needs to reflect the logic in bpf/lib/policy.h __account_and_check().
 		if !entry.AuthRequirement.IsExplicit() &&
-			other.AuthRequirement.AuthType() > entry.AuthRequirement.AuthType() {
+			other.AuthRequirement.AuthType() > entry.AuthRequirement.AuthType() &&
+			other.AllowPrecedence() >= entry.AllowPrecedence() {
 			entry.AuthRequirement = other.AuthRequirement.AsDerived()
 		}
 		return entry
@@ -343,33 +344,30 @@ func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
 	// both L3 and L4 matches found
 	if haveL3 && haveL4 {
 		// Precedence rules of the bpf datapath between two policy entries:
-		// 1. Deny is selected, if any
-		// 2. Higher proxy port priority wins
-		// 3. If both entries are allows at the same proxy port priority, the one with more
+		// 1. higher precedence entry wins, but auth may need to be propagated.
+		// 2. if Deny at same precedence, no further processing is needed
+		// 3. if both entries are allows at the same precedence, the one with more
 		//    specific L4 is selected
-		// 4. If the two allows on the same proxy port priority have equal port/proto, then
+		// 4. If the two allows on the same precedence have equal port/proto, then
 		//    the policy for a specific L3 is selected (rather than the L4-only entry)
 		//
 		// If the selected entry has non-explicit auth type, it gets the auth type from the
 		// other entry, if the other entry's auth type is numerically higher.
 
-		// 1. Deny wins
-		// Check for the L3 deny first to match the datapath behavior
-		if l3entry.IsDeny() {
+		// 1. Entry with higher precedence is selected.
+		//    Auth requirement does not propagate from a lower precedence rule to a
+		//    higher precedence rule!
+		if l3entry.Precedence > l4entry.Precedence {
 			return l3entry, true
 		}
-		if l4entry.IsDeny() {
+		if l4entry.Precedence > l3entry.Precedence {
 			return l4entry, true
 		}
 
-		// 2. Entry with higher proxy port priority is selected.
-		//    Auth requirement does not propagate from a lower proxy port priority rule to a
-		//    higher proxy port priority rule!
-		if l3entry.ProxyPortPriority > l4entry.ProxyPortPriority {
+		// 2. Entries at the same precedence,
+		// Check for the L3 deny first to match the datapath behavior
+		if l3entry.IsDeny() {
 			return l3entry, true
-		}
-		if l4entry.ProxyPortPriority > l3entry.ProxyPortPriority {
-			return l4entry, true
 		}
 
 		// 3. Two allow entries, select the one with more specific L4
@@ -580,8 +578,9 @@ func (e mapStateEntry) String() string {
 func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes ChangeState) bool {
 	var datapathEqual bool
 	oldEntry, exists := ms.get(key)
-	// Only merge if both old and new are allows or denies
-	if exists && oldEntry.IsDeny() == entry.IsDeny() {
+	// Only merge if both old and new have the same precedence
+	// (ignoring any difference in the proxy port precedence)
+	if exists && oldEntry.Precedence.ProxyPortPrecedenceMayDiffer(entry.Precedence) {
 		// Do nothing if entries are equal
 		if entry.Equal(&oldEntry) {
 			return false // nothing to do
@@ -598,10 +597,9 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 		oldEntry.derivedFromRules = oldEntry.derivedFromRules.Merge(entry.derivedFromRules)
 
 		ms.updateExisting(key, oldEntry)
-	} else if !exists || entry.IsDeny() {
-		// Insert a new entry if one did not exist or a deny entry is overwriting an allow
-		// entry
-
+	} else if !exists || entry.Precedence > oldEntry.Precedence {
+		// Insert a new entry if one did not exist or if the new entry is of
+		// a higher precedence.
 		// Save old value before any changes, if any
 		if exists {
 			changes.insertOldIfNotExists(key, oldEntry)
@@ -627,8 +625,13 @@ func (ms *mapState) addKeyWithChanges(key Key, entry mapStateEntry, changes Chan
 }
 
 // deleteKeyWithChanges deletes a 'key' from 'ms' keeping track of incremental changes in 'changes'
-func (ms *mapState) deleteKeyWithChanges(key Key, changes ChangeState) {
+// Note: key is only deleted if the 'precedence' matches with the precedence field of the found
+// entry
+func (ms *mapState) deleteKeyWithChanges(key Key, precedence types.Precedence, changes ChangeState) {
 	if entry, exists := ms.get(key); exists {
+		if entry.Precedence != precedence {
+			return
+		}
 		// Only record as a delete if the entry was not added on the same round of changes
 		if changes.insertOldIfNotExists(key, entry) && changes.Deletes != nil {
 			changes.Deletes[key] = struct{}{}
@@ -655,18 +658,17 @@ func (ms *mapState) revertChanges(changes ChangeState) {
 }
 
 // insertWithChanges contains the most important business logic for policy insertions. It inserts a
-// key and entry into the map only if not covered by a deny entry.
+// key and entry into the map only if not covered by an entry of a higher precedence.
 //
 // Whenever the bpf datapath finds both L4-only and L3/L4 matching policy entries for a given
 // packet, it uses the following logic to choose the policy entry:
-//  1. Deny is selected, if any
-//  2. Among two allows the one with higher proxy port priority is selected
-//  3. Otherwise, the L4-only entry is chosen if it has more specific port/proto than
-//     the L3/L4 entry
-//  4. Otherwise the L3/L4 entry is chosen
+//  1. Entry with higher precedence value is selected
+//  2. When at the same precedence, the L4-only entry is chosen if it has more
+//     specific port/proto than the L3/L4 entry
+//  3. Otherwise the L3/L4 entry is chosen
 //
-// This selects the higher precedence rule either by the deny status, or by the more
-// specific L4, and for the L3/L4 entry overwise. This means that it suffices to manage
+// This selects the higher precedence rule either by the numerical precedence value, or by the more
+// specific L4, and for the L3/L4 entry overwise. This means that it suffices to manage explicit and
 // deny precedence among the keys with the same ID here, the datapath take care of the precedence
 // between different IDs (that is, between a specific ID and the wildcard ID (==0)
 //
@@ -692,17 +694,23 @@ func (ms *mapState) revertChanges(changes ChangeState) {
 // Incremental changes performed are recorded in 'changes'.
 func (ms *mapState) insertWithChanges(newKey Key, newEntry mapStateEntry, features policyFeatures, changes ChangeState) {
 	if newEntry.IsDeny() {
-		// Bail if covered by another (different) deny key
+		// Bail if covered by a key of higher precedence, or by a deny key of the same
+		// precedence
 		for k, v := range ms.BroaderOrEqualKeys(newKey) {
-			if v.IsDeny() && k != newKey {
+			if v.Precedence > newEntry.Precedence ||
+				// New deny entry is also bailed due to different covering deny key
+				// of the same precedence, equal keys need to be merged
+				v.Precedence == newEntry.Precedence && k != newKey {
 				return
 			}
 		}
 
-		// Delete covered allows and denies with a different key
+		// Delete covered entries of lower precedence, and
+		// same precedence deny entries if the keys are different
 		for k, v := range ms.NarrowerOrEqualKeys(newKey) {
-			if !v.IsDeny() || k != newKey {
-				ms.deleteKeyWithChanges(k, changes)
+			if v.Precedence < newEntry.Precedence ||
+				v.Precedence == newEntry.Precedence && k != newKey {
+				ms.deleteKeyWithChanges(k, v.Precedence, changes)
 			}
 		}
 	} else {
@@ -712,25 +720,28 @@ func (ms *mapState) insertWithChanges(newKey Key, newEntry mapStateEntry, featur
 			return
 		}
 
-		// Bail if covered by a deny key or a key with a higher proxy port priority.
+		// Bail if covered by a key of an higher precedence.
 		//
 		// This can be skipped if no rules have proxy redirects, non-zero precedence,
 		// and there are no deny rules.
 		if features.contains(precedenceFeatures) {
 			for _, v := range ms.BroaderOrEqualKeys(newKey) {
-				if v.IsDeny() || v.ProxyPortPriority > newEntry.ProxyPortPriority {
+				if v.Precedence > newEntry.Precedence {
 					return
 				}
 			}
 		}
 
-		// Delete covered allow entries with lower proxy port priority.
+		// Delete covered entries of lower precedence.
+		//
+		// NOTE: We do not delete covered allow entries on the same precedence, as they may
+		// specify proxy redirection or different auth types.
 		//
 		// This can be skipped if all rules have the same precedence
 		if features.contains(precedenceFeatures) {
 			for k, v := range ms.NarrowerOrEqualKeys(newKey) {
-				if !v.IsDeny() && v.ProxyPortPriority < newEntry.ProxyPortPriority {
-					ms.deleteKeyWithChanges(k, changes)
+				if v.Precedence < newEntry.Precedence {
+					ms.deleteKeyWithChanges(k, v.Precedence, changes)
 				}
 			}
 		}
@@ -748,7 +759,7 @@ func (ms *mapState) overrideProxyPortForAuth(newEntry mapStateEntry, k Key, v ma
 
 		// Proxy port can be changed in-place, trie is not affected
 		v.ProxyPort = newEntry.ProxyPort
-		v.ProxyPortPriority = newEntry.ProxyPortPriority
+		v.Precedence = newEntry.Precedence
 
 		ms.entries[k] = v
 		return true
@@ -777,7 +788,7 @@ func (ms *mapState) overrideAuthRequirement(newEntry mapStateEntry, k Key, v map
 // entry evaluation. If there is a covering map key for 'newKey'
 // which denies traffic matching 'newKey', then this function should not be called.
 func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, features policyFeatures, changes ChangeState) {
-	// Bail if covered by a deny key or a key with a higher proxy port priority and current
+	// Bail if covered by a deny key or a key with a higher precedence and current
 	// entry has no explicit auth.
 	var derived bool
 	newEntryHasExplicitAuth := newEntry.AuthRequirement.IsExplicit()
@@ -785,9 +796,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, feat
 		if v.IsDeny() {
 			return // bail if covered by deny
 		}
-		if v.ProxyPortPriority > newEntry.ProxyPortPriority {
+		if v.Precedence > newEntry.Precedence {
 			if !newEntryHasExplicitAuth {
-				// Covering entry has higher proxy port priority and newEntry has a
+				// Covering entry has higher precedence and newEntry has a
 				// default auth type => can bail out
 				return
 			}
@@ -795,7 +806,7 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, feat
 			// newEnry has a different explicit auth requirement, must propagate
 			// proxy port and priority and keep it
 			newEntry.ProxyPort = v.ProxyPort
-			newEntry.ProxyPortPriority = v.ProxyPortPriority
+			newEntry.Precedence = v.Precedence
 
 			// Can break out:
 			// - if there were covering denies the allow 'v' would
@@ -805,8 +816,11 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, feat
 			break
 		}
 		// Fill in the AuthType from the most specific covering key with the same ID and an
-		// explicit auth type
-		if !derived && !newEntryHasExplicitAuth && !k.PortProtoIsEqual(newKey) && v.AuthRequirement.IsExplicit() {
+		// explicit auth type, ignoring any difference in proxy port precedence
+		if !derived && !newEntryHasExplicitAuth &&
+			!k.PortProtoIsEqual(newKey) &&
+			v.AuthRequirement.IsExplicit() &&
+			v.AllowPrecedence() >= newEntry.AllowPrecedence() {
 			// AuthType from the most specific covering key is applied to 'newEntry' as
 			// derived auth type.
 			newEntry.AuthRequirement = v.AuthRequirement.AsDerived()
@@ -814,7 +828,7 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, feat
 		}
 	}
 
-	// Delete covered allow entries with lower proxy port priority, but keep
+	// Delete covered allow entries with lower precedence, but keep
 	// entries with different "auth" and propagate proxy port and priority to them.
 	//
 	// Check if the new key is the most specific covering key of any other key
@@ -822,9 +836,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry mapStateEntry, feat
 	// entry to such entries.
 	var propagated bool
 	for k, v := range ms.SubsetKeysWithSameID(newKey) {
-		if !v.IsDeny() && v.ProxyPortPriority < newEntry.ProxyPortPriority {
+		if v.Precedence < newEntry.Precedence {
 			if !ms.overrideProxyPortForAuth(newEntry, k, v, changes) {
-				ms.deleteKeyWithChanges(k, changes)
+				ms.deleteKeyWithChanges(k, v.Precedence, changes)
 				continue
 			}
 		}
@@ -996,7 +1010,7 @@ func (mc *MapChanges) consumeMapChanges(p *EndpointPolicy, features policyFeatur
 		} else {
 			// Delete the contribution of this cs to the key and collect incremental
 			// changes
-			p.policyMapState.deleteKeyWithChanges(key, changes)
+			p.policyMapState.deleteKeyWithChanges(key, entry.Precedence, changes)
 		}
 	}
 

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -374,8 +374,8 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeKafka,
-					Priority: ListenerPriorityKafka,
+					L7Parser:         ParserTypeKafka,
+					ListenerPriority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 					},
@@ -390,8 +390,8 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 					},
@@ -406,8 +406,8 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: L7ParserType("tester"),
-					Priority: ListenerPriorityProxylib,
+					L7Parser:         L7ParserType("tester"),
+					ListenerPriority: ListenerPriorityProxylib,
 					L7Rules: api.L7Rules{
 						L7Proto: "tester",
 						L7:      []api.PortRuleL7{l7Rule.Ingress[0].ToPorts[0].Rules.L7[0]},
@@ -512,8 +512,8 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 					},
@@ -532,8 +532,8 @@ func TestWildcardL4RulesIngress(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeKafka,
-					Priority: ListenerPriorityKafka,
+					L7Parser:         ParserTypeKafka,
+					ListenerPriority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 					},
@@ -657,8 +657,8 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeDNS,
-					Priority: ListenerPriorityDNS,
+					L7Parser:         ParserTypeDNS,
+					ListenerPriority: ListenerPriorityDNS,
 					L7Rules: api.L7Rules{
 						DNS: []api.PortRuleDNS{dnsRule.Egress[0].ToPorts[0].Rules.DNS[0]},
 					},
@@ -673,8 +673,8 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 					},
@@ -809,8 +809,8 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 					},
@@ -829,8 +829,8 @@ func TestWildcardL4RulesEgress(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar1: nil,
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeDNS,
-					Priority: ListenerPriorityDNS,
+					L7Parser:         ParserTypeDNS,
+					ListenerPriority: ListenerPriorityDNS,
 					L7Rules: api.L7Rules{
 						DNS: []api.PortRuleDNS{dnsRule.Egress[0].ToPorts[0].Rules.DNS[0]},
 					},
@@ -905,8 +905,8 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				cachedSelectors[0]: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{
 							Headers: []string{"X-My-Header: true"},
@@ -1017,8 +1017,8 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeKafka,
-					Priority: ListenerPriorityKafka,
+					L7Parser:         ParserTypeKafka,
+					ListenerPriority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{kafkaRule.Ingress[0].ToPorts[0].Rules.Kafka[0]},
 					},
@@ -1033,8 +1033,8 @@ func TestWildcardL3RulesIngressFromEntities(t *testing.T) {
 			Ingress:  true,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Ingress[0].ToPorts[0].Rules.HTTP[0]},
 					},
@@ -1130,8 +1130,8 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeDNS,
-					Priority: ListenerPriorityDNS,
+					L7Parser:         ParserTypeDNS,
+					ListenerPriority: ListenerPriorityDNS,
 					L7Rules: api.L7Rules{
 						DNS: []api.PortRuleDNS{dnsRule.Egress[0].ToPorts[0].Rules.DNS[0]},
 					},
@@ -1146,8 +1146,8 @@ func TestWildcardL3RulesEgressToEntities(t *testing.T) {
 			Ingress:  false,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorBar2: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{httpRule.Egress[0].ToPorts[0].Rules.HTTP[0]},
 					},
@@ -1225,8 +1225,8 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/"}, {}},
 				},

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -52,6 +52,12 @@ type PolicyContext interface {
 	// such rules being evaluated.
 	GetEnvoyHTTPRules(l7Rules *api.L7Rules) (*cilium.HttpNetworkPolicyRules, bool)
 
+	// SetPriority sets the priority level for the first rule being processed.
+	SetPriority(level uint32)
+
+	// Priority returns the priority level for the current rule.
+	Priority() uint32
+
 	// IsDeny returns true if the policy computation should be done for the
 	// policy deny case. This function returns different values depending on the
 	// code path as it can be changed during the policy calculation.
@@ -78,6 +84,10 @@ type PolicyContext interface {
 type policyContext struct {
 	repo *Repository
 	ns   string
+
+	// level is the precedence level for the rule being processed.
+	level uint32
+
 	// isIngress is set to true for ingress rule processing, false for egress
 	isIngress bool
 	// isDeny this field is set to true if the given policy computation should
@@ -127,6 +137,16 @@ func (p *policyContext) GetTLSContext(tls *api.TLSContext) (ca, public, private 
 
 func (p *policyContext) GetEnvoyHTTPRules(l7Rules *api.L7Rules) (*cilium.HttpNetworkPolicyRules, bool) {
 	return p.repo.GetEnvoyHTTPRules(l7Rules, p.ns)
+}
+
+// SetPriority sets the precedence level for the first rule being processed.
+func (p *policyContext) SetPriority(level uint32) {
+	p.level = level
+}
+
+// Priority returns the precedence level for the current rule.
+func (p *policyContext) Priority() uint32 {
+	return p.level
 }
 
 // IsDeny returns true if the policy computation should be done for the

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -474,8 +474,8 @@ func TestL7WithIngressWildcard(t *testing.T) {
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
 							td.wildcardCachedSelector: &PerSelectorPolicy{
-								L7Parser: ParserTypeHTTP,
-								Priority: ListenerPriorityHTTP,
+								L7Parser:         ParserTypeHTTP,
+								ListenerPriority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
 								},
@@ -563,8 +563,8 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 						PerSelectorPolicies: L7DataMap{
 							cachedSelectorHost: nil,
 							td.wildcardCachedSelector: &PerSelectorPolicy{
-								L7Parser: ParserTypeHTTP,
-								Priority: ListenerPriorityHTTP,
+								L7Parser:         ParserTypeHTTP,
+								ListenerPriority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
 								},
@@ -1060,7 +1060,7 @@ func TestEndpointPolicy_GetRuleMeta(t *testing.T) {
 
 	// test non-empty mapstate
 	p.policyMapState = emptyMapState(log).withState(mapStateMap{
-		key1: newMapStateEntry(makeSingleRuleOrigin(lbls, logstr), 0, 0, false, NoAuthRequirement),
+		key1: newMapStateEntry(0, makeSingleRuleOrigin(lbls, logstr), 0, 0, false, NoAuthRequirement),
 	})
 
 	rm, err := p.GetRuleMeta(key1)
@@ -1073,7 +1073,7 @@ func TestEndpointPolicy_GetRuleMeta(t *testing.T) {
 
 	// test mapstate from dump
 	msDump := MapStateMap{
-		key1: types.NewMapStateEntry(false, 0, 0, NoAuthRequirement),
+		key1: types.NewMapStateEntry(0, false, 0, 0, NoAuthRequirement),
 	}
 
 	p = &EndpointPolicy{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -450,7 +450,7 @@ func (result *l4PolicyMap) resolveL4Policy(
 
 	policyCtx.SetDeny(false)
 	if !r.Deny {
-		policyCtx.SetPriority(0)
+		policyCtx.SetPriority(r.Priority)
 		cnt, err := result.mergeL4Filter(policyCtx, r)
 		if err != nil {
 			return err
@@ -462,7 +462,7 @@ func (result *l4PolicyMap) resolveL4Policy(
 
 	policyCtx.SetDeny(true)
 	if r.Deny {
-		policyCtx.SetPriority(0)
+		policyCtx.SetPriority(r.Priority)
 		cnt, err := result.mergeL4Filter(policyCtx, r)
 		if err != nil {
 			return err

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -59,9 +59,9 @@ func TestL4Policy(t *testing.T) {
 	}
 	l7map := L7DataMap{
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Parser: ParserTypeHTTP,
-			Priority: ListenerPriorityHTTP,
-			L7Rules:  l7rules,
+			L7Parser:         ParserTypeHTTP,
+			ListenerPriority: ListenerPriorityHTTP,
+			L7Rules:          l7rules,
 		},
 	}
 
@@ -150,8 +150,8 @@ func TestL4Policy(t *testing.T) {
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}, {}},
 				},
@@ -326,15 +326,15 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}, {}},
 				},
 			},
 			td.cachedSelectorB: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -386,14 +386,14 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	}
 	l7map := L7DataMap{
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Parser: ParserTypeKafka,
-			Priority: ListenerPriorityKafka,
-			L7Rules:  l7rules,
+			L7Parser:         ParserTypeKafka,
+			ListenerPriority: ListenerPriorityKafka,
+			L7Rules:          l7rules,
 		},
 		td.cachedSelectorB: &PerSelectorPolicy{
-			L7Parser: ParserTypeKafka,
-			Priority: ListenerPriorityKafka,
-			L7Rules:  l7rules,
+			L7Parser:         ParserTypeKafka,
+			ListenerPriority: ListenerPriorityKafka,
+			L7Rules:          l7rules,
 		},
 	}
 
@@ -459,14 +459,14 @@ func TestMergeL7PolicyIngress(t *testing.T) {
 	// The L3-dependent L7 rules are not merged together.
 	l7map = L7DataMap{
 		td.cachedSelectorB: &PerSelectorPolicy{
-			L7Parser: ParserTypeKafka,
-			Priority: ListenerPriorityKafka,
-			L7Rules:  fooRules,
+			L7Parser:         ParserTypeKafka,
+			ListenerPriority: ListenerPriorityKafka,
+			L7Rules:          fooRules,
 		},
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Parser: ParserTypeKafka,
-			Priority: ListenerPriorityKafka,
-			L7Rules:  barRules,
+			L7Parser:         ParserTypeKafka,
+			ListenerPriority: ListenerPriorityKafka,
+			L7Rules:          barRules,
 		},
 	}
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
@@ -530,15 +530,15 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}, {}},
 				},
 			},
 			td.cachedSelectorB: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/private", Method: "GET"}},
 				},
@@ -599,15 +599,15 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 			wildcard: td.wildcardCachedSelector,
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{Path: "/public", Method: "GET"}, {}},
 					},
 				},
 				td.cachedSelectorB: &PerSelectorPolicy{
-					L7Parser: ParserTypeHTTP,
-					Priority: ListenerPriorityHTTP,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
 					L7Rules: api.L7Rules{
 						HTTP: []api.PortRuleHTTP{{Path: "/private", Method: "GET"}},
 					},
@@ -624,15 +624,15 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 			wildcard: td.wildcardCachedSelector,
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: &PerSelectorPolicy{
-					L7Parser: ParserTypeKafka,
-					Priority: ListenerPriorityKafka,
+					L7Parser:         ParserTypeKafka,
+					ListenerPriority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{{Topic: "foo"}, {}},
 					},
 				},
 				td.cachedSelectorB: &PerSelectorPolicy{
-					L7Parser: ParserTypeKafka,
-					Priority: ListenerPriorityKafka,
+					L7Parser:         ParserTypeKafka,
+					ListenerPriority: ListenerPriorityKafka,
 					L7Rules: api.L7Rules{
 						Kafka: []kafka.PortRule{{Topic: "foo"}},
 					},
@@ -692,14 +692,14 @@ func TestMergeL7PolicyEgress(t *testing.T) {
 	// The l3-dependent l7 rules are not merged together.
 	l7map := L7DataMap{
 		td.cachedSelectorB: &PerSelectorPolicy{
-			L7Parser: ParserTypeKafka,
-			Priority: ListenerPriorityKafka,
-			L7Rules:  fooRules,
+			L7Parser:         ParserTypeKafka,
+			ListenerPriority: ListenerPriorityKafka,
+			L7Rules:          fooRules,
 		},
 		td.wildcardCachedSelector: &PerSelectorPolicy{
-			L7Parser: ParserTypeKafka,
-			Priority: ListenerPriorityKafka,
-			L7Rules:  barRules,
+			L7Parser:         ParserTypeKafka,
+			ListenerPriority: ListenerPriorityKafka,
+			L7Rules:          barRules,
 		},
 	}
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
@@ -1988,8 +1988,8 @@ func TestL4WildcardMerge(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -2005,8 +2005,8 @@ func TestL4WildcardMerge(t *testing.T) {
 			Port: 7000, Protocol: api.ProtoTCP, U8Proto: 6,
 			PerSelectorPolicies: L7DataMap{
 				td.cachedSelectorC: &PerSelectorPolicy{
-					L7Parser: "testparser",
-					Priority: ListenerPriorityProxylib,
+					L7Parser:         "testparser",
+					ListenerPriority: ListenerPriorityProxylib,
 					L7Rules: api.L7Rules{
 						L7Proto: "testparser",
 						L7:      []api.PortRuleL7{{"Key": "Value"}, {}},
@@ -2118,8 +2118,8 @@ func TestL4WildcardMerge(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -2175,8 +2175,8 @@ func TestL4WildcardMerge(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -2238,8 +2238,8 @@ func TestL3L4L7Merge(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorC: nil,
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -2288,8 +2288,8 @@ func TestL3L4L7Merge(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorC: nil,
 			td.wildcardCachedSelector: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
 				},
@@ -2437,8 +2437,8 @@ func TestMergeL7PolicyEgressWithMultipleSelectors(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: nil,
 			td.cachedSelectorC: &PerSelectorPolicy{
-				L7Parser: ParserTypeHTTP,
-				Priority: ListenerPriorityHTTP,
+				L7Parser:         ParserTypeHTTP,
+				ListenerPriority: ListenerPriorityHTTP,
 				L7Rules: api.L7Rules{
 					HTTP: []api.PortRuleHTTP{{Method: "GET"}, {Host: "foo"}},
 				},
@@ -2460,26 +2460,26 @@ func TestMergeListenerReference(t *testing.T) {
 	err := ps.mergeRedirect(ps)
 	require.NoError(t, err)
 	require.Empty(t, ps.Listener)
-	require.Equal(t, ListenerPriority(0), ps.Priority)
+	require.Equal(t, ListenerPriority(0), ps.ListenerPriority)
 
 	// Listener reference remains when the other has none
 	ps0 := &PerSelectorPolicy{Listener: "listener0"}
 	err = ps0.mergeRedirect(ps)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps0.Listener)
-	require.Equal(t, ListenerPriority(0), ps0.Priority)
+	require.Equal(t, ListenerPriority(0), ps0.ListenerPriority)
 
 	// Listener reference is propagated when there is none to begin with
 	err = ps.mergeRedirect(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps.Listener)
-	require.Equal(t, ListenerPriority(0), ps.Priority)
+	require.Equal(t, ListenerPriority(0), ps.ListenerPriority)
 
 	// A listener is not changed when there is no change
 	err = ps0.mergeRedirect(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener0", ps0.Listener)
-	require.Equal(t, ListenerPriority(0), ps0.Priority)
+	require.Equal(t, ListenerPriority(0), ps0.ListenerPriority)
 
 	// Cannot merge two different listeners with the default (zero) priority
 	ps0a := &PerSelectorPolicy{Listener: "listener0a"}
@@ -2491,46 +2491,46 @@ func TestMergeListenerReference(t *testing.T) {
 
 	// Listener with a defined (non-zero) priority takes precedence over
 	// a listener with an undefined (zero) priority
-	ps1 := &PerSelectorPolicy{Listener: "listener1", Priority: 1}
+	ps1 := &PerSelectorPolicy{Listener: "listener1", ListenerPriority: 1}
 	err = ps1.mergeRedirect(ps0)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps1.Listener)
-	require.Equal(t, ListenerPriority(1), ps1.Priority)
+	require.Equal(t, ListenerPriority(1), ps1.ListenerPriority)
 
 	err = ps0.mergeRedirect(ps1)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps0.Listener)
-	require.Equal(t, ListenerPriority(1), ps0.Priority)
+	require.Equal(t, ListenerPriority(1), ps0.ListenerPriority)
 
 	// Listener with the lower priority value takes precedence
-	ps2 := &PerSelectorPolicy{Listener: "listener2", Priority: 2}
+	ps2 := &PerSelectorPolicy{Listener: "listener2", ListenerPriority: 2}
 	err = ps1.mergeRedirect(ps2)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps1.Listener)
-	require.Equal(t, ListenerPriority(1), ps1.Priority)
+	require.Equal(t, ListenerPriority(1), ps1.ListenerPriority)
 
 	err = ps2.mergeRedirect(ps1)
 	require.NoError(t, err)
 	require.Equal(t, "listener1", ps2.Listener)
-	require.Equal(t, ListenerPriority(1), ps2.Priority)
+	require.Equal(t, ListenerPriority(1), ps2.ListenerPriority)
 
 	// Cannot merge two different listeners with the same priority
-	ps12 := &PerSelectorPolicy{Listener: "listener1", Priority: 2}
-	ps2 = &PerSelectorPolicy{Listener: "listener2", Priority: 2}
+	ps12 := &PerSelectorPolicy{Listener: "listener1", ListenerPriority: 2}
+	ps2 = &PerSelectorPolicy{Listener: "listener2", ListenerPriority: 2}
 	err = ps12.mergeRedirect(ps2)
 	require.Error(t, err)
 	err = ps2.mergeRedirect(ps12)
 	require.Error(t, err)
 
 	// Lower priority is propagated also when the listeners are the same
-	ps23 := &PerSelectorPolicy{Listener: "listener2", Priority: 3}
+	ps23 := &PerSelectorPolicy{Listener: "listener2", ListenerPriority: 3}
 	err = ps2.mergeRedirect(ps23)
 	require.NoError(t, err)
 	require.Equal(t, "listener2", ps2.Listener)
-	require.Equal(t, ListenerPriority(2), ps2.Priority)
+	require.Equal(t, ListenerPriority(2), ps2.ListenerPriority)
 
 	err = ps23.mergeRedirect(ps2)
 	require.NoError(t, err)
 	require.Equal(t, "listener2", ps23.Listener)
-	require.Equal(t, ListenerPriority(2), ps23.Priority)
+	require.Equal(t, ListenerPriority(2), ps23.ListenerPriority)
 }

--- a/pkg/policy/types/policyentry.go
+++ b/pkg/policy/types/policyentry.go
@@ -12,7 +12,14 @@ import (
 //
 // +deepequal-gen=true
 type PolicyEntry struct {
-	// Authentication specifies the cryptographic authentication required for the traffic to be allowed
+	// Priority defines the precedence of this rule in relation to other rules.  Lower values
+	// take precedence over higher values. Rules having the default priority level 0 are
+	// considered first, then the rest of the rules, from the earliest to later priority levels.
+	// This is currently limited to 24 bits, i.e., max allowed priority is (1<<24-1).
+	Priority uint32
+
+	// Authentication specifies the cryptographic authentication required for the traffic to be
+	// allowed
 	Authentication *api.Authentication
 
 	// Log specifies custom policy-specific Hubble logging configuration.

--- a/pkg/policy/types/zz_generated.deepequal.go
+++ b/pkg/policy/types/zz_generated.deepequal.go
@@ -128,6 +128,9 @@ func (in *PolicyEntry) DeepEqual(other *PolicyEntry) bool {
 		return false
 	}
 
+	if in.Priority != other.Priority {
+		return false
+	}
 	if (in.Authentication == nil) != (other.Authentication == nil) {
 		return false
 	} else if in.Authentication != nil {


### PR DESCRIPTION
Generalize datapath precedence handling for deny and proxy redirect verdicts to use a generic precedence field. This allows building support k8s ClusterNetworkPolicies without further changes needed into the bpf datapath code.

Build support for ordered rule processing into policy package. Unit tests are added but API definition is left for further work.

```release-note
Cilium policy engine now supports enforcing ordered policy rules.
```