### PR TITLE
[v1.17] gh: ipsec-e2e: enable no-ipsec-xfrm-error test

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -361,9 +361,6 @@ jobs:
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: ${{ env.job_name }}-${{ matrix.name }}-post-rotate
-          # Opt-out from `no-ipsec-xfrm-error`, seeing XfrmOutPolBlock errors.
-          tests: 'no-interrupted-connections'
-          extra-connectivity-test-flags: "--include-conn-disrupt-test"
 
       - name: Start unencrypted packets check for tests
         uses: ./.github/actions/bpftrace/start


### PR DESCRIPTION
Manual backport of
* [ ] #42780 (first patch isn't needed)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42780
```