### PR TITLE
Use helm to configure CiliumNode instead of custom CNI for ENI/Azure/Alibaba Cloud

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -16,6 +16,10 @@ cilium-agent [flags]
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --agent-not-ready-taint-key string                          Key of the taint indicating that Cilium is not ready on the node (default "node.cilium.io/agent-not-ready")
+      --alibabacloud-security-group-tags stringToString           List of tags to use when evaluating what security groups to use for the ENI at the node level (default [])
+      --alibabacloud-security-groups strings                      List of security groups to attach to any ENI that is created and attached to the instance at the node level
+      --alibabacloud-vswitch-tags stringToString                  List of tags to use when evaluating what VSwitches to use for ENI and IP allocation at the node level (default [])
+      --alibabacloud-vswitches strings                            List of VSwitches to use for ENI and IP allocation at the node level
       --allocator-list-timeout duration                           Timeout for listing allocator state before exiting (default 3m0s)
       --allow-icmp-frag-needed                                    Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                                    Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -23,6 +23,7 @@ cilium-agent [flags]
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --auto-create-cilium-node-resource                          Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                                   Enable automatic L2 routing between nodes
+      --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bgp-router-id-allocation-ip-pool string                   IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
       --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
       --bpf-auth-map-max int                                      Maximum number of entries in auth map (default 524288)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -194,7 +194,7 @@ cilium-agent [flags]
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level
-      --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation (default [])
+      --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation at the node level (default [])
       --eni-first-interface-index int                             Index of the first ENI to use for IP allocation at the node level
       --eni-security-group-tags stringToString                    List of tags to use when evaluating what AWS security groups to use for the ENI at the node level (default [])
       --eni-security-groups strings                               List of security groups to attach to any ENI that is created and attached to the instance at the node level
@@ -286,9 +286,11 @@ cilium-agent [flags]
       --ipam string                                               Backend to use for IPAM (default "cluster-pool")
       --ipam-cilium-node-update-rate duration                     Maximum rate at which the CiliumNode custom resource is updated (default 15s)
       --ipam-default-ip-pool string                               Name of the default IP Pool when using multi-pool (default "default")
+      --ipam-max-allocate int                                     Maximum number of IPs that can be allocated at the node level
       --ipam-min-allocate int                                     Minimum number of IPs that must be allocated when the node is first bootstrapped at the node level
       --ipam-multi-pool-pre-allocation map                        Defines the minimum number of IPs a node should pre-allocate from each pool (default default=8)
       --ipam-pre-allocate int                                     Number of IP addresses that must be available for allocation in the IPAMspec at the node level
+      --ipam-static-ip-tags stringToString                        List of tags to determine the pool of IPs from which to attribute a static IP to the node at the node level, this currently works with AWS and Azure (default [])
       --ipsec-key-file string                                     Path to IPsec key file
       --ipsec-key-rotation-duration duration                      Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -16,6 +16,7 @@ cilium-agent hive [flags]
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-algorithm-annotation                               Enable service-level annotation for configuring BPF load balancing algorithm
       --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -99,7 +99,7 @@ cilium-agent hive [flags]
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level
-      --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation (default [])
+      --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation at the node level (default [])
       --eni-first-interface-index int                             Index of the first ENI to use for IP allocation at the node level
       --eni-security-group-tags stringToString                    List of tags to use when evaluating what AWS security groups to use for the ENI at the node level (default [])
       --eni-security-groups strings                               List of security groups to attach to any ENI that is created and attached to the instance at the node level
@@ -173,8 +173,10 @@ cilium-agent hive [flags]
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam-max-allocate int                                     Maximum number of IPs that can be allocated at the node level
       --ipam-min-allocate int                                     Minimum number of IPs that must be allocated when the node is first bootstrapped at the node level
       --ipam-pre-allocate int                                     Number of IP addresses that must be available for allocation in the IPAMspec at the node level
