### PR TITLE
clustermesh: fix helm etcd tls error by disabling gRPC gateway

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -137,6 +137,7 @@ spec:
         - --advertise-client-urls=https://localhost:2379
         - --initial-cluster-token=$(INITIAL_CLUSTER_TOKEN)
         - --auto-compaction-retention=1
+        - --enable-grpc-gateway=false
         {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
         - --listen-metrics-urls=http://0.0.0.0:{{ .Values.clustermesh.apiserver.metrics.etcd.port }}
         - --metrics={{ .Values.clustermesh.apiserver.metrics.etcd.mode }}


### PR DESCRIPTION
When using the clustermesh.apiserver.tls.auto.method=cronJob configuration, Helm uses the cilium/certgen image to create the required clustermesh mTLS certificates. However, the generated clustermesh-apiserver-server-cert lacks the TLS Web Client Authentication extended key usage extension, which is required for proper etcd gRPC Gateway mTLS authentication.

Since Cilium uses the etcd gRPC client directly and does not require the gRPC Gateway, this fix disables the etcd gRPC Gateway on boot to avoid the certificate validation error.

The below issue explains how we were able to reproduce the following error logs in the clustermesh `etcd` container:

```
{"level":"warn","ts":"2025-12-03T17:44:33.697480Z","caller":"embed/config_logging.go:194","msg":"rejected connection on client endpoint","remote-addr":"127.0.0.1:34890","server-name":"","error":"tls: failed to verify certificate: x509: certificate specifies an incompatible key usage"}
2025/12/03 17:44:33 WARNING: [core[] [Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "0.0.0.0:2379", ServerName: "0.0.0.0:2379", }. Err: connection error: desc = "error reading server preface: remote error: tls: bad certificate"
```

Fixes: #43099

```release-note
Fix helm clustermesh etcd tls error by disabling etcd gRPC gateway
```

Feel free to comment on any missing details or code changes, it's my first time opening an issue in this project. 😄 
