### PR TITLE
endpoint: Wait for controllers shutdown on endpoint stop

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1291,7 +1291,7 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	}
 
 	e.removeDirectories()
-	e.controllers.RemoveAll()
+	// Controllers are already stopped and cleaned up by Stop()
 	e.cleanPolicySignals()
 
 	if !e.isProperty(PropertyFakeEndpoint) {

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -376,4 +376,9 @@ func (e *Endpoint) Stop() {
 	// if anything is blocking on it. If a delete request has already been
 	// enqueued for this endpoint, this is a no-op.
 	e.closeBPFProgramChannel()
+
+	// Wait for all controllers to fully terminate. This ensures controller
+	// goroutines are cleaned up and prevents race conditions where controllers
+	// might access resources (like LocalNodeStore) that are being shut down.
+	e.controllers.RemoveAllAndWait()
 }


### PR DESCRIPTION
During daemon shutdown, endpoint controllers (particularly CEP sync) were only having their context cancelled but never explicitly stopped and waited on. This caused a race where in-flight controller executions could access LocalNodeStore after it had been set to nil, resulting in a nil pointer panic.

See:
```
Waiting for all endpoints' goroutines to be stopped.
All endpoints' goroutines stopped.
failed to delete reporter status tree
Datapath signal listener exiting
Datapath signal listener done
Signal handler closed. Stopping conntrack garbage collector
Stopped gops server
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1c0 pc=0x177a0b9]
goroutine 116049 [running]:
github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Get(_, {_, _})
/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:192 +0x79
github.com/cilium/cilium/pkg/node.getLocalNode(_)
/go/src/github.com/cilium/cilium/pkg/node/address.go:45 +0x8d
github.com/cilium/cilium/pkg/node.GetIPv4(0x28?)
/go/src/github.com/cilium/cilium/pkg/node/address.go:231 +0x25
github.com/cilium/cilium/pkg/node.GetCiliumEndpointNodeIP(0x0?)
/go/src/github.com/cilium/cilium/pkg/node/address.go:251 +0x25
github.com/cilium/cilium/pkg/endpoint.getEndpointNetworking(0xc001304270, 0xc01d532a10)
/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint_status.go:38 +0xa5
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).GetCiliumEndpointStatus(0xc010abea08)
/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint_status.go:74 +0x18b
github.com/cilium/cilium/pkg/endpointmanager.(*EndpointSynchronizer).RunK8sCiliumEndpoint
Sync.func1({0x5337190, 0xc016e47450})
/go/src/github.com/cilium/cilium/pkg/endpointmanager/endpointsynchronizer.go:136 +0x376
github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc006e6e9a0)
/go/src/github.com/cilium/cilium/pkg/controller/controller.go:333 +0x1c7
created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in
goroutine 116100
/go/src/github.com/cilium/cilium/pkg/controller/manager.go:124 +0x4ae
```

I moved `RemoveAll` from the endpoint `Delete` method to the `Stop` one and replaced it with the blocking `RemoveAllAndWait` variant, ensuring all controller goroutines fully terminate. This also fixes a potential goroutine leak in the normal endpoint deletion path where controllers were only cancelled but not properly cleaned up.