### PR TITLE
docs: add ztunnel documentation page

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -466,6 +466,7 @@ Makefile* @cilium/build
 /Documentation/security/images/cilium_threat_model* @cilium/security @cilium/docs-structure
 /Documentation/security/network/encryption-ipsec.rst @cilium/ipsec @cilium/docs-structure
 /Documentation/security/network/encryption-wireguard.rst @cilium/wireguard @cilium/docs-structure
+/Documentation/security/network/encryption-ztunnel.rst @cilium/ztunnel @cilium/docs-structure
 /Documentation/security/network/proxy/ @cilium/proxy @cilium/docs-structure
 /Documentation/security/policy-creation.rst @cilium/sig-policy @cilium/docs-structure
 /Documentation/security/policy/ @cilium/sig-policy @cilium/docs-structure

--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -29,8 +29,21 @@ authenticated using mutual TLS before being sent to the destination.
 Generating secrets for authentication
 =====================================
 
-TODO(ldelossa)
+Cilium's ztunnel integration requires a set a set of private keys and
+accompanying to certificates be present via Kubernetes secrets. This follows the
+same pattern as IPsec key injections.
 
+These keys can be generated with the following bash script prior to deploying
+Cilium.
+
+.. literalinclude:: ../../../examples/kubernetes-ztunnel/generate-secrets.sh
+   :language: bash
+
+The 'bootstrap' keys are used to secure the connection between ztunnel and
+Cilium's xDS and certificate server implementation.
+
+The 'ca' keys are used as the root certificate for creating in-memory and
+ephemeral client certificates on ztunnel's request.
 
 Enable ztunnel in Cilium
 ========================

--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -1,0 +1,185 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _encryption_ztunnel:
+
+*************************************
+Ztunnel Transparent Encryption (Beta)
+*************************************
+
+.. include:: ../../beta.rst
+
+This guide explains how to configure Cilium to use ztunnel for transparent
+encryption and mutual TLS (mTLS) authentication between Cilium-managed endpoints.
+ztunnel is a purpose-built per-node proxy that provides transparent Layer 4 mTLS
+encryption and authentication for pod-to-pod communication.
+
+When ztunnel is enabled in Cilium, the agent running on each cluster node
+establishes a control plane connection with the local ztunnel proxy. Cilium
+enrolls pods into the mesh on a per-namespace basis, allowing fine-grained
+control over which workloads participate in mTLS encryption. Enrolled pods have
+their traffic transparently redirected to the ztunnel proxy using iptables rules
+configured in their network namespace, where the traffic is encrypted and
+authenticated using mutual TLS before being sent to the destination.
+
+
+Generating secrets for authentication
+=====================================
+
+TODO(ldelossa)
+
+
+Enable ztunnel in Cilium
+========================
+
+Before you install Cilium with ztunnel enabled, ensure that:
+
+* The necessary Kubernetes secrets are available.
+* Cluster Mesh is not enabled (ztunnel is currently not compatible with Cluster Mesh).
+
+.. tabs::
+
+    .. group-tab:: Cilium CLI
+
+       If you are deploying Cilium with the Cilium CLI, pass the following
+       options:
+
+       .. parsed-literal::
+
+          cilium install |CHART_VERSION| \
+             --set encryption.enabled=true \
+             --set encryption.type=ztunnel
+
+    .. group-tab:: Helm
+
+       If you are deploying Cilium with Helm by following
+       :ref:`k8s_install_helm`, pass the following options:
+
+       .. parsed-literal::
+
+           helm install cilium |CHART_RELEASE| \\
+             --namespace kube-system \\
+             --set encryption.enabled=true \\
+             --set encryption.type=ztunnel
+
+
+Enrolling Namespaces
+====================
+
+After enabling ztunnel in Cilium, you need to explicitly enroll namespaces to
+enable mTLS encryption for their workloads. This is done by applying a label
+to the namespace:
+
+.. code-block:: shell-session
+
+    kubectl label namespace <namespace-name> io.cilium/mtls-enabled=true
+
+To verify that a namespace is enrolled:
+
+.. code-block:: shell-session
+
+    kubectl get namespace <namespace-name> --show-labels
+
+When a namespace is enrolled:
+
+* All existing pods in the namespace (except ztunnel pods themselves) are enrolled
+* Iptables rules are configured in each pod's network namespace for traffic redirection
+* Pod metadata is sent to the ztunnel proxy via the ZDS protocol
+* Future pods created in the namespace are automatically enrolled
+
+To disenroll a namespace:
+
+.. code-block:: shell-session
+
+    kubectl label namespace <namespace-name> io.cilium/mtls-enabled-
+
+This will:
+
+#. Disenroll all pods in the namespace from ztunnel
+#. Remove the iptables rules from each pod's network namespace
+#. Notify ztunnel to stop processing traffic for those workloads
+
+Validate the Setup
+==================
+
+#. Check that ztunnel has been enabled:
+
+   .. code-block:: shell-session
+
+      kubectl -n kube-system describe cm cilium-config | grep enable-ztunnel -A2
+
+   You should see output indicating that ztunnel encryption is enabled.
+
+#. Check which namespaces are enrolled:
+
+   .. code-block:: shell-session
+
+      kubectl get namespaces -l io.cilium/mtls-enabled=true
+
+   This shows all namespaces labeled for ztunnel enrollment.
+
+   To verify that these namespaces are actually enrolled in the StateDB table:
+
+   .. code-block:: shell-session
+
+      kubectl exec -n kube-system ds/cilium -- cilium-dbg statedb dump | jq '.["mtls-enrolled-namespaces"]'
+
+   The results of this query should show which namespaces have been successfully
+   processed by the enrollment reconciler.
+
+#. Run a ``bash`` shell in one of the Cilium pods hosting a mtls-enrolled pod with
+   ``kubectl -n kube-system exec -ti pod/<cillium-pod-hosting-mtls-pod> -- bash`` 
+   and execute the following commands:
+
+   Install tcpdump
+
+   .. code-block:: shell-session
+
+       $ apt-get update
+       $ apt-get -y install tcpdump
+
+   Check that traffic is encrypted. In the example below, this can be verified
+   by the fact that packets will have a destination port of 15008 (HBONE).
+   In the example below, ``eth0`` is the interface used for pod-to-pod
+   communication. Replace this interface with e.g. ``cilium_vxlan`` if
+   tunneling is enabled.
+
+   .. code-block:: shell-session
+
+       tcpdump -i eth0 port 15008
+       tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
+       listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
+       13:00:06.982499 IP 10.244.1.95.15008 > 10.244.2.3.33446: ...
+       13:00:06.982536 IP 10.244.2.3.33446 > 10.244.1.95.15008: ...
+       13:00:06.982675 IP 10.244.2.3.33446 > 10.244.1.95.15008: ...
+
+
+Limitations
+===========
+
+* The ztunnel integration currently only supports enrollment via namespace
+  labels. Pod-level enrollment is not supported.
+
+* Only TCP traffic is currently supported for mTLS encryption. UDP and other
+  protocols are not redirected to ztunnel.
+
+* The integration requires iptables support in the kernel and cannot be used
+  with environments that do not support iptables (such as some minimal container
+  runtimes).
+
+* Ztunnel interferes with Cilium network policy as traffic is encrypted before
+  it leaves the pod, meaning L4 policies won't work except for directly
+  targeting the ztunnel HBONE port (15008).
+
+Known Issues
+============
+
+* Cluster Mesh is not currently supported when ztunnel is enabled. Attempting
+  to enable both will result in a validation error.
+
+* Pods without a network namespace path (such as host-networked pods) cannot
+  be enrolled in ztunnel and will be skipped during enrollment.
+

