### PR TITLE
bpf:overlay: remove empty overlay_ingress_policy_hook infra

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -46,8 +46,6 @@
 #include "lib/arp.h"
 #include "lib/encap.h"
 
-#define overlay_ingress_policy_hook(ctx, ip4, identity, ext_err) CTX_ACT_OK
-
 #ifdef ENABLE_IPV6
 static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 				       __u32 *identity,
@@ -292,7 +290,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	const struct endpoint_info *ep;
 	bool __maybe_unused is_dsr = false;
 	fraginfo_t fraginfo __maybe_unused;
-	int ret;
+	int ret __maybe_unused;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
@@ -436,10 +434,6 @@ skip_vtep:
 	if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
 		return ipv4_local_delivery(ctx, ETH_HLEN, *identity, MARK_MAGIC_IDENTITY,
 					   ip4, ep, METRIC_INGRESS, false, true, 0);
-
-	ret = overlay_ingress_policy_hook(ctx, ip4, *identity, ext_err);
-	if (ret != CTX_ACT_OK)
-		return ret;
 
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.


### PR DESCRIPTION
This PR has been split from https://github.com/cilium/cilium/pull/42891.
This is not used anymore in the codebase, let's remove it. See https://github.com/cilium/cilium/pull/42891#issuecomment-3576253106.