### PR TITLE
[v1.16] Backport Endpoint Selector Policy deadlock fixes

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -277,7 +277,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics) (*policyGener
 	// TODO: GH-7515: Consider ways to compute policy outside of the
 	// endpoint regeneration process, ideally as part of the policy change
 	// handler.
-	err = repo.GetPolicyCache().UpdatePolicy(securityIdentity)
+	err = repo.GetPolicyCache().UpdatePolicy(securityIdentity, uint64(e.ID))
 	if err != nil {
 		e.getLogger().WithError(err).Warning("Failed to update policy")
 		repo.Mutex.RUnlock()

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -76,7 +76,7 @@ func (cache *PolicyCache) delete(identity *identityPkg.Identity) bool {
 	cip, ok := cache.policies[identity.ID]
 	if ok {
 		delete(cache.policies, identity.ID)
-		cip.getPolicy().Detach()
+		cip.getPolicy().detach()
 	}
 	return ok
 }
@@ -219,7 +219,7 @@ func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy) {
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {
 		// Release the references the previous policy holds on the selector cache.
-		oldPolicy.Detach()
+		oldPolicy.detach()
 	}
 }
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -85,10 +85,10 @@ func TestCachePopulation(t *testing.T) {
 	policy1 := cache.insert(identity1)
 
 	// Calculate the policy and observe that it's cached
-	updated, err := cache.updateSelectorPolicy(identity1)
+	updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
-	updated, err = cache.updateSelectorPolicy(identity1)
+	updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.Equal(t, false, updated)
 	policy2 := cache.insert(identity1)
@@ -99,13 +99,13 @@ func TestCachePopulation(t *testing.T) {
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	updated, err = cache.updateSelectorPolicy(identity1)
+	updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.Error(t, err)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint()
 	ep3.SetIdentity(1234, true)
-	_, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity())
+	_, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 	require.Error(t, err)
 	require.Equal(t, false, updated)
 
@@ -117,7 +117,7 @@ func TestCachePopulation(t *testing.T) {
 	identity3 := ep3.GetSecurityIdentity()
 	policy3 := cache.insert(identity3)
 	require.NotEqual(t, policy1, policy3)
-	updated, err = cache.updateSelectorPolicy(identity3)
+	updated, err = cache.updateSelectorPolicy(identity3, ep3.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
 	idp3 := policy3.(*cachedSelectorPolicy).getPolicy()
@@ -430,7 +430,7 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // entries for an endpoint with the specified labels.
 func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (MapState, error) {
 	sp := d.Repository.GetPolicyCache().insert(identity)
-	d.Repository.GetPolicyCache().UpdatePolicy(identity)
+	d.Repository.GetPolicyCache().UpdatePolicy(identity, 0)
 	epp := sp.Consume(DummyOwner{})
 	if epp == nil {
 		return nil, errors.New("policy distillation failure")

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1783,13 +1783,13 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 // circular pointer references.
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
-func (l4 *L4Policy) Detach(selectorCache *SelectorCache) {
+func (l4 *L4Policy) detach(selectorCache *SelectorCache) {
 	l4.Ingress.Detach(selectorCache)
 	l4.Egress.Detach(selectorCache)
 
 	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
 	l4.users = nil
-	l4.mutex.Unlock()
 }
 
 // Attach makes all the L4Filters to point back to the L4Policy that contains them.

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1798,7 +1798,7 @@ func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpoint
 	if !isDelete {
 		for ePolicy := range l4.users {
 			if endpointID != ePolicy.PolicyOwner.GetID() {
-				ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+				go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
 					Reason:            "selector policy has changed because of another endpoint with the same identity",
 					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 				})

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/bitlpm"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -1781,14 +1782,29 @@ func (l4Policy *L4Policy) AccumulateMapChanges(l4 *L4Filter, cs CachedSelector, 
 
 // Detach makes the L4Policy ready for garbage collection, removing
 // circular pointer references.
+// The endpointID argument is only necessary if isDelete is false.
+// It ensures that detach does not call a regeneration trigger on
+// the same endpoint that initiated a selector policy update.
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
-func (l4 *L4Policy) detach(selectorCache *SelectorCache) {
+func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpointID uint64) {
 	l4.Ingress.Detach(selectorCache)
 	l4.Egress.Detach(selectorCache)
 
 	l4.mutex.Lock()
 	defer l4.mutex.Unlock()
+	// If this detach is a delete there is no reason to initiate
+	// a regenerate.
+	if !isDelete {
+		for ePolicy := range l4.users {
+			if endpointID != ePolicy.PolicyOwner.GetID() {
+				ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "selector policy has changed because of another endpoint with the same identity",
+					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+				})
+			}
+		}
+	}
 	l4.users = nil
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1669,11 +1669,17 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 	// In the case of an policy update it is possible that an
 	// endpoint has started regeneration before the policy was
 	// updated, and that the policy was updated before the said
-	// endpoint reached this point. In this case the endpoint's
-	// policy is going to be recomputed soon after and we do
-	// nothing here.
+	// endpoint reached this point. In this case, we need to
+	// ensure that the endpoint will be regenerated at least once
+	// afterward. This to ensure it doesn't get stuck with a
+	// detached policy.
 	if l4.users != nil {
 		l4.users[user] = struct{}{}
+	} else {
+		go user.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+			Reason:            "selector policy has changed because of another endpoint with the same identity",
+			RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+		})
 	}
 
 	l4.mutex.Unlock()

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1371,7 +1371,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.Detach(td.sc)
+	expectedDeny.detach(td.sc)
 
 	// L4 from app3 has no rules
 	expectedDeny = NewL4Policy(repo.GetRevision())
@@ -1380,7 +1380,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 	require.Equal(t, 0, l4IngressDenyPolicy.Len())
 	require.Equal(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy)
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.Detach(td.sc)
+	expectedDeny.detach(td.sc)
 }
 
 func buildDenyRule(from, to, port string) api.Rule {

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1371,7 +1371,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.detach(td.sc)
+	expectedDeny.detach(td.sc, true, 0)
 
 	// L4 from app3 has no rules
 	expectedDeny = NewL4Policy(repo.GetRevision())
@@ -1380,7 +1380,7 @@ func TestMinikubeGettingStartedDeny(t *testing.T) {
 	require.Equal(t, 0, l4IngressDenyPolicy.Len())
 	require.Equal(t, expectedDeny.Ingress.PortRules, l4IngressDenyPolicy)
 	l4IngressDenyPolicy.Detach(td.sc)
-	expectedDeny.detach(td.sc)
+	expectedDeny.detach(td.sc, true, 0)
 }
 
 func buildDenyRule(from, to, port string) api.Rule {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2061,7 +2061,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressPolicy.Detach(td.sc)
-	expected.Detach(td.sc)
+	expected.detach(td.sc)
 
 	// L4 from app3 has no rules
 	expected = NewL4Policy(repo.GetRevision())
@@ -2070,7 +2070,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 	require.Equal(t, 0, l4IngressPolicy.Len())
 	require.Equal(t, expected.Ingress.PortRules, l4IngressPolicy)
 	l4IngressPolicy.Detach(td.sc)
-	expected.Detach(td.sc)
+	expected.detach(td.sc)
 }
 
 func buildSearchCtx(from, to string, port uint16) *SearchContext {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -2061,7 +2061,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		t.Errorf("Resolved policy did not match expected")
 	}
 	l4IngressPolicy.Detach(td.sc)
-	expected.detach(td.sc)
+	expected.detach(td.sc, true, 0)
 
 	// L4 from app3 has no rules
 	expected = NewL4Policy(repo.GetRevision())
@@ -2070,7 +2070,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 	require.Equal(t, 0, l4IngressPolicy.Len())
 	require.Equal(t, expected.Ingress.PortRules, l4IngressPolicy)
 	l4IngressPolicy.Detach(td.sc)
-	expected.detach(td.sc)
+	expected.detach(td.sc, true, 0)
 }
 
 func buildSearchCtx(from, to string, port uint16) *SearchContext {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -89,11 +89,11 @@ func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
 	p.L4Policy.removeUser(user)
 }
 
-// Detach releases resources held by a selectorPolicy to enable
+// detach releases resources held by a selectorPolicy to enable
 // successful eventual GC.  Note that the selectorPolicy itself if not
 // modified in any way, so that it can be used concurrently.
-func (p *selectorPolicy) Detach() {
-	p.L4Policy.Detach(p.SelectorCache)
+func (p *selectorPolicy) detach() {
+	p.L4Policy.detach(p.SelectorCache)
 }
 
 // DistillPolicy filters down the specified selectorPolicy (which acts

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -217,7 +217,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		epPolicy := ip.DistillPolicy(DummyOwner{}, false)
 		n += epPolicy.policyMapState.Len()
 	}
-	ip.detach()
+	ip.detach(true, 0)
 	fmt.Printf("Number of MapState entries: %d\n", n/b.N)
 }
 
@@ -227,7 +227,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 	epPolicy := ip.DistillPolicy(DummyOwner{}, false)
 	n := epPolicy.policyMapState.Len()
-	ip.detach()
+	ip.detach(true, 0)
 	assert.True(t, n > 0)
 }
 
@@ -301,7 +301,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -394,7 +394,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -500,7 +500,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	require.Equal(t, 0, len(policy.policyMapChanges.changes))
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -665,7 +665,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	}, deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.detach()
+	policy.selectorPolicy.detach(true, 0)
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -217,7 +217,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		epPolicy := ip.DistillPolicy(DummyOwner{}, false)
 		n += epPolicy.policyMapState.Len()
 	}
