### PR TITLE
node/store: Ignore node events with mismatched cluster names in kvstore mode

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -316,6 +316,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EncryptNode, defaults.EncryptNode, "Enables encrypting traffic from non-Cilium pods and host networking (only supported with WireGuard, beta)")
 	option.BindEnv(vp, option.EncryptNode)
 
+	flags.Bool(option.EnableKVStoreClusterNameMismatchFilter, false, "Enables kvstore observer filtering of update/delete events of nodes which do not match local cluster name ")
+	option.BindEnv(vp, option.EnableKVStoreClusterNameMismatchFilter)
+	flags.MarkHidden(option.EnableKVStoreClusterNameMismatchFilter)
+
 	flags.StringSlice(option.IPv4PodSubnets, []string{}, "List of IPv4 pod subnets to preconfigure for encryption")
 	option.BindEnv(vp, option.IPv4PodSubnets)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -161,6 +161,8 @@ const (
 	// EncryptNode enables node IP encryption
 	EncryptNode = "encrypt-node"
 
+	EnableKVStoreClusterNameMismatchFilter = "enable-kvstore-cluster-name-mismatch-filter"
+
 	// GopsPort is the TCP port for the gops server.
 	GopsPort = "gops-port"
 
@@ -1417,6 +1419,8 @@ type DaemonConfig struct {
 	HostV6Addr          net.IP   // Host v6 address of the snooping device
 	EncryptInterface    []string // Set of network facing interface to encrypt over
 	EncryptNode         bool     // Set to true for encrypting node IP traffic
+
+	EnableKVStoreClusterNameMismatchFilter bool
 
 	// If set to true the daemon will detect new and deleted datapath devices
 	// at runtime and reconfigure the datapath to load programs onto the new
@@ -3066,6 +3070,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableLocalRedirectPolicy = vp.GetBool(EnableLocalRedirectPolicy)
 	c.EncryptInterface = vp.GetStringSlice(EncryptInterface)
 	c.EncryptNode = vp.GetBool(EncryptNode)
+	c.EnableKVStoreClusterNameMismatchFilter = vp.GetBool(EnableKVStoreClusterNameMismatchFilter)
 	c.IdentityChangeGracePeriod = vp.GetDuration(IdentityChangeGracePeriod)
 	c.IdentityRestoreGracePeriod = vp.GetDuration(IdentityRestoreGracePeriod)
 	c.IPAM = vp.GetString(IPAM)


### PR DESCRIPTION
When a cluster name is changed in kvstore mode and cilium-agent is restarted, two node entries may briefly exist: [$old_cluster_name/$node] and [$new_cluster_name/$node]. The stale entry for the old cluster name is eventually removed by the kvstore's TTL lease expiration. However, this removal event currently triggers the deletion of related IPcache entries, ipsets, (auto-direct-node) routes, and potentially other resources.

This commit introduces a filter for node events from [source.KVStore], ensuring that only events matching the current cluster name are processed. Node events associated with an outdated cluster name are ignored, preventing unnecessary cleanup of resources belonging to the active cluster.

This workaround is specific to v1.16, where the cluster name schema enforcement was introduced \[1\]. In newer versions, users are not expected to change the cluster name, so we assume that this issue does not occur.

\[1\]: https://github.com/cilium/cilium/pull/32641
