### PR TITLE
k8s/policy: introduce config adapter for DaemonConfig

### DIFF
--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -141,7 +141,7 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		p.metricsManager.AddCNP(cnp.CiliumNetworkPolicy)
 	}
 
-	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName))
+	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.config.ClustermeshPolicyConfig, p.config.ClusterName))
 	if err != nil {
 		scopedLog.Warn(
 			"Unable to add CiliumNetworkPolicy",

--- a/pkg/policy/k8s/cilium_network_policy_test.go
+++ b/pkg/policy/k8s/cilium_network_policy_test.go
@@ -15,7 +15,6 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 )
@@ -61,7 +60,7 @@ func Test_GH33432(t *testing.T) {
 
 	p := &policyWatcher{
 		log:                hivetest.Logger(t),
-		config:             &option.DaemonConfig{},
+		config:             policyWatcherConfig{},
 		k8sResourceSynced:  &k8sSynced.Resources{CacheStatus: make(k8sSynced.CacheStatus)},
 		k8sAPIGroups:       &k8sSynced.APIGroups{},
 		policyImporter:     policyImporter,

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -213,15 +213,13 @@ func (p *policyWatcher) updateToServicesPolicies(ev serviceEvent) error {
 			continue
 		}
 
-		if p.config.Debug {
-			p.log.Debug(
-				"Service updated or deleted, recalculating CiliumNetworkPolicy rules",
-				logfields.CiliumNetworkPolicyName, cnp.Name,
-				logfields.K8sAPIVersion, cnp.APIVersion,
-				logfields.K8sNamespace, cnp.Namespace,
-				logfields.ServiceID, ev.name,
-			)
-		}
+		p.log.Debug(
+			"Service updated or deleted, recalculating CiliumNetworkPolicy rules",
+			logfields.CiliumNetworkPolicyName, cnp.Name,
+			logfields.K8sAPIVersion, cnp.APIVersion,
+			logfields.K8sNamespace, cnp.Namespace,
+			logfields.ServiceID, ev.name,
+		)
 		initialRecvTime := time.Now()
 
 		resourceID := resourceIDForCiliumNetworkPolicy(key, cnp)

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 )
@@ -243,7 +242,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 
 	p := &policyWatcher{
 		log:                hivetest.Logger(t),
-		config:             &option.DaemonConfig{},
+		config:             policyWatcherConfig{},
 		k8sResourceSynced:  &k8sSynced.Resources{CacheStatus: make(k8sSynced.CacheStatus)},
 		k8sAPIGroups:       &k8sSynced.APIGroups{},
 		db:                 servicesFixture.db,
@@ -504,7 +503,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 
 	p := &policyWatcher{
 		log:                hivetest.Logger(t),
-		config:             &option.DaemonConfig{},
+		config:             policyWatcherConfig{},
 		k8sResourceSynced:  &k8sSynced.Resources{CacheStatus: make(k8sSynced.CacheStatus)},
 		k8sAPIGroups:       &k8sSynced.APIGroups{},
 		policyImporter:     policyImporter,

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -22,14 +22,12 @@ import (
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/option"
 	policycell "github.com/cilium/cilium/pkg/policy/cell"
 )
 
 type policyWatcher struct {
-	log                     *slog.Logger
-	config                  *option.DaemonConfig
-	clusterMeshPolicyConfig cmtypes.PolicyConfig
+	log    *slog.Logger
+	config policyWatcherConfig
 
 	k8sResourceSynced *k8sSynced.Resources
 	k8sAPIGroups      *k8sSynced.APIGroups
@@ -170,7 +168,7 @@ func (p *policyWatcher) watchResources(ctx context.Context) {
 				case resource.Upsert:
 					err = p.addK8sNetworkPolicyV1(
 						event.Object, k8sAPIGroupNetworkingV1Core, knpDone,
-						cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName),
+						cmtypes.LocalClusterNameForPolicies(p.config.ClustermeshPolicyConfig, p.config.ClusterName),
 					)
 				case resource.Delete:
 					err = p.deleteK8sNetworkPolicyV1(event.Object, k8sAPIGroupNetworkingV1Core, knpDone)


### PR DESCRIPTION
Previously, we were depending on the whole DaemonConfig. This makes it way harder to understand what configurations options from DaemonConfig actually matter for policy watcher without checking implementation.
This PR extracts configuration to separate structure and add adapter to make it explicit. This will make it easier to test policyWatcher.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
