### PR TITLE
ci: add k8s 1.34 version for GKE workflows

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -13,4 +13,7 @@ k8s:
   - version: "1.33"
     zone: us-west1-c
     vmIndex: 4
+  - version: "1.34"
+    zone: us-east1-c
+    vmIndex: 5
     default: true


### PR DESCRIPTION
https://docs.cloud.google.com/kubernetes-engine/docs/release-schedule 

1.34 regular support available since 2025-11-25