### PR TITLE
workflows/kpr: Reduce test concurrency to 2

### DIFF
--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -51,7 +51,6 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 25
-          maxPodsPerNode: 110
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
@@ -64,7 +63,6 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 25
-          maxPodsPerNode: 110
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
@@ -138,7 +136,6 @@ runs:
           privateNetworking: true
           volumeType: "gp3"
           volumeSize: 20
-          maxPodsPerNode: 110
           taints:
            - key: "cilium.io/no-schedule"
              value: "true"

--- a/.github/workflows/conformance-kpr.yaml
+++ b/.github/workflows/conformance-kpr.yaml
@@ -107,6 +107,7 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
       extra-args: '{"kpr": true, "advanced-features": true}'
+      test-concurrency: 2
 
   conformance-eks-kpr-ipsec:
     name: Conformance EKS with KPR + IPsec
@@ -132,6 +133,7 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
       extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
+      test-concurrency: 2
 
   merge-upload-and-status:
     name: Merge Upload and Status


### PR DESCRIPTION
As original discovered by Bernardo, the pods were failing to be
scheduled on nodes. Although the suggestion to increase the number of
pods to 110 seemed ideal, it made it just a coincidence for the tests to
be passing. Even if we increase the number of pods on the node we might
get other issues [1] related with the maximum number of ENIs the nodes of
this type support, which in the case of t3a.medium is 3 ENIs × 6 IPs = max
18 IPs. Thus, we will reduce the number of concurrent tests to 2,
similar to the other jobs, which will facilitate the pressure put on the
nodes to run pods in parallel.

[1] "no IPs currently available on the node, allocation will be retried
once Cilium Operator allocates more IPs"

Fixes https://github.com/cilium/cilium/issues/42816
