### PR TITLE
tunnel:agent: Error out in case of disabled underlayProtocol

### DIFF
--- a/pkg/datapath/tunnel/tunnel.go
+++ b/pkg/datapath/tunnel/tunnel.go
@@ -81,18 +81,6 @@ var (
 )
 
 func newConfig(in newConfigIn) (Config, error) {
-	switch EncapProtocol(in.Cfg.TunnelProtocol) {
-	case VXLAN, Geneve:
-	default:
-		return configDisabled, fmt.Errorf("invalid tunnel protocol %q", in.Cfg.TunnelProtocol)
-	}
-
-	switch UnderlayProtocol(in.Cfg.UnderlayProtocol) {
-	case IPv4, IPv6:
-	default:
-		return configDisabled, fmt.Errorf("invalid IP family for underlay %q", in.Cfg.UnderlayProtocol)
-	}
-
 	cfg := Config{
 		underlay:       UnderlayProtocol(in.Cfg.UnderlayProtocol),
 		protocol:       EncapProtocol(in.Cfg.TunnelProtocol),
@@ -101,10 +89,6 @@ func newConfig(in newConfigIn) (Config, error) {
 		srcPortHigh:    0,
 		deviceName:     "",
 		shouldAdaptMTU: false,
-	}
-
-	if _, err := fmt.Sscanf(in.Cfg.TunnelSourcePortRange, "%d-%d", &cfg.srcPortLow, &cfg.srcPortHigh); err != nil {
-		return configDisabled, fmt.Errorf("invalid tunnel source port range %q", in.Cfg.TunnelSourcePortRange)
 	}
 
 	var enabled bool
@@ -136,6 +120,18 @@ func newConfig(in newConfigIn) (Config, error) {
 		if cfg.port == 0 {
 			cfg.port = defaults.TunnelPortGeneve
 		}
+	default:
+		return configDisabled, fmt.Errorf("invalid tunnel protocol %q", cfg.protocol)
+	}
+
+	switch cfg.underlay {
+	case IPv4, IPv6:
+	default:
+		return configDisabled, fmt.Errorf("invalid IP family for underlay %q", cfg.underlay)
+	}
+
+	if _, err := fmt.Sscanf(in.Cfg.TunnelSourcePortRange, "%d-%d", &cfg.srcPortLow, &cfg.srcPortHigh); err != nil {
+		return configDisabled, fmt.Errorf("invalid tunnel source port range %q", in.Cfg.TunnelSourcePortRange)
 	}
 
 	return cfg, nil

--- a/pkg/datapath/tunnel/tunnel_test.go
+++ b/pkg/datapath/tunnel/tunnel_test.go
@@ -36,12 +36,14 @@ func TestConfig(t *testing.T) {
 		shouldAdaptMTU bool
 	}{
 		{
-			name:      "invalid protocol",
+			name:      "tunnel enabled, invalid protocol",
+			enablers:  []any{enabler(false), enabler(true)},
 			ucfg:      userCfg{UnderlayProtocol: string(IPv4), TunnelProtocol: "invalid", TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
 			shallFail: true,
 		},
 		{
-			name:      "invalid underlay",
+			name:      "tunnel enabled, invalid underlay",
+			enablers:  []any{enabler(true), enabler(false)},
 			ucfg:      userCfg{UnderlayProtocol: "invalid", TunnelProtocol: string(VXLAN), TunnelPort: 0, TunnelSourcePortRange: defaults.TunnelSourcePortRange},
 			shallFail: true,
 		},


### PR DESCRIPTION
Prior to this commit, it was possible to select a disabled underlay protocol, causing potential MTU calculation errors. For example, in an IPv6-only cluster, the defaul value for underlayProtocol is IPv4, and nothing prevents the agent from running with this incorrect information. That leads to error in computing the MTU, accounting for 50B of overhead rather than the 70B for the IPv6 underlay case.

The above problems lead to fragmentation, and in some configuration to packet drops and no pod-to-pod connectivity. Let's just error in case of a disabled selected underlay protocol, so that at least the user is well aware that something was wrong during Cilium installation.

See comment https://github.com/cilium/cilium/issues/23917#issuecomment-3548526755.

For previous IPv6-only cluster in native routing, this will not cause troubles, given the previous commit: config enablers/validators are run first, and immediately return a disabled config in case it is not needed.