### PR TITLE
gateway-api: Skip MeshGRPCRouteWeight to stabilize CI

### DIFF
--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -71,6 +71,9 @@ func TestConformance(t *testing.T) {
 			})
 		}
 	}
+	// TODO: Run MeshGRPCRouteWeight once it is deflaked upstream. See
+	//       GH-42456 for details.
+	skipTests = append(skipTests, "MeshGRPCRouteWeight")
 	options.UnusableNetworkAddresses = unusableNetworkAddresses
 	options.UsableNetworkAddresses = usableNetworkAddresses
 	options.SkipTests = append(options.SkipTests, skipTests...)

--- a/pkg/status/cell.go
+++ b/pkg/status/cell.go
@@ -121,6 +121,7 @@ func (r Config) Flags(flags *pflag.FlagSet) {
 	flags.String("status-collector-stackdump-path", r.StatusCollectorStackdumpPath, "The path where probe stackdumps should be written to")
 }
 
+// Dummy change
 func newStatusCollector(params statusParams) StatusCollector {
 	collector := &statusCollector{
 		statusParams:    params,


### PR DESCRIPTION
MeshGRPCRouteWeight has a ~5% flake rate, so skip this until the test can be deflaked upstream.

Related: https://github.com/cilium/cilium/issues/42456