### PR TITLE
bpf, maps: update links to bpf headers

### DIFF
--- a/pkg/bpf/endpoint.go
+++ b/pkg/bpf/endpoint.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/types"
 )
 
-// Must be in sync with ENDPOINT_KEY_* in <bpf/lib/common.h>
+// Must be in sync with ENDPOINT_KEY_* in <bpf/lib/eps.h>
 const (
 	EndpointKeyIPv4 uint8 = 1
 	EndpointKeyIPv6 uint8 = 2
@@ -21,7 +21,7 @@ const (
 
 // EndpointKey represents the key value of the endpoints BPF map
 //
-// Must be in sync with struct endpoint_key in <bpf/lib/common.h>
+// Must be in sync with struct endpoint_key in <bpf/lib/eps.h>
 type EndpointKey struct {
 	// represents both IPv6 and IPv4 (in the lowest four bytes)
 	IP        types.IPv6 `align:"$union0"`

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -35,7 +35,7 @@ const (
 
 // Key implements the bpf.MapKey interface.
 //
-// Must be in sync with struct ipcache_key in bpf/...
+// Must be in sync with struct ipcache_key in <bpf/lib/eps.h>
 type Key struct {
 	Prefixlen uint32 `align:"lpm_key"`
 	ClusterID uint16 `align:"cluster_id"`

--- a/pkg/maps/l2respondermap/l2_responder_map4.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4.go
@@ -114,7 +114,7 @@ func (m *l2ResponderMap) IterateWithCallback(cb IterateCallback) error {
 
 // L2ResponderKey implements the bpf.MapKey interface.
 //
-// Must be in sync with struct l2_responder_v4_key in bpf/...
+// Must be in sync with struct l2_responder_v4_key in <bpf/lib/l2_responder.h>
 type L2ResponderKey struct {
 	IP      types.IPv4 `align:"ip4"`
 	IfIndex uint32     `align:"ifindex"`

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -125,7 +125,7 @@ type pad2uint32 [2]uint32
 
 // EndpointInfo represents the value of the endpoints BPF map.
 //
-// Must be in sync with struct endpoint_info in <bpf/lib/common.h>
+// Must be in sync with struct endpoint_info in <bpf/lib/eps.h>
 type EndpointInfo struct {
 	IfIndex uint32 `align:"ifindex"`
 	Unused  uint16 `align:"unused"`

--- a/pkg/maps/metricsmap/metricsmap.go
+++ b/pkg/maps/metricsmap/metricsmap.go
@@ -57,7 +57,7 @@ const (
 	MaxEntries = 1024
 	// dirIngress and dirEgress values should match with
 	// METRIC_INGRESS, METRIC_EGRESS and METRIC_SERVICE
-	// in bpf/lib/common.h
+	// in bpf/lib/metrics.h
 	dirUnknown = 0
 	dirIngress = 1
 	dirEgress  = 2
@@ -78,7 +78,7 @@ var direction = map[uint8]string{
 	dirService: "SERVICE",
 }
 
-// Key must be in sync with struct metrics_key in <bpf/lib/common.h>
+// Key must be in sync with struct metrics_key in <bpf/lib/metrics.h>
 type Key struct {
 	Reason uint8 `align:"reason"`
 	Dir    uint8 `align:"dir"`
@@ -89,7 +89,7 @@ type Key struct {
 	Reserved [3]uint8 `align:"reserved"`
 }
 
-// Value must be in sync with struct metrics_value in <bpf/lib/common.h>
+// Value must be in sync with struct metrics_value in <bpf/lib/metrics.h>
 type Value struct {
 	Count uint64 `align:"count"`
 	Bytes uint64 `align:"bytes"`

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -100,8 +100,9 @@ func (pe *PolicyEntry) String() string {
 
 func (pe *PolicyEntry) New() bpf.MapValue { return &PolicyEntry{} }
 
-// PolicyKey represents a key in the BPF policy map for an endpoint. It must
-// match the layout of policy_key in bpf/lib/common.h.
+// PolicyKey represents a key in the BPF policy map for an endpoint.
+//
+// Must be in sync with struct policy_key in <bpf/lib/policy.h>
 type PolicyKey struct {
 	Prefixlen        uint32 `align:"lpm_key"`
 	Identity         uint32 `align:"sec_label"`
@@ -147,8 +148,9 @@ const (
 	StaticPrefixBits = uint32(sizeofPolicyKey-sizeofPrefixlen)*8 - uint32(FullPrefixBits)
 )
 
-// PolicyEntry represents an entry in the BPF policy map for an endpoint. It must
-// match the layout of policy_entry in bpf/lib/common.h.
+// PolicyEntry represents an entry in the BPF policy map for an endpoint.
+//
+// Must be in sync with struct policy_entry in <bpf/lib/policy.h>
 type PolicyEntry struct {
 	ProxyPortNetwork  uint16                        `align:"proxy_port"` // In network byte-order
 	Flags             policyEntryFlags              `align:"deny"`

--- a/pkg/maps/vtep/vtep.go
+++ b/pkg/maps/vtep/vtep.go
@@ -37,7 +37,7 @@ type Map interface {
 
 // Key implements the bpf.MapKey interface.
 //
-// Must be in sync with struct vtep_key in <bpf/lib/common.h>
+// Must be in sync with struct vtep_key in <bpf/lib/vtep.h>
 type Key struct {
 	IP types.IPv4 `align:"vtep_ip"`
 }


### PR DESCRIPTION
After commit cf6291797702 ("bpf: common: move structs & definitions into feature-specific headers"), some definitions were moved to their respective feature header. Adjust the references in the Go type godoc comments accordingly and also use a common format while at it.