### PR TITLE
bgp: Decouple GoBGP from BGP manager

### DIFF
--- a/pkg/bgp/gobgp/provider.go
+++ b/pkg/bgp/gobgp/provider.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gobgp
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/bgp/types"
+)
+
+// RouterProvider provides GoBGP server instances.
+type RouterProvider struct{}
+
+func NewRouterProvider() types.RouterProvider {
+	return &RouterProvider{}
+}
+
+func (p *RouterProvider) NewRouter(ctx context.Context, log *slog.Logger, params types.ServerParameters) (types.Router, error) {
+	return NewGoBGPServer(ctx, log, params)
+}

--- a/pkg/bgp/manager/instance/instance.go
+++ b/pkg/bgp/manager/instance/instance.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/cilium/cilium/pkg/bgp/gobgp"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -29,17 +28,17 @@ func (i *BGPInstance) NotifyStateChange() {
 	}
 }
 
-// NewBGPInstance will start an underlying BGP instance utilizing types.ServerParameters
-// for its initial configuration.
+// NewBGPInstance will start an underlying BGP instance using the provided types.RouterProvider,
+// utilizing types.ServerParameters for its initial configuration.
 //
 // The returned BGPInstance has a nil CiliumBGPNodeInstance config, and is
 // ready to be provided to ReconcileBGPConfig.
 //
 // Canceling the provided context will kill the BGP instance along with calling the
 // underlying Router's Stop() method.
-func NewBGPInstance(ctx context.Context, log *slog.Logger, name string, params types.ServerParameters) (*BGPInstance, error) {
-	gobgpCtx, cancel := context.WithCancel(ctx)
-	s, err := gobgp.NewGoBGPServer(gobgpCtx, log, params)
+func NewBGPInstance(ctx context.Context, routerProvider types.RouterProvider, log *slog.Logger, name string, params types.ServerParameters) (*BGPInstance, error) {
+	routerCtx, cancel := context.WithCancel(ctx)
+	s, err := routerProvider.NewRouter(routerCtx, log, params)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	"github.com/cilium/cilium/pkg/bgp/gobgp"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/reconciler"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
@@ -165,7 +166,7 @@ func TestGetRoutes(t *testing.T) {
 					ListenPort: -1,
 				},
 			}
-			testInstance, err := instance.NewBGPInstance(context.Background(), hivetest.Logger(t), "test-instance", srvParams)
+			testInstance, err := instance.NewBGPInstance(context.Background(), gobgp.NewRouterProvider(), hivetest.Logger(t), "test-instance", srvParams)
 			require.NoError(t, err)
 
 			testInstance.Config = &v2.CiliumBGPNodeInstance{

--- a/pkg/bgp/manager/reconciler/default_gateway_test.go
+++ b/pkg/bgp/manager/reconciler/default_gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgp/gobgp"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -519,7 +520,7 @@ func setupBGPInstance(logger *slog.Logger) (*instance.BGPInstance, error) {
 		},
 	}
 
-	testInstance, err := instance.NewBGPInstance(context.Background(), logger, "test-instance", srvParams)
+	testInstance, err := instance.NewBGPInstance(context.Background(), gobgp.NewRouterProvider(), logger, "test-instance", srvParams)
 	return testInstance, err
 }
 

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"context"
+	"log/slog"
 	"net/netip"
 	"strings"
 
@@ -459,6 +460,11 @@ type StopRequest struct {
 	// FullDestroy should be set to true if full destroy of the router instance should be performed.
 	// Note that this causes sending a Cease notification to BGP peers, which terminates Graceful Restart progress.
 	FullDestroy bool
+}
+
+// RouterProvider provides instances of underlying BGP router implementation.
+type RouterProvider interface {
+	NewRouter(ctx context.Context, log *slog.Logger, params ServerParameters) (Router, error)
 }
 
 // Router is vendor-agnostic cilium bgp configuration layer. Parameters of this layer


### PR DESCRIPTION
Decouples GoBGP from BGP Manager by introducing a new generic RouterProvider type. The GoBGP server becomes its implementation.

This allows easier mocking of GoBGP in tests, as well as potentially plugging other router providers in the future.
