### PR TITLE
bpf/tests/scapy: use a BPF map instead of trace_pipe for asserts and remove 128byte buf limit

### DIFF
--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -105,15 +105,9 @@ ifdef BPF_TEST
 endif
 
 run: $(TEST_OBJECTS)
-	$(QUIET) $(SUDO) bash -c 'cat /sys/kernel/debug/tracing/trace_pipe > $(TRACE_PIPE_LOG) & \
-	echo $$! > $(TRACE_PIPE_PID)'; STATUS=0; \
 	$(GO) test ./bpftest \
 		-bpf-test-path $(ROOT_DIR)/bpf/tests \
 		$(BPF_TEST_FLAGS) \
-	| $(GOTEST_FORMATTER) || STATUS=$$?; \
-	$(SUDO) kill -9 $$(cat $(TRACE_PIPE_PID)) || true; \
-	rm -f $(TRACE_PIPE_PID) || true; \
-	$(ROOT_DIR)/bpf/tests/scapy/./trace_diff_pkts.py $(TRACE_PIPE_LOG) || true; \
-	exit $$STATUS
+	| $(GOTEST_FORMATTER);
 
 -include $(TEST_OBJECTS:.o=.d)

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -185,12 +185,6 @@ static struct scapy_assert __scapy_assert = {0};
 				test_fail_now();					\
 			}								\
 			++scapy_assert_map_cnt;						\
-			hexdump_len_off(__FILE__ ":" LINE_STRING " assert '"		\
-					NAME "' FAILED! Got (ctx)",			\
-					FIRST_LAYER, CTX, _len, OFF);			\
-			scapy_hexdump(__FILE__ ":" LINE_STRING " assert '"		\
-				      NAME "' FAILED! Expected (buf)",			\
-				      FIRST_LAYER, _BUF, _BUF_LEN);			\
 			test_fail_now();						\
 		}									\
 	} while (0)
@@ -210,28 +204,5 @@ static struct scapy_assert __scapy_assert = {0};
 				    #BUF_NAME, BUF(BUF_NAME),			\
 				    sizeof(BUF(BUF_NAME)), LEN);		\
 	} do {} while (0)
-
-static __always_inline
-void scapy_hexdump(const char *msg, const char *first_layer,
-		   const unsigned char *scapy_buf, const __u16 len)
-{
-	int i;
-	char buf[HD_MAX_BYTES * 2 + 1] = {0};
-	char *b;
-
-	if (len > HD_MAX_BYTES) {
-		hex_printk("%s: pkt[%s]", msg, "ERROR: len too big!");
-		return;
-	}
-
-	for (i = 0; i < len; ++i) {
-		b = (char *)&scapy_buf[i];
-		buf[i * 2]     = __hexdump_nibble_to_char((*b & 0xF0) >> 4);
-		buf[i * 2 + 1] = __hexdump_nibble_to_char((*b & 0x0F));
-	}
-
-	buf[2 * i] = '\0';
-	hex_printk("%s: pkt_hex %s[%s]", msg, first_layer, buf);
-}
 
 #include "output/gen_pkts.h"


### PR DESCRIPTION
This patchset:

* Changes the Scapy infrastructure to use a BPF map instead of the `trace_pipe`, hugely simplifying code. It also speeds up execution slightly.
* Removes the limitation of Scapy asserts with pkts > 128byte (which comes from custom builtins limitation).

See commit messages for details.

I will tackle this TODO in a follow-up PR:

> `TODO: add assert num given the limitations of test_log() (no support to serialize strings).`

Which should allow cleaner messages when reusing test code with the new `ASSERT_CTX_BUF_OFF2()`.

```release-note
bpf/tests: use map instead of trace_pipe
bpf/tests: remove BPF unit test 128 byte Scapy limitation 
```

This is a follow-up PR on TODO4 in:

* #40294

>```TODO4: don't use `trace_pipe` and post-processing to enrich assertions. It might be easier to use a map to store failed assertions, and post-process from there.```

> ```Using trace_pipe for sending failed assert data back to the unit test go prog is... hacky. It might be worth looking into using a BPF map for this.```