### PR TITLE
policy: Marshal L4Filter marshalling errors into json

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1201,7 +1201,11 @@ func (sp *PerSelectorPolicy) redirectType() redirectTypes {
 func (l4 *L4Filter) Marshal() string {
 	b, err := json.Marshal(l4)
 	if err != nil {
-		b = []byte("\"L4Filter error: " + err.Error() + "\"")
+		jsonErr, err2 := json.Marshal(err.Error())
+		if err2 != nil {
+			jsonErr = []byte("unable to marshall error")
+		}
+		return "L4Filter error: " + string(jsonErr)
 	}
 	return string(b)
 }


### PR DESCRIPTION
If we were to add a field type into L4Filter that cannot be encoded into
JSON, then used the JSON marshalling function to export the filter into
the local policy API, Cilium could potentially end up sending broken
json back to the client.

In this case, there should not be any sensitive information in the error
type so we should be able to encode the error into JSON and hand that
back to the client instead. It's highly unlikely that encoding itself
would also encounter JSON marshalling errors, but in that case let's
just encode a static string in the result.

Found by CodeQL.

Reported-by: @ferozsalam
