### PR TITLE
.github/workflows: copy stable workflows to main branch

### DIFF
--- a/.github/workflows/auto-labeler-v1.18.yaml
+++ b/.github/workflows/auto-labeler-v1.18.yaml
@@ -1,0 +1,88 @@
+name: PR and Issues Auto Labeler
+
+on:
+  pull_request_target:
+    branches:
+      - v1.18
+    types:
+      - opened
+      - reopened
+
+jobs:
+  external-contributions:
+    if: |
+      (
+        (github.event.pull_request.author_association != 'OWNER') &&
+        (github.event.pull_request.author_association != 'COLLABORATOR') &&
+        (github.event.pull_request.author_association != 'MEMBER')
+      )
+    runs-on: ubuntu-24.04
+    name: External Contributions
+    permissions:
+      pull-requests: write
+    steps:
+        # Detect if the secret 'CHECK_TEAM_ORG_APP_ID' is set. If it's not set, don't
+        # bother running this GH workflow.
+      - name: Check if CHECK_TEAM_ORG_APP_ID is set in github secrets
+        id: check_secret
+        run: |
+          echo "is_CHECK_TEAM_ORG_APP_ID_set: ${{ secrets.CHECK_TEAM_ORG_APP_ID != '' }}"
+          echo is_CHECK_TEAM_ORG_APP_ID_set="${{ secrets.CHECK_TEAM_ORG_APP_ID != '' }}" >> $GITHUB_OUTPUT
+
+      - name: Get token
+        # Get a token with the read:org permissions so that the GH action
+        # can read the team membership for a user. We need to do this over a
+        # GH app because GH actions don't have support for these type of
+        # permissions.
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.CHECK_TEAM_ORG_PEM }}
+          APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}
+
+      - name: Check author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        id: author_association
+        # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+        with:
+          github-token: ${{ steps.get_token.outputs.app_token }}
+          script: |
+            try {
+              const result = await github.rest.orgs.checkMembershipForUser({
+                org: "${{ github.repository_owner }}",
+                username: "${{github.event.pull_request.user.login}}",
+              })
+              return result.status == 204;
+            } catch {
+              return false;
+            }
+
+      - name: Print author association
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
+        run: |
+          echo author_association_from_event=${{ github.event.pull_request.author_association }}
+          echo author_association_from_api=${{ steps.author_association.outputs.result }}
+
+      - name: Set label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' && steps.author_association.outputs.result != 'true' }}
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["kind/community-contribution"]
+            })
+
+  auto-labeler:
+    name: Auto Labeler
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Label The PR
+      uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/.github/workflows/build-images-base-v1.16.yaml
+++ b/.github/workflows/build-images-base-v1.16.yaml
@@ -1,0 +1,363 @@
+name: Base Image Release Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.16
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - images/runtime/**
+      - images/builder/**
+  # This workflow can be reused so that renovate can execute this workflow_dispatch:
+  # run from a different environment than 'release-base-images'. See
+  # build-images-base-renovate.yaml
+  workflow_call:
+    secrets:
+      QUAY_BASE_RELEASE_USERNAME_202411:
+        required: true
+      QUAY_BASE_RELEASE_PASSWORD_202411:
+        required: true
+      AUTO_COMMITTER_PEM_202411:
+        required: true
+      AUTO_COMMITTER_APP_ID_202411:
+        required: true
+    inputs:
+      environment:
+        type: string
+        default: "release-base-images"
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    # Skip this workflow for branches that are created by renovate and event type is pull_request_target
+    if: ${{ ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
+    name: Build and Push Images
+    timeout-minutes: 60
+    environment: ${{ inputs.environment || 'release-base-images' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch/images/runtime/
+          cp ./images/runtime/update-cilium-runtime-image.sh ../cilium-base-branch/images/runtime/
+          mkdir -p ../cilium-base-branch/images/builder/
+          cp ./images/builder/update-cilium-builder-image.sh ../cilium-base-branch/images/builder/
+          mkdir -p ../cilium-base-branch/images/scripts/
+          cp ./images/scripts/get-image-digest.sh ../cilium-base-branch/images/scripts/
+          mkdir -p ../cilium-base-branch/api/v1
+          cp ./api/v1/Makefile ../cilium-base-branch/api/v1/
+          cp ./Makefile.defs ../cilium-base-branch/Makefile.defs
+          cp ./Makefile.quiet ../cilium-base-branch/Makefile.quiet
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set-up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Generating image tag for Cilium-Runtime
+        id: runtime-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/runtime | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Checking if tag for Cilium-Runtime already exists
+        id: cilium-runtime-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{  steps.runtime-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 }}
+          password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD_202411 }}
+
+      - name: Release build cilium-runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_release_runtime
+        with:
+          provenance: false
+          context: ./images/runtime
+          file: ./images/runtime/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+
+      - name: Sign Container Image Runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${{ steps.docker_build_release_runtime.outputs.digest }}
+
+
+      - name: Generate SBOM
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+
+      - name: Attach SBOM to Container Image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign attach sbom --sbom sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${{ steps.docker_build_release_runtime.outputs.digest }}
+
+      - name: Sign SBOM Image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          docker_build_release_runtime_digest="${{ steps.docker_build_release_runtime.outputs.digest }}"
+          image_name="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${docker_build_release_runtime_digest/:/-}.sbom"
+          docker_build_release_runtime_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign -y "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${docker_build_release_runtime_sbom_digest}"
+
+      - name: Image Release Digest Runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## cilium-runtime" > image-digest/cilium-runtime.txt
+          echo "" >> image-digest/cilium-runtime.txt
+          echo "\`quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}\`" >> image-digest/cilium-runtime.txt
+          echo "" >> image-digest/cilium-runtime.txt
+
+      - name: Upload artifact digests runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest cilium-runtime
+          path: image-digest
+          retention-days: 1
+
+      - name: Update Runtime Image
+        id: update-runtime-image
+        run: |
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+          if ! git diff --quiet; then
+            git commit -sam "images: update cilium-{runtime,builder}"
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generating image tag for Cilium-Builder
+        id: builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/builder | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Checking if tag for Cilium-Builder already exists
+        id: cilium-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{  steps.builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' && steps.cilium-runtime-tag-in-repositories.outputs.exists != 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 }}
+          password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD_202411 }}
+
+      - name: Release build cilium-builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_release_builder
+        with:
+          provenance: false
+          context: ./images/builder
+          file: ./images/builder/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+
+      - name: Sign Container Image Builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${{ steps.docker_build_release_builder.outputs.digest }}
+
+      - name: Generate SBOM
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+
+      - name: Attach SBOM to Container Image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign attach sbom --sbom sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${{ steps.docker_build_release_builder.outputs.digest }}
+
+      - name: Sign SBOM Image
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          docker_build_release_builder_digest="${{ steps.docker_build_release_builder.outputs.digest }}"
+          image_name="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${docker_build_release_builder_digest/:/-}.sbom"
+          docker_build_release_builder_sbom_digest="sha256:$(docker buildx imagetools inspect --raw ${image_name} | sha256sum | head -c 64)"
+          cosign sign -y "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${docker_build_release_builder_sbom_digest}"
+
+      - name: Image Release Digest Builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## cilium-builder" > image-digest/cilium-builder.txt
+          echo "" >> image-digest/cilium-builder.txt
+          echo "\`quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}\`" >> image-digest/cilium-builder.txt
+          echo "" >> image-digest/cilium-builder.txt
+
+      - name: Upload artifact digests builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest cilium-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Update Runtime Image
+        run: |
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+
+      - name: Update Builder Images
+        run: |
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+
+      - name: Update protobuf APIs and commit changes
+        id: update-builder-image
+        run: |
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+            export CONTAINER_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+            export CONTAINER_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+          export VOLUME=$PWD/api/v1
+          make -C ../cilium-base-branch/api/v1
+          if ! git diff --quiet; then
+            if [[ "${{ steps.update-runtime-image.outputs.committed }}" == "true" ]]; then
+              git commit --amend -sam "images: update cilium-{runtime,builder}"
+            else
+              git commit -sam "images: update cilium-{runtime,builder}"
+            fi
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get token
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM_202411 }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID_202411 }}
+
+      - name: Push changes into PR
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
+        env:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
+
+  image-digests:
+    name: Display Digests
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment || 'release-base-images' }}
+    needs: build-and-push
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: image-digest/
+          pattern: "*image-digest *"
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/build-images-base-v1.17.yaml
+++ b/.github/workflows/build-images-base-v1.17.yaml
@@ -1,0 +1,364 @@
+name: Base Image Release Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.17
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - images/runtime/**
+      - images/builder/**
+  # This workflow can be reused so that renovate can execute this workflow_dispatch:
+  # run from a different environment than 'release-base-images'. See
+  # build-images-base-renovate.yaml
+  workflow_call:
+    secrets:
+      QUAY_BASE_RELEASE_USERNAME_202411:
+        required: true
+      QUAY_BASE_RELEASE_PASSWORD_202411:
+        required: true
+      AUTO_COMMITTER_PEM_202411:
+        required: true
+      AUTO_COMMITTER_APP_ID_202411:
+        required: true
+    inputs:
+      environment:
+        type: string
+        default: "release-base-images"
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  has-credentials:
+    name: Check for Quay secrets
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment || 'release-base-images' }}
+    timeout-minutes: 2
+    outputs:
+      present: ${{ steps.secrets.outputs.present }}
+    steps:
+      - name: Check for secrets
+        id: secrets
+        env:
+          has_credentials: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 && secrets.QUAY_BASE_RELEASE_PASSWORD_202411 && 1 }}
+        if: ${{ env.has_credentials }}
+        run:
+          echo 'present=1' >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    needs: has-credentials
+    # Skip this workflow for repositories without credentials and branches that are created by renovate where the event type is pull_request_target
+    if: ${{ needs.has-credentials.outputs.present && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
+    name: Build and Push Images
+    timeout-minutes: 60
+    environment: ${{ inputs.environment || 'release-base-images' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch/images/runtime/
+          cp ./images/runtime/update-cilium-runtime-image.sh ../cilium-base-branch/images/runtime/
+          mkdir -p ../cilium-base-branch/images/builder/
+          cp ./images/builder/update-cilium-builder-image.sh ../cilium-base-branch/images/builder/
+          mkdir -p ../cilium-base-branch/images/scripts/
+          cp ./images/scripts/get-image-digest.sh ../cilium-base-branch/images/scripts/
+          mkdir -p ../cilium-base-branch/api/v1
+          cp ./api/v1/Makefile ../cilium-base-branch/api/v1/
+          cp ./Makefile.defs ../cilium-base-branch/Makefile.defs
+          cp ./Makefile.quiet ../cilium-base-branch/Makefile.quiet
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set-up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Generating image tag for Cilium-Runtime
+        id: runtime-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/runtime | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Checking if tag for Cilium-Runtime already exists
+        id: cilium-runtime-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{  steps.runtime-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 }}
+          password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD_202411 }}
+
+      - name: Release build cilium-runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_release_runtime
+        with:
+          provenance: false
+          context: ./images/runtime
+          file: ./images/runtime/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+
+      - name: Sign Container Image Runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${{ steps.docker_build_release_runtime.outputs.digest }}
+
+
+      - name: Generate SBOM
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+
+      - name: Attach SBOM attestation to container image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign attest -y --predicate sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${{ steps.docker_build_release_runtime.outputs.digest }}
+
+      - name: Image Release Digest Runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## cilium-runtime" > image-digest/cilium-runtime.txt
+          echo "" >> image-digest/cilium-runtime.txt
+          echo "\`quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}\`" >> image-digest/cilium-runtime.txt
+          echo "" >> image-digest/cilium-runtime.txt
+
+      - name: Upload artifact digests runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest cilium-runtime
+          path: image-digest
+          retention-days: 1
+
+      - name: Update Runtime Image
+        id: update-runtime-image
+        run: |
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+          if ! git diff --quiet; then
+            git commit -sam "images: update cilium-{runtime,builder}"
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generating image tag for Cilium-Builder
+        id: builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/builder | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Checking if tag for Cilium-Builder already exists
+        id: cilium-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{  steps.builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' && steps.cilium-runtime-tag-in-repositories.outputs.exists != 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 }}
+          password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD_202411 }}
+
+      - name: Release build cilium-builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_release_builder
+        with:
+          provenance: false
+          context: ./images/builder
+          file: ./images/builder/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+
+      - name: Sign Container Image Builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${{ steps.docker_build_release_builder.outputs.digest }}
+
+      - name: Generate SBOM
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+
+      - name: Attach SBOM attestation to container image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign attest -y --predicate sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${{ steps.docker_build_release_builder.outputs.digest }}
+
+      - name: Image Release Digest Builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## cilium-builder" > image-digest/cilium-builder.txt
+          echo "" >> image-digest/cilium-builder.txt
+          echo "\`quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}\`" >> image-digest/cilium-builder.txt
+          echo "" >> image-digest/cilium-builder.txt
+
+      - name: Upload artifact digests builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest cilium-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Update Runtime Image
+        run: |
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+
+      - name: Update Builder Images
+        run: |
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+
+      - name: Update protobuf APIs and commit changes
+        id: update-builder-image
+        run: |
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+            export CONTAINER_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+            export CONTAINER_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+          export VOLUME=$PWD/api/v1
+          make -C ../cilium-base-branch/api/v1
+          if ! git diff --quiet; then
+            if [[ "${{ steps.update-runtime-image.outputs.committed }}" == "true" ]]; then
+              git commit --amend -sam "images: update cilium-{runtime,builder}"
+            else
+              git commit -sam "images: update cilium-{runtime,builder}"
+            fi
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get token
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM_202411 }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID_202411 }}
+
+      - name: Push changes into PR
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
+        env:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
+
+  image-digests:
+    name: Display Digests
+    runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment || 'release-base-images' }}
+    needs: build-and-push
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: image-digest/
+          pattern: "*image-digest *"
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/build-images-base-v1.18.yaml
+++ b/.github/workflows/build-images-base-v1.18.yaml
@@ -1,0 +1,336 @@
+name: Base Image Release Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.18
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - images/runtime/**
+      - images/builder/**
+  # This workflow can be reused so that renovate can execute this workflow_dispatch:
+  # run from a different environment than 'release-base-images'. See
+  # build-images-base-renovate.yaml
+  workflow_call:
+    secrets:
+      QUAY_BASE_RELEASE_USERNAME_202411:
+        required: true
+      QUAY_BASE_RELEASE_PASSWORD_202411:
+        required: true
+      AUTO_COMMITTER_PEM_202411:
+        required: true
+      AUTO_COMMITTER_APP_ID_202411:
+        required: true
+    inputs:
+      environment:
+        required: true
+        type: string
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    # Skip this workflow for repositories without credentials and branches that are created by renovate where the event type is pull_request_target
+    if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
+    name: Build and Push Images
+    timeout-minutes: 60
+    environment: ${{ inputs.environment || 'release-base-images' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout base or default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # This workflow is supposed to run only on pull_request_target context, but in case workflow call is made from a push context we still keep the default to default_branch
+          ref: ${{ github.base_ref || github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch/images/runtime/
+          cp ./images/runtime/update-cilium-runtime-image.sh ../cilium-base-branch/images/runtime/
+          mkdir -p ../cilium-base-branch/images/builder/
+          cp ./images/builder/update-cilium-builder-image.sh ../cilium-base-branch/images/builder/
+          mkdir -p ../cilium-base-branch/images/scripts/
+          cp ./images/scripts/get-image-digest.sh ../cilium-base-branch/images/scripts/
+          mkdir -p ../cilium-base-branch/api/v1
+          cp ./api/v1/Makefile ../cilium-base-branch/api/v1/
+          cp ./Makefile.defs ../cilium-base-branch/Makefile.defs
+          cp ./Makefile.quiet ../cilium-base-branch/Makefile.quiet
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set-up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Generating image tag for Cilium-Runtime
+        id: runtime-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/runtime | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Checking if tag for Cilium-Runtime already exists
+        id: cilium-runtime-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{  steps.runtime-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 }}
+          password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD_202411 }}
+
+      - name: Release build cilium-runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_release_runtime
+        with:
+          provenance: false
+          context: ./images/runtime
+          file: ./images/runtime/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+
+      - name: Sign Container Image Runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${{ steps.docker_build_release_runtime.outputs.digest }}
+
+
+      - name: Generate SBOM
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}
+
+      - name: Attach SBOM attestation to container image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign attest -y --predicate sbom_cilium-runtime_${{ steps.runtime-tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime@${{ steps.docker_build_release_runtime.outputs.digest }}
+
+      - name: Image Release Digest Runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## cilium-runtime" > image-digest/cilium-runtime.txt
+          echo "" >> image-digest/cilium-runtime.txt
+          echo "\`quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}\`" >> image-digest/cilium-runtime.txt
+          echo "" >> image-digest/cilium-runtime.txt
+
+      - name: Upload artifact digests runtime
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest cilium-runtime
+          path: image-digest
+          retention-days: 1
+
+      - name: Update Runtime Image
+        id: update-runtime-image
+        run: |
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+          if ! git diff --quiet; then
+            git commit -sam "images: update cilium-{runtime,builder}"
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generating image tag for Cilium-Builder
+        id: builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./images/builder | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Checking if tag for Cilium-Builder already exists
+        id: cilium-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{  steps.builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' && steps.cilium-runtime-tag-in-repositories.outputs.exists != 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_BASE_RELEASE_USERNAME_202411 }}
+          password: ${{ secrets.QUAY_BASE_RELEASE_PASSWORD_202411 }}
+
+      - name: Release build cilium-builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_release_builder
+        with:
+          provenance: false
+          context: ./images/builder
+          file: ./images/builder/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+
+      - name: Sign Container Image Builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${{ steps.docker_build_release_builder.outputs.digest }}
+
+      - name: Generate SBOM
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}
+
+      - name: Attach SBOM attestation to container image
+        if: ${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}
+        run: |
+          cosign attest -y --predicate sbom_cilium-builder_${{ steps.builder-tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder@${{ steps.docker_build_release_builder.outputs.digest }}
+
+      - name: Image Release Digest Builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          echo "## cilium-builder" > image-digest/cilium-builder.txt
+          echo "" >> image-digest/cilium-builder.txt
+          echo "\`quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}\`" >> image-digest/cilium-builder.txt
+          echo "" >> image-digest/cilium-builder.txt
+
+      - name: Upload artifact digests builder
+        if: ${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest cilium-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Update Runtime Image
+        run: |
+          if [[ "${{ steps.cilium-runtime-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${{ steps.docker_build_release_runtime.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}")
+            ../cilium-base-branch/images/runtime/update-cilium-runtime-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-runtime:${{ steps.runtime-tag.outputs.tag }}@${digest}"
+          fi
+
+      - name: Update Builder Images
+        run: |
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+
+      - name: Update protobuf APIs and commit changes
+        id: update-builder-image
+        run: |
+          if [[ "${{ steps.cilium-builder-tag-in-repositories.outputs.exists == 'false' }}" == "true" ]]; then
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}"
+            export CONTAINER_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${{ steps.docker_build_release_builder.outputs.digest }}
+          else
+            digest=$(../cilium-base-branch/images/scripts/get-image-digest.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}")
+            ../cilium-base-branch/images/builder/update-cilium-builder-image.sh "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+            export CONTAINER_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-builder:${{ steps.builder-tag.outputs.tag }}@${digest}"
+          fi
+          export VOLUME=$PWD/api/v1
+          make -C ../cilium-base-branch/api/v1
+          if ! git diff --quiet; then
+            if [[ "${{ steps.update-runtime-image.outputs.committed }}" == "true" ]]; then
+              git commit --amend -sam "images: update cilium-{runtime,builder}"
+            else
+              git commit -sam "images: update cilium-{runtime,builder}"
+            fi
+            echo committed="true" >> $GITHUB_OUTPUT
+          else
+            echo committed="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get token
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM_202411 }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID_202411 }}
+
+      - name: Push changes into PR
+        if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
+        env:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
+
+      - name: Prepare for Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: image-digest/
+          pattern: "*image-digest *"
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/build-images-ci-v1.16.yaml
+++ b/.github/workflows/build-images-ci-v1.16.yaml
@@ -1,0 +1,394 @@
+name: Image CI Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.16
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - v1.16
+      - ft/v1.16/**
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+  # To be able to check if base images were built
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || (github.event_name == 'merge_group' && github.run_id) }}
+  cancel-in-progress: true
+
+jobs:
+  wait-for-base-images:
+    name: Wait for lint checks
+    uses: ./.github/workflows/wait-for-status-check.yaml
+    with:
+      # Only run this job if the event is pull_request_target and if the PR
+      # is not opened from a fork.
+      # This is to avoid waiting for base images on push to main or merge_group
+      # events as the lint-images-base does not run on those events.
+      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
+      timeout-minutes: 2
+      poll-interval: 15
+
+  build-and-push-prs:
+    timeout-minutes: 45
+    name: Build and Push Images
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-latest' }}
+    needs: wait-for-base-images
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+            dockerfile: ./images/cilium/Dockerfile
+
+          - name: operator-aws
+            dockerfile: ./images/operator/Dockerfile
+
+          - name: operator-azure
+            dockerfile: ./images/operator/Dockerfile
+
+          - name: operator-alibabacloud
+            dockerfile: ./images/operator/Dockerfile
+
+          - name: operator-generic
+            dockerfile: ./images/operator/Dockerfile
+
+          - name: hubble-relay
+            dockerfile: ./images/hubble-relay/Dockerfile
+
+          - name: clustermesh-apiserver
+            dockerfile: ./images/clustermesh-apiserver/Dockerfile
+
+          - name: docker-plugin
+            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Check for disk usage and cleanup /mnt
+        shell: bash
+        run: |
+          echo "# Disk usage"
+          df -h
+          echo "# Usage for /mnt"
+          sudo du --human-readable \
+                --threshold 50m \
+                -- /mnt
+          echo "# Removing all contents of /mnt except /mnt/swapfile"
+          sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
+
+      - name: Setup docker volumes into /mnt
+        # This allows us to make use of all available disk.
+        shell: bash
+        run: |
+          sudo systemctl stop docker
+          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
+          sudo ln -s /mnt/docker-volumes /var/lib/docker/volumes
+          sudo systemctl start docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        # Disable GC entirely to avoid buildkit from GC caches.
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+             gc=false
+
+      - name: Login to quay.io for CI
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_CI }}
+          password: ${{ secrets.QUAY_PASSWORD_CI }}
+
+      - name: Getting image tag
+        id: tag
+        run: |
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
+            tag=${{ github.event.pull_request.head.sha }}
+          else
+            tag=${{ github.sha }}
+          fi
+          if [[ "${{ github.event_name == 'push' }}" == "true" ]]; then
+            if [[ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
+              floating_tag=latest
+            else
+              floating_tag="${{ github.ref_name }}"
+            fi
+            echo floating_tag=${floating_tag} >> $GITHUB_OUTPUT
+          fi
+          echo tag=${tag} >> $GITHUB_OUTPUT
+
+          normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${tag}"
+          race_tag="${normal_tag}-race"
+          unstripped_tag="${normal_tag}-unstripped"
+
+          if [ -n "${floating_tag}" ]; then
+            floating_normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${floating_tag}"
+            normal_tag="${normal_tag},${floating_normal_tag}"
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build race and unstripped images for merge_group or push events.
+            race_tag=""
+            unstripped_tag=""
+          fi
+
+          echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
+          echo race_tag=${race_tag} >> $GITHUB_OUTPUT
+          echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+
+      # Load Golang cache build from GitHub
+      - name: Restore Golang cache build from GitHub
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        id: go-cache
+        with:
+          path: /tmp/.cache/go
+          key: ${{ runner.os }}-go-${{ matrix.name }}-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.name }}-cache-
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+          docker buildx du
+
+      - name: Create cache directories if they don't exist
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/go
+
+      # Import GitHub's cache build to docker cache
+      - name: Copy ${{ matrix.name }} Golang cache to docker cache
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          provenance: false
+          context: /tmp/.cache/go
+          file: ./images/cache/Dockerfile
+          push: false
+          platforms: linux/amd64
+          target: import-cache
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+          docker buildx du
+
+      - name: Check build constraints
+        id: check
+        run: |
+          echo build="true" >> $GITHUB_OUTPUT
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: CI Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tag.outputs.normal_tag }}
+          target: release
+          build-args: |
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: CI race detection Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci_detect_race_condition
+        if: ${{ steps.check.outputs.build != '' && steps.tag.outputs.race_tag != ''}}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.race_tag }}
+          target: release
+          build-args: |
+            BASE_IMAGE=quay.io/cilium/cilium-runtime:b21eb30e9334659f2f5b42ec71ad373fc6a10239@sha256:96a219d4c99c02049fecc7798a0f3a0494a4e589115cb36172e75c7d0383c148
+            MODIFIERS="LOCKDEBUG=1 RACE=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: CI Unstripped Binaries Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci_unstripped
+        if: ${{ steps.check.outputs.build != '' && steps.tag.outputs.unstripped_tag != ''}}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.unstripped_tag }}
+          target: release
+          build-args: |
+            MODIFIERS="NOSTRIP=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Sign Container Images
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          fi
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: Generate SBOM (race)
+        if: ${{ matrix.name != 'cilium-cli' && steps.docker_build_ci_detect_race_condition.outcome != 'skipped' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
+
+      - name: Generate SBOM (unstripped)
+        if: ${{ matrix.name != 'cilium-cli' && steps.docker_build_ci_unstripped.outcome != 'skipped' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
+
+      - name: Attach SBOM to Container Images
+        run: |
+          cosign attest -y --predicate sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            cosign attest -y --predicate sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            cosign attest -y --predicate sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          fi
+
+      - name: CI Image Releases digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+          # shellcheck disable=SC2078
+          if [ ${{ github.event_name == 'push' && !startsWith(github.ref_name, 'ft/') }} ]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}@${{ steps.docker_build_ci.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          fi
+          echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped@${{ steps.docker_build_ci_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          fi
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+
+      - name: Check for disk usage
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          df -h
+
+  image-digests:
+    if: ${{ always() }}
+    name: Display Digests
+    runs-on: ubuntu-24.04
+    needs: build-and-push-prs
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: image-digest/
+          pattern: "*image-digest *"
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat
+
+  pre-comment:
+    # Avoid running the "Trigger CI from renovate PRs" environment if we don't need to.
+    name: Pre-Comment
+    needs: build-and-push-prs
+    runs-on: ubuntu-24.04
+    if: ${{
+         github.event_name == 'pull_request_target' &&
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
+        }}
+    steps:
+    - name: Debug
+      run: |
+        echo ${{ github.event.pull_request.user.login }}
+        echo ${{ github.event.event_name }}
+
+  comment:
+    name: Post test comment for Renovate PRs after images built
+    runs-on: ubuntu-24.04
+    needs: pre-comment
+    environment: "Trigger CI from renovate PRs"
+    if: ${{
+         github.event_name == 'pull_request_target' &&
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
+        }}
+    steps:
+      - name: Post /test comment
+        env:
+          TOKEN: ${{ secrets.AUTO_COMMENT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo ${TOKEN} | gh auth login --with-token
+          gh pr --repo ${GITHUB_REPOSITORY} comment ${PULL_REQUEST_NUMBER} --body "/test"

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -1,0 +1,433 @@
+name: Image CI Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.17
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - v1.17
+      - ft/v1.17/**
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+  # To be able to check if base images were built
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || (github.event_name == 'merge_group' && github.run_id) }}
+  cancel-in-progress: true
+
+jobs:
+  wait-for-base-images:
+    name: Wait for lint checks
+    uses: ./.github/workflows/wait-for-status-check.yaml
+    with:
+      # Only run this job if the event is pull_request_target and if the PR
+      # is not opened from a fork.
+      # This is to avoid waiting for base images on push to main or merge_group
+      # events as the lint-images-base does not run on those events.
+      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
+      timeout-minutes: 2
+      poll-interval: 15
+
+  build-and-push-prs:
+    timeout-minutes: 45
+    name: Build and Push Images
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-latest' }}
+    needs: wait-for-base-images
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+            dockerfile: ./images/cilium/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: cilium-cli
+            dockerfile: ./cilium-cli/Dockerfile
+            platforms: linux/amd64
+            require-dir: cilium-cli
+
+          - name: operator-aws
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: operator-azure
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: operator-alibabacloud
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: operator-generic
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: hubble-relay
+            dockerfile: ./images/hubble-relay/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: clustermesh-apiserver
+            dockerfile: ./images/clustermesh-apiserver/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: docker-plugin
+            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch
+          cp -r .github/actions/set-runtime-image ../cilium-base-branch
+
+      - name: Check for disk usage and cleanup /mnt
+        shell: bash
+        run: |
+          echo "# Disk usage"
+          df -h
+          echo "# Usage for /mnt"
+          sudo du --human-readable \
+                --threshold 50m \
+                -- /mnt
+          echo "# Removing all contents of /mnt except /mnt/swapfile"
+          sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
+
+      - name: Setup docker volumes into /mnt
+        # This allows us to make use of all available disk.
+        shell: bash
+        run: |
+          sudo systemctl stop docker
+          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
+          sudo ln -s /mnt/docker-volumes /var/lib/docker/volumes
+          sudo systemctl start docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        # Disable GC entirely to avoid buildkit from GC caches.
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+             gc=false
+
+      - name: Login to quay.io for CI
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_CI }}
+          password: ${{ secrets.QUAY_PASSWORD_CI }}
+
+      - name: Getting image tag
+        id: tag
+        run: |
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
+            tag=${{ github.event.pull_request.head.sha }}
+          else
+            tag=${{ github.sha }}
+          fi
+          if [[ "${{ github.event_name == 'push' }}" == "true" ]]; then
+            if [[ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
+              floating_tag=latest
+            else
+              floating_tag="${{ github.ref_name }}"
+            fi
+            echo floating_tag=${floating_tag} >> $GITHUB_OUTPUT
+          fi
+          echo tag=${tag} >> $GITHUB_OUTPUT
+
+          normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${tag}"
+          race_tag="${normal_tag}-race"
+          unstripped_tag="${normal_tag}-unstripped"
+
+          if [ -n "${floating_tag}" ]; then
+            floating_normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${floating_tag}"
+            normal_tag="${normal_tag},${floating_normal_tag}"
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build race and unstripped images for merge_group or push events.
+            race_tag=""
+            unstripped_tag=""
+          fi
+
+          echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
+          echo race_tag=${race_tag} >> $GITHUB_OUTPUT
+          echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+
+      - name: Copy runtime image tag from untrusted branch
+        run: |
+          cp -r .github/actions/set-runtime-image/runtime-image.txt ../cilium-base-branch/set-runtime-image/
+
+      - name: Set runtime image environment variable
+        uses: ./../cilium-base-branch/set-runtime-image
+        with:
+          repository: ${{ env.CILIUM_RUNTIME_IMAGE_PREFIX }}
+
+      # Load Golang cache build from GitHub
+      - name: Restore Golang cache build from GitHub
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        id: go-cache
+        with:
+          path: /tmp/.cache/go
+          key: ${{ runner.os }}-go-${{ matrix.name }}-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.name }}-cache-
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+          docker buildx du
+
+      - name: Create cache directories if they don't exist
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/go
+
+      # Import GitHub's cache build to docker cache
+      - name: Copy ${{ matrix.name }} Golang cache to docker cache
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          provenance: false
+          context: /tmp/.cache/go
+          file: ./images/cache/Dockerfile
+          push: false
+          platforms: linux/amd64
+          target: import-cache
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+          docker buildx du
+
+      - name: Check build constraints
+        id: check
+        run: |
+          if [[ -z "${{ matrix.require-dir }}" ]] ||
+             [[ -d "${{ matrix.require-dir }}" ]]; then
+            echo build="true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: CI Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci
+        if: ${{ steps.check.outputs.build != '' }}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: ${{ matrix.platforms }}
+          tags: ${{ steps.tag.outputs.normal_tag }}
+          target: release
+          build-args: |
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: CI race detection Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci_detect_race_condition
+        if: ${{ steps.check.outputs.build != '' && steps.tag.outputs.race_tag != ''}}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.race_tag }}
+          target: release
+          build-args: |
+            BASE_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            MODIFIERS="LOCKDEBUG=1 RACE=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: CI Unstripped Binaries Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci_unstripped
+        if: ${{ steps.check.outputs.build != '' && steps.tag.outputs.unstripped_tag != ''}}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.unstripped_tag }}
+          target: release
+          build-args: |
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            MODIFIERS="NOSTRIP=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Sign Container Images
+        if: ${{ steps.check.outputs.build != '' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          fi
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        if: ${{ matrix.name != 'cilium-cli' }}
+        with:
+          artifact-name: sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: Generate SBOM (race)
+        if: ${{ matrix.name != 'cilium-cli' && steps.docker_build_ci_detect_race_condition.outcome != 'skipped' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
+
+      - name: Generate SBOM (unstripped)
+        if: ${{ matrix.name != 'cilium-cli' && steps.docker_build_ci_unstripped.outcome != 'skipped' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
+
+      - name: Attach SBOM attestation to container image
+        if: ${{ matrix.name != 'cilium-cli' }}
+        run: |
+          cosign attest -y --predicate sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            cosign attest -y --predicate sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            cosign attest -y --predicate sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          fi
+
+      - name: CI Image Releases digests
+        shell: bash
+        if: ${{ steps.check.outputs.build != '' }}
+        run: |
+          mkdir -p image-digest/
+          # shellcheck disable=SC2078
+          if [ ${{ github.event_name == 'push' && !startsWith(github.ref_name, 'ft/') }} ]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}@${{ steps.docker_build_ci.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          fi
+          echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped@${{ steps.docker_build_ci_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          fi
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        if: ${{ steps.check.outputs.build != '' }}
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+
+      - name: Check for disk usage
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          df -h
+
+  image-digests:
+    if: ${{ always() }}
+    name: Display Digests
+    runs-on: ubuntu-24.04
+    needs: build-and-push-prs
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: image-digest/
+          pattern: "*image-digest *"
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat
+
+  pre-comment:
+    # Avoid running the "Trigger CI from renovate PRs" environment if we don't need to.
+    name: Pre-Comment
+    needs: build-and-push-prs
+    runs-on: ubuntu-24.04
+    if: ${{
+         github.event_name == 'pull_request_target' &&
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
+        }}
+    steps:
+    - name: Debug
+      run: |
+        echo ${{ github.event.pull_request.user.login }}
+        echo ${{ github.event.event_name }}
+
+  comment:
+    name: Post test comment for Renovate PRs after images built
+    runs-on: ubuntu-24.04
+    needs: pre-comment
+    environment: "Trigger CI from renovate PRs"
+    if: ${{
+         github.event_name == 'pull_request_target' &&
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
+        }}
+    steps:
+      - name: Post /test comment
+        env:
+          TOKEN: ${{ secrets.AUTO_COMMENT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo ${TOKEN} | gh auth login --with-token
+          gh pr --repo ${GITHUB_REPOSITORY} comment ${PULL_REQUEST_NUMBER} --body "/test"

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -1,0 +1,459 @@
+name: Image CI Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.18
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - v1.18
+      - ft/v1.18/**
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
+  # To be able to check if base images were built
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || (github.event_name == 'merge_group' && github.run_id) }}
+  cancel-in-progress: true
+
+jobs:
+  wait-for-base-images:
+    name: Wait for lint checks
+    uses: ./.github/workflows/wait-for-status-check.yaml
+    with:
+      # Only run this job if the event is pull_request_target and if the PR
+      # is not opened from a fork.
+      # This is to avoid waiting for base images on push to main or merge_group
+      # events as the lint-images-base does not run on those events.
+      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
+      timeout-minutes: 2
+      poll-interval: 15
+
+  build-and-push-prs:
+    timeout-minutes: 45
+    name: Build and Push Images
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    needs: wait-for-base-images
+    outputs:
+      sha: ${{ steps.tag.outputs.sha }}
+    strategy:
+      matrix:
+        include:
+          - name: cilium
+            dockerfile: ./images/cilium/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: cilium-cli
+            dockerfile: ./cilium-cli/Dockerfile
+            platforms: linux/amd64
+            require-dir: cilium-cli
+
+          - name: operator-aws
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: operator-azure
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: operator-alibabacloud
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: operator-generic
+            dockerfile: ./images/operator/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: hubble-relay
+            dockerfile: ./images/hubble-relay/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: clustermesh-apiserver
+            dockerfile: ./images/clustermesh-apiserver/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+          - name: docker-plugin
+            dockerfile: ./images/cilium-docker-plugin/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
+    steps:
+      - name: Checkout base or default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # We first check if base_ref exist, meaning we're in pull_request_target context, and if not we just use default_branch
+          ref: ${{ github.base_ref || github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch
+          cp -r .github/actions/set-runtime-image ../cilium-base-branch
+
+      - name: Check for disk usage and cleanup /mnt
+        shell: bash
+        run: |
+          echo "# Disk usage"
+          df -h
+          echo "# Usage for /mnt"
+          sudo du --human-readable \
+                --threshold 50m \
+                -- /mnt
+          if compgen -G "/mnt/.*" > /dev/null; then
+            echo "# Hidden files in /mnt:"
+            sudo du --human-readable --threshold 50m -- /mnt/.* 2>/dev/null
+          fi
+          echo "# Removing all contents of /mnt except /mnt/swapfile"
+          sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
+
+      - name: Setup docker volumes into /mnt
+        # This allows us to make use of all available disk.
+        shell: bash
+        run: |
+          sudo systemctl stop docker
+          sudo mv /var/lib/docker/volumes /mnt/docker-volumes
+          sudo ln -s /mnt/docker-volumes /var/lib/docker/volumes
+          sudo systemctl start docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        # Disable GC entirely to avoid buildkit from GC caches.
+        with:
+          buildkitd-config-inline: |
+            [worker.oci]
+             gc=false
+
+      - name: Login to quay.io for CI
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME_CI }}
+          password: ${{ secrets.QUAY_PASSWORD_CI }}
+
+      - name: Getting image tag
+        id: tag
+        run: |
+          if [ "${{ github.event.pull_request.head.sha }}" != "" ]; then
+            sha=${{ github.event.pull_request.head.sha }}
+          else
+            sha=${{ github.sha }}
+          fi
+          echo sha=${sha} >> $GITHUB_OUTPUT
+
+          tag=${sha}
+          echo tag=${tag} >> $GITHUB_OUTPUT
+
+          if [[ "${{ github.event_name == 'push' }}" == "true" ]]; then
+            if [[ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
+              floating_tag=latest
+            else
+              floating_tag="${{ github.ref_name }}"
+              # Remove slashes from branch names
+              floating_tag=${floating_tag##*/}
+            fi
+            echo floating_tag=${floating_tag} >> $GITHUB_OUTPUT
+          fi
+
+          normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${tag}"
+          race_tag="${normal_tag}-race"
+          unstripped_tag="${normal_tag}-unstripped"
+
+          if [ -n "${floating_tag}" ]; then
+            floating_normal_tag="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${floating_tag}"
+            normal_tag="${normal_tag},${floating_normal_tag}"
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build race and unstripped images for merge_group or push events.
+            race_tag=""
+            unstripped_tag=""
+          fi
+
+          echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
+          echo race_tag=${race_tag} >> $GITHUB_OUTPUT
+          echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ steps.tag.outputs.sha }}
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+
+      - name: Copy runtime image tag from untrusted branch
+        run: |
+          cp -r .github/actions/set-runtime-image/runtime-image.txt ../cilium-base-branch/set-runtime-image/
+
+      - name: Set runtime image environment variable
+        uses: ./../cilium-base-branch/set-runtime-image
+        with:
+          repository: ${{ env.CILIUM_RUNTIME_IMAGE_PREFIX }}
+
+      # Load Golang cache build from GitHub
+      - name: Restore Golang cache build from GitHub
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        id: go-cache
+        with:
+          path: /tmp/.cache/go
+          key: ${{ runner.os }}-go-${{ matrix.name }}-cache-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.name }}-cache-
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+          docker buildx du
+
+      - name: Create cache directories if they don't exist
+        if: ${{ steps.go-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.cache/go
+
+      # Import GitHub's cache build to docker cache
+      - name: Copy ${{ matrix.name }} Golang cache to docker cache
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          provenance: false
+          context: /tmp/.cache/go
+          file: ./images/cache/Dockerfile
+          push: false
+          platforms: linux/amd64
+          target: import-cache
+
+      - name: Check for disk usage
+        shell: bash
+        run: |
+          df -h
+          docker buildx du
+
+      - name: Check build constraints
+        id: check
+        run: |
+          if [[ -z "${{ matrix.require-dir }}" ]] ||
+             [[ -d "${{ matrix.require-dir }}" ]]; then
+            echo build="true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: CI Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci
+        if: ${{ steps.check.outputs.build != '' }}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: ${{ matrix.platforms }}
+          tags: ${{ steps.tag.outputs.normal_tag }}
+          target: release
+          build-args: |
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: CI race detection Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci_detect_race_condition
+        if: ${{ steps.check.outputs.build != '' && steps.tag.outputs.race_tag != ''}}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.race_tag }}
+          target: release
+          build-args: |
+            BASE_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            MODIFIERS="LOCKDEBUG=1 RACE=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: CI Unstripped Binaries Build ${{ matrix.name }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker_build_ci_unstripped
+        if: ${{ steps.check.outputs.build != '' && steps.tag.outputs.unstripped_tag != ''}}
+        with:
+          provenance: false
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.tag.outputs.unstripped_tag }}
+          target: release
+          build-args: |
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            MODIFIERS="NOSTRIP=1"
+            OPERATOR_VARIANT=${{ matrix.name }}
+
+      - name: Sign Container Images
+        if: ${{ steps.check.outputs.build != '' }}
+        run: |
+          cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          fi
+
+      - name: Generate SBOM
+        if: ${{ matrix.name != 'cilium-cli' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}
+
+      - name: Generate SBOM (race)
+        if: ${{ matrix.name != 'cilium-cli' && steps.docker_build_ci_detect_race_condition.outcome != 'skipped' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race
+
+      - name: Generate SBOM (unstripped)
+        if: ${{ matrix.name != 'cilium-cli' && steps.docker_build_ci_unstripped.outcome != 'skipped' }}
+        uses: anchore/sbom-action@fbfd9c6c189226748411491745178e0c2017392d # v0.20.10
+        with:
+          artifact-name: sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          output-file: ./sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json
+          image: quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
+
+      - name: Attach SBOM attestation to container image
+        if: ${{ matrix.name != 'cilium-cli' }}
+        run: |
+          cosign attest -y --predicate sbom_ci_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci.outputs.digest }}
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            cosign attest -y --predicate sbom_ci_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            cosign attest -y --predicate sbom_ci_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx.json --type spdxjson quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_unstripped.outputs.digest }}
+          fi
+
+      - name: CI Image Releases digests
+        shell: bash
+        if: ${{ steps.check.outputs.build != '' }}
+        run: |
+          mkdir -p image-digest/
+          # shellcheck disable=SC2078
+          if [ ${{ github.event_name == 'push' && !startsWith(github.ref_name, 'ft/') }} ]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.floating_tag }}@${{ steps.docker_build_ci.outputs.digest }}" > image-digest/${{ matrix.name }}.txt
+          fi
+          echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_ci.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          if [[ "${{ steps.docker_build_ci_detect_race_condition.outcome }}" != 'skipped' ]]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-race@${{ steps.docker_build_ci_detect_race_condition.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          fi
+          if [[ "${{ steps.docker_build_ci_unstripped.outcome }}" != 'skipped' ]]; then
+            echo "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped@${{ steps.docker_build_ci_unstripped.outputs.digest }}" >> image-digest/${{ matrix.name }}.txt
+          fi
+
+      # Upload artifact digests
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        if: ${{ steps.check.outputs.build != '' }}
+        with:
+          name: image-digest ${{ matrix.name }}
+          path: image-digest
+          retention-days: 1
+
+      - name: Check for disk usage
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          df -h
+
+  image-digests:
+    if: ${{ always() }}
+    name: Display Digests
+    runs-on: ubuntu-24.04
+    needs: build-and-push-prs
+    steps:
+      - name: Downloading Image Digests
+        shell: bash
+        run: |
+          mkdir -p image-digest/
+
+      - name: Download digests of all images built
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          path: image-digest/
+          pattern: "*image-digest *"
+
+      - name: Image Digests Output
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat
+
+  push-chart:
+    name: Push dev chart
+    needs: build-and-push-prs
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: ./.github/workflows/push-chart-ci.yaml
+    with:
+      checkout_ref: ${{ needs.build-and-push-prs.outputs.sha }}
+      image_tag: ${{ needs.build-and-push-prs.outputs.sha }}
+    secrets: inherit
+
+  pre-comment:
+    # Avoid running the "Trigger CI from renovate PRs" environment if we don't need to.
+    name: Pre-Comment
+    needs: build-and-push-prs
+    runs-on: ubuntu-24.04
+    if: ${{
+         github.event_name == 'pull_request_target' &&
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
+        }}
+    steps:
+    - name: Debug
+      run: |
+        echo ${{ github.event.pull_request.user.login }}
+        echo ${{ github.event.event_name }}
+
+  comment:
+    name: Post test comment for Renovate PRs after images built
+    runs-on: ubuntu-24.04
+    needs: pre-comment
+    environment: "Trigger CI from renovate PRs"
+    if: ${{
+         github.event_name == 'pull_request_target' &&
+         github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
+        }}
+    steps:
+      - name: Post /test comment
+        env:
+          TOKEN: ${{ secrets.AUTO_COMMENT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo ${TOKEN} | gh auth login --with-token
+          gh pr --repo ${GITHUB_REPOSITORY} comment ${PULL_REQUEST_NUMBER} --body "/test"

--- a/.github/workflows/build-images-docs-builder-v1.16.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.16.yaml
@@ -1,0 +1,185 @@
+name: Docs-builder Image Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.16
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - Documentation/Dockerfile
+      - Documentation/requirements.txt
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: docs-builder
+    outputs:
+      tag: ${{ steps.docs-builder-tag.outputs.tag }}
+      digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Generate image tag for docs-builder
+        id: docs-builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./Documentation | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Check if tag for docs-builder already exists
+        id: docs-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DOCS_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_DOCS_BUILDER_PASSWORD }}
+          logout: true
+
+      - name: Build docs-builder image
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker-build-docs-builder
+        with:
+          provenance: false
+          context: ./Documentation
+          file: ./Documentation/Dockerfile
+          push: true
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }}
+
+  # Use a separate job for the steps below, to ensure we're no longer logged
+  # into Quay.io.
+  update-pr:
+    name: Update Pull Request with new image reference
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: docs-builder
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Update docs-builder image reference in CI workflow
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          # Run in Docker to prevent the script from accessing the environment.
+          docker run --rm -v $PWD:/cilium -w /cilium "${NEW_IMAGE}" \
+              bash -c "git config --global --add safe.directory /cilium && \
+                       /cilium/Documentation/update-docs-builder-image.sh ${NEW_IMAGE}"
+          git commit -sam "ci: update docs-builder"
+
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM_202411 }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID_202411 }}
+
+      - name: Push changes into PR
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.QUAY_ORGANIZATION }}/cilium.git HEAD:"$REF"
+
+  image-digest:
+    name: Retrieve and display image digest
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Retrieve image digest
+        shell: bash
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          mkdir -p image-digest/
+          echo "## docs-builder" > image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+          echo "\`${NEW_IMAGE}\`" >> image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest docs-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Output image digest
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/build-images-docs-builder-v1.17.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.17.yaml
@@ -1,0 +1,185 @@
+name: Docs-builder Image Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.17
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - Documentation/Dockerfile
+      - Documentation/requirements.txt
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: docs-builder
+    outputs:
+      tag: ${{ steps.docs-builder-tag.outputs.tag }}
+      digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Generate image tag for docs-builder
+        id: docs-builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./Documentation | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Check if tag for docs-builder already exists
+        id: docs-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DOCS_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_DOCS_BUILDER_PASSWORD }}
+          logout: true
+
+      - name: Build docs-builder image
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker-build-docs-builder
+        with:
+          provenance: false
+          context: ./Documentation
+          file: ./Documentation/Dockerfile
+          push: true
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }}
+
+  # Use a separate job for the steps below, to ensure we're no longer logged
+  # into Quay.io.
+  update-pr:
+    name: Update Pull Request with new image reference
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: docs-builder
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Update docs-builder image reference in CI workflow
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          # Run in Docker to prevent the script from accessing the environment.
+          docker run --rm -v $PWD:/cilium -w /cilium "${NEW_IMAGE}" \
+              bash -c "git config --global --add safe.directory /cilium && \
+                       /cilium/Documentation/update-docs-builder-image.sh ${NEW_IMAGE}"
+          git commit -sam "ci: update docs-builder"
+
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM_202411 }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID_202411 }}
+
+      - name: Push changes into PR
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git HEAD:"$REF"
+
+  image-digest:
+    name: Retrieve and display image digest
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Retrieve image digest
+        shell: bash
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          mkdir -p image-digest/
+          echo "## docs-builder" > image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+          echo "\`${NEW_IMAGE}\`" >> image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest docs-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Output image digest
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/build-images-docs-builder-v1.18.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.18.yaml
@@ -1,0 +1,185 @@
+name: Docs-builder Image Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    branches:
+      - v1.18
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - Documentation/Dockerfile
+      - Documentation/requirements.txt
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: docs-builder
+    outputs:
+      tag: ${{ steps.docs-builder-tag.outputs.tag }}
+      digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
+    steps:
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Generate image tag for docs-builder
+        id: docs-builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./Documentation | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Check if tag for docs-builder already exists
+        id: docs-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DOCS_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_DOCS_BUILDER_PASSWORD }}
+          logout: true
+
+      - name: Build docs-builder image
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: docker-build-docs-builder
+        with:
+          provenance: false
+          context: ./Documentation
+          file: ./Documentation/Dockerfile
+          push: true
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }}
+
+  # Use a separate job for the steps below, to ensure we're no longer logged
+  # into Quay.io.
+  update-pr:
+    name: Update Pull Request with new image reference
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: docs-builder
+    steps:
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Update docs-builder image reference in CI workflow
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          # Run in Docker to prevent the script from accessing the environment.
+          docker run --rm -v $PWD:/cilium -w /cilium "${NEW_IMAGE}" \
+              bash -c "git config --global --add safe.directory /cilium && \
+                       /cilium/Documentation/update-docs-builder-image.sh ${NEW_IMAGE}"
+          git commit -sam "ci: update docs-builder"
+
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM_202411 }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID_202411 }}
+
+      - name: Push changes into PR
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ github.event.pull_request.head.repo.full_name }}.git HEAD:"$REF"
+
+  image-digest:
+    name: Retrieve and display image digest
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout base branch (trusted)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.base_ref }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Retrieve image digest
+        shell: bash
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          mkdir -p image-digest/
+          echo "## docs-builder" > image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+          echo "\`${NEW_IMAGE}\`" >> image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: image-digest docs-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Output image digest
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/call-backport-label-updater-v1.16.yaml
+++ b/.github/workflows/call-backport-label-updater-v1.16.yaml
@@ -1,0 +1,24 @@
+---
+  name: Call Backport Label Updater
+  on:
+    pull_request_target:
+      types:
+        - closed
+      branches:
+        - v1.16
+
+  jobs:
+    call-backport-label-updater:
+      name: Update backport labels for upstream PR
+      permissions:
+        pull-requests: write
+        repository-projects: read
+      if: |
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.body, 'upstream-prs') &&
+        contains(join(github.event.pull_request.labels.*.name, ', '), 'backport/')
+      uses: cilium/cilium/.github/workflows/update-label-backport-pr.yaml@main
+      with:
+        pr-body: ${{ github.event.pull_request.body }}
+        branch: ${{ github.base_ref }}
+      secrets: inherit

