### PR TITLE
renovate: disable all etcd updates on v1.16 and v1.17

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -773,6 +773,21 @@
       "matchBaseBranches": [
         "!main",
       ]
+    },
+    {
+      // Temporarily disable all etcd updates on v1.16 and v1.17, because newer
+      // versions are compiled with go 1.24.8 or later, which includes a breaking
+      // change in IP addresses parsing affecting the clustermesh-apiserver usage.
+      // See cilium/cilium#42818 for more details and the fix, which is intended
+      // to be backported once we built up sufficient confidence.
+      "enabled": false,
+      "matchDepNames": [
+        "gcr.io/etcd-development/etcd"
+      ],
+      "matchBaseBranches": [
+        "v1.16",
+        "v1.17",
+      ]
     }
   ],
   "kubernetes": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -753,6 +753,14 @@
       ]
     },
     {
+      // Separate patch version updates, so that renovate can update the patch
+      // versions on stable branches.
+      "matchDepNames": [
+        "gcr.io/etcd-development/etcd"
+      ],
+      "separateMinorPatch": true
+    },
+    {
       // Do not allow any major and minor etcd updates into stable branches.
       "enabled": false,
       "matchDepNames": [


### PR DESCRIPTION
Temporarily disable all etcd updates on v1.16 and v1.17, because newer versions are compiled with go 1.24.8 or later, which includes a breaking change in IP addresses parsing affecting the clustermesh-apiserver usage. See cilium/cilium#42818 for more details and the fix, which is intended to be backported once we built up sufficient confidence.

The first commit is intended to fix the updates in stable branches, which appeared to already not work as expected.