### PR TITLE
bpf: ICMP checksum handling in SNAT RevNAT

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -469,13 +469,14 @@ static __always_inline int
 snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 			bool has_l4_header, int l4_off,
 			__be32 old_addr, __be32 new_addr, __u16 addr_off,
-			__be16 old_port, __be16 new_port, __u16 port_off)
+			__be16 old_port, __be16 new_port, __u16 port_off,
+			__wsum l4_csum_diff_from_inner)
 {
 	__wsum sum;
 	int err;
 
 	/* No change needed: */
-	if (old_addr == new_addr && old_port == new_port)
+	if (old_addr == new_addr && old_port == new_port && !l4_csum_diff_from_inner)
 		return 0;
 
 	sum = csum_diff(&old_addr, 4, &new_addr, 4, 0);
@@ -527,9 +528,44 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 		if (csum.offset &&
 		    csum_l4_replace(ctx, l4_off, &csum, 0, sum, flags) < 0)
 			return DROP_CSUM_L4;
+
+		/* Apply additional L4 checksum diff if provided (for ICMP error messages). */
+		if (l4_csum_diff_from_inner && !csum.offset) {
+			csum.offset = offsetof(struct icmphdr, checksum);
+			if (csum_l4_replace(ctx, l4_off, &csum, 0, l4_csum_diff_from_inner, 0) < 0)
+				return DROP_CSUM_L4;
+		}
 	}
 
 	return 0;
+}
+
+static __always_inline void
+snat_v4_calc_icmp_error_csum_diff(__be32 old_addr, __be32 new_addr,
+				  __be16 old_port, __be16 new_port,
+				  bool inner_has_l4_csum, __wsum *diff_for_csum)
+{
+	__be32 old_port32 = (__be32)old_port;
+	__be32 new_port32 = (__be32)new_port;
+
+	*diff_for_csum = 0;
+
+	if (inner_has_l4_csum) {
+		/* Calculate diff value for checksum.
+		 * Reflect the change in the inner L4 checksum caused by the pseudo-address update
+		 * into diff_for_csum.
+		 * All the other changes in inner packet cancel each other out.
+		 */
+		if (old_addr != new_addr)
+			*diff_for_csum = csum_diff(&new_addr, 4, &old_addr, 4, 0);
+	} else {
+		/* Calculate diff value for checksum.
+		 * If the inner L4 header does not include the L4 checksum,
+		 * only the port is modified within the inner L4 header.
+		 */
+		if (old_port != new_port)
+			*diff_for_csum = csum_diff(&old_port32, 4, &new_port32, 4, 0);
+	}
 }
 
 static __always_inline bool
@@ -862,7 +898,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	 */
 	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
 				      tuple.saddr, (*state)->to_saddr, IPV4_DADDR_OFF,
-				      tuple.sport, (*state)->to_sport, port_off);
+				      tuple.sport, (*state)->to_sport, port_off, 0);
 	/* Failing to update the inner L4 checksum is not fatal if the header
 	 * is incomplete.
 	 */
@@ -897,7 +933,7 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	ret = snat_v4_rewrite_headers(ctx, tuple->nexthdr, ETH_HLEN,
 				      ipfrag_has_l4_header(fraginfo), l4_off,
 				      tuple->saddr, state->to_saddr, IPV4_SADDR_OFF,
-				      tuple->sport, to_sport, port_off);
+				      tuple->sport, to_sport, port_off, 0);
 
 	if (update_tuple) {
 		tuple->saddr = state->to_saddr;
@@ -1005,7 +1041,8 @@ nat_icmp_v4:
 static __always_inline __maybe_unused int
 snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 				  __u64 inner_l3_off,
-				  struct ipv4_nat_entry **state)
+				  struct ipv4_nat_entry **state,
+				  __wsum *outer_csum_diff)
 {
 	struct ipv4_ct_tuple tuple = {};
 	struct iphdr iphdr;
@@ -1013,6 +1050,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	__u32 icmpoff;
 	__u8 type;
 	bool icmp_has_inner_l4_csum = true;
+	bool is_inner_l4_csum_enabled = true;
 	int ret;
 	__u32 total_inner_len = (__u32)(ctx_full_len(ctx) - inner_l3_off);
 
@@ -1080,10 +1118,29 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	    total_inner_len < iphdr.ihl + TCP_CSUM_OFF + sizeof(__u16))
 		icmp_has_inner_l4_csum = false;
 
