### PR TITLE
ctmaps: remove unused local map types

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -67,8 +67,6 @@ const (
 	MapNameAny6Global = MapNameAny6 + "global"
 	MapNameAny4Global = MapNameAny4 + "global"
 
-	mapNumEntriesLocal = 64000
-
 	TUPLE_F_OUT     = 0
 	TUPLE_F_IN      = 1
 	TUPLE_F_RELATED = 2
@@ -357,21 +355,11 @@ func doGCForFamily(m *Map, filter GCFilter, next4, next6 func(GCEvent), ipv6 boo
 	// to happen concurrently.
 	globalDeleteLock[m.mapType].Lock()
 	if ipv6 {
-		if m.mapType.isGlobal() {
-			filterCallback := cleanup(m, filter, natMap, &stats, next6, true)
-			stats.dumpError = iterate[CtKey6Global, CtEntry](m, &stats, filterCallback)
-		} else {
-			filterCallback := cleanup(m, filter, natMap, &stats, next6, true)
-			stats.dumpError = iterate[CtKey6, CtEntry](m, &stats, filterCallback)
-		}
+		filterCallback := cleanup(m, filter, natMap, &stats, next6, true)
+		stats.dumpError = iterate[CtKey6Global, CtEntry](m, &stats, filterCallback)
 	} else {
-		if m.mapType.isGlobal() {
-			filterCallback := cleanup(m, filter, natMap, &stats, next4, true)
-			stats.dumpError = iterate[CtKey4Global, CtEntry](m, &stats, filterCallback)
-		} else {
-			filterCallback := cleanup(m, filter, natMap, &stats, next4, true)
-			stats.dumpError = iterate[CtKey4, CtEntry](m, &stats, filterCallback)
-		}
+		filterCallback := cleanup(m, filter, natMap, &stats, next4, true)
+		stats.dumpError = iterate[CtKey4Global, CtEntry](m, &stats, filterCallback)
 	}
 	globalDeleteLock[m.mapType].Unlock()
 

--- a/pkg/maps/ctmap/per_cluster_ctmap_test.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap_test.go
@@ -174,20 +174,20 @@ func TestPrivilegedPerClusterCTMapsCleanup(t *testing.T) {
 		{
 			name:    "IPv4",
 			ipv4:    true,
-			present: []mapType{mapTypeIPv6TCPGlobal, mapTypeIPv6AnyLocal},
-			absent:  []mapType{mapTypeIPv4TCPGlobal, mapTypeIPv4AnyLocal},
+			present: []mapType{mapTypeIPv6TCPGlobal, mapTypeIPv6AnyGlobal},
+			absent:  []mapType{mapTypeIPv4TCPGlobal, mapTypeIPv4AnyGlobal},
 		},
 		{
 			name:    "IPv6",
 			ipv6:    true,
-			present: []mapType{mapTypeIPv4TCPGlobal, mapTypeIPv4AnyLocal},
-			absent:  []mapType{mapTypeIPv6TCPGlobal, mapTypeIPv6AnyLocal},
+			present: []mapType{mapTypeIPv4TCPGlobal, mapTypeIPv4AnyGlobal},
+			absent:  []mapType{mapTypeIPv6TCPGlobal, mapTypeIPv6AnyGlobal},
 		},
 		{
 			name:   "dual",
 			ipv4:   true,
 			ipv6:   true,
-			absent: []mapType{mapTypeIPv4TCPGlobal, mapTypeIPv4AnyLocal, mapTypeIPv6TCPGlobal, mapTypeIPv6AnyLocal},
+			absent: []mapType{mapTypeIPv4TCPGlobal, mapTypeIPv4AnyGlobal, mapTypeIPv6TCPGlobal, mapTypeIPv6AnyGlobal},
 		},
 	}
 

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -26,12 +26,8 @@ const (
 	// * IPv4 or IPv6;
 	// * TCP or non-TCP (shortened to Any)
 	// * Local (endpoint-specific) or global (endpoint-oblivious).
-	mapTypeIPv4TCPLocal mapType = iota
-	mapTypeIPv6TCPLocal
-	mapTypeIPv4TCPGlobal
+	mapTypeIPv4TCPGlobal mapType = iota
 	mapTypeIPv6TCPGlobal
-	mapTypeIPv4AnyLocal
-	mapTypeIPv6AnyLocal
 	mapTypeIPv4AnyGlobal
 	mapTypeIPv6AnyGlobal
 	mapTypeMax
@@ -40,18 +36,10 @@ const (
 // String renders the map type into a user-readable string.
 func (m mapType) String() string {
 	switch m {
-	case mapTypeIPv4TCPLocal:
-		return "Local IPv4 TCP CT map"
-	case mapTypeIPv6TCPLocal:
-		return "Local IPv6 TCP CT map"
 	case mapTypeIPv4TCPGlobal:
 		return "Global IPv4 TCP CT map"
 	case mapTypeIPv6TCPGlobal:
 		return "Global IPv6 TCP CT map"
-	case mapTypeIPv4AnyLocal:
-		return "Local IPv4 non-TCP CT map"
-	case mapTypeIPv6AnyLocal:
-		return "Local IPv6 non-TCP CT map"
 	case mapTypeIPv4AnyGlobal:
 		return "Global IPv4 non-TCP CT map"
 	case mapTypeIPv6AnyGlobal:
@@ -62,13 +50,13 @@ func (m mapType) String() string {
 
 func (m mapType) name() string {
 	switch m {
-	case mapTypeIPv4TCPLocal, mapTypeIPv4TCPGlobal:
+	case mapTypeIPv4TCPGlobal:
 		return "tcp4"
-	case mapTypeIPv6TCPLocal, mapTypeIPv6TCPGlobal:
+	case mapTypeIPv6TCPGlobal:
 		return "tcp6"
-	case mapTypeIPv4AnyLocal, mapTypeIPv4AnyGlobal:
+	case mapTypeIPv4AnyGlobal:
 		return "any4"
-	case mapTypeIPv6AnyLocal, mapTypeIPv6AnyGlobal:
+	case mapTypeIPv6AnyGlobal:
 		return "any6"
 	default:
 		panic("Unexpected map type " + m.String())
@@ -77,7 +65,7 @@ func (m mapType) name() string {
 
 func (m mapType) isIPv4() bool {
 	switch m {
-	case mapTypeIPv4TCPLocal, mapTypeIPv4TCPGlobal, mapTypeIPv4AnyLocal, mapTypeIPv4AnyGlobal:
+	case mapTypeIPv4TCPGlobal, mapTypeIPv4AnyGlobal:
 		return true
 	}
 	return false
@@ -85,23 +73,7 @@ func (m mapType) isIPv4() bool {
 
 func (m mapType) isIPv6() bool {
 	switch m {
-	case mapTypeIPv6TCPLocal, mapTypeIPv6TCPGlobal, mapTypeIPv6AnyLocal, mapTypeIPv6AnyGlobal:
-		return true
-	}
-	return false
-}
-
-func (m mapType) isLocal() bool {
-	switch m {
-	case mapTypeIPv4TCPLocal, mapTypeIPv6TCPLocal, mapTypeIPv4AnyLocal, mapTypeIPv6AnyLocal:
-		return true
-	}
-	return false
-}
-
-func (m mapType) isGlobal() bool {
-	switch m {
-	case mapTypeIPv4TCPGlobal, mapTypeIPv6TCPGlobal, mapTypeIPv4AnyGlobal, mapTypeIPv6AnyGlobal:
+	case mapTypeIPv6TCPGlobal, mapTypeIPv6AnyGlobal:
 		return true
 	}
 	return false
@@ -109,7 +81,7 @@ func (m mapType) isGlobal() bool {
 
 func (m mapType) isTCP() bool {
 	switch m {
-	case mapTypeIPv4TCPLocal, mapTypeIPv6TCPLocal, mapTypeIPv4TCPGlobal, mapTypeIPv6TCPGlobal:
+	case mapTypeIPv4TCPGlobal, mapTypeIPv6TCPGlobal:
 		return true
 	}
 	return false
@@ -117,10 +89,6 @@ func (m mapType) isTCP() bool {
 
 func (m mapType) key() bpf.MapKey {
 	switch m {
-	case mapTypeIPv4TCPLocal, mapTypeIPv4AnyLocal:
-		return &CtKey4{}
-	case mapTypeIPv6TCPLocal, mapTypeIPv6AnyLocal:
-		return &CtKey6{}
 	case mapTypeIPv4TCPGlobal, mapTypeIPv4AnyGlobal:
 		return &CtKey4Global{}
 	case mapTypeIPv6TCPGlobal, mapTypeIPv6AnyGlobal:
@@ -148,9 +116,6 @@ func (m mapType) maxEntries() int {
 		}
 		return option.CTMapEntriesGlobalAnyDefault
 
-	case mapTypeIPv4TCPLocal, mapTypeIPv6TCPLocal, mapTypeIPv4AnyLocal, mapTypeIPv6AnyLocal:
-		return mapNumEntriesLocal
-
 	default:
 		panic("Unexpected map type " + m.String())
 	}
@@ -170,16 +135,16 @@ func FilterMapsByProto(maps []*Map, ipVsn CTMapIPVersion) (ctMapTCP *Map, ctMapA
 		switch ipVsn {
 		case CTMapIPv4:
 			switch m.mapType {
-			case mapTypeIPv4TCPLocal, mapTypeIPv4TCPGlobal:
+			case mapTypeIPv4TCPGlobal:
 				ctMapTCP = m
-			case mapTypeIPv4AnyLocal, mapTypeIPv4AnyGlobal:
+			case mapTypeIPv4AnyGlobal:
 				ctMapAny = m
 			}
 		case CTMapIPv6:
 			switch m.mapType {
-			case mapTypeIPv6TCPLocal, mapTypeIPv6TCPGlobal:
+			case mapTypeIPv6TCPGlobal:
 				ctMapTCP = m
-			case mapTypeIPv6AnyLocal, mapTypeIPv6AnyGlobal:
+			case mapTypeIPv6AnyGlobal:
 				ctMapAny = m
 			}
 		}

--- a/pkg/maps/ctmap/types_test.go
+++ b/pkg/maps/ctmap/types_test.go
@@ -46,16 +46,10 @@ func TestMaxEntries(t *testing.T) {
 			option.Config.CTMapEntriesGlobalAny = tt.any
 
 			for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
-				if mapType.isLocal() {
-					assert.Equal(t, mapNumEntriesLocal, mapType.maxEntries())
-				}
-
-				if mapType.isGlobal() {
-					if mapType.isTCP() {
-						assert.Equal(t, tt.etcp, mapType.maxEntries())
-					} else {
-						assert.Equal(t, tt.eany, mapType.maxEntries())
-					}
+				if mapType.isTCP() {
+					assert.Equal(t, tt.etcp, mapType.maxEntries())
+				} else {
+					assert.Equal(t, tt.eany, mapType.maxEntries())
 				}
 			}
 


### PR DESCRIPTION
https://github.com/cilium/cilium/commit/20f0e004901d81a278ec9d18fa4526046b426323 ("Remove deprecated  CONNTRACK_LOCAL option") removed the last bits logic dealing with local CT and NAT maps. Let's take a step further and additionally remove the now unused local map types.