### PR TITLE
v1.17 Backport Endpoint Selector Policy deadlock fixes

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -218,7 +218,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 
 	var selectorPolicy policy.SelectorPolicy
-	selectorPolicy, result.policyRevision, err = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats)
+	selectorPolicy, result.policyRevision, err = e.policyGetter.GetPolicyRepository().GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats, e.GetID())
 	if err != nil {
 		e.getLogger().WithError(err).Warning("Failed to calculate SelectorPolicy")
 		return err

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -58,7 +58,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 	cip, ok := cache.policies[identity.ID]
 	if ok {
 		delete(cache.policies, identity.ID)
-		cip.getPolicy().Detach()
+		cip.getPolicy().detach()
 	}
 	return ok
 }
@@ -178,6 +178,6 @@ func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy) {
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {
 		// Release the references the previous policy holds on the selector cache.
-		oldPolicy.Detach()
+		oldPolicy.detach()
 	}
 }

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -58,7 +58,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 	cip, ok := cache.policies[identity.ID]
 	if ok {
 		delete(cache.policies, identity.ID)
-		cip.getPolicy().detach()
+		cip.getPolicy().detach(true, 0)
 	}
 	return ok
 }
@@ -66,11 +66,15 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 // updateSelectorPolicy resolves the policy for the security identity of the
 // specified endpoint and stores it internally. It will skip policy resolution
 // if the cached policy is already at the revision specified in the repo.
+// The endpointID specifies which endpoint initiated this selector policy
+// update. This ensures that endpoints are not continuously triggering regenerations
+// of themselves if the selector policy is created and initiates a regeneration trigger
+// on detach.
 //
 // Returns whether the cache was updated, or an error.
 //
 // Must be called with repo.Mutex held for reading.
-func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity) (*selectorPolicy, bool, error) {
+func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
 	cip := cache.lookupOrCreate(identity)
 
 	// As long as UpdatePolicy() is triggered from endpoint
@@ -96,7 +100,7 @@ func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity) (
 		return nil, false, err
 	}
 
-	cip.setPolicy(selPolicy)
+	cip.setPolicy(selPolicy, endpointID)
 
 	return selPolicy, true, nil
 }
@@ -173,11 +177,14 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 }
 
 // setPolicy updates the reference to the SelectorPolicy that is cached.
-// Calls Detach() on the old policy, if any.
-func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy) {
+// Calls Detach() on the old policy, if any. It passes the endpointID of
+// the endpoint that initiated the old selector policy detach. Since detach
+// can trigger endpoint regenerations of all it users, this ensures
+// that endpoints do not continuously update themselves.
+func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) {
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {
 		// Release the references the previous policy holds on the selector cache.
-		oldPolicy.detach()
+		oldPolicy.detach(false, endpointID)
 	}
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -54,10 +54,10 @@ func TestCacheManagement(t *testing.T) {
 	require.False(t, deleted)
 
 	// Insert identity twice. Should be the same policy.
-	policy1, updated, err := cache.updateSelectorPolicy(identity)
+	policy1, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
-	policy2, updated, err := cache.updateSelectorPolicy(identity)
+	policy2, updated, err := cache.updateSelectorPolicy(identity, ep1.Id)
 	require.NoError(t, err)
 	require.False(t, updated)
 	// must be same pointer
@@ -76,13 +76,13 @@ func TestCacheManagement(t *testing.T) {
 	ep3.SetIdentity(1234, true)
 	identity3 := ep3.GetSecurityIdentity()
 	require.NotEqual(t, identity, identity3)
-	policy1, _, _ = cache.updateSelectorPolicy(identity)
+	policy1, _, _ = cache.updateSelectorPolicy(identity, ep1.Id)
 	require.NotNil(t, policy1)
-	policy3, _, _ := cache.updateSelectorPolicy(identity3)
+	policy3, _, _ := cache.updateSelectorPolicy(identity3, ep3.Id)
 	require.NotNil(t, policy3)
 	require.NotSame(t, policy3, policy1)
 	_ = cache.delete(identity)
-	_, updated, _ = cache.updateSelectorPolicy(identity3)
+	_, updated, _ = cache.updateSelectorPolicy(identity3, ep3.Id)
 	require.False(t, updated)
 }
 
@@ -95,26 +95,26 @@ func TestCachePopulation(t *testing.T) {
 	require.Equal(t, identity1, ep2.GetSecurityIdentity())
 
 	// Calculate the policy and observe that it's cached
-	policy1, updated, err := cache.updateSelectorPolicy(identity1)
+	policy1, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
-	_, updated, err = cache.updateSelectorPolicy(identity1)
+	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.False(t, updated)
-	policy2, _, _ := cache.updateSelectorPolicy(identity1)
+	policy2, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NotNil(t, policy2)
 	require.Same(t, policy1, policy2)
 
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	_, updated, _ = cache.updateSelectorPolicy(identity1)
+	_, updated, _ = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.True(t, updated)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint()
 	ep3.SetIdentity(1234, true)
-	policy3, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity())
+	policy3, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
 
@@ -401,7 +401,7 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // distillEndpointPolicy distills the policy repository into an EndpointPolicy
 // Caller is responsible for Ready() & Detach() when done with the policy
 func (d *policyDistillery) distillEndpointPolicy(owner PolicyOwner, identity *identity.Identity) (*EndpointPolicy, error) {
-	sp, _, err := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{})
+	sp, _, err := d.Repository.GetSelectorPolicy(identity, 0, &dummyPolicyStats{}, owner.GetID())
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate policy: %w", err)
 	}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1806,17 +1806,17 @@ func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn *versioned.Tx) {
 	l4Policy.mutex.RUnlock()
 }
 