+	/* For UDP, a checksum value of zero means that no checksum */
+	if (tuple.nexthdr == IPPROTO_UDP) {
+		__be16 l4_csum_be = 0;
+
+		if (ctx_load_bytes(ctx, icmpoff + offsetof(struct udphdr, check),
+				   &l4_csum_be, sizeof(l4_csum_be)) < 0)
+			return DROP_INVALID;
+		if (l4_csum_be == 0)
+			is_inner_l4_csum_enabled = false;
+	}
+
+	/* Calculate the diff for the outer ICMP checksum. */
+	snat_v4_calc_icmp_error_csum_diff(tuple.daddr, (*state)->to_daddr,
+					  tuple.dport, (*state)->to_dport,
+					  icmp_has_inner_l4_csum &&
+					  is_inner_l4_csum_enabled,
+					  outer_csum_diff);
+
 	/* The embedded packet was SNATed on egress. Reverse it again: */
-	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, (int)inner_l3_off, true, icmpoff,
+	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, (int)inner_l3_off,
+				      true, icmpoff,
 				      tuple.daddr, (*state)->to_daddr, IPV4_SADDR_OFF,
-				      tuple.dport, (*state)->to_dport, port_off);
+				      tuple.dport, (*state)->to_dport, port_off, 0);
 	/* Failing to update the inner L4 checksum is not fatal if the header
 	 * is incomplete.
 	 */
@@ -1105,6 +1162,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 	__u64 off, inner_l3_off;
 	__be16 to_dport = 0;
 	__u16 port_off = 0;
+	__wsum outer_csum_diff = 0;
 	int ret;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
@@ -1169,7 +1227,8 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 rev_nat_icmp_v4:
 			inner_l3_off = off + sizeof(struct icmphdr);
 
-			ret = snat_v4_rev_nat_handle_icmp_error(ctx, inner_l3_off, &state);
+			ret = snat_v4_rev_nat_handle_icmp_error(ctx, inner_l3_off, &state,
+								&outer_csum_diff);
 			if (IS_ERR(ret))
 				return ret;
 
@@ -1194,7 +1253,8 @@ rewrite:
 	return snat_v4_rewrite_headers(ctx, tuple.nexthdr, ETH_HLEN,
 				       ipfrag_has_l4_header(fraginfo), (int)off,
 				       tuple.daddr, state->to_daddr, IPV4_DADDR_OFF,
-				       tuple.dport, to_dport, port_off);
+				       tuple.dport, to_dport, port_off,
+				       outer_csum_diff);
 }
 #else /* defined(ENABLE_IPV4) && defined(ENABLE_NODEPORT) */
 static __always_inline __maybe_unused

