### PR TITLE
CODEOWNERS: fix up priority for tools/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -691,10 +691,10 @@ Makefile* @cilium/build
 # Misc. tests
 /test/k8s/config.go @cilium/sig-k8s
 /test/k8s/pod_mac_address.go @cilium/sig-k8s
+/tools/ @cilium/contributing
 /tools/complexity-diff @cilium/loader
 /tools/dpgen @cilium/loader
 /tools/metricslint @cilium/metrics
-/tools/ @cilium/contributing
 /USERS.md @cilium/community
 /go.sum @cilium/vendor
 /go.mod @cilium/vendor


### PR DESCRIPTION
CODEOWNERS expects the coarse-grained ownership entry for a directory to be listed first, with more fine-grained entries following as needed.

Fix this up for tools/, so that the fine-grained entries get applied when assigning code ownership.