### PR TITLE
renovate: add generated files after changing documentation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -580,7 +580,8 @@
           "make -C Documentation update-cmdref"
         ],
         "fileFilters": [
-          "Documentation/cmdref/cilium_connectivity_test.md"
+          "Documentation/cmdref/cilium_connectivity_test.md",
+          "Documentation/cmdref/cilium_connectivity_perf.md"
         ],
         "executionMode": "update"
       }


### PR DESCRIPTION
Add more generated files after updating the
cilium-cli/defaults/defaults.go file.