### PR TITLE
Log policy updates at debug level

### DIFF
--- a/pkg/policy/cell/identity_updater.go
+++ b/pkg/policy/cell/identity_updater.go
@@ -133,7 +133,7 @@ func (i *identityUpdater) UpdateIdentities(added, deleted identity.IdentityMap) 
 
 	start := time.Now()
 
-	i.logger.Info(
+	i.logger.Debug(
 		"Processing identity update",
 		logfields.AddedPolicyID, slices.Collect(maps.Keys(added)),
 		logfields.DeletedPolicyID, slices.Collect(maps.Keys(deleted)),
@@ -188,7 +188,7 @@ func (i *identityUpdater) doUpdatePolicyMaps(ctx context.Context) error {
 		return nil
 	}
 
-	i.logger.Info(
+	i.logger.Debug(
 		"Incremental policy update: waiting for endpoint notifications to complete",
 		logfields.Count, len(q.wgs),
 	)
@@ -213,7 +213,7 @@ func (i *identityUpdater) doUpdatePolicyMaps(ctx context.Context) error {
 	// Direct all endpoints to consume the incremental changes and update policy.
 	// This returns a wg that is done when all endpoints have updated both their bpf
 	// policymaps as well as Envoy. (Or if ctx is closed).
-	i.logger.Info("Incremental policy update: triggering UpdatePolicyMaps for all endpoints")
+	i.logger.Debug("Incremental policy update: triggering UpdatePolicyMaps for all endpoints")
 	updatedWG := i.epmanager.UpdatePolicyMaps(ctx, noopWG)
 	updatedWG.Wait()
 	metrics.PolicyIncrementalUpdateDuration.WithLabelValues("global").Observe(time.Since(q.firstStartTime).Seconds())

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -181,7 +181,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 
 	// Batch the set of updates to the ipcache.
 	if len(ipcUpdates) > 0 {
-		i.log.Info("inserting ipcache metadata for CIDR prefixes from policy", logfields.Count, len(ipcUpdates))
+		i.log.Debug("inserting ipcache metadata for CIDR prefixes from policy", logfields.Count, len(ipcUpdates))
 		nextIPCRev := i.ipc.UpsertMetadataBatch(ipcUpdates...)
 
 		// If the ipcache has already started, then we should wait for our update to commit.
@@ -220,7 +220,7 @@ func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID
 		}
 	}
 	if len(ipcUpdates) > 0 {
-		i.log.Info("pruning stale policy CIDR prefix ipcache metadata entries", logfields.Count, len(ipcUpdates))
+		i.log.Debug("pruning stale policy CIDR prefix ipcache metadata entries", logfields.Count, len(ipcUpdates))
 		// No need to wait for completion.
 		i.ipc.RemoveMetadataBatch(ipcUpdates...)
 	}
@@ -237,7 +237,7 @@ func (i *policyImporter) processUpdates(ctx context.Context, updates []*policyty
 		return nil
 	}
 
-	i.log.Info("Processing policy updates", logfields.Count, len(updates))
+	i.log.Debug("Processing policy updates", logfields.Count, len(updates))
 
 	// First, allocate local identities for all prefixes referenced by policies.
 	//
@@ -270,13 +270,13 @@ func (i *policyImporter) processUpdates(ctx context.Context, updates []*policyty
 		idsToRegen.Merge(*regen)
 
 		if len(upd.Rules) == 0 {
-			i.log.Info("Deleted policy from repository",
+			i.log.Debug("Deleted policy from repository",
 				logfields.Resource, upd.Resource,
 				logfields.PolicyRevision, endRevision,
 				logfields.DeletedRules, oldRuleCnt,
 				logfields.Identity, slices.Collect(truncate(regen.Members(), 100)))
 		} else {
-			i.log.Info("Upserted policy to repository",
+			i.log.Debug("Upserted policy to repository",
 				logfields.Resource, upd.Resource,
 				logfields.PolicyRevision, endRevision,
 				logfields.DeletedRules, oldRuleCnt,
@@ -315,7 +315,7 @@ func (i *policyImporter) processUpdates(ctx context.Context, updates []*policyty
 
 	// All policy updates have been applied; regenerate all affected endpoints.
 	// Unaffected endpoints can merely have their policy revision set.
-	i.log.Info("Policy repository updates complete, triggering endpoint updates",
+	i.log.Debug("Policy repository updates complete, triggering endpoint updates",
 		logfields.PolicyRevision, endRevision)
 	if i.epm != nil {
 		i.epm.UpdatePolicy(idsToRegen, startRevision, endRevision)


### PR DESCRIPTION
High churn clusters log significantly more (10x to 20x) log lines since 1.17 at 783465b85fba9491d7e2fe810b81e5bfde00fdab "policy: add policy import cell".

This commit changes the policy update log lines added in that commit to Debug level to avoid filling up the logs with policy update information by default.