### PR TITLE
endpoint: fix endpoint deadlock when writing headers fails

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -441,6 +441,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	dir := datapathRegenCtxt.currentDir
 	if datapathRegenCtxt.regenerationLevel >= regeneration.RegenerateWithDatapath {
 		if err := e.writeHeaderfile(datapathRegenCtxt.nextDir); err != nil {
+			e.unlock()
 			return 0, fmt.Errorf("write endpoint header file: %w", err)
 		}
 		dir = datapathRegenCtxt.nextDir


### PR DESCRIPTION
In cases when writeHeaderfile fails with any error, we were not releasing endpoint lock.

Example stacktrace:
```
goroutine 49226834 [sync.Mutex.Lock, 1132 minutes]:

/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:859
[...]
/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:411
[...]
 /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:444
```

` /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:444` corresponds to https://github.com/cilium/cilium/blob/8d87ca7a88fbabdf7660fe6148c80686962f94f5/pkg/endpoint/bpf.go#L444
Note that we acquired endpoint lock before.

`/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:411` corresponds to https://github.com/cilium/cilium/blob/8d87ca7a88fbabdf7660fe6148c80686962f94f5/pkg/endpoint/bpf.go#L411

`/go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:859` corresponds to https://github.com/cilium/cilium/blob/8d87ca7a88fbabdf7660fe6148c80686962f94f5/pkg/endpoint/bpf.go#L859 that is trying to get endpoint lock again.

Fixes: #39429

```release-note
Fixes a deadlock that was causing endpoint to be stuck without progressing with any updates.
```
