### PR TITLE
policy: init policy api layer with cluster info in hive cell

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -174,8 +174,6 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		return fmt.Errorf("error while opening/creating BPF maps: %w", err)
 	}
 
-	policyAPI.InitEntities(params.ClusterInfo.Name)
-
 	bootstrapStats.restore.Start()
 	// fetch old endpoints before k8s is configured.
 	if err := params.EndpointRestorer.FetchOldEndpoints(ctx, params.DaemonConfig.StateDir); err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -26,7 +26,6 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
@@ -1258,7 +1257,6 @@ type daemonParams struct {
 	Devices             statedb.Table[*datapathTables.Device]
 	DirectRoutingDevice datapathTables.DirectRoutingDevice
 	IPIdentityWatcher   *ipcache.LocalIPIdentityWatcher
-	ClusterInfo         cmtypes.ClusterInfo
 	IPsecAgent          datapath.IPsecAgent
 	SyncHostIPs         *syncHostIPs
 	NodeDiscovery       *nodediscovery.NodeDiscovery

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -75,6 +76,8 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 			}
 		})
 	}
+
+	policyapi.InitEntities(params.ClusterInfo.Name)
 
 	// policy repository: maintains list of active Rules and their subject
 	// security identities. Also constructs the SelectorCache, a precomputed


### PR DESCRIPTION
This commit moves the initialization of the policy api layer with cluster information from the daemon (`configureDemon`) to the policy hive cell (creation of  policy repository).