-// Detach makes the L4Policy ready for garbage collection, removing
+// detach makes the L4Policy ready for garbage collection, removing
 // circular pointer references.
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
-func (l4 *L4Policy) Detach(selectorCache *SelectorCache) {
+func (l4 *L4Policy) detach(selectorCache *SelectorCache) {
 	l4.Ingress.Detach(selectorCache)
 	l4.Egress.Detach(selectorCache)
 
 	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
 	l4.users = nil
-	l4.mutex.Unlock()
 }
 
 // Attach makes all the L4Filters to point back to the L4Policy that contains them.

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -1808,14 +1809,29 @@ func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn *versioned.Tx) {
 
 // detach makes the L4Policy ready for garbage collection, removing
 // circular pointer references.
+// The endpointID argument is only necessary if isDelete is false.
+// It ensures that detach does not call a regeneration trigger on
+// the same endpoint that initiated a selector policy update.
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
-func (l4 *L4Policy) detach(selectorCache *SelectorCache) {
+func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpointID uint64) {
 	l4.Ingress.Detach(selectorCache)
 	l4.Egress.Detach(selectorCache)
 
 	l4.mutex.Lock()
 	defer l4.mutex.Unlock()
+	// If this detach is a delete there is no reason to initiate
+	// a regenerate.
+	if !isDelete {
+		for ePolicy := range l4.users {
+			if endpointID != ePolicy.PolicyOwner.GetID() {
+				ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "selector policy has changed because of another endpoint with the same identity",
+					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+				})
+			}
+		}
+	}
 	l4.users = nil
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1825,7 +1825,7 @@ func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpoint
 	if !isDelete {
 		for ePolicy := range l4.users {
 			if endpointID != ePolicy.PolicyOwner.GetID() {
-				ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+				go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
 					Reason:            "selector policy has changed because of another endpoint with the same identity",
 					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 				})

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1965,6 +1965,6 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()
-	p.detach()
+	p.detach(true, 0)
 	assert.Positive(t, n)
 }

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1965,6 +1965,6 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()
-	p.Detach()
+	p.detach()
 	assert.Positive(t, n)
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -138,7 +138,7 @@ type PolicyRepository interface {
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
-	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error)
+	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
 
 	GetRevision() uint64
 	GetRulesList() *models.Policy
