### PR TITLE
ztunnel: introduce end to end connectivity tests

### DIFF
--- a/.github/actions/ztunnel-certs/action.yaml
+++ b/.github/actions/ztunnel-certs/action.yaml
@@ -1,0 +1,42 @@
+name: Generate ZTunnel Certificates
+description: |
+  Generate TLS certificates for ztunnel and create the cilium-ztunnel-secrets
+  Kubernetes secret required for ztunnel encryption mode.
+runs:
+  using: composite
+  steps:
+    - id: generate-certs
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ACTION_DIR="${{ github.action_path }}"
+        WORKDIR=$(mktemp -d)
+        trap "rm -rf ${WORKDIR}" EXIT
+
+        cd "${WORKDIR}"
+
+        # Bootstrap certificates: TLS between ztunnel and the Cilium agent xDS server
+        openssl genrsa -out bootstrap-private.key 2048
+        openssl req -x509 -new -nodes \
+            -key bootstrap-private.key \
+            -sha256 -days 3650 \
+            -out bootstrap-root.crt \
+            -config "${ACTION_DIR}/bootstrap.conf"
+
+        # CA certificates: used by Cilium agent to sign workload certificates for ztunnel mTLS
+        openssl genrsa -out ca-private.key 2048
+        openssl req -x509 -new -nodes \
+            -key ca-private.key \
+            -sha256 -days 3650 \
+            -out ca-root.crt \
+            -config "${ACTION_DIR}/ca.conf"
+
+        # Create Kubernetes secret
+        kubectl --namespace kube-system create secret generic cilium-ztunnel-secrets \
+            --from-file=bootstrap-private.key=bootstrap-private.key \
+            --from-file=bootstrap-root.crt=bootstrap-root.crt \
+            --from-file=ca-private.key=ca-private.key \
+            --from-file=ca-root.crt=ca-root.crt
+
+        echo "Successfully created cilium-ztunnel-secrets in kube-system namespace"

--- a/.github/actions/ztunnel-certs/bootstrap.conf
+++ b/.github/actions/ztunnel-certs/bootstrap.conf
@@ -1,0 +1,18 @@
+[ req ]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[ req_distinguished_name ]
+O = cluster.local
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost

--- a/.github/actions/ztunnel-certs/ca.conf
+++ b/.github/actions/ztunnel-certs/ca.conf
@@ -1,0 +1,13 @@
+[ req ]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[ req_distinguished_name ]
+O = cluster.local
+
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -9,6 +9,7 @@ triggers:
     - conformance-clustermesh.yaml
     - conformance-delegated-ipam.yaml
     - conformance-ipsec-e2e.yaml
+    - conformance-ztunnel-e2e.yaml
     - conformance-eks.yaml
     - conformance-gateway-api.yaml
     - conformance-ginkgo.yaml
@@ -45,6 +46,9 @@ triggers:
   /ci-ipsec-e2e:
     workflows:
     - conformance-ipsec-e2e.yaml
+  /ci-ztunnel-e2e:
+    workflows:
+    - conformance-ztunnel-e2e.yaml
   /ci-eks:
     workflows:
     - conformance-eks.yaml
@@ -170,3 +174,5 @@ workflows:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   hubble-cli-integration-test.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md)$)
+  conformance-ztunnel-e2e.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -1,0 +1,245 @@
+name: Conformance ZTunnel E2E (ci-ztunnel-e2e)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      base-SHA:
+        description: "SHA of the base branch (target branch of the PR)."
+        required: false
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+
+  setup-and-test:
+    needs: [wait-for-images]
+    name: 'Setup & Test'
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    env:
+      job_name: 'Setup & Test'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'ztunnel-1'
+            kernel: '6.6'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'vxlan'
+          - name: 'ztunnel-2'
+            kernel: '6.12'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'disabled'
+
+    timeout-minutes: 75
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        with:
+          comment_on_pr: false
+
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHA="${{ inputs.SHA }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
+          echo sha=${SHA} >> $GITHUB_OUTPUT
+
+      - name: Resolve full kernel version
+        id: kernel-version
+        uses: ./.github/actions/resolve-kernel-version
+        with:
+          kernel: ${{ matrix.kernel }}
+
+      - name: Derive Cilium installation config and junit type
+        id: cilium-config
+        uses: ./.github/actions/cilium-config
+        with:
+          image-tag: ${{ steps.vars.outputs.sha }}
+          chart-dir: './untrusted/install/kubernetes/cilium'
+          tunnel: ${{ matrix.tunnel }}
+          kpr: ${{ matrix.kpr }}
+          encryption: 'ztunnel'
+          mutual-auth: false
+
+      - name: Set Kind params
+        id: kind-params
+        shell: bash
+        run: |
+          echo params="--xdp --secondary-network \"\" 3 \"\" \"\" ${{ matrix.kube-proxy }} dual" >> $GITHUB_OUTPUT
+
+      - name: Provision K8s on LVH VM
+        id: lvh-kind
+        uses: ./.github/actions/lvh-kind
+        with:
+          test-name: e2e-conformance
+          kernel: ${{ steps.kernel-version.outputs.full }}
+          kind-params: "${{ steps.kind-params.outputs.params }}"
+          kind-image: ${{ env.KIND_K8S_IMAGE }}
+
+      - name: Install Cilium CLI
+        uses: cilium/cilium-cli@db1773e48b18184dd2843eb5383cec4c70b228c5 # v0.18.8
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ steps.vars.outputs.sha }}
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+          path: untrusted
+          sparse-checkout: |
+            install/kubernetes/cilium
+
+      - name: Install Cilium
+        id: install-cilium
+        shell: bash
+        run: |
+          cilium install ${{ steps.cilium-config.outputs.config }}
+
+          cilium status --wait --interactive=false
+          kubectl get pods --all-namespaces -o wide
+          kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
+
+      - name: Wait for ZTunnel DaemonSet
+        shell: bash
+        run: |
+          echo "Waiting for ztunnel-cilium DaemonSet to be ready..."
+          kubectl -n kube-system rollout status daemonset/ztunnel-cilium --timeout=300s
+          kubectl -n kube-system get pods -l app=ztunnel -o wide
+
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          include-unsafe-tests: true
+
+      - name: Run connectivity tests (${{ matrix.name }})
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+
+          cilium connectivity test ${{ steps.e2e_config.outputs.test_flags }} \
+            --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
+            --junit-property github_job_step="Run tests (${{ matrix.name }})"
+
+      - name: Features tested
+        uses: ./.github/actions/feature-status
+        with:
+          title: "Summary of all features tested"
+          json-filename: "${{ env.job_name }} (${{ matrix.name }})"
+
+      - name: Run common post steps
+        if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
+        uses: ./.github/actions/post-logic
+        with:
+          artifacts_suffix: "${{ matrix.name }}"
+          job_status: "${{ job.status }}"
+          capture_features_tested: false
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: setup-and-test
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      success: ${{ needs.setup-and-test.result == 'success' }}

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -186,6 +186,9 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
 
+      - name: Generate ZTunnel certificates
+        uses: ./.github/actions/ztunnel-certs
+
       - name: Install Cilium
         id: install-cilium
         shell: bash

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -323,6 +323,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		multicast{},
 		strictModeEncryption{},
 		ipsecKeyDerivation{},
+		ztunnelPodToPodEncryption{},
 	}
 	return injectTests(tests, connTests...)
 }

