### PR TITLE
renovate: Re-enable major updates for `go-github`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,7 +50,8 @@
     "on sunday"
   ],
   postUpdateOptions: [
-    "gomodTidy"
+    // update source import paths on major updates
+    "gomodUpdateImportPaths"
   ],
   // This ignorePaths configuration option overrides the config:base preset and
   // should not be removed.
@@ -206,11 +207,7 @@
         "go.mod",
         "go.sum"
       ],
-      "postUpdateOptions": [
-        // update source import paths on major updates
-        "gomodUpdateImportPaths"
-      ],
-      matchBaseBranches: [
+      "matchBaseBranches": [
         "main"
       ]
     },
@@ -399,16 +396,6 @@
         "v1.17",
         "v1.16",
       ]
-    },
-    {
-      // Disable major updates for go-github as those require updating import paths
-      "enabled": false,
-      "matchPackageNames": [
-        "github.com/google/go-github/v*",
-      ],
-      "matchUpdateTypes": [
-        "major",
-      ],
     },
     {
       // Avoid updating patch version for statedb as it might contain breaking changes


### PR DESCRIPTION
Major updates were disabled for the `github.com/google/go-github` module in #40326 as renovate was not updating the import paths, which is needed for major updates. It turns out that renovate is able to also update those import paths with the `gomodUpdateImportPaths` `postUpdateOptions` ([ref](https://docs.renovatebot.com/modules/manager/gomod/#major-upgrades-of-dependencies)).

This `postUpdateOptions` is supposed to be configured for the [`all-go-deps-main`](https://github.com/cilium/cilium/blob/36dd14d9c3ab8d0806c1f269327e8f6792a10664/.github/renovate.json5#L202-L216) update group, but this actually conflicts with the top level config [here](https://github.com/cilium/cilium/blob/36dd14d9c3ab8d0806c1f269327e8f6792a10664/.github/renovate.json5#L52-L54) that only configures `gomodTidy`.

I ran some tests on a test repository and was able to confirm that in order to get `gomodUpdateImportPaths` to work as expected, what we need is to remove the `postUpdateOptions` config from the `all-go-deps-main` group and set `gomodUpdateImportPaths` in the top level `postUpdateOptions` instead of `gomodTidy` (we can remove `gomodTidy` because `gomodUpdateImportPaths` is a superset of it).

The only difference will be that for renovate PRs that attempt to do a major go module upgrade, renovate will now also update the import paths (which depending on the dependency may still not be enough).

With this PR I also remove the config block that disabled major updates for `go-github` as renovate should now be able to handle these.

See https://github.com/cilium/cilium/pull/42857#pullrequestreview-3478430031
