### PR TITLE
redirectpolicy: Avoid recomputation when backends do not change

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -84,6 +84,8 @@ type lrpController struct {
 func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 	watchSets := map[lb.ServiceName]*statedb.WatchSet{}
 	var closedWatches []<-chan struct{}
+
+	// Keep track of which LRPs exist across the reconciliation rounds.
 	orphans := sets.New[lb.ServiceName]()
 
 	// Functions to clean up the state from the redirect policy when it is removed.
@@ -121,7 +123,9 @@ func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 		lrps, watch := c.p.LRPs.AllWatch(wtxn)
 		allWatches.Add(watch)
 
+		// Keep track of which LRPs now exist. This becomes the new [orphans] for the next round.
 		existing := sets.New[lb.ServiceName]()
+
 		for lrp := range lrps {
 			if c.p.LRPMetrics != nil && !existing.Has(lrp.ID) {
 				c.p.LRPMetrics.AddLRPConfig(lrp.ID)
@@ -181,6 +185,7 @@ func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 
 		c.p.Metrics.ControllerDuration.Observe(float64(time.Since(t0)) / float64(time.Second))
 
+		// Remember the currently existing LRPs as the potential orphans in the next round.
 		orphans = existing
 
 		// Wait for any of the inputs to change.
@@ -374,6 +379,15 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 
 	}
 
+	// Function to compare whether the new BackendParams produced in the loop below
+	// is equal to the old one. We only compare subset of fields as some of the fields
+	// are managed by the load-balancing control-plane.
+	compareBackendParams := func(a, b *lb.BackendParams) bool {
+		return a.Address == b.Address &&
+			a.State == b.State &&
+			slices.Equal(a.PortNames, b.PortNames)
+	}
+
 	// Construct the BackendParams from matching pods.
 	beps := make([]lb.BackendParams, 0, len(pods))
 	lrpServiceName := lrp.RedirectServiceName()
@@ -397,6 +411,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 					}
 					return []string{}
 				}(),
+				// NOTE: Update [compareBackendParams] if more fields are added here.
 			})
 		}
 	}
@@ -410,7 +425,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 			continue
 		}
 		if slices.ContainsFunc(beps, func(bep lb.BackendParams) bool {
-			return inst.DeepEqual(&bep)
+			return compareBackendParams(inst, &bep)
 		}) {
 			newCount--
 		} else {

--- a/pkg/loadbalancer/redirectpolicy/testdata/avoid-recompute.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/avoid-recompute.txtar
@@ -1,0 +1,167 @@
+# Test to check that pod changes that do not change the resulting redirect backends
+# does not update the LB frontends and backends.
+
+hive/start
+
+# Add all inputs.
+k8s/add service.yaml endpointslice.yaml lrp-svc.yaml pod.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+db/show frontends -f yaml -o frontends-before.yaml
+
+# Add another pod into the namespace of the redirect pod.
+k8s/add pod2.yaml
+sleep 100ms
+
+# The frontend status.id should remain the same when
+# recomputation is skipped.
+db/show frontends -f yaml -o frontends-after.yaml
+cmp frontends-before.yaml frontends-after.yaml
+ 
+# -----
+
+-- lrp-svc.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-svc"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: echo
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        name: "tcp"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+
+
+-- pod2.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: other-pod
+  namespace: test
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 1.1.1.1
+  clusterIPs:
+  - 1.1.1.1
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: tcp
+  port: 8080
+  protocol: TCP
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-svc   service  all
+
+-- services-before.table --
+Name                          Source
+test/echo                     k8s   
+
+-- services.table --
+Name                          Source
+test/echo                     k8s
+test/lrp-svc:local-redirect   k8s   
+
+-- frontends.table --
+Address                  Type          ServiceName                  PortName   Backends              RedirectTo                    Status
+1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
+[1001::1]:8080/TCP       ClusterIP     test/echo                    tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done


### PR DESCRIPTION
The comparison of the old and new BackendParams derived from the pods compared all the fields to see if the backends changed or not to avoid recomputation. This always failed as the LB control-plane set the 'Source' field.

Fix this by using a custom comparison that is coupled to how the BackendParams is produced.

The 'testdata/avoid-recompute.txtar' verifies the fix by comparing the frontend 'Status.ID' field that it remains the same. The issue was reproduced with the same test without the fix.

```release-note
redirectpolicy: Avoid recomputing on pod changes that do not change resulting redirect backends
```
