### PR TITLE
Fix Envoy preflight by removing Envoy bootstrap configmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/configmap.yaml
@@ -1,5 +1,5 @@
 {{- $envoyDS := eq (include "envoyDaemonSetEnabled" .) "true" -}}
-{{- if $envoyDS }}
+{{- if (and $envoyDS (not .Values.preflight.enabled)) }}
 
 ---
 apiVersion: v1

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -213,9 +213,6 @@ spec:
           - name: envoy-artifacts
             mountPath: /var/run/cilium/envoy/artifacts
             readOnly: true
-          - name: envoy-config
-            mountPath: /var/run/cilium/envoy/
-            readOnly: true
           {{- with .Values.preflight.resources }}
           resources:
             {{- toYaml . | trim | nindent 12 }}
@@ -280,14 +277,6 @@ spec:
         hostPath:
           path: "{{ .Values.daemon.runPath }}/envoy/artifacts"
           type: DirectoryOrCreate
-      - name: envoy-config
-        configMap:
-          name: {{ .Values.envoy.bootstrapConfigMap | default "cilium-envoy-config" | quote }}
-          # note: the leading zero means this number is in octal representation: do not remove it
-          defaultMode: 0400
-          items:
-            - key: bootstrap-config.json
-              path: bootstrap-config.json
       {{- end }}
       {{- with .Values.preflight.extraVolumes }}
       {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
This commit removes the Envoy bootstrap ConfigMap from the Envoy preflight - since we are not even running Envoy it's irrelevant anyway, and it means that we can run into ownership issues with Helm.

Depends on #43152 - preflight will not work in `main` until that merges.

Updates: #41556

```release-note
Cilium Preflight check no longer includes Envoy Configmaps, making it easier to correctly run.
```
