### PR TITLE
k8s: remove dead code

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -119,22 +119,6 @@ type CiliumNetworkPolicyNodeStatus struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
-// CreateCNPNodeStatus returns a CiliumNetworkPolicyNodeStatus created from the
-// provided fields.
-func CreateCNPNodeStatus(enforcing, ok bool, cnpError error, rev uint64, annotations map[string]string) CiliumNetworkPolicyNodeStatus {
-	cnpns := CiliumNetworkPolicyNodeStatus{
-		Enforcing:   enforcing,
-		Revision:    rev,
-		OK:          ok,
-		LastUpdated: slimv1.Now(),
-		Annotations: annotations,
-	}
-	if cnpError != nil {
-		cnpns.Error = cnpError.Error()
-	}
-	return cnpns
-}
-
 func (r *CiliumNetworkPolicy) String() string {
 	result := ""
 	result += fmt.Sprintf("TypeMeta: %s, ", r.TypeMeta.String())

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
@@ -210,16 +209,6 @@ func newEndpoints(initialBackendsSize int) *Endpoints {
 	return &Endpoints{
 		Backends: make(map[cmtypes.AddrCluster]*Backend, initialBackendsSize),
 	}
-}
-
-// Prefixes returns the endpoint's backends as a slice of netip.Prefix.
-func (e *Endpoints) Prefixes() []netip.Prefix {
-	prefixes := make([]netip.Prefix, 0, len(e.Backends))
-	for addrCluster := range e.Backends {
-		addr := addrCluster.Addr()
-		prefixes = append(prefixes, netip.PrefixFrom(addr, addr.BitLen()))
-	}
-	return prefixes
 }
 
 type endpointSlice interface {

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -176,17 +176,6 @@ func NamespaceResource(lc cell.Lifecycle, cs client.Clientset, mp workqueue.Metr
 	return resource.New[*slim_corev1.Namespace](lc, lw, mp, resource.WithMetric("Namespace")), nil
 }
 
-func LBIPPoolsResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumLoadBalancerIPPool], error) {
-	if !params.ClientSet.IsEnabled() {
-		return nil, nil
-	}
-	lw := utils.ListerWatcherWithModifiers(
-		utils.ListerWatcherFromTyped(params.ClientSet.CiliumV2().CiliumLoadBalancerIPPools()),
-		opts...,
-	)
-	return resource.New[*cilium_api_v2.CiliumLoadBalancerIPPool](params.Lifecycle, lw, params.MetricsProvider, resource.WithMetric("CiliumLoadBalancerIPPool"), resource.WithCRDSync(params.CRDSyncPromise)), nil
-}
-
 func CiliumIdentityResource(params CiliumResourceParams, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumIdentity], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil


### PR DESCRIPTION
Remove unused code in `pkg/k8s`.

See commit messages for references to the commits removing the last remaining callers.
