### PR TITLE
bpf/test: add scapy self-test and misc fixes

### DIFF
--- a/bpf/tests/_scapy_selftest.c
+++ b/bpf/tests/_scapy_selftest.c
@@ -18,9 +18,11 @@
 
 #define ASSERT1_FAIL "assert1_fail"
 #define ASSERT2_FAIL "assert2_fail"
+#define ASSERT3_FAIL "assert3_fail"
 
 #define LEN_SST_EXP sizeof(BUF(SST_EXP))
 #define LEN_SST_NOT_EXP sizeof(BUF(SST_NOT_EXP))
+#define LEN_SST_NOT_EXP_PAD sizeof(BUF(SST_NOT_EXP_PAD))
 
 /**
  * These are here so that test_fail_now() that returns is captured
@@ -56,7 +58,20 @@ int force_assert_fail_off2(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-static struct scapy_assert null_entry = {0};
+static __always_inline
+int force_assert_fail_ctx_smaller_exp(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(SST_NOT_EXP_PAD, sst_rep_pad);
+
+	ASSERT_CTX_BUF_OFF2(ASSERT3_FAIL, "Ether", ctx, 0, SST_NOT_EXP_PAD,
+			    BUF(SST_NOT_EXP_PAD), LEN_SST_NOT_EXP_PAD,
+			    LEN_SST_NOT_EXP_PAD);
+	fake_test_end();
+
+	return TEST_PASS;
+}
 
 PKTGEN("tc", "1_basic_test")
 int pktgen_scapy_basic_test(struct __ctx_buff *ctx)
@@ -83,6 +98,7 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 
 	BUF_DECL(SST_EXP, sst_req);
 	BUF_DECL(SST_NOT_EXP, sst_rep);
+	BUF_DECL(SST_NOT_EXP_PAD, sst_rep_pad);
 
 	ASSERT_CTX_BUF_OFF(ASSERT1, "Ether", ctx, 0, SST_EXP,
 			   LEN_SST_EXP);
@@ -94,8 +110,10 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 	assert(rc == TEST_FAIL);
 	rc = force_assert_fail_off2(ctx);
 	assert(rc == TEST_FAIL);
+	rc = force_assert_fail_ctx_smaller_exp(ctx);
+	assert(rc == TEST_FAIL);
 
-	assert(scapy_assert_map_cnt == 2);
+	assert(scapy_assert_map_cnt == 3);
 
 	{
 		/* ASSERT_CTX_BUF_OFF */
@@ -108,9 +126,12 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 				    LEN_SST_EXP) == 0);
 		assert(memcmp(entry->name, ASSERT1_FAIL,
 			      sizeof(ASSERT1_FAIL)) == 0);
-		assert(entry->len == LEN_SST_NOT_EXP);
-		rc = map_update_elem(&scapy_assert_map, &id, &null_entry,
-				     BPF_ANY);
+		assert(entry->exp_len == LEN_SST_NOT_EXP);
+		assert(entry->got_len == LEN_SST_EXP);
+		assert(entry->exp_len == entry->got_len);
+
+		rc = map_update_elem(&scapy_assert_map, &id,
+				     &__scapy_null_assert, BPF_ANY);
 		assert(rc == 0);
 	}
 	{
@@ -124,8 +145,28 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 				    LEN_SST_EXP) == 0);
 		assert(memcmp(entry->name, ASSERT2_FAIL,
 			      sizeof(ASSERT2_FAIL)) == 0);
-		rc = map_update_elem(&scapy_assert_map, &id, &null_entry,
-				     BPF_ANY);
+		assert(entry->exp_len == LEN_SST_NOT_EXP);
+		assert(entry->got_len == LEN_SST_EXP);
+		assert(entry->exp_len == entry->got_len);
+		rc = map_update_elem(&scapy_assert_map, &id,
+				     &__scapy_null_assert, BPF_ANY);
+		assert(rc == 0);
+	}
+	{
+		/* len(CTX) < len(EXP) */
+		id = 2;
+		entry = map_lookup_elem(&scapy_assert_map, &id);
+		assert(entry);
+		assert(scapy_memcmp(entry->exp_buf, BUF(SST_NOT_EXP),
+				    LEN_SST_NOT_EXP) == 0);
+		assert(scapy_memcmp(entry->got_buf, __scapy_null_assert.got_buf,
+				    LEN_SST_EXP) == 0);
+		assert(memcmp(entry->name, ASSERT3_FAIL,
+			      sizeof(ASSERT3_FAIL)) == 0);
+		assert(entry->exp_len == LEN_SST_NOT_EXP_PAD);
+		assert(entry->got_len == LEN_SST_EXP);
+		rc = map_update_elem(&scapy_assert_map, &id,
+				     &__scapy_null_assert, BPF_ANY);
 		assert(rc == 0);
 	}
 

