### PR TITLE
modernize: Fix `rangeint` findings in datapath files

### DIFF
--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -614,7 +614,7 @@ func TestPrivilegedDumpReliablyWithCallbackOverlapping(t *testing.T) {
 	defer m.Close()
 
 	// Prepopulate the map.
-	for i := uint32(0); i < maxEntries; i++ {
+	for i := range uint32(maxEntries) {
 		err := m.Update(&TestKey{Key: i}, &TestValue{Value: i + 200})
 		require.NoError(t, err)
 	}

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -499,7 +499,7 @@ func addRemoveIpv6SolNodeMACAddr(ifindex int, mac mac.MAC, add bool) error {
 	var ifr ifreq
 	copy(ifr.Name[:], ifi.Name)
 	ifr.Hwaddr.Family = syscall.AF_UNSPEC
-	for i := 0; i < ETH_ALEN; i++ {
+	for i := range ETH_ALEN {
 		ifr.Hwaddr.Data[i] = int8(mac[i])
 	}
 

--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -110,8 +110,8 @@ func xdpLoadPermutations() iter.Seq[*config.BPFXDP] {
 func permute(n int) iter.Seq[[]bool] {
 	permutation := make([]bool, n)
 	return func(yield func([]bool) bool) {
-		for i := uint64(0); i < (1 << n); i++ {
-			for j := 0; j < n; j++ {
+		for i := range uint64(1 << n) {
+			for j := range n {
 				permutation[j] = (i & (1 << j)) != 0
 			}
 			if !yield(permutation) {

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -317,7 +317,7 @@ var (
 // makeIPs generates count sequential IPv4 IPs
 func makeIPs(count uint32) []netip.Addr {
 	ips := make([]netip.Addr, 0, count)
-	for i := uint32(0); i < count; i++ {
+	for i := range count {
 		ips = append(ips, netip.AddrFrom4([4]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i >> 0)}))
 	}
 	return ips
@@ -463,11 +463,11 @@ func benchmarkUnmarshalJSON(b *testing.B, numDNSEntries int) {
 
 	n := b.N
 	emptyCaches := make([]*DNSCache, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		emptyCaches[i] = NewDNSCache(0)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		err := emptyCaches[i].UnmarshalJSON(data)
 		require.NoError(b, err)
 	}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1491,7 +1491,7 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		for epID := uint64(0); epID < nEPs; epID++ {
+		for epID := range uint64(nEPs) {
 			pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 		}
 		b.StartTimer()

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -477,7 +477,7 @@ func Test_deriveLabelsForNames(t *testing.T) {
 // makeIPs generates count sequential IPv4 IPs
 func makeIPs(count uint32) []netip.Addr {
 	ips := make([]netip.Addr, 0, count)
-	for i := uint32(0); i < count; i++ {
+	for i := range uint32(count) {
 		ips = append(ips, netip.AddrFrom4([4]byte{byte(i >> 24), byte(i >> 16), byte(i >> 8), byte(i >> 0)}))
 	}
 	return ips

--- a/pkg/types/ipv6.go
+++ b/pkg/types/ipv6.go
@@ -12,7 +12,7 @@ import (
 type IPv6 [16]byte
 
 func (v6 IPv6) IsZero() bool {
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		if v6[i] != 0 {
 			return false
 		}


### PR DESCRIPTION
This PR addresses [`rangeint`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_rangeint) findings in datapath owned files in preparation to enabling this analyzer repository-wide (see [here](https://github.com/cilium/cilium/blob/888c09ae6be6034d5c8a362659b7fd082f6b6a1b/.golangci.yaml#L119-L123)).

See #42642