### PR TITLE
chore(lint): add kube api linter

### DIFF
--- a/.custom-gcl.yaml
+++ b/.custom-gcl.yaml
@@ -1,0 +1,8 @@
+# renovate: datasource=docker depName=golangci/golangci-lint
+version: v2.7.1
+name: golangci-lint-cilium
+destination: ./tools/golangci-lint
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  # renovate: datasource=go depName=sigs.k8s.io/kube-api-linter
+  version: 'v0.0.0-20251208100930-d3015c953951'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,7 +44,8 @@
     "install/kubernetes/cilium/templates/spire/**",
     "install/kubernetes/cilium/values.yaml.tmpl",
     "install/kubernetes/Makefile.values",
-    "test/k8s/manifests/netpol-cyclonus"
+    "test/k8s/manifests/netpol-cyclonus",
+    ".custom-gcl.yaml",
   ],
   "schedule": [
     "on sunday"
@@ -966,6 +967,14 @@
       "datasourceTemplate": "github-runners",
       "depNameTemplate": "ubuntu",
       "packageNameTemplate": "ubuntu"
-    }
+    },
+    {
+      "fileMatch": [
+        "^\\.custom-gcl\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+version:\\s+'?(?<currentValue>[^'\"\\s]+)'?"
+      ]
+    },
   ]
 }

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -76,7 +76,14 @@ jobs:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v2.7.1
           skip-cache: true
-          args: "--verbose --modules-download-mode=vendor"
+          args: "--verbose --modules-download-mode=vendor --disable=kubeapilinter"
+      - name: Run kube-api-lint
+        uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
+        with:
+          # renovate: datasource=docker depName=golangci/golangci-lint
+          version: v2.7.1
+          skip-cache: true
+          args: "--verbose --modules-download-mode=vendor --enable-only=kubeapilinter ./pkg/k8s/apis/cilium.io/..."
 
   precheck:
     runs-on: ubuntu-24.04

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     - gosec
     - govet
     - ineffassign
+    - kubeapilinter
     - misspell
     - modernize
     - sloglint
@@ -25,6 +26,21 @@ linters:
     - testifylint
     - unused
   settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: Kube API Linter lints Kube like APIs based on API convetions
+        settings:
+          linters:
+            disable:
+              - "*"
+            enable:
+              - optionalorrequired
+              - duplicatemarkers
+          lintersConfig:
+            optionalorrequired:
+              preferredOptionalMarker: "kubebuilder:validation:Optional"
+              preferredRequiredMarker: "kubebuilder:validation:Required"
     depguard:
       rules:
         main:
@@ -217,6 +233,13 @@ linters:
           - gomodguard
         path: test/
         text: "logrus"
+      - linters:
+          - kubeapilinter
+        path-except: pkg/k8s/apis/cilium\.io/(v2|v2alpha1)/.*types\.go
+      - linters:
+          - kubeapilinter
+        path: pkg/k8s/apis/cilium\.io/(v2|v2alpha1)/.*types\.go
+        text: deepequal-gen
     paths:
       - third_party$
       - builtin$

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -238,6 +238,7 @@
 /CHANGELOG.md @cilium/release-managers
 /.authors.aux @cilium/contributing
 /.clomonitor.yml @cilium/contributing
+/.custom-gcl.yaml @cilium/ci-structure
 /.devcontainer @cilium/ci-structure
 /.gitattributes @cilium/contributing
 /.github/ @cilium/github-sec @cilium/ci-structure

--- a/Makefile
+++ b/Makefile
@@ -423,9 +423,9 @@ custom-lint: ## Run extra local linters
 golangci-lint: ## Run golangci-lint
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION:v%=%),$(GOLANGCILINT_VERSION)))
 	@$(ECHO_CHECK) golangci-lint $(GOLANGCI_LINT_ARGS)
-	$(QUIET) golangci-lint run $(GOLANGCI_LINT_ARGS)
+	$(QUIET) GOLANGCI_LINT_ARGS="$(GOLANGCI_LINT_ARGS)" ./contrib/scripts/golangci-lint.sh
 else
-	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) golangci-lint run $(GOLANGCI_LINT_ARGS)
+	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app -e GOLANGCI_LINT_ARGS="$(GOLANGCI_LINT_ARGS)" docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) ./contrib/scripts/golangci-lint.sh
 endif
 
 golangci-lint-fix: ## Run golangci-lint to automatically fix warnings

--- a/contrib/scripts/golangci-lint.sh
+++ b/contrib/scripts/golangci-lint.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GOLANGCI_LINT_BIN="${GOLANGCI_LINT_BIN:-golangci-lint}"
+GOLANGCI_LINT_ARGS="${GOLANGCI_LINT_ARGS:-}"
+GOLANGCI_LINT_MODULE="${GOLANGCI_LINT_MODULE:-golangci-lint-cilium}"
+GOLANGCI_LINT_DIR="${GOLANGCI_LINT_DIR:-tools/golangci-lint}"
+
+# Extract the version string from "golangci-lint --version" output.
+# Expected format:
+#   golangci-lint has version <version> built with ...
+# Returns only the <version> part (e.g., v2.6.2 or v2.6.2-custom-gcl-<hash>)
+get_golangci_version() {
+	"$1" --version 2>/dev/null | sed -n 's/^golangci-lint has version \([^ ]*\).*/\1/p'
+}
+
+# If the custom binary already exists:
+# - Parse the base version of the system-installed golangci-lint
+# - Parse the base version of the custom-built golangci-lint
+# - If they differ, remove the old custom binary to trigger a rebuild
+if [[ -x "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" ]]; then
+	BASE_VERSION="$(get_golangci_version "${GOLANGCI_LINT_BIN}" || true)"
+	CUSTOM_VERSION_RAW="$(get_golangci_version "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" || true)"
+
+	# Custom version looks like:
+	#   vX.Y.Z-custom-gcl-<hash>
+	# Strip the "-custom-gcl-..." suffix to get the base version.
+	CUSTOM_BASE_VERSION="${CUSTOM_VERSION_RAW%%-custom-gcl-*}"
+
+	# Rebuild the custom binary if:
+	# - version extraction failed, or
+	# - base versions do not match
+	if [[ -z "${BASE_VERSION}" || -z "${CUSTOM_BASE_VERSION}" || "${BASE_VERSION}" != "${CUSTOM_BASE_VERSION}" ]]; then
+		rm -f "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}"
+	fi
+fi
+
+# If the golangci-lint custom module binary does NOT exist,
+# build the custom golangci-lint module using `golangci-lint custom`.
+if  [ ! -x "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" ]; then
+	"${GOLANGCI_LINT_BIN}" custom
+fi
+
+# Execute lint with custom binary
+"${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" run ${GOLANGCI_LINT_ARGS} --disable=kubeapilinter
+"${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" run ${GOLANGCI_LINT_ARGS} --enable-only=kubeapilinter ./pkg/k8s/apis/cilium.io/...

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpclusterconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpclusterconfigs.yaml
@@ -104,12 +104,9 @@ spec:
                                 - addressFamily
                                 type: object
                               mode:
