### PR TITLE
etcd: require quorum/leader on etcd range requests

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -891,8 +891,7 @@ func (e *etcdClient) paginatedList(ctx context.Context, log *slog.Logger, prefix
 	for {
 		res, err := e.client.Get(ctx, start, client.WithRange(end),
 			client.WithSort(client.SortByKey, client.SortAscend),
-			client.WithRev(revision), client.WithSerializable(),
-			client.WithLimit(int64(e.listBatchSize)),
+			client.WithRev(revision), client.WithLimit(int64(e.listBatchSize)),
 		)
 		if err != nil {
 			return nil, 0, err


### PR DESCRIPTION
tl;dr this fixes an issue where cilium-agents cause network starvation for etcd and potentially cause OOM kills of etcd, in situations where there is no leader in the cluster. We have seen this cause network starvation on etcd, and triggering a loop of OOM kills - leading to situations that are hard to recover from.

See commit messages for more information.

This failure mode is also "hidden" in cilium-agent/operator metrics, so I'll open a separate patchset to add more visibility on kvstore operations done by the watcher. In logs it will look like this, and run in a loop;
```
time=2025-11-25T12:56:27.283937796Z level=info source=/go/src/github.com/cilium/cilium/pkg/kvstore/etcd.go:721 msg="Successfully listed keys before starting watcher" module=agent.infra.kvstore-client backendName=etcd endpoints=[http://10.244.0.168:2379] config=/var/lib/etcd-config/etcd.config prefix=cilium/state/identities/v1/id count=3 revision=76
time=2025-11-25T12:56:27.486119046Z level=info source=/go/src/github.com/cilium/cilium/pkg/kvstore/etcd.go:833 msg="Etcd watcher errored. Triggering relist of all keys" module=agent.infra.kvstore-client backendName=etcd endpoints=[http://10.244.0.168:2379] config=/var/lib/etcd-config/etcd.config prefix=cilium/state/identities/v1/id error="etcdserver: no leader" revision=0
```

Fixes: 08d891a ("Add leader requirement to watch from Etcd.")

Added the above ^ `Fixes` tag since that made this _worse_. The `client.WithSerializable` has been here since it was introduced in 2017 in https://github.com/cilium/cilium/pull/1365.

```release-note
Ensure cilium-agent gracefully does fallbacks when etcd is in a bad state.
```
