### PR TITLE
[v1.18] bpf: lxc: transfer source identity for lxc-to-host policy

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -679,6 +679,7 @@ ct_recreate6:
 	 * enabled, jump to the bpf_host program to enforce ingress host policies.
 	 */
 	if (*dst_sec_identity == HOST_ID) {
+		ctx_store_meta(ctx, CB_SRC_LABEL, SECLABEL_IPV6);
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
 		ret = tail_call_policy(ctx, HOST_EP_ID);
 
@@ -1150,6 +1151,7 @@ ct_recreate4:
 	 * program may not yet be present at this time.
 	 */
 	if (*dst_sec_identity == HOST_ID) {
+		ctx_store_meta(ctx, CB_SRC_LABEL, SECLABEL_IPV4);
 		ctx_store_meta(ctx, CB_FROM_HOST, 0);
 		ret = tail_call_policy(ctx, HOST_EP_ID);
 


### PR DESCRIPTION
Minimal backport of
* [ ] #42548

so that `v1.19` can make use of this functionality right away (as discussed [here](https://github.com/cilium/cilium/pull/42548#discussion_r2502057430)).