### PR TITLE
bpf: clear mark content before storing the cluster ID

### DIFF
--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -122,6 +122,7 @@ ctx_set_cluster_id_mark(struct __sk_buff *ctx, __u32 cluster_id)
 	__u32 cluster_id_lower = (cluster_id & 0xFF);
 	__u32 cluster_id_upper = ((cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN));
 
+	ctx->mark &= MARK_MAGIC_KEY_MASK;
 	ctx->mark |=  cluster_id_lower | cluster_id_upper | MARK_MAGIC_CLUSTER_ID;
 }
 

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -60,6 +60,8 @@
 /* Set the LXC source address to be the address of pod one */
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = CLIENT_IP})
 
+ASSIGN_CONFIG(__u32, security_label, 0x10042)
+
 #include "lib/ipcache.h"
 #include "lib/lb.h"
 #include "lib/policy.h"
@@ -158,6 +160,7 @@ int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 	struct iphdr *l3;
 	struct ipv4_ct_tuple tuple;
 	struct ct_entry *entry;
+	__u32 cluster_id;
 
 	test_init();
 
@@ -231,6 +234,11 @@ int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 	entry = map_lookup_elem(&per_cluster_ct_tcp4_2, &tuple);
 	if (!entry)
 		test_fatal("couldn't find egress conntrack entry");
+
+	cluster_id = ctx_get_cluster_id_mark(ctx);
+	if (cluster_id != BACKEND_CLUSTER_ID)
+		test_fatal("ctx->mark cluster_id should be %u, got %u",
+			   BACKEND_CLUSTER_ID, cluster_id);
 
 	test_finish();
 }


### PR DESCRIPTION
Currently, the ctx_set_cluster_id_mark helper does not clear the mark before storing the cluster ID. However, the resulting value is not correct in case the same portions of the mark did already contain some value. For instance, this can happen if set_identity_mark got called before, which is now the case since 26602426a073 ("bpf: lxc: always set identity mark on forwarded egressing traffic").

Let's get this fixed by explicitly masking the mark before storing the cluster ID. Rather than wiping out the entire content, we preserve the "magic" part, which is not expected to interfere.

Set the backport/affect labels coherently with https://github.com/cilium/cilium/pull/42551.