### PR TITLE
workflows/kpr: set maxPodsPerNode for eks nodegroups in ci

### DIFF
--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -51,6 +51,7 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 25
+          maxPodsPerNode: 110
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
@@ -63,6 +64,7 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 25
+          maxPodsPerNode: 110
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
@@ -136,6 +138,7 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 20
+          maxPodsPerNode: 110
           taints:
            - key: "cilium.io/no-schedule"
              value: "true"


### PR DESCRIPTION
ci-kpr has been failing quite frequently lately, and after looking at the sysdump i found some pods were on Pending state.
pod status said it couldnt find a node, as there were no pod slots available in the cluster (eks instances get a maxpods of 17 apparently)

this PR changes the number of pods for all eks node groups

ex failed one:
https://github.com/cilium/cilium/actions/runs/19533808794/job/55922985606

Fixes: #[42816](https://github.com/cilium/cilium/issues/42816)

```release-note
CI: set maxPodsPerNode for eks nodegroups in ci
```
