### PR TITLE
deps: Bump GoBGP to latest v3.37 fork version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -333,7 +333,7 @@ replace sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16
 
 // Using private fork of gobgp. See commit msg for more context as to why we
 // are using a private fork.
-replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464
+replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
 
 tool (
 	github.com/AdamKorcz/go-118-fuzz-build/testing

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.7.0 h1:4EKBtTweQrJoD4q45qDGu8udulmYMo48Y0BhEbrB1jc=
 github.com/cilium/fake v0.7.0/go.mod h1:hA1YsEjgIs5Gdeq/DVrDWGuhLCoVok7THTvQaGDO5bc=
-github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464 h1:lQMPil6k4HhTG3PJXxKsNFzjqPHOnu55uQg+1rhl0VE=
-github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
+github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674 h1:RPXlDz/YCj2qscehc5oVFwHgUTDQGYHIgTxlN65F8R8=
+github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
 github.com/cilium/hive v0.0.0-20251021073839-03494cb6c4de h1:Kvp7XGVwH6zoLZx2As7ufnFohE94WwcU+WDJWzloOK8=
 github.com/cilium/hive v0.0.0-20251021073839-03494cb6c4de/go.mod h1:6qtm9+eQD8D1SsqGFgNE63lNeys9PZswouh37X5ZhWU=
 github.com/cilium/linters v0.3.0 h1:XZzur3mcyM04YSnDeoKSb1l+9W7k3kvUoL0yF8ICCQA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1291,7 +1291,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
-# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464
+# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
 ## explicit; go 1.23.0
 github.com/osrg/gobgp/v3/api
 github.com/osrg/gobgp/v3/internal/pkg/table
@@ -2902,4 +2902,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
 sigs.k8s.io/yaml/kyaml
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
-# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20250717193620-26a4abb75464
+# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674


### PR DESCRIPTION
Bumps GoBGP to the latest version in [cilium fork](https://github.com/cilium/gobgp/tree/v3.37.0-with-fix) of GoBGP v3.37 to pull recent fixes.

