### PR TITLE
bpf: nodeport: let tail_nodeport_nat_ingress_ipv*() use source identity

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1108,7 +1108,7 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 		.reason = TRACE_REASON_CT_REPLY,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
-	__u32 src_id = 0;
+	__u32 src_id = ctx_load_meta(ctx, CB_SRC_LABEL);
 	__s8 ext_err = 0;
 	int ret;
 
@@ -2434,7 +2434,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
-	__u32 src_id = 0;
+	__u32 src_id = ctx_load_meta(ctx, CB_SRC_LABEL);
 	__s8 ext_err = 0;
 	int ret;
 


### PR DESCRIPTION
All callers provide a source identity (of various quality) in CB_SRC_LABEL. Let's make use of it when raising a drop notification.

In detail:
* `bpf_xdp` passes UNKNOWN_ID, no change.
* `from-netdev` passes the result of an ipcache lookup.
* `from-overlay` obtained the identity from the tunnel header.
* `from-wireguard` either passes the result of an ipcache lookup, or WORLD_ID.