### PR TITLE
[v1.16] ci: fix nodegroups volume size

### DIFF
--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -44,7 +44,7 @@ runs:
           spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
-          volumeSize: 10
+          volumeSize: 25
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
@@ -56,7 +56,7 @@ runs:
           spot: ${{ inputs.spot }}
           privateNetworking: true
           volumeType: "gp3"
-          volumeSize: 10
+          volumeSize: 25
           taints:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"


### PR DESCRIPTION
Following forcing of AL2023 per default, new default ami used for nodes requires 20gb minimum.

```
This AWS::EKS::Nodegroup resource is in a CREATE_FAILED state.

Resource handler returned message: "Volume of size 10GB is smaller than snapshot 'snap-00a7e1db053990bc5', expect size>= 20GB (Service: Eks, Status Code: 400, Request ID:  ****) (SDK Attempt Count: 1)" (RequestToken: ****, HandlerErrorCode: InvalidRequest)
```

Should fix issue in https://github.com/cilium/cilium/pull/43040 EKS based workflows