-                                allOf:
-                                - enum:
-                                  - DefaultGateway
-                                - enum:
-                                  - DefaultGateway
                                 description: mode is the mode of the auto-discovery.
+                                enum:
+                                - DefaultGateway
                                 type: string
                             required:
                             - mode

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpnodeconfigs.yaml
@@ -105,12 +105,9 @@ spec:
                                 - addressFamily
                                 type: object
                               mode:
-                                allOf:
-                                - enum:
-                                  - DefaultGateway
-                                - enum:
-                                  - DefaultGateway
                                 description: mode is the mode of the auto-discovery.
+                                enum:
+                                - DefaultGateway
                                 type: string
                             required:
                             - mode

--- a/pkg/k8s/apis/cilium.io/v2/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_advert_types.go
@@ -76,8 +76,10 @@ type CiliumBGPAdvertisement struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPAdvertisementSpec `json:"spec"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_cluster_types.go
@@ -34,15 +34,18 @@ type CiliumBGPClusterConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec defines the desired cluster configuration of the BGP control plane.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPClusterConfigSpec `json:"spec"`
 
 	// Status is a running status of the cluster configuration
 	//
 	// +kubebuilder:validation:Optional
-	Status CiliumBGPClusterConfigStatus `json:"status"`
+	Status CiliumBGPClusterConfigStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -155,7 +158,6 @@ type BGPAutoDiscovery struct {
 	// mode is the mode of the auto-discovery.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=DefaultGateway
 	Mode BGPAutoDiscoveryMode `json:"mode"`
 
 	// defaultGateway is the configuration for auto-discovery of the default gateway.
@@ -169,6 +171,7 @@ type DefaultGateway struct {
 	// addressFamily is the address family of the default gateway.
 	//
 	// +kubebuilder:validation:Enum=ipv4;ipv6
+	// +kubebuilder:validation:Required
 	AddressFamily string `json:"addressFamily"`
 }
 
@@ -184,7 +187,7 @@ type PeerConfigReference struct {
 type CiliumBGPClusterConfigStatus struct {
 	// The current conditions of the CiliumBGPClusterConfig
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=type
 	// +deepequal-gen=false

--- a/pkg/k8s/apis/cilium.io/v2/bgp_node_override_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_node_override_types.go
@@ -22,9 +22,12 @@ type CiliumBGPNodeConfigOverride struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the specification of the desired behavior of the CiliumBGPNodeConfigOverride.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPNodeConfigOverrideSpec `json:"spec"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/bgp_node_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_node_types.go
@@ -21,14 +21,17 @@ type CiliumBGPNodeConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the specification of the desired behavior of the CiliumBGPNodeConfig.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPNodeSpec `json:"spec"`
 
 	// Status is the most recently observed status of the CiliumBGPNodeConfig.
 	// +kubebuilder:validation:Optional
