### PR TITLE
bpf: conntrack: populate nat info in ct_lookup_fill_state

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -275,6 +275,8 @@ ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
 #ifdef USE_LOOPBACK_LB
 		state->loopback = entry->lb_loopback;
 #endif
+		ipv6_addr_copy(&state->nat_addr, &entry->nat_addr);
+		state->nat_port = entry->nat_port;
 		state->node_port = entry->node_port;
 		state->dsr_internal = entry->dsr_internal;
 		state->proxy_redirect = entry->proxy_redirect;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1223,6 +1223,20 @@ __ct_has_nodeport_egress_entry(const struct ct_entry *entry,
 	return check_dsr && entry->dsr_internal;
 }
 
+static __always_inline const struct ct_entry *
+ct_get_nodeport_egress_entry4(const void *map,
+			      struct ipv4_ct_tuple *ingress_tuple)
+{
+	__u8 prev_flags = ingress_tuple->flags;
+	const struct ct_entry *entry;
+
+	ingress_tuple->flags = TUPLE_F_OUT;
+	entry = map_lookup_elem(map, ingress_tuple);
+	ingress_tuple->flags = prev_flags;
+
+	return entry;
+}
+
 /* The function tries to determine whether the flow identified by the given
  * CT_INGRESS tuple belongs to a NodePort traffic (i.e., outside client => N/S
  * LB => local backend).
@@ -1237,13 +1251,9 @@ ct_has_nodeport_egress_entry4(const void *map,
 			      struct ipv4_ct_tuple *ingress_tuple,
 			      __u16 *rev_nat_index, bool check_dsr)
 {
-	__u8 prev_flags = ingress_tuple->flags;
-	struct ct_entry *entry;
+	const struct ct_entry *entry;
 
-	ingress_tuple->flags = TUPLE_F_OUT;
-	entry = map_lookup_elem(map, ingress_tuple);
-	ingress_tuple->flags = prev_flags;
-
+	entry = ct_get_nodeport_egress_entry4(map, ingress_tuple);
 	if (!entry)
 		return false;
 
@@ -1266,18 +1276,28 @@ ct_has_dsr_egress_entry4(const void *map, struct ipv4_ct_tuple *ingress_tuple)
 	return 0;
 }
 
-static __always_inline bool
-ct_has_nodeport_egress_entry6(const void *map,
-			      struct ipv6_ct_tuple *ingress_tuple,
-			      __u16 *rev_nat_index, bool check_dsr)
+static __always_inline const struct ct_entry *
+ct_get_nodeport_egress_entry6(const void *map,
+			      struct ipv6_ct_tuple *ingress_tuple)
 {
 	__u8 prev_flags = ingress_tuple->flags;
-	struct ct_entry *entry;
+	const struct ct_entry *entry;
 
 	ingress_tuple->flags = TUPLE_F_OUT;
 	entry = map_lookup_elem(map, ingress_tuple);
 	ingress_tuple->flags = prev_flags;
 
+	return entry;
+}
+
+static __always_inline bool
+ct_has_nodeport_egress_entry6(const void *map,
+			      struct ipv6_ct_tuple *ingress_tuple,
+			      __u16 *rev_nat_index, bool check_dsr)
+{
+	const struct ct_entry *entry;
+
+	entry = ct_get_nodeport_egress_entry6(map, ingress_tuple);
 	if (!entry)
 		return false;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -810,6 +810,8 @@ create_ct:
 		if (port == 0)
 			return DROP_INVALID;
 
+		ipv6_addr_copy(&ct_state_new.nat_addr, addr);
+		ct_state_new.nat_port = port;
 		ct_state_new.src_sec_id = WORLD_IPV6_ID;
 		ct_state_new.dsr_internal = 1;
 
@@ -2196,6 +2198,8 @@ create_ct:
 			 */
 			return DROP_INVALID;
 
+		ct_state_new.nat_addr.p4 = addr;
+		ct_state_new.nat_port = port;
 		ct_state_new.src_sec_id = WORLD_IPV4_ID;
 		ct_state_new.dsr_internal = 1;
 
