### PR TITLE
[network-driver]: Add support for dummy interfaces

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -411,6 +411,8 @@ spec:
           mountPath: /var/lib/kubelet/plugins
         - name: plugin-registry
           mountPath: /var/lib/kubelet/plugins_registry
+        - name: nri-plugin
+          mountPath: /var/run/nri
         {{- range .Values.extraHostPathMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
@@ -1065,6 +1067,10 @@ spec:
       - name: plugin-registry
         hostPath:
           path: /var/lib/kubelet/plugins_registry
+          type: Directory
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
           type: Directory
       {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
       - name: hubble-tls

--- a/pkg/networkdriver/cell.go
+++ b/pkg/networkdriver/cell.go
@@ -6,10 +6,9 @@ package networkdriver
 import (
 	"log/slog"
 
-	kube_types "k8s.io/apimachinery/pkg/types"
-
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	kube_types "k8s.io/apimachinery/pkg/types"
 
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/lock"
@@ -35,7 +34,30 @@ type networkDriverParams struct {
 	JobGroup  job.Group
 }
 
-func getNetworkDriverConfig(kc k8sClient.Clientset) (*Config, error) {
+// getNetworkDriverConfig returns the network driver configuration.
+// This will be deprecated in favor a configuration passed via a Custom Resource.
+//
+// An example configuration to manage dummy devices is:
+//
+//	{
+//		DraRegistrationRetry:   time.Second,
+//		DraRegistrationTimeout: 30 * time.Second,
+//		PublishInterval:        3 * time.Second,
+//		DriverName:             "dummy.cilium.k8s.io",
+//		DeviceManagerConfigs: map[types.DeviceManagerType]types.DeviceManagerConfig{
+//			types.DeviceManagerTypeDummy: dummy.DummyConfig{Enabled: true},
+//		},
+//		Pools: []PoolConfig{
+//			{
+//				Name: "dummy-devices",
+//				Filter: types.DeviceFilter{
+//					DriverTypes: []types.DeviceManagerType{types.DeviceManagerTypeDummy},
+//					IfNames:     []string{"dummy"},
+//				},
+//			},
+//		},
+//	}
+func getNetworkDriverConfig(_ k8sClient.Clientset) (*Config, error) {
 	return nil, nil
 }
 

--- a/pkg/networkdriver/devicemanagers/managers.go
+++ b/pkg/networkdriver/devicemanagers/managers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/cilium/cilium/pkg/networkdriver/dummy"
 	"github.com/cilium/cilium/pkg/networkdriver/sriov"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
 )
@@ -25,7 +26,12 @@ func InitManager(logger *slog.Logger, managerType types.DeviceManagerType, drive
 		}
 
 		return sriov.NewManager(logger, c)
+	case dummy.DummyConfig:
+		if managerType != types.DeviceManagerTypeDummy {
+			return nil, fmt.Errorf("%w: expected %T, got %T", errInvalidConfigurationForManager, dummy.DummyConfig{}, c)
+		}
 
+		return dummy.NewManager(logger, c)
 	}
 
 	return nil, errUnknownManagerType

--- a/pkg/networkdriver/driver.go
+++ b/pkg/networkdriver/driver.go
@@ -10,19 +10,16 @@ import (
 	"os"
 	"path"
 
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/containerd/nri/pkg/stub"
 	resourceapi "k8s.io/api/resource/v1"
-	"k8s.io/utils/ptr"
-
 	kube_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
-
-	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/job"
+	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"

--- a/pkg/networkdriver/driver.go
+++ b/pkg/networkdriver/driver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/networkdriver/devicemanagers"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
 	node_types "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (
@@ -271,7 +272,7 @@ func (driver *Driver) Start(ctx cell.HookContext) error {
 				select {
 				case <-ctx.Done():
 					return nil
-				default:
+				case <-time.After(time.Second):
 					driver.logger.DebugContext(ctx, "Restarting NRI plugin", logfields.Name, driver.driverName)
 				}
 			}

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dummy
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"slices"
+	"strings"
+
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/networkdriver/types"
+)
+
+type DummyConfig struct {
+	Enabled bool
+}
+
+func (cfg DummyConfig) IsEnabled() bool {
+	return cfg.Enabled
+}
+
+type DummyManager struct {
+	logger *slog.Logger
+	config DummyConfig
+}
+
+func (m *DummyManager) init() error {
+	return nil
+}
+
+func NewManager(logger *slog.Logger, cfg DummyConfig) (*DummyManager, error) {
+	mgr := &DummyManager{
+		logger: logger,
+		config: cfg,
+	}
+
+	return mgr, mgr.init()
+}
+
+func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
+	links, err := safenetlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get links: %w", err)
+	}
+
+	var (
+		devices []types.Device
+		errs    []error
+	)
+
+	for _, link := range links {
+		if link.Type() != "dummy" {
+			continue
+		}
+
+		// Skip down interfaces
+		if link.Attrs().Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		devices = append(devices, DummyDevice{
+			name:   link.Attrs().Name,
+			hwAddr: link.Attrs().HardwareAddr.String(),
+			mtu:    link.Attrs().MTU,
+			flags:  link.Attrs().Flags.String(),
+		})
+	}
+
+	return devices, errors.Join(errs...)
+}
+
+type DummyDevice struct {
+	name   string
+	hwAddr string
+	mtu    int
+	flags  string
+}
+
+func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
+	result["interface_name"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
+	result["mac_address"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.hwAddr)}
+	result["mtu"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.mtu))}
+	result["flags"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.flags)}
+
+	return result
+}
+
+func (d DummyDevice) Setup(cfg types.DeviceConfig) error {
+	return nil
+}
+
+func (d DummyDevice) Free(cfg types.DeviceConfig) error {
+	return nil
+}
+
+func (d DummyDevice) Match(filter types.DeviceFilter) bool {
+	if len(filter.DriverTypes) != 0 && !slices.Contains(filter.DriverTypes, types.DeviceManagerTypeDummy) {
+		return false
+	}
+	for _, ifname := range filter.IfNames {
+		if !strings.HasPrefix(d.IfName(), ifname) {
+			return false
+		}
+	}
+	return true
+}
+
+func (d DummyDevice) IfName() string {
+	return d.name
+}
+
+func (d DummyDevice) KernelIfName() string {
+	return d.name
+}

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -20,10 +20,12 @@ type DeviceManagerType int
 
 const (
 	sriovDeviceManagerStr = "sr-iov"
+	dummyDeviceManagerStr = "dummy"
 )
 
 const (
 	DeviceManagerTypeSRIOV DeviceManagerType = iota
+	DeviceManagerTypeDummy
 
 	DeviceManagerTypeUnknown
 )
