### PR TITLE
bpf:overlay: adjust deliver to cilium_host@ingress

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -57,8 +57,8 @@ static __always_inline int ipv6_host_delivery(struct __ctx_buff *ctx)
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_NET_IFINDEX);
-	return ctx_redirect(ctx, CILIUM_NET_IFINDEX, 0);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_HOST_IFINDEX);
+	return ctx_redirect(ctx, CILIUM_HOST_IFINDEX, BPF_F_INGRESS);
 }
 
 static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
@@ -201,8 +201,8 @@ static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iph
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_NET_IFINDEX);
-	return ctx_redirect(ctx, CILIUM_NET_IFINDEX, 0);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_HOST_IFINDEX);
+	return ctx_redirect(ctx, CILIUM_HOST_IFINDEX, BPF_F_INGRESS);
 }
 
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)


### PR DESCRIPTION
Prior to this, we were delivering packets to cilium_net@egress.
Given there's no program attached, and we just want the packet to reach
the to-host program, let's adjust the redirection to the cilium_host@ingress
interface, where the `cil_to_host` program is attached (HostFW, etc.).