### PR TITLE
datapath: fix up description text for host_ep_id config value

### DIFF
--- a/bpf/include/bpf/config/endpoint.h
+++ b/bpf/include/bpf/config/endpoint.h
@@ -19,4 +19,4 @@ DECLARE_CONFIG(__u32, security_label, "The endpoint's security label")
 #define SECLABEL_IPV4 SECLABEL
 #define SECLABEL_IPV6 SECLABEL
 
-DECLARE_CONFIG(__u16, host_ep_id, "The host endpoint's security ID")
+DECLARE_CONFIG(__u16, host_ep_id, "The host endpoint ID")

--- a/pkg/datapath/config/host_config.go
+++ b/pkg/datapath/config/host_config.go
@@ -29,7 +29,7 @@ type BPFHost struct {
 	// Length of the Ethernet header on this device. May be set to zero on L2-less
 	// devices. (default __ETH_HLEN).
 	EthHeaderLength uint8 `config:"eth_header_length"`
-	// The host endpoint's security ID.
+	// The host endpoint ID.
 	HostEpID uint16 `config:"host_ep_id"`
 	// Ifindex of the interface the bpf program is attached to.
 	InterfaceIfindex uint32 `config:"interface_ifindex"`

--- a/pkg/datapath/config/lxc_config.go
+++ b/pkg/datapath/config/lxc_config.go
@@ -32,7 +32,7 @@ type BPFLXC struct {
 	EndpointIPv6 [16]byte `config:"endpoint_ipv6"`
 	// The endpoint's network namespace cookie.
 	EndpointNetNSCookie uint64 `config:"endpoint_netns_cookie"`
-	// The host endpoint's security ID.
+	// The host endpoint ID.
 	HostEpID uint16 `config:"host_ep_id"`
 	// Ifindex of the interface the bpf program is attached to.
 	InterfaceIfindex uint32 `config:"interface_ifindex"`


### PR DESCRIPTION
The Endpoint ID is a __u16 value that uniquely identifies the endpoint on the local node, and is used for instance to index into the policy tailcall map.

The Security Identity is a __u32 value that has cluster-wide scope, and can be shared amongst multiple endpoints.

Thou shalt not confuse the two meanings.