### PR TITLE
pkg/lrp: add forceRedirectOrDrop to CLRP

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
@@ -60,6 +60,17 @@ spec:
                   RedirectBackend specifies backend configuration to redirect traffic to.
                   It can not be empty.
                 properties:
+                  forceRedirectOrDrop:
+                    default: false
+                    description: |-
+                      ForceRedirectOrDrop indicates whether traffic matching RedirectFrontend should be
+                      redirected/dropped even if no backends match LocalEndpointSelector.
+
+                      If false (default): If no backends are found, the redirect is removed and traffic
+                      proceeds to the original destination.
+
+                      If true: If no backends are found, traffic is dropped.
+                    type: boolean
                   localEndpointSelector:
                     description: LocalEndpointSelector selects node local pod(s) where
                       traffic is redirected to.

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -152,6 +152,18 @@ type RedirectBackend struct {
 	//
 	// +kubebuilder:validation:Required
 	ToPorts []PortInfo `json:"toPorts"`
+
+	// ForceRedirectOrDrop indicates whether traffic matching RedirectFrontend should be
+	// redirected/dropped even if no backends match LocalEndpointSelector.
+	//
+	// If false (default): If no backends are found, the redirect is removed and traffic
+	// proceeds to the original destination.
+	//
+	// If true: If no backends are found, traffic is dropped.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	ForceRedirectOrDrop bool `json:"forceRedirectOrDrop,omitempty"`
 }
 
 // CiliumLocalRedirectPolicySpec specifies the configurations for redirecting traffic

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -2421,6 +2421,10 @@ func (in *RedirectBackend) DeepEqual(other *RedirectBackend) bool {
 		}
 	}
 
+	if in.ForceRedirectOrDrop != other.ForceRedirectOrDrop {
+		return false
+	}
+
 	return true
 }
 

