### PR TITLE
fix(chart): cilium-configmap with unended condition

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3063,7 +3063,7 @@
    * - :spelling:ignore:`loadBalancer`
      - Configure service load balancing
      - object
-     - ``{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}``
+     - ``{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]},"serviceTopology":false}``
    * - :spelling:ignore:`loadBalancer.acceleration`
      - acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it).
      - string
@@ -3084,6 +3084,10 @@
      - List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation.
      - list
      - ``[]``
+   * - :spelling:ignore:`loadBalancer.serviceTopology`
+     - serviceTopology enables K8s Topology Aware Hints -based service endpoints filtering
+     - bool
+     - ``false``
    * - :spelling:ignore:`localRedirectPolicies.addressMatcherCIDRs`
      - Limit the allowed addresses in Address Matcher rule of Local Redirect Policies to the given CIDRs. @schema@ type: [null, array] @schema@
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -748,6 +748,7 @@ selftests
 serverinfo
 serviceAccount
 serviceMonitor
+serviceTopology
 serviceaccount
 setrlimit
 sfc

--- a/USERS.md
+++ b/USERS.md
@@ -538,6 +538,12 @@ Users (Alphabetically)
       L: https://github.com/xiaods/k8e
       Q: @xds2000
 
+    * N: Labyrinth Labs
+      D: One stop shop for Cloud, AWS, Kubernetes
+      U: Networking, network policies, Hubble for network visibility
+      L: https://lablabs.io
+      Q: @mliner
+
     * N: LinkPool
       D: LinkPool is a professional Web3 infrastructure provider.
       U: LinkPool is using Cilium as the CNI for its on-premise production clusters

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -815,12 +815,13 @@ contributors across the globe, there is almost always someone available to help.
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | livenessProbe.requireK8sConnectivity | bool | `false` | whether to require k8s connectivity as part of the check. |
-| loadBalancer | object | `{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
+| loadBalancer | object | `{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]},"serviceTopology":false}` | Configure service load balancing |
 | loadBalancer.acceleration | string | `"disabled"` | acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it). |
 | loadBalancer.l7 | object | `{"algorithm":"round_robin","backend":"disabled","ports":[]}` | L7 LoadBalancer |
 | loadBalancer.l7.algorithm | string | `"round_robin"` | Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. service.cilium.io/lb-l7-algorithm) Applicable values: round_robin, least_request, random |
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. service.cilium.io/lb-l7, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing by way of service annotation. |
 | loadBalancer.l7.ports | list | `[]` | List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation. |
+| loadBalancer.serviceTopology | bool | `false` | serviceTopology enables K8s Topology Aware Hints -based service endpoints filtering |
 | localRedirectPolicies.addressMatcherCIDRs | string | `nil` | Limit the allowed addresses in Address Matcher rule of Local Redirect Policies to the given CIDRs. @schema@ type: [null, array] @schema@ |
 | localRedirectPolicies.enabled | bool | `false` | Enable local redirect policies. |
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -906,9 +906,9 @@ data:
 {{- end }}
 {{- if hasKey .Values.loadBalancer "serviceTopology" }}
   enable-service-topology: {{ .Values.loadBalancer.serviceTopology | quote }}
-# {{- end }}
-
 {{- end }}
+{{- end }}
+
 {{- if hasKey .Values.maglev "tableSize" }}
   bpf-lb-maglev-table-size: {{ .Values.maglev.tableSize | quote}}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4690,6 +4690,9 @@
             }
           },
           "type": "object"
+        },
+        "serviceTopology": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2493,8 +2493,7 @@ loadBalancer:
 
   # -- serviceTopology enables K8s Topology Aware Hints -based service
   # endpoints filtering
-  # serviceTopology: false
-
+  serviceTopology: false
   # -- L7 LoadBalancer
   l7:
     # -- Enable L7 service load balancing via envoy proxy.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2519,7 +2519,7 @@ loadBalancer:
 
   # -- serviceTopology enables K8s Topology Aware Hints -based service
   # endpoints filtering
-  # serviceTopology: false
+  serviceTopology: false
 
   # -- L7 LoadBalancer
   l7:


### PR DESCRIPTION
### Description of change

Even though the helm chart seems to be valid (tested locally), I believe that there is a logical issue with the missing `{{- end}}` statement (previously commented in commit mentioned below). It can prevent the future problems in case helm will be more strict with template validation.

- addin Labyrinth Labs as Cilium users
- fixing chart
  - logical issue with the missing `{{- end}}` for condition (currently commented)
  - uncommenting default value for `loadbalancer.serviceTopology: false` in order to make it visible in chart-docs so that Cilium users are aware if this option, plus adjusting description to make it more clear for first users 

Fixes: [commit](https://github.com/cilium/cilium/commit/c432c7132e2b05a6d8c6d0fbf3142d123c4b723a#diff-83e9b8b2ccacddb2fbdb28fbcfa148473d05056c0b4c955fc971709b469d7331R789)

### Release note
```release-note
Fix bug where more Helm options were gated by `loadbalancer` option than intended
```
