### PR TITLE
policy: add metric on selector cache cardinality and performance

### DIFF
--- a/pkg/policy/types/metrics.go
+++ b/pkg/policy/types/metrics.go
@@ -20,6 +20,24 @@ const (
 	// LabelValueSCOther is used for security identities allocated locally
 	// on the current node.
 	LabelValueSCOther = "other"
+
+	// LabelValueSCTypePeer is used for the normal selector cache
+	LabelValueSCTypePeer = "peer"
+
+	// LabelValueSCOperationAddSelector is used for the operation that adds a new selector
+	LabelValueSCOperationAddSelector = "add_selector"
+
+	// LabelValueSCOperationRemoveSelector is used for the operation that removes a selector
+	LabelValueSCOperationRemoveSelector = "remove_selector"
+
+	// LabelValueSCOperationIdentityUpdates is used for the operation that updates one or more identities in the cache
+	LabelValueSCOperationIdentityUpdates = "identity_updates"
+
+	// LabelValueSCOperation is used for the actual Selector Cache Operation duration
+	LabelValueSCOperation = "operation"
+
+	// LabelValueSCOperationLock is used for the actual lock time during the Selector Cache Operation duration
+	LabelValueSCOperationLock = "lock"
 )
 
 type PolicyMetrics interface {


### PR DESCRIPTION
This adds a new set of metrics for the selector cache. Both in terms of cardinality, but also around the performance of various operations.

Mostly opening now so we can start discussing performance around https://github.com/cilium/cilium/pull/42008. The same applies to https://github.com/cilium/cilium/pull/42580, so that we can add a separate `type="subject"` value.

I'm don't think we need a histogram here, and that a summary (_count + _sum) is sufficient, but can't see that used elsewhere.

```bash
$ k get --raw /api/v1/namespaces/kube-system/pods/http:<pod-name>:9962/proxy/metrics | egrep "^cilium_policy_selector_cache"
cilium_policy_selector_cache_identities{type="peer"} 13
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.0005"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.001"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.005"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.025"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.05"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.1"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.2"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="0.4"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="add_selector",scope="operation",type="peer",le="+Inf"} 2
cilium_policy_selector_cache_operation_duration_seconds_sum{operation="add_selector",scope="operation",type="peer"} 3.0375e-05
cilium_policy_selector_cache_operation_duration_seconds_count{operation="add_selector",scope="operation",type="peer"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.0005"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.001"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.005"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.025"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.05"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.1"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.2"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="0.4"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="lock",type="peer",le="+Inf"} 2
cilium_policy_selector_cache_operation_duration_seconds_sum{operation="identity_updates",scope="lock",type="peer"} 8.2e-08
cilium_policy_selector_cache_operation_duration_seconds_count{operation="identity_updates",scope="lock",type="peer"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.0005"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.001"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.005"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.025"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.05"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.1"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.2"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="0.4"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="identity_updates",scope="operation",type="peer",le="+Inf"} 2
cilium_policy_selector_cache_operation_duration_seconds_sum{operation="identity_updates",scope="operation",type="peer"} 8.612499999999999e-05
cilium_policy_selector_cache_operation_duration_seconds_count{operation="identity_updates",scope="operation",type="peer"} 2
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.0005"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.001"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.005"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.025"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.05"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.1"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.2"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="0.4"} 4
cilium_policy_selector_cache_operation_duration_seconds_bucket{operation="remove_selector",scope="operation",type="peer",le="+Inf"} 4
cilium_policy_selector_cache_operation_duration_seconds_sum{operation="remove_selector",scope="operation",type="peer"} 2.4376000000000002e-05
cilium_policy_selector_cache_operation_duration_seconds_count{operation="remove_selector",scope="operation",type="peer"} 4
cilium_policy_selector_cache_selectors{type="peer"} 2
```

```release-note
n/a yet.
```
