### PR TITLE
monitor: fix debug capture field ordering 

### DIFF
--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -234,13 +234,13 @@ const (
 // DebugMsg is the message format of the debug message found in the BPF ring buffer
 type DebugMsg struct {
 	api.DefaultSrcDstGetter
-	Type    uint8
-	SubType uint8
-	Source  uint16
-	Hash    uint32
-	Arg1    uint32
-	Arg2    uint32
-	Arg3    uint32
+	Type    uint8  `align:"type"`
+	SubType uint8  `align:"subtype"`
+	Source  uint16 `align:"source"`
+	Hash    uint32 `align:"hash"`
+	Arg1    uint32 `align:"arg1"`
+	Arg2    uint32 `align:"arg2"`
+	Arg3    uint32 `align:"arg3"`
 }
 
 // Dump prints the message according to the verbosity level specified
@@ -435,15 +435,16 @@ const (
 // DebugCapture is the metadata sent along with a captured packet frame
 type DebugCapture struct {
 	api.DefaultSrcDstGetter
-	Type    uint8
-	SubType uint8
+	Type    uint8 `align:"type"`
+	SubType uint8 `align:"subtype"`
 	// Source, if populated, is the ID of the source endpoint.
-	Source  uint16
-	Hash    uint32
-	Len     uint32
-	OrigLen uint32
-	Arg1    uint32
-	Arg2    uint32
+	Source  uint16 `align:"source"`
+	Hash    uint32 `align:"hash"`
+	OrigLen uint32 `align:"len_orig"`
+	Len     uint16 `align:"len_cap"`
+	Version uint16 `align:"version"`
+	Arg1    uint32 `align:"arg1"`
+	Arg2    uint32 `align:"arg2"`
 	// data
 }
 
@@ -475,8 +476,9 @@ func (n *DebugCapture) Decode(data []byte) error {
 	n.SubType = data[1]
 	n.Source = byteorder.Native.Uint16(data[2:4])
 	n.Hash = byteorder.Native.Uint32(data[4:8])
-	n.Len = byteorder.Native.Uint32(data[8:12])
-	n.OrigLen = byteorder.Native.Uint32(data[12:16])
+	n.OrigLen = byteorder.Native.Uint32(data[8:12])
+	n.Len = byteorder.Native.Uint16(data[12:14])
+	n.Version = byteorder.Native.Uint16(data[14:16])
 	n.Arg1 = byteorder.Native.Uint32(data[16:20])
 	n.Arg2 = byteorder.Native.Uint32(data[20:24])
 
@@ -576,7 +578,7 @@ type DebugCaptureVerbose struct {
 	Prefix    string `json:"prefix,omitempty"`
 
 	Source uint16 `json:"source"`
-	Bytes  uint32 `json:"bytes"`
+	Bytes  uint16 `json:"bytes"`
 
 	Summary string `json:"summary,omitempty"`
 }

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -51,23 +51,23 @@ var (
 
 // DropNotify is the message format of a drop notification in the BPF ring buffer
 type DropNotify struct {
-	Type      uint8
-	SubType   uint8
-	Source    uint16
-	Hash      uint32
-	OrigLen   uint32
-	CapLen    uint16
-	Version   uint16
-	SrcLabel  identity.NumericIdentity
-	DstLabel  identity.NumericIdentity
-	DstID     uint32
-	Line      uint16
-	File      uint8
-	ExtError  int8
-	Ifindex   uint32
-	Flags     uint8
-	_         [3]uint8
-	IPTraceID uint64
+	Type      uint8                    `align:"type"`
+	SubType   uint8                    `align:"subtype"`
+	Source    uint16                   `align:"source"`
+	Hash      uint32                   `align:"hash"`
+	OrigLen   uint32                   `align:"len_orig"`
+	CapLen    uint16                   `align:"len_cap"`
+	Version   uint16                   `align:"version"`
+	SrcLabel  identity.NumericIdentity `align:"src_label"`
+	DstLabel  identity.NumericIdentity `align:"dst_label"`
+	DstID     uint32                   `align:"dst_id"`
+	Line      uint16                   `align:"line"`
+	File      uint8                    `align:"file"`
+	ExtError  int8                     `align:"ext_error"`
+	Ifindex   uint32                   `align:"ifindex"`
+	Flags     uint8                    `align:"flags"`
+	_         [3]uint8                 `align:"pad2"`
+	IPTraceID uint64                   `align:"ip_trace_id"`
 	// data
 }
 

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -48,22 +48,22 @@ const (
 
 // PolicyVerdictNotify is the message format of a policy verdict notification in the bpf ring buffer
 type PolicyVerdictNotify struct {
-	Type        uint8
-	SubType     uint8
-	Source      uint16
-	Hash        uint32
-	OrigLen     uint32
-	CapLen      uint16
-	Version     uint16
-	RemoteLabel identity.NumericIdentity
-	Verdict     int32
-	DstPort     uint16
-	Proto       uint8
-	Flags       uint8
-	AuthType    uint8
-	_           [3]uint8
-	Cookie      uint32
-	_           uint32
+	Type        uint8                    `align:"type"`
+	SubType     uint8                    `align:"subtype"`
+	Source      uint16                   `align:"source"`
+	Hash        uint32                   `align:"hash"`
+	OrigLen     uint32                   `align:"len_orig"`
+	CapLen      uint16                   `align:"len_cap"`
+	Version     uint16                   `align:"version"`
+	RemoteLabel identity.NumericIdentity `align:"remote_label"`
+	Verdict     int32                    `align:"verdict"`
+	DstPort     uint16                   `align:"dst_port"`
+	Proto       uint8                    `align:"proto"`
+	Flags       uint8                    `align:"dir"`
+	AuthType    uint8                    `align:"auth_type"`
+	_           [3]uint8                 `align:"pad1"`
+	Cookie      uint32                   `align:"cookie"`
+	_           uint32                   `align:"pad2"`
 	// data
 }
 

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -40,15 +40,15 @@ const (
 type TraceSockNotify struct {
 	api.DefaultSrcDstGetter
 
-	Type       uint8
-	XlatePoint uint8
-	L4Proto    uint8
-	Flags      uint8
-	DstPort    uint16
-	_          uint16
-	SockCookie uint64
-	CgroupId   uint64
-	DstIP      types.IPv6
+	Type       uint8      `align:"type"`
+	XlatePoint uint8      `align:"xlate_point"`
+	L4Proto    uint8      `align:"l4_proto"`
+	Flags      uint8      `align:"ipv6"`
+	DstPort    uint16     `align:"dst_port"`
+	_          uint16     `align:"pad2"`
+	SockCookie uint64     `align:"sock_cookie"`
+	CgroupId   uint64     `align:"cgroup_id"`
+	DstIP      types.IPv6 `align:"dst_ip"`
 }
 
 // Dump prints the message according to the verbosity level specified

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -48,21 +48,21 @@ const (
 
 // TraceNotify is the message format of a trace notification in the BPF ring buffer
 type TraceNotify struct {
-	Type      uint8
-	ObsPoint  uint8
-	Source    uint16
-	Hash      uint32
-	OrigLen   uint32
-	CapLen    uint16
-	Version   uint16
-	SrcLabel  identity.NumericIdentity
-	DstLabel  identity.NumericIdentity
-	DstID     uint16
-	Reason    uint8
-	Flags     uint8
-	Ifindex   uint32
-	OrigIP    types.IPv6
-	IPTraceID uint64
+	Type      uint8                    `align:"type"`
+	ObsPoint  uint8                    `align:"subtype"`
+	Source    uint16                   `align:"source"`
+	Hash      uint32                   `align:"hash"`
+	OrigLen   uint32                   `align:"len_orig"`
+	CapLen    uint16                   `align:"len_cap"`
+	Version   uint16                   `align:"version"`
+	SrcLabel  identity.NumericIdentity `align:"src_label"`
+	DstLabel  identity.NumericIdentity `align:"dst_label"`
+	DstID     uint16                   `align:"dst_id"`
+	Reason    uint8                    `align:"reason"`
+	Flags     uint8                    `align:"flags"`
+	Ifindex   uint32                   `align:"ifindex"`
+	OrigIP    types.IPv6               `align:"$union0"`
+	IPTraceID uint64                   `align:"ip_trace_id"`
 	// data
 }
 


### PR DESCRIPTION
The fields of the `DebugCapture` did not actually match the datapath struct. We wrongly put the original length in the length field, and the OrigLen field contained the captured length in the lower bits and the notify version in the upper bits.

While we're at it, add alignment tags, so this doesn't happen again


I guess we never noticed it because hardly anyone ever enables debug events and Hubble doesn't use these length fields. You'd only notice that things aren't quite right if you closely look at the cilium monitor output (and even there we only ever used the `Len` field which just contained the original length instead of the captured length).
So this is technically a bug, but the impact was very small.

```release-note
Fix reported packet length in cilium monitor debug capture events
```
