### PR TITLE
operator: shut down immediately on losing the lead

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -516,9 +515,12 @@ func runOperator(log *slog.Logger, lc *LeaderLifecycle, clientset k8sClient.Clie
 				}
 			},
 			OnStoppedLeading: func() {
-				log.Info("Leader election lost", logfields.OperatorID, operatorID)
-				// Cleanup everything here, and exit.
-				shutdowner.Shutdown(hive.ShutdownWithError(errors.New("Leader election lost")))
+				// It's imperative that we stop immediately here. Concurrent execution threads
+				// acting on shared state in k8s/kvstore do so under the assumption that this
+				// operator leads the deployment, which is no longer true once we hit this callback.
+				// If we linger longer than the grace period between the RenewDeadline and the
+				// LeaseDuration, we end up with two operators acting as leaders.
+				logging.Fatal(log, "Leader election lost, shutting down.", logfields.OperatorID, operatorID)
 			},
 			OnNewLeader: func(identity string) {
 				if identity == operatorID {


### PR DESCRIPTION
This fixes a bug observed in the wild. It causes "split brain", i.e. multiple operators acting as leader. One manifestation is multiple CiliumNode CRs containing the same PodCIDR, leading to conflicting pod IP allocations and misrouted traffic.

The leader election package works by refreshing a lease object. If the lease object is not refreshed for a specified timeout, the lease duration (default 15s), the leader is assumed to be down and any other instance can try to become leader. The acting leader will attempt to refresh their lease for a shorter amount of time, the renewal deadline (default 10s). When the package fails to refresh the lease within its renewal deadline, it calls the OnStoppedLeading callback - from this moment on, it's wrong for any concurrent thread of execution in the operator to act as if it was still the leader. The difference between the two timeouts acts as a grace period (by default 5s), after which it is _catastrophic_ to act, since that amounts to two leaders acting. A lot of code assumes it only runs when it is the only leader, and hence breakage is guaranteed with two leaders.

Before this patch, the code was not respecting the hard deadline, if some stop hook in the hive shutdown sequence was blocking, it's possible that other components didn't even notice the beginning of shutdown until past the hard deadline. One way in which this could go wrong is pod CIDR allocation for CiliumNodes, where the resulting mess can only be cleaned up manually.

```release-note
In rare cases, the cilium-operator losing the lead of the HA deployment could continue acting as if leading for at most a minute, leading to split-brain problems such as double allocation of pod CIDRs.  
```
