### PR TITLE
check-encryption-leak: do not trace TCP RST packets as leaked

### DIFF
--- a/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
+++ b/.github/actions/bpftrace/scripts/check-encryption-leaks.bt
@@ -84,6 +84,8 @@ struct dnshdr {
 // - WG pod-to-pod:   outer packet is encrypted (encap bit not set), similarly as VinE.
 // - WG node-to-node: currently unsupported, only pod-to-pod leak detection checks.
 //
+// We ignore TCP RST packets (see https://github.com/cilium/cilium/issues/35485).
+//
 // Note: br_forward is not exclusive of Kind. We run this script in CI where we
 // expect only br-kind-cilium (and br-kind-cilium-secondary). To run this script
 // on a local setup, ensure that no other bridges interfere.
@@ -116,6 +118,13 @@ kprobe:br_forward
     $udph = ((struct udphdr*) ($skb->head + $skb->inner_transport_header));
     $tcph = ((struct tcphdr*) ($skb->head + $skb->inner_transport_header));
     $icmph = ((struct icmphdr*) ($skb->head + $skb->inner_transport_header));
+  }
+
+  // Ignore TCP RST packets.
+  if ((($proto == PROTO_IPV4 && $ip4h->protocol == PROTO_TCP) ||
+       ($proto == PROTO_IPV6 && $ip6h->nexthdr == PROTO_TCP)) &&
+      $tcph->rst) {
+    return;
   }
 
   if ($proto == PROTO_IPV4) {


### PR DESCRIPTION
This substantially reverts https://github.com/cilium/cilium/pull/41765, re-applying https://github.com/cilium/cilium/pull/36962 (modified code for readability).

During our CLI tests, we observe some auto-generated TCP RST packets from the kernel in response to TCP-FIN packets sent by, most likely, some idle's timeout expiring. Envoy would generate TCP-FIN, but the kernel replies with a RST, given there's not a socket anymore listening to that port.

We thought that after VinE we were able to catch such packets in our to-netdev program, but we kept observing them while adding unrelated tests to our CLI suite (see https://github.com/cilium/cilium/actions/runs/19833684454). Thus, we revert the latest change, and keep ignoring TCP RST packets.