### PR TITLE
bpf:maps: mark read-only to maps that are only updated from user-space

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -803,7 +803,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	{
 		struct remote_endpoint_info fake_info = {0};
 		struct vtep_key vkey = {};
-		struct vtep_value *vtep;
+		const struct vtep_value *vtep;
 
 		vkey.vtep_ip = ip4->daddr & CONFIG(vtep_mask);
 		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -613,8 +613,8 @@ ipv6_forward_to_destination(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 
 #ifdef ENABLE_SRV6
 	{
-		__u32 *vrf_id;
-		union v6addr *sid;
+		const __u32 *vrf_id;
+		const union v6addr *sid;
 
 		/* Determine if packet belongs to a VRF */
 		vrf_id = srv6_lookup_vrf6(&ip6->saddr, &ip6->daddr);
@@ -1059,8 +1059,8 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 
 #ifdef ENABLE_SRV6
 	{
-		__u32 *vrf_id;
-		union v6addr *sid;
+		const __u32 *vrf_id;
+		const union v6addr *sid;
 
 		/* Determine if packet belongs to a VRF */
 		vrf_id = srv6_lookup_vrf4(ip4->saddr, ip4->daddr);

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -334,7 +334,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 #ifdef ENABLE_VTEP
 	{
 		struct vtep_key vkey = {};
-		struct vtep_value *vtep;
+		const struct vtep_value *vtep;
 
 		vkey.vtep_ip = ip4->saddr & CONFIG(vtep_mask);
 		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
@@ -465,7 +465,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	int ret;
 	struct bpf_tunnel_key key = {};
 	struct vtep_key vkey = {};
-	struct vtep_value *info;
+	const struct vtep_value *info;
 	__u32 key_size;
 
 	key_size = TUNNEL_KEY_WITHOUT_SRC_IP;

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -50,7 +50,7 @@ struct {
 	__type(value, struct lpm_val);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CIDR4_HMAP_ELEMS);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_cidr_v4_fix __section_maps_btf;
 
 struct {
@@ -59,7 +59,7 @@ struct {
 	__type(value, struct lpm_val);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CIDR4_LMAP_ELEMS);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_cidr_v4_dyn __section_maps_btf;
 
 struct {
@@ -68,7 +68,7 @@ struct {
 	__type(value, struct lpm_val);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CIDR4_HMAP_ELEMS);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_cidr_v6_fix __section_maps_btf;
 
 struct {
@@ -77,7 +77,7 @@ struct {
 	__type(value, struct lpm_val);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CIDR4_LMAP_ELEMS);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_cidr_v6_dyn __section_maps_btf;
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -136,7 +136,7 @@ struct {
 	__type(value, struct remote_endpoint_info);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, IPCACHE_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_ipcache_v2 __section_maps_btf;
 
 /* IPCACHE_STATIC_PREFIX gets sizeof non-IP, non-prefix part of ipcache_key */

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -29,6 +29,7 @@ struct {
 	__type(value, struct encrypt_config);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 1);
+	__uint(map_flags, BPF_F_RDONLY_PROG_COND);
 } cilium_encrypt_state __section_maps_btf;
 
 static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
@@ -36,7 +37,7 @@ static __always_inline __u8 get_min_encrypt_key(__u8 peer_key __maybe_unused)
 #ifdef ENABLE_IPSEC
 	__u8 local_key = 0;
 	__u32 encrypt_key = 0;
-	struct encrypt_config *cfg;
+	const struct encrypt_config *cfg;
 
 	cfg = map_lookup_elem(&cilium_encrypt_state, &encrypt_key);
 	/* Having no key info for a context is the same as no encryption */

--- a/bpf/lib/map_defs.h
+++ b/bpf/lib/map_defs.h
@@ -16,3 +16,15 @@
 #else
 #define LRU_MEM_FLAVOR 0
 #endif
+
+/* BPF_F_RDONLY_PROG makes maps read-only from BPF programs (but writable from
+ * user-space). This prevents accidental updates from the datapath for maps that
+ * should only be managed by the agent.
+ * In BPF tests, we need to populate these maps from BPF programs, so we
+ * conditionally disable the flag when BPF_TEST is defined.
+ */
+#ifdef BPF_TEST
+#define BPF_F_RDONLY_PROG_COND 0
+#else
+#define BPF_F_RDONLY_PROG_COND BPF_F_RDONLY_PROG
+#endif

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -175,7 +175,7 @@ struct {
 	__type(value, struct lpm_val);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 16384);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_ipmasq_v4 __section_maps_btf;
 
 #if defined(ENABLE_IPV4) && defined(ENABLE_NODEPORT)
@@ -1270,7 +1270,7 @@ struct {
 	__type(value, struct lpm_val);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 16384);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_ipmasq_v6 __section_maps_btf;
 
 #if defined(ENABLE_IPV6) && defined(ENABLE_NODEPORT)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2335,7 +2335,7 @@ nodeport_rev_dnat_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	__u32 src_sec_identity __maybe_unused = SECLABEL;
 	bool allow_neigh_map = true;
 	fraginfo_t fraginfo;
-	__u32 *vrf_id __maybe_unused = NULL;
+	const __u32 *vrf_id __maybe_unused = NULL;
 	__u32 monitor = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -2416,7 +2416,7 @@ skip_revdnat:
 redirect:
 #if defined(ENABLE_SRV6) && defined(IS_BPF_LXC)
 	if (vrf_id) {
-		union v6addr *sid;
+		const union v6addr *sid;
 		/* Do policy lookup if it belongs to a VRF */
 		sid = srv6_lookup_policy4(*vrf_id, ip4->daddr);
 		if (sid) {

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -163,7 +163,7 @@ struct {
 	__type(value, struct policy_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, POLICY_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_policy_v2 __section_maps_btf;
 
 /* Return a verdict for the chosen 'policy', possibly propagating the auth type from 'policy2', if

--- a/bpf/lib/srv6.h
+++ b/bpf/lib/srv6.h
@@ -14,7 +14,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, SRV6_VRF_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_srv6_vrf_v6 __section_maps_btf;
 
 struct {
@@ -23,7 +23,7 @@ struct {
 	__type(value, union v6addr);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, SRV6_POLICY_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_srv6_policy_v6 __section_maps_btf;
 
 struct {
@@ -32,7 +32,7 @@ struct {
     __type(value, __u32);      /* VRF ID */
     __uint(pinning, LIBBPF_PIN_BY_NAME);
     __uint(max_entries, SRV6_SID_MAP_SIZE);
-    __uint(map_flags, BPF_F_NO_PREALLOC);
+    __uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_srv6_sid __section_maps_btf;
 
 struct srv6_srh {
@@ -49,7 +49,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, SRV6_VRF_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_srv6_vrf_v4 __section_maps_btf;
 
 struct {
@@ -58,7 +58,7 @@ struct {
 	__type(value, union v6addr);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, SRV6_POLICY_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_srv6_policy_v4 __section_maps_btf;
 
 #ifdef ENABLE_SRV6
@@ -72,7 +72,7 @@ struct {
 	      - 4))
 #  define SRV6_VRF_PREFIX4_LEN(PREFIX) (SRV6_VRF_STATIC_PREFIX4 + (PREFIX))
 #  define SRV6_VRF_IPV4_PREFIX SRV6_VRF_PREFIX4_LEN(32)
-static __always_inline __u32*
+static __always_inline const __u32*
 srv6_lookup_vrf4(__be32 sip, __be32 dip)
 {
 	struct srv6_vrf_key4 key = {
@@ -91,7 +91,7 @@ srv6_lookup_vrf4(__be32 sip, __be32 dip)
 	      - 4))
 #  define SRV6_POLICY_PREFIX4_LEN(PREFIX) (SRV6_POLICY_STATIC_PREFIX4 + (PREFIX))
 #  define SRV6_POLICY_IPV4_PREFIX SRV6_POLICY_PREFIX4_LEN(32)
-static __always_inline union v6addr *
+static __always_inline const union v6addr *
 srv6_lookup_policy4(__u32 vrf_id, __be32 dip)
 {
 	struct srv6_policy_key4 key = {
@@ -111,7 +111,7 @@ srv6_lookup_policy4(__u32 vrf_id, __be32 dip)
 	      - 16))
 #  define SRV6_VRF_PREFIX6_LEN(PREFIX) (SRV6_VRF_STATIC_PREFIX6 + (PREFIX))
 #  define SRV6_VRF_IPV6_PREFIX SRV6_VRF_PREFIX6_LEN(128)
-static __always_inline __u32*
+static __always_inline const __u32*
 srv6_lookup_vrf6(const struct in6_addr *sip, const struct in6_addr *dip)
 {
 	struct srv6_vrf_key6 key = {
@@ -131,7 +131,7 @@ srv6_lookup_vrf6(const struct in6_addr *sip, const struct in6_addr *dip)
 # define SRV6_POLICY_PREFIX6_LEN(PREFIX) (SRV6_POLICY_STATIC_PREFIX6 + (PREFIX))
 # define SRV6_POLICY_IPV6_PREFIX SRV6_POLICY_PREFIX6_LEN(128)
 
-static __always_inline union v6addr *
+static __always_inline const union v6addr *
 srv6_lookup_policy6(__u32 vrf_id, const struct in6_addr *dip)
 {
 	struct srv6_policy_key6 key = {
@@ -145,7 +145,7 @@ srv6_lookup_policy6(__u32 vrf_id, const struct in6_addr *dip)
 static __always_inline __u32
 srv6_lookup_sid(const struct in6_addr *sid)
 {
-	__u32 *vrf_id;
+	const __u32 *vrf_id;
 
 	vrf_id = map_lookup_elem(&cilium_srv6_sid, sid);
 	if (vrf_id)

--- a/bpf/lib/vtep.h
+++ b/bpf/lib/vtep.h
@@ -24,7 +24,7 @@ struct {
 	__type(value, struct vtep_value);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, VTEP_MAP_SIZE);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_vtep_map __section_maps_btf;
 #endif /* ENABLE_VTEP */
 

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -175,7 +175,7 @@ func OpenMapElems(logger *slog.Logger, pinPath string, prefixlen int, prefixdyn 
 		KeySize:    uint32(unsafe.Sizeof(uint32(0)) + uintptr(bytes)),
 		ValueSize:  uint32(LPM_MAP_VALUE_SIZE),
 		MaxEntries: maxelem,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}, path.Dir(pinPath))
 

--- a/pkg/maps/encrypt/encrypt.go
+++ b/pkg/maps/encrypt/encrypt.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -62,7 +63,7 @@ func newMap(lc cell.Lifecycle, ipsecCfg datapath.IPsecConfig, dc *option.DaemonC
 		&EncryptKey{},
 		&EncryptValue{},
 		MaxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	).WithCache().WithEvents(dc.GetEventBufferConfig(MapName))
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -249,7 +249,7 @@ func newIPCacheMap(name string) *bpf.Map {
 		&Key{},
 		&RemoteEndpointInfo{},
 		MaxEntries,
-		unix.BPF_F_NO_PREALLOC)
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG)
 }
 
 func newIPCacheMapV1(name string) *bpf.Map {

--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -61,7 +61,7 @@ func IPMasq4Map(registry *metrics.Registry) *bpf.Map {
 			&Key4{},
 			&Value{},
 			MaxEntriesIPv4,
-			unix.BPF_F_NO_PREALLOC,
+			unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(MapNameIPv4))
 	})
@@ -76,7 +76,7 @@ func IPMasq6Map(registry *metrics.Registry) *bpf.Map {
 			&Key6{},
 			&Value{},
 			MaxEntriesIPv6,
-			unix.BPF_F_NO_PREALLOC,
+			unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(MapNameIPv6))
 	})

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -428,6 +429,7 @@ func newPolicyMap(logger *slog.Logger, id uint16, maxEntries int, stats *StatsMa
 	path := bpf.LocalMapPath(logger, MapName, id)
 	mapType := ebpf.LPMTrie
 	flags := bpf.GetMapMemoryFlags(mapType)
+	flags |= unix.BPF_F_RDONLY_PROG
 
 	return &PolicyMap{
 		Map: bpf.NewMap(

--- a/pkg/maps/srv6map/policy.go
+++ b/pkg/maps/srv6map/policy.go
@@ -154,7 +154,7 @@ func newPolicyMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*Poli
 		&PolicyKey4{},
 		&PolicyValue{},
 		maxPolicyEntries,
-		unix.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 	)
 
 	m6 := bpf.NewMap(
@@ -163,7 +163,7 @@ func newPolicyMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*Poli
 		&PolicyKey6{},
 		&PolicyValue{},
 		maxPolicyEntries,
-		unix.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 	)
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/srv6map/sid.go
+++ b/pkg/maps/srv6map/sid.go
@@ -86,7 +86,7 @@ func newSIDMap(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*SIDMap],
 		&SIDKey{},
 		&SIDValue{},
 		maxSIDEntries,
-		unix.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 	)
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/srv6map/vrf.go
+++ b/pkg/maps/srv6map/vrf.go
@@ -158,7 +158,7 @@ func newVRFMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*VRFMap4
 		&VRFKey4{},
 		&VRFValue{},
 		maxVRFEntries,
-		unix.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 	)
 
 	m6 := bpf.NewMap(
@@ -167,7 +167,7 @@ func newVRFMaps(dc *option.DaemonConfig, lc cell.Lifecycle) (bpf.MapOut[*VRFMap4
 		&VRFKey6{},
 		&VRFValue{},
 		maxVRFEntries,
-		unix.BPF_F_NO_PREALLOC,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
 	)
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/vtep/vtep.go
+++ b/pkg/maps/vtep/vtep.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -140,7 +142,7 @@ func newMap(logger *slog.Logger, registry *metrics.Registry) *vtepMap {
 			&Key{},
 			&VtepEndpointInfo{},
 			MaxEntries,
-			0,
+			unix.BPF_F_RDONLY_PROG,
 		).WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(MapName)),
 		logger: logger,


### PR DESCRIPTION
LB maps, node maps, and LRP maps are excluded from this PR as I think it needs to investigate more when marking read-only. So, another PR would be followed up.

Fixes: #42473 

```release-note
bpf:maps: mark read-only to maps that are only used by the agent
```
