### PR TITLE
contrib: fix kind clustermesh setup

### DIFF
--- a/contrib/testing/kind-clustermesh1.yaml
+++ b/contrib/testing/kind-clustermesh1.yaml
@@ -24,6 +24,8 @@ startupProbe:
   failureThreshold: 9999
 clustermesh:
   useAPIServer: true
+  config:
+    enabled: true
   apiserver:
     image:
       pullPolicy: Never

--- a/contrib/testing/kind-clustermesh2.yaml
+++ b/contrib/testing/kind-clustermesh2.yaml
@@ -24,6 +24,8 @@ startupProbe:
   failureThreshold: 9999
 clustermesh:
   useAPIServer: true
+  config:
+    enabled: true
   apiserver:
     image:
       pullPolicy: Never


### PR DESCRIPTION
As we recently set authMode to true by default in 562ba2c17808330df0f1bb8b4605c15412d234c7, a setup with `useAPIServer=true` now needs to create the `clustermesh-remote-users` themselves or just set `config.enabled=true`. In the dev setup, the clustermesh-apiserver hanging because of that and we can also just set `config.enabled=true` to fix it!