### PR TITLE
[CFP-39876]: Implement global namespace support for CEP, identities and slices

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -15,6 +15,7 @@ import (
 	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -68,6 +69,9 @@ var Synchronization = cell.Module(
 	"clustermesh-synchronization",
 	"Synchronize information from Kubernetes to KVStore",
 
+	// Provide the namespace manager.
+	cmnamespace.Cell,
+
 	cell.Group(
 		cell.Provide(
 			func(syncState syncstate.SyncState) operatorWatchers.ServiceSyncConfig {
@@ -101,6 +105,7 @@ var Synchronization = cell.Module(
 		cell.Provide(
 			newCiliumIdentityOptions,
 			newCiliumIdentityConverter,
+			newCiliumIdentityNamespacer,
 		),
 		cell.Invoke(RegisterSynchronizer[*cilium_api_v2.CiliumIdentity]),
 	),
@@ -109,6 +114,7 @@ var Synchronization = cell.Module(
 		cell.Provide(
 			newCiliumEndpointOptions,
 			newCiliumEndpointConverter,
+			newCiliumEndpointNamespacer,
 		),
 		cell.Invoke(RegisterSynchronizer[*types.CiliumEndpoint]),
 	),
@@ -117,6 +123,7 @@ var Synchronization = cell.Module(
 		cell.Provide(
 			newCiliumEndpointSliceOptions,
 			newCiliumEndpointSliceConverter,
+			newCiliumEndpointSliceNamespacer,
 		),
 		cell.Invoke(RegisterSynchronizer[*cilium_api_v2a1.CiliumEndpointSlice]),
 	),

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -126,10 +126,11 @@ func (nc *CiliumNodeConverter) Convert(event resource.Event[*cilium_api_v2.Ciliu
 
 func newCiliumIdentityOptions() Options[*cilium_api_v2.CiliumIdentity] {
 	return Options[*cilium_api_v2.CiliumIdentity]{
-		Enabled:   true,
-		Resource:  "CiliumIdentity",
-		Prefix:    path.Join(identityCache.IdentitiesPath, "id"),
-		StoreOpts: []store.WSSOpt{store.WSSWithSyncedKeyOverride(identityCache.IdentitiesPath)},
+		Enabled:    true,
+		Resource:   "CiliumIdentity",
+		Prefix:     path.Join(identityCache.IdentitiesPath, "id"),
+		StoreOpts:  []store.WSSOpt{store.WSSWithSyncedKeyOverride(identityCache.IdentitiesPath)},
+		Namespaced: true,
 	}
 }
 
@@ -166,10 +167,11 @@ func (ic *CiliumIdentityConverter) Convert(event resource.Event[*cilium_api_v2.C
 
 func newCiliumEndpointOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[*types.CiliumEndpoint] {
 	return Options[*types.CiliumEndpoint]{
-		Enabled:   !cfg.EnableCiliumEndpointSlice,
-		Resource:  "CiliumEndpoint",
-		Prefix:    path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
-		StoreOpts: []store.WSSOpt{store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath)},
+		Enabled:    !cfg.EnableCiliumEndpointSlice,
+		Resource:   "CiliumEndpoint",
+		Prefix:     path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
+		StoreOpts:  []store.WSSOpt{store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath)},
+		Namespaced: true,
 	}
 }
 
@@ -212,10 +214,11 @@ func ciliumEndpointMapper(endpoint *types.CiliumEndpoint) iter.Seq[store.Key] {
 
 func newCiliumEndpointSliceOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[*cilium_api_v2a1.CiliumEndpointSlice] {
 	return Options[*cilium_api_v2a1.CiliumEndpointSlice]{
-		Enabled:   cfg.EnableCiliumEndpointSlice,
-		Resource:  "CiliumEndpointSlice",
-		Prefix:    path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
-		StoreOpts: []store.WSSOpt{store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath)},
+		Enabled:    cfg.EnableCiliumEndpointSlice,
+		Resource:   "CiliumEndpointSlice",
+		Prefix:     path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
+		StoreOpts:  []store.WSSOpt{store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath)},
+		Namespaced: true,
 	}
 }
 

--- a/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resource_ctors.go
@@ -4,17 +4,26 @@
 package k8s
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/k8s"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+var (
+	PodPrefixLbl = labels.LabelSourceK8s + ":" + k8sConst.PodNamespaceLabel
 )
 
 func CiliumSlimEndpointResource(params k8s.CiliumResourceParams, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
@@ -28,7 +37,13 @@ func CiliumSlimEndpointResource(params k8s.CiliumResourceParams, mp workqueue.Me
 	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw, mp,
 		resource.WithLazyTransform(func() runtime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
-		}, k8s.TransformToCiliumEndpoint), resource.WithCRDSync(params.CRDSyncPromise),
+		}, k8s.TransformToCiliumEndpoint),
+		resource.WithCRDSync(params.CRDSyncPromise),
+		resource.WithIndexers(
+			cache.Indexers{
+				cache.NamespaceIndex: cache.MetaNamespaceIndexFunc, // index by namespace for global namespace lookups
+			},
+		),
 	), nil
 }
 
@@ -55,5 +70,57 @@ func CiliumEndpointSliceResource(params k8s.CiliumResourceParams, mp workqueue.M
 	)
 	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw, mp,
 		resource.WithMetric("CiliumEndpointSlice"), resource.WithCRDSync(params.CRDSyncPromise),
+		resource.WithIndexers(
+			cache.Indexers{
+				cache.NamespaceIndex: ciliumEndpointSliceNamespaceIndexFunc, // index by namespace for global namespace lookups
+			},
+		),
 	), nil
+}
+
+func CiliumIdentityResource(params k8s.CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumIdentity], error) {
+	if !params.ClientSet.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumIdentityList](params.ClientSet.CiliumV2().CiliumIdentities()),
+		opts...,
+	)
+
+	return resource.New[*cilium_api_v2.CiliumIdentity](params.Lifecycle, lw,
+		params.MetricsProvider, resource.WithMetric("CiliumIdentityList"),
+		resource.WithIndexers(
+			cache.Indexers{
+				cache.NamespaceIndex: ciliumIdentityNamespaceIndexFunc, // index by namespace for global namespace lookups
+			},
+		),
+		resource.WithCRDSync(params.CRDSyncPromise)), nil
+}
+
+// ciliumIdentityNamespaceIndexFunc extracts the namespace from CiliumIdentity SecurityLabels.
+// Since CiliumIdentity is cluster-scoped, we extract namespace from security labels.
+func ciliumIdentityNamespaceIndexFunc(obj any) ([]string, error) {
+	switch t := obj.(type) {
+	case *cilium_api_v2.CiliumIdentity:
+		// Look for the namespace in security labels.
+		if namespace, exists := t.SecurityLabels[PodPrefixLbl]; exists {
+			return []string{namespace}, nil
+		}
+		// If no namespace found, return empty slice (no namespace association).
+		return []string{}, nil
+	}
+	return nil, fmt.Errorf("object is not a *cilium_api_v2.CiliumIdentity - got %T", obj)
+}
+
+// ciliumEndpointSliceNamespaceIndexFunc extracts the namespace from CiliumEndpointSlice.
+// Since CiliumEndpointSlice has a dedicated Namespace field, we use that directly.
+func ciliumEndpointSliceNamespaceIndexFunc(obj any) ([]string, error) {
+	switch t := obj.(type) {
+	case *cilium_api_v2alpha1.CiliumEndpointSlice:
+		if t.Namespace != "" {
+			return []string{t.Namespace}, nil
+		}
+		return []string{}, nil
+	}
+	return nil, fmt.Errorf("object is not a *cilium_api_v2alpha1.CiliumEndpointSlice - got %T", obj)
 }

