### PR TITLE
fix(sdp): Make []prefix as non unique index PrefixToIdentityTable

### DIFF
--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -113,6 +113,17 @@ var (
 			return index.NetIPPrefix(key)
 		},
 		FromString: index.NetIPPrefixString,
+		Unique:     false,
+	}
+	IdentityToPrefixIndex = statedb.Index[PrefixToIdentity, identity.NumericIdentity]{
+		Name: "id",
+		FromObject: func(p PrefixToIdentity) index.KeySet {
+			return index.NewKeySet(index.Uint32(p.Identity.Uint32()))
+		},
+		FromKey: func(key identity.NumericIdentity) index.Key {
+			return index.Uint32(key.Uint32())
+		},
+		FromString: index.Uint32String,
 		Unique:     true,
 	}
 )
@@ -389,6 +400,7 @@ func NewPrefixToIdentityTable(db *statedb.DB) (statedb.RWTable[PrefixToIdentity]
 	return statedb.NewTable(
 		db,
 		PrefixToIdentityTableName,
+		IdentityToPrefixIndex,
 		PrefixToIdentityIndex,
 	)
 }


### PR DESCRIPTION
The PrefixToIdentityTable maintains the mapping between IP prefixes and identities. We changed the prefix index to non-unique since many different prefixes may correspond to the same identity which leads to lookup failure when we are searching for a single prefix/ip.
Without the fix, the identity was getting resolved to world due to unique index on prefix slice.
```release-note
 fix(sdp): Make []prefix as non unique index PrefixToIdentityTable 
```
