### PR TITLE
bpf: host: use transferred source identity in lxc-to-host policy

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1888,8 +1888,7 @@ int cil_host_policy(struct __ctx_buff *ctx __maybe_unused)
 		src_sec_identity = HOST_ID;
 		dir = METRIC_EGRESS;
 	} else {
-		/* TODO: in a future release, use CB_SRC_LABEL here */
-		src_sec_identity = UNKNOWN_ID;
+		src_sec_identity = ctx_load_meta(ctx, CB_SRC_LABEL);
 		dir = METRIC_INGRESS;
 	}
 


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/42821 made the necessary changes in `v1.18`, so that `main` can now rely on all in-flight packets carrying the source identity.