### PR TITLE
docs: Add missing IPv6 fragmentation BPF map reference

### DIFF
--- a/Documentation/network/ebpf/maps.rst
+++ b/Documentation/network/ebpf/maps.rst
@@ -29,6 +29,7 @@ Policy                   endpoint         16k             Max 16k allowed identi
 Proxy Map                node             512k            Max 512k concurrent redirected TCP connections to proxy
 Tunnel                   node             64k             Max 32k nodes (IPv4+IPv6) or 64k nodes (IPv4 or IPv6) across all clusters
 IPv4 Fragmentation       node             8k              Max 8k fragmented datagrams in flight simultaneously on the node
+IPv6 Fragmentation       node             8k              Max 8k fragmented datagrams in flight simultaneously on the node
 Session Affinity         node             64k             Max 64k affinities from different clients
 IPv4 Masq                node             16k             Max 16k IPv4 cidrs used by BPF-based ip-masq-agent
 IPv6 Masq                node             16k             Max 16k IPv6 cidrs used by BPF-based ip-masq-agent


### PR DESCRIPTION
The documentation mentioned IPv6 fragmentation handling but omitted the `cilium_ipv6_frag_datagrams __section_maps_btf` [BPF map](https://github.com/cilium/cilium/blob/4287bf000273e924020c36248a75e75d86b02f70/bpf/lib/ipv6.h#L56) used to store datagram metadata. This commit adds the missing reference.