### PR TITLE
Revert "policy: Replace versioned with part.Map"

### DIFF
--- a/pkg/container/versioned/value.go
+++ b/pkg/container/versioned/value.go
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package versioned
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"math"
+	"runtime"
+	"slices"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type version uint64
+
+const (
+	// invalidVersion is never found from the value range.
+	// Also used as the upper bound for new values, so that the value is
+	// found when looking with 'maxVersion'
+	invalidVersion = version(math.MaxUint64)
+
+	// maxVersion in a VersionHandle finds the latest version of all non-removed values
+	maxVersion = version(math.MaxUint64 - 1)
+)
+
+// KeepVersion is an exported version type used when releasing memory held for old versions.
+type KeepVersion version
+
+var (
+	ErrInvalidVersion   = errors.New("invalid version")
+	ErrStaleTransaction = errors.New("stale transaction")
+	ErrStaleVersion     = errors.New("stale version")
+	ErrVersionNotFound  = errors.New("version not found")
+)
+
+// VersionHandle is used to keep values valid for a specific version from being released, so that
+// they are available for use for as long as the VersionHandle is not closed.
+//
+// A special form with a nil coordinator, which is returned by Latest(), always finds the latest
+// versions and does not keep any versions from being released.
+type VersionHandle struct {
+	// 'version' is the version this versionHandle keeps from being released
+	version version
+	// Coordinator of this versionHandle, if any. Used for closing if non-nil.
+	// Atomic due to nilling and for copy prevention.
+	coordinator atomic.Pointer[Coordinator]
+	// Optional stack trace of the caller for debugging purposes
+	stacktrace hclog.CapturedStacktrace
+}
+
+func (h *VersionHandle) IsValid() bool {
+	return h != nil && (h.version == maxVersion || h.coordinator.Load() != nil)
+}
+
+func (h *VersionHandle) Version() KeepVersion {
+	return KeepVersion(h.version)
+}
+
+func (h *VersionHandle) String() string {
+	if h == nil {
+		return "version: <nil>"
+	}
+	validity := "invalid"
+	if h.IsValid() {
+		validity = "valid"
+	}
+	return fmt.Sprintf("%d (%s)", h.version, validity)
+}
+
+// Close releases the held version for removal once no handle for it are no longer held.
+// This may not be called while holding any locks that the 'closer' function passed to the
+// coordinator may take!
+func (h *VersionHandle) Close() error {
+	if h == nil || h.version == invalidVersion {
+		return ErrInvalidVersion
+	}
+	// handle with 'maxVersion' is never closed
+	if h.version != maxVersion {
+		// Using CompareAndSwap makes sure each handle is closed at most once
+		coordinator := h.coordinator.Load()
+		if coordinator != nil && h.coordinator.CompareAndSwap(coordinator, nil) {
+			runtime.SetFinalizer(h, nil)
+			return coordinator.releaseVersion(h.version)
+		}
+		return ErrStaleVersion
+	}
+	return nil
+}
+
+// versionHandleFinalizer is used to warn about missing Close() calls.
+func versionHandleFinalizer(h *VersionHandle) {
+	coordinator := h.coordinator.Load()
+	if coordinator != nil && coordinator.Logger != nil {
+		logger := coordinator.Logger
+		if h.stacktrace != "" {
+			logger = logger.With(logfields.Stacktrace, h.stacktrace)
+		}
+		logger.Error("Handle for version not closed.", logfields.Version, h.version)
+	}
+	h.Close()
+}
+
+func newVersionHandle(version version, coordinator *Coordinator) *VersionHandle {
+	// handle on maxVersion never expires
+	if version == maxVersion {
+		coordinator = nil
+	}
+	h := &VersionHandle{version: version}
+	h.coordinator.Store(coordinator)
+	if coordinator != nil {
+		// Set a finalizer to catch unclosed handles. The finalizer function complains
+		// loudly, so that we do not rely the finalizer for closing.
+		runtime.SetFinalizer(h, versionHandleFinalizer)
+
+		if option.Config.Debug {
+			// capture a stacktrace for debugging
+			h.stacktrace = hclog.Stacktrace()
+		}
+	}
+	return h
+}
+
+// Latest returns a VersionHandle for the latest version of current/non-removed values
+// Only to be used in cases where the latest values are needed and no transactionality is required.
+func Latest() *VersionHandle {
+	return newVersionHandle(maxVersion, nil)
+}
+
+type atomicVersion struct {
+	version atomic.Uint64
+}
+
+func (a *atomicVersion) load() version {
+	return version(a.version.Load())
+}
+
+func (a *atomicVersion) store(version version) {
+	a.version.Store(uint64(version))
+}
+
+type versionCount struct {
+	version version
+	count   int
+}
+
+// Coordinator defines a common version number space for multiple versioned.Values,
+// and provides facilities for cleaning out stale versions.
+// The Value's are not directly managed by the Coordinator, but all the values under coordination
+// should be cleaned by the 'cleaner' function given to the Coordinator.
+type Coordinator struct {
+	// Logger supplied to NewCoordinator. Should be set if logging is desired.
+	Logger *slog.Logger
+
+	// Cleaner is called with the earliest version that must be kept.
+	// Must be set to clean up resources held for old versions.
+	// Cleaner function may be called concurrently, the function must synchronize
+	// use of any shared resources.
+	Cleaner func(KeepVersion)
+
+	// mutex protects the rest of the fields
+	mutex lock.RWMutex
+
+	// version is the version number of the last applied change
+	version version
+
+	// oldest version not cleaned off
+	oldestVersion version
+
+	// versions is an ordered list of outstanding VersionHandles with a reference count.
+	// Outdated values can be cleaned when there are no outstanding VersionHandles for them.
+	versions []versionCount
+}
+
+// PrepareNextVersion returns a transaction to be used when adding or removing values.
+//
+// Callers need to coordinate so that a single goroutine is performing modifications at any one
+// time, consisting of the following operations:
+//
+// - tx := coordinator.PrepareNextVersion()
+//   - value.SetAt(... , tx)
+//   - value.RemoveAt(..., tx)
+//   - ...
+//
+// - tx.Commit()
+func (v *Coordinator) PrepareNextVersion() *Tx {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	return &Tx{
+		nextVersion: v.version + 1,
+		coordinator: v,
+	}
+}
+
+// All values in Tx are constants
+type Tx struct {
+	nextVersion version
+	coordinator *Coordinator
+}
+
+// LatestTx refers to maxVersion without having a coordinator, should only be used for testing.
+var LatestTx = &Tx{nextVersion: maxVersion}
+
+func (tx *Tx) String() string {
+	return strconv.FormatUint(uint64(tx.nextVersion), 10)
+}
+
+func (tx *Tx) After(v KeepVersion) bool {
+	return tx.nextVersion > version(v)
+}
+
+// Commit makes a new version of values available to readers
+// Commit call may be omitted if no changes were actually made.
+func (tx *Tx) Commit() error {
+	return tx.coordinator.commit(tx.nextVersion)
+}
+
+// GetVersionHandle returns a VersionHandle for the given transaction.
+func (tx *Tx) GetVersionHandle() *VersionHandle {
+	// This is only needed to support LatestTx to make some testing easier
+	if tx.coordinator == nil && tx.nextVersion == maxVersion {
+		return Latest()
+	}
+	return tx.coordinator.getVersionHandle(tx.nextVersion)
+}
+
+func versionHandleCmp(a versionCount, b version) int {
+	if a.version < b {
+		return -1
+	}
+	if a.version == b {
+		return 0
+	}
+	return 1
+}
+
+// commit makes a new version of values available to readers
+// and cleans up any possible stale versions
+func (v *Coordinator) commit(version version) error {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+
+	if v.version != version-1 {
+		return ErrStaleVersion
+	}
+	v.version = version
+
+	// clean up stale versions if any
+	v.clean()
+	return nil
+}
+
+func (v *Coordinator) releaseVersion(version version) error {
+	if version == invalidVersion {
+		return ErrInvalidVersion
+	}
+
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+
+	n, found := slices.BinarySearchFunc(v.versions, version, versionHandleCmp)
+	if !found {
+		if v.Logger != nil {
+			v.Logger.Error(
+				"Version not found.",
+				logfields.Version, version,
+				logfields.Stacktrace, hclog.Stacktrace(),
+			)
+		}
+		return ErrVersionNotFound
+	}
+	v.versions[n].count--
+	if v.versions[n].count <= 0 {
+		v.versions = slices.Delete(v.versions, n, n+1)
+	}
+
+	// clean if needed
+	v.clean()
+	return nil
+}
+
+// clean must be called with lock held
+func (v *Coordinator) clean() {
+	// 'keepVersion' is the current version if there are no outstanding VersionHandles
+	keepVersion := v.version
+	if len(v.versions) > 0 {
+		// otherwise it is the oldest version for which there is an outstanding handle, if
+		// older than the current version, as if there was an implicit outstanding handle
+		// for the current version.
+		keepVersion = min(v.version, v.versions[0].version)
+	}
+
+	// Call the cleaner for 'keepVersion' only if not already called for this 'keepVersion'.
+	if keepVersion > v.oldestVersion {
+		// The cleaner is called from a goroutine without holding any locks
+		if v.Cleaner != nil {
+			if v.Logger != nil {
+				v.Logger.Debug(
+					"releaseVersion: calling cleaner",
+					logfields.OldVersion, v.oldestVersion,
+					logfields.NewVersion, keepVersion,
+				)
+			}
+			go v.Cleaner(KeepVersion(keepVersion))
+			v.oldestVersion = keepVersion
+		} else if v.Logger != nil {
+			v.Logger.Warn("VersionHandle.Close: Cleaner function not set")
+		}
+	}
+}
+
+// getVersionHandle returns a VersionHandle for the given version.
+func (v *Coordinator) getVersionHandle(version version) *VersionHandle {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	return v.getVersionHandleLocked(version)
+}
+
+func (v *Coordinator) getVersionHandleLocked(version version) *VersionHandle {
+	// never get a handle for the invalid version
+	if version == invalidVersion {
+		version = maxVersion
+	}
+
+	if version < v.oldestVersion {
+		oldVersion := version
+		version = v.oldestVersion
+		if v.Logger != nil {
+			v.Logger.Warn(
+				"GetVersionHandle: Handle to a stale version requested, returning oldest valid version instead",
+				logfields.Stacktrace, hclog.Stacktrace(),
+				logfields.Version, version,
+				logfields.OldVersion, oldVersion,
+			)
+		}
+	}
+	n, found := slices.BinarySearchFunc(v.versions, version, versionHandleCmp)
+	if !found {
+		v.versions = slices.Insert(v.versions, n, versionCount{version, 1})
+	} else {
+		v.versions[n].count++
+	}
+
+	return newVersionHandle(version, v)
+}
+
+// GetVersionHandle returns a VersionHandle for the current version, so that it can not be
+// cleaned off before the returned VersionHandle is closed.
+func (v *Coordinator) GetVersionHandle() *VersionHandle {
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	return v.getVersionHandleLocked(v.version)
+}
+
+// versionRange is a range from the first to one-past-the-last version, "[first, past)".
+// 'past' is atomically modified to a smaller value when removing or a new version is added.
+type versionRange struct {
+	first version       // first version this value is valid for
+	past  atomicVersion // first version this value is invalid for
+}
+
+func (r *versionRange) contains(version version) bool {
+	return r.first <= version && version < r.past.load()
+}
+
+// valueNode is the node used in the linked list rooted at Value[T]
+type valueNode[T any] struct {
+	versions versionRange
+	next     atomic.Pointer[valueNode[T]]
+	value    T
+}
+
+// Value is a container for versioned values, implemented as a lock-free linked list.
+type Value[T any] struct {
+	// valueNodes are non-overlapping and in sorted by version in ascending order.
+	head atomic.Pointer[valueNode[T]]
+}
+
+// SetAt adds the value with validity starting from 'version'.  All values are added with "infinite"
+// validity, which is then truncated when an overlapping entry is added, or the value is removed.
+// 'next' version must be later than any the current version visible to the readers.
+// Returns an error if this is not the case.
+// Callers must coordinate for mutual exclusion.
+func (v *Value[T]) SetAt(value T, tx *Tx) error {
+	version := tx.nextVersion
+	if version == invalidVersion {
+		return ErrInvalidVersion
+	}
+
+	newNode := &valueNode[T]{
+		versions: versionRange{
+			first: version,
+		},
+		value: value,
+	}
+	// All new values are initially set to never expire
+	// ('invalidVersion' is one past 'maxVersion')
+	newNode.versions.past.store(invalidVersion)
+
+	// find if there is a current value that is valid for this new version
+	node := v.head.Load()
+	prev := &v.head
+	for node != nil {
+		if version < node.versions.first {
+			return fmt.Errorf("SetAt may not add values at versions lower than those already added (%d<%d): %w", version, node.versions.first, ErrStaleVersion)
+		}
+
+		if node.versions.contains(version) {
+			// link the new node after the current one
+			newNode.next.Store(node.next.Load())
+			node.next.Store(newNode)
+
+			// truncate the validity of this node to end at 'version' *after* the new
+			// node with validity starting from 'version' has been linked after it
+			// (above), so that either this or the new value is reachable at all times
+			// for readers with 'version'
+			node.versions.past.store(version)
+			break
+		}
+
+		node = node.next.Load()
+		if node != nil {
+			prev = &node.next
+		}
+	}
+	if node == nil {
+		// Add the new value at the end
+		prev.Store(newNode)
+	}
+
+	return nil
+}
+
+// RemoveAt changes the validity of the stored value previously valid at version 'next' to have
+// ended at version 'next'.
+// 'next' must be later than any the current version visible to the readers.
+// Returns an error if this is not the case.
+// Callers must coordinate for mutual exclusion.
+func (v *Value[T]) RemoveAt(tx *Tx) error {
+	version := tx.nextVersion
+	if version == invalidVersion {
+		return ErrInvalidVersion
+	}
+
+	for node := v.head.Load(); node != nil; node = node.next.Load() {
+		if version < node.versions.first {
+			return fmt.Errorf("RemoveAt may not be called with version lower than existing already (%d<%d): %w", version, node.versions.first, ErrStaleVersion)
+		}
+
+		if node.versions.contains(version) {
+			// Truncate the validity of this node to end at 'version'.
+			// After this readers with 'version' and above no longer see this value,
+			// while readers with versions before 'version' still see this.
+			node.versions.past.store(version)
+			break
+		}
+	}
+	return nil
+}
+
+// RemoveBefore removes all values whose validity ends before 'keepVersion'.
+// Caller must coordinate for mutual exclusion.
+func (v *Value[T]) RemoveBefore(keepVersion KeepVersion) {
+	version := version(keepVersion)
+	// find all values that are no longer valid at 'version'
+	node := v.head.Load()
+	for node != nil && node.versions.past.load() <= version {
+		// This node is no longer visible for readers with 'version' and above,
+		// so this can be safely removed.
+		node = node.next.Load()
+	}
+	v.head.Store(node)
+}
+
+// At returns value of type 'T' valid for the given version, or an empty value if none is found.
+func (v *Value[T]) At(handle *VersionHandle) T {
+	if handle != nil {
+		version := handle.version
+		for node := v.head.Load(); node != nil; node = node.next.Load() {
+			if node.versions.contains(version) {
+				return node.value
+			}
+		}
+	}
+	var empty T
+	return empty
+}
+
+// Versioned is a pair of a version and any type T
+type Versioned[T any] struct {
+	version version
+	value   T
+}
+
+type VersionedSlice[T any] []Versioned[T]
+
+// Append appends a pair of 'nextVersion' and 'value' to VersionedSlice 's', returning updated
+// 's'. Needed to keep members private.
+// Should only be called with monotonically increasing 'nextVersion's, so that the slice remains
+// sorted by version in ascending order.
+func (s VersionedSlice[T]) Append(value T, tx *Tx) VersionedSlice[T] {
+	return append(s, Versioned[T]{
+		version: tx.nextVersion,
+		value:   value,
+	})
+}
+
+// Before returns an iterator over the elements in VersionedSlice 's' having a version earlier than
+// 'keepVersion'.
+// The slice is assumed to be sorted by version in ascending order.
+func (s VersionedSlice[T]) Before(keepVersion KeepVersion) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		version := version(keepVersion)
+		for n := range s {
+			if s[n].version >= version {
+				break
+			}
+			if !yield(s[n].value) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/container/versioned/value_test.go
+++ b/pkg/container/versioned/value_test.go
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package versioned
+
+import (
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type testCleaner struct {
+	oldestVersion atomicVersion
+	cleanerMutex  lock.Mutex
+	cleanerCond   *sync.Cond
+}
+
+func newTestCleaner() *testCleaner {
+	c := &testCleaner{}
+	c.cleanerCond = sync.NewCond(&c.cleanerMutex)
+	return c
+}
+
+func (c *testCleaner) waitUntilOldest(t *testing.T, version version) {
+	c.cleanerMutex.Lock()
+	for oldest := c.oldestVersion.load(); oldest < version; oldest = c.oldestVersion.load() {
+		t.Logf("Waiting due to oldest %d < %d version\n", oldest, version)
+		c.cleanerCond.Wait()
+	}
+	c.cleanerMutex.Unlock()
+}
+
+func (c *testCleaner) cleanValue(keepVersion KeepVersion, value *Value[[]uint32]) {
+	c.cleanerMutex.Lock()
+	defer c.cleanerMutex.Unlock()
+
+	// 'keepVersion' may be older than 'oldestVersion', keep oldestVersion monotonically
+	// increasing
+	oldest := c.oldestVersion.load()
+	if oldest < version(keepVersion) {
+		value.RemoveBefore(keepVersion)
+		c.oldestVersion.store(version(keepVersion))
+		c.cleanerCond.Signal()
+	}
+}
+
+func (c *testCleaner) cleanValues(keepVersion KeepVersion, values []Value[[]uint32]) {
+	c.cleanerMutex.Lock()
+	defer c.cleanerMutex.Unlock()
+
+	// 'keepVersion' may be older than 'oldestVersion', keep oldestVersion monotonically
+	// increasing
+	oldest := c.oldestVersion.load()
+	if oldest < version(keepVersion) {
+		// remove old versions for all values before bumping 'oldestVersion'
+		for i := range values {
+			values[i].RemoveBefore(keepVersion)
+		}
+		c.oldestVersion.store(version(keepVersion))
+		c.cleanerCond.Signal()
+	}
+}
+
+func TestVersionedValue(t *testing.T) {
+	var value1 Value[[]uint32]
+
+	cleaner := newTestCleaner()
+
+	cv := Coordinator{
+		Cleaner: func(keepVersion KeepVersion) {
+			cleaner.cleanValue(keepVersion, &value1)
+		},
+	}
+
+	// Initially empty
+	handle := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle))
+	assert.NoError(t, handle.Close())
+	// 2nd call does nothing
+	assert.Error(t, handle.Close())
+
+	// Add first value
+	handle1 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle1))
+	version1 := handle1.Version()
+
+	tx := cv.PrepareNextVersion()
+	assert.False(t, tx.After(KeepVersion(tx.nextVersion)))
+	assert.True(t, tx.After(version1))
+
+	assert.NoError(t, value1.SetAt([]uint32{100, 200}, tx))
+	assert.NoError(t, tx.Commit())
+
+	oldTx := tx
+	tx = cv.PrepareNextVersion()
+	assert.Equal(t, tx.nextVersion, oldTx.nextVersion+1)
+
+	// New value is invisible for the old handle
+	assert.Empty(t, value1.At(handle))
+
+	// But is visible for any new handles
+	handle2 := cv.GetVersionHandle()
+
+	v := value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	// Set a new value
+	tx = cv.PrepareNextVersion()
+	assert.NoError(t, value1.SetAt([]uint32{100, 150, 200}, tx))
+	assert.NoError(t, tx.Commit())
+
+	// new handle sees the new value
+	handle3 := cv.GetVersionHandle()
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	// Old handle sees the previous value
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	// first handle still sees no value
+	assert.Empty(t, value1.At(handle))
+
+	// delete the value at next version
+	tx = cv.PrepareNextVersion()
+	assert.NoError(t, value1.RemoveAt(tx))
+	assert.NoError(t, tx.Commit())
+
+	// new handle sees an empty value
+	handle4 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle4))
+	assert.Empty(t, value1.At(handle))
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	// closers can be called in any order
+	assert.NoError(t, handle2.Close())
+	assert.NoError(t, handle1.Close())
+
+	// stale handle should now get an empty value after it's closer has been called and a new
+	// value has been inserted
+	cleaner.waitUntilOldest(t, handle3.version)
+	assert.Empty(t, value1.At(handle2))
+
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	assert.NoError(t, handle3.Close())
+
+	cleaner.waitUntilOldest(t, handle4.version)
+	assert.Empty(t, value1.At(handle3))
+
+	assert.NoError(t, handle4.Close())
+
+	// old values have been cleaned off
+	assert.Nil(t, value1.head.Load())
+}
+
+func TestVersionedValueMultiple(t *testing.T) {
+	var value1 Value[[]uint32]
+	var value2 Value[[]uint32]
+
+	cleaner := newTestCleaner()
+
+	cv := Coordinator{
+		Cleaner: func(keepVersion KeepVersion) {
+			cleaner.cleanValue(keepVersion, &value1)
+			cleaner.cleanValue(keepVersion, &value2)
+		},
+	}
+
+	// Initially empty
+	handle := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle))
+	assert.Empty(t, value2.At(handle))
+	assert.NoError(t, handle.Close())
+	assert.Error(t, handle.Close())
+
+	// Add first values
+	handle1 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle1))
+	assert.Empty(t, value2.At(handle1))
+
+	tx := cv.PrepareNextVersion()
+
+	assert.NoError(t, value1.SetAt([]uint32{100, 200}, tx))
+	assert.NoError(t, value2.SetAt([]uint32{110, 190}, tx))
+	assert.NoError(t, tx.Commit())
+
+	oldTx := tx
+	tx = cv.PrepareNextVersion()
+	assert.Equal(t, tx.nextVersion, oldTx.nextVersion+1)
+
+	// New value is invisible for the old handle
+	assert.Empty(t, value1.At(handle1))
+	assert.Empty(t, value2.At(handle1))
+
+	// But is visible for any new handles
+	handle2 := cv.GetVersionHandle()
+
+	v := value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	v = value2.At(handle2)
+	assert.Equal(t, []uint32{110, 190}, v)
+
+	// New value appears at both values at the same version
+	tx = cv.PrepareNextVersion()
+	assert.NoError(t, value1.SetAt([]uint32{100, 150, 200}, tx))
+	assert.NoError(t, value2.SetAt([]uint32{110, 150, 190}, tx))
+	assert.NoError(t, tx.Commit())
+
+	// new handle sees the new value
+	handle3 := cv.GetVersionHandle()
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	v = value2.At(handle3)
+	assert.Equal(t, []uint32{110, 150, 190}, v)
+
+	// Old handle sees the previous values
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	v = value2.At(handle2)
+	assert.Equal(t, []uint32{110, 190}, v)
+
+	// first handle still sees no value
+	assert.Empty(t, value1.At(handle))
+
+	// delete the value1 at next version
+	tx = cv.PrepareNextVersion()
+	assert.NoError(t, value1.RemoveAt(tx))
+	assert.NoError(t, tx.Commit())
+
+	// new handle sees an empty value1, but value2 remains
+	handle4 := cv.GetVersionHandle()
+	assert.Empty(t, value1.At(handle4))
+
+	v = value2.At(handle4)
+	assert.Equal(t, []uint32{110, 150, 190}, v)
+
+	assert.Empty(t, value1.At(handle))
+	assert.Empty(t, value2.At(handle))
+
+	v = value1.At(handle3)
+	assert.Equal(t, []uint32{100, 150, 200}, v)
+
+	v = value2.At(handle3)
+	assert.Equal(t, []uint32{110, 150, 190}, v)
+
+	v = value1.At(handle2)
+	assert.Equal(t, []uint32{100, 200}, v)
+
+	v = value2.At(handle2)
+	assert.Equal(t, []uint32{110, 190}, v)
+
+	// handle closers can be called in any order
+	assert.NoError(t, handle2.Close())
+	assert.NoError(t, handle3.Close())
+	assert.NoError(t, handle1.Close())
+	assert.NoError(t, handle4.Close())
+
+	// old value1 have been cleaned off
+	cleaner.waitUntilOldest(t, tx.nextVersion)
+	assert.Nil(t, value1.head.Load())
+
+	// but value2 remains, as it was not removed
+	assert.NotNil(t, value2.head.Load())
+}
+
+func TestPairSlice(t *testing.T) {
+	cv := Coordinator{}
+	s := make(VersionedSlice[int], 0, 10)
+
+	// 1st value '2000' at version 1
+	tx := cv.PrepareNextVersion()
+	s = s.Append(2000, tx)
+	assert.Len(t, s, 1)
+	assert.Equal(t, version(1), s[0].version)
+	assert.Equal(t, 2000, s[0].value)
+
+	tx.Commit()
+	tx = cv.PrepareNextVersion()
+
+	// 2nd value '1000' at version 2
+	s = s.Append(1000, tx)
+	assert.Len(t, s, 2)
+	assert.Equal(t, version(1), s[0].version)
+	assert.Equal(t, 2000, s[0].value)
+	assert.Equal(t, version(2), s[1].version)
+	assert.Equal(t, 1000, s[1].value)
+
+	tx.Commit()
+	tx = cv.PrepareNextVersion()
+
+	// 3rd value '3000' at version 3
+	s = s.Append(3000, tx)
+	assert.Len(t, s, 3)
+	assert.Equal(t, version(1), s[0].version)
+	assert.Equal(t, 2000, s[0].value)
+	assert.Equal(t, version(2), s[1].version)
+	assert.Equal(t, 1000, s[1].value)
+	assert.Equal(t, version(3), s[2].version)
+	assert.Equal(t, 3000, s[2].value)
+
+	// get all values before version 3; excluding the last value
+	var values []int
+	n := 0
+	for i := range s.Before(KeepVersion(3)) {
+		values = append(values, i)
+		n++
+	}
+	assert.Equal(t, []int{2000, 1000}, values)
+	s = s[n:]
+
+	// get all values upto and including maxVersion; get the lone value
+	values = nil
+	n = 0
+	for i := range s.Before(KeepVersion(invalidVersion)) {
+		values = append(values, i)
+		n++
+	}
+	assert.Equal(t, []int{3000}, values)
+	s = s[n:]
+	assert.Empty(t, s)
+}
+
+func TestVersionedChaos(t *testing.T) {
+	const nValues = 10
+	values := make([]Value[[]uint32], nValues)
+
+	cleaner := newTestCleaner()
+
+	cv := Coordinator{
+		Cleaner: func(keepVersion KeepVersion) {
+			for range nValues {
+				cleaner.cleanValues(keepVersion, values)
+			}
+		},
+	}
+
+	// Initially empty
+	handle := cv.GetVersionHandle()
+	for i := range nValues {
+		assert.Empty(t, values[i].At(handle))
+	}
+	assert.NoError(t, handle.Close())
+	assert.Error(t, handle.Close())
+
+	var mutex lock.Mutex
+	var writerWg, readerWg sync.WaitGroup
+	for range 1000 {
+		for range 100 {
+			readerWg.Add(1)
+			go func() {
+				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+				version := cv.GetVersionHandle()
+				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+				version.Close()
+				readerWg.Done()
+			}()
+		}
+		writerWg.Add(1)
+		go func() {
+			time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+			mutex.Lock()
+			defer mutex.Unlock()
+			// Add some values
+			tx := cv.PrepareNextVersion()
+			idx := rand.IntN(nValues)
+			var value []uint32
+			switch rand.IntN(5) {
+			case 0:
+				value = []uint32{}
+			case 1:
+				value = []uint32{1}
+			case 2:
+				value = []uint32{1, 2}
+			case 3:
+				value = []uint32{1, 2, 3}
+			case 4:
+				value = []uint32{1, 2, 3, 4}
+			case 5:
+				value = []uint32{1, 2, 3, 4, 5}
+			}
+			assert.NoError(t, values[idx].SetAt(value, tx))
+			tx.Commit()
+			writerWg.Done()
+		}()
+	}
+
+	t.Logf("Waiting until all writers are done\n")
+	writerWg.Wait()
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	tx := cv.PrepareNextVersion()
+	for i := range nValues {
+		assert.NoError(t, values[i].RemoveAt(tx))
+	}
+	tx.Commit()
+
+	t.Logf("Waiting until oldest version is %d\n", tx.nextVersion)
+	cleaner.waitUntilOldest(t, tx.nextVersion)
+
+	// Check that all values were removed
+	for i := range nValues {
+		assert.Nil(t, values[i].head.Load())
+	}
+
+	t.Logf("Waiting until all readers are done\n")
+	readerWg.Wait()
+}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1181,18 +1181,24 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	// 'e.desiredPolicy' access.
 	if !e.IsProxyDisabled() {
 		if updateEnvoy {
-			e.getLogger().Debug("applyPolicyMapChanges: Updating Envoy NetworkPolicy")
+			e.getLogger().Debug(
+				"applyPolicyMapChanges: Updating Envoy NetworkPolicy",
+				logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle,
+			)
 			stats.proxyPolicyCalculation.Start()
 			var rf revert.RevertFunc
-			err, rf = e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy, proxyWaitGroup)
+			err, rf = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.SelectorPolicy.L4Policy, e.desiredPolicy.SelectorPolicy.IngressPolicyEnabled, e.desiredPolicy.SelectorPolicy.EgressPolicyEnabled, proxyWaitGroup)
 			stats.proxyPolicyCalculation.End(err == nil)
 			if err == nil {
 				datapathRegenCtxt.revertStack.Push(rf)
 			}
 		} else if hasEnvoyRedirect {
 			// Wait for a possible ongoing update to be done if there were no current changes.
-			e.getLogger().Debug("applyPolicyMapChanges: Using current Networkpolicy")
-			e.proxy.UseCurrentNetworkPolicy(e, e.desiredPolicy, proxyWaitGroup)
+			e.getLogger().Debug(
+				"applyPolicyMapChanges: Using current Networkpolicy",
+				logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle,
+			)
+			e.proxy.UseCurrentNetworkPolicy(e, &e.desiredPolicy.SelectorPolicy.L4Policy, proxyWaitGroup)
 		}
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
@@ -1640,6 +1641,13 @@ func (e *Endpoint) OnProxyPolicyUpdate(revision uint64) {
 		e.proxyPolicyRevision = revision
 	}
 	e.unlock()