-	Status CiliumBGPNodeStatus `json:"status"`
+	Status CiliumBGPNodeStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -149,7 +152,7 @@ type CiliumBGPNodeStatus struct {
 
 	// The current conditions of the CiliumBGPNodeConfig
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=type
 	// +deepequal-gen=false

--- a/pkg/k8s/apis/cilium.io/v2/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_peer_types.go
@@ -50,15 +50,17 @@ type CiliumBGPPeerConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the specification of the desired behavior of the CiliumBGPPeerConfig.
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPPeerConfigSpec `json:"spec"`
 
 	// Status is the running status of the CiliumBGPPeerConfig
 	//
 	// +kubebuilder:validation:Optional
-	Status CiliumBGPPeerConfigStatus `json:"status"`
+	Status CiliumBGPPeerConfigStatus `json:"status,omitempty"`
 }
 
 type CiliumBGPPeerConfigSpec struct {
@@ -116,7 +118,7 @@ type CiliumBGPPeerConfigSpec struct {
 type CiliumBGPPeerConfigStatus struct {
 	// The current conditions of the CiliumBGPPeerConfig
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=type
 	// +deepequal-gen=false

--- a/pkg/k8s/apis/cilium.io/v2/ccec_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccec_types.go
@@ -20,9 +20,11 @@ type CiliumClusterwideEnvoyConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// +k8s:openapi-gen=false
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// +k8s:openapi-gen=false
+	// +kubebuilder:validation:Optional
 	Spec CiliumEnvoyConfigSpec `json:"spec,omitempty"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -29,12 +29,17 @@ type CiliumClusterwideNetworkPolicy struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the desired Cilium specific rule specification.
+	//
+	// +kubebuilder:validation:Optional
 	Spec *api.Rule `json:"spec,omitempty"`
 
 	// Specs is a list of desired Cilium specific rule specification.
+	//
+	// +kubebuilder:validation:Optional
 	Specs api.Rules `json:"specs,omitempty"`
 
 	// Status is the status of the Cilium policy rule.
@@ -44,7 +49,7 @@ type CiliumClusterwideNetworkPolicy struct {
 	// field does not exist in the structure.
 	//
 	// +kubebuilder:validation:Optional
-	Status CiliumNetworkPolicyStatus `json:"status"`
+	Status CiliumNetworkPolicyStatus `json:"status,omitempty"`
 }
 
 // DeepEqual compares 2 CCNPs while ignoring the LastAppliedConfigAnnotation

--- a/pkg/k8s/apis/cilium.io/v2/cec_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types.go
@@ -33,9 +33,11 @@ type CiliumEnvoyConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// +k8s:openapi-gen=false
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// +k8s:openapi-gen=false
+	// +kubebuilder:validation:Optional
 	Spec CiliumEnvoyConfigSpec `json:"spec,omitempty"`
 }
 
@@ -98,7 +100,7 @@ type Service struct {
 	// In CiliumEnvoyConfig namespace defaults to the namespace of the CEC,
 	// In CiliumClusterwideEnvoyConfig namespace defaults to "default".
 	// +kubebuilder:validation:Optional
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 
 	// Ports is a set of port numbers, which can be used for filtering in case of underlying
 	// is exposing multiple port numbers.
@@ -122,7 +124,7 @@ type ServiceListener struct {
 	// In CiliumEnvoyConfig namespace this is overridden to the namespace of the CEC,
 	// In CiliumClusterwideEnvoyConfig namespace defaults to "default".
 	// +kubebuilder:validation:Optional
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 
 	// Ports is a set of service's frontend ports that should be redirected to the Envoy
 	// listener. By default all frontend ports of the service are redirected.
@@ -139,7 +141,7 @@ type ServiceListener struct {
 	// used.
 	//
 	// +kubebuilder:validation:Optional
-	Listener string `json:"listener"`
+	Listener string `json:"listener,omitempty"`
 }
 
 func (l *ServiceListener) ServiceName() loadbalancer.ServiceName {

--- a/pkg/k8s/apis/cilium.io/v2/cegp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cegp_types.go
@@ -22,8 +22,10 @@ type CiliumEgressGatewayPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// +k8s:openapi-gen=false
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Optional
 	Spec CiliumEgressGatewayPolicySpec `json:"spec,omitempty"`
 }
 
@@ -48,10 +50,14 @@ type CIDR string
 type CiliumEgressGatewayPolicySpec struct {
 	// Egress represents a list of rules by which egress traffic is
 	// filtered from the source pods.
+	//
+	// +kubebuilder:validation:Required
 	Selectors []EgressRule `json:"selectors"`
 
 	// DestinationCIDRs is a list of destination CIDRs for destination IP addresses.
 	// If a destination IP matches any one CIDR, it will be selected.
+	//
+	// +kubebuilder:validation:Required
 	DestinationCIDRs []CIDR `json:"destinationCIDRs"`
 
 	// ExcludedCIDRs is a list of destination CIDRs that will be excluded
@@ -60,11 +66,13 @@ type CiliumEgressGatewayPolicySpec struct {
 	// effect.
 	//
 	// +kubebuilder:validation:Optional
-	ExcludedCIDRs []CIDR `json:"excludedCIDRs"`
+	ExcludedCIDRs []CIDR `json:"excludedCIDRs,omitempty"`
 
 	// EgressGateway is the gateway node responsible for SNATing traffic.
 	// In case multiple nodes are a match for the given set of labels, the first node
 	// in lexical ordering based on their name will be selected.
+	//
+	// +kubebuilder:validation:Required
 	EgressGateway *EgressGateway `json:"egressGateway"`
 
 	// Optional list of gateway nodes responsible for SNATing traffic.
@@ -102,6 +110,8 @@ type EgressGateway struct {
 	// When none of the Interface or EgressIP fields is specified, the
 	// policy will use the first IPv4 assigned to the interface with the
 	// default route.
+	//
+	// +kubebuilder:validation:Optional
 	Interface string `json:"interface,omitempty"`
 
 	// EgressIP is the source IP address that the egress traffic is SNATed
@@ -117,19 +127,26 @@ type EgressGateway struct {
 	// default route.
 	//
 	// +kubebuilder:validation:Format=ipv4
+	// +kubebuilder:validation:Optional
 	EgressIP string `json:"egressIP,omitempty"`
 }
 
 type EgressRule struct {
 	// Selects Namespaces using cluster-scoped labels. This field follows standard label
 	// selector semantics; if present but empty, it selects all namespaces.
+	//
+	// +kubebuilder:validation:Optional
 	NamespaceSelector *slimv1.LabelSelector `json:"namespaceSelector,omitempty"`
 
 	// This is a label selector which selects Pods. This field follows standard label
 	// selector semantics; if present but empty, it selects all pods.
+	//
+	// +kubebuilder:validation:Optional
 	PodSelector *slimv1.LabelSelector `json:"podSelector,omitempty"`
 
 	// This is a label selector which selects Pods by Node. This field follows standard label
 	// selector semantics; if present but empty, it selects all nodes.
+	//
+	// +kubebuilder:validation:Optional
 	NodeSelector *slimv1.LabelSelector `json:"nodeSelector,omitempty"`
 }

--- a/pkg/k8s/apis/cilium.io/v2/cidrgroups_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cidrgroups_types.go
@@ -24,6 +24,7 @@ type CiliumCIDRGroup struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/pkg/k8s/apis/cilium.io/v2/clrp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/clrp_types.go
@@ -29,9 +29,12 @@ type CiliumLocalRedirectPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// +k8s:openapi-gen=false
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the desired behavior of the local redirect policy.
+	//
+	// +kubebuilder:validation:Optional
 	Spec CiliumLocalRedirectPolicySpec `json:"spec,omitempty"`
 
 	// Status is the most recent status of the local redirect policy.
@@ -39,7 +42,7 @@ type CiliumLocalRedirectPolicy struct {
 	//
 	// +deepequal-gen=false
 	// +kubebuilder:validation:Optional
-	Status CiliumLocalRedirectPolicyStatus `json:"status"`
+	Status CiliumLocalRedirectPolicyStatus `json:"status,omitempty"`
 }
 
 type Frontend struct {
@@ -72,12 +75,14 @@ type RedirectFrontend struct {
 	// redirected.
 	//
 	// +kubebuilder:validation:OneOf
+	// +kubebuilder:validation:Optional
 	AddressMatcher *Frontend `json:"addressMatcher,omitempty"`
 
 	// ServiceMatcher specifies Kubernetes service and port that matches
 	// traffic to be redirected.
 	//
 	// +kubebuilder:validation:OneOf
+	// +kubebuilder:validation:Optional
 	ServiceMatcher *ServiceInfo `json:"serviceMatcher,omitempty"`
 }
 
@@ -102,7 +107,7 @@ type PortInfo struct {
 	//
 	// +kubebuilder:validation:Pattern=`^([0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$`
 	// +kubebuilder:validation:Optional
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 type ServiceInfo struct {
@@ -183,7 +188,7 @@ type CiliumLocalRedirectPolicySpec struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="skipRedirectFromBackend is immutable"
-	SkipRedirectFromBackend bool `json:"skipRedirectFromBackend"`
+	SkipRedirectFromBackend bool `json:"skipRedirectFromBackend,omitempty"`
 
 	// Description can be used by the creator of the policy to describe the
 	// purpose of this policy.
@@ -195,6 +200,8 @@ type CiliumLocalRedirectPolicySpec struct {
 // CiliumLocalRedirectPolicyStatus is the status of a Local Redirect Policy.
 type CiliumLocalRedirectPolicyStatus struct {
 	// TODO Define status(aditi)
+	//
+	// +kubebuilder:validation:Optional
 	OK bool `json:"ok,omitempty"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/cnc_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnc_types.go
@@ -23,9 +23,12 @@ type CiliumNodeConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is the desired Cilium configuration overrides for a given node
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumNodeConfigSpec `json:"spec"`
 }
 
@@ -34,12 +37,16 @@ type CiliumNodeConfigSpec struct {
 	// Defaults is treated the same as the cilium-config ConfigMap - a set
 	// of key-value pairs parsed by the agent and operator processes.
 	// Each key must be a valid config-map data field (i.e. a-z, A-Z, -, _, and .)
+	//
+	// +kubebuilder:validation:Required
 	Defaults map[string]string `json:"defaults"`
 
 	// NodeSelector is a label selector that determines to which nodes
 	// this configuration applies.
 	// If not supplied, then this config applies to no nodes. If
 	// empty, then it applies to all nodes.
+	//
+	// +kubebuilder:validation:Required
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -33,19 +33,24 @@ type CiliumNetworkPolicy struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the desired Cilium specific rule specification.
+	//
+	// +kubebuilder:validation:Optional
 	Spec *api.Rule `json:"spec,omitempty"`
 
 	// Specs is a list of desired Cilium specific rule specification.
+	//
+	// +kubebuilder:validation:Optional
 	Specs api.Rules `json:"specs,omitempty"`
 
 	// Status is the status of the Cilium policy rule
 	//
 	// +deepequal-gen=false
 	// +kubebuilder:validation:Optional
-	Status CiliumNetworkPolicyStatus `json:"status"`
+	Status CiliumNetworkPolicyStatus `json:"status,omitempty"`
 }
 
 // DeepEqual compares 2 CNPs.
@@ -75,9 +80,11 @@ type CiliumNetworkPolicyStatus struct {
 
 	// DerivativePolicies is the status of all policies derived from the Cilium
 	// policy
+	//
+	// +kubebuilder:validation:Optional
 	DerivativePolicies map[string]CiliumNetworkPolicyNodeStatus `json:"derivativePolicies,omitempty"`
 
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map
@@ -92,22 +99,32 @@ type CiliumNetworkPolicyStatus struct {
 type CiliumNetworkPolicyNodeStatus struct {
 	// OK is true when the policy has been parsed and imported successfully
 	// into the in-memory policy repository on the node.
+	//
+	// +kubebuilder:validation:Optional
 	OK bool `json:"ok,omitempty"`
 
 	// Error describes any error that occurred when parsing or importing the
 	// policy, or realizing the policy for the endpoints to which it applies
 	// on the node.
+	//
+	// +kubebuilder:validation:Optional
 	Error string `json:"error,omitempty"`
 
 	// LastUpdated contains the last time this status was updated
+	//
+	// +kubebuilder:validation:Optional
 	LastUpdated slimv1.Time `json:"lastUpdated,omitempty"`
 
 	// Revision is the policy revision of the repository which first implemented
 	// this policy.
+	//
+	// +kubebuilder:validation:Optional
 	Revision uint64 `json:"localPolicyRevision,omitempty"`
 
 	// Enforcing is set to true once all endpoints present at the time the
 	// policy has been imported are enforcing this policy.
+	//
+	// +kubebuilder:validation:Optional
 	Enforcing bool `json:"enforcing,omitempty"`
 
 	// Annotations corresponds to the Annotations in the ObjectMeta of the CNP
@@ -116,6 +133,8 @@ type CiliumNetworkPolicyNodeStatus struct {
 	// Annotations in CiliumNetworkPolicyNodeStatus will be X=Y once the
 	// CNP that was imported corresponding to Annotation X=Y has been realized on
 	// the node.
+	//
+	// +kubebuilder:validation:Optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
@@ -253,16 +272,18 @@ const (
 
 type NetworkPolicyCondition struct {
 	// The type of the policy condition
+	// +kubebuilder:validation:Required
 	Type PolicyConditionType `json:"type"`
 	// The status of the condition, one of True, False, or Unknown
+	// +kubebuilder:validation:Required
 	Status v1.ConditionStatus `json:"status"`
 	// The last time the condition transitioned from one status to another.
-	// +optional
+	// +kubebuilder:validation:Optional
 	LastTransitionTime slimv1.Time `json:"lastTransitionTime,omitempty"`
 	// The reason for the condition's last transition.
-	// +optional
+	// +kubebuilder:validation:Optional
 	Reason string `json:"reason,omitempty"`
 	// A human readable message indicating details about the transition.
-	// +optional
+	// +kubebuilder:validation:Optional
 	Message string `json:"message,omitempty"`
 }

--- a/pkg/k8s/apis/cilium.io/v2/errors.go
+++ b/pkg/k8s/apis/cilium.io/v2/errors.go
@@ -22,6 +22,7 @@ var (
 // +k8s:deepcopy-gen=false
 // +deepequal-gen=false
 type ErrParse struct {
+	// +kubebuilder:validation:Required
 	msg string
 }
 

--- a/pkg/k8s/apis/cilium.io/v2/lbipam_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/lbipam_types.go
@@ -27,6 +27,7 @@ type CiliumLoadBalancerIPPool struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is a human readable description for a BGP load balancer
@@ -43,7 +44,7 @@ type CiliumLoadBalancerIPPool struct {
 	//
 	// +deepequal-gen=false
 	// +kubebuilder:validation:Optional
-	Status CiliumLoadBalancerIPPoolStatus `json:"status"`
+	Status CiliumLoadBalancerIPPoolStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -68,7 +69,7 @@ type CiliumLoadBalancerIPPoolSpec struct {
 	// ServiceSelector selects a set of services which are eligible to receive IPs from this
 	//
 	// +kubebuilder:validation:Optional
-	ServiceSelector *slimv1.LabelSelector `json:"serviceSelector"`
+	ServiceSelector *slimv1.LabelSelector `json:"serviceSelector,omitempty"`
 	// AllowFirstLastIPs, if set to `Yes` or undefined means that the first and last IPs of each CIDR will be allocatable.
 	// If `No`, these IPs will be reserved. This field is ignored for /{31,32} and /{127,128} CIDRs since
 	// reserving the first and last IPs would make the CIDRs unusable.
@@ -84,7 +85,7 @@ type CiliumLoadBalancerIPPoolSpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	Disabled bool `json:"disabled"`
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=Yes;No
@@ -97,9 +98,8 @@ const (
 
 // CiliumLoadBalancerIPPoolIPBlock describes a single IP block.
 type CiliumLoadBalancerIPPoolIPBlock struct {
-	// +kubebuilder:validation:Format=cidr
 	// +kubebuilder:validation:Optional
-	Cidr IPv4orIPv6CIDR `json:"cidr"`
+	Cidr IPv4orIPv6CIDR `json:"cidr,omitempty"`
 	// +kubebuilder:validation:Optional
 	Start string `json:"start,omitempty"`
 	// +kubebuilder:validation:Optional
@@ -111,7 +111,7 @@ type CiliumLoadBalancerIPPoolIPBlock struct {
 // CiliumLoadBalancerIPPoolStatus contains the status of a CiliumLoadBalancerIPPool.
 type CiliumLoadBalancerIPPoolStatus struct {
 	// Current service state
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -37,10 +37,11 @@ type CiliumEndpoint struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// +kubebuilder:validation:Optional
-	Status EndpointStatus `json:"status"`
+	Status EndpointStatus `json:"status,omitempty"`
 }
 
 // EndpointPolicyState defines the state of the Policy mode: "enforcing", "non-enforcing", "disabled"
@@ -49,22 +50,34 @@ type EndpointPolicyState string
 // EndpointStatus is the status of a Cilium endpoint.
 type EndpointStatus struct {
 	// ID is the cilium-agent-local ID of the endpoint.
+	//
+	// +kubebuilder:validation:Optional
 	ID int64 `json:"id,omitempty"`
 
 	// Controllers is the list of failing controllers for this endpoint.
+	//
+	// +kubebuilder:validation:Optional
 	Controllers ControllerList `json:"controllers,omitempty"`
 
 	// ExternalIdentifiers is a set of identifiers to identify the endpoint
 	// apart from the pod name. This includes container runtime IDs.
+	//
+	// +kubebuilder:validation:Optional
 	ExternalIdentifiers *models.EndpointIdentifiers `json:"external-identifiers,omitempty"`
 
 	// Health is the overall endpoint & subcomponent health.
+	//
+	// +kubebuilder:validation:Optional
 	Health *models.EndpointHealth `json:"health,omitempty"`
 
 	// Identity is the security identity associated with the endpoint
+	//
+	// +kubebuilder:validation:Optional
 	Identity *EndpointIdentity `json:"identity,omitempty"`
 
 	// Log is the list of the last few warning and error log entries
+	//
+	// +kubebuilder:validation:Optional
 	Log []models.EndpointStatusChange `json:"log,omitempty"`
 
 	// Networking is the networking properties of the endpoint.
@@ -77,16 +90,21 @@ type EndpointStatus struct {
 	// +kubebuilder:validation:Optional
 	Encryption EncryptionSpec `json:"encryption,omitempty"`
 
+	// +kubebuilder:validation:Optional
 	Policy *EndpointPolicy `json:"policy,omitempty"`
 
 	// State is the state of the endpoint.
 	//
 	// +kubebuilder:validation:Enum=creating;waiting-for-identity;not-ready;waiting-to-regenerate;regenerating;restoring;ready;disconnecting;disconnected;invalid
+	// +kubebuilder:validation:Optional
 	State string `json:"state,omitempty"`
 
+	// +kubebuilder:validation:Optional
 	NamedPorts models.NamedPorts `json:"named-ports,omitempty"`
 
 	// ServiceAccount is the service account associated with the endpoint
+	//
+	// +kubebuilder:validation:Optional
 	ServiceAccount string `json:"service-account,omitempty"`
 }
 
@@ -103,15 +121,23 @@ func (c ControllerList) Sort() {
 // ControllerStatus is the status of a failing controller.
 type ControllerStatus struct {
 	// Name is the name of the controller
+	//
+	// +kubebuilder:validation:Optional
 	Name string `json:"name,omitempty"`
 
 	// Configuration is the controller configuration
+	//
+	// +kubebuilder:validation:Optional
 	Configuration *models.ControllerStatusConfiguration `json:"configuration,omitempty"`
 
 	// Status is the status of the controller
+	//
+	// +kubebuilder:validation:Optional
 	Status ControllerStatusStatus `json:"status,omitempty"`
 
 	// UUID is the UUID of the controller
+	//
+	// +kubebuilder:validation:Optional
 	UUID string `json:"uuid,omitempty"`
 }
 
@@ -119,39 +145,57 @@ type ControllerStatus struct {
 
 // ControllerStatusStatus is the detailed status section of a controller.
 type ControllerStatusStatus struct {
-	ConsecutiveFailureCount int64  `json:"consecutive-failure-count,omitempty"`
-	FailureCount            int64  `json:"failure-count,omitempty"`
-	LastFailureMsg          string `json:"last-failure-msg,omitempty"`
-	LastFailureTimestamp    string `json:"last-failure-timestamp,omitempty"`
-	LastSuccessTimestamp    string `json:"last-success-timestamp,omitempty"`
-	SuccessCount            int64  `json:"success-count,omitempty"`
+	// +kubebuilder:validation:Optional
+	ConsecutiveFailureCount int64 `json:"consecutive-failure-count,omitempty"`
+	// +kubebuilder:validation:Optional
+	FailureCount int64 `json:"failure-count,omitempty"`
+	// +kubebuilder:validation:Optional
+	LastFailureMsg string `json:"last-failure-msg,omitempty"`
+	// +kubebuilder:validation:Optional
+	LastFailureTimestamp string `json:"last-failure-timestamp,omitempty"`
+	// +kubebuilder:validation:Optional
+	LastSuccessTimestamp string `json:"last-success-timestamp,omitempty"`
+	// +kubebuilder:validation:Optional
+	SuccessCount int64 `json:"success-count,omitempty"`
 }
 
 // EndpointPolicy represents the endpoint's policy by listing all allowed
 // ingress and egress identities in combination with L4 port and protocol.
 type EndpointPolicy struct {
+	// +kubebuilder:validation:Optional
 	Ingress *EndpointPolicyDirection `json:"ingress,omitempty"`
-	Egress  *EndpointPolicyDirection `json:"egress,omitempty"`
+	// +kubebuilder:validation:Optional
+	Egress *EndpointPolicyDirection `json:"egress,omitempty"`
 }
 
 // EndpointPolicyDirection is the list of allowed identities per direction.
 type EndpointPolicyDirection struct {
-	Enforcing bool                `json:"enforcing"`
-	Allowed   AllowedIdentityList `json:"allowed,omitempty"`
-	Denied    DenyIdentityList    `json:"denied,omitempty"`
+	// +kubebuilder:validation:Required
+	Enforcing bool `json:"enforcing"`
+	// +kubebuilder:validation:Optional
+	Allowed AllowedIdentityList `json:"allowed,omitempty"`
+	// +kubebuilder:validation:Optional
+	Denied DenyIdentityList `json:"denied,omitempty"`
 	// Deprecated
+	// +kubebuilder:validation:Optional
 	Removing AllowedIdentityList `json:"removing,omitempty"`
 	// Deprecated
+	// +kubebuilder:validation:Optional
 	Adding AllowedIdentityList `json:"adding,omitempty"`
-	State  EndpointPolicyState `json:"state,omitempty"`
+	// +kubebuilder:validation:Optional
+	State EndpointPolicyState `json:"state,omitempty"`
 }
 
 // IdentityTuple specifies a peer by identity, destination port and protocol.
 type IdentityTuple struct {
-	Identity       uint64            `json:"identity,omitempty"`
+	// +kubebuilder:validation:Optional
+	Identity uint64 `json:"identity,omitempty"`
+	// +kubebuilder:validation:Optionals
 	IdentityLabels map[string]string `json:"identity-labels,omitempty"`
-	DestPort       uint16            `json:"dest-port,omitempty"`
-	Protocol       uint8             `json:"protocol,omitempty"`
+	// +kubebuilder:validation:Optional
+	DestPort uint16 `json:"dest-port,omitempty"`
+	// +kubebuilder:validation:Optional
+	Protocol uint8 `json:"protocol,omitempty"`
 }
 
 // +k8s:deepcopy-gen=false
@@ -200,9 +244,13 @@ func (d DenyIdentityList) Sort() {
 // EndpointIdentity is the identity information of an endpoint.
 type EndpointIdentity struct {
 	// ID is the numeric identity of the endpoint
+	//
+	// +kubebuilder:validation:Optional
 	ID int64 `json:"id,omitempty"`
 
 	// Labels is the list of labels associated with the identity
+	//
+	// +kubebuilder:validation:Optional
 	Labels []string `json:"labels,omitempty"`
 }
 
@@ -234,9 +282,11 @@ type CiliumIdentity struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// SecurityLabels is the source-of-truth set of labels for this identity.
+	// +kubebuilder:validation:Required
 	SecurityLabels map[string]string `json:"security-labels"`
 }
 
@@ -246,9 +296,11 @@ type CiliumIdentity struct {
 // CiliumIdentityList is a list of CiliumIdentity objects.
 type CiliumIdentityList struct {
 	metav1.TypeMeta `json:",inline"`
+	// +kubebuilder:validation:Required
 	metav1.ListMeta `json:"metadata"`
 
 	// Items is a list of CiliumIdentity
+	// +kubebuilder:validation:Required
 	Items []CiliumIdentity `json:"items"`
 }
 
@@ -256,7 +308,9 @@ type CiliumIdentityList struct {
 
 // AddressPair is a pair of IPv4 and/or IPv6 address.
 type AddressPair struct {
+	// +kubebuilder:validation:Optional
 	IPV4 string `json:"ipv4,omitempty"`
+	// +kubebuilder:validation:Optional
 	IPV6 string `json:"ipv6,omitempty"`
 }
 
@@ -280,10 +334,12 @@ func (a AddressPairList) Sort() {
 // EndpointNetworking is the addressing information of an endpoint.
 type EndpointNetworking struct {
 	// IP4/6 addresses assigned to this Endpoint
+	// +kubebuilder:validation:Required
 	Addressing AddressPairList `json:"addressing"`
 
 	// NodeIP is the IP of the node the endpoint is running on. The IP must
 	// be reachable between nodes.
+	// +kubebuilder:validation:Optional
 	NodeIP string `json:"node,omitempty"`
 }
 
@@ -317,9 +373,12 @@ type CiliumNode struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec defines the desired specification/configuration of the node.
+	//
+	// +kubebuilder:validation:Required
 	Spec NodeSpec `json:"spec"`
 
 	// Status defines the realized specification/configuration and status
@@ -332,9 +391,13 @@ type CiliumNode struct {
 // NodeAddress is a node address.
 type NodeAddress struct {
 	// Type is the type of the node address
+	//
+	// +kubebuilder:validation:Optional
 	Type addressing.AddressType `json:"type,omitempty"`
 
 	// IP is an IP of a node
+	//
+	// +kubebuilder:validation:Optional
 	IP string `json:"ip,omitempty"`
 }
 
@@ -344,6 +407,8 @@ type NodeSpec struct {
 	// node name which is typically the FQDN of the node. The InstanceID
 	// typically refers to the identifier used by the cloud provider or
 	// some other means of identification.
+	//
+	// +kubebuilder:validation:Optional
 	InstanceID string `json:"instance-id,omitempty"`
 
 	// BootID is a unique node identifier generated on boot

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_advert_types.go
@@ -68,8 +68,10 @@ type CiliumBGPAdvertisement struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPAdvertisementSpec `json:"spec"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_cluster_types.go
@@ -22,15 +22,18 @@ type CiliumBGPClusterConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec defines the desired cluster configuration of the BGP control plane.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPClusterConfigSpec `json:"spec"`
 
 	// Status is a running status of the cluster configuration
 	//
 	// +kubebuilder:validation:Optional
-	Status CiliumBGPClusterConfigStatus `json:"status"`
+	Status CiliumBGPClusterConfigStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -140,14 +143,14 @@ type PeerConfigReference struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="cilium.io"
-	Group string `json:"group"`
+	Group string `json:"group,omitempty"`
 
 	// Kind is the kind of the peer config resource.
 	// If not specified, the default of "CiliumBGPPeerConfig" is used.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="CiliumBGPPeerConfig"
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// Name is the name of the peer config resource.
 	// Name refers to the name of a Kubernetes object (typically a CiliumBGPPeerConfig).
@@ -159,7 +162,7 @@ type PeerConfigReference struct {
 type CiliumBGPClusterConfigStatus struct {
 	// The current conditions of the CiliumBGPClusterConfig
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=type
 	// +deepequal-gen=false

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_override_types.go
@@ -22,9 +22,12 @@ type CiliumBGPNodeConfigOverride struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the specification of the desired behavior of the CiliumBGPNodeConfigOverride.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPNodeConfigOverrideSpec `json:"spec"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_node_types.go
@@ -21,14 +21,17 @@ type CiliumBGPNodeConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the specification of the desired behavior of the CiliumBGPNodeConfig.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPNodeSpec `json:"spec"`
 
 	// Status is the most recently observed status of the CiliumBGPNodeConfig.
 	// +kubebuilder:validation:Optional
-	Status CiliumBGPNodeStatus `json:"status"`
+	Status CiliumBGPNodeStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -144,7 +147,7 @@ type CiliumBGPNodeStatus struct {
 
 	// The current conditions of the CiliumBGPNodeConfig
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=type
 	// +deepequal-gen=false

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgp_peer_types.go
@@ -57,15 +57,18 @@ type CiliumBGPPeerConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is the specification of the desired behavior of the CiliumBGPPeerConfig.
+	//
+	// +kubebuilder:validation:Required
 	Spec CiliumBGPPeerConfigSpec `json:"spec"`
 
 	// Status is the running status of the CiliumBGPPeerConfig
 	//
 	// +kubebuilder:validation:Optional
-	Status CiliumBGPPeerConfigStatus `json:"status"`
+	Status CiliumBGPPeerConfigStatus `json:"status,omitempty"`
 }
 
 type CiliumBGPPeerConfigSpec struct {
@@ -146,7 +149,7 @@ func (gr *CiliumBGPNeighborGracefulRestart) SetDefaults() {
 type CiliumBGPPeerConfigStatus struct {
 	// The current conditions of the CiliumBGPPeerConfig
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=map
 	// +listMapKey=type
 	// +deepequal-gen=false

--- a/pkg/k8s/apis/cilium.io/v2alpha1/cidrgroups_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/cidrgroups_types.go
@@ -24,6 +24,7 @@ type CiliumCIDRGroup struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/pkg/k8s/apis/cilium.io/v2alpha1/cnc_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/cnc_types.go
@@ -23,9 +23,11 @@ type CiliumNodeConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is the desired Cilium configuration overrides for a given node
+	// +kubebuilder:validation:Required
 	Spec CiliumNodeConfigSpec `json:"spec"`
 }
 
@@ -34,12 +36,16 @@ type CiliumNodeConfigSpec struct {
 	// Defaults is treated the same as the cilium-config ConfigMap - a set
 	// of key-value pairs parsed by the agent and operator processes.
 	// Each key must be a valid config-map data field (i.e. a-z, A-Z, -, _, and .)
+	//
+	// +kubebuilder:validation:Required
 	Defaults map[string]string `json:"defaults"`
 
 	// NodeSelector is a label selector that determines to which nodes
 	// this configuration applies.
 	// If not supplied, then this config applies to no nodes. If
 	// empty, then it applies to all nodes.
+	//
+	// +kubebuilder:validation:Required
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
@@ -24,6 +24,7 @@ type CiliumGatewayClassConfig struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is a human-readable of a GatewayClass configuration.
@@ -35,7 +36,7 @@ type CiliumGatewayClassConfig struct {
 	//
 	// +deepequal-gen=false
 	// +kubebuilder:validation:Optional
-	Status CiliumGatewayClassConfigStatus `json:"status"`
+	Status CiliumGatewayClassConfigStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -70,52 +71,53 @@ type ServiceConfig struct {
 	//
 	// +kubebuilder:validation:Enum=LoadBalancer;NodePort
 	// +kubebuilder:default="LoadBalancer"
+	// +kubebuilder:validation:Optional
 	Type corev1.ServiceType `json:"type,omitempty"`
 
 	// Sets the Service.Spec.ExternalTrafficPolicy in generated Service objects to the given value.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="Cluster"
 	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy,omitempty"`
 
 	// Sets the Service.Spec.LoadBalancerClass in generated Service objects to the given value.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	LoadBalancerClass *string `json:"loadBalancerClass,omitempty"`
 
 	// Sets the Service.Spec.IPFamilies in generated Service objects to the given value.
 	//
 	// +listType=atomic
-	// +optional
+	// +kubebuilder:validation:Optional
 	IPFamilies []corev1.IPFamily `json:"ipFamilies,omitempty"`
 
 	// Sets the Service.Spec.IPFamilyPolicy in generated Service objects to the given value.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	IPFamilyPolicy *corev1.IPFamilyPolicy `json:"ipFamilyPolicy,omitempty"`
 
 	// Sets the Service.Spec.AllocateLoadBalancerNodePorts in generated Service objects to the given value.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	AllocateLoadBalancerNodePorts *bool `json:"allocateLoadBalancerNodePorts,omitempty"`
 
 	// Sets the Service.Spec.LoadBalancerSourceRanges in generated Service objects to the given value.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +listType=atomic
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
 
 	// LoadBalancerSourceRangesPolicy defines the policy for the LoadBalancerSourceRanges if the incoming traffic
 	// is allowed or denied.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=Allow;Deny
 	// +kubebuilder:default="Allow"
 	LoadBalancerSourceRangesPolicy LoadBalancerSourceRangesPolicyType `json:"loadBalancerSourceRangesPolicy,omitempty"`
 
 	// Sets the Service.Spec.TrafficDistribution in generated Service objects to the given value.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	TrafficDistribution *string `json:"trafficDistribution,omitempty"`
 }
 
@@ -140,7 +142,7 @@ type CiliumGatewayClassConfigSpec struct {
 // CiliumGatewayClassConfigStatus contains the status of a CiliumGatewayClassConfig.
 type CiliumGatewayClassConfigStatus struct {
 	// Current service state
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map

--- a/pkg/k8s/apis/cilium.io/v2alpha1/ippool_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/ippool_types.go
@@ -22,6 +22,7 @@ type CiliumPodIPPool struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:validation:Required
@@ -32,12 +33,12 @@ type IPPoolSpec struct {
 	// IPv4 specifies the IPv4 CIDRs and mask sizes of the pool
 	//
 	// +kubebuilder:validation:Optional
-	IPv4 *IPv4PoolSpec `json:"ipv4"`
+	IPv4 *IPv4PoolSpec `json:"ipv4,omitempty"`
 
 	// IPv6 specifies the IPv6 CIDRs and mask sizes of the pool
 	//
 	// +kubebuilder:validation:Optional
-	IPv6 *IPv6PoolSpec `json:"ipv6"`
+	IPv6 *IPv6PoolSpec `json:"ipv6,omitempty"`
 
 	// PodSelector selects the set of Pods that are eligible to receive IPs from
 	// this pool when neither the Pod nor its Namespace specify an explicit

--- a/pkg/k8s/apis/cilium.io/v2alpha1/l2announcement_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/l2announcement_types.go
@@ -27,6 +27,7 @@ type CiliumL2AnnouncementPolicy struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is a human readable description of a L2 announcement policy
@@ -38,7 +39,7 @@ type CiliumL2AnnouncementPolicy struct {
 	//
 	// +deepequal-gen=false
 	// +kubebuilder:validation:Optional
-	Status CiliumL2AnnouncementPolicyStatus `json:"status"`
+	Status CiliumL2AnnouncementPolicyStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -66,7 +67,7 @@ type CiliumL2AnnouncementPolicySpec struct {
 	// If nil this policy applies to all nodes.
 	//
 	// +kubebuilder:validation:Optional
-	NodeSelector *slimv1.LabelSelector `json:"nodeSelector"`
+	NodeSelector *slimv1.LabelSelector `json:"nodeSelector,omitempty"`
 	// ServiceSelector selects a set of services which will be announced over L2 networks.
 	// The loadBalancerClass for a service must be nil or specify a supported class, e.g.
 	// "io.cilium/l2-announcer". Refer to the following document for additional details
@@ -77,22 +78,22 @@ type CiliumL2AnnouncementPolicySpec struct {
 	// If nil this policy applies to all services.
 	//
 	// +kubebuilder:validation:Optional
-	ServiceSelector *slimv1.LabelSelector `json:"serviceSelector"`
+	ServiceSelector *slimv1.LabelSelector `json:"serviceSelector,omitempty"`
 	// If true, the loadbalancer IPs of the services are announced
 	//
 	// If nil this policy applies to all services.
 	//
 	// +kubebuilder:validation:Optional
-	LoadBalancerIPs bool `json:"loadBalancerIPs"`
+	LoadBalancerIPs bool `json:"loadBalancerIPs,omitempty"`
 	// If true, the external IPs of the services are announced
 	//
 	// +kubebuilder:validation:Optional
-	ExternalIPs bool `json:"externalIPs"`
+	ExternalIPs bool `json:"externalIPs,omitempty"`
 	// A list of regular expressions that express which network interface(s) should be used
 	// to announce the services over. If nil, all network interfaces are used.
 	//
 	// +kubebuilder:validation:Optional
-	Interfaces []string `json:"interfaces"`
+	Interfaces []string `json:"interfaces,omitempty"`
 }
 
 // +deepequal-gen=false
@@ -100,7 +101,7 @@ type CiliumL2AnnouncementPolicySpec struct {
 // CiliumL2AnnouncementPolicyStatus contains the status of a CiliumL2AnnouncementPolicy.
 type CiliumL2AnnouncementPolicyStatus struct {
 	// Current service state
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map

--- a/pkg/k8s/apis/cilium.io/v2alpha1/lbipam_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/lbipam_types.go
@@ -27,6 +27,7 @@ type CiliumLoadBalancerIPPool struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec is a human readable description for a BGP load balancer
@@ -43,7 +44,7 @@ type CiliumLoadBalancerIPPool struct {
 	//
 	// +deepequal-gen=false
 	// +kubebuilder:validation:Optional
-	Status CiliumLoadBalancerIPPoolStatus `json:"status"`
+	Status CiliumLoadBalancerIPPoolStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -68,7 +69,7 @@ type CiliumLoadBalancerIPPoolSpec struct {
 	// ServiceSelector selects a set of services which are eligible to receive IPs from this
 	//
 	// +kubebuilder:validation:Optional
-	ServiceSelector *slimv1.LabelSelector `json:"serviceSelector"`
+	ServiceSelector *slimv1.LabelSelector `json:"serviceSelector,omitempty"`
 	// AllowFirstLastIPs, if set to `Yes` or undefined means that the first and last IPs of each CIDR will be allocatable.
 	// If `No`, these IPs will be reserved. This field is ignored for /{31,32} and /{127,128} CIDRs since
 	// reserving the first and last IPs would make the CIDRs unusable.
@@ -84,7 +85,7 @@ type CiliumLoadBalancerIPPoolSpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
-	Disabled bool `json:"disabled"`
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=Yes;No
@@ -97,9 +98,8 @@ const (
 
 // CiliumLoadBalancerIPPoolIPBlock describes a single IP block.
 type CiliumLoadBalancerIPPoolIPBlock struct {
-	// +kubebuilder:validation:Format=cidr
 	// +kubebuilder:validation:Optional
-	Cidr IPv4orIPv6CIDR `json:"cidr"`
+	Cidr IPv4orIPv6CIDR `json:"cidr,omitempty"`
 	// +kubebuilder:validation:Optional
 	Start string `json:"start,omitempty"`
 	// +kubebuilder:validation:Optional
@@ -111,7 +111,7 @@ type CiliumLoadBalancerIPPoolIPBlock struct {
 // CiliumLoadBalancerIPPoolStatus contains the status of a CiliumLoadBalancerIPPool.
 type CiliumLoadBalancerIPPoolStatus struct {
 	// Current service state
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +listType=map

--- a/pkg/k8s/apis/cilium.io/v2alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/types.go
@@ -17,18 +17,24 @@ type IPv4orIPv6CIDR string
 type EgressRule struct {
 	// Selects Namespaces using cluster-scoped labels. This field follows standard label
 	// selector semantics; if present but empty, it selects all namespaces.
+	//
+	// +kubebuilder:validation:Optional
 	NamespaceSelector *slimv1.LabelSelector `json:"namespaceSelector,omitempty"`
 
 	// This is a label selector which selects Pods. This field follows standard label
 	// selector semantics; if present but empty, it selects all pods.
+	//
+	// +kubebuilder:validation:Optional
 	PodSelector *slimv1.LabelSelector `json:"podSelector,omitempty"`
 }
 
 // CoreCiliumEndpoint is slim version of status of CiliumEndpoint.
 type CoreCiliumEndpoint struct {
 	// Name indicate as CiliumEndpoint name.
+	// +kubebuilder:validation:Optional
 	Name string `json:"name,omitempty"`
 	// IdentityID is the numeric identity of the endpoint
+	// +kubebuilder:validation:Optional
 	IdentityID int64 `json:"id,omitempty"`
 	// Networking is the networking properties of the endpoint.
 
@@ -37,9 +43,11 @@ type CoreCiliumEndpoint struct {
 	// Encryption is the encryption configuration of the node
 
 	// +kubebuilder:validation:Optional
-	Encryption cilium_v2.EncryptionSpec `json:"encryption"`
-	NamedPorts models.NamedPorts        `json:"named-ports,omitempty"`
+	Encryption cilium_v2.EncryptionSpec `json:"encryption,omitempty"`
+	// +kubebuilder:validation:Optional
+	NamedPorts models.NamedPorts `json:"named-ports,omitempty"`
 	// ServiceAccount is the service account of the endpoint.
+	// +kubebuilder:validation:Optional
 	ServiceAccount string `json:"service-account,omitempty"`
 }
 
@@ -54,14 +62,19 @@ type CiliumEndpointSlice struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`
 	// +deepequal-gen=false
+	// +kubebuilder:validation:Required
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Namespace indicate as CiliumEndpointSlice namespace.
 	// All the CiliumEndpoints within the same namespace are put together
 	// in CiliumEndpointSlice.
+	//
+	// +kubebuilder:validation:Optional
 	Namespace string `json:"namespace,omitempty"`
 
 	// Endpoints is a list of coreCEPs packed in a CiliumEndpointSlice
+	//
+	// +kubebuilder:validation:Required
 	Endpoints []CoreCiliumEndpoint `json:"endpoints"`
 }
 

--- a/tools/golangci-lint/.gitignore
+++ b/tools/golangci-lint/.gitignore
@@ -1,0 +1,2 @@
+# custom golangci-lint
+golangci-lint-cilium


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Related: #42985 

## Description

This PR adds kube-api-lint.

### github actions
golangci-lint workflow automatically detects .custom-gcl.yaml and runs it accordingly.

### local
For local development, implemented support for generating the golangci-lint-cilium module and running the lint checks through that module.

Currently, only the optionalorrequired rules of the kube API linter have been applied and updated.

# discuss
## one
While working on this, I wasn’t able to resolve the timeout issues that occurred when integrating kube-api-lint into the existing golangci-lint run.
As a fallback, I ended up separating the existing golangci-lint and kube-api-lint steps. For kube-api-lint, I configured it to only run against the pkg/k8s/apis/cilium.io/... packages where the kube APIs live.

My concern is that this increases the number of maintenance points in the CI pipeline.
What do you, as a reviewer of this PR, think about this trade-off?

## two
When using --fix with the optionalfields and requiredfields features provided by the kube API linter, some fields are automatically converted into pointer types.
I think this may have unintended effects on existing logic that relies on Go’s zero values.

Because of this, I think a gradual transition will be necessary.