@@ -853,7 +853,7 @@ func wildcardRule(lbls labels.LabelArray, ingress bool) *rule {
 // This is used to skip policy calculation when a certain revision delta is
 // known to not affect the given identity. Pass a skipRevision of 0 to force
 // calculation.
-func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics) (SelectorPolicy, uint64, error) {
+func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error) {
 	stats.WaitingForPolicyRepository().Start()
 	r.RLock()
 	defer r.RUnlock()
@@ -870,7 +870,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	stats.PolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, updated, err := r.policyCache.updateSelectorPolicy(id)
+	sp, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
 	stats.PolicyCalculation().EndError(err)
 
 	// If we hit cache, reset the statistics.

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1371,7 +1371,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.Detach(td.sc)
+	expectedDeny.detach(td.sc)
 
 	// L4 from app3 has no rules
 	expectedDeny = NewL4Policy(repo.GetRevision())
@@ -1380,7 +1380,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 	require.Equal(t, 0, l4IngressDenyPolicy.Len())
 	require.Equal(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy)
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.Detach(td.sc)
+	expectedDeny.detach(td.sc)
 }
 
 func buildDenyRule(from, to, port string) api.Rule {

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1371,7 +1371,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.detach(td.sc)
+	expectedDeny.detach(td.sc, true, 0)
 
 	// L4 from app3 has no rules
 	expectedDeny = NewL4Policy(repo.GetRevision())
@@ -1380,7 +1380,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 	require.Equal(t, 0, l4IngressDenyPolicy.Len())
 	require.Equal(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy)
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.detach(td.sc)
+	expectedDeny.detach(td.sc, true, 0)
 }
 
 func buildDenyRule(from, to, port string) api.Rule {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2065,7 +2065,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressPolicy.Detach(td.sc)
-	expected.Detach(td.sc)
+	expected.detach(td.sc)
 
 	// L4 from app3 has no rules
 	expected = NewL4Policy(repo.GetRevision())
@@ -2074,7 +2074,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 	require.Equal(t, 0, l4IngressPolicy.Len())
 	require.Equal(t, expected.Ingress.PortRules, l4IngressPolicy)
 	l4IngressPolicy.Detach(td.sc)
-	expected.Detach(td.sc)
+	expected.detach(td.sc)
 }
 
 func buildSearchCtx(from, to string, port uint16) *SearchContext {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2065,7 +2065,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressPolicy.Detach(td.sc)
-	expected.detach(td.sc)
+	expected.detach(td.sc, true, 0)
 
 	// L4 from app3 has no rules
 	expected = NewL4Policy(repo.GetRevision())
@@ -2074,7 +2074,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 	require.Equal(t, 0, l4IngressPolicy.Len())
 	require.Equal(t, expected.Ingress.PortRules, l4IngressPolicy)
 	l4IngressPolicy.Detach(td.sc)
-	expected.detach(td.sc)
+	expected.detach(td.sc, true, 0)
 }
 
 func buildSearchCtx(from, to string, port uint16) *SearchContext {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -143,11 +143,11 @@ func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
 	p.L4Policy.removeUser(user)
 }
 
-// Detach releases resources held by a selectorPolicy to enable
+// detach releases resources held by a selectorPolicy to enable
 // successful eventual GC.  Note that the selectorPolicy itself if not
 // modified in any way, so that it can be used concurrently.
-func (p *selectorPolicy) Detach() {
-	p.L4Policy.Detach(p.SelectorCache)
+func (p *selectorPolicy) detach() {
+	p.L4Policy.detach(p.SelectorCache)
 }
 
 // DistillPolicy filters down the specified selectorPolicy (which acts

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/container/versioned"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -120,6 +121,7 @@ type PolicyOwner interface {
 	PolicyDebug(fields logrus.Fields, msg string)
 	IsHost() bool
 	MapStateSize() int
+	RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool
 }
 
 // newSelectorPolicy returns an empty selectorPolicy stub.
@@ -146,8 +148,11 @@ func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
 // detach releases resources held by a selectorPolicy to enable
 // successful eventual GC.  Note that the selectorPolicy itself if not
 // modified in any way, so that it can be used concurrently.
-func (p *selectorPolicy) detach() {
-	p.L4Policy.detach(p.SelectorCache)
+// The endpointID argument is only necessary if isDelete is false.
+// It ensures that detach does not call a regeneration trigger on
+// the same endpoint that initiated a selector policy update.
+func (p *selectorPolicy) detach(isDelete bool, endpointID uint64) {
+	p.L4Policy.detach(p.SelectorCache, isDelete, endpointID)
 }
 
 // DistillPolicy filters down the specified selectorPolicy (which acts

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -192,7 +192,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
-	ip.detach()
+	ip.detach(true, 0)
 	b.Logf("Number of MapState entries: %d\n", owner.mapStateSize)
 }
 
