### PR TITLE
egressgw: rework FIB lookup & redirect

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -60,12 +60,6 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	__u32 oif;
 	int ret;
 
-	/* Immediate redirect to egress_ifindex requires L2 resolution.
-	 * Fall back to FIB lookup on older kernels.
-	 */
-	if (egress_ifindex && neigh_resolver_without_nh_available())
-		return redirect_neigh(egress_ifindex, NULL, 0, 0);
-
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr,
 				  egress_ifindex ?: ctx_get_ifindex(ctx),
 				  egress_ifindex ? BPF_FIB_LOOKUP_OUTPUT : 0);
@@ -370,9 +364,6 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	struct bpf_fib_lookup_padded fib_params = {};
 	__u32 oif;
 	int ret;
-
-	if (egress_ifindex && neigh_resolver_without_nh_available())
-		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v6(ctx, &fib_params,
 				  (struct in6_addr *)egress_ip,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -66,7 +66,8 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	if (egress_ifindex && neigh_resolver_without_nh_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
-	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
+	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr,
+				  ctx_get_ifindex(ctx), 0);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
@@ -374,7 +375,8 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 
 	ret = (__s8)fib_lookup_v6(ctx, &fib_params,
 				  (struct in6_addr *)egress_ip,
-				  (struct in6_addr *)daddr, 0);
+				  (struct in6_addr *)daddr,
+				  ctx_get_ifindex(ctx), 0);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -67,7 +67,8 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr,
-				  ctx_get_ifindex(ctx), 0);
+				  egress_ifindex ?: ctx_get_ifindex(ctx),
+				  egress_ifindex ? BPF_FIB_LOOKUP_OUTPUT : 0);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
@@ -376,7 +377,8 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	ret = (__s8)fib_lookup_v6(ctx, &fib_params,
 				  (struct in6_addr *)egress_ip,
 				  (struct in6_addr *)daddr,
-				  ctx_get_ifindex(ctx), 0);
+				  egress_ifindex ?: ctx_get_ifindex(ctx),
+				  egress_ifindex ? BPF_FIB_LOOKUP_OUTPUT : 0);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -201,10 +201,10 @@ fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 static __always_inline int
 fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 	      const struct in6_addr *ipv6_src, const struct in6_addr *ipv6_dst,
-	      int flags)
+	      __u32 ifindex, int flags)
 {
 	fib_params->l.family	= AF_INET6;
-	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+	fib_params->l.ifindex	= ifindex;
 
 	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_src,
 		       (union v6addr *)ipv6_src);
@@ -236,7 +236,8 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		struct bpf_fib_lookup_padded fib_params = {0};
 		int fib_result;
 
-		fib_result = fib_lookup_v6(ctx, &fib_params, &ip6->saddr, &ip6->daddr, 0);
+		fib_result = fib_lookup_v6(ctx, &fib_params, &ip6->saddr, &ip6->daddr,
+					   ctx_get_ifindex(ctx), 0);
 		switch (fib_result) {
 		case BPF_FIB_LKUP_RET_SUCCESS:
 		case BPF_FIB_LKUP_RET_NO_NEIGH:
@@ -267,9 +268,9 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
  */
 static __always_inline int
 fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
-	      __be32 ipv4_src, __be32 ipv4_dst, int flags) {
+	      __be32 ipv4_src, __be32 ipv4_dst, __u32 ifindex, int flags) {
 	fib_params->l.family	= AF_INET;
-	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+	fib_params->l.ifindex	= ifindex;
 	fib_params->l.ipv4_src	= ipv4_src;
 	fib_params->l.ipv4_dst	= ipv4_dst;
 
@@ -298,7 +299,8 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		struct bpf_fib_lookup_padded fib_params = {0};
 		int fib_result;
 
-		fib_result = fib_lookup_v4(ctx, &fib_params, ip4->saddr, ip4->daddr, 0);
+		fib_result = fib_lookup_v4(ctx, &fib_params, ip4->saddr, ip4->daddr,
+					   ctx_get_ifindex(ctx), 0);
 		switch (fib_result) {
 		case BPF_FIB_LKUP_RET_SUCCESS:
 		case BPF_FIB_LKUP_RET_NO_NEIGH:


### PR DESCRIPTION
`egress_gw_fib_lookup_and_redirect()` is used from two contexts on an EGW node:
* `from-overlay`, after EGW traffic from a client on a worker node arrives via the overlay network and has matched an EGW policy entry (in the form `from <PodIP> to <CIDR>: use <EgressIP> and <ifindex>`). If no `ifindex` is provided, we need the FIB lookup to select the egress interface. If we have an `ifindex`, we still need some processing to rewrite the L2 header. The packet then is bpf-redirected straight from `cilium_vxlan` to the selected egress interface.
* `to-netdev`, to apply the same logic (EGW policy lookup + interface selection + L2 rewrite) for clients that live on the GW node.

Currently we skip the FIB lookup when the EGW policy entry provides the `ifindex`, and immediately call `bpf_redirect_neigh()` without providing next-hop info. Since the packet hasn't been SNATed yet (its IP header is still "from `PodIP` to `external-EP`"), the helper then determines the next-hop based on the `PodIP` - when it should actually use the `EgressIP`.

This PR reworks `egress_gw_fib_lookup_and_redirect()` so that
* it **always** does the FIB lookup, respecting the selected `EgressIP`. The precise next-hop info then gets passed to `fib_do_redirect()`, which lets `bpf_redirect_neigh()` handle the L2 rewrite.
* when the `ifindex` is available, we use it to scope the FIB lookup to that specific interface.