### PR TITLE
Add labels to non-idempotent resources

### DIFF
--- a/Documentation/configuration/argocd-issues.rst
+++ b/Documentation/configuration/argocd-issues.rst
@@ -13,20 +13,18 @@ Troubleshooting Cilium deployed with Argo CD
 There have been reports from users hitting issues with Argo CD. This documentation 
 page outlines some of the known issues and their solutions.
 
-Argo CD deletes CustomResourceDefinitions
-=========================================
+Argo CD deletes Cilium custom resources
+=======================================
 
 When deploying Cilium with Argo CD, some users have reported that Cilium-generated custom resources disappear,
-causing one or more of the following issues:
+causing the following issues:
 
 - ``ciliumid`` not found (:gh-issue:`17614`)
-- Argo CD Out-of-sync issues for hubble-generate-certs (:gh-issue:`14550`)
-- Out-of-sync issues for Cilium using Argo CD (:gh-issue:`18298`)
 
 Solution
 --------
 
-To prevent these issues, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
+To prevent this issue, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
 
 Here is an example snippet:
 
@@ -40,9 +38,27 @@ Here is an example snippet:
        clusters:
          - "*"
 
+Argo CD show resources permanently out-of-sync
+==============================================
 
-Also, it has been reported that the problem may affect all workloads you deploy with Argo CD in a cluster running Cilium, not just Cilium itself.
-If so, you will need the following exclusions in your Argo CD application definition to avoid getting “out of sync” when Hubble rotates its certificates.
+- Argo CD Out-of-sync issues for hubble-generate-certs (:gh-issue:`14550`)
+- Out-of-sync issues for Cilium using Argo CD (:gh-issue:`18298`)
+
+Solution
+--------
+
+You may pick one of the following approaches.
+
+The ``argocd.argoproj.io/compare-options: IgnoreExtraneous`` annotation can be added to resources, which use non-idempotent helm generators to avoid this issue.
+The helm value ``nonIdempotentAnnotations`` is available for the purpose and can be set in your values file.
+
+.. code-block:: yaml
+
+    nonIdempotentAnnotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+
+Exclusions can be set in your Argo CD application definition to avoid getting “out of sync” when certificates get regenerated.
+The example below is for Hubble, similar secrets exist however for clustermesh as well. They are all labeled with ``cilium.io/helm-template-non-idempotent: "true"``.
 
 .. code-block:: yaml
 

