### PR TITLE
bgp: Fix invalid dereference in peerAddressesFromPolicy by empty neighbors

### DIFF
--- a/pkg/bgp/manager/reconciler/policies.go
+++ b/pkg/bgp/manager/reconciler/policies.go
@@ -514,8 +514,9 @@ func peerAddressesFromPolicy(p *types.RoutePolicy) ([]netip.Addr, bool) {
 	for _, s := range p.Statements {
 		if s.Conditions.MatchNeighbors == nil || len(s.Conditions.MatchNeighbors.Neighbors) == 0 {
 			allPeers = true
+		} else {
+			addrs = append(addrs, s.Conditions.MatchNeighbors.Neighbors...)
 		}
-		addrs = append(addrs, s.Conditions.MatchNeighbors.Neighbors...)
 	}
 	return addrs, allPeers
 }


### PR DESCRIPTION
If `Conditions.MatchNeighbors` is `nil`, we can not dereference it in the append statement.

The issue was introduced in https://github.com/cilium/cilium/pull/42714


