### PR TITLE
.github/workflows: make adjustments for new GitHub workflow behavior

### DIFF
--- a/.github/workflows/auto-labeler-v1.18.yaml
+++ b/.github/workflows/auto-labeler-v1.18.yaml
@@ -8,6 +8,7 @@ on:
       - opened
       - reopened
 
+
 jobs:
   external-contributions:
     if: |

--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
       - reopened
+    branches-ignore:
+      - v1.18
+      - v1.17
+      - v1.16
 
 jobs:
   external-contributions:

--- a/.github/workflows/build-images-base-v1.16.yaml
+++ b/.github/workflows/build-images-base-v1.16.yaml
@@ -12,23 +12,6 @@ on:
     paths:
       - images/runtime/**
       - images/builder/**
-  # This workflow can be reused so that renovate can execute this workflow_dispatch:
-  # run from a different environment than 'release-base-images'. See
-  # build-images-base-renovate.yaml
-  workflow_call:
-    secrets:
-      QUAY_BASE_RELEASE_USERNAME_202411:
-        required: true
-      QUAY_BASE_RELEASE_PASSWORD_202411:
-        required: true
-      AUTO_COMMITTER_PEM_202411:
-        required: true
-      AUTO_COMMITTER_APP_ID_202411:
-        required: true
-    inputs:
-      environment:
-        type: string
-        default: "release-base-images"
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -46,7 +29,7 @@ jobs:
     if: ${{ ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment: 'release-base-images'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout default branch (trusted)
@@ -342,7 +325,7 @@ jobs:
   image-digests:
     name: Display Digests
     runs-on: ubuntu-24.04
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment: 'release-base-images'
     needs: build-and-push
     steps:
       - name: Downloading Image Digests

--- a/.github/workflows/build-images-base-v1.17.yaml
+++ b/.github/workflows/build-images-base-v1.17.yaml
@@ -12,23 +12,6 @@ on:
     paths:
       - images/runtime/**
       - images/builder/**
-  # This workflow can be reused so that renovate can execute this workflow_dispatch:
-  # run from a different environment than 'release-base-images'. See
-  # build-images-base-renovate.yaml
-  workflow_call:
-    secrets:
-      QUAY_BASE_RELEASE_USERNAME_202411:
-        required: true
-      QUAY_BASE_RELEASE_PASSWORD_202411:
-        required: true
-      AUTO_COMMITTER_PEM_202411:
-        required: true
-      AUTO_COMMITTER_APP_ID_202411:
-        required: true
-    inputs:
-      environment:
-        type: string
-        default: "release-base-images"
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -44,7 +27,7 @@ jobs:
   has-credentials:
     name: Check for Quay secrets
     runs-on: ubuntu-24.04
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment: 'release-base-images'
     timeout-minutes: 2
     outputs:
       present: ${{ steps.secrets.outputs.present }}
@@ -63,7 +46,7 @@ jobs:
     if: ${{ needs.has-credentials.outputs.present && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment: 'release-base-images'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout default branch (trusted)
@@ -343,7 +326,7 @@ jobs:
   image-digests:
     name: Display Digests
     runs-on: ubuntu-24.04
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment: 'release-base-images'
     needs: build-and-push
     steps:
       - name: Downloading Image Digests

--- a/.github/workflows/build-images-base-v1.18.yaml
+++ b/.github/workflows/build-images-base-v1.18.yaml
@@ -12,23 +12,6 @@ on:
     paths:
       - images/runtime/**
       - images/builder/**
-  # This workflow can be reused so that renovate can execute this workflow_dispatch:
-  # run from a different environment than 'release-base-images'. See
-  # build-images-base-renovate.yaml
-  workflow_call:
-    secrets:
-      QUAY_BASE_RELEASE_USERNAME_202411:
-        required: true
-      QUAY_BASE_RELEASE_PASSWORD_202411:
-        required: true
-      AUTO_COMMITTER_PEM_202411:
-        required: true
-      AUTO_COMMITTER_APP_ID_202411:
-        required: true
-    inputs:
-      environment:
-        required: true
-        type: string
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -46,7 +29,7 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment: 'release-base-images'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -10,6 +10,10 @@ on:
     paths:
       - images/runtime/**
       - images/builder/**
+    branches-ignore:
+      - v1.18
+      - v1.17
+      - v1.16
   # This workflow can be reused so that renovate can execute this workflow_dispatch:
   # run from a different environment than 'release-base-images'. See
   # build-images-base-renovate.yaml

--- a/.github/workflows/build-images-ci-v1.16.yaml
+++ b/.github/workflows/build-images-ci-v1.16.yaml
@@ -9,10 +9,6 @@ on:
       - opened
       - synchronize
       - reopened
-  push:
-    branches:
-      - v1.16
-      - ft/v1.16/**
 
 permissions:
   # To be able to access the repository with `actions/checkout`
@@ -82,6 +78,11 @@ jobs:
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
+
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch
+          cp -r .github/actions/set-runtime-image ../cilium-base-branch
 
       - name: Check for disk usage and cleanup /mnt
         shell: bash
@@ -169,6 +170,15 @@ jobs:
         run: |
           df -h
 
+      - name: Copy runtime image tag from untrusted branch
+        run: |
+          cp -r .github/actions/set-runtime-image/runtime-image.txt ../cilium-base-branch/set-runtime-image/
+
+      - name: Set runtime image environment variable
+        uses: ./../cilium-base-branch/set-runtime-image
+        with:
+          repository: ${{ env.CILIUM_RUNTIME_IMAGE_PREFIX }}
+
       # Load Golang cache build from GitHub
       - name: Restore Golang cache build from GitHub
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -228,6 +238,7 @@ jobs:
           tags: ${{ steps.tag.outputs.normal_tag }}
           target: release
           build-args: |
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: CI race detection Build ${{ matrix.name }}
@@ -243,7 +254,8 @@ jobs:
           tags: ${{ steps.tag.outputs.race_tag }}
           target: release
           build-args: |
-            BASE_IMAGE=quay.io/cilium/cilium-runtime:b21eb30e9334659f2f5b42ec71ad373fc6a10239@sha256:96a219d4c99c02049fecc7798a0f3a0494a4e589115cb36172e75c7d0383c148
+            BASE_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
             MODIFIERS="LOCKDEBUG=1 RACE=1"
             OPERATOR_VARIANT=${{ matrix.name }}
 
@@ -260,6 +272,7 @@ jobs:
           tags: ${{ steps.tag.outputs.unstripped_tag }}
           target: release
           build-args: |
+            CILIUM_RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
             MODIFIERS="NOSTRIP=1"
             OPERATOR_VARIANT=${{ matrix.name }}
 

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -9,10 +9,6 @@ on:
       - opened
       - synchronize
       - reopened
-  push:
-    branches:
-      - v1.17
-      - ft/v1.17/**
 
 permissions:
   # To be able to access the repository with `actions/checkout`

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -9,10 +9,6 @@ on:
       - opened
       - synchronize
       - reopened
-  push:
-    branches:
-      - v1.18
-      - ft/v1.18/**
 
 permissions:
   # To be able to access the repository with `actions/checkout`

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -7,6 +7,10 @@ on:
       - opened
       - synchronize
       - reopened
+    branches-ignore:
+      - v1.18
+      - v1.17
+      - v1.16
   push:
     branches:
       - main

--- a/.github/workflows/build-images-docs-builder-v1.16.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.16.yaml
@@ -13,6 +13,7 @@ on:
       - Documentation/Dockerfile
       - Documentation/requirements.txt
 
+
 permissions:
   # To be able to access the repository with `actions/checkout`
   contents: read

--- a/.github/workflows/build-images-docs-builder-v1.17.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.17.yaml
@@ -13,6 +13,7 @@ on:
       - Documentation/Dockerfile
       - Documentation/requirements.txt
 
+
 permissions:
   # To be able to access the repository with `actions/checkout`
   contents: read

--- a/.github/workflows/build-images-docs-builder-v1.18.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.18.yaml
@@ -13,6 +13,7 @@ on:
       - Documentation/Dockerfile
       - Documentation/requirements.txt
 
+
 permissions:
   # To be able to access the repository with `actions/checkout`
   contents: read

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -10,6 +10,10 @@ on:
     paths:
       - Documentation/Dockerfile
       - Documentation/requirements.txt
+    branches-ignore:
+      - v1.18
+      - v1.17
+      - v1.16
 
 permissions:
   # To be able to access the repository with `actions/checkout`

--- a/.github/workflows/call-backport-label-updater-v1.16.yaml
+++ b/.github/workflows/call-backport-label-updater-v1.16.yaml
@@ -2,10 +2,10 @@
   name: Call Backport Label Updater
   on:
     pull_request_target:
-      types:
-        - closed
       branches:
         - v1.16
+      types:
+        - closed
 
   jobs:
     call-backport-label-updater:

--- a/.github/workflows/call-backport-label-updater-v1.17.yaml
+++ b/.github/workflows/call-backport-label-updater-v1.17.yaml
@@ -2,10 +2,10 @@
   name: Call Backport Label Updater
   on:
     pull_request_target:
-      types:
-        - closed
       branches:
         - v1.17
+      types:
+        - closed
 
   jobs:
     call-backport-label-updater:

--- a/.github/workflows/call-backport-label-updater-v1.18.yaml
+++ b/.github/workflows/call-backport-label-updater-v1.18.yaml
@@ -2,10 +2,10 @@
   name: Call Backport Label Updater
   on:
     pull_request_target:
-      types:
-        - closed
       branches:
         - v1.18
+      types:
+        - closed
 
   jobs:
     call-backport-label-updater:

--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -6,6 +6,9 @@
         - closed
       branches:
         - v[0-9]+.[0-9]+*
+        - '!v1.18'
+        - '!v1.17'
+        - '!v1.16'
 
   jobs:
     call-backport-label-updater:


### PR DESCRIPTION
This was a semi-automatic change that makes the following changes across all affected files:
 - Creates new *-<branch>.yaml versioned files
 - Adds branches filter to pull_request_target (e.g., branches: [v1.18])
 - Add "ignore branches" for all files without the prefix *-<branch>.yaml so that we don't run `pull_request_target` from main branch for stable branches events.

A special mention to .github/workflows/build-images-base-v1.16.yaml which had to suffer more adjustments in order for it to work with the set-runtime-image which allows the workflow to use a dynamic CILIUM_RUNTIME image without hardcoding it in the workflow. Having this value hardcoded would it make difficult for renovate to update the this value on the v1.16 branch and test it on that same PR.

Fixes: 23454eb6094e (".github/workflows: copy stable workflows to main branch")