@@ -2210,12 +2214,15 @@ create_ct:
 	case CT_ESTABLISHED:
 		/* For TCP we only expect DSR info on the SYN, so CT_ESTABLISHED
 		 * is unexpected and we need to refresh the CT entry.
-		 *
-		 * Otherwise we tolerate DSR info on an established connection.
-		 * TODO: how do we know if we need to refresh the SNAT entry?
 		 */
 		if (tuple->nexthdr == IPPROTO_TCP && port)
 			goto create_ct;
+
+		 /*
+		 * Otherwise we tolerate DSR info on an established connection.
+		 * TODO: obtain NAT info from CT lookup, and compare it against
+		 *	 DSR info. Re-create on mismatch.
+		 */
 		break;
 	default:
 		return DROP_UNKNOWN_CT;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -124,6 +124,22 @@ static __always_inline bool nodeport_uses_dsr(bool flip __maybe_unused,
 #endif
 }
 
+#if defined(ENABLE_IPV4)
+static __always_inline struct ipv4_nat_entry *
+nodeport_dsr_lookup_v4_nat_entry(const struct ipv4_ct_tuple *nat_tuple)
+{
+	return snat_v4_lookup(nat_tuple);
+}
+#endif
+
+#if defined(ENABLE_IPV6)
+static __always_inline struct ipv6_nat_entry *
+nodeport_dsr_lookup_v6_nat_entry(const struct ipv6_ct_tuple *nat_tuple)
+{
+	return snat_v6_lookup(nat_tuple);
+}
+#endif
+
 #ifdef HAVE_ENCAP
 static __always_inline int
 nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
@@ -598,12 +614,6 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline struct ipv6_nat_entry *
-nodeport_dsr_lookup_v6_nat_entry(const struct ipv6_ct_tuple *nat_tuple)
-{
-	return snat_v6_lookup(nat_tuple);
-}
-
 static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 					   const struct ipv6hdr *ip6 __maybe_unused,
 					   const union v6addr *svc_addr __maybe_unused,
@@ -835,34 +845,54 @@ create_ct:
 }
 #endif /* ENABLE_DSR */
 
-static __always_inline const struct lb6_reverse_nat *
+static __always_inline bool
 nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
-				struct ipv6_ct_tuple *tuple)
+				struct ipv6_ct_tuple *tuple,
+				struct lb6_reverse_nat *nat_info)
 {
-	struct ipv6_nat_entry *dsr_entry __maybe_unused;
-	struct ipv6_ct_tuple dsr_tuple __maybe_unused;
-	__u16 rev_nat_index = 0;
+	const struct ct_entry *entry;
 
-	if (!ct_has_nodeport_egress_entry6(get_ct_map6(tuple), tuple,
-					   &rev_nat_index, is_defined(ENABLE_DSR)))
-		return NULL;
+	entry = ct_get_nodeport_egress_entry6(get_ct_map6(tuple), tuple);
+	if (!entry)
+		return false;
 
-	if (rev_nat_index)
-		return lb6_lookup_rev_nat_entry(ctx, rev_nat_index);
+	if (entry->node_port) {
+		if (entry->rev_nat_index) {
+			__u16 rev_nat_index = entry->rev_nat_index;
+			const struct lb6_reverse_nat *tmp;
 
-#ifdef ENABLE_DSR
-	dsr_tuple = *tuple;
+			tmp = lb6_lookup_rev_nat_entry(ctx, rev_nat_index);
+			if (tmp) {
+				ipv6_addr_copy(&nat_info->address,
+					       &tmp->address);
+				nat_info->port = tmp->port;
+				return true;
+			}
+		}
 
-	dsr_tuple.flags = NAT_DIR_EGRESS;
-	dsr_tuple.sport = tuple->dport;
-	dsr_tuple.dport = tuple->sport;
+		return false;
+	}
 
-	dsr_entry = nodeport_dsr_lookup_v6_nat_entry(&dsr_tuple);
-	if (dsr_entry)
-		return &dsr_entry->nat_info;
-#endif
+	if (is_defined(ENABLE_DSR) && entry->dsr_internal) {
+		struct ipv6_nat_entry *dsr_entry;
+		struct ipv6_ct_tuple dsr_tuple;
 
-	return NULL;
+		dsr_tuple = *tuple;
+
+		dsr_tuple.flags = NAT_DIR_EGRESS;
+		dsr_tuple.sport = tuple->dport;
+		dsr_tuple.dport = tuple->sport;
+
+		dsr_entry = nodeport_dsr_lookup_v6_nat_entry(&dsr_tuple);
+		if (dsr_entry) {
+			ipv6_addr_copy(&nat_info->address,
+				       &dsr_entry->nat_info.address);
+			nat_info->port = dsr_entry->nat_info.port;
+			return true;
+		}
+	}
+
+	return false;
 }
 
 #ifdef ENABLE_NAT_46X64_GATEWAY
