### PR TITLE
fqdn: Remove erroneous e.ID check

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1089,7 +1089,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// - the source is known to be in the host networking namespace, or
 	// - the destination is known to be outside of the cluster, or
 	// - is the local host
-	if option.Config.DNSProxyEnableTransparentMode && !ep.IsHost() && !epAddr.IsLoopback() && ep.ID != uint16(identity.ReservedIdentityHost) && targetServerID.IsCluster() && targetServerID != identity.ReservedIdentityHost {
+	if option.Config.DNSProxyEnableTransparentMode && !ep.IsHost() && !epAddr.IsLoopback() && targetServerID.IsCluster() && targetServerID != identity.ReservedIdentityHost {
 		dialer.LocalAddr = w.RemoteAddr()
 		key = sharedClientKey(protocol, epIPPort, targetServerAddrStr)
 	}


### PR DESCRIPTION
Remove the incorrect check for endpoint ID in DNS proxy. This was checking the endpoint ID while the intent was to check the endpoint security ID. Since we already check for 'ep.IsHost()' the security identity check would have been superfluous anyway, so just remove it.

Fixes: #42879

```release-note
Do not opt-out Endpoint ID 1 from dnsproxy transparent mode.
```
