### PR TITLE
workflows/eks: Reduce test concurrency to 2

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  test_concurrency: 3
+  test_concurrency: 2
   clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.220.0


### PR DESCRIPTION
Similarly as in https://github.com/cilium/cilium/pull/43016, we observe that in `ci-eks` in the `Setup conn-disrupt-test before rotating` step not all replicas of the deployment `cilium-test-1/test-conn-disrupt-client` become available.

Let's reduce test concurrency for EKS.