--- a/bpf/tests/icmp_error_revnat.c
+++ b/bpf/tests/icmp_error_revnat.c
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#include <bpf/config/node.h>
+
+#define DEBUG
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/nat.h>
+#include <lib/time.h>
+
+#include "bpf_nat_tuples.h"
+#include "scapy.h"
+
+/* IP addresses mapping to Scapy definitions (in host byte order):
+ * v4_node_one   = "10.0.10.1"  -> IP_ENDPOINT (node/endpoint)
+ * v4_pod_one    = "192.168.0.1" -> IP_HOST (pod being SNATed)
+ * v4_pod_two    = "192.168.0.2" -> IP_ROUTER (pod sending ICMP error)
+ */
+#define IP_ENDPOINT ((10 << 24) | (0 << 16) | (10 << 8) | 1)    /* 10.0.10.1 */
+#define IP_HOST     ((192 << 24) | (168 << 16) | (0 << 8) | 1)  /* 192.168.0.1 */
+#define IP_ROUTER   ((192 << 24) | (168 << 16) | (0 << 8) | 2)  /* 192.168.0.2 */
+#define IP_WORLD    IP_ROUTER  /* same as router for this test */
+
+/* Test snat_v4_rev_nat() with ICMP error containing embedded TCP packet
+ *
+ * Flow:
+ * 1. Simulate an outgoing connection: endpoint (10.0.10.1:3030) -> pod (192.168.0.2:80)
+ *    This gets SNATed to: pod (192.168.0.1:NODEPORT_PORT_MIN_NAT) -> pod (192.168.0.2:80)
+ * 2. Pod sends back ICMP Frag Needed error about the SNATed packet
+ * 3. snat_v4_rev_nat() should reverse the NAT in both outer and inner (embedded) packets
+ * 4. Result: ICMP error should be addressed to endpoint (10.0.10.1)
+ *            with embedded packet showing original src (10.0.10.1:3030)
+ */
+PKTGEN("tc", "nat4_icmp_error_tcp_snat_revnat")
+int nat4_icmp_error_tcp_snat_revnat_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	/* Use Scapy-generated ICMP error packet */
+	BUF_DECL(ICMP4_ERR_FRAG_NEEDED_FOR_REVNAT, icmp4_err_frag_needed_for_revnat);
+	BUILDER_PUSH_BUF(builder, ICMP4_ERR_FRAG_NEEDED_FOR_REVNAT);
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "nat4_icmp_error_tcp_snat_revnat")
+int nat4_icmp_error_tcp_snat_revnat_setup(struct __ctx_buff *ctx)
+{
+	/* Set up NAT mapping to simulate prior outgoing connection.
+	 * Original tuple: endpoint -> pod
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.saddr = bpf_htonl(IP_ENDPOINT),  /* 10.0.10.1 */
+		.daddr = bpf_htonl(IP_WORLD),      /* 192.168.0.2 */
+		.sport = bpf_htons(3030),
+		.dport = bpf_htons(80),
+		.flags = 0,
+	};
+
+	/* NAT target: translate to pod IP */
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),  /* 192.168.0.1 */
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MIN_NAT,
+	};
+
+	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
+	void *map;
+	int ret;
+
+	/* Get SNAT map */
+	map = get_cluster_snat_map_v4(target.cluster_id);
+	if (!map)
+		return TEST_ERROR;
+
+	/* Create NAT mapping */
+	ret = snat_v4_new_mapping(ctx, map, &tuple, &state, &target,
+				  false, NULL);
+	if (ret != 0)
+		return TEST_ERROR;
+
+	/* Now call snat_v4_rev_nat() - this is the function under test.
+	 * It should:
+	 * 1. Reverse NAT the outer IP dst: pod -> endpoint
+	 * 2. Reverse NAT the embedded IP src: pod -> endpoint
+	 * 3. Restore the embedded TCP sport: NODEPORT_PORT_MIN_NAT -> 3030
+	 */
+	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
+	if (ret != 0)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "nat4_icmp_error_tcp_snat_revnat")
+int nat4_icmp_error_tcp_snat_revnat_check(const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	/* First 4 bytes contain the return code from SETUP */
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* Verify SETUP succeeded */
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	/* Compare the packet with expected output after rev-NAT.
+	 * Note: offset sizeof(__u32) to skip the return code prepended by framework.
+	 */
+	BUF_DECL(ICMP4_ERR_FRAG_NEEDED_AFTER_REVNAT, icmp4_err_frag_needed_after_revnat);
+	ASSERT_CTX_BUF_OFF("icmp4_revnat_ok", "Ether", ctx, sizeof(__u32),
+			   ICMP4_ERR_FRAG_NEEDED_AFTER_REVNAT,
+			   sizeof(BUF(ICMP4_ERR_FRAG_NEEDED_AFTER_REVNAT)));
+
+	test_finish();
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -1,0 +1,26 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+
+from pkt_defs_common import *
+
+# outer IPv4 (pod_two -> pod_one), ICMP Destination Unreachable / Fragmentation Needed,
+# embedded original IPv4 + TCP with SNAT'd port
+icmp4_err_frag_needed_for_revnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_two, dst=v4_pod_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_pod_one, dst=v4_pod_two, flags="DF") /
+    TCP(sport=32768, dport=80)  # NODEPORT_PORT_MIN_NAT (SNAT'd port)
+)
+
+
+# After rev-NAT: pod_two -> node_one, with original port restored
+icmp4_err_frag_needed_after_revnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_two, dst=v4_node_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_node_one, dst=v4_pod_two, flags="DF") /
+    TCP(sport=3030, dport=80)  # original port restored
+)

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -12,3 +12,4 @@ from tc_l2_announce_pkt_defs import *
 from tc_l2_announce6_pkt_defs import *
 from wg_from_netdev_pkt_defs import *
 from tc_wireguard_from_overlay_pkt_defs import *
+from icmp_err_revnat_pkt_defs import *


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/40827

When a LB node forwards packets to a backend-pod on another node,
the packets are SNATed.
The corresponding reverse NAT (RevNAT) is then applied
to the reply packets.

Checksum recaluculation is required when RevNAT.
When the reply packet is an ICMP error packet, the checksum
in the ICMP header must be recalculated to reflect the changes
of the inner packet header.
https://datatracker.ietf.org/doc/html/rfc5508#section-4.1

Since that logic was missing, it has been added in this commit.


