### PR TITLE
metricsmap: provide metrics BPF map via hive

### DIFF
--- a/cilium-dbg/cmd/bpf_metrics_flush.go
+++ b/cilium-dbg/cmd/bpf_metrics_flush.go
@@ -19,8 +19,14 @@ var bpfMetricsFlushCmd = &cobra.Command{
 	Short: "Clear BPF datapath traffic metrics (test purpose only)",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf metrics flush")
-		metricsmap.InitMap(log)
-		flushMetrics(&metricsmap.Metrics)
+
+		mm, err := metricsmap.LoadMetricsMap(log)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error loading BPF metrics map: %v\n", err)
+			os.Exit(1)
+		}
+
+		flushMetrics(mm)
 	},
 }
 

--- a/cilium-dbg/cmd/bpf_metrics_list.go
+++ b/cilium-dbg/cmd/bpf_metrics_list.go
@@ -53,8 +53,14 @@ var bpfMetricsListCmd = &cobra.Command{
 	Short: "List BPF datapath traffic metrics",
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf metrics list")
-		metricsmap.InitMap(log)
-		listMetrics(&metricsmap.Metrics)
+
+		mm, err := metricsmap.LoadMetricsMap(log)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error loading BPF metrics map: %v\n", err)
+			os.Exit(1)
+		}
+
+		listMetrics(mm)
 	},
 }
 

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
-	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/option"
@@ -91,10 +90,6 @@ func initMaps(params daemonParams) error {
 
 	if err := lxcmap.LXCMap(params.MetricsRegistry).OpenOrCreate(); err != nil {
 		return fmt.Errorf("initializing lxc map: %w", err)
-	}
-
-	if err := metricsmap.Metrics.OpenOrCreate(); err != nil {
-		return fmt.Errorf("initializing metrics map: %w", err)
 	}
 
 	for _, m := range ctmap.GlobalMaps(option.Config.EnableIPv4,


### PR DESCRIPTION
This commit refactors the metrics map to be provided via hive cell instead of being accessed via global functions.

This ensures that the BPF map is properly opened (& created) before accessing it (map is initialized in a hive lifecycle hook) (incl. loader).

Usages of the metrics map (e.g. collector) are refactored to access the map via dependency.

Note: The cilium-dbg tooling still uses a global function to access the map - but it no longer creates the map if it doesn't exist.