### PR TITLE
fqdn: rewrite name manager test to use real ipcache

### DIFF
--- a/pkg/fqdn/namemanager/cell.go
+++ b/pkg/fqdn/namemanager/cell.go
@@ -124,13 +124,13 @@ type NameManager interface {
 	// associated with that selector.
 	// This function also evaluates if any DNS names in the cache are matched by
 	// this new selector and updates the labels for those DNS names accordingly.
-	RegisterFQDNSelector(selector api.FQDNSelector)
+	RegisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64)
 
 	// UnregisterFQDNSelector removes this FQDNSelector from the set of
 	// IPs which are being tracked by the identityNotifier. The result
 	// of this is that an IP may be evicted from IPCache if it is no longer
 	// selected by any other FQDN selector.
-	UnregisterFQDNSelector(selector api.FQDNSelector)
+	UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64)
 	// UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs
 	// have changed for a name they will be reflected in updatedDNSIPs.
 	UpdateGenerateDNS(ctx context.Context, lookupTime time.Time, name string, record *fqdn.DNSIPRecords) <-chan error

--- a/pkg/fqdn/namemanager/manager.go
+++ b/pkg/fqdn/namemanager/manager.go
@@ -139,7 +139,7 @@ func New(params ManagerParams) *manager {
 // associated with that selector.
 // This function also evaluates if any DNS names in the cache are matched by
 // this new selector and updates the labels for those DNS names accordingly.
-func (n *manager) RegisterFQDNSelector(selector api.FQDNSelector) {
+func (n *manager) RegisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64) {
 	n.Lock()
 	defer n.Unlock()
 
@@ -181,14 +181,14 @@ func (n *manager) RegisterFQDNSelector(selector api.FQDNSelector) {
 	// that is the case, we want to update the IPCache metadata for all
 	// associated IPs
 	selectedNamesAndIPs := n.mapSelectorsToNamesLocked(selector)
-	n.updateMetadata(deriveLabelsForNames(selectedNamesAndIPs, n.allSelectors))
+	return n.updateMetadata(deriveLabelsForNames(selectedNamesAndIPs, n.allSelectors))
 }
 
 // UnregisterFQDNSelector removes this FQDNSelector from the set of
 // IPs which are being tracked by the identityNotifier. The result
 // of this is that an IP may be evicted from IPCache if it is no longer
 // selected by any other FQDN selector.
-func (n *manager) UnregisterFQDNSelector(selector api.FQDNSelector) {
+func (n *manager) UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64) {
 	n.Lock()
 	defer n.Unlock()
 
@@ -208,7 +208,7 @@ func (n *manager) UnregisterFQDNSelector(selector api.FQDNSelector) {
 
 	// Re-compute labels for affected names and IPs
 	selectedNamesAndIPs := n.mapSelectorsToNamesLocked(selector)
-	n.updateMetadata(deriveLabelsForNames(selectedNamesAndIPs, n.allSelectors))
+	return n.updateMetadata(deriveLabelsForNames(selectedNamesAndIPs, n.allSelectors))
 }
 
 // UpdateGenerateDNS inserts the new DNS information into the cache. If the IPs

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
-	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -99,7 +100,14 @@ func TestMapIPsToSelectors(t *testing.T) {
 func TestNameManagerIPCacheUpdates(t *testing.T) {
 	logger := hivetest.Logger(t)
 
-	ipc := newMockIPCache()
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           t.Context(),
+		Logger:            logger,
+		IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+		IdentityUpdater:   &dummyIdentityUpdater{},
+	})
+	ipc.TriggerLabelInjection()
+	defer ipc.Shutdown()
 	nameManager := New(ManagerParams{
 		Logger: logger,
 		Config: NameManagerConfig{
@@ -110,41 +118,79 @@ func TestNameManagerIPCacheUpdates(t *testing.T) {
 		IPCache: ipc,
 	})
 
-	nameManager.RegisterFQDNSelector(ciliumIOSel)
+	err := ipc.WaitForRevision(t.Context(), nameManager.RegisterFQDNSelector(ciliumIOSel))
+	require.NoError(t, err)
 
 	// Simulate lookup for single selector
 	prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1.1.1.1/32"))
-	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{prefix.AsPrefix().Addr()}})
-	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel()}))
+	<-nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), dns.FQDN("cilium.io"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{prefix.AsPrefix().Addr()}})
+
+	id, found := ipc.LookupByPrefix(prefix.String())
+	require.True(t, found)
+	ident := ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 
 	// Add match pattern
