### PR TITLE
renovate: disable helm v4 until third party license is checked

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -280,7 +280,9 @@
         // Stop updating envoy control plane packages until they pushed the
         // tag to stop go mod from erroring. See https://github.com/cilium/cilium/issues/41574
         "github.com/envoyproxy/go-control-plane/contrib",
-        "github.com/envoyproxy/go-control-plane/envoy"
+        "github.com/envoyproxy/go-control-plane/envoy",
+        // We can't update to helm v4 until https://github.com/helm/helm/issues/31525 is fixed
+        "helm.sh/helm/v4"
       ],
       "matchPackagePatterns": [
         // We can't update these libraries until github.com/shoenig/go-m1cpu


### PR DESCRIPTION
CNCF is tracking the issue here https://github.com/cncf/foundation/issues/1154