### PR TITLE
bgp: Fix GoBGP policy prefix type conversion

### DIFF
--- a/pkg/bgp/gobgp/conversions.go
+++ b/pkg/bgp/gobgp/conversions.go
@@ -242,7 +242,7 @@ func toGoBGPPolicyStatement(apiStatement *types.RoutePolicyStatement, name strin
 			ds.Prefixes = append(ds.Prefixes, p)
 		}
 		s.Conditions.PrefixSet = &gobgp.MatchSet{
-			Type: toGoBGPPolicyMatchType(apiStatement.Conditions.MatchNeighbors.Type),
+			Type: toGoBGPPolicyMatchType(apiStatement.Conditions.MatchPrefixes.Type),
 			Name: ds.Name,
 		}
 		definedSets = append(definedSets, ds)

--- a/pkg/bgp/types/test_fixtures.go
+++ b/pkg/bgp/types/test_fixtures.go
@@ -96,7 +96,7 @@ var (
 					{
 						Conditions: RoutePolicyConditions{
 							MatchNeighbors: &RoutePolicyNeighborMatch{
-								Type:      RoutePolicyMatchAny,
+								Type:      RoutePolicyMatchInvert,
 								Neighbors: []netip.Addr{netip.MustParseAddr("172.16.0.1"), netip.MustParseAddr("10.10.10.10")},
 							},
 							MatchPrefixes: &RoutePolicyPrefixMatch{
@@ -137,7 +137,7 @@ var (
 								Neighbors: []netip.Addr{netip.MustParseAddr("fe80::210:5aff:feaa:20a2")},
 							},
 							MatchPrefixes: &RoutePolicyPrefixMatch{
-								Type: RoutePolicyMatchAny,
+								Type: RoutePolicyMatchInvert,
 								Prefixes: []RoutePolicyPrefix{
 									{
 										CIDR:         netip.MustParsePrefix("2001:0DB8::/64"),


### PR DESCRIPTION
Fixes invalid conversion logic for the BGP prefix condition type and enhances the tests input to cover this case.

Bug in the recently introduced change (https://github.com/cilium/cilium/pull/42714), so not marking as bug in release notes.