### PR TITLE
bgp: Enhance TestRoutePolicySoftReset unit test

### DIFF
--- a/pkg/bgp/manager/reconciler/policies_test.go
+++ b/pkg/bgp/manager/reconciler/policies_test.go
@@ -994,38 +994,50 @@ func TestRoutePolicySoftReset(t *testing.T) {
 
 			current := RoutePolicyMap{}
 			for _, policy := range tt.currentPolicies {
-				current[policy.name] = &types.RoutePolicy{
+				routePolicy := &types.RoutePolicy{
 					Name: policy.name,
 					Type: policy.typ,
 					Statements: []*types.RoutePolicyStatement{
 						{
-							Conditions: types.RoutePolicyConditions{
-								MatchNeighbors: &types.RoutePolicyNeighborMatch{
-									Type:      types.RoutePolicyMatchAny,
-									Neighbors: policy.neighbors,
-								},
+							Actions: types.RoutePolicyActions{
+								RouteAction: types.RoutePolicyActionAccept,
 							},
 						},
 					},
 				}
+				if len(policy.neighbors) > 0 {
+					routePolicy.Statements[0].Conditions = types.RoutePolicyConditions{
+						MatchNeighbors: &types.RoutePolicyNeighborMatch{
+							Type:      types.RoutePolicyMatchAny,
+							Neighbors: policy.neighbors,
+						},
+					}
+				}
+				current[policy.name] = routePolicy
 			}
 
 			desired := RoutePolicyMap{}
 			for _, policy := range tt.desiredPolicies {
-				desired[policy.name] = &types.RoutePolicy{
+				routePolicy := &types.RoutePolicy{
 					Name: policy.name,
 					Type: policy.typ,
 					Statements: []*types.RoutePolicyStatement{
 						{
-							Conditions: types.RoutePolicyConditions{
-								MatchNeighbors: &types.RoutePolicyNeighborMatch{
-									Type:      types.RoutePolicyMatchAny,
-									Neighbors: policy.neighbors,
-								},
+							Actions: types.RoutePolicyActions{
+								RouteAction: types.RoutePolicyActionAccept,
 							},
 						},
 					},
 				}
+				if len(policy.neighbors) > 0 {
+					routePolicy.Statements[0].Conditions = types.RoutePolicyConditions{
+						MatchNeighbors: &types.RoutePolicyNeighborMatch{
+							Type:      types.RoutePolicyMatchAny,
+							Neighbors: policy.neighbors,
+						},
+					}
+				}
+				desired[policy.name] = routePolicy
 			}
 
 			_, err := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{


### PR DESCRIPTION
As a follow up to 3d3cd3b88fbcee41c96c5d3ca6b27a34a61046be this enhances `TestRoutePolicySoftReset` test to properly cover `peerAddressesFromPolicy` func - now properly produces policy statements without `MatchNeighbors` condition if empty neighbors are provided to the test, as e.g. in the "new policy with empty neighbors (all neighbors)" test.

