### PR TITLE
ci: install libtinfo5 for clang in build commits workflow

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -161,6 +161,26 @@ jobs:
               - 'pkg/**'
               - 'test/**'
 
+      - name: Setup additional repositories
+        shell: bash
+        run: |
+          # This is required for libtinfo5
+          uri="http://security.ubuntu.com/ubuntu"
+          arch="amd64"
+          if [ ${{ runner.arch }} == "ARM64" ]; then
+            uri="http://ports.ubuntu.com/ubuntu-ports"
+            arch="arm64"
+          fi
+
+          sudo tee -a /etc/apt/sources.list.d/jammy-security.sources <<EOF
+          Types: deb
+          URIs: $uri
+          Suites: jammy-updates
+          Components: main universe restricted multiverse
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          Architectures: $arch
+          EOF
+
       - name: Set clang directory
         if: steps.test-tree.outputs.src == 'true'
         id: set_clang_dir
@@ -170,7 +190,7 @@ jobs:
         if: steps.test-tree.outputs.src == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libtinfo6
+          sudo apt-get install -y --no-install-recommends libtinfo5
 
       - name: Install LLVM and Clang
         if: steps.test-tree.outputs.src == 'true'


### PR DESCRIPTION
On v1.17, the "Build Commits" workflow currently fails to build the bpf unit tests because the clang version used on this branch is still linked against libtinfo5, but the workflow installs libtinfo6:

    clang -Wall -Wextra -Werror -Wshadow -Wno-unused-parameter -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end -Wdeclaration-after-statement -g -I../../bpf/ -I../../bpf/include -I. -D__NR_CPUS__=4 -O2 -Werror -I../../bpf/ unit-test.c -o unit-test
    clang: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory

Fix this by using the same approach as in the integration test workflow and install libtinfo5 from the correct Ubuntu repository when on Ubuntu 24.04 or later.