### PR TITLE
[v1.17] ci: bump ubuntu version for lint build commit workflow

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -168,7 +168,7 @@ jobs:
         if: steps.test-tree.outputs.src == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtinfo5
+          sudo apt-get install -y --no-install-recommends libtinfo6
 
       - name: Install LLVM and Clang
         if: steps.test-tree.outputs.src == 'true'

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build_commits:
     name: Check if build works for every commit
-    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-22.04' }}
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 180
     steps:
       - name: Collect Workflow Telemetry

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -113,6 +113,7 @@ jobs:
           # do a git diff
           filters: |
             src:
+              - '.github/workflows/lint-build-commits.yaml'
               - 'bpf/**'
 
       # Runs only if code under bpf/ is changed.
@@ -156,6 +157,7 @@ jobs:
           # do a git diff
           filters: |
             src:
+              - '.github/workflows/lint-build-commits.yaml'
               - 'pkg/**'
               - 'test/**'
 


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/40680, with the addition of an extra commit to ensure that all steps are always run upon workflow changes. Successful run: https://github.com/cilium/cilium/actions/runs/19458732379/job/55677819890?pr=42842