### PR TITLE
pkg/envoy: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -4,7 +4,6 @@
 package envoy
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -14,6 +13,7 @@ import (
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -1670,9 +1670,8 @@ func Test_getPublicListenerAddress(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getPublicListenerAddress(tt.args.port, tt.args.ipv4, tt.args.ipv6); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getPublicListenerAddress() = %v, want %v", got, tt.want)
-			}
+			got := getPublicListenerAddress(tt.args.port, tt.args.ipv4, tt.args.ipv6)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -1742,12 +1741,8 @@ func Test_getLocalListenerAddresses(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotAdditional := GetLocalListenerAddresses(tt.args.port, tt.args.ipv4, tt.args.ipv6)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getLocalListenerAddresses() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(gotAdditional, tt.wantAdditional) {
-				t.Errorf("getLocalListenerAddresses() got1 = %v, want %v", gotAdditional, tt.wantAdditional)
-			}
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantAdditional, gotAdditional)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 3 usages of `reflect.DeepEqual` in the `pkg/envoy/` package:

- `pkg/envoy/xds_server_test.go` (3 usages)

**Note:** `pkg/envoy/xds/server_e2e_test.go` was intentionally excluded as it uses `reflect.DeepEqual` inside a helper function (`responseCheck`) that returns an `assert.Comparison` for use with `require.Condition()`, not for direct test assertions.

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/envoy/ -v -run "Test_getPublicListenerAddress|Test_getLocalListenerAddresses"
=== RUN   Test_getPublicListenerAddress
--- PASS: Test_getPublicListenerAddress (0.00s)
=== RUN   Test_getLocalListenerAddresses
--- PASS: Test_getLocalListenerAddresses (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/envoy	0.032s
```

## Follow-up

This is an incremental change affecting the pkg/envoy package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768
- #42769
- #43207

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/envoy tests for better error messages
```