--- a/install/kubernetes/Makefile
+++ b/install/kubernetes/Makefile
@@ -76,6 +76,8 @@ update-versions: update-chart cilium/values.yaml # Update the Helm values file t
 
 CRD_FILES := $(shell find $(ROOT_DIR)/examples/crds/*/ -type f)
 CRDS := $(foreach path,$(patsubst %.yaml,%,$(CRD_FILES)),$(shell basename $(path)))
+RAND_FILES := $(shell grep -R -l -e "rand" -e "shuffle" -e "genPrivateKey" -e "genCA" -e "genSignedCert" -e "UUID" -e "cilium.ca.setup" --include="*.yaml" $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates)
+RAND_SECRETS := $(foreach rand_file,$(RAND_FILES),$(shell grep -l -e 'kind: Secret' $(rand_file)))
 lint:
 	$(ECHO_CHECK)
 	$(QUIET)grep -RL $(COMMON_LABELS_EXCLUSIONS) .Values.commonLabels $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/*.yaml $(ROOT_DIR)/$(RELATIVE_DIR)/cilium/templates/**/*.yaml >> missing_label
@@ -92,6 +94,13 @@ lint:
 		|| (echo -e "$$crd not found in $(CHART_FILE).\nPlease update the chart to include $$crd."; exit 1); \
 	done
 	$(QUIET)$(HELM) lint --with-subcharts --values ./cilium/values.yaml ./cilium
+	$(QUIET)echo -e "non-idempotent secrets:"; \
+	for rand_secret in $(RAND_SECRETS); do \
+                grep -l -e "cilium.io/helm-template-non-idempotent" $$rand_secret \
+                || (echo -e "$$rand_secret missing label \"cilium.io/helm-template-non-idempotent\".\nPlease add the label to it."; exit 1); \
+                grep -l -e "nonIdempotentAnnotations" $$rand_secret \
+                || (echo -e "$$rand_secret missing annotations placeholder \"nonIdempotentAnnotations\".\nPlease add it."; exit 1); \
+	done
 
 docs:
 	$(QUIET)$(HELM_DOCS)

--- a/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
@@ -11,8 +11,13 @@ kind: Secret
 metadata:
   name: {{ .commonCASecretName }}
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+    cilium.io/helm-template-non-idempotent: "true"
+  {{- with .Values.nonIdempotentAnnotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/admin-secret.yaml
@@ -8,12 +8,16 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-admin-cert
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.clustermesh.annotations }}
+    cilium.io/helm-template-non-idempotent: "true"
   annotations:
+  {{- with .Values.clustermesh.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/local-secret.yaml
@@ -8,12 +8,16 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-local-cert
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.clustermesh.annotations }}
+    cilium.io/helm-template-non-idempotent: "true"
   annotations:
+  {{- with .Values.clustermesh.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/remote-secret.yaml
@@ -8,12 +8,16 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-remote-cert
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.clustermesh.annotations }}
+    cilium.io/helm-template-non-idempotent: "true"
   annotations:
+  {{- with .Values.clustermesh.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-helm/server-secret.yaml
@@ -10,12 +10,16 @@ kind: Secret
 metadata:
   name: clustermesh-apiserver-server-cert
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.clustermesh.annotations }}
+    cilium.io/helm-template-non-idempotent: "true"
   annotations:
+  {{- with .Values.clustermesh.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/metrics-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/metrics-server-secret.yaml
@@ -10,13 +10,17 @@ kind: Secret
 metadata:
   name: hubble-metrics-server-certs
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    cilium.io/helm-template-non-idempotent: "true"
 
-  {{- with .Values.hubble.annotations }}
   annotations:
+  {{- with .Values.hubble.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-client-secret.yaml
@@ -17,13 +17,17 @@ kind: Secret
 metadata:
   name: hubble-relay-client-certs
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    cilium.io/helm-template-non-idempotent: "true"
 
-  {{- with .Values.hubble.annotations }}
   annotations:
+  {{- with .Values.hubble.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/relay-server-secret.yaml
@@ -10,13 +10,17 @@ kind: Secret
 metadata:
   name: hubble-relay-server-certs
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    cilium.io/helm-template-non-idempotent: "true"
 
-  {{- with .Values.hubble.annotations }}
   annotations:
+  {{- with .Values.hubble.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/server-secret.yaml
@@ -18,13 +18,17 @@ kind: Secret
 metadata:
   name: hubble-server-certs
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    cilium.io/helm-template-non-idempotent: "true"
 
-  {{- with .Values.hubble.annotations }}
   annotations:
+  {{- with .Values.hubble.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls

--- a/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-helm/ui-client-certs.yaml
@@ -10,13 +10,17 @@ metadata:
   name: hubble-ui-client-certs
   namespace: {{ include "cilium.namespace" . }}
 
-  {{- with .Values.commonLabels }}
   labels:
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    cilium.io/helm-template-non-idempotent: "true"
 
-  {{- with .Values.hubble.annotations }}
   annotations:
+  {{- with .Values.hubble.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nonIdempotentAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls


### PR DESCRIPTION
Some of the secrets generated by Helm use functions that are not idempotent. This is problematic when such resources
are reconciled by external systems like Argo CD. This adds a label to them: `isovalent.io/non-idempotent: "true"` so that they can easily get identified.
Some logic is also being added to the lint target to try and identify the addition of non-idempotent secrets that are missing the label.

```release-note
Some of the secrets generated by Helm use functions that are not idempotent. They are now labelled with `cilium.io/helm-template-non-idempotent: "true"` so that they can easily get identified.
```
