### PR TITLE
pkg/k8s/utils: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -5,10 +5,10 @@ package utils
 
 import (
 	"context"
-	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,9 +107,7 @@ func TestServiceAndEndpoints(t *testing.T) {
 			sort.Strings(got)
 			sort.Strings(tt.want)
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("Expected %v, retrieved: %v", tt.want, got)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -187,9 +185,7 @@ func TestEndpointSlices(t *testing.T) {
 			sort.Strings(got)
 			sort.Strings(tt.want)
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("Expected %v, retrieved: %v", tt.want, got)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -291,9 +287,8 @@ func TestValidIPs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ValidIPs(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ValidIPs() = %v, want %v", got, tt.want)
-			}
+			got := ValidIPs(tt.args)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -324,9 +319,8 @@ func TestIsPodRunning(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsPodRunning(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("TestIsPodRunning() = %v, want %v", got, tt.want)
-			}
+			got := IsPodRunning(tt.args)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -413,9 +407,8 @@ func TestGetLatestPodReadiness(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetLatestPodReadiness(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetLatestPodReadiness() = %v, want %v", got, tt.want)
-			}
+			got := GetLatestPodReadiness(tt.args)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -536,9 +529,8 @@ func TestStripPodLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := StripPodSpecialLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("StripPodSpecialLabels() = %v, want %v", got, tt.want)
-			}
+			got := StripPodSpecialLabels(tt.labels)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -591,9 +583,8 @@ func Test_filterPodLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RemoveCiliumLabels(tt.labels); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("filterPodLabels() = %v, want %v", got, tt.want)
-			}
+			got := RemoveCiliumLabels(tt.labels)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/k8s/utils/workload_test.go
+++ b/pkg/k8s/utils/workload_test.go
@@ -11,8 +11,9 @@
 package utils
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -97,12 +98,8 @@ func TestDeploymentMetadata(t *testing.T) {
 				t.Fatalf("expected ok=%t, got ok=%t", tt.expectOK, ok)
 			}
 			if ok {
-				if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-					t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-				}
-				if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-					t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-				}
+				assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta, "Object metadata")
+				assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta, "Type metadata")
 			}
 		})
 	}
@@ -189,12 +186,8 @@ func TestCronJobMetadata(t *testing.T) {
 				t.Fatalf("expected ok=true, got ok=%t", ok)
 			}
 			if ok {
-				if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-					t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-				}
-				if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-					t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-				}
+				assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta, "Object metadata")
+				assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta, "Type metadata")
 			}
 		})
 	}
@@ -251,12 +244,8 @@ func TestDeploymentConfigMetadata(t *testing.T) {
 			if !ok {
 				t.Fatalf("expected ok=true, got ok=%t", ok)
 			}
-			if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-				t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-			}
-			if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-				t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-			}
+			assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta, "Object metadata")
+			assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta, "Type metadata")
 		})
 	}
 }
@@ -319,12 +308,8 @@ func TestStatefulSetMetadata(t *testing.T) {
 				t.Fatalf("expected ok=true, got ok=%t", ok)
 			}
 			if ok {
-				if !reflect.DeepEqual(gotObjectMeta, tt.wantObjectMetadata) {
-					t.Errorf("Object metadata got %+v want %+v", gotObjectMeta, tt.wantObjectMetadata)
-				}
-				if !reflect.DeepEqual(gotTypeMeta, tt.wantTypeMetadata) {
-					t.Errorf("Type metadata got %+v want %+v", gotTypeMeta, tt.wantTypeMetadata)
-				}
+				assert.Equal(t, tt.wantObjectMetadata, gotObjectMeta, "Object metadata")
+				assert.Equal(t, tt.wantTypeMetadata, gotTypeMeta, "Type metadata")
 			}
 		})
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 15 usages of `reflect.DeepEqual` in the `pkg/k8s/utils/` package:

- `pkg/k8s/utils/workload_test.go` (8 usages)
- `pkg/k8s/utils/utils_test.go` (7 usages)

**Note:** `pkg/k8s/apis/cilium.io/v2/types_test.go` and `pkg/k8s/informer/benchmarks/informer_benchmarks_test.go` were intentionally excluded as they use `reflect.DeepEqual` for benchmark performance comparisons and control flow logic, not for test assertions.

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/k8s/utils/ -v -run "TestDeployment|TestCronJob|TestStatefulSet"
=== RUN   TestDeploymentMetadata
--- PASS: TestDeploymentMetadata (0.00s)
=== RUN   TestCronJobMetadata
--- PASS: TestCronJobMetadata (0.00s)
=== RUN   TestDeploymentConfigMetadata
--- PASS: TestDeploymentConfigMetadata (0.00s)
=== RUN   TestStatefulSetMetadata
--- PASS: TestStatefulSetMetadata (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/k8s/utils	0.023s

$ go test ./pkg/k8s/utils/ -run "TestValidIPs|TestIsPodRunning|TestStripPodSpecialLabels"
ok  	github.com/cilium/cilium/pkg/k8s/utils	0.015s
```

## Follow-up

This is an incremental change affecting the pkg/k8s/utils/ package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768 
- #42769

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/k8s/utils tests for better error messages
```