### PR TITLE
datapath/gneigh: allow to explicitly set source hardware address on send

### DIFF
--- a/pkg/datapath/gneigh/processor.go
+++ b/pkg/datapath/gneigh/processor.go
@@ -163,10 +163,10 @@ func (gp *processor) send(ep *endpoint.Endpoint, ip netip.Addr, iface Interface)
 	)
 
 	if ip.Is4() {
-		err = gp.params.Sender.SendArp(iface, ip)
+		err = gp.params.Sender.SendArp(iface, ip, iface.HardwareAddr())
 		proto = "ARP"
 	} else {
-		err = gp.params.Sender.SendNd(iface, ip)
+		err = gp.params.Sender.SendNd(iface, ip, iface.HardwareAddr())
 		proto = "ND"
 	}
 

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -374,7 +374,7 @@ func garpOnNewEntry(arMap l2respondermap.Map, sender gneigh.Sender, ip netip.Add
 		return fmt.Errorf("garp %s@%d: %w", ip, ifIndex, err)
 	}
 
-	err = sender.SendArp(iface, ip)
+	err = sender.SendArp(iface, ip, iface.HardwareAddr())
 	if err != nil {
 		return fmt.Errorf("garp %s@%d: %w", ip, ifIndex, err)
 	}
@@ -393,7 +393,7 @@ func gneighOnNewEntry(ndMap l2v6respondermap.Map, sender gneigh.Sender, ip netip
 		return fmt.Errorf("gneigh adv %s@%d: %w", ip, ifIndex, err)
 	}
 
-	err = sender.SendNd(iface, ip)
+	err = sender.SendNd(iface, ip, iface.HardwareAddr())
 	if err != nil {
 		return fmt.Errorf("gneigh adv %s@%d: %w", ip, ifIndex, err)
 	}


### PR DESCRIPTION
Let `Send.Send{Arp,Nd}` and thus also `{Arp,Nd}Sender.Send` take an explicit source hardware address. This allows sending gratuitous ARP/ND packets with source hardware address other than the interface's hardware address.

Adjust the existing callers to pass the interface hardware address instead of storing them in the sender.