--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -320,7 +320,7 @@ func (c *lrpController) updateRedirects(wtxn writer.WriteTxn, ws *statedb.WatchS
 		// In address-based mode there is no existing service/frontend to match against and
 		// instead the frontend is created here.
 		for _, feM := range lrp.FrontendMappings {
-			if len(pods) == 0 {
+			if len(pods) == 0 && !lrp.ForceRedirectOrDrop {
 				// No pods exist to redirect the traffic to. Remove the frontend to let the traffic
 				// be handled normally.
 				c.p.Writer.DeleteFrontend(wtxn, feM.feAddr)
@@ -463,7 +463,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 
 func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.Frontend, pods []podInfo) bool {
 	// 0. Don't redirect if we have no matching target pods.
-	if len(pods) == 0 {
+	if len(pods) == 0 && !lrp.ForceRedirectOrDrop {
 		return false
 	}
 

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
@@ -109,6 +109,9 @@ type LocalRedirectPolicy struct {
 	// SkipRedirectFromBackend is the flag that enables/disables redirection
 	// for traffic matching the policy frontend(s) from the backends selected by the policy
 	SkipRedirectFromBackend bool
+	// ForceRedirectOrDrop indicates whether traffic matching RedirectFrontend should be
+	// redirected/dropped even if no backends match LocalEndpointSelector.
+	ForceRedirectOrDrop bool
 }
 
 func (lrp *LocalRedirectPolicy) TableHeader() []string {
@@ -326,5 +329,6 @@ func getSanitizedLocalRedirectPolicy(cfg Config, log *slog.Logger, name, namespa
 		FrontendType:            frontendType,
 		SkipRedirectFromBackend: spec.SkipRedirectFromBackend,
 		ID:                      lb.NewServiceName(namespace, name),
+		ForceRedirectOrDrop:     redirectTo.ForceRedirectOrDrop,
 	}, nil
 }

--- a/pkg/loadbalancer/redirectpolicy/testdata/force-redirect.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/force-redirect.txtar
@@ -1,0 +1,87 @@
+#! --lrp-address-matcher-cidrs=169.254.169.0/24
+
+hive start
+
+# Add a pod
+k8s/add pod.yaml
+
+# Add LRP with ForceRedirectOrDrop enabled
+k8s/add lrp.yaml
+
+# Wait for the frontend.
+db/show frontends
+* stdout '169.254.169.254:8080/TCP.*10.244.2.1:80/TCP.*Done'
+
+# Delete the pod
+k8s/delete pod.yaml
+
+# Frontend should still exist, but with no backends because of ForceRedirectOrDrop
+db/show frontends
+* stdout '169.254.169.254:8080/TCP'
+! stdout '169.254.169.254:80/TCP'
+
+# Update LRP to disable ForceRedirectOrDrop
+replace 'forceRedirectOrDrop: true' 'forceRedirectOrDrop: false' lrp.yaml
+k8s/update lrp.yaml
+
+# Frontend should be gone (no backends and no force redirect)
+db/show frontends
+* stdout 'Address.*Type.*ServiceName.*Backends.*RedirectTo.*Status'
+!* stdout '169.254.169.254'
+
+# ---
+
+-- lrp.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-force"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    forceRedirectOrDrop: true
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready


### PR DESCRIPTION
# add `forceRedirectOrDrop` to CLRP

This commit implements a `forceRedirectOrDrop` functionality in CiliumLocalRedirectPolicy. When enabled, this flag ensures that traffic matching the `RedirectFrontend` is dropped if no backends are found (i.e., `LocalEndpointSelector` matches no pods). If there is a backend (via overrideIP), then traffic is redirected regardless of if the backend is healthy.

## Changes

-   **Added `forceRedirectOrDrop` flag:** A new boolean field `forceRedirectOrDrop` is added to the `redirectBackend` section of the `CiliumLocalRedirectPolicySpec`.
-   **Controller modification:** The LRP controller is updated to preserve the frontend service entry in the BPF map even when the backend count is zero, provided `forceRedirectOrDrop` is set to `true`.
-   **Datapath behavior:** The existing BPF datapath behavior is leveraged. When a service has no backends, the BPF program returns `DROP_NO_SERVICE`, which results in the packet being dropped.
-   **New test case:** A new test case is added to verify the `forceRedirectOrDrop` functionality.
-   **CRD documentation:** The `ciliumlocalredirectpolicies.yaml` CRD documentation is updated to include the new `forceRedirectOrDrop` field.

## Feature Example

The `forceRedirectOrDrop` flag controls the behavior of the local redirect policy when no backends are available.

**Without `forceRedirectOrDrop` (default behavior):**

If `forceRedirectOrDrop` is `false` or not set, and the `LocalEndpointSelector` matches no pods, the entire redirect policy is withdrawn. Traffic will proceed to the original destination as if the policy did not exist. There is no change with the current behavior.

**With `forceRedirectOrDrop: true`:**

If `forceRedirectOrDrop` is set to `true`, and the `LocalEndpointSelector` matches no pods, the frontend redirect rule is kept in place, but with no backends. Any traffic matching the frontend will be dropped by the BPF datapath. This is useful in scenarios where you want to ensure that traffic does not bypass the redirect policy, even if the backend services are temporarily unavailable.

For example, consider a policy that redirects traffic from `169.254.169.254:8080` to a local proxy pod. If the proxy pod is deleted, with `forceRedirectOrDrop: true`, traffic to `169.254.169.254:8080` will be dropped. If `forceRedirectOrDrop: false`, the traffic would be sent to `169.254.169.254:8080` on the host.

## Example YAML

Here is an example of a `CiliumLocalRedirectPolicy` with the `forceRedirectOrDrop` flag enabled:

```yaml
apiVersion: "cilium.io/v2"
kind: CiliumLocalRedirectPolicy
metadata:
  name: "lrp-force"
  namespace: "test"
spec:
  redirectFrontend:
    addressMatcher:
      ip: "169.254.169.254"
      toPorts:
        - port: "8080"
          protocol: TCP
  redirectBackend:
    forceRedirectOrDrop: true
    localEndpointSelector:
      matchLabels:
        app: proxy
    toPorts:
      - port: "80"
        protocol: TCP
```

TODO: Once https://github.com/cilium/cilium/pull/41645 is merged, this PR will require a rewrite to ensure that they are compatible.

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
