### PR TITLE
.gitattributes: mark datapath config files as autogenerated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@ pkg/k8s/client/clientset/** linguist-generated
 pkg/k8s/client/informers/** linguist-generated
 pkg/k8s/client/listers/** linguist-generated
 *.bt linguist-language=D
+pkg/datapath/config/*_config.go linguist-generated
 
 # Merge driver configuration for specific paths
 # To set up these merge drivers locally, run:


### PR DESCRIPTION
They are automatically generated by `tools/dpgen`.