+      --ipam-static-ip-tags stringToString                        List of tags to determine the pool of IPs from which to attribute a static IP to the node at the node level, this currently works with AWS and Azure (default [])
       --ipsec-key-file string                                     Path to IPsec key file
       --ipsec-key-rotation-duration duration                      Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -15,6 +15,10 @@ cilium-agent hive [flags]
       --agent-health-require-k8s-connectivity                     Require Kubernetes connectivity in agent health endpoint (default true)
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
+      --alibabacloud-security-group-tags stringToString           List of tags to use when evaluating what security groups to use for the ENI at the node level (default [])
+      --alibabacloud-security-groups strings                      List of security groups to attach to any ENI that is created and attached to the instance at the node level
+      --alibabacloud-vswitch-tags stringToString                  List of tags to use when evaluating what VSwitches to use for ENI and IP allocation at the node level (default [])
+      --alibabacloud-vswitches strings                            List of VSwitches to use for ENI and IP allocation at the node level
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -22,6 +22,7 @@ cilium-agent hive dot-graph [flags]
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")
       --bpf-lb-algorithm-annotation                               Enable service-level annotation for configuring BPF load balancing algorithm
       --bpf-lb-dsr-dispatch string                                BPF load balancing DSR dispatch method ("opt", "ipip", "geneve") (default "opt")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -105,7 +105,7 @@ cilium-agent hive dot-graph [flags]
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level
-      --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation (default [])
+      --eni-exclude-interface-tags stringToString                 List of tags to use when excluding ENIs for Cilium IP allocation at the node level (default [])
       --eni-first-interface-index int                             Index of the first ENI to use for IP allocation at the node level
       --eni-security-group-tags stringToString                    List of tags to use when evaluating what AWS security groups to use for the ENI at the node level (default [])
       --eni-security-groups strings                               List of security groups to attach to any ENI that is created and attached to the instance at the node level
@@ -178,8 +178,10 @@ cilium-agent hive dot-graph [flags]
       --ignore-flags-drift-checker strings                        Ignores specified flags during drift checking
       --ingress-secrets-namespace string                          IngressSecretsNamespace is the namespace having tls secrets used by CEC, originating from Ingress controller
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
+      --ipam-max-allocate int                                     Maximum number of IPs that can be allocated at the node level
       --ipam-min-allocate int                                     Minimum number of IPs that must be allocated when the node is first bootstrapped at the node level
       --ipam-pre-allocate int                                     Number of IP addresses that must be available for allocation in the IPAMspec at the node level
+      --ipam-static-ip-tags stringToString                        List of tags to determine the pool of IPs from which to attribute a static IP to the node at the node level, this currently works with AWS and Azure (default [])
       --ipsec-key-file string                                     Path to IPsec key file
       --ipsec-key-rotation-duration duration                      Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -21,6 +21,10 @@ cilium-agent hive dot-graph [flags]
       --agent-health-require-k8s-connectivity                     Require Kubernetes connectivity in agent health endpoint (default true)
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
+      --alibabacloud-security-group-tags stringToString           List of tags to use when evaluating what security groups to use for the ENI at the node level (default [])
+      --alibabacloud-security-groups strings                      List of security groups to attach to any ENI that is created and attached to the instance at the node level
+      --alibabacloud-vswitch-tags stringToString                  List of tags to use when evaluating what VSwitches to use for ENI and IP allocation at the node level (default [])
+      --alibabacloud-vswitches strings                            List of VSwitches to use for ENI and IP allocation at the node level
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
       --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bpf-lb-algorithm string                                   BPF load balancing algorithm ("random", "maglev") (default "random")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2723,7 +2723,11 @@
    * - :spelling:ignore:`ipam.nodeSpec`
      - NodeSpec configuration for the IPAM
      - object
