### PR TITLE
cli: clustermesh: use ca bundle to connect clusters

### DIFF
--- a/Documentation/cmdref/cilium_clustermesh_connect.md
+++ b/Documentation/cmdref/cilium_clustermesh_connect.md
@@ -11,6 +11,7 @@ cilium clustermesh connect [flags]
 ### Options
 
 ```
+      --allow-mismatching-ca           Allow connecting clusters with mismatching CA certificates by adding remote CAs to the CA bundle
       --connection-mode string         Connection mode: unicast, bidirectional or mesh (default "bidirectional")
       --destination-context strings    Comma separated list of Kubernetes configuration contexts of destination cluster
       --destination-endpoint strings   IP of ClusterMesh service of destination cluster

--- a/cilium-cli/cli/clustermesh.go
+++ b/cilium-cli/cli/clustermesh.go
@@ -223,4 +223,5 @@ func addCommonConnectFlags(cmd *cobra.Command, params *clustermesh.Parameters) {
 	cmd.Flags().StringSliceVar(&params.DestinationEndpoints, "destination-endpoint", []string{}, "IP of ClusterMesh service of destination cluster")
 	cmd.Flags().StringSliceVar(&params.SourceEndpoints, "source-endpoint", []string{}, "IP of ClusterMesh service of source cluster")
 	cmd.Flags().IntVar(&params.Parallel, "parallel", 1, "Number of parallel connection of destination cluster")
+	cmd.Flags().BoolVar(&params.AllowMismatchingCA, "allow-mismatching-ca", false, "Allow connecting clusters with mismatching CA certificates by adding remote CAs to the CA bundle")
 }


### PR DESCRIPTION
TLS keys inside values was recently deprecated (https://github.com/cilium/cilium/pull/42576), so this commit changes the CLI connect command to trust each clusters CA in CA bundle.

```release-note
cli: clustermesh: use ca bundle to connect clusters
```
