### PR TITLE
datapath/gneigh: Remove deprecated L2PodAnnouncementsInterface flag

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -373,7 +373,8 @@ Removed Options
   mode and had this flag explicitly set to ``true``, please unset it and let Cilium v1.18 migrate your rules prior
   to the upgrade to Cilium v1.19. Azure IPAM users are unaffected by this change, as Cilium continues to use
   old-style IP rules with Azure IPAM.
-
+* The previously deprecated ``--l2-pod-announcements-interface`` flag has been removed. The
+  ``--l2-pod-announcements-interface-pattern`` flag should be used instead.
 
 Deprecated Options
 ~~~~~~~~~~~~~~~~~~

--- a/pkg/datapath/gneigh/cells.go
+++ b/pkg/datapath/gneigh/cells.go
@@ -9,8 +9,6 @@ import (
 )
 
 const (
-	// L2PodAnnouncementsInterface is the interface used to send Gratuitous ARP|ND messages.
-	L2PodAnnouncementsInterface        = "l2-pod-announcements-interface"
 	L2PodAnnouncementsInterfacePattern = "l2-pod-announcements-interface-pattern"
 
 	EnableL2PodAnnouncements = "enable-l2-pod-announcements"
@@ -18,7 +16,6 @@ const (
 
 // Config contains the configuration for the Gneigh cell.
 type Config struct {
-	L2PodAnnouncementsInterface        string
 	L2PodAnnouncementsInterfacePattern string
 	EnableL2PodAnnouncements           bool
 }
@@ -28,8 +25,6 @@ func (def Config) Enabled() bool {
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
-	flags.String(L2PodAnnouncementsInterface, def.L2PodAnnouncementsInterface, "Interface used for sending gratuitous ARP and NDP messages")
-	flags.MarkDeprecated(L2PodAnnouncementsInterface, "use --"+L2PodAnnouncementsInterfacePattern+" instead")
 	flags.String(L2PodAnnouncementsInterfacePattern, def.L2PodAnnouncementsInterfacePattern, "Regex matching interfaces used for sending gratuitous ARP and NDP messages")
 	flags.Bool(EnableL2PodAnnouncements, def.EnableL2PodAnnouncements, "Enable announcing Pod IPs with Gratuitous ARP and NDP")
 }
@@ -37,7 +32,6 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 // This cell can't be enabled by default, it's entirely env dependent.
 var defaultConfig = Config{
 	EnableL2PodAnnouncements:           false,
-	L2PodAnnouncementsInterface:        "",
 	L2PodAnnouncementsInterfacePattern: "",
 }
 

--- a/pkg/datapath/gneigh/processor.go
+++ b/pkg/datapath/gneigh/processor.go
@@ -41,31 +41,17 @@ func newGNeighProcessor(p processorParams) (*processor, error) {
 		return nil, nil
 	}
 
-	if p.Config.L2PodAnnouncementsInterface != "" && p.Config.L2PodAnnouncementsInterfacePattern != "" {
-		return nil, fmt.Errorf("only one of '--%s' and '--%s' can be set", L2PodAnnouncementsInterface, L2PodAnnouncementsInterfacePattern)
-	}
-
 	var (
 		devicesRegex *regexp.Regexp
 		err          error
 	)
-	if p.Config.L2PodAnnouncementsInterface != "" {
-		devicesRegex, err = regexp.Compile("^" + p.Config.L2PodAnnouncementsInterface + "$")
-		if err != nil {
-			return nil, fmt.Errorf("failed to compile devices regex: %w", err)
-		}
-
-		// See https://github.com/cilium/cilium/issues/38229
-		p.Logger.Warn("The '--" + L2PodAnnouncementsInterface + "' flag is deprecated and will be removed in a future release. Please use '--" + L2PodAnnouncementsInterfacePattern + "' instead.")
-
-	} else if p.Config.L2PodAnnouncementsInterfacePattern != "" {
+	if p.Config.L2PodAnnouncementsInterfacePattern != "" {
 		devicesRegex, err = regexp.Compile(p.Config.L2PodAnnouncementsInterfacePattern)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compile devices regex: %w", err)
 		}
-
 	} else {
-		return nil, fmt.Errorf("'--%s' or '--%s' must be set, when --%s=true", L2PodAnnouncementsInterface, L2PodAnnouncementsInterfacePattern, EnableL2PodAnnouncements)
+		return nil, fmt.Errorf("'--%s' must be set, when --%s=true", L2PodAnnouncementsInterfacePattern, EnableL2PodAnnouncements)
 	}
 
 	gp := &processor{


### PR DESCRIPTION
In v1.18 the `l2-pod-announcements-interface-pattern` flag was added which allows for the selection of multiple interfaces using a regex pattern. The older `l2-pod-announcements-interface` flag was marked as deprecated at that time.

This commit removes the deprecated flag.

Fixes: #38229

```release-note
Remove deprecated `l2-pod-announcements-interface` flag
```
