### PR TITLE
neighborsmap: introduce hive cell

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
-	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -117,12 +116,6 @@ func initMaps(params daemonParams) error {
 		}
 	}
 
-	if params.KPRConfig.KubeProxyReplacement {
-		if err := neighborsmap.InitMaps(option.Config.EnableIPv4,
-			option.Config.EnableIPv6); err != nil {
-			return fmt.Errorf("initializing neighbors map: %w", err)
-		}
-	}
 	if params.KPRConfig.KubeProxyReplacement || option.Config.EnableBPFMasquerade {
 		if err := nat.CreateRetriesMaps(option.Config.EnableIPv4,
 			option.Config.EnableIPv6); err != nil {

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/l2v6respondermap"
 	"github.com/cilium/cilium/pkg/maps/multicast"
 	"github.com/cilium/cilium/pkg/maps/nat"
+	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
@@ -59,6 +60,9 @@ var Cell = cell.Module(
 
 	// Provides access to the multicast maps.
 	multicast.Cell,
+
+	// Initializes the neighbors map in the datapath
+	neighborsmap.Cell,
 
 	// Provides access to the SRv6 maps.
 	srv6map.Cell,

--- a/pkg/maps/neighborsmap/cell.go
+++ b/pkg/maps/neighborsmap/cell.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package neighborsmap
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides the neighborsmap.Map that stores IP to mac address
+// mappings for NodePort clients. It is primarily managed from the
+// datapath; Cilium side is used to create the map only.
+var Cell = cell.Module(
+	"neighbors-map",
+	"Initializes neighbors bpf map",
+
+	// Provided to init at startup (The Loader depends on all maps via bpf.Mapout)
+	cell.Provide(newNeighborsMap),
+)
+
+func newNeighborsMap(lifecycle cell.Lifecycle, daemonConfig *option.DaemonConfig, kprConfig kpr.KPRConfig) bpf.MapOut[Map] {
+	if !kprConfig.KubeProxyReplacement {
+		return bpf.NewMapOut(Map(nil))
+	}
+
+	neighborsMap := newMap(daemonConfig.NeighMapEntriesGlobal, daemonConfig.IPv4Enabled(), daemonConfig.IPv6Enabled())
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(context cell.HookContext) error {
+			return neighborsMap.init()
+		},
+		OnStop: func(context cell.HookContext) error {
+			// no need to close because the maps are only created for datapath (Create)
+			return nil
+		},
+	})
+
+	return bpf.NewMapOut(Map(neighborsMap))
+}


### PR DESCRIPTION
This commit introduces a hive cell for the neighbors map. It moves the logic to create the neighbors bpf map at Agent startup from the legacy daemon init logic to a hive lifecycle start hook.

The `Loader` automatically depends on all BPF maps (via `bpf.MapOut`) - this way, the map gets created before the first use of the `Loader`.