### PR TITLE
endpoint/restore: initiate restore in EndpointRestorer hive lifecycle start hook

### DIFF
--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -15,7 +15,6 @@ type bootstrapStatistics struct {
 	k8sInit   spanstat.SpanStat
 	restore   spanstat.SpanStat
 	ipam      spanstat.SpanStat
-	fqdn      spanstat.SpanStat
 	kvstore   spanstat.SpanStat
 }
 
@@ -41,7 +40,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"k8sInit":   &b.k8sInit,
 		"restore":   &b.restore,
 		"ipam":      &b.ipam,
-		"fqdn":      &b.fqdn,
 		"kvstore":   &b.kvstore,
 	}
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -129,12 +129,6 @@ func initAndValidateDaemonConfig(params daemonConfigParams) error {
 }
 
 func configureDaemon(ctx context.Context, params daemonParams) error {
-	// Load cached information from restored endpoints in to FQDN NameManager and DNS proxies
-	bootstrapStats.fqdn.Start()
-	params.DNSNameManager.RestoreCache(params.EndpointRestorer.GetState().possible)
-	params.DNSProxy.BootstrapFQDN(params.EndpointRestorer.GetState().possible)
-	bootstrapStats.fqdn.End(true)
-
 	if params.Clientset.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 		// Errors are handled inside WaitForCRDsToRegister. It will fatal on a

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -129,15 +129,6 @@ func initAndValidateDaemonConfig(params daemonConfigParams) error {
 }
 
 func configureDaemon(ctx context.Context, params daemonParams) error {
-	var err error
-
-	bootstrapStats.restore.Start()
-	// fetch old endpoints before k8s is configured.
-	if err := params.EndpointRestorer.FetchOldEndpoints(ctx, params.DaemonConfig.StateDir); err != nil {
-		params.Logger.Error("Unable to read existing endpoints", logfields.Error, err)
-	}
-	bootstrapStats.restore.End(true)
-
 	// Load cached information from restored endpoints in to FQDN NameManager and DNS proxies
 	bootstrapStats.fqdn.Start()
 	params.DNSNameManager.RestoreCache(params.EndpointRestorer.GetState().possible)
@@ -223,7 +214,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
-	err = params.EndpointRestorer.RestoreOldEndpoints()
+	err := params.EndpointRestorer.RestoreOldEndpoints()
 	bootstrapStats.restore.EndError(err)
 	if err != nil {
 		return err

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -36,8 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
-	"github.com/cilium/cilium/pkg/fqdn/bootstrap"
-	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -1232,8 +1230,6 @@ type daemonParams struct {
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	IPAM                *ipam.IPAM
 	CRDSyncPromise      promise.Promise[k8sSynced.CRDSync]
-	DNSProxy            bootstrap.FQDNProxyBootstrapper
-	DNSNameManager      namemanager.NameManager
 	KPRConfig           kpr.KPRConfig
 	KPRInitializer      kprinitializer.KPRInitializer
 	InfraIPAllocator    infraendpoints.InfraIPAllocator

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -73,7 +73,8 @@ func registerEndpointRestoreFinishJob(jobGroup job.Group, endpointRestorer *endp
 type endpointRestorerParams struct {
 	cell.In
 
-	Resolver promise.Resolver[endpointstate.Restorer]
+	Resolver             promise.Resolver[endpointstate.Restorer]
+	RestorationNotifiers []endpointstate.RestorationNotifier `group:"endpointRestorationNotifiers"`
 
 	Lifecycle           cell.Lifecycle
 	DaemonConfig        *option.DaemonConfig
@@ -161,6 +162,14 @@ func newEndpointRestorer(params endpointRestorerParams) *endpointRestorer {
 			if err := restorer.readOldEndpointsFromDisk(ctx); err != nil {
 				params.Logger.Error("Unable to read existing endpoints", logfields.Error, err)
 			}
+
+			params.Logger.Debug("Notify endpoint restoration notifiers about restored endpoints", logfields.Registrations, len(params.RestorationNotifiers))
+			for _, r := range params.RestorationNotifiers {
+				if r != nil {
+					r.RestorationNotify(restorer.restoreState.possible)
+				}
+			}
+
 			return nil
 		},
 	})
@@ -391,10 +400,6 @@ func (r *endpointRestorer) readOldEndpointsFromDisk(ctx context.Context) error {
 		r.logger.Info("No old endpoints found.")
 	}
 	return nil
-}
-
-func (r *endpointRestorer) GetState() *endpointRestoreState {
-	return r.restoreState
 }
 
 // restoreOldEndpoints performs the second step in restoring the endpoint structure,

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -76,6 +76,7 @@ type endpointRestorerParams struct {
 	Resolver promise.Resolver[endpointstate.Restorer]
 
 	Lifecycle           cell.Lifecycle
+	DaemonConfig        *option.DaemonConfig
 	Logger              *slog.Logger
 	K8sWatcher          *watchers.K8sWatcher
 	Clientset           k8sClient.Clientset
@@ -94,6 +95,7 @@ type endpointRestorerParams struct {
 
 type endpointRestorer struct {
 	logger              *slog.Logger
+	stateDir            string
 	k8sWatcher          *watchers.K8sWatcher
 	clientset           k8sClient.Clientset
 	endpointCreator     endpointcreator.EndpointCreator
@@ -118,6 +120,7 @@ type endpointRestorer struct {
 func newEndpointRestorer(params endpointRestorerParams) *endpointRestorer {
 	restorer := &endpointRestorer{
 		logger:              params.Logger,
+		stateDir:            params.DaemonConfig.StateDir,
 		k8sWatcher:          params.K8sWatcher,
 		clientset:           params.Clientset,
 		endpointCreator:     params.EndpointCreator,
@@ -148,10 +151,15 @@ func newEndpointRestorer(params endpointRestorerParams) *endpointRestorer {
 	params.Resolver.Resolve(restorer)
 
 	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(cell.HookContext) error {
+		OnStart: func(ctx cell.HookContext) error {
 			if err := restorer.clearStaleCiliumEndpointVeths(); err != nil {
 				// log and continue
 				params.Logger.Warn("Unable to clean stale endpoint interfaces", logfields.Error, err)
+			}
+
+			// read old endpoints from disk before k8s is configured
+			if err := restorer.readOldEndpointsFromDisk(ctx); err != nil {
+				params.Logger.Error("Unable to read existing endpoints", logfields.Error, err)
 			}
 			return nil
 		},
@@ -348,13 +356,13 @@ func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
 	return nil
 }
 
-// fetchOldEndpoints reads the list of existing endpoints previously managed by Cilium when it was
+// readOldEndpointsFromDisk reads the list of existing endpoints previously managed by Cilium when it was
 // last run and associated it with container workloads. This function performs the first step in
 // restoring the endpoint structure.  It needs to be followed by a call to restoreOldEndpoints()
 // once k8s has been initialized and regenerateRestoredEndpoints() once the endpoint builder is
 // ready. In summary:
 //
-// 1. fetchOldEndpoints(): Unmarshal old endpoints
+// 1. readOldEndpointFromDisk(): read old endpoints from disk
 //   - used to start DNS proxy with restored DNS history and rules
 //
 // 2. restoreOldEndpoints(): validate endpoint data after k8s has been configured
@@ -363,7 +371,7 @@ func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
 //
 // 3. regenerateRestoredEndpoints(): Regenerate the restored endpoints
 //   - recreate endpoint's policy, as well as bpf programs and maps
-func (r *endpointRestorer) FetchOldEndpoints(ctx context.Context, dir string) error {
+func (r *endpointRestorer) readOldEndpointsFromDisk(ctx context.Context) error {
 	if !option.Config.RestoreState {
 		r.logger.Info("Endpoint restore is disabled, skipping restore step")
 		return nil
@@ -371,13 +379,13 @@ func (r *endpointRestorer) FetchOldEndpoints(ctx context.Context, dir string) er
 
 	r.logger.Info("Reading old endpoints...")
 
-	dirFiles, err := os.ReadDir(dir)
+	dirFiles, err := os.ReadDir(r.stateDir)
 	if err != nil {
 		return err
 	}
 	eptsID := endpoint.FilterEPDir(dirFiles)
 
-	r.restoreState.possible = endpoint.ReadEPsFromDirNames(ctx, r.logger, r.endpointCreator, dir, eptsID)
+	r.restoreState.possible = endpoint.ReadEPsFromDirNames(ctx, r.logger, r.endpointCreator, r.stateDir, eptsID)
 
 	if len(r.restoreState.possible) == 0 {
 		r.logger.Info("No old endpoints found.")

--- a/pkg/endpointstate/restorer.go
+++ b/pkg/endpointstate/restorer.go
@@ -3,7 +3,13 @@
 
 package endpointstate
 
-import "context"
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+)
 
 // Restorer wraps a method to wait for endpoints restoration.
 type Restorer interface {
@@ -18,4 +24,19 @@ type Restorer interface {
 	// WaitForInitialPolicy blocks the caller until either the context is
 	// cancelled or initial policies of all restored endpoints have been computed.
 	WaitForInitialPolicy(ctx context.Context) error
+}
+
+// RestorationNotifier is implemented by components that need to be restored with the "old" endpoints
+// that have been read from disk by the Endpoint restorer.
+// Components should register with Hive value groups by using RestorationNotifierOut.
+type RestorationNotifier interface {
+	// RestorationNotify is called once the "old" endpoints have been read from disk.
+	// The Endpoints are not yet exposed to the EndpointManager.
+	RestorationNotify(possible map[uint16]*endpoint.Endpoint)
+}
+
+type RestorationNotifierOut struct {
+	cell.Out
+
+	Restorer RestorationNotifier `group:"endpointRestorationNotifiers"`
 }

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
 	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -19,10 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	proxytypes "github.com/cilium/cilium/pkg/proxy/types"
 )
-
-type FQDNProxyBootstrapper interface {
-	BootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint)
-}
 
 type fqdnProxyBootstrapperParams struct {
 	cell.In
@@ -48,8 +45,7 @@ type fqdnProxyBootstrapper struct {
 }
 
 // newFQDNProxyBootstrapper handles initializing the DNS proxy in concert with the daemon.
-func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBootstrapper {
-
+func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) endpointstate.RestorationNotifierOut {
 	b := &fqdnProxyBootstrapper{
 		logger: params.Logger,
 
@@ -64,7 +60,7 @@ func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBoots
 	// The proxy would not get any traffic in the dry mode anyway, and some of the socket
 	// operations require privileges not available in all unit tests.
 	if option.Config.DryMode || !option.Config.EnableL7Proxy {
-		return b
+		return endpointstate.RestorationNotifierOut{}
 	}
 
 	params.JobGroup.Add(job.OneShot("proxy-bootstrapper", b.startProxy, job.WithShutdown()))
@@ -76,14 +72,16 @@ func newFQDNProxyBootstrapper(params fqdnProxyBootstrapperParams) FQDNProxyBoots
 		},
 	})
 
-	return b
+	return endpointstate.RestorationNotifierOut{
+		Restorer: b,
+	}
 }
 
-var _ FQDNProxyBootstrapper = (*fqdnProxyBootstrapper)(nil)
+var _ endpointstate.RestorationNotifier = (*fqdnProxyBootstrapper)(nil)
 
-// BootstrapFQDN restores per-endpoint cached FQDN L7 rules to the proxy,
+// RestorationNotify implements endpointstate.RestorationNotifier and restores per-endpoint cached FQDN L7 rules to the proxy,
 // so it may immediately listen and start serving.
-func (b *fqdnProxyBootstrapper) BootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint) {
+func (b *fqdnProxyBootstrapper) RestorationNotify(possibleEndpoints map[uint16]*endpoint.Endpoint) {
 	// was proxy disabled?
 	if b.proxy == nil {
 		return

--- a/pkg/fqdn/namemanager/cell.go
+++ b/pkg/fqdn/namemanager/cell.go
@@ -45,6 +45,7 @@ var Cell = cell.Module(
 	}),
 	cell.ProvidePrivate(adaptors),
 	cell.Provide(newForCell),
+	cell.Provide(registerEndpointRestorationNotifier),
 
 	cell.ProvidePrivate(New), // for the API handlers, exposes *manager.
 	cell.Provide(handlers),
@@ -113,6 +114,12 @@ func newForCell(m *manager) NameManager {
 	return m
 }
 
+func registerEndpointRestorationNotifier(m *manager) endpointstate.RestorationNotifierOut {
+	return endpointstate.RestorationNotifierOut{
+		Restorer: m,
+	}
+}
+
 // The NameManager maintains DNS mappings which need to be tracked, due to
 // FQDNSelectors. It is the main structure which relates the FQDN subsystem to
 // the policy subsystem for plumbing the relation between a DNS name and the
@@ -139,11 +146,6 @@ type NameManager interface {
 	LockName(name string)
 	// UnlockName releases a lock previously acquired by LockName()
 	UnlockName(name string)
-
-	// RestoreCache loads cache state from the restored system:
-	// - adds any pre-cached DNS entries
-	// - repopulates the cache from the (persisted) endpoint DNS cache and zombies
-	RestoreCache(eps map[uint16]*endpoint.Endpoint)
 }
 
 // Provides the API handlers for Cilium API.

--- a/pkg/fqdn/namemanager/gc.go
+++ b/pkg/fqdn/namemanager/gc.go
@@ -157,12 +157,12 @@ func (n *manager) doGC(ctx context.Context) error {
 	return nil
 }
 
-// RestoreCache loads cache state from the restored system:
+// RestorationNotify implements endpointstate.RestorationNotifier and loads cache state from the restored system:
 // - adds any pre-cached DNS entries
 // - repopulates the cache from the (persisted) endpoint DNS cache and zombies
-func (n *manager) RestoreCache(eps map[uint16]*endpoint.Endpoint) {
+func (n *manager) RestorationNotify(possibleEndpoints map[uint16]*endpoint.Endpoint) {
 	// Prefill the cache with the CLI provided pre-cache data. This allows various bridging arrangements during upgrades, or just ensure critical DNS mappings remain.
-	// TODO: remove this; it was neeeded for the v1.3-v1.4 upgrade
+	// TODO: remove this; it was needed for the v1.3-v1.4 upgrade
 	preCachePath := option.Config.ToFQDNsPreCache
 	if preCachePath != "" {
 		n.logger.Info("Reading toFQDNs pre-cache data")
@@ -185,7 +185,7 @@ func (n *manager) RestoreCache(eps map[uint16]*endpoint.Endpoint) {
 	// Note: This is TTL aware, and expired data will not be used (e.g. when
 	// restoring after a long delay).
 	now := time.Now()
-	for _, possibleEP := range eps {
+	for _, possibleEP := range possibleEndpoints {
 		// Upgrades from old ciliums have this nil
 		if possibleEP.DNSHistory != nil {
 			n.cache.UpdateFromCache(possibleEP.DNSHistory)


### PR DESCRIPTION
This PR moves the first step of the Endpoint restoration (read old endpoints from disk) from the legacy daemon logic into the Endpoint restorer cell (adding a hive lifecycle hook). Dependent hive cells that are interested in the restoreable endpoints are notified via callback.

Please review the individual commits.