### PR TITLE
helm: let clustermesh-apiserver etcd listen on all IP addresses 

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -129,23 +129,21 @@ spec:
         - --trusted-ca-file=/var/lib/etcd-secrets/ca.crt
         - --cert-file=/var/lib/etcd-secrets/tls.crt
         - --key-file=/var/lib/etcd-secrets/tls.key
-        # Surrounding the IPv4 address with brackets works in this case, since etcd
-        # uses net.SplitHostPort() internally and it accepts the that format.
-        - --listen-client-urls=https://127.0.0.1:2379,https://[$(HOSTNAME_IP)]:2379
-        - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
+        - --listen-client-urls=https://0.0.0.0:2379
+        # We advertise localhost as client URLs for convenience, even though
+        # technically not correct. However, it doesn't matter, as this is a
+        # single replica cluster, and clients directly connect to it via the
+        # address provided as part of their configuration.
+        - --advertise-client-urls=https://localhost:2379
         - --initial-cluster-token=$(INITIAL_CLUSTER_TOKEN)
         - --auto-compaction-retention=1
         {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
-        - --listen-metrics-urls=http://[$(HOSTNAME_IP)]:{{ .Values.clustermesh.apiserver.metrics.etcd.port }}
+        - --listen-metrics-urls=http://0.0.0.0:{{ .Values.clustermesh.apiserver.metrics.etcd.port }}
         - --metrics={{ .Values.clustermesh.apiserver.metrics.etcd.mode }}
         {{- end }}
         env:
         - name: ETCDCTL_API
           value: "3"
-        - name: HOSTNAME_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
         - name: INITIAL_CLUSTER_TOKEN
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Currently, the sidecar etcd instance of the clustermesh-apiserver is explicitly configured to listen for client connections on localhost and the primary Pod IP (as reported by `status.podIP`). To this end, the Pod IP was enclosed in brackets, as that historically used to work properly both in case of IPv4 and IPv6 addresses. However, this is no longer the case starting from etcd v3.6.6, which is compiled using 1.24.10, in turn implementing a stricter validation forbidding to enclose IPv4 addresses in brackets \[1,2], as not RFC compliant. 

In order to bypass this problem, let's change the `lister-client-urls` parameter to listen on all IP addresses; this has the advantage of not requiring the brackets enclosing, and also enables listening on the secondary Pod IP address, if any. We configure 0.0.0.0 (rather than [::]) as the go implementation of Listen already automatically selects the IP family as appropriate \[3]. Similarly, we also change `listen-metrics-urls` to listen on all IP addresses, hence including both localhost and possible secondary Pod IPs. Again, this is not expected to have any negative consequence. 

Slightly trickier is the `advertise-client-urls` setting, which is supposed to advertise the addresses that clients can use to reach this replica. Yet, its value doesn't strictly matter in this context, given that the etcd cluster is composed of a single replica, and clients directly connect to it via the address provided as part of their configuration. Additionally, the provided values appear to be used only when auto synchronization is enabled \[4,5], which is not in this case. Still, even advertising the pod IP was not fully correct there, as not directly reachable from remote clusters. Hence, let's just configure localhost instead, as a placeholder, given that the parameter is always required to be supplied. 

Related: https://github.com/cilium/cilium/pull/42804#issuecomment-3540877156

\[1]: https://go-review.googlesource.com/c/go/+/709838 
\[2]: https://go-review.googlesource.com/c/go/+/712142 
\[3]: https://cs.opensource.google/go/go/+/master:src/net/ipsock_posix.go;l=83-157?q=ipsock_posi 
\[4]: https://github.com/cilium/cilium/blob/f2686609331670df72056a485640bc4b02f5343d/vendor/go.etcd.io/etcd/client/v3/client.go#L210-L228 
\[5]: https://github.com/cilium/cilium/blob/f2686609331670df72056a485640bc4b02f5343d/vendor/go.etcd.io/etcd/client/v3/client.go#L186-L208

<!-- Description of change -->

```release-note
Change the sidecar etcd instance of the Cluster Mesh API Server listen on all IP addresses
```
