### PR TITLE
.github/workflows: Match go runner to BPF in verifier complexity tests

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -178,11 +178,10 @@ jobs:
         with:
           provision: 'false'
           cmd: |
-            # cd into the PR branch so we run the go test from the PR, but on the BPF code of the base branch.
-            cd /host/pull
+            cd /host/base
             mkdir -p /host/datapath-verifier
             # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=20m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/merge --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
+            CGO_ENABLED=0 PRIVILEGED_TESTS=true go${{ env.go-version }} test -v -timeout=20m ./pkg/datapath/loader -run "TestPrivilegedVerifier" --cilium-base-path /host/base --kernel-version ${{ matrix.ci-kernel }} --kernel-name ${{ matrix.kernel-name }} --result-dir /host/datapath-verifier
             mv /host/datapath-verifier/verifier-complexity.json /host/datapath-verifier/verifier-complexity-base.json
 
       - name: Run verifier tests (on PR branch)


### PR DESCRIPTION
The verifier complexity test performs a diff between the base branch and the PR branch to see how the changes in the PR affect the BPF verifier complexity. It currently always checks out the pull request branch for the Go code (runner), which was done to make changes to the runner easier. But this did not take into account what happens when new load time config is introduced which relies on Go code gen. So this commit changes the workflow to always match the Go runner version to the BPF code version.