@@ -203,7 +203,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	epPolicy := ip.DistillPolicy(DummyOwner{}, nil)
 	n := epPolicy.policyMapState.Len()
 	epPolicy.Ready()
-	ip.detach()
+	ip.detach(true, 0)
 	assert.Positive(t, n)
 }
 
@@ -278,7 +278,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -373,7 +373,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -482,7 +482,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	require.Empty(t, policy.policyMapChanges.synced)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -649,7 +649,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	require.Equal(t, Keys{}, changes.Deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -192,7 +192,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
-	ip.Detach()
+	ip.detach()
 	b.Logf("Number of MapState entries: %d\n", owner.mapStateSize)
 }
 
@@ -203,7 +203,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	epPolicy := ip.DistillPolicy(DummyOwner{}, nil)
 	n := epPolicy.policyMapState.Len()
 	epPolicy.Ready()
-	ip.Detach()
+	ip.detach()
 	assert.Positive(t, n)
 }
 
@@ -278,7 +278,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -373,7 +373,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -482,7 +482,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	require.Empty(t, policy.policyMapChanges.synced)
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -649,7 +649,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	require.Equal(t, Keys{}, changes.Deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -197,7 +197,7 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 		owner.mapStateSize = epPolicy.policyMapState.Len()
 		epPolicy.Ready()
 	}
-	ip.Detach()
+	ip.detach()
 	b.Logf("Number of MapState entries: %d\n", owner.mapStateSize)
 }
 
@@ -209,7 +209,7 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(DummyOwner{}, nil)
 		policy.Ready()
-		ip.Detach()
+		ip.detach()
 	}
 }
 
@@ -221,7 +221,7 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(DummyOwner{}, nil)
 		policy.Ready()
-		ip.Detach()
+		ip.detach()
 	}
 }
 
@@ -314,7 +314,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -427,7 +427,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -534,7 +534,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	require.Empty(t, policy.policyMapChanges.synced) // XXX why 0?
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -702,7 +702,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -128,8 +128,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	// Foo isn't selected in the rule1's policy.
 	ingressState = traceState{}
@@ -254,8 +254,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	ingressState = traceState{}
 	egressState = traceState{}
@@ -1153,8 +1153,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
 
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	// A rule for Ports and ICMP
 	rule2 := &rule{
@@ -1212,8 +1212,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, ingressState.selectedRules)
 	require.Equal(t, 1, ingressState.matchedRules)
 
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	// A rule for ICMPv6
 	icmpV6Type := intstr.FromInt(128)
@@ -1605,7 +1605,7 @@ func TestL4RuleLabels(t *testing.T) {
 			require.Len(t, out.RuleOrigin, 1, test.description)
 			require.EqualValues(t, test.expectedEgressLabels[portProto], out.RuleOrigin[out.wildcard], test.description)
 		}
-		finalPolicy.Detach(td.sc)
+		finalPolicy.detach(td.sc)
 	}
 }
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -128,8 +128,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	// Foo isn't selected in the rule1's policy.
 	ingressState = traceState{}
@@ -254,8 +254,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	ingressState = traceState{}
 	egressState = traceState{}
@@ -1153,8 +1153,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
 
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	// A rule for Ports and ICMP
 	rule2 := &rule{
@@ -1212,8 +1212,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, ingressState.selectedRules)
 	require.Equal(t, 1, ingressState.matchedRules)
 
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	// A rule for ICMPv6
 	icmpV6Type := intstr.FromInt(128)
@@ -1605,7 +1605,7 @@ func TestL4RuleLabels(t *testing.T) {
 			require.Len(t, out.RuleOrigin, 1, test.description)
 			require.EqualValues(t, test.expectedEgressLabels[portProto], out.RuleOrigin[out.wildcard], test.description)
 		}
-		finalPolicy.detach(td.sc)
+		finalPolicy.detach(td.sc, true, 0)
 	}
 }
 


### PR DESCRIPTION
 * [x] #37910 (@nathanjsweet) :warning: resolved conflicts
 * [x] #38139 (@nathanjsweet)
 * [x] #42306 (@odinuge)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37910 38139 42306
```

Dedicated backport PR to bundle all related fixes & potential discussion.

See also this discussion: https://github.com/cilium/cilium/pull/37910#issuecomment-3514010439