### PR TITLE
bpf:wireguard: set identity before redirecting to host

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1679,6 +1679,10 @@ int cil_to_host(struct __ctx_buff *ctx)
 #ifdef ENABLE_IDENTITY_MARK
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_IDENTITY)
 		src_id = get_identity(ctx);
+# ifdef ENABLE_WIREGUARD
+	else if (ctx_is_decrypt(ctx))
+		src_id = get_identity(ctx);
+# endif
 #endif
 
 	/* Retrieve values carried either via ctx->mark or ctx->cb.

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -132,6 +132,9 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 identity __maybe_unused, __s8 *ext_err
 	if (ret != 0)
 		return ret;
 
+#ifdef ENABLE_IDENTITY_MARK
+	set_identity_mark(ctx, identity, MARK_MAGIC_DECRYPT);
+#endif
 	return ipv6_host_delivery(ctx);
 }
 
@@ -281,6 +284,14 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 identity __maybe_unused, __s8 *ext_err
 				    sizeof(*ip4), false))
 		return DROP_INVALID;
 
+#ifdef ENABLE_IDENTITY_MARK
+	/* We must use the MARK_MAGIC_DECRYPT rather than MARK_MAGIC_IDENTITY though,
+	 * as at the beginning of the from-wireguard program we mark the packet as
+	 * decrypted. That has been introduced to support Ingress Strict Mode
+	 * (see https://github.com/cilium/cilium/pull/39239).
+	 */
+	set_identity_mark(ctx, identity, MARK_MAGIC_DECRYPT);
+#endif
 	return ipv4_host_delivery(ctx, ip4);
 }
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -280,7 +280,9 @@ enum metric_dir {
 #define MARK_MAGIC_PROXY_INGRESS	0x0A00 /* source identity (upstream traffic only) */
 #define MARK_MAGIC_PROXY_EGRESS		0x0B00 /* source identity (upstream traffic only) */
 #define MARK_MAGIC_HOST			0x0C00
-#define MARK_MAGIC_DECRYPT		0x0D00
+#define MARK_MAGIC_DECRYPT		0x0D00 /* IPSec: source node ID (ingress encrypted traffic)
+						* WireGuard: source identity (ingress decrypted traffic)
+						*/
 #define MARK_MAGIC_ENCRYPT		0x0E00
 #define MARK_MAGIC_IDENTITY		0x0F00 /* source identity */
 #define MARK_MAGIC_TO_PROXY		0x0200


### PR DESCRIPTION
This aligns bpf_wireguard to bpf_overlay, where we set the identity before
redirecting to host. With https://github.com/cilium/cilium/pull/43005, we always retrieve the source identity
also in bpf_wireguard. Also, with https://github.com/cilium/cilium/pull/43000, we enable retrieving the passed
identity in cilium_host@ingress.

We must use the MARK_MAGIC_DECRYPT rather than MARK_MAGIC_IDENTITY though,
as at the beginning of the from-wireguard function we mark the packet as
decrypted. This has been introduced in the Ingress Strict Mode in PR
https://github.com/cilium/cilium/pull/39239.

In addition, this is all protected via the ENABLE_IDENTITY_MARK macro,
to avoid clashing while in chaining mode as we did discover during https://github.com/cilium/cilium/pull/39239.