-	nameManager.RegisterFQDNSelector(ciliumIOSelMatchPattern)
-	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), ciliumIOSelMatchPattern.IdentityLabel()}))
+	err = ipc.WaitForRevision(t.Context(), nameManager.RegisterFQDNSelector(ciliumIOSelMatchPattern))
+	require.NoError(t, err)
+
+	id, found = ipc.LookupByPrefix(prefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSel.IdentityLabel(), ciliumIOSelMatchPattern.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 
 	// Remove cilium.io matchname, add github.com match name
 	nameManager.RegisterFQDNSelector(githubSel)
-	nameManager.UnregisterFQDNSelector(ciliumIOSel)
-	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel()}))
+	err = ipc.WaitForRevision(t.Context(), nameManager.UnregisterFQDNSelector(ciliumIOSel))
+	require.NoError(t, err)
+
+	id, found = ipc.LookupByPrefix(prefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 
 	// Same IP matched by two selectors
-	nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), dns.FQDN("github.com"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{prefix.AsPrefix().Addr()}})
-	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel()}))
+	<-nameManager.UpdateGenerateDNS(context.TODO(), time.Now(), dns.FQDN("github.com"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{prefix.AsPrefix().Addr()}})
+	id, found = ipc.LookupByPrefix(prefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 
 	// Additional unique IPs for each selector
 	githubPrefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.2/32"))
 	awesomePrefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.3/32"))
 	n := time.Now()
-	nameManager.UpdateGenerateDNS(context.TODO(), n, dns.FQDN("github.com"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{githubPrefix.AsPrefix().Addr()}})
-	nameManager.UpdateGenerateDNS(context.TODO(), n, dns.FQDN("awesomecilium.io"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{awesomePrefix.AsPrefix().Addr()}})
-	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel()}))
-	require.Equal(t, ipc.labelsForPrefix(githubPrefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
-	require.Equal(t, ipc.labelsForPrefix(awesomePrefix), labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel()}))
+	<-nameManager.UpdateGenerateDNS(context.TODO(), n, dns.FQDN("github.com"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{githubPrefix.AsPrefix().Addr()}})
+	<-nameManager.UpdateGenerateDNS(context.TODO(), n, dns.FQDN("awesomecilium.io"), &fqdn.DNSIPRecords{TTL: 60, IPs: []netip.Addr{awesomePrefix.AsPrefix().Addr()}})
+	id, found = ipc.LookupByPrefix(prefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), githubSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
+	id, found = ipc.LookupByPrefix(githubPrefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{githubSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
+	id, found = ipc.LookupByPrefix(awesomePrefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{ciliumIOSelMatchPattern.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
 
 	// Removing selector should remove from IPCache
-	nameManager.UnregisterFQDNSelector(ciliumIOSelMatchPattern)
-	require.NotContains(t, ipc.metadata, awesomePrefix)
-	require.Equal(t, ipc.labelsForPrefix(prefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
-	require.Equal(t, ipc.labelsForPrefix(githubPrefix), labels.FromSlice([]labels.Label{githubSel.IdentityLabel()}))
+	err = ipc.WaitForRevision(t.Context(), nameManager.UnregisterFQDNSelector(ciliumIOSelMatchPattern))
+	require.NoError(t, err)
+	id, found = ipc.LookupByPrefix(awesomePrefix.String())
+	require.False(t, found)
+
+	id, found = ipc.LookupByPrefix(prefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{githubSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
+
+	id, found = ipc.LookupByPrefix(githubPrefix.String())
+	require.True(t, found)
+	ident = ipc.IdentityAllocator.LookupIdentityByID(t.Context(), id.ID)
+	require.Equal(t, labels.FromSlice([]labels.Label{githubSel.IdentityLabel(), labels.ParseLabel("reserved:world-ipv4")}), ident.Labels)
+
 }
 
 func Test_deriveLabelsForNames(t *testing.T) {
@@ -202,61 +248,10 @@ func makeIPs(count uint32) []netip.Addr {
 	return ips
 }
 
-type mockIPCache struct {
-	metadata map[cmtypes.PrefixCluster]map[ipcacheTypes.ResourceID]labels.Labels
-}
+type dummyIdentityUpdater struct{}
 
-func newMockIPCache() *mockIPCache {
-	return &mockIPCache{
-		metadata: make(map[cmtypes.PrefixCluster]map[ipcacheTypes.ResourceID]labels.Labels),
-	}
-}
-
-func (m *mockIPCache) labelsForPrefix(prefix cmtypes.PrefixCluster) labels.Labels {
-	lbls := labels.Labels{}
-	for _, l := range m.metadata[prefix] {
-		lbls.MergeLabels(l)
-	}
-	return lbls
-}
-
-func (m *mockIPCache) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
-	for _, mu := range updates {
-		prefixMetadata, ok := m.metadata[mu.Prefix]
-		if !ok {
-			prefixMetadata = make(map[ipcacheTypes.ResourceID]labels.Labels)
-		}
-
-		for _, aux := range mu.Metadata {
-			if lbls, ok := aux.(labels.Labels); ok {
-				prefixMetadata[mu.Resource] = lbls
-				break
-			}
-		}
-
-		m.metadata[mu.Prefix] = prefixMetadata
-	}
-
-	return 0
-}
-
-func (m *mockIPCache) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64) {
-	for _, mu := range updates {
-		for _, aux := range mu.Metadata {
-			if _, ok := aux.(labels.Labels); ok {
-				delete(m.metadata[mu.Prefix], mu.Resource)
-				break
-			}
-		}
-
-		if len(m.metadata[mu.Prefix]) == 0 {
-			delete(m.metadata, mu.Prefix)
-		}
-	}
-
-	return 0
-}
-
-func (m *mockIPCache) WaitForRevision(ctx context.Context, rev uint64) error {
-	return nil
+func (*dummyIdentityUpdater) UpdateIdentities(added, deleted identity.IdentityMap) <-chan struct{} {
+	c := make(chan struct{})
+	close(c)
+	return c
 }

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -312,7 +312,7 @@ type identityNotifier interface {
 	// RegisterFQDNSelector exposes this FQDNSelector so that the identity labels
 	// of IPs contained in a DNS response that matches said selector can be
 	// associated with that selector.
-	RegisterFQDNSelector(selector api.FQDNSelector)
+	RegisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64)
 
 	// UnregisterFQDNSelector removes this FQDNSelector from the set of
 	// IPs which are being tracked by the identityNotifier. The result
@@ -320,7 +320,7 @@ type identityNotifier interface {
 	// selected by any other FQDN selector.
 	// This occurs when there are no more users of a given FQDNSelector for the
 	// SelectorCache.
-	UnregisterFQDNSelector(selector api.FQDNSelector)
+	UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64)
 }
 
 // AddFQDNSelector adds the given api.FQDNSelector in to the selector cache. If

--- a/pkg/testutils/identity/notifier.go
+++ b/pkg/testutils/identity/notifier.go
@@ -15,6 +15,10 @@ func NewDummyIdentityNotifier() *DummyIdentityNotifier {
 	}
 }
 
-func (d DummyIdentityNotifier) RegisterFQDNSelector(selector api.FQDNSelector) {}
+func (d DummyIdentityNotifier) RegisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64) {
+	return
+}
 
-func (d DummyIdentityNotifier) UnregisterFQDNSelector(selector api.FQDNSelector) {}
+func (d DummyIdentityNotifier) UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64) {
+	return
+}


### PR DESCRIPTION
This rewrites the name manager test around selectors to use the real ipcache. We want to do this to ensure we catch regressions if the ipcache starts behaving a different way.

This also starts returning the ipcacheRevision on FQDN selector changes.

These test depend on https://github.com/cilium/cilium/pull/42815 to fix the ipcache issues. Without that patchset, these tests won't pass.

Fixes: #issue-number