@@ -1995,12 +2025,6 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline struct ipv4_nat_entry *
-nodeport_dsr_lookup_v4_nat_entry(const struct ipv4_ct_tuple *nat_tuple)
-{
-	return snat_v4_lookup(nat_tuple);
-}
-
 static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 					   struct iphdr *ip4 __maybe_unused,
 					   __be32 svc_addr __maybe_unused,
@@ -2232,34 +2256,52 @@ create_ct:
 }
 #endif /* ENABLE_DSR */
 
-static __always_inline const struct lb4_reverse_nat *
+static __always_inline bool
 nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
-				struct ipv4_ct_tuple *tuple)
+				struct ipv4_ct_tuple *tuple,
+				struct lb4_reverse_nat *nat_info)
 {
-	struct ipv4_nat_entry *dsr_entry __maybe_unused;
-	struct ipv4_ct_tuple dsr_tuple __maybe_unused;
-	__u16 rev_nat_index = 0;
+	const struct ct_entry *entry;
 
-	if (!ct_has_nodeport_egress_entry4(get_ct_map4(tuple), tuple,
-					   &rev_nat_index, is_defined(ENABLE_DSR)))
-		return NULL;
+	entry = ct_get_nodeport_egress_entry4(get_ct_map4(tuple), tuple);
+	if (!entry)
+		return false;
 
-	if (rev_nat_index)
-		return lb4_lookup_rev_nat_entry(ctx, rev_nat_index);
+	if (entry->node_port) {
+		if (entry->rev_nat_index) {
+			__u16 rev_nat_index = entry->rev_nat_index;
+			const struct lb4_reverse_nat *tmp;
 
-#ifdef ENABLE_DSR
-	dsr_tuple = *tuple;
+			tmp = lb4_lookup_rev_nat_entry(ctx, rev_nat_index);
+			if (tmp) {
+				nat_info->address = tmp->address;
+				nat_info->port = tmp->port;
+				return true;
+			}
+		}
 
-	dsr_tuple.flags = NAT_DIR_EGRESS;
-	dsr_tuple.sport = tuple->dport;
-	dsr_tuple.dport = tuple->sport;
+		return false;
+	}
 
-	dsr_entry = nodeport_dsr_lookup_v4_nat_entry(&dsr_tuple);
-	if (dsr_entry)
-		return &dsr_entry->nat_info;
-#endif
+	if (is_defined(ENABLE_DSR) && entry->dsr_internal) {
+		struct ipv4_nat_entry *dsr_entry;
+		struct ipv4_ct_tuple dsr_tuple;
 
-	return NULL;
+		dsr_tuple = *tuple;
+
+		dsr_tuple.flags = NAT_DIR_EGRESS;
+		dsr_tuple.sport = tuple->dport;
+		dsr_tuple.dport = tuple->sport;
+
+		dsr_entry = nodeport_dsr_lookup_v4_nat_entry(&dsr_tuple);
+		if (dsr_entry) {
+			nat_info->address = dsr_entry->nat_info.address;
+			nat_info->port = dsr_entry->nat_info.port;
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /* Reverse NAT handling of node-port traffic for the case where the

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -877,6 +877,14 @@ nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
 		struct ipv6_nat_entry *dsr_entry;
 		struct ipv6_ct_tuple dsr_tuple;
 
+		if (entry->nat_port) {
+			ipv6_addr_copy(&nat_info->address,
+				       &entry->nat_addr);
+
+			nat_info->port = entry->nat_port;
+			return true;
+		}
+
 		dsr_tuple = *tuple;
 
 		dsr_tuple.flags = NAT_DIR_EGRESS;
@@ -2230,6 +2238,7 @@ create_ct:
 		ret = ct_create4(get_ct_map4(tuple), NULL, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, ext_err);
 		if (!IS_ERR(ret))
+			/* TODO remove this in v1.20 */
 			ret = snat_v4_create_dsr(tuple, addr, port, ext_err);
 
 		if (IS_ERR(ret))
@@ -2286,6 +2295,12 @@ nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
 	if (is_defined(ENABLE_DSR) && entry->dsr_internal) {
 		struct ipv4_nat_entry *dsr_entry;
 		struct ipv4_ct_tuple dsr_tuple;
+
+		if (entry->nat_port) {
+			nat_info->address = entry->nat_addr.p4;
+			nat_info->port = entry->nat_port;
+			return true;
+		}
 
 		dsr_tuple = *tuple;
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -388,7 +388,7 @@ func purgeCtEntry(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func(
 	tupleType := t.GetFlags()
 
 	if tupleType == tuple.TUPLE_F_SERVICE && ACT != nil {
-		actCountFailed(entry.RevNAT, uint32(entry.BackendID))
+		actCountFailed(entry.RevNAT, uint32(entry.Union0[1]))
 	}
 
 	next(GCEvent{

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -525,15 +525,14 @@ func (k *CtKey6Global) GetTupleKey() tuple.TupleKey {
 
 // CtEntry represents an entry in the connection tracking table.
 type CtEntry struct {
-	Reserved0 uint64 `align:"reserved0"`
-	BackendID uint64 `align:"backend_id"`
-	Packets   uint64 `align:"packets"`
-	Bytes     uint64 `align:"bytes"`
-	Lifetime  uint32 `align:"lifetime"`
-	Flags     uint16 `align:"rx_closing"`
+	Union0   [2]uint64 `align:"$union0"`
+	Packets  uint64    `align:"packets"`
+	Bytes    uint64    `align:"bytes"`
+	Lifetime uint32    `align:"lifetime"`
+	Flags    uint16    `align:"rx_closing"`
 	// RevNAT is in network byte order
 	RevNAT           uint16 `align:"rev_nat_index"`
-	Reserved4        uint16 `align:"reserved4"`
+	NatPort          uint16 `align:"nat_port"`
 	TxFlagsSeen      uint8  `align:"tx_flags_seen"`
 	RxFlagsSeen      uint8  `align:"rx_flags_seen"`
 	SourceSecurityID uint32 `align:"src_sec_id"`
@@ -614,7 +613,7 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		timeDiff = ""
 	}
 
-	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d BackendID=%d \n",
+	return fmt.Sprintf("expires=%d%s Packets=%d Bytes=%d RxFlagsSeen=%#02x LastRxReport=%d TxFlagsSeen=%#02x LastTxReport=%d %s RevNAT=%d SourceSecurityID=%d BackendID=%d NatPort=%d \n",
 		c.Lifetime,
 		timeDiff,
 		c.Packets,
@@ -626,7 +625,9 @@ func (c *CtEntry) StringWithTimeDiff(toRemSecs func(uint32) string) string {
 		c.flagsString(),
 		byteorder.NetworkToHost16(c.RevNAT),
 		c.SourceSecurityID,
-		c.BackendID)
+		c.Union0[1],
+		// TODO NatAddr, either IPv4 or IPv6
+		c.NatPort)
 }
 
 // String returns the readable format


### PR DESCRIPTION
In commit 243c6c20e58f ("bpf: nodeport: stash DSR RevDNAT info in CT entry"), nat_addr and nat_port fields were added to the CT entry but ct_lookup_fill_state() was not updated to copy these values into the ct_state structure.
Fix by copying nat_addr and nat_port from the CT entry to ct_state.

Fixes: 243c6c20e58f ("bpf: nodeport: stash DSR RevDNAT info in CT entry")