### PR TITLE
[v1.18] lb: Implement Hybrid-DSR via annotation infrastructure

### DIFF
--- a/pkg/loadbalancer/hybrid_dsr_test.go
+++ b/pkg/loadbalancer/hybrid_dsr_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+func TestToSVCForwardingMode_Hybrid(t *testing.T) {
+	tests := []struct {
+		name     string
+		lbMode   string
+		proto    []uint8
+		expected SVCForwardingMode
+	}{
+		{
+			name:     "Hybrid mode with TCP should return DSR",
+			lbMode:   LBModeHybrid,
+			proto:    []uint8{uint8(u8proto.TCP)},
+			expected: SVCForwardingModeDSR,
+		},
+		{
+			name:     "Hybrid mode with UDP should return SNAT",
+			lbMode:   LBModeHybrid,
+			proto:    []uint8{uint8(u8proto.UDP)},
+			expected: SVCForwardingModeSNAT,
+		},
+		{
+			name:     "Hybrid mode with SCTP should return SNAT",
+			lbMode:   LBModeHybrid,
+			proto:    []uint8{uint8(u8proto.SCTP)},
+			expected: SVCForwardingModeSNAT,
+		},
+		{
+			name:     "Hybrid mode without protocol should return SNAT",
+			lbMode:   LBModeHybrid,
+			proto:    nil,
+			expected: SVCForwardingModeSNAT,
+		},
+		{
+			name:     "DSR mode with TCP should return DSR",
+			lbMode:   LBModeDSR,
+			proto:    []uint8{uint8(u8proto.TCP)},
+			expected: SVCForwardingModeDSR,
+		},
+		{
+			name:     "DSR mode with UDP should return DSR",
+			lbMode:   LBModeDSR,
+			proto:    []uint8{uint8(u8proto.UDP)},
+			expected: SVCForwardingModeDSR,
+		},
+		{
+			name:     "DSR mode without protocol should return DSR",
+			lbMode:   LBModeDSR,
+			proto:    nil,
+			expected: SVCForwardingModeDSR,
+		},
+		{
+			name:     "SNAT mode with TCP should return SNAT",
+			lbMode:   LBModeSNAT,
+			proto:    []uint8{uint8(u8proto.TCP)},
+			expected: SVCForwardingModeSNAT,
+		},
+		{
+			name:     "SNAT mode with UDP should return SNAT",
+			lbMode:   LBModeSNAT,
+			proto:    []uint8{uint8(u8proto.UDP)},
+			expected: SVCForwardingModeSNAT,
+		},
+		{
+			name:     "SNAT mode without protocol should return SNAT",
+			lbMode:   LBModeSNAT,
+			proto:    nil,
+			expected: SVCForwardingModeSNAT,
+		},
+		{
+			name:     "Unknown mode should return Undef",
+			lbMode:   "unknown",
+			proto:    []uint8{uint8(u8proto.TCP)},
+			expected: SVCForwardingModeUndef,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToSVCForwardingMode(tt.lbMode, tt.proto...)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -79,11 +79,16 @@ const (
 	SVCForwardingModeSNAT  = SVCForwardingMode("snat")
 )
 
-func ToSVCForwardingMode(s string) SVCForwardingMode {
+func ToSVCForwardingMode(s string, proto ...uint8) SVCForwardingMode {
 	switch s {
 	case LBModeDSR:
 		return SVCForwardingModeDSR
 	case LBModeSNAT:
+		return SVCForwardingModeSNAT
+	case LBModeHybrid:
+		if len(proto) > 0 && proto[0] == uint8(u8proto.TCP) {
+			return SVCForwardingModeDSR
+		}
 		return SVCForwardingModeSNAT
 	default:
 		return SVCForwardingModeUndef

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -818,7 +818,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 	isRoutable := !svcKey.IsSurrogate() &&
 		(svcType != loadbalancer.SVCTypeClusterIP || ops.cfg.ExternalClusterIP)
 
-	forwardingMode := loadbalancer.ToSVCForwardingMode(ops.cfg.LBMode)
+	forwardingMode := loadbalancer.ToSVCForwardingMode(ops.cfg.LBMode, uint8(proto))
 	if ops.cfg.LBModeAnnotation && svc.ForwardingMode != loadbalancer.SVCForwardingModeUndef {
 		forwardingMode = svc.ForwardingMode
 	}

--- a/pkg/loadbalancer/tests/testdata/hybrid-dsr.txtar
+++ b/pkg/loadbalancer/tests/testdata/hybrid-dsr.txtar
@@ -1,0 +1,122 @@
+#! --lb-test-fault-probability=0.0 --bpf-lb-mode=hybrid
+
+# Start the test application
+hive start
+
+# Add TCP and UDP services
+k8s/add service-tcp.yaml endpointslice-tcp.yaml
+k8s/add service-udp.yaml endpointslice-udp.yaml
+db/cmp frontends frontends.table
+db/cmp services services.table
+
+# Check maps - TCP should have DSR flag, UDP should not
+lb/maps-dump maps.actual
+* cmp maps.actual maps.expected
+
+#####
+
+-- services.table --
+Name          Source   TrafficPolicy   Flags
+test/echo-tcp k8s      Cluster
+test/echo-udp k8s      Cluster
+
+-- frontends.table --
+Address               Type         ServiceName    PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort     test/echo-tcp  http       Done    10.244.1.1:80/TCP
+0.0.0.0:30782/UDP     NodePort     test/echo-udp  dns        Done    10.244.1.2:53/UDP
+10.96.50.104:80/TCP   ClusterIP    test/echo-tcp  http       Done    10.244.1.1:80/TCP
+10.96.50.105:53/UDP   ClusterIP    test/echo-udp  dns        Done    10.244.1.2:53/UDP
+
+-- service-tcp.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-tcp
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo-tcp
+  sessionAffinity: None
+  type: NodePort
+
+-- endpointslice-tcp.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo-tcp
+  name: echo-tcp-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- service-udp.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-udp
+  namespace: test
+spec:
+  clusterIP: 10.96.50.105
+  clusterIPs:
+  - 10.96.50.105
+  ports:
+  - name: dns
+    nodePort: 30782
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  selector:
+    name: echo-udp
+  sessionAffinity: None
+  type: NodePort
+
+-- endpointslice-udp.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo-udp
+  name: echo-udp-abc123
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker
+ports:
+- name: dns
+  port: 53
+  protocol: UDP
+
+-- maps.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:53/UDP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=2 ADDR=10.96.50.104:80
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=10.96.50.105:53
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable+dsr
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable+dsr
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable+dsr
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable+dsr
+SVC: ID=3 ADDR=0.0.0.0:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/UDP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=10.96.50.105:53/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=10.96.50.105:53/UDP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable


### PR DESCRIPTION
To ensure smooth upgrades to `v1.19`, this picks up the controlplane change from #42788. This way all service map entries have a valid `DSR yes/no` flag, and the datapath can trust the flag whenever the `v1.19` programs start to roll out.