--- a/clustermesh-apiserver/clustermesh/k8s/resources.go
+++ b/clustermesh-apiserver/clustermesh/k8s/resources.go
@@ -30,13 +30,14 @@ var (
 			mcsapi.ServiceExportResource,
 			operatorK8s.EndpointsResource,
 			CiliumNodeResource,
-			k8s.CiliumIdentityResource,
+			CiliumIdentityResource,
 			// The CiliumSlimEndpoint and CiliumEndpointSlice resource constructors in the agent depend
 			// on the LocalNodeStore to index its cache. In the clustermesh-apiserver, there is no
 			// cell providing LocalNodeStore, so we provide the resources with separate
 			// constructors.
 			CiliumSlimEndpointResource,
 			CiliumEndpointSliceResource,
+			k8s.NamespaceResource,
 		),
 	)
 )

--- a/clustermesh-apiserver/clustermesh/namespacers.go
+++ b/clustermesh-apiserver/clustermesh/namespacers.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	cmk8s "github.com/cilium/cilium/clustermesh-apiserver/clustermesh/k8s"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/types"
+)
+
+type GenericNamespacer[T runtime.Object] struct {
+	extract func(T) string
+}
+
+func (gn *GenericNamespacer[T]) ExtractNamespace(event resource.Event[T]) (namespace string) {
+	return gn.extract(event.Object)
+}
+
+// ----- CiliumIdentity ----- //
+
+func newCiliumIdentityNamespacer() Namespacer[*cilium_api_v2.CiliumIdentity] {
+	return &GenericNamespacer[*cilium_api_v2.CiliumIdentity]{
+		extract: func(obj *cilium_api_v2.CiliumIdentity) string {
+			return obj.SecurityLabels[cmk8s.PodPrefixLbl]
+		},
+	}
+}
+
+// ----- CiliumEndpoint ----- //
+
+func newCiliumEndpointNamespacer() Namespacer[*types.CiliumEndpoint] {
+	return &GenericNamespacer[*types.CiliumEndpoint]{
+		extract: func(obj *types.CiliumEndpoint) string {
+			return obj.Namespace
+		},
+	}
+}
+
+// ----- CiliumEndpointSlice ----- //
+
+func newCiliumEndpointSliceNamespacer() Namespacer[*cilium_api_v2a1.CiliumEndpointSlice] {
+	return &GenericNamespacer[*cilium_api_v2a1.CiliumEndpointSlice]{
+		extract: func(obj *cilium_api_v2a1.CiliumEndpointSlice) string {
+			return obj.Namespace
+		},
+	}
+}

