### PR TITLE
bpf: avoid redundant mac rewrite in common case

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -710,7 +710,7 @@ ipv6_forward_to_destination(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		/* See comment in handle_ipv4_from_lxc(). */
 		if ((ct_status == CT_REPLY || ct_status == CT_RELATED) &&
 		    identity_is_remote_node(dst_sec_identity))
-			goto pass_to_stack_hostfw;
+			goto pass_to_stack;
 #endif /* !ENABLE_NODEPORT && ENABLE_HOST_FIREWALL */
 
 		if (info && info->flag_has_tunnel_ep)
@@ -733,14 +733,7 @@ ipv6_forward_to_destination(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		return ret;
 	}
 
-pass_to_stack:
-#ifdef ENABLE_ROUTING
-	ret = ipv6_l3(ctx, ETH_HLEN, NULL, (__u8 *)&router_mac.addr, METRIC_EGRESS);
-	if (unlikely(ret != CTX_ACT_OK))
-		return ret;
-#endif
-
-pass_to_stack_hostfw: __maybe_unused
+pass_to_stack: __maybe_unused
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV6, dst_sec_identity,
 			  TRACE_EP_ID_UNKNOWN, TRACE_IFINDEX_UNKNOWN,
 			  trace->reason, trace->monitor, bpf_htons(ETH_P_IPV6));
@@ -1219,7 +1212,7 @@ skip_vtep:
 		 */
 		if ((ct_status == CT_REPLY || ct_status == CT_RELATED) &&
 		    identity_is_remote_node(dst_sec_identity))
-			goto pass_to_stack_hostfw;
+			goto pass_to_stack;
 #endif /* !ENABLE_NODEPORT && ENABLE_HOST_FIREWALL */
 
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
@@ -1272,14 +1265,7 @@ skip_vtep:
 		return ret;
 	}
 
-pass_to_stack:
-#ifdef ENABLE_ROUTING
-	ret = ipv4_l3(ctx, ETH_HLEN, NULL, (__u8 *)&router_mac.addr, ip4);
-	if (unlikely(ret != CTX_ACT_OK))
-		return ret;
-#endif
-
-pass_to_stack_hostfw: __maybe_unused
+pass_to_stack: __maybe_unused
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL_IPV4, dst_sec_identity,
 			  TRACE_EP_ID_UNKNOWN, TRACE_IFINDEX_UNKNOWN,
 			  trace->reason, trace->monitor, bpf_htons(ETH_P_IP));


### PR DESCRIPTION
In `bpf_lxc.c` there is a redundant destination MAC rewrite. 

```c
pass_to_stack:
#ifdef ENABLE_ROUTING
	ret = ipv6_l3(ctx, ETH_HLEN, NULL, (__u8 *)&router_mac.addr, METRIC_EGRESS);
	if (unlikely(ret != CTX_ACT_OK))
		return ret;
#endif
```

After several cups of coffee and internal banter we have determined that this mac rewrite is unnecessary. 

# ARP responder

In the common case we employee an ARP responder in the eBPF data path. 

In Cilium a pod's default route is over the VETH device, which is a layer 2 device.  
During an application's egress packet flow ARP is performed in and the packet is queued until ARP responds.

Cilium will respond to ARP and the egress packet will then dequeue. 
```mermaid
flowchart LR

subgraph pod-ns
	direction LR
	pod-->ip_output-->ip_neigh_for_gw-->q["queued for ARP or neigh lookup returned"]
end
```
In the common case where Cilium's ARP responder is in place, the data-path will respond with the MAC of the host-side VETH.

Notice, the queued ARP and its responses occur within the pod's network namespace. 
Therefore, we have a valid MAC address the host network namespace is happy to accept during the VETH forwarding handoff. 

# ARP Passthrough

There are scenarios where ARP passthrough is enabled and Cilium is not performing eBPF proxy ARP. 

One scenario is CNI chaining.
However, in this scenario `RequireRouting` is disabled for all endpoints and the above `ipv{4,6}_l3` call which rewrites the destination is not made. 
When `RequireRouting` is set to false the assumed scenario is that the host network namespace is handling ARP, whether that be via proxy arp, or some other mechanism, is not of Cilium's concern. 

The other scenario where ARP passthrough is enabled is when Netkit mode is enabled.
However, Netkit is a layer 3 device by default (and in Cilium's use case).
This device is a bit unique as its configured as a layer 2 device with the `IFF_NOARP` flag set.
This results in layer 2 headers being appended to egress traffic while no ARP is performed.  
A ping over Netkit devices peers looks as follows.

```
18:15:42.358787 00:00:00:00:00:00 > 00:00:00:00:00:00, ethertype IPv4 (0x0800), length 98: 10.1.0.1 > 8.8.8.8: ICMP echo request, id 39351, seq 4, length 64
```

So in the Netkit forwarding path any neighbor creation will have the hard-coded mac address of 0 and no ARP will be required to resolve this. 
The Netkit driver calls `eth_skb_pkt_type` to set `pkt_type` in the forwarding driver, **prior** to running the eBPF program. 
Therefore, the packet is already `PACKET_HOST` when `bpf_lxc` runs and we have no need to rewrite the destination MAC if we are going directly to the stack next, we've been accepted at layer 2 and we're heading towards layer 3 with `PACKET_HOST`. 

# Submission to stack

The redundant destination mac in focus is performed only when:
1. `ENABLE_ROUTING` is defined
	1. defined by default
	2. undefined for CNI chaining mode and EnableEndpointRoutes=true
2. The destination is a remote pod
3. We are immediately heading to the stack next 

Consider that by the time we even evaluate this destination mac rewrite `eth_type_trans` has already been called from the receive path of the ingress device. 
Therefore, even if we rewrite the destination MAC at this point it has no effect, the `pkt_type` is already set and we are going directly into layer 3 processing regardless, where the layer 2 header is of no consequence. 

# Redundant TTL Dec

The `ipv{4,6}_l3` functions are also doing a TTL decrement. 
However, this is also redundant. 
When the packet is submitted to stack if the host stack decides its routable it will perform its own TTL decrement in the `ip_forward` path. 

# Summary

From all perspectives the final `ipv4{4,6}_l3` call in `bpf_lxc` appears redundant. 
If the packet is immediately going to the stack both the TTL decrement and the destination MAC rewrite is of no consequence to the next layer 3 processing path. 

The genesis of this redirect is from commit: 
```
commit 99108598251cf4db382e6e6e0cef9d76a47a93ca
Author: Thomas Graf <thomas@cilium.io>
Date:   Thu Jan 28 00:19:17 2016 +0100

    Use the MAC of the host facing veth end as router MAC
    
    Signed-off-by: Thomas Graf <thomas@cilium.io>
```

In the above commit the original destination MAC rewrite was put in place.
This was redundant even at the genesis for the reasons mentioned above. 

```release-note
bpf: avoid redundant mac rewrite in bpf_lxc egress path
```