### PR TITLE
gateway-api: Skip MeshGRPCRouteWeight to stabilize CI

### DIFF
--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -71,6 +71,9 @@ func TestConformance(t *testing.T) {
 			})
 		}
 	}
+	// TODO: Run MeshGRPCRouteWeight once it is deflaked upstream. See
+	//       GH-42456 for details.
+	skipTests = append(skipTests, "MeshGRPCRouteWeight")
 	options.UnusableNetworkAddresses = unusableNetworkAddresses
 	options.UsableNetworkAddresses = usableNetworkAddresses
 	options.SkipTests = append(options.SkipTests, skipTests...)


### PR DESCRIPTION
MeshGRPCRouteWeight has a ~5% flake rate, so skip this until the test can be deflaked upstream.

```
--- PASS: TestConformance (187.24s)
    --- SKIP: TestConformance/MeshGRPCRouteWeight (0.00s)
```

Related: https://github.com/cilium/cilium/issues/42456