### PR TITLE
Fix preflight generation error

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -413,10 +413,10 @@ rules:
   - patch
   - delete
 {{- end }}
-{{- end }}
 - apiGroups:
   - cilium.io
   resources:
   - ciliumendpointslices
   verbs:
   - deletecollection
+{{- end }}


### PR DESCRIPTION
PR #42161 added the deletecollection permission for the CiliumEndpointSlice object to the Operator clusterrole.

However, it added it outside of a Helm `if` guard that is only invoked when you are running a preflight check.

That change therefore break the preflight and stopped it from running.

This moves that permission inside the clusterrole and fixes the error.
