### PR TITLE
bpf: tests: egressgw: install ipcache_v6_add_world_entry()

### DIFF
--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -83,10 +83,10 @@ ipcache_v4_add_entry_with_mask_size(__be32 addr, __u8 cluster_id, __u32 sec_iden
 static __always_inline void
 __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 		       const union v6addr *tunnel_ep, __u8 spi, bool flag_skip_tunnel,
-		       bool ipv6_underlay)
+		       bool ipv6_underlay, __u32 mask_size)
 {
 	struct ipcache_key key __align_stack_8 = {
-		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(V6_CACHE_KEY_LEN),
+		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(mask_size),
 		.cluster_id = cluster_id,
 		.family = ENDPOINT_KEY_IPV6,
 	};
@@ -103,7 +103,7 @@ ipcache_v6_add_world_entry()
 	union v6addr tunnel_ep = {0};
 
 	__ipcache_v6_add_entry((union v6addr *)v6_all, 0, WORLD_IPV6_ID,
-			       &tunnel_ep, false, false, 0);
+			       &tunnel_ep, 0, false, false, 0);
 }
 
 static __always_inline void
@@ -111,14 +111,15 @@ ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identi
 		     __u32 tunnel_ep, __u8 spi)
 {
 	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
-			       false, false);
+			       false, false, V6_CACHE_KEY_LEN);
 }
 
 static __always_inline void
 ipcache_v6_add_entry_ipv6_underlay(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 				   const union v6addr *tunnel_ep, __u8 spi)
 {
-	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, true);
+	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, true,
+			       V6_CACHE_KEY_LEN);
 }
 
 static __always_inline void
@@ -126,5 +127,5 @@ ipcache_v6_add_entry_with_flags(const union v6addr *addr, __u8 cluster_id, __u32
 				__u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
 	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
-			       flag_skip_tunnel, false);
+			       flag_skip_tunnel, false, V6_CACHE_KEY_LEN);
 }

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -229,7 +229,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
@@ -271,7 +271,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_EXCL_CIDR));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip, 0);
@@ -322,7 +322,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
 				     &egress_ip, 0);
@@ -384,7 +384,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
 	create_ct_entry_v6(ctx, client_port(TEST_DROP_NO_EGRESS_IP));


### PR DESCRIPTION
In a real-world cluster we wouldn't actually expect the cluster-external endpoint to have a dedicated IPcache entry. Instead there's a catch-all entry that we should match against.