### PR TITLE
gateway-api: skip gateway with invalid listener NamespacesFromSelector

### DIFF
--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -146,6 +146,10 @@ func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Obj
 					})
 				}
 			case gatewayv1.NamespacesFromSelector:
+				if l.AllowedRoutes.Namespaces.Selector == nil {
+					scopedLog.WarnContext(ctx, "AllowedRoutes namespace set to Selector but no selector specified", logfields.Gateway, gw.GetName())
+					continue
+				}
 				nsList := &corev1.NamespaceList{}
 				err := c.List(ctx, nsList, client.MatchingLabels(l.AllowedRoutes.Namespaces.Selector.MatchLabels))
 				if err != nil {

--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -238,6 +238,28 @@ var controllerTestFixture = []client.Object{
 			},
 		},
 	},
+
+	// Gateway with allowed routes invalid namespace selector
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-with-invalid-namespaces-selector",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https",
+					Port: 80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromSelector),
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 var namespaceFixtures = []client.Object{


### PR DESCRIPTION
Skip gateway with invalid listener NamespacesFromSelector.

**Why I don't set Gateway Accepted to false ?**
From my reading, the cleanest place to set Gateway status is in Reconcile loop. But the panic happens in the very first gateway query, before Reconcile. I can see 2 ways of setting Gateway status in this query:
- Duplicating functions in `gateway_reconcile.go`
- Changing `gateway_reconcile.go` functions signature to accept client as param instead of making use of `reconciler.Client` in function body. Then these generic functions can be used for both `gateway_reconcile.go` and `controller.go`

Both ways require quite bit of code change, so I want to get feedback from the team first.

Fixes: #41939

```release-note
Correctly handle Gateways with a nil selector when they set NamespacesFromSelector
```
