### PR TITLE
bgp: Add stringers and marshalers for route policy types

### DIFF
--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -163,8 +163,8 @@ const (
 	RoutePolicyMatchInvert
 )
 
-func (d RoutePolicyMatchType) String() string {
-	switch d {
+func (t RoutePolicyMatchType) String() string {
+	switch t {
 	case RoutePolicyMatchAny:
 		return "any"
 	case RoutePolicyMatchAll:
@@ -174,6 +174,14 @@ func (d RoutePolicyMatchType) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+func (t RoutePolicyMatchType) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + t.String() + "\""), nil
+}
+
+func (t RoutePolicyMatchType) MarshalYAML() (any, error) {
+	return t.String(), nil
 }
 
 // RoutePolicyNeighborMatch matches BGP neighbor IP address with the provided IPs using the provided match logic type.
@@ -300,6 +308,27 @@ const (
 	RoutePolicyActionReject
 )
 
+func (a RoutePolicyAction) String() string {
+	switch a {
+	case RoutePolicyActionNone:
+		return "none"
+	case RoutePolicyActionAccept:
+		return "accept"
+	case RoutePolicyActionReject:
+		return "reject"
+	default:
+		return "unknown"
+	}
+}
+
+func (a RoutePolicyAction) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + a.String() + "\""), nil
+}
+
+func (a RoutePolicyAction) MarshalYAML() (any, error) {
+	return a.String(), nil
+}
+
 // RoutePolicyActions define policy actions taken on route matched by a routing policy.
 //
 // +deepequal-gen=true
@@ -350,6 +379,25 @@ const (
 	// RoutePolicyTypeImport represents import routing policy type (affecting how the routes are imported into RIB).
 	RoutePolicyTypeImport
 )
+
+func (t RoutePolicyType) String() string {
+	switch t {
+	case RoutePolicyTypeExport:
+		return "export"
+	case RoutePolicyTypeImport:
+		return "import"
+	default:
+		return "unknown"
+	}
+}
+
+func (t RoutePolicyType) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + t.String() + "\""), nil
+}
+
+func (t RoutePolicyType) MarshalYAML() (any, error) {
+	return t.String(), nil
+}
 
 // RoutePolicy represents a BGP routing policy, also called "route map" in some BGP implementations.
 // It can contain multiple Statements that are evaluated in the given order. Each Statement

--- a/pkg/bgp/types/conversions.go
+++ b/pkg/bgp/types/conversions.go
@@ -96,6 +96,14 @@ func (a Afi) String() string {
 	}
 }
 
+func (a Afi) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + a.String() + "\""), nil
+}
+
+func (a Afi) MarshalYAML() (any, error) {
+	return a.String(), nil
+}
+
 // ParseAfi parses s as an address family identifier.
 // If s is unknown, AfiUnknown is returned.
 func ParseAfi(s string) Afi {
@@ -217,6 +225,14 @@ func (s Safi) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+func (s Safi) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + s.String() + "\""), nil
+}
+
+func (s Safi) MarshalYAML() (any, error) {
+	return s.String(), nil
 }
 
 // ParseSafi parses s as a subsequent address family identifier.


### PR DESCRIPTION
Add `String()`, `MarshalJSON()` and `MarshalYAML()` methods for BGP policy types to allow pretty-printing in logs and debug commands.


