### PR TITLE
pkg/ipam,pkg/labels: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/ipam/cidrset/cidr_set_test.go
+++ b/pkg/ipam/cidrset/cidr_set_test.go
@@ -7,8 +7,9 @@ package cidrset
 import (
 	"math/big"
 	"net"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCIDRSetFullyAllocated(t *testing.T) {
@@ -250,9 +251,7 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
 		}
 
-		if !reflect.DeepEqual(cidrs, rcidrs) {
-			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
-		}
+		assert.Equal(t, cidrs, rcidrs, "expected re-allocated cidrs are the same collection for %v", tc.description)
 	}
 }
 
@@ -320,9 +319,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 		for i := numCIDRs / 2; i < numCIDRs; i++ {
 			rcidrs = append(rcidrs, cidrs[i])
 		}
-		if !reflect.DeepEqual(cidrs, rcidrs) {
-			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
-		}
+		assert.Equal(t, cidrs, rcidrs, "expected re-allocated cidrs are the same collection for %v", tc.description)
 	}
 }
 

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -451,9 +451,8 @@ func TestLabels_GetFromSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.l.GetFromSource(tt.args.source); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Labels.GetFromSource() = %v, want %v", got, tt.want)
-			}
+			got := tt.l.GetFromSource(tt.args.source)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 3 usages of `reflect.DeepEqual` across two packages:

- `pkg/ipam/cidrset/cidr_set_test.go` (2 usages)
- `pkg/labels/labels_test.go` (1 usage)

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/ipam/cidrset/ -v -run "TestCIDRSet_AllocationOccupied"
=== RUN   TestCIDRSet_AllocationOccupied
--- PASS: TestCIDRSet_AllocationOccupied (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/ipam/cidrset	0.003s

$ go test ./pkg/labels/ -v -run "TestLabels_GetFromSource"
=== RUN   TestLabels_GetFromSource
--- PASS: TestLabels_GetFromSource (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/labels	0.015s
```

## Follow-up

This is an incremental change affecting the pkg/ipam/cidrset and pkg/labels packages. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768
- #42769
- #43207

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/ipam and pkg/labels tests for better error messages
```