### PR TITLE
gha: don't filter lint-build-commits steps when workflow is modified

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -68,6 +68,7 @@ jobs:
           # build-commits-bpf: Check if datapath build works for every commit
           filters: |
             src:
+              - '.github/workflows/lint-build-commits.yaml'
               - 'bpf/**'
               - '!**/*.md'
 
@@ -79,6 +80,7 @@ jobs:
           # build-commits-test: Check if ginkgo test suite build works for every commit
           filters: |
             src:
+              - '.github/workflows/lint-build-commits.yaml'
               - 'pkg/**'
               - 'test/**'
               - '!**/*.md'


### PR DESCRIPTION
Otherwise it is easy to regress upon workflow changes, as possible issues may not immediately show up if the triggering files are not modified.

Manual backports to v1.17 and v1.16 included in https://github.com/cilium/cilium/pull/42842 and https://github.com/cilium/cilium/pull/42843 respectively, due to significant context differences.