--- a/.github/workflows/call-backport-label-updater-v1.17.yaml
+++ b/.github/workflows/call-backport-label-updater-v1.17.yaml
@@ -1,0 +1,24 @@
+---
+  name: Call Backport Label Updater
+  on:
+    pull_request_target:
+      types:
+        - closed
+      branches:
+        - v1.17
+
+  jobs:
+    call-backport-label-updater:
+      name: Update backport labels for upstream PR
+      permissions:
+        pull-requests: write
+        repository-projects: read
+      if: |
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.body, 'upstream-prs') &&
+        contains(join(github.event.pull_request.labels.*.name, ', '), 'backport/')
+      uses: cilium/cilium/.github/workflows/update-label-backport-pr.yaml@v1.17
+      with:
+        pr-body: ${{ github.event.pull_request.body }}
+        branch: ${{ github.base_ref }}
+      secrets: inherit

--- a/.github/workflows/call-backport-label-updater-v1.18.yaml
+++ b/.github/workflows/call-backport-label-updater-v1.18.yaml
@@ -1,0 +1,24 @@
+---
+  name: Call Backport Label Updater
+  on:
+    pull_request_target:
+      types:
+        - closed
+      branches:
+        - v1.18
+
+  jobs:
+    call-backport-label-updater:
+      name: Update backport labels for upstream PR
+      permissions:
+        pull-requests: write
+        repository-projects: read
+      if: |
+        github.event.pull_request.merged == true &&
+        contains(github.event.pull_request.body, 'upstream-prs') &&
+        contains(join(github.event.pull_request.labels.*.name, ', '), 'backport/')
+      uses: cilium/cilium/.github/workflows/update-label-backport-pr.yaml@v1.18
+      with:
+        pr-body: ${{ github.event.pull_request.body }}
+        branch: ${{ github.base_ref }}
+      secrets: inherit


### PR DESCRIPTION
Due to some recent changes made by GitHub [1], we need to copy the workflows that use pull_request_target type to the default_branch. This will allow us to have a dedicated workflow for each stable branch.

[1] https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/

Siblings PRs:

https://github.com/cilium/cilium/pull/43239
https://github.com/cilium/cilium/pull/43218
https://github.com/cilium/cilium/pull/43219