### PR TITLE
bpf: Fix comments and typos in map_linux.go

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -271,7 +271,7 @@ func NewMap(name string, mapType ebpf.MapType, mapKey MapKey, mapValue MapValue,
 	}
 }
 
-// NewMap creates a new Map instance - object representing a BPF map
+// NewMapWithInnerSpec creates a new Map instance - object representing a BPF map with an inner map specification
 func NewMapWithInnerSpec(name string, mapType ebpf.MapType, mapKey MapKey, mapValue MapValue,
 	maxEntries int, flags uint32, innerSpec *ebpf.MapSpec) *Map {
 
@@ -355,9 +355,9 @@ func (m *Map) WithCache() *Map {
 
 // WithEvents enables use of the event buffer, if the buffer is enabled.
 // This stores all map events (i.e. add/update/delete) in a bounded event buffer.
-// If eventTTL is not zero, than events that are older than the TTL
+// If eventTTL is not zero, then events that are older than the TTL
 // will periodically be removed from the buffer.
-// Enabling events will use aprox proportional to 100MB for every million capacity
+// Enabling events will use approx proportional to 100MB for every million capacity
 // in maxSize.
 //
 // TODO: The IPCache map have many periodic update events added by a controller for entries such as the 0.0.0.0/0 range.
@@ -428,7 +428,7 @@ func (m *Map) UpdatePressureMetricWithSize(size int32) {
 
 func (m *Map) updatePressureMetric() {
 	// Skipping pressure metric gauge updates for LRU map as the cache size
-	// does not accurately represent the actual map sie.
+	// does not accurately represent the actual map size.
 	if m.spec != nil && m.spec.Type == ebpf.LRUHash {
 		return
 	}


### PR DESCRIPTION
Fix comments and typos in map_linux.go.