-	ip.Detach()
+	ip.detach()
 	fmt.Printf("Number of MapState entries: %d\n", n/b.N)
 }
 
@@ -227,7 +227,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 	epPolicy := ip.DistillPolicy(DummyOwner{}, false)
 	n := epPolicy.policyMapState.Len()
-	ip.Detach()
+	ip.detach()
 	assert.True(t, n > 0)
 }
 
@@ -301,7 +301,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -394,7 +394,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -500,7 +500,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	require.Equal(t, 0, len(policy.policyMapChanges.changes))
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -665,7 +665,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	}, deletes)
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -242,7 +242,7 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		_ = ip.DistillPolicy(DummyOwner{}, false)
-		ip.Detach()
+		ip.detach()
 	}
 }
 
@@ -253,7 +253,7 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		_ = ip.DistillPolicy(DummyOwner{}, false)
-		ip.Detach()
+		ip.detach()
 	}
 }
 
@@ -264,7 +264,7 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		_ = ip.DistillPolicy(DummyOwner{}, false)
-		ip.Detach()
+		ip.detach()
 	}
 }
 
@@ -353,7 +353,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -460,7 +460,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -563,7 +563,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	require.Equal(t, 0, len(policy.policyMapChanges.changes))
 
 	// Have to remove circular reference before testing to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
 	// difference of the internal time.Time from the lock_debug.go.
