### PR TITLE
Fix connectivity tests for access to link-local (host) nodelocaldns

### DIFF
--- a/cilium-cli/connectivity/builder/manifests/allow-all-except-world.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-all-except-world.yaml
@@ -15,17 +15,16 @@ spec:
   - toEndpoints:
     - matchExpressions:
       - { key: io.cilium.k8s.policy.cluster, operator: Exists }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  # For nodelocaldns using a link-local address (the "localip" mode).
   - toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
+    # Including 'world' here may still be needed for versions up to 1.16 (#997)
     toEntities:
+      - host
       - world
   ingress:
   - fromEntities:

--- a/cilium-cli/connectivity/builder/manifests/client-egress-only-dns.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-only-dns.yaml
@@ -36,10 +36,7 @@ spec:
       - { key: 'dns.operator.openshift.io/daemonset-dns', operator: Exists }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "openshift-dns" ] }
       - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}" ] }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  # For nodelocaldns using a link-local address (the "localip" mode).
   - toPorts:
     - ports:
       - port: "53"
@@ -49,5 +46,7 @@ spec:
       rules:
         dns:
         - matchPattern: "*"
+    # Including 'world' here may still be needed for versions up to 1.16 (#997)
     toEntities:
-    - world
+      - host
+      - world

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-knp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-knp.yaml
@@ -25,7 +25,7 @@ spec:
         - port: 53
           # protocol non specified corresponding to ANY in CNP
     # When node-local-dns is deployed with local IP,
-    # Cilium labels its ip as world.
+    # Cilium labels its ip as world (or host after #25298).
     # This change prevents failing the connectivity
     # test for such environments.
     - to:

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo-port-range.yaml
@@ -28,15 +28,14 @@ spec:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  # For nodelocaldns using a link-local address (the "localip" mode).
   - toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
+    # Including 'world' here may still be needed for versions up to 1.16 (#997)
     toEntities:
-    - world
+      - host
+      - world

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-echo.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-echo.yaml
@@ -27,15 +27,14 @@ spec:
     - matchExpressions:
       - { key: 'k8s-app', operator: In, values: [ "kube-dns", "coredns", "node-local-dns", "nodelocaldns" ] }
       - { key: 'io.kubernetes.pod.namespace', operator: In, values: [ "kube-system" ] }
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  # For nodelocaldns using a link-local address (the "localip" mode).
   - toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
+    # Including 'world' here may still be needed for versions up to 1.16 (#997)
     toEntities:
-    - world
+      - host
+      - world

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world-port-range.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world-port-range.yaml
@@ -35,15 +35,14 @@ spec:
         protocol: UDP
       - port: "5353"
         protocol: TCP
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  # For nodelocaldns using a link-local address (the "localip" mode).
   - toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
+    # Including 'world' here may still be needed for versions up to 1.16 (#997)
     toEntities:
-    - world
+      - host
+      - world

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-entities-world.yaml
@@ -34,15 +34,14 @@ spec:
         protocol: UDP
       - port: "5353"
         protocol: TCP
-  # When node-local-dns is deployed with local IP,
-  # Cilium labels its ip as world.
-  # This change prevents failing the connectivity
-  # test for such environments.
+  # For nodelocaldns using a link-local address (the "localip" mode).
   - toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
+    # Including 'world' here may still be needed for versions up to 1.16 (#997)
     toEntities:
-    - world
+      - host
+      - world


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #42528

As discussed there, the policy required for the link-local mode of nodelocaldns to work is now with entity 'host' instead of 'world', but I did not remove 'world' because that would be a risk of a breaking change in case some other unknown use case relies on it. I only added 'host'.

```release-note
Fix connectivity tests for access to link-local nodelocaldns classified as 'host' entity
```
