### PR TITLE
renovate: Allow only patch version for go-control-plane

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -656,6 +656,16 @@
       "versioning": "regex:^(?<major>\\d+)-[a-f0-9]{7}$",
     },
     {
+      // Avoid updating minor or major version for github.com/envoyproxy/go-control-plane/envoy
+      // as we need to update cilium-envoy accordingly.
+      "matchPackageNames": [
+        "github.com/envoyproxy/go-control-plane/envoy",
+      ],
+      "matchUpdateTypes": [
+        "patch",
+      ]
+    },
+    {
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/42801#discussion_r2548808392