### PR TITLE
gha: additionally cleanup disk space in clustermesh upgrade workflow

### DIFF
--- a/.github/actions/disk-cleanup/action.yaml
+++ b/.github/actions/disk-cleanup/action.yaml
@@ -39,7 +39,6 @@ runs:
         }
 
         # Run ALL deletions in parallel - maximum parallelization
-        fast_delete "/opt/hostedtoolcache" &
         fast_delete "/usr/local/lib/android" &
         fast_delete "/usr/share/dotnet" &
         fast_delete "/opt/google/chrome" &

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -165,6 +165,9 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
       - name: Set up newest settings
         id: newest-vars
         uses: ./.github/actions/helm-default


### PR DESCRIPTION
It looks like this workflow recently started failing frequently with errors likely caused by disk space exhaustion. Let's additionally call the dedicated disk-cleanup action, to free some more space.