### PR TITLE
bpf: dsr: store RevDNAT info for DSR connections in CT entry

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -800,6 +800,8 @@ create_ct:
 		if (port == 0)
 			return DROP_INVALID;
 
+		ipv6_addr_copy(&ct_state_new.nat_addr, addr);
+		ct_state_new.nat_port = port;
 		ct_state_new.src_sec_id = WORLD_IPV6_ID;
 		ct_state_new.dsr_internal = 1;
 
@@ -2182,6 +2184,8 @@ create_ct:
 			 */
 			return DROP_INVALID;
 
+		ct_state_new.nat_addr.p4 = addr;
+		ct_state_new.nat_port = port;
 		ct_state_new.src_sec_id = WORLD_IPV4_ID;
 		ct_state_new.dsr_internal = 1;
 
@@ -2196,12 +2200,14 @@ create_ct:
 	case CT_ESTABLISHED:
 		/* For TCP we only expect DSR info on the SYN, so CT_ESTABLISHED
 		 * is unexpected and we need to refresh the CT entry.
-		 *
-		 * Otherwise we tolerate DSR info on an established connection.
-		 * TODO: how do we know if we need to refresh the SNAT entry?
 		 */
 		if (tuple->nexthdr == IPPROTO_TCP && port)
 			goto create_ct;
+
+		/* Otherwise we tolerate DSR info on an established connection.
+		 * TODO: obtain NAT info from CT lookup, and compare it against
+		 *	 DSR info. Re-create on mismatch.
+		 */
 		break;
 	default:
 		return DROP_UNKNOWN_CT;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -867,6 +867,14 @@ nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
 		struct ipv6_nat_entry *dsr_entry;
 		struct ipv6_ct_tuple dsr_tuple;
 
+		if (entry->nat_port) {
+			ipv6_addr_copy(&nat_info->address,
+				       &entry->nat_addr);
+
+			nat_info->port = entry->nat_port;
+			return true;
+		}
+
 		dsr_tuple = *tuple;
 
 		dsr_tuple.flags = NAT_DIR_EGRESS;
@@ -2216,6 +2224,7 @@ create_ct:
 		ret = ct_create4(get_ct_map4(tuple), NULL, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, ext_err);
 		if (!IS_ERR(ret))
+			/* TODO remove this in v1.20 */
 			ret = snat_v4_create_dsr(tuple, addr, port, ext_err);
 
 		if (IS_ERR(ret))
@@ -2271,6 +2280,12 @@ nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
 	if (is_defined(ENABLE_DSR) && entry->dsr_internal) {
 		struct ipv4_nat_entry *dsr_entry;
 		struct ipv4_ct_tuple dsr_tuple;
+
+		if (entry->nat_port) {
+			nat_info->address = entry->nat_addr.p4;
+			nat_info->port = entry->nat_port;
+			return true;
+		}
 
 		dsr_tuple = *tuple;
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -384,7 +384,7 @@ func purgeCtEntry(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func(
 	tupleType := t.GetFlags()
 
 	if tupleType == tuple.TUPLE_F_SERVICE && ACT != nil {
-		actCountFailed(entry.RevNAT, uint32(entry.BackendID))
+		actCountFailed(entry.RevNAT, uint32(entry.Union0[1]))
 	}
 
 	next(GCEvent{

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -309,15 +309,15 @@ func (k *CtKey6Global) GetTupleKey() tuple.TupleKey {
 
 // CtEntry represents an entry in the connection tracking table.
 type CtEntry struct {
-	Reserved0 uint64 `align:"reserved0"`
-	BackendID uint64 `align:"backend_id"`
-	Packets   uint64 `align:"packets"`
-	Bytes     uint64 `align:"bytes"`
-	Lifetime  uint32 `align:"lifetime"`
-	Flags     uint16 `align:"rx_closing"`
+	Union0   [2]uint64 `align:"$union0"`
+	Packets  uint64    `align:"packets"`
+	Bytes    uint64    `align:"bytes"`
+	Lifetime uint32    `align:"lifetime"`
+	Flags    uint16    `align:"rx_closing"`
 	// RevNAT is in network byte order
-	RevNAT           uint16 `align:"rev_nat_index"`
-	Reserved4        uint16 `align:"reserved4"`
+	RevNAT uint16 `align:"rev_nat_index"`
+	// NatPort is in network byte order
+	NatPort          uint16 `align:"nat_port"`
 	TxFlagsSeen      uint8  `align:"tx_flags_seen"`
 	RxFlagsSeen      uint8  `align:"rx_flags_seen"`
 	SourceSecurityID uint32 `align:"src_sec_id"`
@@ -398,7 +398,7 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		timeDiff = ""
 	}
 
-	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d BackendID=%d \n",
+	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d BackendID=%d NatPort=%d \n",
 		c.Lifetime,
 		timeDiff,
 		c.Packets,
@@ -410,7 +410,9 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		c.flagsString(),
 		byteorder.NetworkToHost16(c.RevNAT),
 		c.SourceSecurityID,
-		c.BackendID)
+		c.Union0[1],
+		// TODO NatAddr, either IPv4 or IPv6
+		byteorder.NetworkToHost16(c.NatPort))
 }
 
 // String returns the readable format


### PR DESCRIPTION
When the first packet for a DSR'd connection arrives at the backend node, we currently extract the embedded RevDNAT information in the `from-{overlay,wireguard,netdev}` program, and push it into a NAT entry. But there's actually enough room in the CT entry itself to store a full IPv6 address and port - so let's do that, and use it in the nodeport RevDNAT path for reply processing.

For now we keep all the legacy processing for DSR RevDNAT via NAT entry intact, so that we can (1) handle existing connections (without NAT info in the CT entry), and (2) downgrade to an older Cilium which doesn't handle NAT info in the CT entry.

Future work is to also use this NAT space in the CT entry for the BPF masq engine, and SNAT-ed connections on the LB node. That should be enough justification for using up all the precious free space in the CT entry :).