### PR TITLE
renovate: Add cilium-envoy group explicitly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -697,6 +697,7 @@
       ]
     },
     {
+      "groupName": "cilium-envoy",
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],
@@ -709,6 +710,7 @@
       ]
     },
     {
+      "groupName": "cilium-envoy",
       "matchDepNames": [
         "quay.io/cilium/cilium-envoy"
       ],


### PR DESCRIPTION
The goal is to avoid multiple PRs for the same update

https://github.com/cilium/cilium/pull/43136
https://github.com/cilium/cilium/pull/43135

