### PR TITLE
renovate: Update image-tools images regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -655,20 +655,28 @@
       }
     },
     {
-      // The images from the image-tools repository have a timestamp-based versioning scheme, see https://github.com/cilium/image-tools/pull/286
+      // Images from the image-tools repository that have a timestamp-based versioning scheme
+      // See https://github.com/cilium/image-tools/pull/286
       "matchPackageNames": [
-        "quay.io/cilium/cilium-bpftool",
-        "quay.io/cilium/ca-certificates",
-        "quay.io/cilium/cilium-checkpatch",
         "quay.io/cilium/image-compilers",
-        "quay.io/cilium/iptables",
-        "quay.io/cilium/cilium-llvm",
         "quay.io/cilium/image-maker",
-        "quay.io/cilium/network-perf",
         "quay.io/cilium/startup-script",
         "quay.io/cilium/image-tester",
       ],
       "versioning": "regex:^(?<major>\\d+)-[a-f0-9]{7}$",
+    },
+    {
+      // Images from the image-tools repository that have a semantic + timestamp-based versioning scheme
+      // See https://github.com/cilium/image-tools/pull/413
+      // See each image for an example version tag
+      "matchPackageNames": [
+        "quay.io/cilium/cilium-bpftool",    // 7.4.0-1758805548-08727cd
+        "quay.io/cilium/cilium-checkpatch", // 5.12-1755701578-b97bd7a
+        "quay.io/cilium/iptables",          // 1.8.8-1-1758805548-08727cd
+        "quay.io/cilium/cilium-llvm",       // 19.1.7-1758805548-08727cd
+        "quay.io/cilium/network-perf",      // 3.19-1758616553-aad452d
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+)|(?<patch>))(-\\d+)?-(?<build>\\d+)-[a-f0-9]{7}$",
     },
     {
       // Avoid updating minor or major version for github.com/envoyproxy/go-control-plane/envoy


### PR DESCRIPTION
This PR updates the custom versioning regex used for the images from the `image-tools` repository to reflect image versioning scheme changes from https://github.com/cilium/image-tools/pull/413.

The existing regex is kept for images that still follow the previous versioning scheme (`image-compilers`, `image-maker`, `startup-script` and `image-tester`). Other images now have a slighlty more elaborate regex to account for their "semantic + timestamp + commit sha" new versioning scheme.

Reference: https://docs.renovatebot.com/modules/versioning/regex/

Note: we're using the `build` capture group for the timestamp element

Note: Renovate requires that all previous capture groups match (even if with an empty value), this is why the `patch` capture group is configured to either match the patch version component or match to an empty value in case the version does not have a patch number (like for the `checkpatch` and `network-perf` images).

The new regex properly matches all the expected segments for the concerned images:
<img width="723" height="466" alt="image" src="https://github.com/user-attachments/assets/8cfc8929-22c2-4a72-b181-390d28e66181" />

Using this renovate config on a test repository, renovate properly tracks the versioning of those images:
<img width="747" height="205" alt="image" src="https://github.com/user-attachments/assets/56ea1a9a-df64-4ab8-8940-136b06b2fc9c" />
Note: in that example above, the `llvm` image has a tag from the old versioning scheme but that image now uses the new versioning scheme so renovate ignores it.