@@ -727,7 +727,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	}
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
-	policy.selectorPolicy.Detach()
+	policy.selectorPolicy.detach()
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
 	cachedSelectorTest = td.sc.FindCachedIdentitySelector(api.NewESFromLabels(lblTest))

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -129,8 +129,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	// Foo isn't selected in the rule1's policy.
 	ingressState = traceState{}
@@ -255,8 +255,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	ingressState = traceState{}
 	egressState = traceState{}
@@ -1154,8 +1154,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
 
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	// A rule for Ports and ICMP
 	rule2 := &rule{
@@ -1213,8 +1213,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, ingressState.selectedRules)
 	require.Equal(t, 1, ingressState.matchedRules)
 
-	res.Detach(td.sc)
-	expected.Detach(td.sc)
+	res.detach(td.sc)
+	expected.detach(td.sc)
 
 	// A rule for ICMPv6
 	icmpV6Type := intstr.FromInt(128)
@@ -1606,7 +1606,7 @@ func TestL4RuleLabels(t *testing.T) {
 			require.Equal(t, 1, len(out.RuleOrigin), test.description)
 			require.EqualValues(t, test.expectedEgressLabels[portProto], out.RuleOrigin[out.wildcard], test.description)
 		}
-		finalPolicy.Detach(td.sc)
+		finalPolicy.detach(td.sc)
 	}
 }
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -129,8 +129,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	// Foo isn't selected in the rule1's policy.
 	ingressState = traceState{}
@@ -255,8 +255,8 @@ func TestL4Policy(t *testing.T) {
 
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	ingressState = traceState{}
 	egressState = traceState{}
@@ -1154,8 +1154,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, egressState.selectedRules)
 	require.Equal(t, 1, egressState.matchedRules)
 
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	// A rule for Ports and ICMP
 	rule2 := &rule{
@@ -1213,8 +1213,8 @@ func TestICMPPolicy(t *testing.T) {
 	require.Equal(t, 1, ingressState.selectedRules)
 	require.Equal(t, 1, ingressState.matchedRules)
 
-	res.detach(td.sc)
-	expected.detach(td.sc)
+	res.detach(td.sc, true, 0)
+	expected.detach(td.sc, true, 0)
 
 	// A rule for ICMPv6
 	icmpV6Type := intstr.FromInt(128)
@@ -1606,7 +1606,7 @@ func TestL4RuleLabels(t *testing.T) {
 			require.Equal(t, 1, len(out.RuleOrigin), test.description)
 			require.EqualValues(t, test.expectedEgressLabels[portProto], out.RuleOrigin[out.wildcard], test.description)
 		}
-		finalPolicy.detach(td.sc)
+		finalPolicy.detach(td.sc, true, 0)
 	}
 }
 


### PR DESCRIPTION
 * [ ] #37910 (@nathanjsweet) :warning: resolved conflicts
 * [ ] #38139 (@nathanjsweet)
 * [ ] #42306 (@odinuge)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 37910 38139 42306
```

Fixes: #43060
