### PR TITLE
helm: allow missing verbs for cilium-agent clusterrole

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -42,6 +42,9 @@ rules:
   - pods
   - endpoints
   - nodes
+{{- if not $readSecretsOnlyFromSecretsNamespace }}
+  - secrets
+{{- end }}
   verbs:
   - get
   - list
@@ -87,14 +90,6 @@ rules:
   # until we figure out how to avoid "get" inside the preflight, and then
   # should be removed ideally.
   - get
-{{- if not $readSecretsOnlyFromSecretsNamespace }}
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-{{- end }}
 - apiGroups:
   - cilium.io
   resources:

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -42,6 +42,9 @@ rules:
   - pods
   - endpoints
   - nodes
+{{- if $readSecretsOnlyFromSecretsNamespace }}
+  - secrets
+{{- end }}
   verbs:
   - get
   - list
@@ -87,14 +90,6 @@ rules:
   # until we figure out how to avoid "get" inside the preflight, and then
   # should be removed ideally.
   - get
-{{- if $readSecretsOnlyFromSecretsNamespace }}
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-{{- end }}
 - apiGroups:
   - cilium.io
   resources:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Chart documentation describes that cilium-agent should have GET,LIST, and WATCH permissions for the secrets resource in default apiGroup when readSecretsOnlyFromSecretsNamespace is false. Currently, only GET permission is provided in the role RBAC configuration.

This commit moves the conditional logic of adding the secrets resource to the apiGroup already defined that has these verbs allowed for resources in same apiGroup.

Fixes: #42789

```release-note
allow missing verbs for cilium-agent cluster role when readSecretsOnlyFromSecretsNamespace is false
```
