### PR TITLE
ipcache: Fix leak in CIDR metadata consolidation logic

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -504,6 +504,11 @@ type MU struct {
 	IsCIDR   bool
 }
 
+// cidrResourceID is a fixed resource type to represent CIDR metadata entries
+// from policies. This resource type represents entries from the CIDR
+// consolidation optimization logic.
+var cidrResourceID = ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "", "consolidated-prefix")
+
 // UpsertMetadata upserts a given IP and some corresponding information into
 // the ipcache metadata map. See IPMetadata for a list of types that are valid
 // to pass into this function. This will trigger asynchronous calculation of
@@ -522,7 +527,11 @@ func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
 	ipc.metadata.Lock()
 	for _, upd := range updates {
 		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Add(upd.Prefix) {
-			prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, upd.Resource, upd.Metadata...)...)
+			resource := upd.Resource
+			if upd.IsCIDR {
+				resource = cidrResourceID
+			}
+			prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, resource, upd.Metadata...)...)
 		}
 	}
 	ipc.metadata.Unlock()
@@ -553,7 +562,11 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 	ipc.metadata.Lock()
 	for _, upd := range updates {
 		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Delete(upd.Prefix) {
-			prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, upd.Resource, upd.Metadata...)...)
+			resource := upd.Resource
+			if upd.IsCIDR {
+				resource = cidrResourceID
+			}
+			prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, resource, upd.Metadata...)...)
 		}
 	}
 	ipc.metadata.Unlock()


### PR DESCRIPTION
It is possible to leak CIDR entries in the ipcache metadata layer due to
mishandling the ipcache resource for CIDR entries. The CIDR entries were
inserted into the ipcache but in a way where we attempted to optimize
the entries by consolidating all CIDRs that appear in policies into a
single resource per CIDR. See added test for more details on the leak.

Also, the logic checks that it is only a CIDR entry (only
from CIDR statements in policies) before consolidating. This way, we
don't break the FQDN name manager when there is overlap in the CIDRs
because we don't want to consolidate the ipcache metadata resources when
they are of different types.

Fixes: https://github.com/cilium/cilium/pull/39176
Fixes: a3bd1a69b3b262209bfa6a614ab9c86eca4f7d0f ("ipcache: Consolidate prefixes from various resources")
Reported-by: Sebastian Wicki <sebastian@isovalent.com>
Co-authored-by: Odin Ugedal <odin@uged.al>
Co-authored-by: Odin Ugedal <ougedal@palantir.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
