### PR TITLE
cilium-cli/connectivity: remove matcher for bpf/init.sh errors

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -80,7 +80,6 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		panicMessage:         nil,
 		deadLockHeader:       nil,
 		RunInitFailed:        nil,
-		emptyBPFInitArg:      nil,
 		RemovingMapMsg:       {stringMatcher("globals/cilium_policy")},
 		symbolSubstitution:   nil,
 		uninitializedRegen:   nil,
@@ -412,7 +411,6 @@ const (
 	panicMessage                       = "panic:"
 	deadLockHeader                     = "POTENTIAL DEADLOCK:"                                  // from github.com/sasha-s/go-deadlock/deadlock.go:header
 	RunInitFailed                      = "JoinEP: "                                             // from https://github.com/cilium/cilium/pull/5052
-	emptyBPFInitArg                    = "empty argument passed to bpf/init.sh"                 // from https://github.com/cilium/cilium/issues/10228
 	RemovingMapMsg                     = "Removing map to allow for property upgrade"           // from https://github.com/cilium/cilium/pull/10626
 	symbolSubstitution                 = "Skipping symbol substitution"                         //
 	uninitializedRegen                 = "Uninitialized regeneration level"                     // from https://github.com/cilium/cilium/pull/10949


### PR DESCRIPTION
`bpf/init.sh` is gone since Cilium 1.15, commit 9764bee9d963 ("init.sh: remove script"). No need to check for its errors anymore.
