### PR TITLE
ci: cleanup disk space in cilium-cli build workflow

### DIFF
--- a/.github/workflows/cilium-cli.yaml
+++ b/.github/workflows/cilium-cli.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
       - name: Setup go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:


### PR DESCRIPTION
Sometimes, the workflow fails because it's running out of disk space. Try to remediate that by cleaning up runner disk space before building the CLI.