-     - ``{"ipamMinAllocate":null,"ipamPreAllocate":null}``
+     - ``{"ipamMaxAllocate":null,"ipamMinAllocate":null,"ipamPreAllocate":null,"ipamStaticIPTags":[]}``
+   * - :spelling:ignore:`ipam.nodeSpec.ipamMaxAllocate`
+     - IPAM max allocate @schema type: [null, integer] @schema
+     - string
+     - ``nil``
    * - :spelling:ignore:`ipam.nodeSpec.ipamMinAllocate`
      - IPAM min allocate @schema type: [null, integer] @schema
      - string
@@ -2732,6 +2736,10 @@
      - IPAM pre allocate @schema type: [null, integer] @schema
      - string
      - ``nil``
+   * - :spelling:ignore:`ipam.nodeSpec.ipamStaticIPTags`
+     - IPAM static IP tags (currently only works with AWS and Azure)
+     - list
+     - ``[]``
    * - :spelling:ignore:`ipam.operator.autoCreateCiliumPodIPPools`
      - IP pools to auto-create in multi-pool IPAM mode.
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -36,6 +36,22 @@
      - Enable AlibabaCloud ENI integration
      - bool
      - ``false``
+   * - :spelling:ignore:`alibabacloud.nodeSpec.securityGroupTags`
+     - 
+     - list
+     - ``[]``
+   * - :spelling:ignore:`alibabacloud.nodeSpec.securityGroups`
+     - 
+     - list
+     - ``[]``
+   * - :spelling:ignore:`alibabacloud.nodeSpec.vSwitchTags`
+     - 
+     - list
+     - ``[]``
+   * - :spelling:ignore:`alibabacloud.nodeSpec.vSwitches`
+     - 
+     - list
+     - ``[]``
    * - :spelling:ignore:`annotateK8sNode`
      - Annotate k8s node upon initialization with Cilium's metadata.
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -256,6 +256,10 @@
      - Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (\ ``aksbyocni.enabled``\ ) instead.
      - bool
      - ``false``
+   * - :spelling:ignore:`azure.nodeSpec.azureInterfaceName`
+     - 
+     - string
+     - ``""``
    * - :spelling:ignore:`bandwidthManager`
      - Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.
      - object

--- a/Documentation/network/concepts/ipam/azure.rst
+++ b/Documentation/network/concepts/ipam/azure.rst
@@ -172,12 +172,9 @@ The following parameters are available to control the IP allocation:
 
   If unspecified, this value defaults to 8.
 
-``spec.ipam.max-above-watermark``
-  The maximum number of addresses to allocate beyond the addresses needed to
-  reach the PreAllocate watermark.  Going above the watermark can help reduce
-  the number of API calls to allocate IPs.
+``spec.azure.interface-name``
+  The name of the interface to use for IP allocation.
 
-  If let unspecified, the value defaults to 0.
 
 *******************
 Operational Details

--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -211,14 +211,6 @@ allocation:
 
   If unspecified, no minimum number of IPs is required.
 
-``spec.ipam.max-allocate``
-  The maximum number of IPs that can be allocated to the node.
-  When the current amount of allocated IPs will approach this value,
-  the considered value for PreAllocate will decrease down to 0 in order to
-  not attempt to allocate more addresses than defined.
-
-  If unspecified, no maximum number of IPs will be enforced.
-
 ``spec.ipam.pre-allocate``
   The number of IP addresses that must be available for allocation at all
   times.  It defines the buffer of addresses available immediately without
@@ -226,14 +218,10 @@ allocation:
 
   If unspecified, this value defaults to 8.
 
-``spec.ipam.max-above-watermark``
-  The maximum number of addresses to allocate beyond the addresses needed to
-  reach the PreAllocate watermark.  Going above the watermark can help reduce
-  the number of API calls to allocate IPs, e.g. when a new ENI is allocated, as
-  many secondary IPs as possible are allocated. Limiting the amount can help
-  reduce waste of IPs.
+``spec.ipam.static-ip-tags``
+  A map of tags to select a pool of IPs from which to assign a static IP to the node.
 
-  If let unspecified, the value defaults to 0.
+  If unspecified, no tags are required.
 
 ``spec.eni.first-interface-index``
   The index of the first ENI to use for IP allocation, e.g. if the node has
