### PR TITLE
endpointmanager: fix CEP deletion race during pod migration

### DIFF
--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -17,7 +17,10 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
@@ -238,9 +241,15 @@ func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 type endpointSynchronizerParams struct {
 	cell.In
 
-	Clientset client.Clientset
+	Clientset           client.Clientset
+	CiliumEndpoint      resource.Resource[*types.CiliumEndpoint]
+	CiliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
 }
 
 func newEndpointSynchronizer(p endpointSynchronizerParams) EndpointResourceSynchronizer {
-	return &EndpointSynchronizer{Clientset: p.Clientset}
+	return &EndpointSynchronizer{
+		Clientset:           p.Clientset,
+		CiliumEndpoint:      p.CiliumEndpoint,
+		CiliumEndpointSlice: p.CiliumEndpointSlice,
+	}
 }


### PR DESCRIPTION
During pod migration with make-before-break scheduling, a race condition causes CiliumEndpoint resources to be incorrectly deleted, leaving pods unmanaged indefinitely.

The issue occurs when:
1. Pod migrates from node A to node B (sub-second timing)
2. Node B creates new CEP with updated NodeIP
3. Node A's cleanup runs, deletes CEP by name without verifying ownership
4. Node B's sync controller caches stale CEP reference, never detects deletion

This results in pods running for days without CEPs, bypassing network policies and becoming invisible to monitoring.

The fix adds a periodic existence check in the CEP sync controller:

pkg/endpointmanager/endpointsynchronizer.go: Periodically verify CEP existence using local resource store. If CEP deleted externally, trigger automatic recreation within 10 seconds.

This uses the local CEP resource store (maintained by informer) instead of API calls for better performance.


```release-note
Recreate CiliumEndpoints (k8s resource) if they are accidentally deleted.
```