### PR TITLE
ipcache/restore: initiate restore in IPCache hive lifecycle start hook

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -573,7 +573,6 @@ Makefile* @cilium/build
 /pkg/hubble/metrics @cilium/hubble-metrics
 /pkg/iana/ @cilium/sig-agent
 /pkg/identity @cilium/sig-policy
-/pkg/identity/restoration @cilium/sig-policy @cilium/ipcache
 /pkg/idpool/ @cilium/sig-policy
 /pkg/ip/ @cilium/sig-agent
 /pkg/ipalloc/ @cilium/sig-ipam
@@ -583,6 +582,7 @@ Makefile* @cilium/build
 /pkg/ipam/allocator/azure/ @cilium/sig-ipam @cilium/azure
 /pkg/ipam/allocator/clusterpool/ @cilium/sig-ipam @cilium/operator
 /pkg/ipcache/ @cilium/ipcache
+/pkg/ipcache/restore @cilium/sig-policy @cilium/ipcache
 /pkg/ipmasq @cilium/sig-agent
 /pkg/k8s/ @cilium/sig-k8s
 /pkg/k8s/apis/cilium.io/client/crds/v2/ @cilium/sig-k8s

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -147,16 +147,6 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	ctmap.InitMapInfo(params.MetricsRegistry, params.DaemonConfig.EnableIPv4, params.DaemonConfig.EnableIPv6, params.KPRConfig.KubeProxyReplacement || params.DaemonConfig.EnableBPFMasquerade)
 
-	// Collect CIDR identities from the "old" bpf ipcache and restore them
-	// in to the metadata layer.
-	if params.DaemonConfig.RestoreState && !params.DaemonConfig.DryMode {
-		// this *must* be called before initMaps(), which will "hide"
-		// the "old" ipcache.
-		if err := params.IdentityRestorer.RestoreLocalIdentities(); err != nil {
-			params.Logger.Warn("Failed to restore existing identities from the previous ipcache. This may cause policy interruptions during restart.", logfields.Error, err)
-		}
-	}
-
 	bootstrapStats.daemonInit.End(true)
 
 	// Open or create BPF maps.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
-	identityrestoration "github.com/cilium/cilium/pkg/identity/restoration"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -1237,7 +1236,6 @@ type daemonParams struct {
 	EndpointManager     endpointmanager.EndpointManager
 	EndpointRestorer    *endpointRestorer
 	IdentityAllocator   identitycell.CachingIdentityAllocator
-	IdentityRestorer    *identityrestoration.LocalIdentityRestorer
 	Policy              policy.PolicyRepository
 	MonitorAgent        monitorAgent.Agent
 	DB                  *statedb.DB

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
-	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
@@ -92,20 +91,6 @@ func initMaps(params daemonParams) error {
 
 	if err := lxcmap.LXCMap(params.MetricsRegistry).OpenOrCreate(); err != nil {
 		return fmt.Errorf("initializing lxc map: %w", err)
-	}
-
-	// The ipcache is shared between endpoints. Unpin the old ipcache map created
-	// by any previous instances of the agent to prevent new endpoints from
-	// picking up the old map pin. The old ipcache will continue to be used by
-	// loaded bpf programs, it will just no longer be updated by the agent.
-	//
-	// This is to allow existing endpoints that have not been regenerated yet to
-	// continue using the existing ipcache until the endpoint is regenerated for
-	// the first time and its bpf programs have been replaced. Existing endpoints
-	// are using a policy map which is potentially out of sync as local identities
-	// are re-allocated on startup.
-	if err := ipcachemap.IPCacheMap(params.MetricsRegistry).Recreate(); err != nil {
-		return fmt.Errorf("initializing ipcache map: %w", err)
 	}
 
 	if err := metricsmap.Metrics.OpenOrCreate(); err != nil {

--- a/pkg/identity/cell/cell.go
+++ b/pkg/identity/cell/cell.go
@@ -9,7 +9,6 @@ import (
 	identityapi "github.com/cilium/cilium/pkg/identity/api"
 	identitycache "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/identity/restoration"
 )
 
 // Cell provides the identity controlplane that is responsible to allocate and manage security identities
@@ -25,7 +24,4 @@ var Cell = cell.Module(
 
 	// IdentityApiHandler provides the Identity Cilium API
 	identityapi.Cell,
-
-	// LocalIdentityRestorer restores the identities at startup
-	restoration.Cell,
 )


### PR DESCRIPTION
This PR moves the initiation of the IPCache restoration from the legacy daemon logic into the IPCache cell (using a Hive lifecycle hook).

Please review the individual commits.