@@ -280,6 +268,17 @@ allocation:
   ``subnet-tags`` or ``first-interface-index`` to exclude additional interfaces.
 
   If unspecified, no tags are used to exclude interfaces.
+
+``spec.eni.use-primary-address``
+  Whether an ENI's primary address should be available for allocations on the node.
+
+  If unspecified, this option is disabled.
+
+``spec.eni.disable-prefix-delegation``
+  Whether ENI prefix delegation should be disabled on this node.
+
+  If unspecified, this option is disabled.
+
 
 ``spec.eni.delete-on-termination``
   Remove the ENI when the instance is terminated

--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -90,8 +90,36 @@ Configuration
 Custom ENI Configuration
 ========================
 
-Custom ENI configuration can be defined with a custom CNI configuration
-``ConfigMap``:
+Custom ENI configuration can be defined from Helm or with a custom CNI
+configuration ``ConfigMap``.
+
+If you configure both helm and Custom CNI for the same field, Custom CNI is 
+preferred over Helm configuration.
+
+Helm
+----
+
+The ENI configuration can be specified via Helm, using either the ``--set`` flag
+or a values file.
+
+The following example configures Cilium to:
+
+* Use subnets with the tag ``foo=bar`` to create ENIs.
+* Use index 1 as the first interface for pod IP allocation.
+* Set the minimum number of IPs to allocate to 10.
+
+.. parsed-literal::
+
+  helm upgrade cilium |CHART_RELEASE| \\
+    --namespace kube-system \\
+    --reuse-values \\
+    --set eni.enabled=true \\
+    --set eni.nodeSpec.subnetTags={foo=bar} \\
+    --set eni.nodeSpec.firstInterfaceIndex=1 \\
+    --set ipam.nodeSpec.ipamMinAllocate=10
+
+The full list of available options can be found in the :ref:`helm_reference`
+section in the ``eni.nodeSpec`` and ``ipam.nodeSpec`` sections.
 
 Create a CNI configuration
 --------------------------

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -114,6 +114,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.rotatedIdentitiesQueueSize | int | `1024` | Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers. |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (`aksbyocni.enabled`) instead. |
+| azure.nodeSpec.azureInterfaceName | string | `""` |  |
 | bandwidthManager | object | `{"bbr":false,"bbrHostNamespaceOnly":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
 | bandwidthManager.bbr | bool | `false` | Activate BBR TCP congestion control for Pods |
 | bandwidthManager.bbrHostNamespaceOnly | bool | `false` | Activate BBR TCP congestion control for Pods in the host namespace only. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -730,9 +730,11 @@ contributors across the globe, there is almost always someone available to help.
 | ipam.installUplinkRoutesForDelegatedIPAM | bool | `false` | Install ingress/egress routes through uplink on host for Pods when working with delegated IPAM plugin. |
 | ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/network/concepts/ipam/ |
 | ipam.multiPoolPreAllocation | string | `""` | Pre-allocation settings for IPAM in Multi-Pool mode |
-| ipam.nodeSpec | object | `{"ipamMinAllocate":null,"ipamPreAllocate":null}` | NodeSpec configuration for the IPAM |
+| ipam.nodeSpec | object | `{"ipamMaxAllocate":null,"ipamMinAllocate":null,"ipamPreAllocate":null,"ipamStaticIPTags":[]}` | NodeSpec configuration for the IPAM |
+| ipam.nodeSpec.ipamMaxAllocate | string | `nil` | IPAM max allocate @schema type: [null, integer] @schema |
 | ipam.nodeSpec.ipamMinAllocate | string | `nil` | IPAM min allocate @schema type: [null, integer] @schema |
 | ipam.nodeSpec.ipamPreAllocate | string | `nil` | IPAM pre allocate @schema type: [null, integer] @schema |
+| ipam.nodeSpec.ipamStaticIPTags | list | `[]` | IPAM static IP tags (currently only works with AWS and Azure) |
 | ipam.operator.autoCreateCiliumPodIPPools | object | `{}` | IP pools to auto-create in multi-pool IPAM mode. |
 | ipam.operator.clusterPoolIPv4MaskSize | int | `24` | IPv4 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv4PodCIDRList | list | `["10.0.0.0/8"]` | IPv4 CIDR list range to delegate to individual nodes for IPAM. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -59,6 +59,10 @@ contributors across the globe, there is almost always someone available to help.
 | agentNotReadyTaintKey | string | `"node.cilium.io/agent-not-ready"` | Configure the key of the taint indicating that Cilium is not ready on the node. When set to a value starting with `ignore-taint.cluster-autoscaler.kubernetes.io/`, the Cluster Autoscaler will ignore the taint on its decisions, allowing the cluster to scale up. |
 | aksbyocni.enabled | bool | `false` | Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (`azure.enabled`) instead. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
+| alibabacloud.nodeSpec.securityGroupTags | list | `[]` |  |
+| alibabacloud.nodeSpec.securityGroups | list | `[]` |  |
+| alibabacloud.nodeSpec.vSwitchTags | list | `[]` |  |
+| alibabacloud.nodeSpec.vSwitches | list | `[]` |  |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | annotations | object | `{}` | Annotations to be added to all top-level cilium-agent objects (resources under templates/cilium-agent) |
 | apiRateLimit | string | `nil` | The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1141,6 +1141,12 @@ data:
   {{- if ne .Values.ipam.nodeSpec.ipamPreAllocate nil }}
   ipam-pre-allocate: {{ .Values.ipam.nodeSpec.ipamPreAllocate | quote }}
   {{- end }}
+  {{- if ne .Values.ipam.nodeSpec.ipamMaxAllocate nil }}
+  ipam-max-allocate: {{ .Values.ipam.nodeSpec.ipamMaxAllocate | quote }}
+  {{- end }}
+  {{- if .Values.ipam.nodeSpec.ipamStaticIPTags }}
+  ipam-static-ip-tags: {{ .Values.ipam.nodeSpec.ipamStaticIPTags | join "," | quote }}
+  {{- end }}
 {{- end }}
 {{- if .Values.ipam.multiPoolPreAllocation }}
   ipam-multi-pool-pre-allocation: {{ .Values.ipam.multiPoolPreAllocation | quote }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -641,6 +641,9 @@ data:
 {{- end }}
   azure-use-primary-address: {{ $azureUsePrimaryAddress | quote }}
 {{- end }}
+{{- if .Values.azure.nodeSpec.azureInterfaceName }}
+  azure-interface-name: {{ .Values.azure.nodeSpec.azureInterfaceName | quote }}
+{{- end }}
 
 {{- if .Values.alibabacloud.enabled }}
   enable-endpoint-routes: "true"

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -649,6 +649,18 @@ data:
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
 {{- end }}
+{{- if .Values.alibabacloud.nodeSpec.vSwitches }}
+  alibabacloud-vswitches: {{ .Values.alibabacloud.nodeSpec.vSwitches | join "," | quote }}
+{{- end }}
+{{- if .Values.alibabacloud.nodeSpec.vSwitchTags }}
+  alibabacloud-vswitch-tags: {{ .Values.alibabacloud.nodeSpec.vSwitchTags | join "," | quote }}
+{{- end }}
+{{- if .Values.alibabacloud.nodeSpec.securityGroups }}
+  alibabacloud-security-groups: {{ .Values.alibabacloud.nodeSpec.securityGroups | join "," | quote }}
+{{- end }}
+{{- if .Values.alibabacloud.nodeSpec.securityGroupTags }}
+  alibabacloud-security-group-tags: {{ .Values.alibabacloud.nodeSpec.securityGroupTags | join "," | quote }}
+{{- end }}
 
 {{- if hasKey .Values "l7Proxy" }}
   # Enables L7 proxy for L7 policy enforcement and visibility

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4102,6 +4102,12 @@
         },
         "nodeSpec": {
           "properties": {
+            "ipamMaxAllocate": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
             "ipamMinAllocate": {
               "type": [
                 "null",
@@ -4113,6 +4119,10 @@
                 "null",
                 "integer"
               ]
+            },
+            "ipamStaticIPTags": {
+              "items": {},
+              "type": "array"
             }
           },
           "type": "object"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -440,6 +440,14 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "nodeSpec": {
+          "properties": {
+            "azureInterfaceName": {
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -58,6 +58,27 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "nodeSpec": {
+          "properties": {
+            "securityGroupTags": {
+              "items": {},
+              "type": "array"
+            },
+            "securityGroups": {
+              "items": {},
+              "type": "array"
+            },
+            "vSwitchTags": {
+              "items": {},
+              "type": "array"
+            },
+            "vSwitches": {
+              "items": {},
+              "type": "array"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -443,6 +443,8 @@ azure:
   # clientID: 00000000-0000-0000-0000-000000000000
   # clientSecret: 00000000-0000-0000-0000-000000000000
   # userAssignedIdentityID: 00000000-0000-0000-0000-000000000000
+  nodeSpec:
+    azureInterfaceName: ""
 alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -448,6 +448,11 @@ azure:
 alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false
+  nodeSpec:
+    vSwitches: []
+    vSwitchTags: []
+    securityGroups: []
+    securityGroupTags: []
 # -- Enable bandwidth manager to optimize TCP and UDP workloads and allow
 # for rate-limiting traffic from individual Pods with EDT (Earliest Departure
 # Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2137,6 +2137,13 @@ ipam:
     # type: [null, integer]
     # @schema
     ipamPreAllocate: ~
+    # -- IPAM max allocate
+    # @schema
+    # type: [null, integer]
+    # @schema
+    ipamMaxAllocate: ~
+    # -- IPAM static IP tags (currently only works with AWS and Azure)
+    ipamStaticIPTags: []
 # -- defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when
 # no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none
 # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2153,6 +2153,13 @@ ipam:
     # type: [null, integer]
     # @schema
     ipamPreAllocate: ~
+    # -- IPAM max allocate
+    # @schema
+    # type: [null, integer]
+    # @schema
+    ipamMaxAllocate: ~
+    # -- IPAM static IP tags (currently only works with AWS and Azure)
+    ipamStaticIPTags: []
 # -- defaultLBServiceIPAM indicates the default LoadBalancer Service IPAM when
 # no LoadBalancer class is set. Applicable values: lbipam, nodeipam, none
 # @schema

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -446,6 +446,8 @@ azure:
   # clientID: 00000000-0000-0000-0000-000000000000
   # clientSecret: 00000000-0000-0000-0000-000000000000
   # userAssignedIdentityID: 00000000-0000-0000-0000-000000000000
+  nodeSpec:
+    azureInterfaceName: ""
 alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -451,6 +451,11 @@ azure:
 alibabacloud:
   # -- Enable AlibabaCloud ENI integration
   enabled: false
+  nodeSpec:
+    vSwitches: []
+    vSwitchTags: []
+    securityGroups: []
+    securityGroupTags: []
 # -- Enable bandwidth manager to optimize TCP and UDP workloads and allow
 # for rate-limiting traffic from individual Pods with EDT (Earliest Departure
 # Time) through the "kubernetes.io/egress-bandwidth" Pod annotation.

--- a/pkg/nodediscovery/cell.go
+++ b/pkg/nodediscovery/cell.go
@@ -50,6 +50,11 @@ var defaultConfig = config{
 	ENIDeleteOnTermination:     defaults.ENIDeleteOnTermination,
 
 	AzureInterfaceName: "",
+
+	AlibabaCloudVSwitches:         []string{},
+	AlibabaCloudVSwitchTags:       map[string]string{},
+	AlibabaCloudSecurityGroups:    []string{},
+	AlibabaCloudSecurityGroupTags: map[string]string{},
 }
 
 type config struct {
@@ -69,6 +74,11 @@ type config struct {
 	ENIDeleteOnTermination     bool
 
 	AzureInterfaceName string
+
+	AlibabaCloudVSwitches         []string
+	AlibabaCloudVSwitchTags       map[string]string
+	AlibabaCloudSecurityGroups    []string
+	AlibabaCloudSecurityGroupTags map[string]string
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
@@ -88,4 +98,9 @@ func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("eni-delete-on-termination", c.ENIDeleteOnTermination, "Whether the ENI should be deleted when the associated instance is terminated at the node level")
 
 	flags.String("azure-interface-name", c.AzureInterfaceName, "InterfaceName the cilium-operator will use to allocate all the IPs on at the node level")
+
+	flags.StringSlice("alibabacloud-vswitches", c.AlibabaCloudVSwitches, "List of VSwitches to use for ENI and IP allocation at the node level")
+	flags.StringToString("alibabacloud-vswitch-tags", c.AlibabaCloudVSwitchTags, "List of tags to use when evaluating what VSwitches to use for ENI and IP allocation at the node level")
+	flags.StringSlice("alibabacloud-security-groups", c.AlibabaCloudSecurityGroups, "List of security groups to attach to any ENI that is created and attached to the instance at the node level")
+	flags.StringToString("alibabacloud-security-group-tags", c.AlibabaCloudSecurityGroupTags, "List of tags to use when evaluating what security groups to use for the ENI at the node level")
 }

--- a/pkg/nodediscovery/cell.go
+++ b/pkg/nodediscovery/cell.go
@@ -32,7 +32,12 @@ var Cell = cell.Module(
 
 var defaultConfig = config{
 	IPAMMinAllocate: 0,
-	IPAMPreAllocate: 0,
+	// default pre-allocate value is 8 and will be set by operator.
+	// Using 0 here will not really set the value since kubernetes will
+	// treat zero as unset value.
+	IPAMPreAllocate:  0,
+	IPAMMaxAllocate:  0,
+	IPAMStaticIPTags: map[string]string{},
 
 	ENIFirstInterfaceIndex:     defaults.ENIFirstInterfaceIndex,
 	ENISubnetIDs:               []string{},
@@ -46,8 +51,10 @@ var defaultConfig = config{
 }
 
 type config struct {
-	IPAMMinAllocate int
-	IPAMPreAllocate int
+	IPAMMinAllocate  int
+	IPAMPreAllocate  int
+	IPAMMaxAllocate  int
+	IPAMStaticIPTags map[string]string
 
 	ENIFirstInterfaceIndex     int
 	ENISubnetIDs               []string
@@ -63,9 +70,11 @@ type config struct {
 func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Int("ipam-min-allocate", c.IPAMMinAllocate, "Minimum number of IPs that must be allocated when the node is first bootstrapped at the node level")
 	flags.Int("ipam-pre-allocate", c.IPAMPreAllocate, "Number of IP addresses that must be available for allocation in the IPAMspec at the node level")
+	flags.Int("ipam-max-allocate", c.IPAMMaxAllocate, "Maximum number of IPs that can be allocated at the node level")
+	flags.StringToString("ipam-static-ip-tags", c.IPAMStaticIPTags, "List of tags to determine the pool of IPs from which to attribute a static IP to the node at the node level, this currently works with AWS and Azure")
 
 	flags.Int("eni-first-interface-index", c.ENIFirstInterfaceIndex, "Index of the first ENI to use for IP allocation at the node level")
-	flags.StringToString("eni-exclude-interface-tags", c.ENIExcludeInterfaceTags, "List of tags to use when excluding ENIs for Cilium IP allocation")
+	flags.StringToString("eni-exclude-interface-tags", c.ENIExcludeInterfaceTags, "List of tags to use when excluding ENIs for Cilium IP allocation at the node level")
 	flags.StringSlice("eni-subnet-ids", c.ENISubnetIDs, "List of subnet ids to use when evaluating what AWS subnets to use for ENI and IP allocation at the node level")
 	flags.StringToString("eni-subnet-tags", c.ENISubnetTags, "List of tags to use when evaluating what AWS subnets to use for ENI and IP allocation at the node level")
 	flags.StringSlice("eni-security-groups", c.ENISecurityGroups, "List of security groups to attach to any ENI that is created and attached to the instance at the node level")

--- a/pkg/nodediscovery/cell.go
+++ b/pkg/nodediscovery/cell.go
@@ -48,6 +48,8 @@ var defaultConfig = config{
 	ENIUsePrimaryAddress:       defaults.UseENIPrimaryAddress,
 	ENIDisablePrefixDelegation: defaults.ENIDisableNodeLevelPD,
 	ENIDeleteOnTermination:     defaults.ENIDeleteOnTermination,
+
+	AzureInterfaceName: "",
 }
 
 type config struct {
@@ -65,6 +67,8 @@ type config struct {
 	ENIUsePrimaryAddress       bool
 	ENIDisablePrefixDelegation bool
 	ENIDeleteOnTermination     bool
+
+	AzureInterfaceName string
 }
 
 func (c config) Flags(flags *pflag.FlagSet) {
@@ -82,4 +86,6 @@ func (c config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("eni-use-primary-address", c.ENIUsePrimaryAddress, "Whether an ENI's primary address should be available for allocations on the node at the node level")
 	flags.Bool("eni-disable-prefix-delegation", c.ENIDisablePrefixDelegation, "Whether ENI prefix delegation should be disabled on this node at the node level")
 	flags.Bool("eni-delete-on-termination", c.ENIDeleteOnTermination, "Whether the ENI should be deleted when the associated instance is terminated at the node level")
+
+	flags.String("azure-interface-name", c.AzureInterfaceName, "InterfaceName the cilium-operator will use to allocate all the IPs on at the node level")
 }

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -554,6 +554,15 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		nodeResource.Spec.AlibabaCloud.CIDRBlock = vpcCidrBlock
 		nodeResource.Spec.AlibabaCloud.AvailabilityZone = zoneID
 
+		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
+		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
+		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
+		nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
+		nodeResource.Spec.AlibabaCloud.VSwitches = n.config.AlibabaCloudVSwitches
+		nodeResource.Spec.AlibabaCloud.VSwitchTags = n.config.AlibabaCloudVSwitchTags
+		nodeResource.Spec.AlibabaCloud.SecurityGroups = n.config.AlibabaCloudSecurityGroups
+		nodeResource.Spec.AlibabaCloud.SecurityGroupTags = n.config.AlibabaCloudSecurityGroupTags
+
 		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
 			if c.AlibabaCloud.VPCID != "" {
 				nodeResource.Spec.AlibabaCloud.VPCID = c.AlibabaCloud.VPCID

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -425,6 +425,8 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 
 		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
 		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
+		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
+		nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
 
 		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
 			if c.IPAM.MinAllocate != 0 {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -499,6 +499,12 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		// consistent results.
 		nodeResource.Spec.InstanceID = strings.ToLower(strings.TrimPrefix(ln.Local.ProviderID, azureTypes.ProviderPrefix))
 
+		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
+		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
+		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
+		nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
+		nodeResource.Spec.Azure.InterfaceName = n.config.AzureInterfaceName
+
 		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
 			if c.IPAM.MinAllocate != 0 {
 				nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate


### PR DESCRIPTION
This PR is the 2nd step to provide the config flags through helm after https://github.com/cilium/cilium/pull/43086. so people dont have to use the custom CNI to configure the CiliumNode to improve the UX expereince for AWS/Azure/Alibaba Cloud

fixes : #40790

```release-note
Add the new flags of Azure/Alibaba and ipam for cilium agent, and users can use helm to configure the agent directly without using custom CNI
```