--- a/Documentation/security/network/encryption.rst
+++ b/Documentation/security/network/encryption.rst
@@ -11,7 +11,7 @@ Transparent Encryption
 ************************************
 
 Cilium supports the transparent encryption of Cilium-managed host traffic and
-traffic between Cilium-managed endpoints either using IPsec or WireGuard®:
+traffic between Cilium-managed endpoints using IPsec, WireGuard®, or ztunnel:
 
 .. toctree::
    :maxdepth: 1
@@ -19,6 +19,7 @@ traffic between Cilium-managed endpoints either using IPsec or WireGuard®:
 
    encryption-ipsec
    encryption-wireguard
+   encryption-ztunnel
 
 .. admonition:: Video
  :class: attention

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -32,6 +32,7 @@ Datadog
 Dataplane
 Deconfigure
 Dinan
+Disenroll
 Dockerfile
 Dockerfiles
 Donenfeld
@@ -309,6 +310,7 @@ dereference
 deserialization
 detections
 dev
+disenroll
 disjunct
 distro
 distros
@@ -578,6 +580,7 @@ modularizing
 mountPath
 mov
 mtk
+mtls
 mtu
 mul
 multicast

--- a/examples/kubernetes-ztunnel/generate-secrets.sh
+++ b/examples/kubernetes-ztunnel/generate-secrets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -eu
+
+# == Bootstrap ===
+openssl genrsa -out bootstrap-private.key 2048
+
+echo '
+[ req ]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[ req_distinguished_name ]
+O = cluster.local
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+' > openssl.conf
+
+openssl req -x509 -new -nodes -key bootstrap-private.key -sha256 -days 3650 -out bootstrap-root.crt -config openssl.conf
+
+# == CA ==
+openssl genrsa -out ca-private.key 2048
+
+echo '
+[ req ]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[ req_distinguished_name ]
+O = cluster.local
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+' > openssl.conf
+
+openssl req -x509 -new -nodes -key ca-private.key -sha256 -days 3650 -out ca-root.crt -config openssl.conf
+
+kubectl --namespace kube-system create secret generic cilium-ztunnel-secrets \
+      --from-file=bootstrap-private.key=bootstrap-private.key \
+      --from-file=bootstrap-root.crt=bootstrap-root.crt \
+      --from-file=ca-private.key=ca-private.key \
+      --from-file=ca-root.crt=ca-root.crt


### PR DESCRIPTION
Says what it does on the tin.

Related: #38548

**Note from maintainers, this is the documentation PR. The implementation was done on these:** 
https://github.com/cilium/cilium/pull/42169
https://github.com/cilium/cilium/pull/42364
https://github.com/cilium/cilium/pull/42766

```release-note
Add ztunnel support
```