### PR TITLE
renovate: Fix image-tools regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -671,12 +671,20 @@
       // See each image for an example version tag
       "matchPackageNames": [
         "quay.io/cilium/cilium-bpftool",    // 7.4.0-1758805548-08727cd
-        "quay.io/cilium/cilium-checkpatch", // 5.12-1755701578-b97bd7a
         "quay.io/cilium/iptables",          // 1.8.8-1-1758805548-08727cd
         "quay.io/cilium/cilium-llvm",       // 19.1.7-1758805548-08727cd
+      ],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-\\d+)?-(?<build>\\d+)-[a-f0-9]{7}$",
+    },
+    {
+      // Images from the image-tools repository that have a semantic (major.minor only) + timestamp-based versioning scheme
+      // See https://github.com/cilium/image-tools/pull/413
+      // See each image for an example version tag
+      "matchPackageNames": [
+        "quay.io/cilium/cilium-checkpatch", // 5.12-1755701578-b97bd7a
         "quay.io/cilium/network-perf",      // 3.19-1758616553-aad452d
       ],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+)|(?<patch>))(-\\d+)?-(?<build>\\d+)-[a-f0-9]{7}$",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-[a-f0-9]{7}$",
     },
     {
       // Avoid updating minor or major version for github.com/envoyproxy/go-control-plane/envoy


### PR DESCRIPTION
Fixes #43091

Related PR #43087:
> Note: Renovate requires that all previous capture groups match (even if with an empty value), this is why the patch capture group is configured to either match the patch version component or match to an empty value in case the version does not have a patch number (like for the checkpatch and network-perf images).

I did test that initial PR on mend-hosted renovate, but it looks like cilium's self-hosted flavor does not like that config. To solve the issue here I split the images that have a patch component in their version from the ones that don't in two separate groups with their own regex.

For images that have no patch component, we capture the timestamp as `patch` instead of `build` as renovate does not like to have lower priority version component defined if a higher priority one isn't.