### PR TITLE
Introduce "unsupported protocol action" logic via ipcache unroutable flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -56,6 +56,7 @@ cilium-agent [flags]
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic
       --bpf-lb-sock-hostns-only                                   Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
+      --bpf-lb-unsupported-protocol-action string                 BPF unsupported protocol action ("forward", "drop") (default "forward")
       --bpf-map-dynamic-size-ratio float                          Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps (default 0.0025)
       --bpf-nat-global-max int                                    Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                                  Maximum number of entries for the global BPF neighbor table (default 524288)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -27,6 +27,7 @@ cilium-agent hive [flags]
       --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
+      --bpf-lb-unsupported-protocol-action string                 BPF unsupported protocol action ("forward", "drop") (default "forward")
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-policy-map-pressure-metrics-threshold float           Sets threshold for emitting pressure metrics of policy maps (default 0.1)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-agent hive dot-graph [flags]
       --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
+      --bpf-lb-unsupported-protocol-action string                 BPF unsupported protocol action ("forward", "drop") (default "forward")
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-policy-map-pressure-metrics-threshold float           Sets threshold for emitting pressure metrics of policy maps (default 0.1)

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -106,7 +106,8 @@ struct remote_endpoint_info {
 			flag_has_tunnel_ep:1,
 			flag_ipv6_tunnel_ep:1,
 			flag_remote_cluster:1,
-			pad2:4;
+			flag_unroutable:1,
+			pad2:3;
 };
 
 struct ipcache_key {

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -487,6 +487,10 @@ data:
   bpf-lb-mode-annotation: {{ .Values.bpf.lbModeAnnotation | quote }}
 {{- end }}
 
+{{- if hasKey .Values.bpf "lbUnsupportedProtocolAction" }}
+  bpf-lb-unsupported-protocol-action: {{ .Values.bpf.lbUnsupportedProtocolAction | quote }}
+{{- end }}
+
   bpf-distributed-lru: {{ .Values.bpf.distributedLRU.enabled | quote }}
   bpf-events-drop-enabled: {{ .Values.bpf.events.drop.enabled | quote }}
   bpf-events-policy-verdict-enabled: {{ .Values.bpf.events.policyVerdict.enabled | quote }}

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -533,6 +533,7 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 	sv.Ports = make([]slim_core_v1.ServicePort, len(svc.Spec.Ports))
 	copy(sv.Ports, svc.Spec.Ports)
 	sv.Namespace = svc.Namespace
+	sv.UnsupportedProtocolAction, _ = annotation.GetAnnotationUnsupportedProtoAction(svc)
 	sv.Selector = make(map[string]string)
 	maps.Copy(sv.Selector, svc.Spec.Selector)
 	sv.Status = svc.Status.DeepCopy()

--- a/pkg/annotation/datapath.go
+++ b/pkg/annotation/datapath.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package annotation
+
+import (
+	"fmt"
+	"strings"
+
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+)
+
+type UnsupportedProtoAction string
+
+const (
+	UnsupportedProtoActionUnspec  = UnsupportedProtoAction("")
+	UnsupportedProtoActionDrop    = UnsupportedProtoAction(datapathOption.UnsupportedProtoActionDrop)
+	UnsupportedProtoActionForward = UnsupportedProtoAction(datapathOption.UnsupportedProtoActionForward)
+)
+
+func GetAnnotationUnsupportedProtoAction(obj annotatedObject) (UnsupportedProtoAction, error) {
+	if value, ok := Get(obj, NetworkUnsupportedProtoAction); ok {
+		val := UnsupportedProtoAction(strings.ToLower(value))
+		switch val {
+		case UnsupportedProtoActionDrop, UnsupportedProtoActionForward:
+			return val, nil
+		default:
+			return UnsupportedProtoActionUnspec, fmt.Errorf("value %q is not valid for annotation %q", value, NetworkUnsupportedProtoAction)
+		}
+	}
+	return UnsupportedProtoActionUnspec, nil
+}

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -179,6 +179,18 @@ const (
 	//		use SNAT so that reply traffic comes back
 	ServiceForwardingMode = ServicePrefix + "/forwarding-mode"
 
+	// NetworkUnsupportedProtoAction annotations determine whether packets towards
+	// Service IPs with unsupported transport protocols are handled.
+	//
+	// Allowed values are of type annotation.UnsupportedProtoAction and map onto
+	// standard datapath option strings.
+	//
+	// Allowed values:
+	// - drop	Drop in datapath to avoid routing loops
+	// - forward	Forward to network stack for processing
+	//
+	NetworkUnsupportedProtoAction = NetworkPrefix + "/unsupported-protocol-action"
+
 	// NoTrack / NoTrackAlias is the annotation name used to store the port and
 	// protocol that we should bypass kernel conntrack for a given pod. This
 	// applies for both TCP and UDP connection. Current use case is NodeLocalDNS.

--- a/pkg/bgp/test/script_test.go
+++ b/pkg/bgp/test/script_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/test/commands"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
@@ -101,6 +103,14 @@ func TestPrivilegedScript(t *testing.T) {
 			}
 		}
 
+		// A fresh instance of ipcache is needed for LoadBalancer
+		ipcacheConfig := &ipcache.Configuration{
+			Context: t.Context(),
+			Logger:  hivetest.Logger(t),
+		}
+		ipc := ipcache.NewIPCache(ipcacheConfig)
+		t.Cleanup(func() { ipc.Shutdown() })
+
 		h := ciliumhive.New(
 			metrics.Cell,
 
@@ -129,6 +139,14 @@ func TestPrivilegedScript(t *testing.T) {
 			lbcell.Cell,
 			maglev.Cell,
 			cell.Provide(source.NewSources),
+			cell.Provide(
+				regeneration.NewFence,
+				ipcache.NewLocalIPIdentityWatcher,
+				ipcache.NewIPIdentitySynchronizer,
+				func() *ipcache.IPCache {
+					return ipc
+				},
+			),
 			cell.Config(loadbalancer.TestConfig{}),
 			cell.Provide(
 				func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg }, // newLBMaps expects *TestConfig

--- a/pkg/datapath/option/option.go
+++ b/pkg/datapath/option/option.go
@@ -19,3 +19,14 @@ const (
 	// L2 mode.
 	DatapathModeNetkitL2 = "netkit-l2"
 )
+
+// Available options for Unsupported Protocol Actions
+const (
+	// UnsupportedProtoActionDrop specifies that traffic carrying unsupported
+	// protocol types should be dropped in the datapath.
+	UnsupportedProtoActionDrop = "drop"
+
+	// UnsupportedProtoActionForward specifies that traffic carrying unsupported
+	// protocol types should be forwarded to the host for processing.
+	UnsupportedProtoActionForward = "forward"
+)

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -35,6 +35,7 @@ var (
 	ResourceKindFile      = ResourceKind("file")
 	ResourceKindNetpol    = ResourceKind("netpol")
 	ResourceKindNode      = ResourceKind("node")
+	ResourceKindService   = ResourceKind("svc")
 )
 
 // NewResourceID returns a ResourceID populated with the standard fields for

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -121,6 +121,12 @@ type EndpointFlags struct {
 	// It's always unset when clustermesh is disabled or for pods.
 	flagRemoteCluster bool
 
+	// flagUnroutable is set when it's preferential that traffic towards
+	// an IP or CIDR should be dropped in the datapath. This can be used to
+	// facilitate dropping of unknown transport protocols to avoid routing
+	// loops.
+	flagUnroutable bool
+
 	// Note: if you add any more flags here, be sure to update (*prefixInfo).flatten()
 	// to merge them across different resources.
 }
@@ -135,6 +141,11 @@ func (e *EndpointFlags) SetRemoteCluster(remote bool) {
 	e.flagRemoteCluster = remote
 }
 
+func (e *EndpointFlags) SetUnroutable(unroutable bool) {
+	e.isInit = true
+	e.flagUnroutable = unroutable
+}
+
 func (e EndpointFlags) IsValid() bool {
 	return e.isInit
 }
@@ -144,6 +155,7 @@ func (e EndpointFlags) IsValid() bool {
 const (
 	FlagSkipTunnel    uint8 = 1 << iota
 	FlagRemoteCluster uint8 = 1 << 3
+	FlagUnroutable    uint8 = 1 << 4
 )
 
 func (e EndpointFlags) Uint8() uint8 {
@@ -153,6 +165,9 @@ func (e EndpointFlags) Uint8() uint8 {
 	}
 	if e.flagRemoteCluster {
 		flags |= FlagRemoteCluster
+	}
+	if e.flagUnroutable {
+		flags |= FlagUnroutable
 	}
 	return flags
 }

--- a/pkg/loadbalancer/benchmark/benchmark.go
+++ b/pkg/loadbalancer/benchmark/benchmark.go
@@ -26,7 +26,9 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -111,7 +113,7 @@ func RunBenchmark(testSize int, iterations int, loglevel slog.Level, validate bo
 		db     *statedb.DB
 		bo     *lbreconciler.BPFOps
 	)
-	h := testHive(maps, services, endpoints, &writer, &db, &bo)
+	h := testHive(log, maps, services, endpoints, &writer, &db, &bo)
 
 	if err := h.Start(log, context.TODO()); err != nil {
 		panic(err)
@@ -509,7 +511,9 @@ var (
 	}
 )
 
-func testHive(maps lbmaps.LBMaps,
+func testHive(
+	log *slog.Logger,
+	maps lbmaps.LBMaps,
 	services chan resource.Event[*slim_corev1.Service],
 	endpoints chan resource.Event[*k8s.Endpoints],
 	writerPtr **writer.Writer,
@@ -522,6 +526,13 @@ func testHive(maps lbmaps.LBMaps,
 		EnableIPv6: true,
 	}
 
+	// A fresh instance of ipcache is needed.
+	ipcacheConfig := &ipcache.Configuration{
+		Context: context.TODO(),
+		Logger:  log,
+	}
+	ipc := ipcache.NewIPCache(ipcacheConfig)
+
 	return hive.New(
 		cell.Module(
 			"loadbalancer-test",
@@ -529,7 +540,14 @@ func testHive(maps lbmaps.LBMaps,
 
 			k8sClient.FakeClientCell(),
 			node.LocalNodeStoreTestCell,
-
+			cell.Provide(
+				regeneration.NewFence,
+				ipcache.NewLocalIPIdentityWatcher,
+				ipcache.NewIPIdentitySynchronizer,
+				func() *ipcache.IPCache {
+					return ipc
+				},
+			),
 			cell.Provide(
 				func() cmtypes.ClusterInfo {
 					return cmtypes.ClusterInfo{}

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -72,6 +73,10 @@ const (
 	// pushing packets to backends under DSR ("opt", "ipip", "geneve")
 	LoadBalancerDSRDispatchName = "bpf-lb-dsr-dispatch"
 
+	// LBUnsupportedProtoActionName is the config option for setting the action we
+	// take when processing unsupported transport protocols ("drop, forward")
+	LBUnsupportedProtoActionName = "bpf-lb-unsupported-protocol-action"
+
 	// ExternalClusterIPName is the name of the option to enable
 	// cluster external access to ClusterIP services.
 	ExternalClusterIPName = "bpf-lb-external-clusterip"
@@ -126,6 +131,12 @@ const (
 
 	// DSR dispatch mode to encapsulate to Geneve
 	DSRDispatchGeneve = "geneve"
+
+	// Unsupported Protocol Action is to forward as normal
+	LBUnsupportedProtoActionForward = string(annotation.UnsupportedProtoActionForward)
+
+	// Unsupported Protocol Action is to drop
+	LBUnsupportedProtoActionDrop = string(annotation.UnsupportedProtoActionDrop)
 )
 
 // UserConfig is the configuration provided by the user that has not been processed.
@@ -181,6 +192,9 @@ type UserConfig struct {
 	// DSRDispatch indicates the method for pushing packets to
 	// backends under DSR ("opt", "ipip", "geneve")
 	DSRDispatch string `mapstructure:"bpf-lb-dsr-dispatch"`
+
+	// LBUnsupportedProtocAction indicates how we handle unsupported transport protocols
+	LBUnsupportedProtoAction string `mapstructure:"bpf-lb-unsupported-protocol-action"`
 
 	// ExternalClusterIP enables routing to ClusterIP services from outside
 	// the cluster. This mirrors the behaviour of kube-proxy.
@@ -318,6 +332,9 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 
 	flags.String(LoadBalancerDSRDispatchName, def.DSRDispatch, "BPF load balancing DSR dispatch method (\"opt\", \"ipip\", \"geneve\")")
 
+	flags.String(LBUnsupportedProtoActionName, def.LBUnsupportedProtoAction, fmt.Sprintf("BPF unsupported protocol action (\"%s\", \"%s\")",
+		LBUnsupportedProtoActionForward, LBUnsupportedProtoActionDrop))
+
 	flags.Bool(ExternalClusterIPName, def.ExternalClusterIP, "Enable external access to ClusterIP services (default false)")
 
 	flags.Bool(AlgorithmAnnotationName, def.AlgorithmAnnotation, "Enable service-level annotation for configuring BPF load balancing algorithm")
@@ -448,6 +465,12 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig Depreca
 		return Config{}, fmt.Errorf("The value --%s=%s is not supported as default under annotation mode", LoadBalancerModeName, cfg.LBMode)
 	}
 
+	switch cfg.LBUnsupportedProtoAction {
+	case LBUnsupportedProtoActionDrop, LBUnsupportedProtoActionForward:
+	default:
+		return Config{}, fmt.Errorf("Invalid value for --%s: %s", LBUnsupportedProtoActionName, cfg.LBUnsupportedProtoAction)
+	}
+
 	/* FIXME:
 
 	if cfg.NodePortMode == option.NodePortModeDSR &&
@@ -495,6 +518,8 @@ var DefaultUserConfig = UserConfig{
 	LBMode: LBModeSNAT,
 
 	DSRDispatch: DSRDispatchOption,
+
+	LBUnsupportedProtoAction: LBUnsupportedProtoActionForward,
 
 	// Defaults to false to retain prior behaviour to not route external packets
 	// to ClusterIP services.

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -28,8 +28,10 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
@@ -73,6 +75,14 @@ func TestScript(t *testing.T) {
 	scripttest.Test(t,
 		ctx,
 		func(t testing.TB, args []string) *script.Engine {
+			// A fresh instance of ipcache is needed.
+			ipcacheConfig := &ipcache.Configuration{
+				Context: t.Context(),
+				Logger:  log,
+			}
+			ipc := ipcache.NewIPCache(ipcacheConfig)
+			t.Cleanup(func() { ipc.Shutdown() })
+
 			h := hive.New(
 				k8sClient.FakeClientCell(),
 				daemonk8s.ResourcesCell,
@@ -85,6 +95,14 @@ func TestScript(t *testing.T) {
 				cell.Config(loadbalancer.TestConfig{}),
 				maglev.Cell,
 				node.LocalNodeStoreTestCell,
+				cell.Provide(
+					regeneration.NewFence,
+					ipcache.NewLocalIPIdentityWatcher,
+					ipcache.NewIPIdentitySynchronizer,
+					func() *ipcache.IPCache {
+						return ipc
+					},
+				),
 				cell.Provide(
 					func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 					func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg },

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -1061,15 +1061,22 @@ func (a L3n4Addr) String() string {
 // StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
 // format for IPv4 and "[IPv6]:Port/Protocol[/Scope]" format for IPv6.
 func (a L3n4Addr) StringWithProtocol() string {
+	return a.StringWithProtocolDelimited("/")
+}
+
+// StringWithProtocolDelimited returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
+// format for IPv4 and "[IPv6]:Port/Protocol[/Scope]" format for IPv6, but using the
+// specified delimiter at the forward-slash positions.
+func (a L3n4Addr) StringWithProtocolDelimited(delim string) string {
 	rep := a.rep()
 	var scope string
 	if rep.scope == ScopeInternal {
-		scope = "/i"
+		scope = delim + "i"
 	}
 	if a.IsIPv6() {
-		return "[" + rep.addrCluster.String() + "]:" + strconv.FormatUint(uint64(rep.Port), 10) + "/" + rep.Protocol + scope
+		return "[" + rep.addrCluster.String() + "]:" + strconv.FormatUint(uint64(rep.Port), 10) + delim + rep.Protocol + scope
 	}
-	return rep.addrCluster.String() + ":" + strconv.FormatUint(uint64(rep.Port), 10) + "/" + rep.Protocol + scope
+	return rep.addrCluster.String() + ":" + strconv.FormatUint(uint64(rep.Port), 10) + delim + rep.Protocol + scope
 }
 
 // StringID returns the L3n4Addr as string to be used for unique identification

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -1467,6 +1467,10 @@ func (ops *BPFOps) syncIPCache(fe *loadbalancer.Frontend, svcAction annotation.U
 	case annotation.UnsupportedProtoActionDrop:
 		ipCacheFlags.SetUnroutable(true)
 	default:
+		// Unspecified annotation, use LB configuration
+		if ops.cfg.LBUnsupportedProtoAction == loadbalancer.LBUnsupportedProtoActionDrop {
+			ipCacheFlags.SetUnroutable(true)
+		}
 	}
 
 	ops.log.Debug("Synchronise IPCache entry",

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/byteorder"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
@@ -113,6 +114,7 @@ type BPFOps struct {
 
 	cfg           loadbalancer.Config
 	extCfg        loadbalancer.ExternalConfig
+	ipcache       *ipcache.IPCache
 	maglev        *maglev.Maglev
 	lastUpdatedAt atomic.Pointer[time.Time]
 	pruneCount    atomic.Int32
@@ -180,6 +182,7 @@ type bpfOpsParams struct {
 	Log            *slog.Logger
 	Config         loadbalancer.Config
 	ExternalConfig loadbalancer.ExternalConfig
+	IPCache        *ipcache.IPCache
 	LBMaps         maps.LBMaps
 	Maglev         *maglev.Maglev
 	DB             *statedb.DB
@@ -196,6 +199,7 @@ func newBPFOps(p bpfOpsParams) *BPFOps {
 	ops := &BPFOps{
 		cfg:       p.Config,
 		extCfg:    p.ExternalConfig,
+		ipcache:   p.IPCache,
 		maglev:    p.Maglev,
 		log:       newRateLimitingLogger(p.Log),
 		LBMaps:    p.LBMaps,

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -22,10 +22,12 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/byteorder"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
@@ -33,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -488,6 +491,9 @@ func (ops *BPFOps) deleteFrontend(fe *loadbalancer.Frontend) error {
 	if err := ops.deleteWildcard(fe, feID); err != nil {
 		return fmt.Errorf("delete wildcard: %w", err)
 	}
+
+	// Synchronise ipcache entry, using Action=Unspec to force a deletion.
+	ops.syncIPCache(fe, annotation.UnsupportedProtoActionUnspec)
 
 	// Decrease the backend reference counts and drop state associated with the frontend.
 	ops.updateBackendRefCounts(fe.Address, nil)
@@ -1081,6 +1087,9 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 		return fmt.Errorf("upsert wildcard: %w", err)
 	}
 
+	// Synchronise ipcache entry.
+	ops.syncIPCache(fe, svc.UnsupportedProtoAction)
+
 	// Calculate the number of existing backend references, so we can cleanup if there there
 	// has been a change.
 	numPreviousBackends := len(ops.backendReferences[fe.Address])
@@ -1152,6 +1161,22 @@ func (ops *BPFOps) useWildcard(fe *loadbalancer.Frontend) bool {
 		// Only external scoped entries can parent wildcard entries
 		return fe.Address.Scope() == loadbalancer.ScopeExternal
 	}
+	return false
+}
+
+func (ops *BPFOps) useIPCache(fe *loadbalancer.Frontend) bool {
+	// Never allow a zero address to touch the IPCache
+	if fe.Address.AddrCluster().IsUnspecified() {
+		return false
+	}
+
+	switch fe.Type {
+	case loadbalancer.SVCTypeLoadBalancer,
+		loadbalancer.SVCTypeClusterIP,
+		loadbalancer.SVCTypeExternalIPs:
+		return fe.Address.Scope() == loadbalancer.ScopeExternal
+	}
+
 	return false
 }
 
@@ -1414,6 +1439,56 @@ func (ops *BPFOps) deleteWildcard(fe *loadbalancer.Frontend, feID loadbalancer.S
 	}
 
 	return nil
+}
+
+func (ops *BPFOps) syncIPCache(fe *loadbalancer.Frontend, svcAction annotation.UnsupportedProtoAction) {
+	if !ops.useIPCache(fe) {
+		return
+	}
+
+	// Compute the resource ID that uniquely identifies the references
+	// between this FE and the underlying IPCache entry. Note these are
+	// in a specific format, delimited by a forward-slash, so we delimit
+	// the FE L3n4Addr with a colon instead.
+	feResourceID := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindService,
+		fe.Service.Name.Namespace(),
+		fe.Address.StringWithProtocolDelimited(":"),
+	)
+
+	// Compute IPCache flags for this FE. Note we only initialise the Unroutable
+	// flag to True if we have a legitimaste 'drop' action. In any other case,
+	// the flags are uninitialised.
+	ipCacheFlags := ipcacheTypes.EndpointFlags{}
+
+	switch svcAction {
+	case annotation.UnsupportedProtoActionForward:
+		// Do nothing
+	case annotation.UnsupportedProtoActionDrop:
+		ipCacheFlags.SetUnroutable(true)
+	default:
+	}
+
+	ops.log.Debug("Synchronise IPCache entry",
+		logfields.Type, fe.Type,
+		logfields.ResourceID, feResourceID,
+		logfields.Flags, ipCacheFlags,
+	)
+
+	if ipCacheFlags.IsValid() {
+		ops.ipcache.UpsertMetadata(
+			fe.Address.AddrCluster().AsPrefixCluster(),
+			source.Local,
+			feResourceID,
+			ipCacheFlags,
+		)
+	} else {
+		ops.ipcache.RemoveMetadata(
+			fe.Address.AddrCluster().AsPrefixCluster(),
+			feResourceID,
+			ipCacheFlags,
+		)
+	}
 }
 
 var _ reconciler.Operations[*loadbalancer.Frontend] = &BPFOps{}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -1246,11 +1247,21 @@ func TestBPFOps(t *testing.T) {
 				external := extCfg
 				cfg := cfg
 				cfg.LBAlgorithm = algo
+
+				// A fresh instance of ipcache is needed.
+				ipcacheConfig := &ipcache.Configuration{
+					Context: t.Context(),
+					Logger:  log,
+				}
+				ipc := ipcache.NewIPCache(ipcacheConfig)
+				t.Cleanup(func() { ipc.Shutdown() })
+
 				p := bpfOpsParams{
 					Lifecycle:      lc,
 					Log:            log,
 					Config:         cfg,
 					ExternalConfig: external,
+					IPCache:        ipc,
 					LBMaps:         lbmaps,
 					Maglev:         maglev,
 					DB:             db,
@@ -1272,11 +1283,21 @@ func TestBPFOps(t *testing.T) {
 			// fresh IDs.
 			external := extCfg
 			cfg.LBAlgorithm = setWithAlgo.algo
+
+			// A fresh instance of ipcache is needed.
+			ipcacheConfig := &ipcache.Configuration{
+				Context: t.Context(),
+				Logger:  log,
+			}
+			ipc := ipcache.NewIPCache(ipcacheConfig)
+			t.Cleanup(func() { ipc.Shutdown() })
+
 			p := bpfOpsParams{
 				Lifecycle:      lc,
 				Log:            log,
 				Config:         cfg,
 				ExternalConfig: external,
+				IPCache:        ipc,
 				LBMaps:         lbmaps,
 				Maglev:         maglev,
 				DB:             db,

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -77,14 +77,15 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 
 	name := loadbalancer.NewServiceName(svc.Namespace, svc.Name)
 	s = &loadbalancer.Service{
-		Name:                name,
-		Source:              source,
-		Labels:              labels.Map2Labels(svc.Labels, string(source)),
-		Selector:            svc.Spec.Selector,
-		Annotations:         svc.Annotations,
-		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
-		ForwardingMode:      loadbalancer.SVCForwardingModeUndef,
-		LoadBalancerClass:   svc.Spec.LoadBalancerClass,
+		Name:                   name,
+		Source:                 source,
+		Labels:                 labels.Map2Labels(svc.Labels, string(source)),
+		Selector:               svc.Spec.Selector,
+		Annotations:            svc.Annotations,
+		HealthCheckNodePort:    uint16(svc.Spec.HealthCheckNodePort),
+		ForwardingMode:         loadbalancer.SVCForwardingModeUndef,
+		UnsupportedProtoAction: annotation.UnsupportedProtoActionUnspec,
+		LoadBalancerClass:      svc.Spec.LoadBalancerClass,
 	}
 
 	if cfg.LBModeAnnotation {
@@ -97,6 +98,16 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 				logfields.Annotations, annotation.ServiceForwardingMode,
 			)
 		}
+	}
+
+	unsupportedProtoAction, err := annotation.GetAnnotationUnsupportedProtoAction(svc)
+	if err == nil {
+		s.UnsupportedProtoAction = unsupportedProtoAction
+	} else {
+		log().Warn("Ignoring annotation",
+			logfields.Error, err,
+			logfields.Annotations, annotation.NetworkUnsupportedProtoAction,
+		)
 	}
 
 	if localNode != nil {

--- a/pkg/loadbalancer/repl/main.go
+++ b/pkg/loadbalancer/repl/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	uhive "github.com/cilium/hive"
@@ -16,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -91,6 +93,7 @@ var Hive = hive.New(
 	cell.Config(loadbalancer.TestConfig{}),
 	cell.Config(envoyCfg.SecretSyncConfig{}),
 	cell.Provide(
+		func() *ipcache.IPCache { return ipcache.NewIPCache(&ipcache.Configuration{Context: context.TODO()}) },
 		func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 		source.NewSources,
 		tables.NewNodeAddressTable,

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -58,6 +58,10 @@ type Service struct {
 	// to the backend. If undefined the default mode is used (--bpf-lb-mode).
 	ForwardingMode SVCForwardingMode
 
+	// UnsupportedProtoAction controls whether we drop or forward traffic carrying
+	// unsupported transport protocols.
+	UnsupportedProtoAction annotation.UnsupportedProtoAction
+
 	// SessionAffinity if true will enable the client IP based session affinity.
 	SessionAffinity bool
 
@@ -241,6 +245,10 @@ func (svc *Service) TableRow() []string {
 
 	if svc.ForwardingMode != SVCForwardingModeUndef {
 		flags = append(flags, "ForwardingMode="+string(svc.ForwardingMode))
+	}
+
+	if svc.UnsupportedProtoAction != annotation.UnsupportedProtoActionUnspec {
+		flags = append(flags, "UnsupportedProtoAction="+string(svc.UnsupportedProtoAction))
 	}
 
 	if svc.TrafficDistribution != TrafficDistributionDefault {

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -28,8 +28,10 @@ import (
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
@@ -76,6 +78,14 @@ func TestScript(t *testing.T) {
 			}
 			log := hivetest.Logger(t, opts...)
 
+			// A fresh instance of ipcache is needed.
+			ipcacheConfig := &ipcache.Configuration{
+				Context: t.Context(),
+				Logger:  log,
+			}
+			ipc := ipcache.NewIPCache(ipcacheConfig)
+			t.Cleanup(func() { ipc.Shutdown() })
+
 			h := hive.New(
 				k8sClient.FakeClientCell(),
 				daemonk8s.ResourcesCell,
@@ -89,6 +99,14 @@ func TestScript(t *testing.T) {
 				metrics.Cell,
 				maglev.Cell,
 				node.LocalNodeStoreTestCell,
+				cell.Provide(
+					regeneration.NewFence,
+					ipcache.NewLocalIPIdentityWatcher,
+					ipcache.NewIPIdentitySynchronizer,
+					func() *ipcache.IPCache {
+						return ipc
+					},
+				),
 				cell.Provide(
 					func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
 					func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg },

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -62,6 +62,7 @@ Address              Instances
   "ExtTrafficPolicy": "Cluster",
   "IntTrafficPolicy": "Cluster",
   "ForwardingMode": "",
+  "UnsupportedProtoAction": "",
   "SessionAffinity": false,
   "SessionAffinityTimeout": 0,
   "LoadBalancerClass": null,
@@ -229,6 +230,7 @@ natpolicy: ""
 exttrafficpolicy: Cluster
 inttrafficpolicy: Cluster
 forwardingmode: ""
+unsupportedprotoaction: ""
 sessionaffinity: false
 sessionaffinitytimeout: 0s
 loadbalancerclass: null

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -203,6 +203,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.DSRDispatch != other.DSRDispatch {
 		return false
 	}
+	if in.LBUnsupportedProtoAction != other.LBUnsupportedProtoAction {
+		return false
+	}
 	if in.ExternalClusterIP != other.ExternalClusterIP {
 		return false
 	}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -576,6 +576,9 @@ const (
 	// Resource is a resource
 	Resource = "resource"
 
+	// ReourceID is an IPCache ResourceID
+	ResourceID = "resourceID"
+
 	// ConflictingResource is a resource that conflicts with 'Resource'
 	ConflictingResource = "conflictingResource"
 

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -147,6 +147,9 @@ func (f RemoteEndpointInfoFlags) String() string {
 	if f&FlagRemoteCluster != 0 {
 		flags += "remotecluster,"
 	}
+	if f&FlagUnroutable != 0 {
+		flags += "unroutable,"
+	}
 
 	if flags == "" {
 		return "<none>"
@@ -168,6 +171,11 @@ const (
 	// FlagRemoteCluster is set when the node is in a remote cluster.
 	// It's always unset when clustermesh is disabled or for pods.
 	FlagRemoteCluster
+	// FlagUnroutable is set when it's preferential that traffic towards
+	// an IP or CIDR should be dropped in the datapath. This can be used to
+	// facilitate dropping of unknown transport protocols to avoid routing
+	// loops.
+	FlagUnroutable
 )
 
 // RemoteEndpointInfo implements the bpf.MapValue interface. It contains the


### PR DESCRIPTION
Introduces `Unsupported Protocol Action` feature that allows Cilium to drop traffic to unknown transport protocols in the data path via new `unroutable` IPCache flag.

This action can be configured at both a node-level via the `bpf-lb-unsupported-protocol-action` flag, and a service-level via the `network.cilium.io/unsupported-protocol-action` annotation.

Accepted values for both are `forward` or `drop`. The former is default, unless explicitly modified with said configuration flag. The annotation takes precedence over the config flag, where an annotation exists and is an accepted value.

The LoadBalancer control plane is updated to program IPCache entries on Frontends of type `ClusterIP`, `LoadBalancer`, or `ExternalIP`, where action=drop is derived from the parent Service configuration.

The bpf_host program will drop any traffic to a matching IPCache entry with `flag_unroutable` set, via the `DROP_UNROUTABLE` return code. Therefore, traffic to Cilium managed VIPs on unknown protocols will be filtered in the datapath.

**TODO - test coverage not yet added**

---

**Test with crafted GRE packet**

```
# note 2 VIPs, one with UnsupportedProtoAction=drop

$ cilium-dbg shell db/show services
Name                         Source   PortNames                          TrafficPolicy            Flags
default/kubernetes           k8s      https=443                          Cluster
default/netshoot-service     k8s      iperf1-tcp=8000, iperf1-udp=8000   Cluster                  UnsupportedProtoAction=drop
default/netshoot-service2    k8s      iperf2-tcp=8001, iperf2-udp=8001   Cluster
kube-system/cilium-envoy     k8s      envoy-metrics=9964                 Cluster
kube-system/cilium-ingress   k8s      http=80, https=443                 Cluster
kube-system/hubble-peer      k8s      peer-service=443                   Ext=Cluster, Int=Local
kube-system/hubble-relay     k8s      =80                                Cluster
kube-system/kube-dns         k8s      dns=53, dns-tcp=53, metrics=9153   Cluster

$ cilium-dbg shell db/show frontends | grep 10.244.255.20
10.244.255.200:8000/TCP                         LoadBalancer   default/netshoot-service     iperf1-tcp     10.1.2.29:8000/TCP                                     Done     2m43s
10.244.255.200:8000/UDP                         LoadBalancer   default/netshoot-service     iperf1-udp     10.1.2.29:8000/UDP                                     Done     2m43s
10.244.255.201:8001/TCP                         LoadBalancer   default/netshoot-service2    iperf2-tcp     10.1.2.123:8001/TCP                                    Done     2m44s
10.244.255.201:8001/UDP                         LoadBalancer   default/netshoot-service2    iperf2-udp     10.1.2.123:8001/UDP                                    Done     2m44s
```

Crafted GRE packet to `10.244.255.200` (action=drop through annotation)

```
$ hubble observe -P -f --ip 10.244.255.0/24
time=2025-11-20T16:18:14.704Z level=WARN msg="Hubble CLI version is lower than Hubble Relay, API compatibility is not guaranteed, updating to a matching or higher version is recommended" hubble-cli-version=1.18.0 hubble-relay-version=1.19.0-dev+g428129b9
Nov 20 16:18:40.290: 8.8.8.8 (world-ipv4) <> 10.244.255.200 (world-ipv4) from-network FORWARDED (IPv4)
Nov 20 16:18:40.290: 8.8.8.8 (world-ipv4) <> 10.244.255.200 (world-ipv4) Stale or unroutable IP DROPPED (IPv4)
```

Crafted GRE packet to `10.244.255.201` (action=forward as default)

```
$ hubble observe -P -f --ip 10.244.255.0/24
time=2025-11-20T16:19:32.856Z level=WARN msg="Hubble CLI version is lower than Hubble Relay, API compatibility is not guaranteed, updating to a matching or higher version is recommended" hubble-cli-version=1.18.0 hubble-relay-version=1.19.0-dev+g428129b9
Nov 20 16:19:35.420: 8.8.8.8 (world-ipv4) <> 10.244.255.201 (world-ipv4) from-network FORWARDED (IPv4)
Nov 20 16:19:35.420: 8.8.8.8 (world-ipv4) <> 10.244.255.201 (world-ipv4) to-network FORWARDED (IPv4)
```

---

Release Notes

```release-note
Introduces unsupported-protocol-action feature so Cilium can be configured to drop unsupported protocols towards Cilium-managed IPs in the data path.
```