### PR TITLE
renovate: adjust quay.io/cilium/cilium-envoy regex versioning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -700,7 +700,7 @@
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
       "allowedVersions": "/^v1\\.34\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "v1.18",
@@ -712,7 +712,7 @@
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)-(?<revision>.*)$",
+      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
       "allowedVersions": "/^v1\\.35\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "main",


### PR DESCRIPTION
As documented in the renovate docs:
```
all capture groups must contain only purely numeric values.
Even if there is a string prefix which is identical in all
available versions, it must not be part of the capture group.
For example a build capture group containing r4 cannot be
evaluated as number; Renovate cannot compare the build in
this case. The capture group must be 4 instead.
```
and since the quay.io/cilium/cilium-envoy image contains non-numeric characters, for example  v1.35.3-1764238404-a890eb288598920fc146308ef4b05004f2ee7bcf, we can't use the last string as part of the "revision".
