### PR TITLE
ces: remove max rate limits for ces controller

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -43,9 +43,6 @@ const (
 	// Default CES Synctime, multiple consecutive syncs with k8s-apiserver are
 	// batched and synced together after a short delay.
 	DefaultCESSyncTime = 500 * time.Millisecond
-
-	CESWriteQPSLimitMax = 50
-	CESWriteQPSBurstMax = 100
 )
 
 func (c *Controller) initializeQueue() {

--- a/operator/pkg/ciliumendpointslice/rate_limit.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit.go
@@ -98,12 +98,6 @@ func (rlc *rateLimitConfig) updateRateLimitWithNodes(nodes int, force bool) bool
 			Limit: rlc.dynamicRateLimit[index].Limit,
 			Burst: rlc.dynamicRateLimit[index].Burst,
 		}
-		if rlc.current.Limit > CESWriteQPSLimitMax {
-			rlc.current.Limit = CESWriteQPSLimitMax
-		}
-		if rlc.current.Burst > CESWriteQPSBurstMax {
-			rlc.current.Burst = CESWriteQPSBurstMax
-		}
 		return true
 	}
 	return false


### PR DESCRIPTION
Previously, hard-coded limits on the CES controller QPS limit and burst were added to prevent user misconfiguration. However, these limits can be too low for some users and are also re-configured silently so users may not be aware that their cluster is not using the provided configuration. Remove hard-coded limits and default to using the actual configured value.

I have seen the context for why these limits were added: https://github.com/cilium/cilium/pull/24675#discussion_r1160898189 reported to be to avoid user misconfiguration. However, with the latest updates to the control plane, I have noticed in my testing that we are able to achieve better results when these limits are higher than the hard-coded limits. (It also is a bit of a silent reconfiguration, so I did not notice my cluster was not doing what I expected it to be doing for some time 😅). I considered raising these limits, but the limits are best configured on a per-scenario and per-cluster configuration basis. Given that CES has been released for quite some time, I would like to propose to just eliminate this limit and allow users the freedom to configure their clusters.


```release-note
ces: remove controller maximum limits on QPS
```
