### PR TITLE
bugfix: allow for allowedRoutes to be accepted in Gateway API

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -772,7 +772,7 @@ func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parent
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
 			Reason:  string(gatewayv1.RouteReasonAccepted),
-			Message: "Accepted HTTPRoute",
+			Message: "Accepted " + input.GetGVK().Kind,
 		})
 
 		// set ResolvedRefs to okay, this wil be overwritten in checks if needed
@@ -902,7 +902,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateTLSRouteStatus(ctx, scopedLog, &original, tlsr); err != nil {
-			return fmt.Errorf("failed to update HTTPRoute status: %w", err)
+			return fmt.Errorf("failed to update TLSRoute status: %w", err)
 		}
 
 		// Update the cached copy with the same status changes to prevent re-fetching from client cache.
@@ -936,7 +936,7 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateGRPCRouteStatus(ctx, scopedLog, &original, grpcr); err != nil {
-			return fmt.Errorf("failed to update HTTPRoute status: %w", err)
+			return fmt.Errorf("failed to update GRPCRoute status: %w", err)
 		}
 
 		// Update the cached copy with the same status changes to prevent re-fetching from client cache.

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -99,7 +99,6 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 
 		return false, nil
 	}
-
 	for _, listener := range gw.Spec.Listeners {
 		if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
 			continue
@@ -114,7 +113,6 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 				break
 			}
 		}
-
 		if !allowed {
 			input.SetParentCondition(parentRef, metav1.Condition{
 				Type:    string(gatewayv1.RouteConditionAccepted),
@@ -123,7 +121,14 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 				Message: routeGVK.Kind + " is not allowed to attach to this Gateway due to route kind restrictions",
 			})
 
-			return false, nil
+		} else {
+			input.SetParentCondition(parentRef, metav1.Condition{
+				Type:    string(gatewayv1.RouteConditionAccepted),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(gatewayv1.RouteReasonAccepted),
+				Message: "Accepted " + routeGVK.Kind,
+			})
+			return true, nil
 		}
 	}
 


### PR DESCRIPTION
Previously the CheckGatewayRouteAllowed returned route restrictions if there were more than 1 listener in the Gateway. Also fixed the tlsroute and grpc logs to be the correct objects.

<!-- Description of change -->

- return success if a route is allowed
- log the correct objects 

Fixes: #42013