The below is an error message of `nat4_icmp_error_tcp_snat_revnat` ([new test](https://github.com/cilium/cilium/pull/43196/commits/c4fff34f4e484af5328add58afff0f007a0ad002)) without the [checksum recalculate patch](https://github.com/cilium/cilium/pull/43196/commits/8495c0c5c063e2bd8c896e74f7d636f69666d18f).
<details><summary> <strong>An error message of RevNAT BPF-test</strong> </summary>

```
--- FAIL: TestBPF (39.66s)
--- FAIL: TestBPF/icmp_error_revnat.o (0.55s)
--- FAIL: TestBPF/icmp_error_revnat.o/nat4_icmp_error_tcp_snat_revnat (0.42s)

    bpf_test.go:577: icmp_error_revnat.c:137: CTX and buffer 'ICMP4_ERR_FRAG_NEEDED_AFTER_REVNAT' content mismatch 
    bpf_test.go:421:   Scapy asserts failed: 1
    bpf_test.go:428: 
        === START ./scapy.h:171 'icmp4_revnat_ok' ===
        >>> Expected (len: 164 bytes) <<<
        ###[ Ethernet ]### 
          dst       = 13:37:13:37:13:37
          src       = de:ad:be:ef:de:ef
          type      = IPv4
        ###[ IP ]### 
             version   = 4
             ihl       = 5
             tos       = 0x0
             len       = 68
             id        = 1
             flags     = 
             frag      = 0
             ttl       = 64
             proto     = icmp
             chksum    = 0xa60d
             src       = 192.168.0.2
             dst       = 10.0.10.1
             \options   \
        ###[ ICMP ]### 
                type      = dest-unreach
                code      = fragmentation-needed
                chksum    = 0xcbe5
                reserved  = 0
                length    = 0
                nexthopmtu= 1500
                unused    = ''
        ###[ IP in ICMP ]### 
                   version   = 4
                   ihl       = 5
                   tos       = 0x0
                   len       = 40
                   id        = 1
                   flags     = DF
                   frag      = 0
                   ttl       = 64
                   proto     = tcp
                   chksum    = 0x6624
                   src       = 10.0.10.1
                   dst       = 192.168.0.2
                   \options   \
        ###[ TCP in ICMP ]### 
                      sport     = 3030
                      dport     = http
                      seq       = 0
                      ack       = 0
                      dataofs   = 5
                      reserved  = 0
                      flags     = S
                      window    = 8192
                      chksum    = 0xaf11
                      urgptr    = 0
                      options   = ''
        
        >>> Got (len: 164 bytes) <<<
        ###[ Ethernet ]### 
          dst       = 13:37:13:37:13:37
          src       = de:ad:be:ef:de:ef
          type      = IPv4
        ###[ IP ]### 
             version   = 4
             ihl       = 5
             tos       = 0x0
             len       = 68
             id        = 1
             flags     = 
             frag      = 0
             ttl       = 64
             proto     = icmp
             chksum    = 0xa60d
             src       = 192.168.0.2
             dst       = 10.0.10.1
             \options   \
        ###[ ICMP ]### 
                type      = dest-unreach
                code      = fragmentation-needed
                chksum    = 0x788e
                reserved  = 0
                length    = 0
                nexthopmtu= 1500
                unused    = ''
        ###[ IP in ICMP ]### 
                   version   = 4
                   ihl       = 5
                   tos       = 0x0
                   len       = 40
                   id        = 1
                   flags     = DF
                   frag      = 0
                   ttl       = 64
                   proto     = tcp
                   chksum    = 0x6624
                   src       = 10.0.10.1
                   dst       = 192.168.0.2
                   \options   \
        ###[ TCP in ICMP ]### 
                      sport     = 3030
                      dport     = http
                      seq       = 0
                      ack       = 0
                      dataofs   = 5
                      reserved  = 0
                      flags     = S
                      window    = 8192
                      chksum    = 0xaf11
                      urgptr    = 0
                      options   = ''
        
        >>> Diff <<<
          --- a/pkt (Expected)
          +++ b/pkt (Got)
        
          - [ Ether ][ IP ][ ICMP ].chksum: 52197
          + [ Ether ][ IP ][ ICMP ].chksum: 30862
        
        === END ./scapy.h:171 'icmp4_revnat_ok' ===

┌──────────────────────────────────────────────────────────────────────────────────────────────┐
│  STATUS │ ELAPSED │                  PACKAGE                   │ COVER │ PASS │ FAIL │ SKIP  │
│─────────┼─────────┼────────────────────────────────────────────┼───────┼──────┼──────┼───────│
│  FAIL   │ 39.70s  │ github.com/cilium/cilium/bpf/tests/bpftest │  --   │ 594  │  3   │  0    │
└──────────────────────────────────────────────────────────────────────────────────────────────┘
```

</details>


```release-note
Fix ICMP error packet handling by adding the missing checksum recalculation performed during RevNAT for SNATed load-balanced traffic.
```