### PR TITLE
[v1.18] vendor: Bump to StateDB v0.4.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cilium/hive v0.0.0-20250611195437-5a5dacdfb354
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.4.5
+	github.com/cilium/statedb v0.4.6
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.4.5 h1:WP1xbkAdDup0wOkhRZUJG/Wh4+ZLAOgl7yIIxJ3vIEo=
-github.com/cilium/statedb v0.4.5/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
+github.com/cilium/statedb v0.4.6 h1:pundFmW0Dhinsv0ZINdFsxzlb6d3ZQkQM7aJW9eMtD8=
+github.com/cilium/statedb v0.4.6/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/Makefile
+++ b/vendor/github.com/cilium/statedb/Makefile
@@ -6,7 +6,7 @@ build:
 	go build ./...
 
 test:
-	go test ./... -cover -vet=all -test.count 1
+	PART_VALIDATE=1 go test ./... -cover -vet=all -test.count 1
 
 test-race:
 	go test -race ./... -test.count 1

--- a/vendor/github.com/cilium/statedb/part/tree.go
+++ b/vendor/github.com/cilium/statedb/part/tree.go
@@ -69,6 +69,7 @@ func (t *Tree[T]) Txn() *Txn[T] {
 		txn = newTxn[T](t.opts)
 	}
 	txn.opts = t.opts
+	txn.oldRoot = t.root
 	txn.root = t.root
 	txn.size = t.size
 	return txn

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -290,7 +290,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.4.5
+# github.com/cilium/statedb v0.4.6
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This fixes few cases where a watch channel was not properly closed (empty key and removal of now empty leafless inner node). Luckily the surface area for bugs was small; this was only really affecting `PrefixWatch`. This was only used by LRP and this could've potentially caused not processing the removal of a pod namespace in a situation where all the pods under that namespace was removed in one single WriteTxn. There were no known incidents in v1.18 caused by this.

https://github.com/cilium/statedb/releases/tag/v0.4.6