### PR TITLE
endpoint: fix endpoint policy deadlock stuck in waiting-to-regenerate

### DIFF
--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -303,7 +303,6 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 	if !regenTriggered {
 		regenMetadata := &regeneration.ExternalRegenerationMetadata{
 			Reason:            "Initial build on endpoint creation",
-			ParentContext:     ctx,
 			RegenerationLevel: regeneration.RegenerateWithDatapath,
 		}
 		build, err := ep.SetRegenerateStateIfAlive(regenMetadata)


### PR DESCRIPTION
tl;dr: This fixes a deadlock caused by context cancellation of the request context after the "PUT /endpoint/{id}" endpoint successfully returns. This results in the endpoint regeneration being cancelled in the middle of the regeneration, leaving the endpoint stuck in "waiting-to-regenerate". This results in succeeding regenerations "waiting" for the current one that is cancelled, and the endpoint never progresses. The only mitigation is restarting the agent, or deleting the pod.

**See the commit messages for more context**

This has been an issue for many releases, and we have reproduced this on v1.15 and current main (~v1.19).

This is the same kind of issue as https://github.com/cilium/cilium/pull/37086, but that PR did not fix the root cause, instead made one way of hitting this impossible.

```release-note
Fix issue where endpoints got stuck in "waiting-to-regenerate"
```
