### PR TITLE
Mark the --policy-deny-response=icmp feature as experimental

### DIFF
--- a/Documentation/security/policy/intro.rst
+++ b/Documentation/security/policy/intro.rst
@@ -116,12 +116,12 @@ This behavior can be configured with the ``--policy-deny-response`` option:
 **none** (default)
   Silently drop denied packets. Applications will experience connection timeouts when policy denies traffic.
 
-**icmp**
+**icmp** (experimental)
   Send an ICMP Destination Unreachable response back to the source pod when egress traffic is denied by policy.
   This provides immediate feedback to applications that the connection was rejected.
 
 .. note::
-   This feature only applies to ipv4 egress pod traffic denied by network policy.
+   This is an experimental feature and only applies to ipv4 egress pod traffic denied by network policy.
    Ingress traffic denial behavior and ipv6 are not supported currently. Check :gh-issue:`41859` for updates
 
 .. warning::

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -460,7 +460,7 @@ const (
 	// PolicyDenyResponse is the name of the option to pick how to handle ipv4 egress traffic denied by policy
 	PolicyDenyResponse = "policy-deny-response"
 
-	// PolicyDenyResponseIcmp is the name of the option to reject traffic denied by policy with an ICMP response
+	// PolicyDenyResponseIcmp is the name of the option to reject traffic denied by policy with an ICMP response (experimental)
 	PolicyDenyResponseIcmp = "icmp"
 
 	// PolicyDenyResponseNone is the name of the option to silently drop traffic denied by policy


### PR DESCRIPTION
Follow-up to https://github.com/cilium/cilium/pull/41406, marking this feature as experimental for now (see https://github.com/cilium/cilium/issues/41859 for more details)