### PR TITLE
policy: add EntityNamespace for intra-namespace traffic

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -28,6 +28,9 @@ var (
 	//go:embed manifests/allow-cluster-entity.yaml
 	allowClusterEntityPolicyYAML string
 
+	//go:embed manifests/allow-intra-namespace-entity-ccnp.yaml
+	allowIntraNamespaceEntityPolicyYAML string
+
 	//go:embed manifests/client-egress-only-dns.yaml
 	clientEgressOnlyDNSPolicyYAML string
 
@@ -333,6 +336,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 		clientEgressL7TlsHeaders{},
 		egresstoSpecificNamespace{},
 		ingressfromSpecificNamespace{},
+		namespaceEntity{},
 	}
 	return injectTests(tests, ct)
 }

--- a/cilium-cli/connectivity/builder/manifests/allow-intra-namespace-entity-ccnp.yaml
+++ b/cilium-cli/connectivity/builder/manifests/allow-intra-namespace-entity-ccnp.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-intra-namespace-entity
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: ccnp
+  ingress:
+    - fromEntities:
+        - namespace
+  egress:
+    - toEntities:
+        - namespace

--- a/cilium-cli/connectivity/builder/namespace_entity.go
+++ b/cilium-cli/connectivity/builder/namespace_entity.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"strings"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type namespaceEntity struct{}
+
+func (t namespaceEntity) build(ct *check.ConnectivityTest, _ map[string]string) {
+	// This policy allows traffic only within the same namespace using
+	// the "namespace" entity. Pods with kind=ccnp in any namespace can
+	// communicate with other pods in the SAME namespace, but not across
+	// namespaces.
+	newTest("namespace-entity", ct).
+		WithFeatureRequirements(features.RequireEnabled(features.CCNP)).
+		WithCiliumClusterwidePolicy(allowIntraNamespaceEntityPolicyYAML).
+		WithScenarios(tests.CCNPClienttoClient()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			// When source and destination are in the same namespace,
+			// traffic should be allowed. When in different namespaces,
+			// traffic should be dropped.
+			// Pod.Name() returns "namespace/name", so we extract the namespace
+			// from the first part.
+			srcName := a.Source().Name()
+			dstName := a.Destination().Name()
+			srcNS := strings.Split(srcName, "/")[0]
+			dstNS := strings.Split(dstName, "/")[0]
+			if srcNS == dstNS {
+				return check.ResultOK, check.ResultOK
+			}
+			return check.ResultDrop, check.ResultNone
+		})
+}

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -12,7 +12,7 @@ import (
 // individual identities.  Entities are used to describe "outside of cluster",
 // "host", etc.
 //
-// +kubebuilder:validation:Enum=all;world;cluster;host;init;ingress;unmanaged;remote-node;health;none;kube-apiserver
+// +kubebuilder:validation:Enum=all;world;cluster;host;init;ingress;unmanaged;remote-node;health;none;kube-apiserver;namespace
 type Entity string
 
 const (
@@ -60,6 +60,14 @@ const (
 
 	// EntityKubeAPIServer is an entity that represents the kube-apiserver.
 	EntityKubeAPIServer Entity = "kube-apiserver"
+
+	// EntityNamespace is an entity that represents all endpoints in the same
+	// namespace as the policy. This entity is only valid in namespaced
+	// CiliumNetworkPolicy resources, not in CiliumClusterwideNetworkPolicy.
+	// Using this entity allows creating a single policy that permits
+	// intra-namespace communication without having to specify the namespace
+	// explicitly.
+	EntityNamespace Entity = "namespace"
 )
 
 var (
@@ -112,6 +120,15 @@ var (
 		// initialized at runtime as it depends on user configuration
 		// such as the cluster name. See InitEntities() below.
 		EntityCluster: {},
+
+		// EntityNamespace is populated with an empty entry to allow
+		// basic rule validation. Unlike other entities, EntityNamespace
+		// is context-dependent and cannot be resolved to a static
+		// endpoint selector. It is expanded to a namespace-specific
+		// endpoint selector at policy parse time in
+		// pkg/k8s/apis/cilium.io/utils/utils.go when the policy's
+		// namespace context is known.
+		EntityNamespace: {},
 	}
 )
 

--- a/pkg/policy/types/policyentry_test.go
+++ b/pkg/policy/types/policyentry_test.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+func TestEntityNamespaceMarker(t *testing.T) {
+	// Test that EntityNamespaceMarker implements PeerSelector
+	var _ PeerSelector = EntityNamespaceMarker{}
+
+	marker := EntityNamespaceMarker{}
+	marker.IsPeerSelector() // Should compile and not panic
+}
+
+func TestPeerSelectorSliceHasEntityNamespaceMarker(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    PeerSelectorSlice
+		expected bool
+	}{
+		{
+			name:     "empty slice",
+			slice:    PeerSelectorSlice{},
+			expected: false,
+		},
+		{
+			name:     "nil slice",
+			slice:    nil,
+			expected: false,
+		},
+		{
+			name: "only EndpointSelectors",
+			slice: PeerSelectorSlice{
+				api.NewESFromLabels(),
+				api.NewESFromLabels(),
+			},
+			expected: false,
+		},
+		{
+			name: "only EntityNamespaceMarker",
+			slice: PeerSelectorSlice{
+				EntityNamespaceMarker{},
+			},
+			expected: true,
+		},
+		{
+			name: "mixed with EntityNamespaceMarker",
+			slice: PeerSelectorSlice{
+				api.NewESFromLabels(),
+				EntityNamespaceMarker{},
+				api.NewESFromLabels(),
+			},
+			expected: true,
+		},
+		{
+			name: "CIDR and FQDN without marker",
+			slice: PeerSelectorSlice{
+				api.CIDR("10.0.0.0/8"),
+				api.FQDNSelector{MatchName: "example.com"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.slice.HasEntityNamespaceMarker()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPeerSelectorSliceGetAsEndpointSelectors(t *testing.T) {
+	// Test that GetAsEndpointSelectors ignores EntityNamespaceMarker
+	slice := PeerSelectorSlice{
+		api.NewESFromLabels(),
+		EntityNamespaceMarker{},
+		api.NewESFromLabels(),
+	}
+
+	selectors := slice.GetAsEndpointSelectors()
+	// Should only return the two EndpointSelectors, not the marker
+	require.Len(t, selectors, 2)
+}
+
+func TestPeerSelectorSliceGetAsEndpointSelectorsWithNamespace(t *testing.T) {
+	// Use the proper label format: "k8s.io.kubernetes.pod.namespace"
+	// The label source prefix is added differently in the matching code
+	namespaceLabel := "io.kubernetes.pod.namespace"
+
+	tests := []struct {
+		name          string
+		slice         PeerSelectorSlice
+		namespace     string
+		expectedCount int
+	}{
+		{
+			name: "expand marker with namespace",
+			slice: PeerSelectorSlice{
+				EntityNamespaceMarker{},
+			},
+			namespace:     "my-namespace",
+			expectedCount: 1,
+		},
+		{
+			name: "marker with empty namespace returns nothing",
+			slice: PeerSelectorSlice{
+				EntityNamespaceMarker{},
+			},
+			namespace:     "",
+			expectedCount: 0,
+		},
+		{
+			name: "mixed selectors with marker",
+			slice: PeerSelectorSlice{
+				api.NewESFromLabels(),
+				EntityNamespaceMarker{},
+				api.NewESFromLabels(),
+			},
+			namespace:     "test-ns",
+			expectedCount: 3, // 2 original + 1 expanded from marker
+		},
+		{
+			name: "no marker just returns regular selectors",
+			slice: PeerSelectorSlice{
+				api.NewESFromLabels(),
+				api.NewESFromLabels(),
+			},
+			namespace:     "any-ns",
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selectors := tt.slice.GetAsEndpointSelectorsWithNamespace(tt.namespace, namespaceLabel)
+			require.Len(t, selectors, tt.expectedCount)
+		})
+	}
+}
+
+func TestPeerSelectorSliceDeepEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        PeerSelectorSlice
+		b        PeerSelectorSlice
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "empty and nil are equal (both have len 0)",
+			a:        PeerSelectorSlice{},
+			b:        nil,
+			expected: true, // DeepEqual treats empty and nil as equal since len() == 0
+		},
+		{
+			name:     "both empty",
+			a:        PeerSelectorSlice{},
+			b:        PeerSelectorSlice{},
+			expected: true,
+		},
+		{
+			name:     "both have EntityNamespaceMarker",
+			a:        PeerSelectorSlice{EntityNamespaceMarker{}},
+			b:        PeerSelectorSlice{EntityNamespaceMarker{}},
+			expected: true,
+		},
+		{
+			name:     "one has marker, other doesn't",
+			a:        PeerSelectorSlice{EntityNamespaceMarker{}},
+			b:        PeerSelectorSlice{api.NewESFromLabels()},
+			expected: false,
+		},
+		{
+			name:     "different lengths",
+			a:        PeerSelectorSlice{EntityNamespaceMarker{}, EntityNamespaceMarker{}},
+			b:        PeerSelectorSlice{EntityNamespaceMarker{}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.a.DeepEqual(&tt.b)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add a new "namespace" entity that allows policies to permit traffic only within the same namespace
- For CNP (namespaced policies): EntityNamespace is expanded at parse time to a namespace-specific endpoint selector
- For CCNP (cluster-wide policies): EntityNamespace flows through the pipeline as a marker and is expanded at policy computation time when the endpoint's namespace is known

## Use Case
This enables a single CiliumClusterwideNetworkPolicy to allow intra-namespace communication for ALL namespaces, replacing verbose per-namespace policies:

```yaml
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: allow-intra-namespace
spec:
  endpointSelector: {}
  ingress:
    - fromEntities: [namespace]
  egress:
    - toEntities: [namespace]
```

## Changes
- `pkg/policy/api/entity.go` - Added EntityNamespace constant
- `pkg/policy/types/policyentry.go` - Added EntityNamespaceMarker type for CCNP pipeline
- `pkg/k8s/apis/cilium.io/utils/utils.go` - CNP/CCNP parsing logic
- `pkg/policy/utils/parserules.go` - Entity merging logic
- `pkg/policy/l4.go` - Runtime expansion of marker

## Test plan
- [x] Unit tests for EntityNamespace in `pkg/policy/api/entity_test.go`
- [x] Unit tests for EntityNamespaceMarker in `pkg/policy/types/policyentry_test.go`
- [x] Unit tests for parserules in `pkg/policy/utils/parserules_test.go`
- [x] Unit tests for CNP/CCNP parsing in `pkg/k8s/apis/cilium.io/utils/utils_test.go`
- [x] E2E test in `cilium-cli/connectivity/builder/namespace_entity.go`
- [ ] Manual testing in a cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)