### PR TITLE
Add CNI ADD hooks

### DIFF
--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -17,6 +17,20 @@ import (
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
+// LinkConfig contains the GRO/GSO, MTU values and buffer margins to be configured on both sides of
+// the created pair.
+type LinkConfig struct {
+	GROIPv6MaxSize int
+	GSOIPv6MaxSize int
+
+	GROIPv4MaxSize int
+	GSOIPv4MaxSize int
+
+	DeviceMTU      int
+	DeviceHeadroom uint16
+	DeviceTailroom uint16
+}
+
 // Connector configuration. As per BIGTCP, the values here will not be calculated
 // until the Hive has started. This is necessary to allow other dependencies to
 // setup their interfaces etc.

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -10,25 +10,11 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/netns"
 )
-
-// RenameLinkInRemoteNs renames the netdevice in the target namespace to the
-// provided dstIfName.
-func RenameLinkInRemoteNs(ns *netns.NetNS, srcIfName, dstIfName string) error {
-	return ns.Do(func() error {
-		err := link.Rename(srcIfName, dstIfName)
-		if err != nil {
-			return fmt.Errorf("failed to rename link from %q to %q: %w", srcIfName, dstIfName, err)
-		}
-		return nil
-	})
-}
 
 // SetupVeth sets up the net interface, the temporary interface and fills up some endpoint
 // fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the created

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -46,19 +46,6 @@ func SetupVeth(defaultLogger *slog.Logger, id string, cfg LinkConfig, sysctl sys
 	return veth, link, tmpIfName, err
 }
 
-// LinkConfig contains the GRO/GSO, MTU values and buffer margins to be configured on both sides of the created pair.
-type LinkConfig struct {
-	GROIPv6MaxSize int
-	GSOIPv6MaxSize int
-
-	GROIPv4MaxSize int
-	GSOIPv4MaxSize int
-
-	DeviceMTU      int
-	DeviceHeadroom uint16
-	DeviceTailroom uint16
-}
-
 // SetupVethWithNames sets up the net interface, the peer interface and fills up some endpoint
 // fields such as mac, NodeMac, ifIndex and ifName. Returns a pointer for the created
 // veth, a pointer for the peer link and error if something fails.

--- a/plugins/cilium-cni/cmd/hooks.go
+++ b/plugins/cilium-cni/cmd/hooks.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	cniTypesV1 "github.com/containernetworking/cni/pkg/types/100"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/datapath/connector"
+	"github.com/cilium/cilium/plugins/cilium-cni/types"
+)
+
+// OnConfigReady is invoked at the beginning of [(*Cmd).Add], right after the CNI network
+// configuration, CNI arguments and the Cilium agent configuration were loaded. It may be used to
+// sets up internal state of the hook.
+type OnConfigReady interface {
+	OnConfigReady(netConf *types.NetConf, cniArgs *types.ArgsSpec, conf *models.DaemonConfigurationStatus) error
+}
+
+// OnIPAMReady is invoked after IPAM configuration was validated. It may be used to derive further
+// endpoint configuration related to IPAM.
+type OnIPAMReady interface {
+	OnIPAMReady(ipam *models.IPAMResponse) error
+}
+
+// OnLinkConfigReady is invoked before the datapath connectors are called to create the pod's
+// network links (i.e. veth or netkit pairs). It may be used to further modify the link
+// configuration.
+type OnLinkConfigReady interface {
+	OnLinkConfigReady(linkConfig *connector.LinkConfig) error
+}
+
+// OnInterfaceConfigReady is invoked right before the pod's network interface pair is configured and
+// the endpoint creation request is sent to the daemon. It may be used to modify the endpoint
+// creation request, the command state and the CNI result accumulated so far.
+type OnInterfaceConfigReady interface {
+	OnInterfaceConfigReady(cmd *CmdState, ep *models.EndpointChangeRequest, res *cniTypesV1.Result) error
+}
+
+// WithOnConfigReady adds a new callback to be invoked after the CNI network configuration, CNI
+// arguments and the Cilium agent configuration were loaded.
+func WithOnConfigReady(f OnConfigReady) Option {
+	return func(cmd *Cmd) {
+		cmd.onConfigReady = append(cmd.onConfigReady, f)
+	}
+}
+
+// WithOnIPAMReady adds a new callback to be invoked after IPAM configuration was validated.
+func WithOnIPAMReady(f OnIPAMReady) Option {
+	return func(cmd *Cmd) {
+		cmd.onIPAMReady = append(cmd.onIPAMReady, f)
+	}
+}
+
+// WithOnLinkConfigReady adds a new callback to be invoked before the datapath connectors are called
+// to create the pod's network links.
+func WithOnLinkConfigReady(f OnLinkConfigReady) Option {
+	return func(cmd *Cmd) {
+		cmd.onLinkConfigReady = append(cmd.onLinkConfigReady, f)
+	}
+}
+
+// WithOnInterfaceConfigReady adds a new callback to be invoked before the pod's network interface
+// pair is configured.
+func WithOnInterfaceConfigReady(f OnInterfaceConfigReady) Option {
+	return func(cmd *Cmd) {
+		cmd.onInterfaceConfigReady = append(cmd.onInterfaceConfigReady, f)
+	}
+}

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -6,12 +6,6 @@ package main
 import (
 	"runtime"
 
-	"github.com/containernetworking/cni/pkg/skel"
-	cniVersion "github.com/containernetworking/cni/pkg/version"
-
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/version"
 	"github.com/cilium/cilium/plugins/cilium-cni/cmd"
 )
 
@@ -20,10 +14,5 @@ func init() {
 }
 
 func main() {
-	// slogloggercheck: the logger has been initialized with default settings
-	logger := logging.DefaultSlogLogger.With(logfields.LogSubsys, "cilium-cni")
-	c := cmd.NewCmd(logger)
-	skel.PluginMainFuncs(c.CNIFuncs(),
-		cniVersion.PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"),
-		"Cilium CNI plugin "+version.Version)
+	cmd.PluginMain()
 }


### PR DESCRIPTION
The first 2 commits are preparatory refactoring.

The 3rd commit refactors the cilium CNI plugin to have a single main entry point. This simplifies use in downstream implementations of the Cilium CNI plugin.

The 4th commit adds callback hooks to be invoked during CNI ADD, akin to the Hubble `On*` callback hooks. This allows downstream implementation of the Cilium CNI plugin to amend configuration performed for an endpoint during CNI ADD.

See commit messages for more details.