--- a/cilium-cli/connectivity/builder/node_to_node_encryption.go
+++ b/cilium-cli/connectivity/builder/node_to_node_encryption.go
@@ -21,5 +21,8 @@ func (t nodeToNodeEncryption) build(ct *check.ConnectivityTest, _ map[string]str
 				features.RequireEnabled(features.EncryptionPod),
 				features.RequireEnabled(features.EncryptionNode),
 			),
-		).WithFeatureRequirements(features.RequireModeIsNot(features.EncryptionPod, "ipsec"))
+		).WithFeatureRequirements(
+		features.RequireModeIsNot(features.EncryptionPod, "ipsec"),
+		features.RequireDisabled(features.Ztunnel),
+	)
 }

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -25,6 +25,7 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithCondition(func() bool {
 			return !versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion)
 		}).
+		WithFeatureRequirements(features.RequireDisabled(features.Ztunnel)).
 		WithScenarios(
 			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
 		)
@@ -46,6 +47,7 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithFeatureRequirements(
 			features.RequireEnabled(features.L7Proxy),
 			features.RequireEnabled(features.EncryptionPod),
+			features.RequireDisabled(features.Ztunnel),
 		).
 		WithCiliumPolicy(clientsEgressL7HTTPFromAnyPolicyYAML).
 		WithCiliumPolicy(echoIngressL7HTTPFromAnywherePolicyYAML).

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
@@ -23,6 +23,7 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 			// this test only runs post v1.18.0 clusters
 			return versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion)
 		}).
+		WithFeatureRequirements(features.RequireDisabled(features.Ztunnel)).
 		WithScenarios(
 			tests.PodToPodEncryptionV2(),
 		)
@@ -36,6 +37,7 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 		WithFeatureRequirements(
 			features.RequireEnabled(features.L7Proxy),
 			features.RequireEnabled(features.EncryptionPod),
+			features.RequireDisabled(features.Ztunnel),
 		).
 		WithCiliumPolicy(clientsEgressL7HTTPFromAnyPolicyYAML).
 		WithCiliumPolicy(echoIngressL7HTTPFromAnywherePolicyYAML).

--- a/cilium-cli/connectivity/builder/ztunnel_pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/ztunnel_pod_to_pod_encryption.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type ztunnelPodToPodEncryption struct{}
+
+func (t ztunnelPodToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]string) {
+	// Encryption checks are always executed as a sanity check, asserting whether
+	// unencrypted packets shall, or shall not, be observed based on the feature set.
+	newTest("ztunnel-pod-to-pod-encryption", ct).
+		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithFeatureRequirements(
+			features.RequireEnabled(features.Ztunnel),
+			features.RequireMode(features.EncryptionPod, "ztunnel"),
+		).
+		WithSetupFunc(func(ctx context.Context, t *check.Test, testCtx *check.ConnectivityTest) error {
+			return check.DeployZtunnelTestEnv(ctx, t, testCtx)
+		}).
+		WithScenarios(
+			tests.ZTunnelEnrolledToEnrolledSameNode(),
+			tests.ZTunnelEnrolledToEnrolledDifferentNode(),
+			tests.ZTunnelUnenrolledToUnenrolledSameNode(),
+			tests.ZTunnelUnenrolledToUnenrolledDifferentNode(),
+			tests.ZTunnelEnrolledToEnrolledCrossNamespaceSameNode(),
+			tests.ZTunnelEnrolledToEnrolledCrossNamespaceDifferentNode(),
+		)
+}

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -132,11 +132,9 @@ const (
 	perfPodRoleProfiling = perfPodRole("profiling")
 )
 
-var (
-	appLabels = map[string]string{
-		"app.kubernetes.io/name": "cilium-cli",
-	}
-)
+var appLabels = map[string]string{
+	"app.kubernetes.io/name": "cilium-cli",
+}
 
 type deploymentParameters struct {
 	Name                          string
@@ -173,7 +171,8 @@ func (p *deploymentParameters) args() []string {
 func (p *deploymentParameters) ports() (ports []corev1.ContainerPort) {
 	if p.Port != 0 {
 		ports = append(ports, corev1.ContainerPort{
-			Name: p.namedPort(), ContainerPort: int32(p.Port), HostPort: int32(p.HostPort)})
+			Name: p.namedPort(), ContainerPort: int32(p.Port), HostPort: int32(p.HostPort),
+		})
 	}
 
 	return ports
@@ -727,8 +726,210 @@ func (ct *ConnectivityTest) deployNamespace(ctx context.Context) error {
 	return nil
 }
 
-func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
+// DeployZtunnelTestEnv deploys the test infrastructure for ztunnel e2e tests.
+// This is exported so it can be called from the test's WithSetupFunc.
+func DeployZtunnelTestEnv(ctx context.Context, t *Test, ct *ConnectivityTest) error {
+	namespaceConfigs := []struct {
+		name string
+		obj  *corev1.Namespace
+	}{
+		{
+			name: "cilium-test-ztunnel-enrolled-0",
+			obj: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cilium-test-ztunnel-enrolled-0",
+				},
+			},
+		},
+		{
+			name: "cilium-test-ztunnel-enrolled-1",
+			obj: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cilium-test-ztunnel-enrolled-1",
+				},
+			},
+		},
+		{
+			name: "cilium-test-ztunnel-unenrolled",
+			obj: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cilium-test-ztunnel-unenrolled",
+				},
+			},
+		},
+	}
 