--- a/bpf/tests/_scapy_selftest.c
+++ b/bpf/tests/_scapy_selftest.c
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+
+#include "pktgen.h"
+
+/* We need to mock loggers to test ASSERT MACRO failures */
+#define __ASSERT_TRACE_FAIL_LEN(...)
+#define __ASSERT_TRACE_FAIL_BUF(...)
+#include "scapy.h"
+
+#define fake_test_end() (void)suite_result; } while (0)
+
+#define ASSERT1 "assert1"
+#define ASSERT2 "assert2"
+
+#define ASSERT1_FAIL "assert1_fail"
+#define ASSERT2_FAIL "assert2_fail"
+
+#define LEN_SST_EXP sizeof(BUF(SST_EXP))
+#define LEN_SST_NOT_EXP sizeof(BUF(SST_NOT_EXP))
+
+/**
+ * These are here so that test_fail_now() that returns is captured
+ * for expected errors
+ */
+static __always_inline
+int force_assert_fail_off(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(SST_NOT_EXP, sst_rep);
+
+	ASSERT_CTX_BUF_OFF(ASSERT1_FAIL, "Ether", ctx, 0, SST_NOT_EXP,
+			   LEN_SST_NOT_EXP);
+
+	fake_test_end();
+
+	return TEST_PASS;
+}
+
+static __always_inline
+int force_assert_fail_off2(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(SST_NOT_EXP, sst_rep);
+
+	ASSERT_CTX_BUF_OFF2(ASSERT2_FAIL, "Ether", ctx, 0, SST_NOT_EXP,
+			    BUF(SST_NOT_EXP), LEN_SST_NOT_EXP,
+			    LEN_SST_NOT_EXP);
+	fake_test_end();
+
+	return TEST_PASS;
+}
+
+static struct scapy_assert null_entry = {0};
+
+PKTGEN("tc", "1_basic_test")
+int pktgen_scapy_basic_test(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(SST_EXP, sst_req);
+	BUILDER_PUSH_BUF(builder, SST_EXP);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "1_basic_test")
+int check_scapy_basic_test(struct __ctx_buff *ctx)
+{
+	int rc, id;
+	struct scapy_assert *entry;
+
+	test_init();
+
+	BUF_DECL(SST_EXP, sst_req);
+	BUF_DECL(SST_NOT_EXP, sst_rep);
+
+	ASSERT_CTX_BUF_OFF(ASSERT1, "Ether", ctx, 0, SST_EXP,
+			   LEN_SST_EXP);
+	ASSERT_CTX_BUF_OFF2(ASSERT2, "Ether", ctx, 0, SST_EXP,
+			    BUF(SST_EXP), LEN_SST_EXP, LEN_SST_EXP);
+
+	/* Test failures */
+	rc = force_assert_fail_off(ctx);
+	assert(rc == TEST_FAIL);
+	rc = force_assert_fail_off2(ctx);
+	assert(rc == TEST_FAIL);
+
+	assert(scapy_assert_map_cnt == 2);
+
+	{
+		/* ASSERT_CTX_BUF_OFF */
+		id = 0;
+		entry = map_lookup_elem(&scapy_assert_map, &id);
+		assert(entry);
+		assert(scapy_memcmp(entry->exp_buf, BUF(SST_NOT_EXP),
+				    LEN_SST_NOT_EXP) == 0);
+		assert(scapy_memcmp(entry->got_buf, BUF(SST_EXP),
+				    LEN_SST_EXP) == 0);
+		assert(memcmp(entry->name, ASSERT1_FAIL,
+			      sizeof(ASSERT1_FAIL)) == 0);
+		assert(entry->len == LEN_SST_NOT_EXP);
+		rc = map_update_elem(&scapy_assert_map, &id, &null_entry,
+				     BPF_ANY);
+		assert(rc == 0);
+	}
+	{
+		/* ASSERT_CTX_BUF_OFF2 */
+		id = 1;
+		entry = map_lookup_elem(&scapy_assert_map, &id);
+		assert(entry);
+		assert(scapy_memcmp(entry->exp_buf, BUF(SST_NOT_EXP),
+				    LEN_SST_NOT_EXP) == 0);
+		assert(scapy_memcmp(entry->got_buf, BUF(SST_EXP),
+				    LEN_SST_EXP) == 0);
+		assert(memcmp(entry->name, ASSERT2_FAIL,
+			      sizeof(ASSERT2_FAIL)) == 0);
+		rc = map_update_elem(&scapy_assert_map, &id, &null_entry,
+				     BPF_ANY);
+		assert(rc == 0);
+	}
+
+	test_finish();
+
+	return 0;
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -130,12 +130,16 @@ static __u32 scapy_assert_map_cnt;
 /* Needs to be here not to blow up stack size */
 static struct scapy_assert __scapy_assert = {0};
 
+#ifndef __ASSERT_TRACE_FAIL_LEN
 #define __ASSERT_TRACE_FAIL_LEN(BUF_NAME, _BUF_LEN, LEN)		\
 	test_log("Buffer '" BUF_NAME "' of len (%d) < LEN  (%d)",	\
 			 _BUF_LEN, LEN)
+#endif /* __ASSERT_TRACE_FAIL_LEN */
 
+#ifndef __ASSERT_TRACE_FAIL_BUF
 #define __ASSERT_TRACE_FAIL_BUF(BUF_NAME, _BUF_LEN, LEN)		\
 	test_log("CTX and buffer '" BUF_NAME "' content mismatch ")
+#endif /* __ASSERT_TRACE_FAIL_BUF */
 
 static __always_inline
 bool __assert_map_add_failure(const char *name, const __u8 name_len,

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -169,7 +169,7 @@ static struct scapy_assert __scapy_assert = {0};
 		if (!_ok) {								\
 			__scapy_assert.len = LEN;					\
 			scapy_memcpy(__scapy_assert.exp_buf, _BUF, LEN);		\
-			if (__DATA + (LEN) < __DATA_END) {				\
+			if (__DATA + (LEN) <= __DATA_END) {				\
 				scapy_memcpy(__scapy_assert.got_buf, __DATA, LEN);	\
 			}								\
 			scapy_strncpy(__scapy_assert.name, NAME, sizeof(NAME));		\

--- a/bpf/tests/scapy/parser.py
+++ b/bpf/tests/scapy/parser.py
@@ -32,10 +32,14 @@ def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
             # Remove trailing );
             scapy_buf = re.sub(r'\s*\)\s*;\s*$', '', scapy_buf)
 
-            if name in bufs and scapy_buf != bufs[name]:
-                raise Exception(f"Mismatching packet definitions with name '{name}'; found '{scapy_buf}' and '{bufs[name]}'")
+            try:
+                buf = eval(scapy_buf)
+            except Exception as e:
+                raise Exception(f"Unknown scapy buffer '{scapy_buf}'. Please make sure it's defined under scapy/*_pkt_defs.py")
 
-            buf = eval(scapy_buf)
+            if name in bufs and buf != bufs[name]["buf"]:
+                raise Exception(f"Mismatching packet definitions with name '{name}'; found '{scapy_buf}' and '{bufs[name]}'.")
+
             bufs[name] = {
                 "str": scapy_buf,
                 "buf": buf,

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -6,6 +6,7 @@ from scapy.all import *
 from pkt_defs_common import *
 
 # Test packet/buffer definitions
+from selftest_pkt_defs import *
 from ipv6_ndp_pkt_defs import *
 from tc_l2_announce_pkt_defs import *
 from tc_l2_announce6_pkt_defs import *

--- a/bpf/tests/scapy/selftest_pkt_defs.py
+++ b/bpf/tests/scapy/selftest_pkt_defs.py
@@ -17,3 +17,13 @@ sst_rep = (
     ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
         hwsrc=mac_two, hwdst=mac_one)
 )
+
+# Padded reply to test
+sst_rep_pad = (
+    Ether(dst=mac_one, src=mac_two) /
+    ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
+        hwsrc=mac_two, hwdst=mac_one) /
+    Raw("A"*8)
+)
+
+assert len(bytes(sst_rep_pad)) == (len(bytes(sst_rep)) + 8)

--- a/bpf/tests/scapy/selftest_pkt_defs.py
+++ b/bpf/tests/scapy/selftest_pkt_defs.py
@@ -1,0 +1,19 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+
+from pkt_defs_common import *
+
+## Scapy self tests (_scapy_selftest.c)
+sst_req = (
+    Ether(dst=mac_bcast, src=mac_one) /
+    ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, \
+        hwsrc=mac_one, hwdst=mac_bcast)
+)
+
+sst_rep = (
+    Ether(dst=mac_one, src=mac_two) /
+    ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
+        hwsrc=mac_two, hwdst=mac_one)
+)

--- a/tools/legacyhguardcheck/main.go
+++ b/tools/legacyhguardcheck/main.go
@@ -75,6 +75,7 @@ var exclude = []string{
 	"bpf/tests/common.h",
 	"bpf/tests/bpf_skb_255_tests.c",
 	"bpf/tests/bpf_skb_511_tests.c",
+	"bpf/tests/scapy.h",
 }
 
 func checkFile(filePath string) (bool, error) {


### PR DESCRIPTION
This patch series:

* Adds a Scapy self-test to make sure the testing framework doesn't regress.
* Fixes two bugs in `parser.py`: 
  * If `BUF_DECL()` were defined in different scopes with the same
     identifier _and_ the same contents, `parser.py` was incorrectly
     marking the second as content mismatch with the first one, given
     that the comparison code was incorrect.
  * If `BUF_DECL()` referenced a non-existing Scapy buffer, the error was obscure.
* Fixes bug in https://github.com/cilium/cilium/commit/fd5402f22c916412fb28d17f00f544bf60c0791d which led to a failed ASSERT not writting the ctx buffer in "got".
* Refactor ` ASSERT_CTX_BUFF_OFF(` to reduce the amount of MACRO code.

```release-note
Add BPF unit test scapy self test and misc fixes.
```
