### PR TITLE
ci/connectivity: check for XFRM errors without conn-disrupt

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -341,6 +341,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 func finalTests(ct *check.ConnectivityTest) error {
 	return injectTests([]testBuilder{
 		noUnexpectedPacketDrops{},
+		noIpsecXfrmErrorsFinal{},
 		checkLogErrors{},
 	}, ct)
 }

--- a/cilium-cli/connectivity/builder/no_ipsec_xfrm_errors.go
+++ b/cilium-cli/connectivity/builder/no_ipsec_xfrm_errors.go
@@ -17,3 +17,12 @@ func (t noIpsecXfrmErrors) build(ct *check.ConnectivityTest, _ map[string]string
 		WithFeatureRequirements(features.RequireMode(features.EncryptionPod, "ipsec")).
 		WithScenarios(tests.NoIPsecXfrmErrors(ct.Params().ExpectedXFRMErrors))
 }
+
+type noIpsecXfrmErrorsFinal struct{}
+
+func (t noIpsecXfrmErrorsFinal) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("no-ipsec-xfrm-errors", ct).
+		WithCondition(func() bool { return !ct.Params().IncludeConnDisruptTest }).
+		WithFeatureRequirements(features.RequireMode(features.EncryptionPod, "ipsec")).
+		WithScenarios(tests.NoIPsecXfrmErrorsFinal(ct.Params().ExpectedXFRMErrors))
+}


### PR DESCRIPTION
### Checklist
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

### Description
The `no-ipsec-xfrm-error` connectivity test is currently only run in combination with conn-disrupt testing, collecting XFRM errors before and after the conn-disrupt run to confirm that no non-negligible errors have occurred. This change adds a standalone variant that checks for XFRM errors as part of `finalTests`, similar to how we check for packet drops or warnings/errors in the logs. This allows detecting XFRM errors even without conn-disrupt testing.
Fixes: #42725

```release-note
connectivity: Check for IPsec XFRM errors independently of conn-disrupt testing
```
