### PR TITLE
xds: Do not log an error on a done context

### DIFF
--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -441,6 +441,14 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *slog.Logge
 			state.pendingWatchCancel = nil
 
 			if !recvOK {
+				// chosen channel was closed. If context has an error (e.g.,
+				// cancelled or deadline exceeded) we should not log an error here.
+				if ctx.Err() != nil {
+					// The context is done, so the doneChIndex case WILL fire,
+					// can just continue here
+					continue
+				}
+
 				scopedLogger.Error(
 					"xDS resource watch failed; terminating",
 					logfields.XDSTypeURL, state.typeURL,


### PR DESCRIPTION
reflect.Select chooses the select case randomly when multiple cases could be chosen. If a watch channel is chosen due to it getting closed, it is likely that the reason for the closure was context cancellation, rather than some other error condition. If this is the case debug log the cancellation via the done channel case, instead of logging a watch error.

This fixes CI flakes due to unexpected error logs like here:

level=debug source=/go/src/github.com/cilium/cilium/pkg/envoy/xds/watcher.go:169 msg="context canceled, terminating resource watch" module=agent.controlplane.envoy-proxy xdsAckedVersion=21 xdsClientNode=127.0.0.1 xdsTypeURL=type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret level=error source=/go/src/github.com/cilium/cilium/pkg/envoy/xds/server.go:444 msg="xDS resource watch failed; terminating" module=agent.controlplane.envoy-proxy xdsStreamID=21 xdsClientNode=host~127.0.0.1~no-id~localdomain xdsTypeURL=type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
