### PR TITLE
policy: Mark FromRequires and ToRequires as deprecated

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -1066,6 +1066,12 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
+                      type: array
                     toServices:
                       description: |-
                         ToServices is a list of services to which the endpoint subject
@@ -1626,6 +1632,12 @@ spec:
                             type: array
                         type: object
                       type: array
+                    toRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
+                      type: array
                     toServices:
                       description: |-
                         ToServices is a list of services to which the endpoint subject
@@ -2171,6 +2183,12 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      type: array
+                    fromRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
                       type: array
                     icmps:
                       description: |-
@@ -3087,6 +3105,12 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      type: array
+                    fromRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
                       type: array
                     icmps:
                       description: |-
@@ -4330,6 +4354,12 @@ spec:
                               type: object
                           type: object
                         type: array
+                      toRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
+                        type: array
                       toServices:
                         description: |-
                           ToServices is a list of services to which the endpoint subject
@@ -4891,6 +4921,12 @@ spec:
                               type: array
                           type: object
                         type: array
+                      toRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
+                        type: array
                       toServices:
                         description: |-
                           ToServices is a list of services to which the endpoint subject
@@ -5436,6 +5472,12 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        type: array
+                      fromRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
                         type: array
                       icmps:
                         description: |-
@@ -6353,6 +6395,12 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        type: array
+                      fromRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
                         type: array
                       icmps:
                         description: |-

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -1069,6 +1069,12 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
+                      type: array
                     toServices:
                       description: |-
                         ToServices is a list of services to which the endpoint subject
@@ -1629,6 +1635,12 @@ spec:
                             type: array
                         type: object
                       type: array
+                    toRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
+                      type: array
                     toServices:
                       description: |-
                         ToServices is a list of services to which the endpoint subject
@@ -2174,6 +2186,12 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      type: array
+                    fromRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
                       type: array
                     icmps:
                       description: |-
@@ -3090,6 +3108,12 @@ spec:
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
+                      type: array
+                    fromRequires:
+                      description: Deprecated.
+                      items:
+                        type: string
+                      maxItems: 0
                       type: array
                     icmps:
                       description: |-
@@ -4333,6 +4357,12 @@ spec:
                               type: object
                           type: object
                         type: array
+                      toRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
+                        type: array
                       toServices:
                         description: |-
                           ToServices is a list of services to which the endpoint subject
@@ -4894,6 +4924,12 @@ spec:
                               type: array
                           type: object
                         type: array
+                      toRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
+                        type: array
                       toServices:
                         description: |-
                           ToServices is a list of services to which the endpoint subject
@@ -5439,6 +5475,12 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        type: array
+                      fromRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
                         type: array
                       icmps:
                         description: |-
@@ -6356,6 +6398,12 @@ spec:
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
+                        type: array
+                      fromRequires:
+                        description: Deprecated.
+                        items:
+                          type: string
+                        maxItems: 0
                         type: array
                       icmps:
                         description: |-

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -30,6 +30,11 @@ type EgressCommonRule struct {
 	// +kubebuilder:validation:Optional
 	ToEndpoints []EndpointSelector `json:"toEndpoints,omitempty"`
 
+	// Deprecated.
+	//
+	// +kubebuilder:validation:MaxItems=0
+	ToRequires []string `json:"toRequires,omitempty"`
+
 	// ToCIDR is a list of IP blocks which the endpoint subject to the rule
 	// is allowed to initiate connections. Only connections destined for
 	// outside of the cluster and not targeting the host will be subject

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -31,6 +31,11 @@ type IngressCommonRule struct {
 	// +kubebuilder:validation:Optional
 	FromEndpoints []EndpointSelector `json:"fromEndpoints,omitempty"`
 
+	// Deprecated.
+	//
+	// +kubebuilder:validation:MaxItems=0
+	FromRequires []string `json:"fromRequires,omitempty"`
+
 	// FromCIDR is a list of IP blocks which the endpoint subject to the
 	// rule is allowed to receive connections from. Only connections which
 	// do *not* originate from the cluster or from the local host are subject

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -163,6 +163,11 @@ func (in *EgressCommonRule) DeepCopyInto(out *EgressCommonRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ToRequires != nil {
+		in, out := &in.ToRequires, &out.ToRequires
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ToCIDR != nil {
 		in, out := &in.ToCIDR, &out.ToCIDR
 		*out = make(CIDRSlice, len(*in))
@@ -518,6 +523,11 @@ func (in *IngressCommonRule) DeepCopyInto(out *IngressCommonRule) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.FromRequires != nil {
+		in, out := &in.FromRequires, &out.FromRequires
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.FromCIDR != nil {
 		in, out := &in.FromCIDR, &out.FromCIDR

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -222,6 +222,23 @@ func (in *EgressCommonRule) deepEqual(other *EgressCommonRule) bool {
 		}
 	}
 
+	if ((in.ToRequires != nil) && (other.ToRequires != nil)) || ((in.ToRequires == nil) != (other.ToRequires == nil)) {
+		in, other := &in.ToRequires, &other.ToRequires
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.ToCIDR != nil) && (other.ToCIDR != nil)) || ((in.ToCIDR == nil) != (other.ToCIDR == nil)) {
 		in, other := &in.ToCIDR, &other.ToCIDR
 		if other == nil || !in.DeepEqual(other) {
@@ -615,6 +632,23 @@ func (in *IngressCommonRule) deepEqual(other *IngressCommonRule) bool {
 		} else {
 			for i, inElement := range *in {
 				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
+		}
+	}
+
+	if ((in.FromRequires != nil) && (other.FromRequires != nil)) || ((in.FromRequires == nil) != (other.FromRequires == nil)) {
+		in, other := &in.FromRequires, &other.FromRequires
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
 					return false
 				}
 			}


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/42615 removed support for FromRequires and ToRequires. Removing fields from a CRD is a delicate matter; fortunately, we do not set PreserveUnknownFields, but it plays badly with upgrades and downgrades.

This change reintroduces the fields, but marks them as deprecated with MaxItems=0. Note that
[]interface{} can not be used as the field type because the CRD generator can not deal with this type, so we make it a string array.

Closes #43088