--- a/clustermesh-apiserver/clustermesh/synchronizer.go
+++ b/clustermesh-apiserver/clustermesh/synchronizer.go
@@ -13,10 +13,13 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/clustermesh-apiserver/syncstate"
+	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -28,12 +31,23 @@ type Options[T runtime.Object] struct {
 	Resource  string
 	Prefix    string
 	StoreOpts []store.WSSOpt
+	// Namespaced indicates whether namespace changes should trigger resynchronization
+	// of all resources of this type. If true, a namespace watcher will be started to monitor
+	// namespace changes and resynchronize resources accordingly. Only required for certain resource types.
+	Namespaced bool
 }
 
 // Converter knows how to convert a given Kubernetes event into the corresponding
 // set of kvstore upsert and delete operations.
 type Converter[T runtime.Object] interface {
 	Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey])
+}
+
+// Namespacer is an interface that defines methods to handle namespace-related operations
+// for Kubernetes resources in the context of clustermesh synchronization.
+type Namespacer[T runtime.Object] interface {
+	// ExtractNamespace retrieves the namespace of a given event's object.
+	ExtractNamespace(resource.Event[T]) (namespace string)
 }
 
 type syncParams[T runtime.Object] struct {
@@ -50,6 +64,10 @@ type syncParams[T runtime.Object] struct {
 	Options   Options[T]
 	Converter Converter[T]
 	SyncState syncstate.SyncState
+
+	NamespaceManager cmnamespace.Manager
+	Namespaces       resource.Resource[*slim_corev1.Namespace]
+	Namespacer       Namespacer[T] `optional:"true"`
 }
 
 // RegisterSynchronizer registers a new synchronizer for the given resource,
@@ -66,44 +84,125 @@ func RegisterSynchronizer[T runtime.Object](in syncParams[T]) {
 	store := in.Factory.NewSyncStore(
 		in.ClusterInfo.Name, in.Client,
 		in.Options.Prefix, in.Options.StoreOpts...)
+
 	synced := in.SyncState.WaitForResource()
+
+	// process is a helper function to log and execute store operations.
+	process := func(invoker, op, key string, do func() error) {
+		logger.Info("Updating resource in etcd",
+			logfields.Reason, invoker,
+			logfields.Operation, op,
+			logfields.Key, key,
+		)
+		if err := do(); err != nil {
+			logger.Warn("Failed updating resource in etcd",
+				logfields.Error, err,
+				logfields.Reason, invoker,
+				logfields.Operation, op,
+				logfields.Key, key,
+			)
+		}
+	}
 
 	in.JobGroup.Add(
 		job.OneShot(
 			fmt.Sprintf("%s-sync", strings.ToLower(in.Options.Resource)),
 			func(ctx context.Context, _ cell.Health) error {
-				for event := range in.Resource.Events(ctx) {
-					event.Done(nil)
+				resourceStore, err := in.Resource.Store(ctx)
+				if err != nil {
+					return err
+				}
+				logger.Info("Starting synchronization")
 
-					if event.Kind == resource.Sync {
-						logger.Info("Initial entries successfully received from Kubernetes")
-						store.Synced(ctx, synced)
-						continue
-					}
+				// Get event channels
+				resourceEvents := in.Resource.Events(ctx)
+				var namespaceEvents <-chan resource.Event[*slim_corev1.Namespace]
+				if in.Options.Namespaced {
+					logger.Debug("Namespace watcher is enabled for resource type")
+					namespaceEvents = in.Namespaces.Events(ctx)
+				} else {
+					logger.Debug("Namespace watcher is not enabled for resource type")
+				}
 
-					process := func(op, key string, do func() error) {
-						logger.Info("Updating resource in etcd",
-							logfields.Operation, op,
-							logfields.Key, key,
-						)
+				for resourceEvents != nil || namespaceEvents != nil {
+					select {
+					case event, ok := <-resourceEvents:
+						if !ok {
+							resourceEvents = nil
+							continue
+						}
 
-						if err := do(); err != nil {
-							logger.Warn("Failed updating resource in etcd",
-								logfields.Error, err,
-								logfields.Operation, op,
-								logfields.Key, key,
-							)
+						if event.Kind == resource.Sync {
+							event.Done(nil)
+							logger.Info("Initial entries successfully received from Kubernetes")
+							store.Synced(ctx, synced)
+							continue
+						}
+						// Filter the event based on namespace global status.
+						// Only required for certain resource types.
+						// Ignore delete events as they should always be processed.
+						if event.Kind != resource.Delete && in.Options.Namespaced {
+							ns := in.Namespacer.ExtractNamespace(event)
+							if ns == "" {
+								logger.Error("Failed to determine namespace for resource event, skipping",
+									logfields.Name, event.Key.Name,
+								)
+								// No way to process this event, just mark done and continue.
+								event.Done(nil)
+								continue
+							}
+							isGlobal, err := in.NamespaceManager.IsGlobalNamespaceByName(ns)
+							if err != nil {
+								logger.Warn("Failed to determine if namespace is global",
+									logfields.Error, err,
+									logfields.K8sNamespace, ns,
+								)
+								// Retry this as it might succeed later.
+								event.Done(err)
+								continue
+							}
+							if !isGlobal {
+								logger.Debug("Deleting resource event as it is not in a global namespace",
+									logfields.Name, event.Key.Name,
+									logfields.K8sNamespace, ns,
+								)
+								// Handle resources transitioning out of global namespaces.
+								// If a resource was previously in a global namespace and is now
+								// in a non-global namespace (e.g.,mutable fields like in CiliumEndpointSlice),
+								// we need to delete it from kvstore. Convert the event to a delete to ensure cleanup.
+								// event.Done will be called later during normal processing.
+								event.Kind = resource.Delete
+							}
+						}
+
+						// No possible errors past this point.
+						event.Done(nil)
+
+						upserts, deletes := in.Converter.Convert(event)
+						for upsert := range upserts {
+							process("resource-event", "upsert", upsert.GetKeyName(), func() error { return store.UpsertKey(ctx, upsert) })
+						}
+						for delete := range deletes {
+							process("resource-event", "delete", delete.GetKeyName(), func() error { return store.DeleteKey(ctx, delete) })
+						}
+					case event, ok := <-namespaceEvents:
+						if !ok {
+							namespaceEvents = nil
+							continue
+						}
+						event.Done(nil)
+						for resEvent := range namespaceHandler(in, resourceStore, event) {
+							upserts, deletes := in.Converter.Convert(resEvent)
+							for upsert := range upserts {
+								process("namespace-event", "upsert", upsert.GetKeyName(), func() error { return store.UpsertKey(ctx, upsert) })
+							}
+							for delete := range deletes {
+								process("namespace-event", "delete", delete.GetKeyName(), func() error { return store.DeleteKey(ctx, delete) })
+							}
 						}
 					}
-
-					upserts, deletes := in.Converter.Convert(event)
-					for upsert := range upserts {
-						process("upsert", upsert.GetKeyName(), func() error { return store.UpsertKey(ctx, upsert) })
-					}
-					for delete := range deletes {
-						process("delete", delete.GetKeyName(), func() error { return store.DeleteKey(ctx, delete) })
-					}
 				}
+				logger.Info("Stopping synchronization")
 				return nil
 			},
 		),
@@ -115,4 +214,46 @@ func RegisterSynchronizer[T runtime.Object](in syncParams[T]) {
 			},
 		),
 	)
+}
+
+// namespaceHandler handles namespace events to resynchronize resources
+// associated with the namespace based on whether it is global or not.
+// Return an iterator of events to be processed.
+func namespaceHandler[T runtime.Object](
+	in syncParams[T], rs resource.Store[T],
+	event resource.Event[*slim_corev1.Namespace]) iter.Seq[resource.Event[T]] {
+	return func(yield func(resource.Event[T]) bool) {
+		if event.Kind == resource.Sync {
+			return
+		}
+		isGlobal := in.NamespaceManager.IsGlobalNamespaceByObject(event.Object)
+
+		// Sync all entries in the Resource store to reflect the namespace change.
+		objects, err := rs.ByIndex(cache.NamespaceIndex, event.Key.Name)
+		if err != nil {
+			in.Logger.Warn("Failed to list resources for namespace update",
+				logfields.Error, err,
+			)
+			return
+		}
+		for _, obj := range objects {
+			resEvent := resource.Event[T]{
+				Key:    resource.NewKey(obj),
+				Object: obj,
+			}
+			// Determine the event kind. If namespace is being deleted,
+			// all associated resources should be deleted.
+			// If namespace is upserted/updated and is global,
+			// resources should be upserted. Otherwise, they should be deleted
+			// (ex: annotated non-global from global).
+			if event.Kind == resource.Upsert && isGlobal {
+				resEvent.Kind = resource.Upsert
+			} else {
+				resEvent.Kind = resource.Delete
+			}
+			if !yield(resEvent) {
+				return
+			}
+		}
+	}
 }

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -2,6 +2,9 @@
 
 hive/start
 
+# Add two namespaces
+k8s/add namespace-1.yaml namespace-2.yaml
+
 # Add two CiliumEndpoints
 k8s/add endpoint-1.yaml endpoint-2.yaml
 
@@ -38,7 +41,34 @@ k8s/delete endpoint-2.yaml
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 
+# Annotate namespace-1 as non-global
+k8s/update namespace-1-annotated.yaml
+
+# Wait for synchronization. No endpoints should remain synced
+kvstore/list -o json cilium/state/ip ips-empty.actual
+* empty ips-empty.actual
+
 # ---
+
+-- namespace-1.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+
+-- namespace-2.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar
+
+-- namespace-1-annotated.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+  annotations:
+    clustermesh.cilium.io/global: "false"
 
 -- endpoint-1.yaml --
 apiVersion: cilium.io/v2

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
@@ -2,6 +2,9 @@
 
 hive/start
 
+# Add three namespaces
+k8s/add namespace-1.yaml namespace-2.yaml namespace-3.yaml
+
 # Add two CiliumEndpointSlices
 k8s/add endpointslice-1.yaml endpointslice-2.yaml
 
@@ -35,7 +38,58 @@ k8s/delete endpointslice-2.yaml
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 
+# Annotate namespace-1 as non-global
+k8s/update namespace-1-annotated.yaml
+
+# Wait for synchronization. Only endpoints in namespace-2 should remain synced
+kvstore/list -o json cilium/state/ip ips-3.actual
+* cmp ips-3.actual ips-3.expected
+
+# Now, annotate namespace-1 as global again
+k8s/update namespace-1.yaml
+
+# Wait for synchronization. endpoint-1-v2 and endpoint-3 should be synced
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# Update CiliumEndpointSlice-3 to update namespace to non-global namespace-3
+cp endpointslice-3.yaml endpointslice-3-v2.yaml
+replace 'fred' 'baz' endpointslice-3-v2.yaml
+k8s/update endpointslice-3-v2.yaml
+
+# Wait for synchronization. Only endpoint-1-v2 should remain synced
+kvstore/list -o json cilium/state/ip ips-1.actual
+* cmp ips-1.actual ips-1.expected
+
 # ---
+
+-- namespace-1.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qux
+
+-- namespace-2.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fred
+
+-- namespace-1-annotated.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: qux
+  annotations:
+    clustermesh.cilium.io/global: "false"
+
+-- namespace-3.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: baz
+  annotations:
+    clustermesh.cilium.io/global: "false"
 
 -- endpointslice-1.yaml --
 apiVersion: cilium.io/v2alpha1
@@ -447,6 +501,80 @@ namespace: fred
   "Metadata": "",
   "K8sNamespace": "fred",
   "K8sPodName": "foo-005",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::d615
+{
+  "IP": "fd00:10:244:2::d615",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b3
+{
+  "IP": "fd00:10:244:2::e4b3",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009",
+  "K8sServiceAccount": "default"
+}
+-- ips-3.expected --
+# cilium/state/ip/v1/default/10.244.2.120
+{
+  "IP": "10.244.2.120",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-005",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::5e16
+{
+  "IP": "fd00:10:244:2::5e16",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199494,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "fred",
+  "K8sPodName": "foo-005",
+  "K8sServiceAccount": "default"
+}
+-- ips-1.expected --
+# cilium/state/ip/v1/default/10.244.2.15
+{
+  "IP": "10.244.2.15",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199477,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199481,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "qux",
+  "K8sPodName": "foo-009",
   "K8sServiceAccount": "default"
 }
 # cilium/state/ip/v1/default/fd00:10:244:2::d615

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
@@ -2,6 +2,9 @@
 
 hive/start
 
+# Add two namespaces
+k8s/add namespace-1.yaml namespace-2.yaml
+
 # Add two CiliumIdentities
 k8s/add identity-1.yaml identity-2.yaml
 
@@ -39,7 +42,41 @@ k8s/delete identity-2.yaml
 kvstore/list -o plain cilium/state/identities identities-1+3.actual
 * cmp identities-1+3.actual identities-1+3.expected
 
+# Annotate namespace-2 as non-global
+k8s/update namespace-2-annotated.yaml
+
+# Wait for synchronization. No identities should remain synced
+kvstore/list -o plain cilium/state/identities identities-empty.actual
+* empty identities-empty.actual
+
+# Add namespace-2 back as global
+k8s/update namespace-2.yaml
+
+# Wait for synchronization. identity-1 and identity-3 should be synced again
+kvstore/list -o plain cilium/state/identities identities-1+3.actual
+* cmp identities-1+3.actual identities-1+3.expected
+
 # ---
+
+-- namespace-1.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+
+-- namespace-2.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar
+
+-- namespace-2-annotated.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar
+  annotations:
+    clustermesh.cilium.io/global: "false"
 
 -- identity-1.yaml --
 apiVersion: cilium.io/v2

--- a/clustermesh-apiserver/clustermesh/testdata/globalnamespace.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/globalnamespace.txtar
@@ -1,0 +1,181 @@
+#! --cluster-id=3 --cluster-name=cluster3 --clustermesh-default-global-namespace=false
+
+hive/start
+
+# Add two namespaces
+k8s/add namespace-1.yaml namespace-2.yaml
+
+# Add two CiliumEndpoints
+k8s/add endpoint-1.yaml endpoint-2.yaml
+
+# Assert that the synced key gets created. We compare on the key only as the
+# value is the timestamp at which synchronization completed
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster3/cilium/state/ip/v1$' synced.actual
+
+# Wait for synchronization. Only endpoint-1 should be synced as it is in a global namespace
+kvstore/list -o json cilium/state/ip ips-1.actual
+* cmp ips-1.actual ips-1.expected
+
+# Annotate namespace-2 as global
+k8s/update namespace-2-annotated.yaml
+
+# Wait for synchronization. Now both endpoints should be synced
+kvstore/list -o json cilium/state/ip ips-1+2.actual
+* cmp ips-1+2.actual ips-1+2.expected
+
+# Annotate namespace-2 as non-global
+k8s/update namespace-2.yaml
+
+# Wait for synchronization. Only endpoint-1 should remain synced
+kvstore/list -o json cilium/state/ip ips-1.actual
+* cmp ips-1.actual ips-1.expected
+
+# Delete namespace-1
+k8s/delete namespace-1.yaml
+
+# Wait for synchronization. No endpoints should remain synced
+kvstore/list -o json cilium/state/ip ips-empty.actual
+* empty ips-empty.actual
+
+# ---
+
+-- namespace-1.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: don
+  annotations:
+    clustermesh.cilium.io/global: "true"
+
+-- namespace-2.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: quixote
+
+-- namespace-2-annotated.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: quixote
+  annotations:
+    clustermesh.cilium.io/global: "true"
+
+-- endpoint-1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-001
+  namespace: don
+status:
+  id: 1481
+  identity:
+    id: 199472
+    labels:
+    - k8s:app=don
+  networking:
+    addressing:
+    - ipv4: 10.244.1.79
+      ipv6: fd00:10:244:1::d643
+    node: 172.18.0.3
+  service-account: default
+  state: ready
+
+-- endpoint-2.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-002
+  namespace: quixote
+status:
+  encryption:
+    key: 5
+  id: 1482
+  identity:
+    id: 199475
+    labels:
+    - k8s:app=quixote
+  networking:
+    addressing:
+    - ipv4: 10.244.2.74
+      ipv6: fd00:10:244:2::e024
+    node: 172.18.0.2
+  service-account: default
+  state: ready
+
+
+-- ips-1.expected --
+# cilium/state/ip/v1/default/10.244.1.79
+{
+  "IP": "10.244.1.79",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "don",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:1::d643
+{
+  "IP": "fd00:10:244:1::d643",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "don",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+2.expected --
+# cilium/state/ip/v1/default/10.244.1.79
+{
+  "IP": "10.244.1.79",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "don",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.74
+{
+  "IP": "10.244.2.74",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "quixote",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:1::d643
+{
+  "IP": "fd00:10:244:1::d643",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "don",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e024
+{
+  "IP": "fd00:10:244:2::e024",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199475,
+  "Key": 5,
+  "Metadata": "",
+  "K8sNamespace": "quixote",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -228,6 +228,9 @@ const (
 	CECUseOriginalSourceAddress = CECPrefix + "/use-original-source-address"
 
 	NoTrackHostPorts = NetworkPrefix + "/no-track-host-ports"
+
+	// GlobalNamespace is the annotation used to mark namespaces for global export in ClusterMesh.
+	GlobalNamespace = ClusterMeshPrefix + "/global"
 )
 
 // CiliumPrefixRegex is a regex matching Cilium specific annotations.

--- a/pkg/clustermesh/namespace/cell.go
+++ b/pkg/clustermesh/namespace/cell.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespace
+
+import "github.com/cilium/hive/cell"
+
+var Cell = cell.Module(
+	"clustermesh-namespace",
+	"Clustermesh global namespace management",
+
+	cell.Config(DefaultConfig),
+	cell.Provide(
+		func(params managerParams) Manager {
+			return newManager(params)
+		},
+	),
+)

--- a/pkg/clustermesh/namespace/config.go
+++ b/pkg/clustermesh/namespace/config.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespace
+
+import "github.com/spf13/pflag"
+
+var DefaultConfig = Config{
+	GlobalNamespacesByDefault: true,
+}
+
+type Config struct {
+	// GlobalNamespacesByDefault marks all namespaces as global by default unless overridden by annotation
+	GlobalNamespacesByDefault bool `mapstructure:"clustermesh-default-global-namespace"`
+}
+
+func (cfg Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(
+		"clustermesh-default-global-namespace",
+		cfg.GlobalNamespacesByDefault,
+		"Mark all namespaces as global by default unless overridden by annotation",
+	)
+	flags.MarkHidden("clustermesh-default-global-namespace")
+}

--- a/pkg/clustermesh/namespace/namespace.go
+++ b/pkg/clustermesh/namespace/namespace.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespace
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+)
+
+type managerParams struct {
+	cell.In
+
+	Logger     *slog.Logger
+	Config     Config
+	Namespaces resource.Resource[*slim_corev1.Namespace]
+	Lifecycle  cell.Lifecycle
+}
+
+type Manager interface {
+	IsGlobalNamespaceByName(ns string) (bool, error)
+	IsGlobalNamespaceByObject(ns *slim_corev1.Namespace) bool
+}
+
+type manager struct {
+	logger *slog.Logger
+	cfg    Config
+	store  resource.Store[*slim_corev1.Namespace]
+}
+
+func newManager(params managerParams) *manager {
+	m := &manager{
+		logger: params.Logger,
+		cfg:    params.Config,
+	}
+
+	params.Lifecycle.Append(cell.Hook{
+		OnStart: func(ctx cell.HookContext) error {
+			store, err := params.Namespaces.Store(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get namespace store: %w", err)
+			}
+			m.store = store
+			return nil
+		},
+	})
+
+	return m
+}
+
+// IsGlobalNamespaceByObject determines whether the given namespace should be treated as a global
+// namespace based on its annotations and the provided configuration.
+func (m *manager) IsGlobalNamespaceByObject(ns *slim_corev1.Namespace) bool {
+	if ns == nil {
+		return false
+	}
+	// Get annotations for the namespace.
+	// If annotated with "clustermesh.cilium.io/global", supercede the default config.
+	annotations := ns.GetAnnotations()
+	if value, ok := annotations[annotation.GlobalNamespace]; ok {
+		return strings.ToLower(value) == "true"
+	}
+	// If the annotation is not present, fall back to the default config.
+	return m.cfg.GlobalNamespacesByDefault
+}
+
+// IsGlobalNamespaceByName determines whether the namespace with the given name should be treated
+// as a global namespace based on its annotations and the provided configuration.
+// It retrieves the namespace object from the named resource store embedded in manager ob.
+func (m *manager) IsGlobalNamespaceByName(ns string) (bool, error) {
+	if m.store == nil {
+		return false, fmt.Errorf("namespace store not initialized")
+	}
+
+	obj, exists, err := m.store.GetByKey(resource.Key{Name: ns})
+	if err != nil {
+		return false, fmt.Errorf("error getting namespace from store: %w", err)
+	}
+	if !exists {
+		return false, fmt.Errorf("namespace %s does not exist in store", ns)
+	}
+	return m.IsGlobalNamespaceByObject(obj), nil
+}

--- a/pkg/clustermesh/namespace/namespace_test.go
+++ b/pkg/clustermesh/namespace/namespace_test.go
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/hive/hivetest"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/k8s"
+	k8sFakeClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+// NewMockNamespaceManager creates a Namespace Manager with a fake clientset and the provided namespaces.
+func NewMockNamespaceManager(t *testing.T, enableDefaultGlobalNamespace bool, namespaces ...*slim_corev1.Namespace) Manager {
+	var (
+		log             = hivetest.Logger(t)
+		lc              = hivetest.Lifecycle(t)
+		cs, _           = k8sFakeClient.NewFakeClientset(log)
+		namespaceRes, _ = k8s.NamespaceResource(lc, cs, nil)
+	)
+	for _, ns := range namespaces {
+		_, err := cs.Slim().CoreV1().Namespaces().Create(t.Context(), ns, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return newManager(managerParams{
+		Logger:     log,
+		Lifecycle:  lc,
+		Namespaces: namespaceRes,
+		Config: Config{
+			GlobalNamespacesByDefault: enableDefaultGlobalNamespace,
+		},
+	})
+}
+
+func TestIsGlobalNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      Config
+		namespace   *slim_corev1.Namespace
+		expected    bool
+		expectError bool
+		description string
+	}{
+		{
+			name: "nil namespace",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace:   nil,
+			expected:    false,
+			description: "nil namespace should always return false",
+		},
+		{
+			name: "annotation true with default false",
+			config: Config{
+				GlobalNamespacesByDefault: false,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "true",
+					},
+				},
+			},
+			expected:    true,
+			description: "annotation=true should override default=false",
+		},
+		{
+			name: "annotation false with default true",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "false",
+					},
+				},
+			},
+			expected:    false,
+			description: "annotation=false should override default=true",
+		},
+		{
+			name: "annotation true uppercase",
+			config: Config{
+				GlobalNamespacesByDefault: false,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "TRUE",
+					},
+				},
+			},
+			expected:    true,
+			description: "annotation value should be case-insensitive",
+		},
+		{
+			name: "annotation mixed case",
+			config: Config{
+				GlobalNamespacesByDefault: false,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "TrUe",
+					},
+				},
+			},
+			expected:    true,
+			description: "annotation value should be case-insensitive",
+		},
+		{
+			name: "no annotation with default true",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+				},
+			},
+			expected:    true,
+			description: "no annotation should fall back to default=true",
+		},
+		{
+			name: "no annotation with default false",
+			config: Config{
+				GlobalNamespacesByDefault: false,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+				},
+			},
+			expected:    false,
+			description: "no annotation should fall back to default=false",
+		},
+		{
+			name: "empty annotations map with default true",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:        "test-ns",
+					Annotations: map[string]string{},
+				},
+			},
+			expected:    true,
+			description: "empty annotations should fall back to default",
+		},
+		{
+			name: "annotation with invalid value",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "invalid",
+					},
+				},
+			},
+			expected:    false,
+			description: "invalid annotation value should be treated as false",
+		},
+		{
+			name: "annotation empty string with default true",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "",
+					},
+				},
+			},
+			expected:    false,
+			description: "empty annotation value should be treated as false",
+		},
+		{
+			name: "annotation true with default true",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "true",
+					},
+				},
+			},
+			expected:    true,
+			description: "annotation=true with default=true should return true",
+		},
+		{
+			name: "annotation false with default false",
+			config: Config{
+				GlobalNamespacesByDefault: false,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "test-ns",
+					Annotations: map[string]string{
+						annotation.GlobalNamespace: "false",
+					},
+				},
+			},
+			expected:    false,
+			description: "annotation=false with default=false should return false",
+		},
+		{
+			name: "namespace does not exist",
+			config: Config{
+				GlobalNamespacesByDefault: true,
+			},
+			namespace: &slim_corev1.Namespace{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name: "non-existent",
+				},
+			},
+			expected:    false,
+			expectError: true,
+			description: "should return error when namespace doesn't exist",
+		},
+	}
+
+	t.Run("ByObject", func(t *testing.T) {
+		for _, tt := range tests {
+			// Skip error scenarios for ByObject
+			if tt.expectError {
+				continue
+			}
+
+			t.Run(tt.name, func(t *testing.T) {
+				var m Manager
+				if tt.namespace != nil {
+					m = NewMockNamespaceManager(t, tt.config.GlobalNamespacesByDefault, tt.namespace)
+				} else {
+					m = NewMockNamespaceManager(t, tt.config.GlobalNamespacesByDefault)
+				}
+
+				result := m.IsGlobalNamespaceByObject(tt.namespace)
+				assert.Equal(t, tt.expected, result, tt.description)
+			})
+		}
+	})
+
+	t.Run("ByName", func(t *testing.T) {
+		for _, tt := range tests {
+			// Skip nil namespace test for ByName
+			if tt.namespace == nil {
+				continue
+			}
+
+			t.Run(tt.name, func(t *testing.T) {
+				// For error scenarios, don't create the namespace
+				var m Manager
+				if tt.expectError {
+					m = NewMockNamespaceManager(t, tt.config.GlobalNamespacesByDefault)
+				} else {
+					m = NewMockNamespaceManager(t, tt.config.GlobalNamespacesByDefault, tt.namespace)
+				}
+
+				result, err := m.IsGlobalNamespaceByName(tt.namespace.Name)
+				if tt.expectError {
+					require.Error(t, err, tt.description)
+				} else {
+					require.NoError(t, err, "should not error for existing namespace")
+					assert.Equal(t, tt.expected, result, tt.description)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
# Description
This PR is laying the foundation for https://github.com/cilium/design-cfps/pull/74 .

Adds namespace-level filtering for a subset of ClusterMesh resource synchronization using the clustermesh.cilium.io/global annotation, allowing administrators to control which namespaces export resources to the kvstore. Resources handled in this PR are CiliumEndpoints, CiliumIdentities and CiliumEndpointSlices.

# Key changes

- New `clustermesh.cilium.io/global` annotation to mark namespaces for export
- Namespace manager tracks global status with `--clustermesh-default-global-namespace` flag (default: true)
- Resource synchronizers filter resource events based on namespace global status
- Automatic cleanup when resources move out of global namespaces
- Namespace event handling triggers resynchronization of affected resources (ex: annotating namespace as global or local)

# Behavior

- All namespaces are global by default (backward compatible), i.e., `--clustermesh-default-global-namespace=true` by default
- Opt-out: add `clustermesh.cilium.io/global: "false"` to namespace
- When flag is `false`, namespaces must opt-in with annotation set to `"true"`
- Resources automatically removed from kvstore when namespace becomes non-global
- The flag is currently hidden from users as feature is incomplete

# Testing Done

- Setup two kind clusters using `make kind-clustermesh`
- Build and install clustermesh with `enable-default-global-namespace=false`
- Exec into kvstoremesh container `k exec -it deploy/clustermesh-apiserver -c kvstoremesh --context=kind-clustermesh2 --namespace=kube-system -- clustermesh-apiserver shell`
- Check clustermesh `kvstore` using `kvstore/list --keys-only --output=string` (no identities or endpoints)
- Annotate default namespace in both cluster
-  Check clustermesh `kvstore` using `kvstore/list --keys-only --output=string` (identities and endpoints present now)
- Created/Deleted deployments to check kvstore is updated accordingly
- Deployed Hubble to make sure during cross cluster communication, flow logs are accurate (with annotation, I see pod -> pod flows, but w/o annotation pod->IP flows)
- New unit tests
- New E2E tests using the Hive script


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
