### PR TITLE
bpf: overlay: remove ENABLE_IPSEC-specific metric updates

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -108,12 +108,6 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 			*identity = info->sec_identity;
 	}
 
-#ifdef ENABLE_IPSEC
-	if (ip6->nexthdr != IPPROTO_ESP)
-		update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
-			       REASON_PLAINTEXT);
-#endif
-
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON)
 	{
 		__u32 egress_ifindex = 0;
@@ -384,12 +378,6 @@ skip_vtep:
 		if (info)
 			*identity = info->sec_identity;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (ip4->protocol != IPPROTO_ESP)
-		update_metrics(ctx_full_len(ctx), METRIC_INGRESS,
-			       REASON_PLAINTEXT);
-#endif
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON)
 	{


### PR DESCRIPTION
After we switched over to Encrypted-overlay mode in v1.18, there should be no reason for special-casing metrics for plaintext traffic in the from-overlay program.

In particular as the REASON_PLAINTEXT metric already gets incremented by the send_trace_notify() at the very start of cil_from_overlay().