### PR TITLE
pkg/container,pkg/dynamicconfig: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -6,11 +6,12 @@ package bitlpm
 import (
 	"fmt"
 	"math/bits"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type uint16Range struct {
@@ -177,9 +178,7 @@ func TestUnsignedUpsert(t *testing.T) {
 				sort.Slice(got, func(i, j int) bool {
 					return got[i].start < got[j].start
 				})
-				if !reflect.DeepEqual(got, tt.ranges[:i+1]) {
-					t.Fatalf("When updating an unsigned trie with the key-prefix %d/%d: got %+v, but expected %+v", pr.start, pr.prefix(), got, tt.ranges[:i+1])
-				}
+				require.Equal(t, tt.ranges[:i+1], got, "When updating an unsigned trie with the key-prefix %d/%d", pr.start, pr.prefix())
 			}
 		})
 	}
@@ -504,9 +503,7 @@ func TestUnsignedAncestors(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Ancestors range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
-			}
+			require.Equal(t, expectedRes, gotRes, "Ancestors range %s", entry)
 		})
 	}
 }
@@ -538,9 +535,7 @@ func TestUnsignedDescendants(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Descendants range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
-			}
+			require.Equal(t, expectedRes, gotRes, "Descendants range %s", entry)
 			// It should still work even if the entry is not present
 			tu.Delete(i, rng)
 			expectedRes = expectedRes[1:]
@@ -549,9 +544,7 @@ func TestUnsignedDescendants(t *testing.T) {
 				gotRes = append(gotRes, v)
 				return true
 			})
-			if !reflect.DeepEqual(expectedRes, gotRes) {
-				t.Fatalf("Descendants range %s, expected to get %v, but got: %v", entry, expectedRes, gotRes)
-			}
+			require.Equal(t, expectedRes, gotRes, "Descendants range %s", entry)
 		})
 	}
 }
@@ -622,9 +615,7 @@ func TestUnsignedDelete(t *testing.T) {
 				sort.Slice(got, func(i, j int) bool {
 					return got[i].start < got[j].start
 				})
-				if !reflect.DeepEqual(got, tt.ranges[i+1:]) {
-					t.Fatalf("When deleting an entry from an unsigned trie with the key-prefix %d/%d: got %+v, but expected %+v", pr.start, pr.prefix(), got, tt.ranges[i+1:])
-				}
+				require.Equal(t, tt.ranges[i+1:], got, "When deleting an entry from an unsigned trie with the key-prefix %d/%d", pr.start, pr.prefix())
 			}
 		})
 		// Delete in reverse order.
@@ -649,9 +640,7 @@ func TestUnsignedDelete(t *testing.T) {
 				sort.Slice(got, func(i, j int) bool {
 					return got[i].start < got[j].start
 				})
-				if !reflect.DeepEqual(got, tt.ranges[:i]) {
-					t.Fatalf("When deleting an entry from an unsigned trie with the key-prefix %d/%d: got %+v, but expected %+v", pr.start, pr.prefix(), got, tt.ranges[:i])
-				}
+				require.Equal(t, tt.ranges[:i], got, "When deleting an entry from an unsigned trie with the key-prefix %d/%d", pr.start, pr.prefix())
 			}
 		})
 	}

--- a/pkg/dynamicconfig/table_test.go
+++ b/pkg/dynamicconfig/table_test.go
@@ -6,7 +6,6 @@ package dynamicconfig
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -71,9 +71,7 @@ func TestWatchAllKeys(t *testing.T) {
 	}
 
 	keys, _ := WatchAllKeys(db.ReadTxn(), dct)
-	if !reflect.DeepEqual(keys, expected) {
-		t.Errorf("WatchAllKeys returned unexpected result. Got: %v, Expected: %v", keys, expected)
-	}
+	assert.Equal(t, expected, keys, "WatchAllKeys returned unexpected result")
 }
 
 func TestWatchKey(t *testing.T) {
@@ -203,9 +201,7 @@ func TestDynamicConfigMap(t *testing.T) {
 				t.Fatalf("waiting for config table timed out: %v", err)
 			}
 
-			if !reflect.DeepEqual(gotMap, tc.expectedConfig) {
-				t.Fatalf("expectedConfig:\n%+v\ngot:\n%+v", tc.expectedConfig, gotMap)
-			}
+			assert.Equal(t, tc.expectedConfig, gotMap)
 
 			for _, cm := range tc.cms {
 				for k, v := range cm.Data {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 8 usages of `reflect.DeepEqual` across two packages:

- `pkg/container/bitlpm/unsigned_test.go` (6 usages)
- `pkg/dynamicconfig/table_test.go` (2 usages)

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/container/bitlpm/ -v -run "TestUnsignedUpsert|TestUnsignedAncestors|TestUnsignedDescendants|TestUnsignedDelete"
=== RUN   TestUnsignedUpsert
--- PASS: TestUnsignedUpsert (0.00s)
=== RUN   TestUnsignedAncestors
--- PASS: TestUnsignedAncestors (0.00s)
=== RUN   TestUnsignedDescendants
--- PASS: TestUnsignedDescendants (0.00s)
=== RUN   TestUnsignedDelete
--- PASS: TestUnsignedDelete (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/container/bitlpm	0.010s

$ go test ./pkg/dynamicconfig/ -v -run "TestWatchAllKeys|TestDynamicConfigMap"
=== RUN   TestWatchAllKeys
--- PASS: TestWatchAllKeys (0.01s)
=== RUN   TestDynamicConfigMap
--- PASS: TestDynamicConfigMap (0.06s)
PASS
ok  	github.com/cilium/cilium/pkg/dynamicconfig	0.102s
```

## Follow-up

This is an incremental change affecting the pkg/container/bitlpm and pkg/dynamicconfig packages. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768
- #42769
- #43207

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/container/bitlpm and pkg/dynamicconfig tests for better error messages
```