### PR TITLE
bpf:wireguard: adjust deliver to cilium_host@ingress

### DIFF
--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -51,8 +51,8 @@ static __always_inline int ipv6_host_delivery(struct __ctx_buff *ctx)
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_NET_IFINDEX);
-	return ctx_redirect(ctx, CILIUM_NET_IFINDEX, 0);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_HOST_IFINDEX);
+	return ctx_redirect(ctx, CILIUM_HOST_IFINDEX, BPF_F_INGRESS);
 }
 
 static __always_inline __u32
@@ -161,8 +161,8 @@ static __always_inline int ipv4_host_delivery(struct __ctx_buff *ctx, struct iph
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_NET_IFINDEX);
-	return ctx_redirect(ctx, CILIUM_NET_IFINDEX, 0);
+	cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, CILIUM_HOST_IFINDEX);
+	return ctx_redirect(ctx, CILIUM_HOST_IFINDEX, BPF_F_INGRESS);
 }
 
 static __always_inline __u32
@@ -245,7 +245,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 identity __maybe_unused, __s8 *ext_err
 	 * ingress BPF program to enforce policies and deliver the packet.
 	 *
 	 * Packet for local Host:
-	 * We always add a L2 header and redirect to cilium_net@egress.
+	 * We always add a L2 header and redirect to cilium_host@ingress.
 	 * Host policies will be enforced in cilium_host@ingress (HostFw).
 	 */
 	ep = lookup_ip4_endpoint(ip4);


### PR DESCRIPTION
Similar to bpf_overlay changes in https://github.com/cilium/cilium/pull/43001.

Prior to this, we were delivering host-related packets to cilium_net@egress after decryption in from_wireguard hook. Given there's no program attached there anymore, and we just want the packet to reach the to-host program, let's adjust the redirection to the cilium_host@ingress interface, where the `cil_to_host` program is attached. The to-host program will take care of the ingress policies (HostFW) before delivering the packet to the host.

Historically (see [1]), the redirection was to cilium_net@egress because the to-host program was attached there. Later (see [2]), the to-host program was moved to cilium_host@ingress, but the redirection was not updated accordingly. I believe there is no reason nowadays to keep the redirection to cilium_net@egress, given there's no program/logic there anymore.

In old kernels, a bpf_redirect() with BPF_F_INGRESS would scrub the packet, as well as a veth traversal. In new kernels, veth traversal or bpf_redirect() in the same netns would preserve the skb metadata/mark. For this reason, the packet reaching the `cilium_host@ingress` would appear the same as before the patch. We simply skip one veth traversal (cilium_net -> cilium_host).

[1] https://github.com/cilium/cilium/commit/d4d9158496d5e32c700f50ed674c27bf3c129aa8
[2] https://github.com/cilium/cilium/commit/1c951ee5b65f9d8bd5cc5b886f4e1855baa8ca82