+}
+
+func (e *Endpoint) GetPolicyVersionHandle() *versioned.VersionHandle {
+	if e.desiredPolicy != nil {
+		return e.desiredPolicy.VersionHandle
+	}
+	return nil
 }
 
 func (e *Endpoint) GetListenerProxyPort(listener string) uint16 {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -918,11 +918,14 @@ func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (erro
 	}
 
 	if !e.IsProxyDisabled() {
-		e.getLogger().Debug("Regenerate: Initial Envoy NetworkPolicy")
+		e.getLogger().Debug(
+			"Regenerate: Initial Envoy NetworkPolicy",
+			logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle,
+		)
 
 		stats.proxyPolicyCalculation.Start()
 		// Initial NetworkPolicy is not reverted
-		err, _ = e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy, nil)
+		err, _ = e.proxy.UpdateNetworkPolicy(e, &e.desiredPolicy.SelectorPolicy.L4Policy, e.desiredPolicy.SelectorPolicy.IngressPolicyEnabled, e.desiredPolicy.SelectorPolicy.EgressPolicyEnabled, nil)
 		stats.proxyPolicyCalculation.End(err == nil)
 		if err != nil {
 			e.getLogger().Warn(

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -19,8 +19,8 @@ type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
 	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
-	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error)
-	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup)
+	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
+	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 	GetListenerProxyPort(listener string) uint16
 	IsSDPEnabled() bool
@@ -50,11 +50,11 @@ func (f *FakeEndpointProxy) RemoveRedirect(id string) {
 }
 
 // UseCurrentNetworkPolicy does nothing.
-func (f *FakeEndpointProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (f *FakeEndpointProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 }
 
 // UpdateNetworkPolicy does nothing.
-func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -112,11 +112,11 @@ func (r *RedirectSuiteProxy) RemoveRedirect(id string) {
 }
 
 // UseCurrentNetworkPolicy does nothing.
-func (f *RedirectSuiteProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (f *RedirectSuiteProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 }
 
 // UpdateNetworkPolicy does nothing.
-func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil
 }
 

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -463,11 +463,11 @@ func (*fakeXdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced bool, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 	panic("unimplemented")
 }
 

--- a/pkg/envoy/test/updater_mock.go
+++ b/pkg/envoy/test/updater_mock.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -42,6 +43,10 @@ func (m *ProxyUpdaterMock) UpdateProxyStatistics(proxyType, l4Protocol string, p
 }
 
 func (m *ProxyUpdaterMock) OnDNSPolicyUpdateLocked(rules restore.DNSRules) {}
+
+func (m *ProxyUpdaterMock) GetPolicyVersionHandle() *versioned.VersionHandle {
+	return versioned.Latest()
+}
 
 func (m *ProxyUpdaterMock) GetListenerProxyPort(listener string) uint16 {
 	return 0

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -5,7 +5,6 @@ package envoy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -40,6 +39,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
@@ -113,11 +113,11 @@ type XDSServer interface {
 	// Only used for testing
 	GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error)
 	// UseCurrentNetworkPolicy waits for any pending update on NetworkPolicy to be acked.
-	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup)
+	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	// UpdateNetworkPolicy adds or updates a network policy in the set published to L7 proxies.
 	// When the proxy acknowledges the network policy update, it will result in
 	// a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
-	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error)
+	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
 	// RemoveNetworkPolicy removes network policies relevant to the specified
 	// endpoint from the set published to L7 proxies, and stops listening for
 	// acks for policies on this endpoint.
@@ -1287,7 +1287,7 @@ func namespacedNametoSyncedSDSSecretName(namespacedName types.NamespacedName, po
 	return fmt.Sprintf("%s/%s-%s", policySecretsNamespace, namespacedName.Namespace, namespacedName.Name)
 }
 
-func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, selectors policy.SelectorSnapshot, sel policy.CachedSelector, l7Rules *policy.PerSelectorPolicy, useFullTLSContext, useSDS bool, policySecretsNamespace string) (*cilium.PortNetworkPolicyRule, bool) {
+func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, version *versioned.VersionHandle, sel policy.CachedSelector, l7Rules *policy.PerSelectorPolicy, useFullTLSContext, useSDS bool, policySecretsNamespace string) (*cilium.PortNetworkPolicyRule, bool) {
 	r := &cilium.PortNetworkPolicyRule{
 		Deny: l7Rules.GetDeny(),
 	}
@@ -1297,7 +1297,7 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, select
 	// Optimize the policy if the endpoint selector is a wildcard by
 	// keeping remote policies list empty to match all remote policies.
 	if !wildcard {
-		selections := sel.GetSelectionsAt(selectors)
+		selections := sel.GetSelectionsAt(version)
 
 		// No remote policies would match this rule. Discard it.
 		if len(selections) == 0 {
@@ -1400,7 +1400,7 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, select
 
 // getWildcardNetworkPolicyRules returns the rules for port 0, which
 // will be considered after port-specific rules.
-func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapshot, selectors policy.L7DataMap) (rules []*cilium.PortNetworkPolicyRule) {
+func (s *xdsServer) getWildcardNetworkPolicyRules(version *versioned.VersionHandle, selectors policy.L7DataMap) (rules []*cilium.PortNetworkPolicyRule) {
 	// selections are pre-sorted, so sorting is only needed if merging selections from multiple selectors
 	if len(selectors) == 1 {
 		for sel, l7 := range selectors {
@@ -1409,7 +1409,7 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 					Deny: l7.GetDeny(),
 				})
 			}
-			selections := sel.GetSelectionsAt(snapshot)
+			selections := sel.GetSelectionsAt(version)
 			if len(selections) == 0 {
 				// No remote policies would match this rule. Discard it.
 				return nil
@@ -1444,7 +1444,7 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 			s.logger.Warn("L3-only rule for selector surprisingly requires proxy redirection!", logfields.Selector, sel)
 		}
 
-		selections := sel.GetSelectionsAt(snapshot)
+		selections := sel.GetSelectionsAt(version)
 		if len(selections) == 0 {
 			continue
 		}
@@ -1496,7 +1496,7 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 	return rules
 }
 
-func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selectors policy.SelectorSnapshot, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext, useSDS bool, dir string, policySecretsNamespace string) []*cilium.PortNetworkPolicy {
+func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4PolicyMap, policyEnforced bool, useFullTLSContext, useSDS bool, dir string, policySecretsNamespace string) []*cilium.PortNetworkPolicy {
 	// TODO: integrate visibility with enforced policy
 	if !policyEnforced {
 		// Always allow all ports
@@ -1506,6 +1506,8 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 	if l4Policy == nil || l4Policy.Len() == 0 {
 		return nil
 	}
+
+	version := ep.GetPolicyVersionHandle()
 
 	PerPortPolicies := make([]*cilium.PortNetworkPolicy, 0, l4Policy.Len())
 	wildcardAllowAll := false
@@ -1517,12 +1519,12 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 			return
 		}
 
-		wildcardRules := s.getWildcardNetworkPolicyRules(selectors, l4.PerSelectorPolicies)
+		wildcardRules := s.getWildcardNetworkPolicyRules(version, l4.PerSelectorPolicies)
 
 		for _, rule := range wildcardRules {
 			s.logger.Debug("Wildcard PortNetworkPolicyRule matching remote IDs",
 				logfields.EndpointID, ep.GetID(),
-				logfields.Version, selectors,
+				logfields.Version, version,
 				logfields.TrafficDirection, dir,
 				logfields.Port, "0",
 				logfields.IsDeny, rule.Deny,
@@ -1595,7 +1597,7 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 			var denyAllRule *cilium.PortNetworkPolicyRule
 
 			for sel, l7 := range l4.PerSelectorPolicies {
-				rule, cs := s.getPortNetworkPolicyRule(ep, selectors, sel, l7, useFullTLSContext, useSDS, policySecretsNamespace)
+				rule, cs := s.getPortNetworkPolicyRule(ep, version, sel, l7, useFullTLSContext, useSDS, policySecretsNamespace)
 				if rule != nil {
 					if !cs {
 						canShortCircuit = false
@@ -1603,7 +1605,7 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 
 					s.logger.Debug("PortNetworkPolicyRule matching remote IDs",
 						logfields.EndpointID, ep.GetID(),
-						logfields.Version, selectors,
+						logfields.Version, version,
 						logfields.TrafficDirection, dir,
 						logfields.Port, port,
 						logfields.ProxyPort, rule.ProxyId,
@@ -1678,7 +1680,7 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 }
 
 // getNetworkPolicy converts a network policy into a cilium.NetworkPolicy.
-func (s *xdsServer) getNetworkPolicy(ep endpoint.EndpointUpdater, selectors policy.SelectorSnapshot, names []string, l4Policy *policy.L4Policy,
+func (s *xdsServer) getNetworkPolicy(ep endpoint.EndpointUpdater, names []string, l4Policy *policy.L4Policy,
 	ingressPolicyEnforced, egressPolicyEnforced, useFullTLSContext, useSDS bool, policySecretsNamespace string,
 ) *cilium.NetworkPolicy {
 	p := &cilium.NetworkPolicy{
@@ -1693,8 +1695,8 @@ func (s *xdsServer) getNetworkPolicy(ep endpoint.EndpointUpdater, selectors poli
 		ingressMap = l4Policy.Ingress.PortRules
 		egressMap = l4Policy.Egress.PortRules
 	}
-	p.IngressPerPortPolicies = s.getDirectionNetworkPolicy(ep, selectors, ingressMap, ingressPolicyEnforced, useFullTLSContext, useSDS, "ingress", policySecretsNamespace)
-	p.EgressPerPortPolicies = s.getDirectionNetworkPolicy(ep, selectors, egressMap, egressPolicyEnforced, useFullTLSContext, useSDS, "egress", policySecretsNamespace)
+	p.IngressPerPortPolicies = s.getDirectionNetworkPolicy(ep, ingressMap, ingressPolicyEnforced, useFullTLSContext, useSDS, "ingress", policySecretsNamespace)
+	p.EgressPerPortPolicies = s.getDirectionNetworkPolicy(ep, egressMap, egressPolicyEnforced, useFullTLSContext, useSDS, "egress", policySecretsNamespace)
 
 	return p
 }
@@ -1715,7 +1717,7 @@ func getNodeIDs(ep endpoint.EndpointUpdater, policy *policy.L4Policy) []string {
 	return nodeIDs
 }
 
-func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -1726,34 +1728,17 @@ func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy 
 		wg = nil
 	}
 
-	nodeIDs := getNodeIDs(ep, &policy.SelectorPolicy.L4Policy)
+	nodeIDs := getNodeIDs(ep, policy)
 
 	// only wait for the most current policy to be acked when no (new) policy is given
 	s.NetworkPolicyMutator.UseCurrent(NetworkPolicyTypeURL, nodeIDs, wg)
 }
 
-// ErrNotImplemented is the error returned by gRPC methods that are not
-// implemented by Cilium.
-var ErrNilPolicy = errors.New("nil EndpointPolicy")
-
-func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy.EndpointPolicy, wg *completion.WaitGroup,
+func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy,
+	ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup,
 ) (error, func() error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
-	if epp == nil {
-		return ErrNilPolicy, nil
-	}
-
-	l4policy := &epp.SelectorPolicy.L4Policy
-	ingressPolicyEnforced := epp.SelectorPolicy.IngressPolicyEnabled
-	egressPolicyEnforced := epp.SelectorPolicy.EgressPolicyEnabled
-	selectors := epp.GetPolicySelectors()
-
-	// Error out if the selectors are no longer valid
-	if !selectors.IsValid() {
-		return policy.ErrStaleSelectors, nil
-	}
 
 	ips := ep.GetPolicyNames()
 	if len(ips) == 0 {
@@ -1770,7 +1755,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 		return nil, func() error { return nil }
 	}
 
-	networkPolicy := s.getNetworkPolicy(ep, selectors, ips, l4policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.useSDS, s.secretManager.GetSecretSyncNamespace())
+	networkPolicy := s.getNetworkPolicy(ep, ips, policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.useSDS, s.secretManager.GetSecretSyncNamespace())
 
 	// First, validate the policy
 	err := networkPolicy.Validate()
@@ -1787,15 +1772,16 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 
 	// When successful, push policy into the cache.
 	var callback func(error)
-	policyRevision := l4policy.Revision
-	callback = func(err error) {
-		if err == nil {
-			go ep.OnProxyPolicyUpdate(policyRevision)
+	if policy != nil {
+		policyRevision := policy.Revision
+		callback = func(err error) {
+			if err == nil {
+				go ep.OnProxyPolicyUpdate(policyRevision)
+			}
 		}
 	}
-
 	epID := ep.GetID()
-	nodeIDs := getNodeIDs(ep, l4policy)
+	nodeIDs := getNodeIDs(ep, policy)
 	resourceName := strconv.FormatUint(epID, 10)
 	revertFunc := s.NetworkPolicyMutator.Upsert(NetworkPolicyTypeURL, resourceName, networkPolicy, nodeIDs, wg, callback)
 	revertUpdatedNetworkPolicyEndpoints := make(map[string]endpoint.EndpointUpdater, len(ips))

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -16,7 +17,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -203,7 +203,7 @@ func (m MockCachedSelector) GetSelections() identity.NumericIdentitySlice {
 	return nil
 }
 
-func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (m MockCachedSelector) GetSelectionsAt(*versioned.VersionHandle) identity.NumericIdentitySlice {
 	return nil
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdndns "github.com/cilium/cilium/pkg/fqdn/dns"
@@ -44,7 +45,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -1425,7 +1425,7 @@ func (t selectorMock) GetSelections() identity.NumericIdentitySlice {
 	panic("implement me")
 }
 
-func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (t selectorMock) GetSelectionsAt(*versioned.VersionHandle) identity.NumericIdentitySlice {
 	panic("implement me")
 }
 

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -86,6 +87,6 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		value := newMapStateEntry(0, NilRuleOrigin, proxyPort, 0, deny, NoAuthRequirement)
 		policyMaps := MapChanges{logger: slog.New(slog.DiscardHandler)}
 		policyMaps.AccumulateMapChanges(adds, deletes, []Key{key}, value)
-		policyMaps.SyncMapChanges(types.MockSelectorSnapshot())
+		policyMaps.SyncMapChanges(versioned.LatestTx)
 	})
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/bitlpm"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
@@ -760,19 +761,19 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 			continue
 		}
 
-		idents := cs.GetSelectionsAt(p.selectors)
+		idents := cs.GetSelectionsAt(p.VersionHandle)
 		if option.Config.Debug {
 			if entry.IsDeny() {
 				scopedLog.Debug(
 					"ToMapState: Denied remote IDs",
-					logfields.Version, p.selectors,
+					logfields.Version, p.VersionHandle,
 					logfields.EndpointSelector, cs,
 					logfields.PolicyID, idents,
 				)
 			} else {
 				scopedLog.Debug(
 					"ToMapState: Allowed remote IDs",
-					logfields.Version, p.selectors,
+					logfields.Version, p.VersionHandle,
 					logfields.EndpointSelector, cs,
 					logfields.PolicyID, idents,
 				)
@@ -826,7 +827,7 @@ func (l4 *L4Filter) IdentitySelectionUpdated(logger *slog.Logger, cs types.Cache
 	}
 }
 
-func (l4 *L4Filter) IdentitySelectionCommit(logger *slog.Logger, txn SelectorSnapshot) {
+func (l4 *L4Filter) IdentitySelectionCommit(logger *slog.Logger, txn *versioned.Tx) {
 	logger.Debug(
 		"identity selection updates done",
 		logfields.NewVersion, txn,
@@ -964,7 +965,7 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints types.Selectors, auth
 		Ingress:             ingress,
 	}
 
-	css, _ := selectorCache.AddSelectorsTxn(l4, origin.stringLabels(), peerEndpoints...)
+	css, _ := selectorCache.AddSelectors(l4, origin.stringLabels(), peerEndpoints...)
 	for _, cs := range css {
 		if cs.IsWildcard() {
 			l4.wildcard = cs
@@ -1119,8 +1120,11 @@ func (l4 *L4Filter) attach(ctx PolicyContext, l4Policy *L4Policy) (policyFeature
 	for cs, sp := range l4.PerSelectorPolicies {
 		if sp != nil {
 			// Allow localhost if requested and this is a redirect that selects the host
+			//
+			// Identities with a reserved:host label are never changed incrementally, so
+			// it is correct to use the latest version here. In case the host identity
+			// is mutated, the whole policy is recomputed.
 			if allowLocalhost && sp.IsRedirect() && cs.Selects(identity.ReservedIdentityHost) {
-				// Make sure host selector is in the selector cache.
 				host := api.ReservedEndpointSelectors[labels.IDNameHost]
 				// Add the cached host selector to the PerSelectorPolicies, if not
 				// already there. Use empty string labels due to this selector being
@@ -1654,7 +1658,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 }
 
 // SyncMapChanges marks earlier updates as completed
-func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn SelectorSnapshot) {
+func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn *versioned.Tx) {
 	// SelectorCache may not be called into while holding this lock!
 	l4Policy.mutex.RLock()
 

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -637,7 +638,7 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 					}
 
 					l4Policy.AccumulateMapChanges(logger, filter, cs, testSel.selections, nil)
-					l4Policy.SyncMapChanges(filter, types.MockSelectorSnapshot())
+					l4Policy.SyncMapChanges(filter, versioned.LatestTx)
 
 					closer, _ := epPolicy.ConsumeMapChanges()
 					closer()

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -308,11 +308,9 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 		hasIngressDefaultDeny, hasEgressDefaultDeny,
 		matchingRules := p.computePolicyEnforcementAndRules(securityIdentity)
 
-	sc := p.GetSelectorCache()
-
 	calculatedPolicy := &selectorPolicy{
 		Revision:             p.GetRevision(),
-		SelectorCache:        sc,
+		SelectorCache:        p.GetSelectorCache(),
 		L4Policy:             NewL4Policy(p.GetRevision()),
 		IngressPolicyEnabled: ingressEnabled,
 		EgressPolicyEnabled:  egressEnabled,
@@ -347,9 +345,6 @@ func (p *Repository) resolvePolicyLocked(securityIdentity *identity.Identity) (*
 
 	// Make the calculated policy ready for incremental updates
 	calculatedPolicy.Attach(&policyCtx)
-
-	// Commit selector changes
-	sc.Commit()
 
 	return calculatedPolicy, nil
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -852,9 +852,9 @@ func TestWildcardCIDRRulesEgress(t *testing.T) {
 	labelsL3 := labels.LabelArray{labels.ParseLabel("L3")}
 	labelsHTTP := labels.LabelArray{labels.ParseLabel("http")}
 
-	cachedSelectors, _ := td.sc.AddSelectorsTxn(dummySelectorCacheUser, EmptyStringLabels,
-		types.ToSelectors(api.CIDR("192.0.0.0/3"))...)
-	td.sc.Commit()
+	cachedSelectors, _ := td.sc.AddSelectors(dummySelectorCacheUser, EmptyStringLabels,
+		types.ToSelector(api.CIDR("192.0.0.0/3")))
+	defer td.sc.RemoveSelectors(cachedSelectors, dummySelectorCacheUser)
 
 	l480Get := api.Rule{
 		Egress: []api.EgressRule{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -38,7 +39,7 @@ type rule struct {
 func (r *rule) IdentitySelectionUpdated(logger *slog.Logger, selector types.CachedSelector, added, deleted []identity.NumericIdentity) {
 }
 
-func (d *rule) IdentitySelectionCommit(*slog.Logger, SelectorSnapshot) {
+func (d *rule) IdentitySelectionCommit(*slog.Logger, *versioned.Tx) {
 }
 
 func (r *rule) IsPeerSelector() bool {

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -7,9 +7,9 @@ import (
 	"iter"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -212,8 +212,8 @@ func (m *selectorMap) Delete(sel *identitySelector) {
 // in FIFO order while not holding any locks.
 type userNotification struct {
 	user     CachedSelectionUser
-	selector CachedSelector   // nil for a sync notification
-	txn      SelectorSnapshot // empty for non-sync notifications
+	selector CachedSelector // nil for a sync notification
+	txn      *versioned.Tx  // nil for non-sync notifications
 	added    []identity.NumericIdentity
 	deleted  []identity.NumericIdentity
 	wg       *sync.WaitGroup
@@ -224,24 +224,12 @@ type userNotification struct {
 type SelectorCache struct {
 	logger *slog.Logger
 
-	// readTxn for getting the current selections without taking any locks
-	// The stored pointer is never nil after initialization.
-	readTxn atomic.Pointer[SelectorSnapshot]
+	versioned *versioned.Coordinator
 
 	mutex lock.RWMutex
 
-	// revision is the revision number of selections, bumped on each commit.
-	revision types.SelectorRevision
-
-	// readableSelections holds the selections as of the last commit from writeableSelections.
-	readableSelections types.SelectionsMap
-
-	// writeableSelections is updated by each operation that may change the selections of a
-	// selector (adding/removing selectors/identities) and is always kept open and committed on
-	// request. Updates from all concurrent callers are pooled to the same write transaction
-	// until Commit() is called.
-	// There may be no other write transactions on 'selections'.
-	writeableSelections types.SelectorWriteTxn
+	// selectorUpdates tracks changed selectors for efficient cleanup of old versions
+	selectorUpdates versioned.VersionedSlice[*identitySelector]
 
 	// idCache contains all known identities as informed by the
 	// kv-store and the local identity facility via our
@@ -267,24 +255,27 @@ type SelectorCache struct {
 	startNotificationsHandlerOnce sync.Once
 }
 
-// GetReadTxn returns a read-only state of the current selectors in the selector cache.
-// The returned SelectorReadTxn should be Close()d as soon as possible to limit memory use.
-func (sc *SelectorCache) GetSelectorSnapshot() SelectorSnapshot {
-	return *sc.readTxn.Load()
-}
-
-// WithRLock calls the given function with the selector cache locked for reading, so that the caller
-// may get ready for getting incremental updates (by registering as a user) that are possible right
-// after the lock is released.  This should only be used with trivial functions that can not lock or
-// sleep.
-func (sc *SelectorCache) WithRLock(f func(sc *SelectorCache)) {
+// GetVersionHandleFunc calls the given function with a versioned.VersionHandle for the
+// current version of SelectorCache selections while selector cache is locked for writing, so that
+// the caller may get ready for getting incremental updates that are possible right after the lock
+// is released.
+// This should only be used with trivial functions that can not lock or sleep.
+// Use the plain 'GetVersionHandle' whenever possible, as it does not lock the selector cache.
+// VersionHandle passed to 'f' must be closed with Close().
+func (sc *SelectorCache) GetVersionHandleFunc(f func(*versioned.VersionHandle)) {
 	// Lock synchronizes with UpdateIdentities() so that we do not use a stale version
 	// that may already have received partial incremental updates.
 	// Incremental updates are delivered asynchronously, so so the caller may still receive
 	// updates for older versions. These should be filtered out.
-	sc.mutex.RLock()
-	defer sc.mutex.RUnlock()
-	f(sc)
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	f(sc.GetVersionHandle())
+}
+
+// GetVersionHandle returns a VersoionHandle for the current version.
+// The returned VersionHandle must be closed with Close()
+func (sc *SelectorCache) GetVersionHandle() *versioned.VersionHandle {
+	return sc.versioned.GetVersionHandle()
 }
 
 // GetModel returns the API model of the SelectorCache.
@@ -296,9 +287,9 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 
 	// Get handle to the current version. Any concurrent updates will not be visible in the
 	// returned model.
-	version := sc.GetSelectorSnapshot()
+	version := sc.GetVersionHandle()
+	defer version.Close()
 
-	// iterating selectors requires read lock
 	for key, sel := range sc.selectors.All() {
 		selections := sel.GetSelectionsAt(version)
 		ids := make([]int64, 0, len(selections))
@@ -323,9 +314,9 @@ func (sc *SelectorCache) Stats() selectorStats {
 	sc.mutex.RLock()
 	defer sc.mutex.RUnlock()
 
-	version := sc.GetSelectorSnapshot()
+	version := sc.GetVersionHandle()
+	defer version.Close()
 
-	// iterating selectors requires read lock
 	for _, sel := range sc.selectors.All() {
 		if !sel.MaySelectPeers() {
 			// Peer selectors impact policymap cardinality, but
@@ -400,7 +391,7 @@ func (sc *SelectorCache) queueUserNotification(user CachedSelectionUser, selecto
 	sc.userCond.Signal()
 }
 
-func (sc *SelectorCache) queueNotifiedUsersCommit(txn SelectorSnapshot, wg *sync.WaitGroup) {
+func (sc *SelectorCache) queueNotifiedUsersCommit(txn *versioned.Tx, wg *sync.WaitGroup) {
 	sc.userMutex.Lock()
 	for user := range sc.notifiedUsers {
 		wg.Add(1)
@@ -425,9 +416,11 @@ func NewSelectorCache(logger *slog.Logger, ids identity.IdentityMap) *SelectorCa
 		selectors: selectorMapInitializer(),
 	}
 	sc.userCond = sync.NewCond(&sc.userMutex)
-	sc.writeableSelections = sc.readableSelections.Txn()
-	readTxn := types.GetSelectorSnapshot(sc.readableSelections, sc.revision)
-	sc.readTxn.Store(&readTxn)
+	sc.versioned = &versioned.Coordinator{
+		Cleaner: sc.oldVersionCleaner,
+		Logger:  logger,
+	}
+
 	return sc
 }
 
@@ -435,6 +428,28 @@ func (sc *SelectorCache) RegisterMetrics() {
 	if err := metrics.Register(newSelectorCacheMetrics(sc)); err != nil {
 		sc.logger.Warn("Selector cache metrics registration failed. No metrics will be reported.", logfields.Error, err)
 	}
+}
+
+// oldVersionCleaner is called from a goroutine without holding any locks
+func (sc *SelectorCache) oldVersionCleaner(keepVersion versioned.KeepVersion) {
+	// Log before taking the lock so that if we ever have a deadlock here this log line will be seen
+	sc.logger.Debug(
+		"Cleaning old selector and identity versions",
+		logfields.Version, keepVersion,
+	)
+
+	// This is called when some versions are no longer needed, from wherever
+	// VersionHandle's may be kept, so we must take the lock to safely access
+	// 'sc.selectorUpdates'.
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
+	n := 0
+	for sel := range sc.selectorUpdates.Before(keepVersion) {
+		sel.selections.RemoveBefore(keepVersion)
+		n++
+	}
+	sc.selectorUpdates = sc.selectorUpdates[n:]
 }
 
 // SetLocalIdentityNotifier injects the provided identityNotifier into the
@@ -474,73 +489,27 @@ type identityNotifier interface {
 	UnregisterFQDNSelector(selector api.FQDNSelector) (ipcacheRevision uint64)
 }
 
-// commit applies all changes since the last commit to the selections and bumps the revision number
-// by one. sc.writeTxn is reused for the next transaction. For this to work `sc.writeTxn` must have
-// been initialized from `sc.selections.Txn()` and no other write transactions for the selections
-// may exist.
-//
-// Lock must be held.
-func (sc *SelectorCache) commit() SelectorSnapshot {
-	sc.revision++
-	sc.readableSelections = sc.writeableSelections.Commit()
-	readTxn := types.GetSelectorSnapshot(sc.readableSelections, sc.revision)
-	sc.readTxn.Store(&readTxn)
-	return readTxn
-}
-
-// Commit makes the selections of new selectors added via AddSelectors visible via
-// CachedSelector.GetSelections() and CachedSelector.GetSelectionsAt().
-func (sc *SelectorCache) Commit() {
-	sc.mutex.Lock()
-	defer sc.mutex.Unlock()
-	sc.commit()
-}
-
-func selectsAll(selectors ...Selector) bool {
-	if len(selectors) == 0 {
-		return true
-	}
-	for idx := range selectors {
-		if selectors[idx].IsWildcard() {
-			return true
-		}
-	}
-	return false
-}
-
-// AddSelectorsTxn adds Selectors in to the selector cache, and returns the corresponding
-// slice of cached selectors.
-// Commit() must be called aftewards to make the selections of new selectors observable by readers.
-func (sc *SelectorCache) AddSelectorsTxn(user CachedSelectionUser, lbls stringLabels, selectors ...Selector) (CachedSelectorSlice, bool) {
-	if selectsAll(selectors...) {
-		selectors = []Selector{types.WildcardSelector}
-	}
-
-	sc.mutex.Lock()
-	defer sc.mutex.Unlock()
-
-	return sc.addSelectorsTxn(user, lbls, selectors...)
-}
-
-// AddSelectors adds Selectors in to the selector cache, and returns the corresponding slice of
-// cached selectors.
-// Selections of new selectors are visible to readers right after this call.
+// AddSelectors adds Selectors in to the selector cache, and iterates through all newly
+// added 'user' for each selector.
 func (sc *SelectorCache) AddSelectors(user CachedSelectionUser, lbls stringLabels, selectors ...Selector) (CachedSelectorSlice, bool) {
-	if selectsAll(selectors...) {
+	selectsAll := len(selectors) == 0 || func() bool {
+		for idx := range selectors {
+			if selectors[idx].IsWildcard() {
+				return true
+			}
+		}
+		return false
+	}()
+	if selectsAll {
 		selectors = []Selector{types.WildcardSelector}
 	}
+
+	css := make(CachedSelectorSlice, len(selectors))
+	added := false
 
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
 
-	defer sc.commit()
-	return sc.addSelectorsTxn(user, lbls, selectors...)
-}
-
-func (sc *SelectorCache) addSelectorsTxn(user CachedSelectionUser, lbls stringLabels, selectors ...Selector) (CachedSelectorSlice, bool) {
-	css := make(CachedSelectorSlice, len(selectors))
-
-	added := false
 	for i, selector := range selectors {
 		// Check if the selector has already been cached
 		key := selector.Key()
@@ -561,7 +530,14 @@ func (sc *SelectorCache) addSelectorsTxn(user CachedSelectionUser, lbls stringLa
 
 // must hold lock for writing
 func (sc *SelectorCache) addSelectorLocked(lbls stringLabels, key string, source Selector) *identitySelector {
-	sel := newIdentitySelector(sc, key, source, lbls)
+	sel := &identitySelector{
+		logger:           sc.logger,
+		key:              key,
+		users:            make(map[CachedSelectionUser]struct{}),
+		cachedSelections: make(map[identity.NumericIdentity]struct{}),
+		source:           source,
+		metadataLbls:     lbls,
+	}
 
 	sc.selectors.Set(key, sel)
 
@@ -578,7 +554,9 @@ func (sc *SelectorCache) addSelectorLocked(lbls stringLabels, key string, source
 
 	// Create the immutable slice representation of the selected
 	// numeric identities
-	sel.updateSelections()
+	txn := sc.versioned.PrepareNextVersion()
+	sel.updateSelections(txn)
+	txn.Commit()
 
 	return sel
 }
@@ -599,7 +577,6 @@ func (sc *SelectorCache) AddIdentitySelectorForTest(user CachedSelectionUser, lb
 	sel, exists := sc.selectors.Get(key)
 	if !exists {
 		sel = sc.addSelectorLocked(lbls, key, types.NewLabelSelector(es))
-		sc.commit()
 	}
 	return sel, sel.addUser(user, sc.localIdentityNotifier)
 }
@@ -610,7 +587,6 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 	sel, exists := sc.selectors.Get(key)
 	if exists && sel.removeUser(user, sc.localIdentityNotifier) {
 		sc.selectors.Delete(sel)
-		sel.updateSelections()
 	}
 }
 
@@ -618,7 +594,6 @@ func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user Cach
 func (sc *SelectorCache) RemoveSelector(selector CachedSelector, user CachedSelectionUser) {
 	sc.mutex.Lock()
 	sc.removeSelectorLocked(selector, user)
-	sc.commit()
 	sc.mutex.Unlock()
 }
 
@@ -628,7 +603,6 @@ func (sc *SelectorCache) RemoveSelectors(selectors CachedSelectorSlice, user Cac
 	for _, selector := range selectors {
 		sc.removeSelectorLocked(selector, user)
 	}
-	sc.commit()
 	sc.mutex.Unlock()
 }
 
@@ -681,7 +655,7 @@ func (sc *SelectorCache) CanSkipUpdate(added, deleted identity.IdentityMap) bool
 // Returns:
 // - updated as true if any changes were made
 // - mutated as true if any identity was mutated
-func (sc *SelectorCache) updateSelections(sel *identitySelector, added identity.NumericIdentitySlice, deleted identity.IdentityMap, wg *sync.WaitGroup) (updated, mutated bool) {
+func (sc *SelectorCache) updateSelections(txn *versioned.Tx, sel *identitySelector, added identity.NumericIdentitySlice, deleted identity.IdentityMap, wg *sync.WaitGroup) (updated, mutated bool) {
 	var adds, dels []identity.NumericIdentity
 	for numericID := range deleted {
 		if _, exists := sel.cachedSelections[numericID]; exists {
@@ -710,7 +684,8 @@ func (sc *SelectorCache) updateSelections(sel *identitySelector, added identity.
 	}
 	if len(dels)+len(adds) > 0 {
 		updated = true
-		sel.updateSelections()
+		sc.selectorUpdates = sc.selectorUpdates.Append(sel, txn)
+		sel.updateSelections(txn)
 		sel.notifyUsers(sc, adds, dels, wg)
 	}
 	return updated, mutated
@@ -739,7 +714,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
 
-	nextRev := sc.revision + 1
+	txn := sc.versioned.PrepareNextVersion()
 
 	// Update idCache so that newly added selectors get
 	// prepopulated with all matching numeric identities.
@@ -747,7 +722,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 		if old, exists := sc.idCache.find(numericID); exists {
 			sc.logger.Debug(
 				"UpdateIdentities: Deleting identity",
-				logfields.NewVersion, nextRev,
+				logfields.NewVersion, txn,
 				logfields.Identity, numericID,
 				logfields.Labels, old.lbls,
 			)
@@ -756,7 +731,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 		} else {
 			sc.logger.Warn(
 				"UpdateIdentities: Skipping Delete of a non-existing identity",
-				logfields.NewVersion, nextRev,
+				logfields.NewVersion, txn,
 				logfields.Identity, numericID,
 			)
 			delete(deleted, numericID)
@@ -771,7 +746,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 			if lbls.Equals(old.lbls) {
 				sc.logger.Debug(
 					"UpdateIdentities: Skipping add of an existing identical identity",
-					logfields.NewVersion, nextRev,
+					logfields.NewVersion, txn,
 					logfields.Identity, numericID,
 				)
 				delete(added, numericID)
@@ -784,14 +759,14 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 			// ipcache.TriggerLabelInjection().
 			if numericID == identity.ReservedIdentityHost {
 				sc.logger.Debug(msg,
-					logfields.NewVersion, nextRev,
+					logfields.NewVersion, txn,
 					logfields.Identity, numericID,
 					logfields.Labels, old.lbls,
 					logfields.LabelsNew, lbls,
 				)
 			} else {
 				sc.logger.Warn(msg,
-					logfields.NewVersion, nextRev,
+					logfields.NewVersion, txn,
 					logfields.Identity, numericID,
 					logfields.Labels, old.lbls,
 					logfields.LabelsNew, lbls,
@@ -800,7 +775,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 		} else {
 			sc.logger.Debug(
 				"UpdateIdentities: Adding a new identity",
-				logfields.NewVersion, nextRev,
+				logfields.NewVersion, txn,
 				logfields.Identity, numericID,
 				logfields.Labels, lbls,
 			)
@@ -821,7 +796,7 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 			// Iterate through all locally used identity selectors and
 			// update the cached numeric identities as required.
 			for sel := range sc.selectors.ByNamespace(ns) {
-				u, m := sc.updateSelections(sel, nsAdded, deleted, wg)
+				u, m := sc.updateSelections(txn, sel, nsAdded, deleted, wg)
 				updated = updated || u
 				mutated = mutated || m
 			}
@@ -829,8 +804,20 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 	}
 
 	if updated {
-		readTxn := sc.commit()
-		sc.queueNotifiedUsersCommit(readTxn, wg)
+		// Launch a waiter that holds the new version as long as needed for users to have
+		// grabbed it
+		sc.queueNotifiedUsersCommit(txn, wg)
+
+		go func(version *versioned.VersionHandle) {
+			wg.Wait()
+			sc.logger.Debug(
+				"UpdateIdentities: Waited for incremental updates to have committed, closing handle on the new version.",
+				logfields.NewVersion, txn,
+			)
+			version.Close()
+		}(txn.GetVersionHandle())
+
+		txn.Commit()
 	}
 	return mutated
 }

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -4,12 +4,14 @@
 package policy
 
 import (
+	"log/slog"
 	"slices"
 	"sort"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -21,8 +23,6 @@ type CachedSelectorSlice = types.CachedSelectorSlice
 type CachedSelectionUser = types.CachedSelectionUser
 type Selector = types.Selector
 type Selectors = types.Selectors
-type SelectorSnapshot = types.SelectorSnapshot
-type SelectorRevision = types.SelectorRevision
 
 // identitySelector is the internal type for all selectors in the
 // selector cache.
@@ -60,28 +60,13 @@ type SelectorRevision = types.SelectorRevision
 // so it must always be given to the user as a pointer to the actual type.
 // (The public methods only expose the CachedSelector interface.)
 type identitySelector struct {
-	selectorCache    *SelectorCache
+	logger           *slog.Logger
 	source           Selector
 	key              string
-	id               types.SelectorId
+	selections       versioned.Value[identity.NumericIdentitySlice]
 	users            map[CachedSelectionUser]struct{}
 	cachedSelections map[identity.NumericIdentity]struct{}
 	metadataLbls     stringLabels
-}
-
-var lastSelectorId types.SelectorId
-
-func newIdentitySelector(sc *SelectorCache, key string, source Selector, lbls stringLabels) *identitySelector {
-	lastSelectorId++
-	return &identitySelector{
-		selectorCache:    sc,
-		key:              key,
-		id:               lastSelectorId,
-		users:            make(map[CachedSelectionUser]struct{}),
-		cachedSelections: make(map[identity.NumericIdentity]struct{}),
-		source:           source,
-		metadataLbls:     lbls,
-	}
 }
 
 func (i *identitySelector) MaySelectPeers() bool {
@@ -90,6 +75,7 @@ func (i *identitySelector) MaySelectPeers() bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -116,8 +102,7 @@ func (i *identitySelector) Equal(b *identitySelector) bool {
 //
 // CachedSelector implementation (== Public API)
 //
-// No locking needed and selector cache must not be locked when making these calls!
-// (SelectorCache.GetReadTxn() takes a read lock)
+// No locking needed.
 //
 
 // GetSelectionsAt returns the set of numeric identities currently
@@ -126,7 +111,7 @@ func (i *identitySelector) Equal(b *identitySelector) bool {
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
 func (i *identitySelector) GetSelections() identity.NumericIdentitySlice {
-	return i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
+	return i.selections.At(versioned.Latest())
 }
 
 // GetSelectionsAt returns the set of numeric identities currently
@@ -134,20 +119,16 @@ func (i *identitySelector) GetSelections() identity.NumericIdentitySlice {
 // that case GetSelectionsAt() will return either the old or new version
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
-func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) identity.NumericIdentitySlice {
-	if !selectors.IsValid() || i.id == 0 {
-		msg := "GetSelectionsAt: Invalid selector snapshot finds nothing"
-		if i.id == 0 {
-			msg = "GetSelectionsAt: Uninitialized identitySelector"
-		}
-		i.selectorCache.logger.Error(
-			msg,
-			logfields.Version, selectors,
+func (i *identitySelector) GetSelectionsAt(version *versioned.VersionHandle) identity.NumericIdentitySlice {
+	if !version.IsValid() {
+		i.logger.Error(
+			"GetSelections: Invalid VersionHandle finds nothing",
+			logfields.Version, version,
 			logfields.Stacktrace, hclog.Stacktrace(),
 		)
 		return identity.NumericIdentitySlice{}
 	}
-	return selectors.Get(i.id)
+	return i.selections.At(version)
 }
 
 func (i *identitySelector) GetMetadataLabels() labels.LabelArray {
@@ -230,22 +211,32 @@ func (i *identitySelector) numUsers() int {
 // cached selections after the cached selections have been changed.
 //
 // lock must be held
-func (i *identitySelector) updateSelections() {
-	if len(i.cachedSelections) == 0 {
-		i.selectorCache.writeableSelections.Delete(i.id)
-		return
-	}
-
-	ids := make(identity.NumericIdentitySlice, 0, len(i.cachedSelections))
-
+func (i *identitySelector) updateSelections(nextVersion *versioned.Tx) {
+	selections := make(identity.NumericIdentitySlice, len(i.cachedSelections))
+	idx := 0
 	for nid := range i.cachedSelections {
-		ids = append(ids, nid)
+		selections[idx] = nid
+		idx++
 	}
-
 	// Sort the numeric identities so that the map iteration order
 	// does not matter. This makes testing easier, but may help
 	// identifying changes easier also otherwise.
-	slices.Sort(ids)
+	slices.Sort(selections)
+	i.setSelections(selections, nextVersion)
+}
 
-	i.selectorCache.writeableSelections.Set(i.id, ids)
+func (i *identitySelector) setSelections(selections identity.NumericIdentitySlice, nextVersion *versioned.Tx) {
+	var err error
+	if len(selections) > 0 {
+		err = i.selections.SetAt(selections, nextVersion)
+	} else {
+		err = i.selections.RemoveAt(nextVersion)
+	}
+	if err != nil {
+		i.logger.Error(
+			"setSelections failed",
+			logfields.Error, err,
+			logfields.Stacktrace, hclog.Stacktrace(),
+		)
+	}
 }

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -5,17 +5,14 @@ package types
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/netip"
 	"slices"
-	"strconv"
 	"strings"
 
-	"github.com/cilium/statedb/part"
-
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -527,66 +524,6 @@ func (p *CIDRSelector) MetricsClass() string {
 	return LabelValueSCWorld
 }
 
-type SelectorId uint64
-type SelectorRevision uint64
-
-func init() {
-	part.RegisterKeyType(func(x SelectorId) []byte {
-		return binary.BigEndian.AppendUint64(nil, uint64(x))
-	})
-}
-
-type SelectionsMap = part.Map[SelectorId, identity.NumericIdentitySlice]
-type SelectorWriteTxn = part.MapTxn[SelectorId, identity.NumericIdentitySlice]
-
-// SelectorSnapshot contains state needed to observe a coherent set of selectors
-type SelectorSnapshot struct {
-	Revision   SelectorRevision
-	selections SelectionsMap
-	valid      bool
-}
-
-func GetSelectorSnapshot(selections SelectionsMap, rev SelectorRevision) SelectorSnapshot {
-	return SelectorSnapshot{selections: selections, Revision: rev, valid: true}
-}
-
-// used for testing only
-func MockSelectorSnapshot() SelectorSnapshot {
-	return SelectorSnapshot{Revision: 1, valid: true}
-}
-
-func (s *SelectorSnapshot) Get(id SelectorId) identity.NumericIdentitySlice {
-	v, _ := s.selections.Get(id)
-	if len(v) == 0 {
-		return nil
-	}
-	return v
-}
-
-// Invalidate should be called on any SelectorReadTxn values that are stored in the heap.
-// This allows GC to reclaim the memory held for old versions of the selections map.
-// Invalidating local variables going out-of-scope does nothing useful.
-func (s *SelectorSnapshot) Invalidate() {
-	s.selections = SelectionsMap{}
-	s.valid = false
-}
-
-func (s *SelectorSnapshot) After(rev SelectorRevision) bool {
-	return s.Revision > rev
-}
-
-func (s *SelectorSnapshot) IsValid() bool {
-	return s.valid
-}
-
-func (s *SelectorSnapshot) String() string {
-	str := " (invalid)"
-	if s.IsValid() {
-		str = " (valid)"
-	}
-	return strconv.FormatUint(uint64(s.Revision), 10) + str
-}
-
 // CachedSelector represents an identity selector owned by the selector cache
 type CachedSelector interface {
 	// GetSelections returns the cached set of numeric identities
@@ -598,7 +535,7 @@ type CachedSelector interface {
 	// GetSelectionsAt returns the cached set of numeric identities
 	// selected by the CachedSelector.  The retuned slice must NOT
 	// be modified, as it is shared among multiple users.
-	GetSelectionsAt(SelectorSnapshot) identity.NumericIdentitySlice
+	GetSelectionsAt(*versioned.VersionHandle) identity.NumericIdentitySlice
 
 	// GetMetadataLabels returns metadata labels for additional context
 	// surrounding the selector. These are typically the labels associated with
@@ -674,7 +611,7 @@ type CachedSelectionUser interface {
 
 	// IdentitySelectionCommit tells the user that all IdentitySelectionUpdated calls relating
 	// to a specific added or removed identity have been made.
-	IdentitySelectionCommit(*slog.Logger, SelectorSnapshot)
+	IdentitySelectionCommit(logger *slog.Logger, txn *versioned.Tx)
 
 	// IsPeerSelector returns true if the selector is used by the policy
 	// engine for selecting traffic for remote peers. False if used for

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -4,6 +4,7 @@
 package endpoint
 
 import (
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -31,6 +32,11 @@ type EndpointUpdater interface {
 	// UpdateProxyStatistics updates the Endpoint's proxy statistics to account
 	// for a new observed flow with the given characteristics.
 	UpdateProxyStatistics(proxyType, l4Protocol string, port, proxyPort uint16, ingress, request bool, verdict accesslog.FlowVerdict)
+
+	// GetPolicyVersionHandle returns the selector cache version handle held for Endpoint's
+	// desired policy, if any.
+	// Must be called with Endpoint's read lock taken.
+	GetPolicyVersionHandle() *versioned.VersionHandle
 
 	// GetListenerProxyPort returns the proxy port for the given listener reference.
 	// Returns zero if the proxy port does not exist (yet).

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -67,11 +67,11 @@ func (p *envoyProxyIntegration) changeLogLevel(level slog.Level) error {
 	return p.adminClient.ChangeLogLevel(level)
 }
 
-func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
-	return p.xdsServer.UpdateNetworkPolicy(ep, policy, wg)
+func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	return p.xdsServer.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
 }
 
-func (p *envoyProxyIntegration) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (p *envoyProxyIntegration) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 	p.xdsServer.UseCurrentNetworkPolicy(ep, policy, wg)
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -328,11 +328,11 @@ func (p *Proxy) removeRedirect(id string) {
 	}
 }
 
-func (p *Proxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
-	return p.envoyIntegration.UpdateNetworkPolicy(ep, policy, wg)
+func (p *Proxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
+	return p.envoyIntegration.UpdateNetworkPolicy(ep, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
 }
 
-func (p *Proxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (p *Proxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 	p.envoyIntegration.UseCurrentNetworkPolicy(ep, policy, wg)
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -201,11 +201,11 @@ func (*fakeXdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
+func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 	panic("unimplemented")
 }
 

--- a/pkg/testutils/policy/selectorcache.go
+++ b/pkg/testutils/policy/selectorcache.go
@@ -6,6 +6,7 @@ package testpolicy
 import (
 	"log/slog"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
@@ -15,7 +16,7 @@ type DummySelectorCacheUser struct{}
 func (d *DummySelectorCacheUser) IdentitySelectionUpdated(logger *slog.Logger, selector types.CachedSelector, added, deleted []identity.NumericIdentity) {
 }
 
-func (d *DummySelectorCacheUser) IdentitySelectionCommit(logger *slog.Logger, txn types.SelectorSnapshot) {
+func (d *DummySelectorCacheUser) IdentitySelectionCommit(logger *slog.Logger, txn *versioned.Tx) {
 }
 
 func (d *DummySelectorCacheUser) IsPeerSelector() bool {

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -24,13 +24,13 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
+	"github.com/cilium/cilium/pkg/container/versioned"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 
@@ -584,7 +584,7 @@ func (d *DNSServerIdentity) GetSelections() identity.NumericIdentitySlice {
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (d *DNSServerIdentity) GetSelectionsAt(_ *versioned.VersionHandle) identity.NumericIdentitySlice {
 	return d.Identities
 }
 


### PR DESCRIPTION
Reverts the last commit from cilium/cilium#42992.

Seeing pretty consistent failures of the `TestTransactionalUpdate` test on `main` now. Looks like this can be bisected back to this change.

Locally I'm able to repro the following error with latest main;
```
=== RUN   TestTransactionalUpdate
    selectorcache_test.go:151:
                Error Trace:    /mnt/code/pkg/policy/selectorcache_test.go:151
                                                        /mnt/code/pkg/policy/selectorcache.go:378
                                                        /usr/local/go/src/runtime/asm_arm64.s:1268
                Error:          Should be false
                Test:           TestTransactionalUpdate
```

With this revert I'm not able to reproduce so far - so its clearly some kind of race here, but its not fully clear to me why. I think we should revert for now until we fully understand whats going on. Its not deterministically failing, and it only does so very rarely - but there has to be a race somewhere.

I think the reason for the CI fail in https://github.com/cilium/cilium/pull/43231 was because some other test took a long time, causing the go testing tooling to realize that the selectorcache is leaking the goroutine `handleUserNotifications` thats never cleaned up. So if all tests take more time than the test timeout, it can hit that. Reproducing that test failure is easy locally, since you can do something like `go test -v -run "TestTransactionalUpdate" -count=100000 -timeout=1s`. This is also probably something we should fix at some point.