### PR TITLE
modernize: Enable `stringsbuilder` analyzer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -120,7 +120,6 @@ linters:
       disable: # TODO: remove each disabled rule and fix it
         - omitzero
         - rangeint
-        - stringsbuilder
         - waitgroup
     govet:
       enable:

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -179,18 +179,20 @@ func (c ciliumCleanup) whatWillBeRemoved() []string {
 	toBeRemoved := []string{}
 
 	if len(c.tcFilters) > 0 {
-		section := "tc filters\n"
+		var section strings.Builder
+		section.WriteString("tc filters\n")
 		for linkName, f := range c.tcFilters {
-			section += fmt.Sprintf("%s %v\n", linkName, f)
+			fmt.Fprintf(&section, "%s %v\n", linkName, f)
 		}
-		toBeRemoved = append(toBeRemoved, section)
+		toBeRemoved = append(toBeRemoved, section.String())
 	}
 	if len(c.xdpLinks) > 0 {
-		section := "xdp programs\n"
+		var section strings.Builder
+		section.WriteString("xdp programs\n")
 		for _, l := range c.xdpLinks {
-			section += fmt.Sprintf("%s: xdp/prog id %v\n", l.Attrs().Name, l.Attrs().Xdp.ProgId)
+			fmt.Fprintf(&section, "%s: xdp/prog id %v\n", l.Attrs().Name, l.Attrs().Xdp.ProgId)
 		}
-		toBeRemoved = append(toBeRemoved, section)
+		toBeRemoved = append(toBeRemoved, section.String())
 	}
 
 	if c.bpfOnly {
@@ -198,27 +200,30 @@ func (c ciliumCleanup) whatWillBeRemoved() []string {
 	}
 
 	if len(c.routes) > 0 {
-		section := "routes\n"
+		var section strings.Builder
+		section.WriteString("routes\n")
 		for _, v := range c.routes {
-			section += fmt.Sprintf("%v\n", v)
+			fmt.Fprintf(&section, "%v\n", v)
 		}
-		toBeRemoved = append(toBeRemoved, section)
+		toBeRemoved = append(toBeRemoved, section.String())
 	}
 
 	if len(c.links) > 0 {
-		section := "links\n"
+		var section strings.Builder
+		section.WriteString("links\n")
 		for _, v := range c.links {
-			section += fmt.Sprintf("%v\n", v)
+			fmt.Fprintf(&section, "%v\n", v)
 		}
-		toBeRemoved = append(toBeRemoved, section)
+		toBeRemoved = append(toBeRemoved, section.String())
 	}
 
 	if len(c.netNSs) > 0 {
-		section := "network namespaces\n"
+		var section strings.Builder
+		section.WriteString("network namespaces\n")
 		for _, n := range c.netNSs {
-			section += fmt.Sprintf("%s\n", n)
+			fmt.Fprintf(&section, "%s\n", n)
 		}
-		toBeRemoved = append(toBeRemoved, section)
+		toBeRemoved = append(toBeRemoved, section.String())
 	}
 	toBeRemoved = append(toBeRemoved, fmt.Sprintf("socketlb bpf programs at %s",
 		defaults.DefaultCgroupRoot))
@@ -324,12 +329,13 @@ func showWhatWillBeRemoved(cleanups []cleanup) {
 		toBeRemoved = append(toBeRemoved, cleanup.whatWillBeRemoved()...)
 	}
 
-	warning := "Warning: Destructive operation. You are about to remove:\n"
+	var warning strings.Builder
+	warning.WriteString("Warning: Destructive operation. You are about to remove:\n")
 	for _, warn := range toBeRemoved {
-		warning += fmt.Sprintf("- %s\n", warn)
+		fmt.Fprintf(&warning, "- %s\n", warn)
 	}
 
-	fmt.Print(warning)
+	fmt.Print(warning.String())
 }
 
 func confirmCleanup() bool {

--- a/hubble/pkg/printer/printer.go
+++ b/hubble/pkg/printer/printer.go
@@ -262,21 +262,21 @@ func (p Printer) getVerdict(f *flowpb.Flow) string {
 }
 
 func formatPolicyNames(policies []*flowpb.Policy) string {
-	msg := ""
+	var msg strings.Builder
 	i := 0
 	for _, policy := range policies {
 		if policy.GetKind() != "" && policy.GetName() != "" {
 			if i == 0 {
-				msg += " BY "
+				msg.WriteString(" BY ")
 			} else {
-				msg += ", "
+				msg.WriteString(", ")
 			}
-			msg += fmt.Sprintf("%s (%s)", policy.GetName(), policy.GetKind())
+			fmt.Fprintf(&msg, "%s (%s)", policy.GetName(), policy.GetKind())
 			i += 1
 		}
 	}
 
-	return msg
+	return msg.String()
 }
 
 func (p Printer) getSummary(f *flowpb.Flow) string {

--- a/pkg/bgp/api/printers.go
+++ b/pkg/bgp/api/printers.go
@@ -185,11 +185,11 @@ func formatStringArray(arr []string) string {
 	if len(arr) == 1 {
 		return arr[0]
 	}
-	res := ""
+	var res strings.Builder
 	for _, str := range arr {
-		res += "{" + str + "} "
+		res.WriteString("{" + str + "} ")
 	}
-	return strings.TrimSpace(res)
+	return strings.TrimSpace(res.String())
 }
 
 func formatFamilies(families []*models.BgpFamily) []string {
@@ -443,15 +443,15 @@ func parseGracefulRestartCap(g *bgppacket.CapGracefulRestart) string {
 }
 
 func parseLongLivedGracefulRestartCap(g *bgppacket.CapLongLivedGracefulRestart) string {
-	llgrStr := ""
+	var llgrStr strings.Builder
 	for _, t := range g.Tuples {
-		llgrStr += fmt.Sprintf("\t\t\t%s, restart time %d sec", bgppacket.AfiSafiToRouteFamily(t.AFI, t.SAFI), t.RestartTime)
+		fmt.Fprintf(&llgrStr, "\t\t\t%s, restart time %d sec", bgppacket.AfiSafiToRouteFamily(t.AFI, t.SAFI), t.RestartTime)
 		if t.Flags == 0x80 {
-			llgrStr += ", forward flag set"
+			llgrStr.WriteString(", forward flag set")
 		}
-		llgrStr += "\n"
+		llgrStr.WriteString("\n")
 	}
-	return llgrStr
+	return llgrStr.String()
 }
 
 func parseExtendedNexthopCap(e *bgppacket.CapExtendedNexthop) string {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -539,16 +539,16 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 					status = "BPF"
 				}
 				if sr.KubeProxyReplacement != nil {
-					devStr := ""
+					var devStr strings.Builder
 					for i, dev := range sr.KubeProxyReplacement.DeviceList {
-						devStr += dev.Name
+						devStr.WriteString(dev.Name)
 						if i+1 != len(sr.KubeProxyReplacement.DeviceList) {
-							devStr += ", "
+							devStr.WriteString(", ")
 						}
 					}
 					status += fmt.Sprintf(
 						"\t[%s]\t%s %s",
-						devStr,
+						devStr.String(),
 						sr.Masquerading.SnatExclusionCidrV4,
 						sr.Masquerading.SnatExclusionCidrV6,
 					)

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -73,11 +73,11 @@ func TestSortMap(t *testing.T) {
 func TestLabelArraySorted(t *testing.T) {
 	lblsString := strings.Join(lblsArray, ";")
 	lblsString += ";"
-	str := ""
+	var str strings.Builder
 	for _, l := range lbls.LabelArray() {
-		str += fmt.Sprintf(`%s:%s=%s;`, l.Source, l.Key, l.Value)
+		fmt.Fprintf(&str, `%s:%s=%s;`, l.Source, l.Key, l.Value)
 	}
-	require.Equal(t, lblsString, str)
+	require.Equal(t, lblsString, str.String())
 }
 
 func TestMap2Labels(t *testing.T) {

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -80,18 +81,18 @@ func runLengthEncodeIDs(ids []loadbalancer.BackendID) string {
 	}
 	count := 1
 	current := ids[0]
-	var runs string
+	var runs strings.Builder
 	for _, id := range ids[1:] {
 		if id == current {
 			count++
 		} else {
-			runs += fmt.Sprintf("%d(%d),", current, count)
+			fmt.Fprintf(&runs, "%d(%d),", current, count)
 			count = 1
 			current = id
 		}
 	}
-	runs += fmt.Sprintf("%d(%d)", current, count)
-	return runs
+	fmt.Fprintf(&runs, "%d(%d)", current, count)
+	return runs.String()
 }
 
 func TestReproducible(t *testing.T) {

--- a/pkg/metrics/cmd.go
+++ b/pkg/metrics/cmd.go
@@ -438,14 +438,14 @@ func getMetricValue(name string, typ dto.MetricType, m *dto.Metric) (float64, st
 		return v, fmt.Sprintf("%f", v)
 	case dto.MetricType_SUMMARY:
 		s := m.Summary
-		x := ""
+		var x strings.Builder
 		for i, q := range s.Quantile {
-			x += fmt.Sprintf("p%d(%s%s)", int(100.0*(*q.Quantile)), prettyValue(*q.Value), suffix)
+			fmt.Fprintf(&x, "p%d(%s%s)", int(100.0*(*q.Quantile)), prettyValue(*q.Value), suffix)
 			if i != len(s.Quantile)-1 {
-				x += " "
+				x.WriteString(" ")
 			}
 		}
-		return 0.0, x
+		return 0.0, x.String()
 
 	case dto.MetricType_HISTOGRAM:
 		b := convertHistogram(m.Histogram)

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -358,18 +358,18 @@ func (o *IntOptions) getFmtOpt(name string) string {
 }
 
 func (o *IntOptions) GetFmtList() string {
-	txt := ""
+	var txt strings.Builder
 
 	o.optsMU.RLock()
 	for _, k := range slices.Sorted(maps.Keys(o.opts)) {
 		def := o.getFmtOpt(k)
 		if def != "" {
-			txt += def + "\n"
+			txt.WriteString(def + "\n")
 		}
 	}
 	o.optsMU.RUnlock()
 
-	return txt
+	return txt.String()
 }
 
 func (o *IntOptions) Dump() {

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -105,17 +105,17 @@ func (p DNSRules) TableHeader() []string {
 
 // TableRow implements statedb.TableWritable.
 func (p DNSRules) TableRow() []string {
-	var dnsRules string
+	var dnsRules strings.Builder
 	for _, sel := range p.DNSRule {
 		if sel != nil && sel.L7Rules.DNS != nil {
-			dnsRules += fmt.Sprintf("%v|", sel.L7Rules.DNS)
+			fmt.Fprintf(&dnsRules, "%v|", sel.L7Rules.DNS)
 		}
 
 	}
 	return []string{
 		fmt.Sprintf("%d", p.EndpointID),
 		p.PortProto.String(),
-		dnsRules,
+		dnsRules.String(),
 	}
 }
 

--- a/test/ginkgo-ext/junit_reporter.go
+++ b/test/ginkgo-ext/junit_reporter.go
@@ -274,8 +274,8 @@ func (reporter *JUnitReporter) failureTypeForState(state types.SpecState) string
 // information that is within the <Checks></Checks> labels. It'll return the
 // given output as first result, and the check output in the second string.
 func reportChecks(output string) (string, string) {
-	var checks string
-	var stdout string
+	var checks strings.Builder
+	var stdout strings.Builder
 	var dest = "stdout"
 
 	for line := range strings.SplitSeq(output, "\n") {
@@ -290,14 +290,14 @@ func reportChecks(output string) (string, string) {
 		}
 		switch dest {
 		case "stdout":
-			stdout += line + "\n"
+			stdout.WriteString(line + "\n")
 			continue
 		case "checks":
-			checks += line + "\n"
+			checks.WriteString(line + "\n")
 			continue
 		}
 	}
-	return stdout, checks
+	return stdout.String(), checks.String()
 }
 
 // mapTestToCODEOWNER maps the test prefix to the corresponding filename


### PR DESCRIPTION
Followup to #42642

Enable the `stringsbuilder` modernize analyzer.

Replace += with `strings.Builder`. This avoids quadratic memory allocation and improves performance.

See https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_stringsbuilder