### PR TITLE
fix: reallocate envoy port on binding failure

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -119,6 +119,7 @@ func newCECResourceParser(params parserParams) *CECResourceParser {
 
 type PortAllocator interface {
 	AllocateCRDProxyPort(name string) (uint16, error)
+	ReallocateCRDProxyPort(name string) (uint16, error)
 	AckProxyPortWithReference(ctx context.Context, name string) error
 	ReleaseProxyPort(name string) error
 }

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -63,6 +63,19 @@ func (m *MockPortAllocator) AllocateCRDProxyPort(name string) (uint16, error) {
 	return m.port, nil
 }
 
+func (m *MockPortAllocator) ReallocateCRDProxyPort(name string) (uint16, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Delete existing port allocation if any
+	delete(m.ports, name)
+
+	m.port++
+	m.ports[name] = &MockPort{port: m.port}
+
+	return m.port, nil
+}
+
 func (m *MockPortAllocator) AckProxyPortWithReference(ctx context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -521,6 +521,11 @@ func (s staticPortAllocator) AllocateCRDProxyPort(name string) (uint16, error) {
 	return 1000, nil
 }
 
+// ReallocateCRDProxyPort implements PortAllocator.
+func (s staticPortAllocator) ReallocateCRDProxyPort(name string) (uint16, error) {
+	return 1001, nil
+}
+
 // ReleaseProxyPort implements PortAllocator.
 func (s staticPortAllocator) ReleaseProxyPort(name string) error {
 	s.log.Info("ReleaseProxyPort", logfields.Listener, name)


### PR DESCRIPTION
Fixes: #42858

This PR adds:

1. **Port binding error detection** (`isPortBindingError`): Detects port binding failures by checking error messages for common indicators like "cannot bind", "address already in use", and "eaddrinuse".

2. **Port reallocation function** (`AllocateCRDProxyPortWithReallocate`): Forces reallocation of a new port by resetting both `ProxyPort` and `rulesPort` when `forceReallocate` is true, ensuring a truly new random port is allocated.

3. **Retry logic** (`retryWithNewPorts`): When a port binding failure is detected:
   - Reallocates a new port for affected listeners
   - Clones only the listeners that need port reallocation (for efficiency)
   - Updates listener addresses with the new port
   - Updates port allocation callbacks
   - Retries the Envoy resource update

4. **Integration** (`Update` method): Integrates the retry logic into the Envoy reconciler's update flow.

**Testing**
- [x] Tested manually by reproducing the issue scenario
- [x] Verified that port reallocation works correctly
- [x] Confirmed that iptables rules are updated with the new port
- [x] Ensured backward compatibility (existing functionality unchanged)

```release-note
Fix: Cilium Ingress now automatically reallocates ports and retries when cilium-envoy fails to bind due to port conflicts
```
