### PR TITLE
gha: wait for cert-manager CRDs to be ready in conformance clustermesh

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -535,6 +535,9 @@ jobs:
             CRD_URL="https://github.com/cert-manager/cert-manager/releases/download/${{ env.CERT_MANAGER_VERSION }}/cert-manager.crds.yaml"
             kubectl --context $ctx apply -f $CRD_URL
 
+            # Wait for the CRDs to have been processed by the Kubernetes API Server.
+            kubectl --context $ctx wait --for condition=established --timeout=1m crds --all
+
             # Create the Cilium CA secret
             kubectl --context $ctx create -n kube-system secret tls cilium-root-ca \
               --key=cilium-ca-key.pem --cert=cilium-ca-crt.pem


### PR DESCRIPTION
Otherwise, we are subject to a possible race condition, in case the issuer is attempted to be created before the corresponding CRD has been processed by the Kubernetes API Server, leading to an error along the lines of:

>  resource mapping not found for name: "cilium" namespace: "kube-system" from "issuer.yaml": no matches for kind "Issuer" in version "cert-manager.io/v1"
