### PR TITLE
tests: remove identity manager from ignored error messages

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -53,7 +53,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, removeInexistentID, knownIssueWireguardCollision, nilDetailsForService}
+		failedToListCRDs, knownIssueWireguardCollision, nilDetailsForService}
 
 	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
 	envoyExternalOtherTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalOtherTarget))}
@@ -409,13 +409,12 @@ const (
 
 	// errors
 	panicMessage                       = "panic:"
-	deadLockHeader                     = "POTENTIAL DEADLOCK:"                                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
-	RunInitFailed                      = "JoinEP: "                                             // from https://github.com/cilium/cilium/pull/5052
-	RemovingMapMsg                     = "Removing map to allow for property upgrade"           // from https://github.com/cilium/cilium/pull/10626
-	symbolSubstitution                 = "Skipping symbol substitution"                         //
-	uninitializedRegen                 = "Uninitialized regeneration level"                     // from https://github.com/cilium/cilium/pull/10949
-	unstableStat                       = "BUG: stat() has unstable behavior"                    // from https://github.com/cilium/cilium/pull/11028
-	removeInexistentID   stringMatcher = "removing identity not added to the identity manager!" // from https://github.com/cilium/cilium/issues/16419
+	deadLockHeader                     = "POTENTIAL DEADLOCK:"                        // from github.com/sasha-s/go-deadlock/deadlock.go:header
+	RunInitFailed                      = "JoinEP: "                                   // from https://github.com/cilium/cilium/pull/5052
+	RemovingMapMsg                     = "Removing map to allow for property upgrade" // from https://github.com/cilium/cilium/pull/10626
+	symbolSubstitution                 = "Skipping symbol substitution"               //
+	uninitializedRegen                 = "Uninitialized regeneration level"           // from https://github.com/cilium/cilium/pull/10949
+	unstableStat                       = "BUG: stat() has unstable behavior"          // from https://github.com/cilium/cilium/pull/11028
 	missingIptablesWait                = "Missing iptables wait arg (-w):"
 	localIDRestoreFail                 = "Could not restore all CIDR identities" // from https://github.com/cilium/cilium/pull/19556
 	routerIPMismatch                   = "Mismatch of router IPs found during restoration"

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -188,7 +188,6 @@ const (
 	opCantBeFulfilled          = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
 	initLeaderElection         = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
 	globalDataSupport          = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
-	removeInexistentID         = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
 	failedToListCRDs           = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
 	retrieveResLock            = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
 	failedToRelLockEmptyName   = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
@@ -254,8 +253,8 @@ var badLogMessages = map[string][]string{
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
 	logutils.ErrorLogs: {opCantBeFulfilled, initLeaderElection, globalDataSupport,
-		removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName,
-		failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
+		failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock,
+		failedToReleaseLock, errorCreatingInitialLeader},
 	logutils.WarningLogs: {cantEnableJIT, delMissingService, podCIDRUnavailable,
 		unableGetNode, objectHasBeenModified, etcdTimeout, endpointRestoreFailed,
 		cantFindIdentityInCache, keyAllocFailedFoundMaster, cantRecreateMasterKey,


### PR DESCRIPTION
This removes a logline in the list of ignored errors. We want to catch this since it points directly to correctness issues. When this occurs, its an issue with the reference counting of identity use - and either there is a leak, or some things are detached prematurely that can cause policy issues.

Fixes: https://github.com/cilium/cilium/issues/16419