+	client := ct.K8sClient()
+
+	for _, nsConfig := range namespaceConfigs {
+		var err error
+
+		// Create namespace
+		_, err = client.GetNamespace(ctx, nsConfig.name, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Creating namespace %s...", client.ClusterName(), nsConfig.name)
+			_, err = client.CreateNamespace(ctx, nsConfig.obj, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create namespace %s: %w", nsConfig.name, err)
+			}
+		}
+
+		// Create client deployment
+		_, err = client.GetDeployment(ctx, nsConfig.name, clientDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s in namespace %s...", client.ClusterName(), clientDeploymentName, nsConfig.name)
+			var clientAffinity *corev1.Affinity
+			if nsConfig.name == "cilium-test-ztunnel-enrolled-0" {
+				// First namespace - just use node affinity
+				clientAffinity = &corev1.Affinity{
+					NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity(),
+				}
+			} else {
+				// Subsequent namespaces - add pod affinity to first namespace's client
+				clientAffinity = &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "name",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{clientDeploymentName},
+										},
+									},
+								},
+								Namespaces:  []string{"cilium-test-ztunnel-enrolled-0"},
+								TopologyKey: corev1.LabelHostname,
+							},
+						},
+					},
+					NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity(),
+				}
+			}
+
+			clientDeployment := newDeployment(deploymentParameters{
+				Name:         clientDeploymentName,
+				Kind:         kindClientName,
+				Image:        ct.params.CurlImage,
+				Command:      []string{"/usr/bin/pause"},
+				Annotations:  ct.params.DeploymentAnnotations.Match(clientDeploymentName),
+				Affinity:     clientAffinity,
+				NodeSelector: ct.params.NodeSelector,
+				Tolerations:  ct.params.GetTolerations(),
+			})
+			_, err = client.CreateServiceAccount(ctx, nsConfig.name, k8s.NewServiceAccount(clientDeploymentName), metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service account %s in namespace %s: %w", clientDeploymentName, nsConfig.name, err)
+			}
+			_, err = client.CreateDeployment(ctx, nsConfig.name, clientDeployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s in namespace %s: %w", clientDeploymentName, nsConfig.name, err)
+			}
+		}
+
+		// Create echo-same-node deployment
+		_, err = client.GetDeployment(ctx, nsConfig.name, echoSameNodeDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s in namespace %s...", client.ClusterName(), echoSameNodeDeploymentName, nsConfig.name)
+			containerPort := 8080
+			echoSameNodeDeployment := newDeployment(deploymentParameters{
+				Name:        echoSameNodeDeploymentName,
+				Kind:        kindEchoName,
+				Port:        containerPort,
+				NamedPort:   "http-8080",
+				Image:       ct.params.JSONMockImage,
+				Labels:      map[string]string{"other": "echo"},
+				Annotations: ct.params.DeploymentAnnotations.Match(echoSameNodeDeploymentName),
+				Affinity: &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{clientDeploymentName}},
+									},
+								},
+								TopologyKey: corev1.LabelHostname,
+							},
+						},
+					},
+					NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity(),
+				},
+				Tolerations:    ct.params.GetTolerations(),
+				ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
+			})
+			_, err = client.CreateServiceAccount(ctx, nsConfig.name, k8s.NewServiceAccount(echoSameNodeDeploymentName), metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service account %s in namespace %s: %w", echoSameNodeDeploymentName, nsConfig.name, err)
+			}
+			_, err = client.CreateDeployment(ctx, nsConfig.name, echoSameNodeDeployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s in namespace %s: %w", echoSameNodeDeploymentName, nsConfig.name, err)
+			}
+		}
+
+		// Create echo-other-node deployment
+		_, err = client.GetDeployment(ctx, nsConfig.name, echoOtherNodeDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			ct.Logf("✨ [%s] Deploying %s in namespace %s...", client.ClusterName(), echoOtherNodeDeploymentName, nsConfig.name)
+			containerPort := 8080
+			echoOtherNodeDeployment := newDeployment(deploymentParameters{
+				Name:        echoOtherNodeDeploymentName,
+				Kind:        kindEchoName,
+				NamedPort:   "http-8080",
+				Port:        containerPort,
+				Image:       ct.params.JSONMockImage,
+				Labels:      map[string]string{"first": "echo"},
+				Annotations: ct.params.DeploymentAnnotations.Match(echoOtherNodeDeploymentName),
+				Affinity: &corev1.Affinity{
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{Key: "name", Operator: metav1.LabelSelectorOpIn, Values: []string{clientDeploymentName}},
+									},
+								},
+								TopologyKey: corev1.LabelHostname,
+							},
+						},
+					},
+					NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity(),
+				},
+				NodeSelector:   ct.params.NodeSelector,
+				ReadinessProbe: newLocalReadinessProbe(containerPort, "/"),
+				Tolerations:    ct.params.GetTolerations(),
+			})
+			_, err = client.CreateServiceAccount(ctx, nsConfig.name, k8s.NewServiceAccount(echoOtherNodeDeploymentName), metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create service account %s in namespace %s: %w", echoOtherNodeDeploymentName, nsConfig.name, err)
+			}
+			_, err = client.CreateDeployment(ctx, nsConfig.name, echoOtherNodeDeployment, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("unable to create deployment %s in namespace %s: %w", echoOtherNodeDeploymentName, nsConfig.name, err)
+			}
+		}
+	}
+
+	// Wait for deployments to be ready
+	namespaces := []string{"cilium-test-ztunnel-enrolled-0", "cilium-test-ztunnel-enrolled-1", "cilium-test-ztunnel-unenrolled"}
+	for _, ns := range namespaces {
+		if err := WaitForDeployment(ctx, ct, client, ns, clientDeploymentName); err != nil {
+			return err
+		}
+		if err := WaitForDeployment(ctx, ct, client, ns, echoSameNodeDeploymentName); err != nil {
+			return err
+		}
+		if err := WaitForDeployment(ctx, ct, client, ns, echoOtherNodeDeploymentName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 	namespaceConfigs := []struct {
 		name string
 		obj  *corev1.Namespace
@@ -788,7 +989,6 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 	}
 
 	return nil
-
 }
 
 // deploy ensures the test Namespace, Services and Deployments are running on the cluster.
@@ -1194,7 +1394,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 			svcHeadless.Spec.Type = corev1.ServiceTypeClusterIP
 			svcHeadless.ObjectMeta.Annotations["service.cilium.io/global-sync-endpoint-slices"] = "true"
 			_, err = ct.clients.dst.GetService(ctx, ct.params.TestNamespace, EchoOtherNodeDeploymentHeadlessServiceName, metav1.GetOptions{})
-
 			if err != nil {
 				ct.Logf("✨ [%s] Deploying %s service...", ct.clients.dst.ClusterName(), EchoOtherNodeDeploymentHeadlessServiceName)
 				_, err = ct.clients.dst.CreateService(ctx, ct.params.TestNamespace, svcHeadless, metav1.CreateOptions{})
@@ -1546,7 +1745,6 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 }
 
 func (ct *ConnectivityTest) DeleteCCNPTestEnv(ctx context.Context, client *k8s.Client) error {
-
 	namespaces := []string{"cilium-test-ccnp1", "cilium-test-ccnp2"}
 
 	for _, ns := range namespaces {
@@ -1570,7 +1768,6 @@ func (ct *ConnectivityTest) DeleteCCNPTestEnv(ctx context.Context, client *k8s.C
 	}
 
 	return nil
-
 }
 
 func (ct *ConnectivityTest) patchDeployment(ctx context.Context) error {
@@ -1605,7 +1802,8 @@ func (ct *ConnectivityTest) patchDeployment(ctx context.Context) error {
 }
 
 func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.Context, deployName, kind string, replicas int, svcName, appLabel string,
-	isExternal bool, cnpFunc func(ns string) *ciliumv2.CiliumNetworkPolicy, protocol string) error {
+	isExternal bool, cnpFunc func(ns string) *ciliumv2.CiliumNetworkPolicy, protocol string,
+) error {
 	command := []string{"tcd-server", "8000"}
 	if len(protocol) != 0 {
 		command = []string{"tcd-server", "--protocol", protocol, "8000"}
@@ -1851,7 +2049,6 @@ func (ct *ConnectivityTest) getGatewayAndNonGatewayNodes() (string, string, erro
 	slices.Sort(workerNodes)
 
 	return workerNodes[0], workerNodes[1], nil
-
 }
 
 func (ct *ConnectivityTest) GetGatewayNodeInternalIP(egressGatewayNode string, ipv6 bool) netip.Addr {
@@ -2098,8 +2295,8 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 		ct.params.PerfParameters.HostNet = false
 
 		// TODO: Merge with existing annotations
-		var lowPrioDeployAnnotations = annotations{bwPrioAnnotationString: "5"}
-		var highPrioDeployAnnotations = annotations{bwPrioAnnotationString: "6"}
+		lowPrioDeployAnnotations := annotations{bwPrioAnnotationString: "5"}
+		highPrioDeployAnnotations := annotations{bwPrioAnnotationString: "6"}
 
 		ct.params.DeploymentAnnotations.Set(`{
 				"` + perClientLowPriorityDeploymentName + `": ` + lowPrioDeployAnnotations.String() + `,
@@ -2126,8 +2323,8 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 		ct.params.PerfParameters.SameNode = false
 		ct.params.PerfParameters.OtherNode = false
 
-		var egressBandwidthAnnotations = annotations{egressBandwidth: "10M"}
-		var ingressBandwidthAnnotations = annotations{ingressBandwidth: "10M"}
+		egressBandwidthAnnotations := annotations{egressBandwidth: "10M"}
+		ingressBandwidthAnnotations := annotations{ingressBandwidth: "10M"}
 		ct.params.DeploymentAnnotations.Set(`{
 				"` + perClientEgressDeploymentName + `": ` + egressBandwidthAnnotations.String() + `,
 			    "` + perServerIngressDeploymentName + `": ` + ingressBandwidthAnnotations.String() + `
@@ -2209,7 +2406,7 @@ func (ct *ConnectivityTest) deploymentListPerf() (srcList []string, dstList []st
 		srcList = append(srcList, perClientLowPriorityDeploymentName)
 		srcList = append(srcList, perClientHighPriorityDeploymentName)
 		srcList = append(srcList, perfServerDeploymentName)
-		return
+		return srcList, dstList
 	}
 
 	if ct.params.PerfParameters.Bandwidth {
@@ -2217,7 +2414,7 @@ func (ct *ConnectivityTest) deploymentListPerf() (srcList []string, dstList []st
 		srcList = append(srcList, perClientIngressDeploymentName)
 		srcList = append(srcList, perServerEgressDeploymentName)
 		srcList = append(srcList, perServerIngressDeploymentName)
-		return
+		return srcList, dstList
 	}
 
 	if ct.params.PerfParameters.PodNet || ct.params.PerfParameters.PodToHost {
@@ -2251,7 +2448,7 @@ func (ct *ConnectivityTest) deploymentListPerf() (srcList []string, dstList []st
 		}
 	}
 
-	return
+	return srcList, dstList
 }
 
 // deploymentList returns 2 lists of Deployments to be used for running tests with.
@@ -2516,7 +2713,6 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 				K8sClient: ct.client,
 				Pod:       pod.DeepCopy(),
 			}
-
 		}
 	}
 

--- a/cilium-cli/connectivity/tests/ztunnel.go
+++ b/cilium-cli/connectivity/tests/ztunnel.go
@@ -1,0 +1,826 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/sniff"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+// Test scenario configuration constants
+const (
+	enrolledNamespace0  = "cilium-test-ztunnel-enrolled-0"
+	enrolledNamespace1  = "cilium-test-ztunnel-enrolled-1"
+	unenrolledNamespace = "cilium-test-ztunnel-unenrolled"
+	ztunnelInboundPort  = 15008
+	echoServerPort      = 8080
+	ztunnelAdminPort    = "15000"
+	maxCurlRetries      = 5
+	curlRetryDelay      = 2 * time.Second
+
+	// Namespace enrollment label for Cilium's ztunnel mTLS
+	mtlsEnabledLabel = "io.cilium/mtls-enabled"
+)
+
+// podLocation defines whether pods are on the same or different nodes
+type podLocation int
+
+const (
+	sameNode podLocation = iota
+	differentNode
+)
+
+// enrollmentStatus defines whether a pod is enrolled in ztunnel mTLS
+type enrollmentStatus int
+
+const (
+	enrolled enrollmentStatus = iota
+	unenrolled
+)
+
+// scenarioConfig defines the configuration for a ztunnel test scenario
+type scenarioConfig struct {
+	name             string
+	clientEnrollment enrollmentStatus
+	serverEnrollment enrollmentStatus
+	location         podLocation
+	sameNamespace    bool
+	expectEncryption bool
+}
+
+// ztunnelTestBase provides shared functionality for all ztunnel test scenarios
+type ztunnelTestBase struct {
+	check.ScenarioBase
+
+	config scenarioConfig
+	ct     *check.ConnectivityTest
+
+	namespace string
+
+	// pods under test
+	client check.Pod
+	server check.Pod
+
+	// host network namespace pods
+	clientHostNS check.Pod
+	serverHostNS check.Pod
+
+	// feature flags
+	ipv4Enabled features.Status
+	ipv6Enabled features.Status
+
+	// finalizers to clean up resources
+	finalizers []func() error
+}
+
+// ZTunnelEnrolledToEnrolledSameNode tests mTLS encryption between enrolled pods on same node
+func ZTunnelEnrolledToEnrolledSameNode() check.Scenario {
+	return newZTunnelTest(scenarioConfig{
+		name:             "enrolled-to-enrolled-same-node",
+		clientEnrollment: enrolled,
+		serverEnrollment: enrolled,
+		location:         sameNode,
+		sameNamespace:    true,
+		expectEncryption: true,
+	})
+}
+
+// ZTunnelEnrolledToEnrolledDifferentNode tests mTLS encryption between enrolled pods on different nodes
+func ZTunnelEnrolledToEnrolledDifferentNode() check.Scenario {
+	return newZTunnelTest(scenarioConfig{
+		name:             "enrolled-to-enrolled-different-node",
+		clientEnrollment: enrolled,
+		serverEnrollment: enrolled,
+		location:         differentNode,
+		sameNamespace:    true,
+		expectEncryption: true,
+	})
+}
+
+// ZTunnelUnenrolledToUnenrolledSameNode tests plain traffic between unenrolled pods on same node
+func ZTunnelUnenrolledToUnenrolledSameNode() check.Scenario {
+	return newZTunnelTest(scenarioConfig{
+		name:             "unenrolled-to-unenrolled-same-node",
+		clientEnrollment: unenrolled,
+		serverEnrollment: unenrolled,
+		location:         sameNode,
+		sameNamespace:    true,
+		expectEncryption: false,
+	})
+}
+
+// ZTunnelUnenrolledToUnenrolledDifferentNode tests plain traffic between unenrolled pods on different nodes
+func ZTunnelUnenrolledToUnenrolledDifferentNode() check.Scenario {
+	return newZTunnelTest(scenarioConfig{
+		name:             "unenrolled-to-unenrolled-different-node",
+		clientEnrollment: unenrolled,
+		serverEnrollment: unenrolled,
+		location:         differentNode,
+		sameNamespace:    true,
+		expectEncryption: false,
+	})
+}
+
+// ZTunnelEnrolledToEnrolledCrossNamespaceSameNode tests mTLS between enrolled pods in different namespaces on same node
+func ZTunnelEnrolledToEnrolledCrossNamespaceSameNode() check.Scenario {
+	return newZTunnelTest(scenarioConfig{
+		name:             "enrolled-to-enrolled-cross-ns-same-node",
+		clientEnrollment: enrolled,
+		serverEnrollment: enrolled,
+		location:         sameNode,
+		sameNamespace:    false,
+		expectEncryption: true,
+	})
+}
+
+// ZTunnelEnrolledToEnrolledCrossNamespaceDifferentNode tests mTLS between enrolled pods in different namespaces on different nodes
+func ZTunnelEnrolledToEnrolledCrossNamespaceDifferentNode() check.Scenario {
+	return newZTunnelTest(scenarioConfig{
+		name:             "enrolled-to-enrolled-cross-ns-different-node",
+		clientEnrollment: enrolled,
+		serverEnrollment: enrolled,
+		location:         differentNode,
+		sameNamespace:    false,
+		expectEncryption: true,
+	})
+}
+
+// newZTunnelTest creates a new ztunnel test with the given configuration
+func newZTunnelTest(config scenarioConfig) check.Scenario {
+	return &ztunnelTestBase{
+		ScenarioBase: check.NewScenarioBase(),
+		config:       config,
+	}
+}
+
+func (s *ztunnelTestBase) Name() string {
+	return s.config.name
+}
+
+// getNamespaceForEnrollment determines which namespace to use based on enrollment and pod type.
+//
+// Namespace distribution strategy:
+// - All 3 test namespaces (enrolled-0, enrolled-1, unenrolled) start without the mtls-enabled label
+// - During test execution, namespaces are dynamically labeled based on enrollment requirements
+// - unenrolled pods use "cilium-test-ztunnel-unenrolled"
+// - enrolled pods in same-namespace tests use "cilium-test-ztunnel-enrolled-0"
+// - enrolled pods in cross-namespace tests:
+//   - Client pods → "cilium-test-ztunnel-enrolled-0"
+//   - Server pods → "cilium-test-ztunnel-enrolled-1"
+//
+// This ensures we test both intra-namespace and inter-namespace mTLS scenarios.
+func (s *ztunnelTestBase) getNamespaceForEnrollment(enrollment enrollmentStatus, podType string) string {
+	if enrollment == unenrolled {
+		return unenrolledNamespace
+	}
+
+	// For same namespace tests, always use enrolled-0
+	if s.config.sameNamespace {
+		return enrolledNamespace0
+	}
+
+	// For cross-namespace tests, client goes to enrolled-0, server to enrolled-1
+	if podType == "client" {
+		return enrolledNamespace0
+	}
+	return enrolledNamespace1
+}
+
+// getPod retrieves a pod matching the specified enrollment status, node location, and type.
+//
+// Pod type can be:
+// - "client": The client pod that initiates HTTP requests
+// - "echo-same-node": Echo server pod with node affinity to be on the same node as client
+// - "echo-other-node": Echo server pod with anti-affinity to be on a different node
+//
+// Deployments are labeled with "name=<deployment-name>", so we list all pods with that label
+// and then filter by node location requirements:
+// - sameNode: Pod must be on the same node as referenceNode
+// - differentNode: Pod must be on a different node than referenceNode
+func (s *ztunnelTestBase) getPod(ctx context.Context, t *check.Test, enrollment enrollmentStatus, podType string, referenceNode string, location podLocation) check.Pod {
+	namespace := s.getNamespaceForEnrollment(enrollment, podType)
+
+	// Determine label selector based on podType
+	// For echo pods, use the full deployment name
+	labelSelector := "name=client"
+	if podType != "client" {
+		labelSelector = fmt.Sprintf("name=%s", podType)
+	}
+
+	pods, err := s.ct.K8sClient().ListPods(ctx, namespace, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		t.Fatalf("Failed to list %s pods in namespace %s with selector %s: %v", podType, namespace, labelSelector, err)
+	}
+
+	if len(pods.Items) == 0 {
+		t.Fatalf("No %s pods found in namespace %s with selector %s", podType, namespace, labelSelector)
+	}
+
+	// Debug: log all found pods
+	t.Debugf("Found %d pods for selector %s in namespace %s:", len(pods.Items), labelSelector, namespace)
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		t.Debugf("  - %s on node %s (phase: %s)", pod.Name, pod.Spec.NodeName, pod.Status.Phase)
+	}
+
+	// Find a pod matching the location requirements
+	pod := filterPodsByLocation(pods.Items, referenceNode, location)
+	if pod == nil {
+		t.Fatalf("Failed to find %s pod matching node location requirements in namespace %s (selector: %s, referenceNode: %s, location: %s, found %d pods)",
+			podType, namespace, labelSelector, referenceNode, locationName(location), len(pods.Items))
+	}
+
+	return check.Pod{
+		K8sClient: s.ct.K8sClient(),
+		Pod:       pod,
+	}
+}
+
+// filterPodsByLocation finds the first pod matching the specified node location constraint.
+// Returns nil if no matching pod is found.
+func filterPodsByLocation(pods []corev1.Pod, referenceNode string, location podLocation) *corev1.Pod {
+	for i := range pods {
+		pod := &pods[i]
+		if referenceNode == "" {
+			return pod
+		}
+		if location == sameNode && pod.Spec.NodeName == referenceNode {
+			return pod
+		}
+		if location == differentNode && pod.Spec.NodeName != referenceNode {
+			return pod
+		}
+	}
+	return nil
+}
+
+// setupTestPods configures client and server pods based on test configuration
+func (s *ztunnelTestBase) setupTestPods(ctx context.Context, t *check.Test) {
+	// Get client pod
+	s.client = s.getPod(ctx, t, s.config.clientEnrollment, "client", "", sameNode)
+
+	// Get server pod based on location and enrollment
+	serverPodType := "echo-same-node"
+	if s.config.location == differentNode {
+		serverPodType = "echo-other-node"
+	}
+
+	s.server = s.getPod(ctx, t, s.config.serverEnrollment, serverPodType, s.client.Pod.Spec.NodeName, s.config.location)
+
+	t.Debugf("Selected pods: client=%s (node=%s, ns=%s), server=%s (node=%s, ns=%s)",
+		s.client.Pod.Name, s.client.Pod.Spec.NodeName, s.client.Pod.Namespace,
+		s.server.Pod.Name, s.server.Pod.Spec.NodeName, s.server.Pod.Namespace)
+}
+
+// assignHostNSPods acquires host namespace pods for packet capture on client and server nodes.
+//
+// Ztunnel runs as a DaemonSet in the host network namespace, so encrypted traffic between
+// nodes flows through the host network stack, not the pod network. To capture this traffic
+// with tcpdump, we need pods with:
+// 1. Host network access (hostNetwork: true)
+// 2. NET_ADMIN capability to run tcpdump
+//
+// These host network pods are deployed by the connectivity test framework.
+func (s *ztunnelTestBase) assignHostNSPods(t *check.Test) {
+	clientHostNS, ok := s.ct.HostNetNSPodsByNode()[s.client.Pod.Spec.NodeName]
+	if !ok {
+		t.Fatalf("Failed to acquire host namespace pod on %s (client's node)", s.client.Pod.Spec.NodeName)
+	}
+	s.clientHostNS = clientHostNS
+
+	serverHostNS, ok := s.ct.HostNetNSPodsByNode()[s.server.Pod.Spec.NodeName]
+	if !ok {
+		t.Fatalf("Failed to acquire host namespace pod on %s (server's node)", s.server.Pod.Spec.NodeName)
+	}
+	s.serverHostNS = serverHostNS
+}
+
+// workload represents a workload in the ztunnel dump_config output
+type workload struct {
+	Name           string   `json:"name"`
+	Namespace      string   `json:"namespace"`
+	ServiceAccount string   `json:"serviceAccount"`
+	UID            string   `json:"uid"`
+	WorkloadIPs    []string `json:"workloadIps"`
+	Node           string   `json:"node"`
+	Status         string   `json:"status"`
+}
+
+// ztunnelDumpConfig represents the dump_config response structure
+type ztunnelDumpConfig struct {
+	Workloads []workload `json:"workloads"`
+}
+
+// validateZTunnelState checks that ztunnels have workload information for enrolled pods
+func (s *ztunnelTestBase) validateZTunnelState(ctx context.Context, t *check.Test) {
+	// Skip validation if neither pod is enrolled
+	if s.config.clientEnrollment == unenrolled && s.config.serverEnrollment == unenrolled {
+		t.Debugf("Skipping ztunnel state validation - no enrolled pods")
+		return
+	}
+
+	fetchWorkloads := func(hostNS *check.Pod) ([]workload, error) {
+		stdout, err := hostNS.K8sClient.ExecInPod(
+			ctx,
+			hostNS.Pod.Namespace,
+			hostNS.Pod.Name,
+			"",
+			[]string{"curl", "-s", fmt.Sprintf("http://localhost:%s/config_dump", ztunnelAdminPort)},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute curl in ztunnel pod: %w", err)
+		}
+
+		var config ztunnelDumpConfig
+		if err := json.Unmarshal(stdout.Bytes(), &config); err != nil {
+			return nil, fmt.Errorf("failed to parse ztunnel dump_config JSON: %w", err)
+		}
+
+		return config.Workloads, nil
+	}
+
+	hasWorkload := func(workloads []workload, uid string) bool {
+		for _, wl := range workloads {
+			if wl.UID == uid {
+				return true
+			}
+		}
+		return false
+	}
+
+	sameNode := s.clientHostNS.Pod.Name == s.serverHostNS.Pod.Name
+
+	validated := false
+	for ctx.Err() == nil {
+		// Fetch workloads from client's ztunnel
+		clientWorkloads, err := fetchWorkloads(&s.clientHostNS)
+		if err != nil {
+			t.Fatalf("Failed to fetch workloads from client ztunnel: %v", err)
+		}
+
+		// Check client ztunnel has enrolled client workload
+		if s.config.clientEnrollment == enrolled {
+			if !hasWorkload(clientWorkloads, string(s.client.Pod.UID)) {
+				t.Debugf("Client ztunnel missing client workload, retrying")
+				time.Sleep(1 * time.Second)
+				continue
+			}
+		}
+
+		// Check client ztunnel has enrolled server workload
+		if s.config.serverEnrollment == enrolled {
+			if !hasWorkload(clientWorkloads, string(s.server.Pod.UID)) {
+				t.Debugf("Client ztunnel missing server workload, retrying")
+				time.Sleep(1 * time.Second)
+				continue
+			}
+		}
+
+		// For different node scenarios, also validate server's ztunnel
+		if !sameNode && s.config.serverEnrollment == enrolled {
+			serverWorkloads, err := fetchWorkloads(&s.serverHostNS)
+			if err != nil {
+				t.Fatalf("Failed to fetch workloads from server ztunnel: %v", err)
+			}
+
+			if !hasWorkload(serverWorkloads, string(s.server.Pod.UID)) {
+				t.Debugf("Server ztunnel missing server workload, retrying")
+				time.Sleep(1 * time.Second)
+				continue
+			}
+		}
+
+		validated = true
+		break
+	}
+
+	if !validated {
+		t.Fatalf("Timed out waiting for ztunnel workload information")
+	}
+	t.Debugf("Ztunnel workload validation complete")
+}
+
+// enrollNamespace adds the mtls-enabled label to a namespace to enroll it in ztunnel mTLS.
+func (s *ztunnelTestBase) enrollNamespace(ctx context.Context, t *check.Test, namespace string) error {
+	t.Debugf("Enrolling namespace %s in ztunnel mTLS", namespace)
+
+	patch := fmt.Appendf(nil, `{"metadata":{"labels":{"%s":"true"}}}`, mtlsEnabledLabel)
+	_, err := s.ct.K8sClient().Clientset.CoreV1().Namespaces().Patch(
+		ctx, namespace, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch namespace %s with enrollment label: %w", namespace, err)
+	}
+
+	t.Debugf("Namespace %s enrolled", namespace)
+	return nil
+}
+
+// disenrollNamespace removes the mtls-enabled label from a namespace to disenroll it from ztunnel mTLS.
+func (s *ztunnelTestBase) disenrollNamespace(ctx context.Context, t *check.Test, namespace string) error {
+	t.Debugf("Disenrolling namespace %s from ztunnel mTLS", namespace)
+
+	patch := fmt.Appendf(nil, `{"metadata":{"labels":{"%s":null}}}`, mtlsEnabledLabel)
+	_, err := s.ct.K8sClient().Clientset.CoreV1().Namespaces().Patch(
+		ctx, namespace, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch namespace %s to remove enrollment label: %w", namespace, err)
+	}
+
+	t.Debugf("Namespace %s disenrolled", namespace)
+	return nil
+}
+
+// createTrafficFiltersForFamily creates tcpdump filters for a specific IP family and port.
+// For same-node scenarios, it creates bidirectional filters since both pods share the same host network.
+// For different-node scenarios, it creates separate client and server filters for directional traffic.
+func createTrafficFiltersForFamily(clientIP, serverIP, suffix string, port int, sameNode bool) map[string]string {
+	filters := make(map[string]string)
+
+	if sameNode {
+		// Same node: bidirectional traffic filter
+		filters["client-"+suffix] = fmt.Sprintf(
+			"tcp and port %d and ((src host %s and dst host %s) or (src host %s and dst host %s))",
+			port, clientIP, serverIP, serverIP, clientIP)
+	} else {
+		// Different nodes: outbound from client
+		filters["client-"+suffix] = fmt.Sprintf(
+			"tcp and dst port %d and src host %s and dst host %s",
+			port, clientIP, serverIP)
+		// Different nodes: inbound to server
+		filters["server-"+suffix] = fmt.Sprintf(
+			"tcp and dst port %d and src host %s and dst host %s",
+			port, clientIP, serverIP)
+	}
+
+	return filters
+}
+
+// createTrafficFilters creates tcpdump filters for encrypted and plain text traffic.
+//
+// We create two sets of filters to prove encryption:
+// 1. Encrypted filters: Detect traffic on port 15008 (ztunnel HBONE proxy port)
+// 2. Plain text filters: Detect traffic on port 8080 (direct HTTP to echo server)
+//
+// Based on enrollment status, tests assert:
+// - enrolled→enrolled: MUST see port 15008, MUST NOT see port 8080
+// - Other scenarios: MUST NOT see port 15008, MUST see port 8080
+func (s *ztunnelTestBase) createTrafficFilters() (encrypted, plainText map[string]string) {
+	encrypted = make(map[string]string)
+	plainText = make(map[string]string)
+
+	sameNode := s.clientHostNS.Pod.Name == s.serverHostNS.Pod.Name
+
+	if s.ipv4Enabled.Enabled {
+		clientIPv4 := s.client.Address(features.IPFamilyV4)
+		serverIPv4 := s.server.Address(features.IPFamilyV4)
+
+		// Create filters for encrypted traffic (port 15008)
+		maps.Copy(encrypted, createTrafficFiltersForFamily(clientIPv4, serverIPv4, "ipv4", ztunnelInboundPort, sameNode))
+
+		// Create filters for plain text traffic (port 8080)
+		maps.Copy(plainText, createTrafficFiltersForFamily(clientIPv4, serverIPv4, "ipv4", echoServerPort, sameNode))
+	}
+
+	if s.ipv6Enabled.Enabled {
+		clientIPv6 := s.client.Address(features.IPFamilyV6)
+		serverIPv6 := s.server.Address(features.IPFamilyV6)
+
+		// Create filters for encrypted traffic (port 15008)
+		maps.Copy(encrypted, createTrafficFiltersForFamily(clientIPv6, serverIPv6, "ipv6", ztunnelInboundPort, sameNode))
+
+		// Create filters for plain text traffic (port 8080)
+		maps.Copy(plainText, createTrafficFiltersForFamily(clientIPv6, serverIPv6, "ipv6", echoServerPort, sameNode))
+	}
+
+	return encrypted, plainText
+}
+
+// startSniffer starts a tcpdump sniffer on the given host network pod.
+func (s *ztunnelTestBase) startSniffer(ctx context.Context, t *check.Test, mode sniff.Mode,
+	hostNS *check.Pod, filter, name string,
+) (*sniff.Sniffer, error) {
+	sniffer, cancel, err := sniff.Sniff(ctx, name, hostNS, "any", filter, mode, sniff.SniffKillTimeout, t)
+	if err != nil {
+		return nil, err
+	}
+	s.finalizers = append(s.finalizers, cancel)
+	return sniffer, nil
+}
+
+// startSnifferForFamily starts tcpdump sniffers for a specific IP family.
+// Returns a map of sniffers keyed by "client-<suffix>" and "server-<suffix>".
+// For same-node scenarios, the server sniffer reuses the client sniffer since both pods
+// share the same host network namespace.
+func (s *ztunnelTestBase) startSnifferForFamily(ctx context.Context, t *check.Test, mode sniff.Mode,
+	filters map[string]string, name, suffix string, sameNode bool,
+) (map[string]*sniff.Sniffer, error) {
+	sniffers := make(map[string]*sniff.Sniffer)
+
+	clientKey := "client-" + suffix
+	serverKey := "server-" + suffix
+	clientFilter := filters[clientKey]
+	serverFilter := filters[serverKey]
+
+	// Start client sniffer (always needed)
+	if clientFilter != "" {
+		sniffer, err := s.startSniffer(ctx, t, mode, &s.clientHostNS, clientFilter, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start client sniffer for %s: %w", suffix, err)
+		}
+		sniffers[clientKey] = sniffer
+	}
+
+	// Start server sniffer only if on different node
+	if !sameNode && serverFilter != "" {
+		sniffer, err := s.startSniffer(ctx, t, mode, &s.serverHostNS, serverFilter, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start server sniffer for %s: %w", suffix, err)
+		}
+		sniffers[serverKey] = sniffer
+	} else if sameNode && serverFilter != "" {
+		// For same node, reuse the client sniffer for server validation.
+		// This works because both pods are on the same node and share the host network namespace,
+		// so a single capture point sees traffic in both directions.
+		sniffers[serverKey] = sniffers[clientKey]
+	}
+
+	return sniffers, nil
+}
+
+// startSniffers starts tcpdump on both client and server host network pods
+func (s *ztunnelTestBase) startSniffers(ctx context.Context, t *check.Test, mode sniff.Mode, filters map[string]string, name string) (map[string]*sniff.Sniffer, error) {
+	allSniffers := make(map[string]*sniff.Sniffer)
+
+	// Check if client and server are on the same node (same host network pod)
+	sameNode := s.clientHostNS.Pod.Name == s.serverHostNS.Pod.Name
+
+	if s.ipv4Enabled.Enabled {
+		sniffers, err := s.startSnifferForFamily(ctx, t, mode, filters, name, "ipv4", sameNode)
+		if err != nil {
+			return nil, err
+		}
+		maps.Copy(allSniffers, sniffers)
+	}
+
+	if s.ipv6Enabled.Enabled {
+		nameIPv6 := fmt.Sprintf("%s-ipv6", name)
+		sniffers, err := s.startSnifferForFamily(ctx, t, mode, filters, nameIPv6, "ipv6", sameNode)
+		if err != nil {
+			return nil, err
+		}
+		maps.Copy(allSniffers, sniffers)
+	}
+
+	return allSniffers, nil
+}
+
+// executeTrafficTest performs curl from client to server with retry and validates sniffers
+func (s *ztunnelTestBase) executeTrafficTest(ctx context.Context, t *check.Test,
+	encryptedSniffers, plainTextSniffers map[string]*sniff.Sniffer,
+) {
+	if s.ipv4Enabled.Enabled {
+		s.executeTrafficForIPFamily(ctx, t, features.IPFamilyV4,
+			encryptedSniffers, plainTextSniffers)
+	}
+
+	if s.ipv6Enabled.Enabled {
+		s.executeTrafficForIPFamily(ctx, t, features.IPFamilyV6,
+			encryptedSniffers, plainTextSniffers)
+	}
+}
+
+// executeTrafficForIPFamily performs curl and validates sniffers for a specific IP family
+func (s *ztunnelTestBase) executeTrafficForIPFamily(ctx context.Context, t *check.Test, ipFamily features.IPFamily,
+	encryptedSniffers, plainTextSniffers map[string]*sniff.Sniffer,
+) {
+	var url string
+	if ipFamily == features.IPFamilyV4 {
+		url = fmt.Sprintf("http://%s:%d/", s.server.Address(ipFamily), echoServerPort)
+	} else {
+		url = fmt.Sprintf("http://[%s]:%d/", s.server.Address(ipFamily), echoServerPort)
+	}
+
+	// Retry loop for curl command
+	var lastErr error
+	for attempt := 1; attempt <= maxCurlRetries; attempt++ {
+		if attempt > 1 {
+			t.Debugf("Retry attempt %d/%d...", attempt, maxCurlRetries)
+			time.Sleep(curlRetryDelay)
+		}
+
+		output, err := s.client.K8sClient.ExecInPod(ctx,
+			s.client.Pod.Namespace, s.client.Pod.Name, s.client.Pod.Labels["name"],
+			[]string{"curl", "-sS", "--fail", "--connect-timeout", "5", "--max-time", "10", url})
+
+		if err == nil && output.Len() > 0 {
+			t.Debugf("Curl succeeded on attempt %d", attempt)
+			lastErr = nil
+			break
+		}
+
+		lastErr = err
+	}
+
+	if lastErr != nil {
+		t.Fatalf("Curl failed after %d attempts: %v", maxCurlRetries, lastErr)
+	}
+
+	// Validate sniffers
+	suffix := "ipv4"
+	if ipFamily == features.IPFamilyV6 {
+		suffix = "ipv6"
+	}
+
+	action := t.NewAction(s, fmt.Sprintf("curl-%s", ipFamily), &s.client, &s.server, ipFamily)
+	action.Run(func(a *check.Action) {
+		// Track validated sniffers to avoid validating the same sniffer twice
+		validated := make(map[*sniff.Sniffer]bool)
+
+		// Validate encrypted traffic sniffers (port 15008)
+		if sniffer, ok := encryptedSniffers["client-"+suffix]; ok && sniffer != nil && !validated[sniffer] {
+			t.Debugf("[%s] Validating encrypted traffic sniffer: client-%s", ipFamily, suffix)
+			sniffer.Validate(a)
+			validated[sniffer] = true
+		}
+		if sniffer, ok := encryptedSniffers["server-"+suffix]; ok && sniffer != nil && !validated[sniffer] {
+			t.Debugf("[%s] Validating encrypted traffic sniffer: server-%s", ipFamily, suffix)
+			sniffer.Validate(a)
+			validated[sniffer] = true
+		}
+
+		// Validate plain text traffic sniffers (port 8080)
+		if sniffer, ok := plainTextSniffers["client-"+suffix]; ok && sniffer != nil && !validated[sniffer] {
+			t.Debugf("[%s] Validating plain text traffic sniffer: client-%s", ipFamily, suffix)
+			sniffer.Validate(a)
+			validated[sniffer] = true
+		}
+		if sniffer, ok := plainTextSniffers["server-"+suffix]; ok && sniffer != nil && !validated[sniffer] {
+			t.Debugf("[%s] Validating plain text traffic sniffer: server-%s", ipFamily, suffix)
+			sniffer.Validate(a)
+			validated[sniffer] = true
+		}
+	})
+}
+
+// waitOnZTunnelDS waits for the ztunnel daemonset to be ready
+func (s *ztunnelTestBase) waitOnZTunnelDS(ctx context.Context, t *check.Test) {
+	if err := check.WaitForDaemonSet(ctx, t, s.ct.K8sClient(), s.namespace, "ztunnel-cilium"); err != nil {
+		t.Fatalf("Failed to wait for ztunnel-cilium daemonset: %s", err)
+	}
+}
+
+func (s *ztunnelTestBase) Run(ctx context.Context, t *check.Test) {
+	s.ct = t.Context()
+	s.namespace = s.ct.Params().CiliumNamespace
+
+	// Cleanup on exit
+	defer func() {
+		for _, f := range s.finalizers {
+			if err := f(); err != nil {
+				t.Debugf("Failed to run finalizer: %v", err)
+			}
+		}
+	}()
+
+	// Get feature flags
+	var ok bool
+	s.ipv4Enabled, ok = s.ct.Feature(features.IPv4)
+	if !ok {
+		t.Fatalf("Failed to detect IPv4 feature")
+	}
+	s.ipv6Enabled, ok = s.ct.Feature(features.IPv6)
+	if !ok {
+		t.Fatalf("Failed to detect IPv6 feature")
+	}
+	if !s.ipv4Enabled.Enabled && !s.ipv6Enabled.Enabled {
+		t.Fatalf("Test requires at least one IP family to be enabled")
+	}
+
+	t.Infof("==== Ztunnel Scenario: %s ====", s.config.name)
+	t.Infof("Configuration: client=%s, server=%s, location=%v, expectEncryption=%v",
+		enrollmentName(s.config.clientEnrollment),
+		enrollmentName(s.config.serverEnrollment),
+		locationName(s.config.location),
+		s.config.expectEncryption)
+
+	// Setup
+	s.waitOnZTunnelDS(ctx, t)
+	s.setupTestPods(ctx, t)
+
+	// Dynamically enroll namespaces based on test configuration
+	// All namespaces start unenrolled, we label them here to enroll
+	namespacesToEnroll := make(map[string]bool)
+	namespacesToDisenroll := make([]string, 0)
+
+	if s.config.clientEnrollment == enrolled {
+		ns := s.client.Pod.Namespace
+		if !namespacesToEnroll[ns] {
+			t.Infof("Enrolling client namespace: %s", ns)
+			if err := s.enrollNamespace(ctx, t, ns); err != nil {
+				t.Fatalf("Failed to enroll client namespace %s: %v", ns, err)
+			}
+			namespacesToEnroll[ns] = true
+			namespacesToDisenroll = append(namespacesToDisenroll, ns)
+		}
+	}
+
+	if s.config.serverEnrollment == enrolled {
+		ns := s.server.Pod.Namespace
+		if !namespacesToEnroll[ns] {
+			t.Infof("Enrolling server namespace: %s", ns)
+			if err := s.enrollNamespace(ctx, t, ns); err != nil {
+				t.Fatalf("Failed to enroll server namespace %s: %v", ns, err)
+			}
+			namespacesToEnroll[ns] = true
+			namespacesToDisenroll = append(namespacesToDisenroll, ns)
+		}
+	}
+
+	// Add cleanup to disenroll namespaces at the end of the test
+	defer func() {
+		if len(namespacesToDisenroll) > 0 {
+			t.Infof("Cleaning up: disenrolling %d namespace(s)", len(namespacesToDisenroll))
+
+			// Disenroll all namespaces
+			for _, ns := range namespacesToDisenroll {
+				t.Debugf("Disenrolling namespace: %s", ns)
+				if err := s.disenrollNamespace(ctx, t, ns); err != nil {
+					t.Debugf("Failed to disenroll namespace %s: %v", ns, err)
+				}
+			}
+		}
+	}()
+
+	s.assignHostNSPods(t)
+
+	timeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+	s.validateZTunnelState(timeout, t)
+
+	// Create traffic filters
+	encryptedFilters, plainTextFilters := s.createTrafficFilters()
+
+	// Determine sniffer modes based on expected encryption
+	var encryptedMode, plainTextMode sniff.Mode
+	if s.config.expectEncryption {
+		// When encryption is expected:
+		// - encrypted traffic (port 15008) should be present (ModeSanity)
+		// - plain text traffic (port 8080) should NOT be present (ModeAssert)
+		encryptedMode = sniff.ModeSanity
+		plainTextMode = sniff.ModeAssert
+		t.Info("Expecting encrypted traffic on port 15008, no plain text on port 8080")
+	} else {
+		// When encryption is NOT expected:
+		// - encrypted traffic (port 15008) should NOT be present (ModeAssert)
+		// - plain text traffic (port 8080) should be present (ModeSanity)
+		encryptedMode = sniff.ModeAssert
+		plainTextMode = sniff.ModeSanity
+		t.Info("Expecting plain text traffic on port 8080, no encrypted traffic on port 15008")
+	}
+
+	// Start sniffers for encrypted traffic (port 15008)
+	encryptedSniffers, err := s.startSniffers(ctx, t, encryptedMode, encryptedFilters, "ztunnel-encrypted")
+	if err != nil {
+		t.Fatalf("Failed to start encrypted traffic sniffers: %s", err)
+	}
+
+	// Start sniffers for plain text traffic (port 8080)
+	plainTextSniffers, err := s.startSniffers(ctx, t, plainTextMode, plainTextFilters, "ztunnel-plaintext")
+	if err != nil {
+		t.Fatalf("Failed to start plain text traffic sniffers: %s", err)
+	}
+
+	// Execute traffic test
+	t.Info("Sending HTTP request...")
+	s.executeTrafficTest(ctx, t, encryptedSniffers, plainTextSniffers)
+
+	t.Info("Test complete")
+}
+
+func enrollmentName(e enrollmentStatus) string {
+	if e == enrolled {
+		return "enrolled"
+	}
+	return "unenrolled"
+}
+
+func locationName(l podLocation) string {
+	if l == sameNode {
+		return "same-node"
+	}
+	return "different-node"
+}

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -123,6 +123,8 @@ const (
 	RHEL Feature = "rhel"
 
 	ExternalEnvoyProxy Feature = "external-envoy-proxy"
+
+	Ztunnel Feature = "enable-ztunnel"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -416,6 +418,10 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 	}
 
 	fs[Tunnel], fs[TunnelPort] = ExtractTunnelFeatureFromConfigMap(cm)
+
+	fs[Ztunnel] = Status{
+		Enabled: cm.Data["enable-ztunnel"] == "true",
+	}
 }
 
 func (fs Set) ExtractFromNodes(nodesWithoutCilium map[string]struct{}) {


### PR DESCRIPTION
This pull requests adds KIND based end to end tests for Cilium's ZTunnel integration. 

Two new test triggers are introduced:
`/ci-ztunnel-e2e` - run KIND based ZTunnel end to end tests 

**note**: commit a2226267ec7d96bbac4e46e5896ec25a4262152d will be removed and exists to run our new tests within the context of this PR. 

Closes: #41901

```release-note
Introduce end-to-end tests for Cilium's ZTunnel integration. 
```