### PR TITLE
datapath/loader: Fix route upsert failure on late ep device registration

### DIFF
--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/callsmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func init() {
@@ -240,21 +241,14 @@ func reloadEndpoint(logger *slog.Logger, db *statedb.DB,
 	}
 
 	if ep.RequireEndpointRoute() {
-		scopedLog := ep.Logger(subsystem).With(
-			logfields.Interface, device,
-		)
 		if ip := ep.IPv4Address(); ip.IsValid() {
 			if err := upsertEndpointRoute(db, devices, rm, ep, netip.PrefixFrom(ip, ip.BitLen())); err != nil {
-				scopedLog.Warn("Failed to upsert route",
-					logfields.Error, err,
-				)
+				return fmt.Errorf("upserting IPv4 route for endpoint %s: %w", ep.StringID(), err)
 			}
 		}
 		if ip := ep.IPv6Address(); ip.IsValid() {
 			if err := upsertEndpointRoute(db, devices, rm, ep, netip.PrefixFrom(ip, ip.BitLen())); err != nil {
-				scopedLog.Warn("Failed to upsert route",
-					logfields.Error, err,
-				)
+				return fmt.Errorf("upserting IPv6 route for endpoint %s: %w", ep.StringID(), err)
 			}
 		}
 	}
@@ -293,9 +287,28 @@ func upsertEndpointRoute(db *statedb.DB, devices statedb.Table[*tables.Device], 
 		return fmt.Errorf("getting or registering owner for endpoint %s: %w", ep.StringID(), err)
 	}
 
-	epDev, _, found := devices.Get(db.ReadTxn(), tables.DeviceIDIndex.Query(ep.GetIfIndex()))
-	if !found {
-		return fmt.Errorf("device %d not found for endpoint %s", ep.GetIfIndex(), ep.StringID())
+	// This timeout is 50 times the current batch interval of the devices controller, and thus should
+	// be sufficient.
+	const devTableWaitTimeout = 5 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), devTableWaitTimeout)
+	defer cancel()
+
+	// Find the device associated with the endpoint. Up to this point we have only got the ifindex
+	// and the table may not yet have been populated with devices. Wait for the device to appear.
+	var epDev *tables.Device
+	for {
+		var found bool
+		var watch <-chan struct{}
+		epDev, _, watch, found = devices.GetWatch(db.ReadTxn(), tables.DeviceIDIndex.Query(ep.GetIfIndex()))
+		if found {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("device %d not found for endpoint %s: %w", ep.GetIfIndex(), ep.StringID(), ctx.Err())
+		case <-watch:
+		}
 	}
 
 	return rm.UpsertRoute(routeReconciler.DesiredRoute{

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -27,8 +27,6 @@ import (
 )
 
 const (
-	subsystem = "datapath-loader"
-
 	symbolFromNetwork = "cil_from_network"
 
 	dirIngress = "ingress"


### PR DESCRIPTION
Currently its possible for endpoint datapath initialization to be triggered before the device table has been populated with the endpoint's device. This happens because the CNI plugin creates the device and then makes an API call to the agent to do the rest. The API server and endpoint subsystem do not wait for the device creation event to be processed by the device controller before proceeding with endpoint initialization using the ifindex obtained from the API call.

Most of the time this works fine, but its a race condition that once in a while causes route upserts to fail. When that happens, no error is returned and thus no retry is attempted, leading to missing routes for the endpoint and persistent connectivity issues.

So, for now we will wait for up to 5 seconds for the device to appear in the table before we give up. And if we do fail to upsert routes, we will return an error so that the endpoint initialization is retried.

Long term, we should make the device object part of the endpoint and have the endpoint subsystem wait for its creation instead.

Fixes: #42592

```release-note
Fixed a race condition while trying to create per endpoint routes which could result in connectivity issues
```
