### PR TITLE
iptables: Fix proxy port restoration for CEC/CCEC ports

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -637,6 +637,7 @@ func (m *Manager) iptProxyRule(rules string, prog runnable, l4proto, ip string, 
 		return nil
 	}
 
+	// NOTE: Proxy port restoration depends on the comment string below, see doGetProxyPorts()
 	rule := []string{
 		"-t", "mangle",
 		"-A", ciliumPreMangleChain,
@@ -1288,7 +1289,7 @@ func (m *Manager) doGetProxyPorts(prog iptablesInterface) map[string]uint16 {
 	}
 
 	re := regexp.MustCompile(
-		"(cilium-[^ ]*) proxy.*TPROXY redirect " +
+		"/\\* cilium: TPROXY to host ([^ ]+) proxy \\*/ TPROXY redirect " +
 			"(0.0.0.0|" + ipfamily.IPv4().Localhost +
 			"|::|" + ipfamily.IPv6().Localhost + ")" +
 			":([1-9][0-9]*) mark",


### PR DESCRIPTION
CiliumEnvoyConfig ports do not have the "cilium-" prefix. Change the regex to not require it and also to capture more of the comment to not make it less robust.

This fixes proxy port churn for CEC/CCEC ports on Cilium restarts and helps avoid churn on Envoy listener xDS updates as well.

Tested locally with `examples/kubernetes/servicemesh/envoy/envoy-helloworld-v1-90-v2-10.yaml` applied. Before agent update:

```
$ kubectl exec -it -n kube-system cilium-m9zzx -- iptables -t mangle -n -L CILIUM_PRE_mangle | grep -E "/\* cilium: TPROXY to host ([^ ]+) proxy \*/ TPROXY redirect (0.0.0.0|127.0.0.1|::|::1):([1-9][0-9]*) mark"
TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0x59890200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 127.0.0.1:35161 mark 0x200/0xffffffff
TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0x59890200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 127.0.0.1:35161 mark 0x200/0xffffffff
TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xfb440200 /* cilium: TPROXY to host default/envoy-lb-listener/envoy-lb-listener proxy */ TPROXY redirect 127.0.0.1:17659 mark 0x200/0xffffffff
TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xfb440200 /* cilium: TPROXY to host default/envoy-lb-listener/envoy-lb-listener proxy */ TPROXY redirect 127.0.0.1:17659 mark 0x200/0xffffffff
```

After agent update:

```
$ kubectl exec -it -n kube-system cilium-75dfv -- iptables -t mangle -n -L CILIUM_PRE_mangle | grep -E "/\* cilium: TPROXY to host ([^ ]+) proxy \*/ TPROXY redirect (0.0.0.0|127.0.0.1|::|::1):([1-9][0-9]*) mark"
TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0x59890200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 127.0.0.1:35161 mark 0x200/0xffffffff
TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0x59890200 /* cilium: TPROXY to host cilium-dns-egress proxy */ TPROXY redirect 127.0.0.1:35161 mark 0x200/0xffffffff
TPROXY     tcp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xfb440200 /* cilium: TPROXY to host default/envoy-lb-listener/envoy-lb-listener proxy */ TPROXY redirect 127.0.0.1:17659 mark 0x200/0xffffffff
TPROXY     udp  --  0.0.0.0/0            0.0.0.0/0            mark match 0xfb440200 /* cilium: TPROXY to host default/envoy-lb-listener/envoy-lb-listener proxy */ TPROXY redirect 127.0.0.1:17659 mark 0x200/0xffffffff
```

Note that agent pod names are different (due to the update), but both the DNS and CEC proxy ports are the same (`35161` and `17659`, respectively).

```release-note
CiliumEnvoyConfig proxy ports are now restored on agent restarts.
```