@@ -32,6 +34,8 @@ func (d DeviceManagerType) String() string {
 	switch d {
 	case DeviceManagerTypeSRIOV:
 		return sriovDeviceManagerStr
+	case DeviceManagerTypeDummy:
+		return dummyDeviceManagerStr
 	}
 
 	return ""
@@ -41,6 +45,8 @@ func (d DeviceManagerType) MarshalText() (text []byte, err error) {
 	switch d {
 	case DeviceManagerTypeSRIOV:
 		return json.Marshal(sriovDeviceManagerStr)
+	case DeviceManagerTypeDummy:
+		return json.Marshal(dummyDeviceManagerStr)
 	}
 
 	return nil, errUnknownDriverType
@@ -56,6 +62,8 @@ func (d *DeviceManagerType) UnmarshalText(text []byte) error {
 	switch strings.ToLower(s) {
 	case sriovDeviceManagerStr:
 		*d = DeviceManagerTypeSRIOV
+	case dummyDeviceManagerStr:
+		*d = DeviceManagerTypeDummy
 	default:
 		return errUnknownDriverType
 	}


### PR DESCRIPTION
The dummy devices manager makes a nice example of how the network driver can be customized to support new type of devices besides the SR-IOV ones. Also, dummy interfaces are handy to test the driver in a local kind cluster without specific hardware.
