### PR TITLE
[v1.16] .github: Consistently clean up workers on start

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -254,7 +254,6 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
-        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -507,7 +507,6 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
-        if: runner.name == 'ubuntu-latest'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables


### PR DESCRIPTION
Manual backport of

* [ ] #39644

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 39644
```