### PR TITLE
k8s: Clarify BGPInterfaceOptions's Name description

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumbgpadvertisements.yaml
@@ -151,7 +151,7 @@ spec:
                       properties:
                         name:
                           description: |-
-                            Name is the name of the local interface which IP addresses should be advertised via BGP.
+                            Name of local interface of whose IP addresses will be advertised via BGP.
                             Each IP address applied on the interface is advertised as a /32 prefix (for IPv4) or a /128 prefix (for IPv6).
                           type: string
                       required:

--- a/pkg/k8s/apis/cilium.io/v2/bgp_advert_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/bgp_advert_types.go
@@ -164,7 +164,7 @@ type BGPServiceOptions struct {
 
 // BGPInterfaceOptions defines the configuration for the Interface advertisement type.
 type BGPInterfaceOptions struct {
-	// Name is the name of the local interface which IP addresses should be advertised via BGP.
+	// Name of local interface of whose IP addresses will be advertised via BGP.
 	// Each IP address applied on the interface is advertised as a /32 prefix (for IPv4) or a /128 prefix (for IPv6).
 	//
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
Use a bit cleaner wording for the BGPInterfaceOptions's Name field description.

