### PR TITLE
maps/nat: remove unnecessary argument `natRequired` on `RetriesMaps`

### DIFF
--- a/cilium-dbg/cmd/bpf_nat_retries_flush.go
+++ b/cilium-dbg/cmd/bpf_nat_retries_flush.go
@@ -29,7 +29,7 @@ func init() {
 
 func flushRetries() {
 	ipv4, ipv6 := getIpEnableStatuses()
-	ipv4Map, ipv6Map := nat.RetriesMaps(ipv4, ipv6, true)
+	ipv4Map, ipv6Map := nat.RetriesMaps(ipv4, ipv6)
 
 	for _, m := range []nat.RetriesMap{ipv4Map, ipv6Map} {
 		if m == nil {

--- a/cilium-dbg/cmd/bpf_nat_retries_list.go
+++ b/cilium-dbg/cmd/bpf_nat_retries_list.go
@@ -28,7 +28,7 @@ var bpfNatRetriesListCmd = &cobra.Command{
 		}
 
 		ipv4, ipv6 := getIpEnableStatuses()
-		ipv4Map, ipv6Map := nat.RetriesMaps(ipv4, ipv6, true)
+		ipv4Map, ipv6Map := nat.RetriesMaps(ipv4, ipv6)
 		if ipv4Map != nil {
 			dumpRetries(ipv4Map)
 		}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -461,10 +461,7 @@ func newRetriesMap(name string) *bpf.Map {
 // RetriesMaps returns the maps that contain the histograms of the number of retries.
 // This should only be used from components which aren't capable of using hive - mainly the cilium-dbg.
 // It needs to initialized beforehand via the Cilium Agent.
-func RetriesMaps(ipv4, ipv6, natRequired bool) (ipv4RetriesMap, ipv6RetriesMap RetriesMap) {
-	if !natRequired {
-		return
-	}
+func RetriesMaps(ipv4 bool, ipv6 bool) (ipv4RetriesMap, ipv6RetriesMap RetriesMap) {
 	if ipv4 {
 		ipv4RetriesMap = newRetriesMap(mapNameSnat4AllocRetries)
 	}


### PR DESCRIPTION
This commit removes the unnecessary argument `natRequired` from the function `nat.RetriesMaps`. Callers (`cilium-dbg` commands) always pass `true`.

follow up of / overlooked in https://github.com/cilium/cilium/pull/43140