### PR TITLE
feat(sdp):  Adding the hive shell to standalone dns proxy

### DIFF
--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/cilium/hive/shell"
 	"github.com/cilium/statedb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,8 +23,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/defaults"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/lookup"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/messagehandler"
+	sdpshell "github.com/cilium/cilium/standalone-dns-proxy/pkg/shell"
 )
 
 var (
@@ -46,6 +49,9 @@ var (
 
 		// includes the message handler for receiving messages from the proxy and sending messages to the gRPC client which in turn sends them to the cilium agent
 		messagehandler.Cell,
+
+		// Shell for inspecting the standalone DNS proxy. Listens on the Unix domain socket.
+		shell.ServerCell(defaults.ShellSockPath),
 
 		cell.Provide(func() *option.DaemonConfig {
 			return option.Config
@@ -75,6 +81,7 @@ func NewDNSProxyCmd(h *hive.Hive) *cobra.Command {
 
 	cmd.AddCommand(
 		h.Command(),
+		sdpshell.Cmd,
 	)
 
 	// slogloggercheck: using default logger for configuration initialization

--- a/standalone-dns-proxy/pkg/defaults/defaults.go
+++ b/standalone-dns-proxy/pkg/defaults/defaults.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package defaults
+
+const (
+	// RuntimePath is the default path to the standalone DNS proxy runtime directory.
+	// This is independent of Cilium's runtime directory to ensure SDP can start
+	// regardless of Cilium's state.
+	RuntimePath = "/var/run/standalone-dns-proxy"
+
+	// ShellSockPath is the path to the UNIX domain socket exposing the debug shell
+	// and health checking for the standalone DNS proxy.
+	ShellSockPath = RuntimePath + "/shell.sock"
+)

--- a/standalone-dns-proxy/pkg/shell/shell.go
+++ b/standalone-dns-proxy/pkg/shell/shell.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package shell
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cilium/hive/shell"
+
+	"github.com/cilium/cilium/pkg/version"
+	sdpDefaults "github.com/cilium/cilium/standalone-dns-proxy/pkg/defaults"
+)
+
+var (
+	// Cmd is the shell command for the standalone DNS proxy
+	Cmd = shell.ShellCmd(
+		sdpDefaults.ShellSockPath,
+		shellPrompt(),
+		shellGreeting,
+	)
+
+	// DefaultConfig is the shell configuration for the standalone DNS proxy
+	DefaultConfig = shell.Config{
+		ShellSockPath: sdpDefaults.ShellSockPath,
+	}
+)
+
+func shellPrompt() string {
+	name, err := os.Hostname()
+	if err == nil {
+		return name + "> "
+	}
+	return "standalone-dns-proxy> "
+}
+
+func shellGreeting(w io.Writer) {
+	const (
+		Red     = "\033[31m"
+		Yellow  = "\033[33m"
+		Blue    = "\033[34m"
+		Green   = "\033[32m"
+		Magenta = "\033[35m"
+		Cyan    = "\033[36m"
+		Reset   = "\033[0m"
+	)
+	fmt.Fprint(w, Yellow+"    /¯¯\\\n")
+	fmt.Fprint(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\n")
+	fmt.Fprintf(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"  Cilium %s\n", version.Version)
+	fmt.Fprint(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"  Standalone DNS Proxy Shell. Type 'help' for commands.\n")
+	fmt.Fprint(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\n")
+	fmt.Fprint(w, Blue+Blue+Blue+"    \\__/"+Reset+"\n")
+	fmt.Fprint(w, "\n")
+}


### PR DESCRIPTION
 Adding the hive shell to standalone dns proxy. It will allow the health cmd be used for liveliness and readiness probes on the daemonset.

> azureuser@vipul-vm:~/ws/cilium$ k exec -it -n kube-system          standalone-dns-proxy-hz7vq      -- standalone-dns-proxy shell health
health
└── job-module-status-metrics                   [OK] Running (46m, x1)

<img width="1285" height="456" alt="image" src="https://github.com/user-attachments/assets/19564fac-4e0b-47db-8d5f-fbfffed9936a" />


```release-note
feat(sdp):  Adding the hive shell to standalone dns proxy
```
