### PR TITLE
fragmap: introduce hive cell

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
-	"github.com/cilium/cilium/pkg/maps/fragmap"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
@@ -127,18 +126,6 @@ func initMaps(params daemonParams) error {
 		if err := nat.CreateRetriesMaps(option.Config.EnableIPv4,
 			option.Config.EnableIPv6); err != nil {
 			return fmt.Errorf("initializing NAT retries map: %w", err)
-		}
-	}
-
-	if option.Config.EnableIPv4FragmentsTracking {
-		if err := fragmap.InitMap4(params.MetricsRegistry, option.Config.FragmentsMapEntries); err != nil {
-			return fmt.Errorf("initializing fragments map: %w", err)
-		}
-	}
-
-	if option.Config.EnableIPv6FragmentsTracking {
-		if err := fragmap.InitMap6(params.MetricsRegistry, option.Config.FragmentsMapEntries); err != nil {
-			return fmt.Errorf("initializing fragments map: %w", err)
 		}
 	}
 

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
+	"github.com/cilium/cilium/pkg/maps/fragmap"
 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
 	"github.com/cilium/cilium/pkg/maps/l2v6respondermap"
 	"github.com/cilium/cilium/pkg/maps/multicast"
@@ -46,6 +47,9 @@ var Cell = cell.Module(
 
 	// Provides access to egressgateway specific maps.
 	egressmap.Cell,
+
+	// Initializes the fragments map in the datapath
+	fragmap.Cell,
 
 	// Provides signalmap for datapath signals
 	signalmap.Cell,

--- a/pkg/maps/fragmap/cell.go
+++ b/pkg/maps/fragmap/cell.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fragmap
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides the fragmap.Map used to associate datagram
+// fragments to the L4 ports of the datagram they belong to, in order to
+// retrieve the full 5-tuple necessary to do L4-based lookups.
+var Cell = cell.Module(
+	"fragments-map",
+	"Initializes fragments bpf map",
+
+	// Provided to init at startup (The Loader depends on all maps via bpf.Mapout)
+	cell.Provide(newFragMap),
+)
+
+func newFragMap(lifecycle cell.Lifecycle, registry *metrics.Registry, daemonConfig *option.DaemonConfig) bpf.MapOut[Map] {
+	fragMap := newMap(registry, daemonConfig.FragmentsMapEntries, daemonConfig.GetEventBufferConfig)
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(context cell.HookContext) error {
+			return fragMap.init()
+		},
+		OnStop: func(context cell.HookContext) error {
+			// no need to close because the maps are only created for datapath (Create)
+			return nil
+		},
+	})
+
+	return bpf.NewMapOut(Map(fragMap))
+}


### PR DESCRIPTION
This commit introduces a hive cell for the fragmap. It moves the logic to create the fragments bpf map at Agent startup from the legacy daemon init logic to a hive lifecycle start hook.

The `Loader` automatically depends on all BPF maps (via `bpf.MapOut`) - this way, the map gets created before the first use of the `Loader`.
