### PR TITLE
bpf: tests: egressgw: enable HostFW

### DIFF
--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -85,7 +85,7 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 		       const union v6addr *tunnel_ep, __u8 spi, bool flag_skip_tunnel,
 		       bool ipv6_underlay)
 {
-	struct ipcache_key key = {
+	struct ipcache_key key __align_stack_8 = {
 		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(V6_CACHE_KEY_LEN),
 		.cluster_id = cluster_id,
 		.family = ENDPOINT_KEY_IPV6,

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -34,7 +34,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_redirect")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
@@ -68,7 +68,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 {
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_EXCL_CIDR));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
@@ -111,7 +111,7 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 	};
 
 	map_delete_elem(&cilium_metrics, &key);
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY,
 				  EGRESS_IP);
@@ -168,7 +168,7 @@ int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 	};
 
 	map_delete_elem(&cilium_metrics, &key);
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
 	create_ct_entry(ctx, client_port(TEST_DROP_NO_EGRESS_IP));

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -6,12 +6,13 @@
 #include "pktgen.h"
 
 /* Enable code paths under test */
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_NODEPORT
-#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_EGRESS_GATEWAY		1
 #define ENABLE_MASQUERADE_IPV4		1
 #define ENABLE_MASQUERADE_IPV6		1
+#define ENABLE_HOST_FIREWALL		1
 #define ENCAP_IFINDEX 0
 
 #include "lib/bpf_host.h"
@@ -38,6 +39,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	create_ct_entry(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -74,6 +76,7 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 				  EGRESS_IP);
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR,
 				  EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -230,6 +233,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -273,6 +277,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 				     &egress_ip, 0);
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
 				     &egress_ip, 0);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	return netdev_send_packet(ctx);
 }

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -6,12 +6,13 @@
 #include "pktgen.h"
 
 /* Enable code paths under test */
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_NODEPORT
-#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_EGRESS_GATEWAY		1
 #define ENABLE_MASQUERADE_IPV4		1
 #define ENABLE_MASQUERADE_IPV6		1
+#define ENABLE_HOST_FIREWALL		1
 #define ENCAP_IFINDEX		42
 #define SECONDARY_IFACE_IFINDEX	44
 
@@ -92,6 +93,7 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -187,6 +189,7 @@ int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -220,6 +223,7 @@ int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP3);
+	ipcache_v4_add_entry(EGRESS_IP3, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -370,6 +374,7 @@ int egressgw_fib_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP2);
+	ipcache_v4_add_entry(EGRESS_IP2, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -411,6 +416,7 @@ int egressgw_snat1_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -515,6 +521,7 @@ int egressgw_tuple_collision1_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -555,6 +562,7 @@ int egressgw_tuple_collision2_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 
@@ -718,6 +726,7 @@ int egressgw_fib_redirect_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
 


### PR DESCRIPTION
```
Let's validate that EGW replies (ext_endpoint -> EgressIP) make it through
the ingress path on the GW node without being blocked by the HostFW.

This relies on the following sequence
1. RevSNAT (turns the packet into ext_endpoint -> PodIP), then
2. HostFW ingress enforcement, which does an on-the-spot ipcache lookup for
   the daddr (PodIP) and breaks out if the matched identity is not HOST_ID.

Also enable HostFW in the "redirect_from_host" tests, even though this only
tests the egress path on the GW node.
```
