### PR TITLE
proxy: Install egress proxy routes with NativeRouting + WireGuard

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1773,8 +1773,17 @@ int cil_to_host(struct __ctx_buff *ctx)
 
 skip_ipsec_nodeport_revdnat:
 # endif /* ENABLE_NODEPORT */
-
 #endif /* ENABLE_IPSEC */
+
+#if defined(ENABLE_WIREGUARD) && !defined(TUNNEL_MODE)
+	/* See above IPSec comment.
+	 * This is because in old kernels the skb->mark is scrubbed when traversing a
+	 * veth pair (https://github.com/cilium/cilium/issues/36329).
+	 */
+	if (ctx->mark == 0 && CONFIG(interface_ifindex) == CILIUM_NET_IFINDEX)
+		ctx->mark = MARK_MAGIC_SKIP_TPROXY;
+#endif
+
 #ifdef ENABLE_HOST_FIREWALL
 	if (!validate_ethertype(ctx, &proto)) {
 		ret = DROP_UNSUPPORTED_L2;

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -447,7 +447,7 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 		m.logger.Warn("enabling IP forwarding via sysctl failed", logfields.Error, err)
 	}
 
-	if m.sharedCfg.EnableIPSec && m.sharedCfg.EnableL7Proxy {
+	if (m.sharedCfg.EnableIPSec || m.sharedCfg.EnableWireguard) && m.sharedCfg.EnableL7Proxy {
 		m.disableIPEarlyDemux()
 	}
 

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -125,8 +125,8 @@ func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled
 //     hair-pinning traffic in Ingress L7 proxy (i.e. backend is in the same node).
 //   - Native routing + IPSec: install Ingress+Egress routes for (a) the same reason
 //     as above, and also to account for XFRM overhead on proxy-to-proxy connections.
-//   - Native routing + WireGuard: install only Ingress routes to account for WireGuard
-//     overhead on reply packets from Ingress L7 proxy in proxy-to-proxy connections.
+//   - Native routing + WireGuard: install Ingress+Egress routes for (a) the same reason
+//     as above, and also to account for WireGuard overhead on proxy-to-proxy connections.
 func requireFromProxyRoutes(ipsecEnabled, wireguardEnabled bool, mtuIn int) (fromIngressProxy, fromEgressProxy bool, mtu int) {
 	if option.Config.TunnelingEnabled() {
 		return
@@ -135,12 +135,9 @@ func requireFromProxyRoutes(ipsecEnabled, wireguardEnabled bool, mtuIn int) (fro
 		fromIngressProxy = true
 	}
 	switch {
-	case ipsecEnabled:
+	case ipsecEnabled, wireguardEnabled:
 		fromIngressProxy = true
 		fromEgressProxy = true
-		mtu = mtuIn
-	case wireguardEnabled:
-		fromIngressProxy = true
 		mtu = mtuIn
 	}
 	return


### PR DESCRIPTION
In https://github.com/cilium/cilium/pull/42835, we enabled installing ingress proxy routes in native routing when WireGuard is enabled. That was to handle proxy-to-proxy connections, replicating the routeMTU that we usually install inside the pods. This way, during a TCP handshake, proxies can share and apply the MSS value.

However, that is not true for the case of a DNS proxy connection, hence UDP, which would leave with the default MTU, not matching the table `MARK_MAGIC_PROXY_EGRESS 0x0B00` given with the previous PR we only install the `MARK_MAGIC_PROXY_INGRESS	0x0A00`. In case the DNS proxy sends a full-size UDP messages, those would fragment as no route would enforce a lower MTU.

Let's fix this by always adding the `fromEgressProxy` route also for WireGuard.

Fixes: #43431.