### PR TITLE
identitygc: skip when cep crd doesn't exist

### DIFF
--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -51,6 +51,7 @@ type params struct {
 type GC struct {
 	logger *slog.Logger
 
+	k8sClient           k8sClient.Clientset
 	clientset           ciliumV2.CiliumIdentityInterface
 	kvstoreClient       kvstore.Client
 	identity            resource.Resource[*v2.CiliumIdentity]
@@ -94,6 +95,7 @@ func registerGC(p params) {
 
 	gc := &GC{
 		logger:              p.Logger,
+		k8sClient:           p.Clientset,
 		clientset:           p.Clientset.CiliumV2().CiliumIdentities(),
 		kvstoreClient:       p.KVStoreClient,
 		identity:            p.Identity,


### PR DESCRIPTION
If the cluster is created without CEP CRDs, the identity gc continually reports errors such as: 'failed to list *v2.CiliumEndpoint'. We should skip trying to GC identities in this case. The expected situation where this is hit is when we disable network policy management, so neither new CiliumIdentities nor CiliumEndpoints are created on the cluster.

```release-note
identitygc: skip delete attempt when cep crd doesn't exist
```
