### PR TITLE
docs: add Helm configuration options for ENI and IPAM nodeSpec

### DIFF
--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -90,8 +90,33 @@ Configuration
 Custom ENI Configuration
 ========================
 
-Custom ENI configuration can be defined with a custom CNI configuration
-``ConfigMap``:
+Custom ENI configuration can be defined from Helm or with a custom CNI
+configuration ``ConfigMap``.
+
+Helm
+----
+
+The ENI configuration can be specified via Helm, using either the ``--set`` flag
+or a values file.
+
+The following example configures Cilium to:
+
+* Use subnets with the tag ``foo=bar`` to create ENIs.
+* Use index 1 as the first interface for pod IP allocation.
+* Set the minimum number of IPs to allocate to 10.
+
+.. parsed-literal::
+
+  helm upgrade cilium |CHART_RELEASE| \\
+    --namespace kube-system \\
+    --reuse-values \\
+    --set eni.enabled=true \\
+    --set eni.nodeSpec.subnetTags={foo=bar} \\
+    --set eni.nodeSpec.firstInterfaceIndex=1 \\
+    --set ipam.nodeSpec.ipamMinAllocate=10
+
+The full list of available options can be found in the :ref:`helm_reference`
+section in the ``eni.nodeSpec`` and ``ipam.nodeSpec`` sections.
 
 Create a CNI configuration
 --------------------------


### PR DESCRIPTION
This is the follow up PR for https://github.com/cilium/cilium/pull/43086 just for the doc 

This commit updates the ENI documentation to include Helm-based configuration options for ENI and IPAM node specifications, so users dont have to use the custom CNI.

Related to #40790

```release-note
Update the documents for eni pages so users can know how to use those flags 
```
