### PR TITLE
feat(sdp): Documentation and templates for standalone DNS Proxy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -388,6 +388,7 @@ Makefile* @cilium/build
 /Documentation/_static/ @cilium/docs-structure
 /Documentation/api.rst @cilium/sig-agent @cilium/docs-structure
 /Documentation/beta.rst @cilium/docs-structure
+/Documentation/alpha.rst @cilium/docs-structure
 /Documentation/reference-guides/bpf/ @cilium/sig-datapath @cilium/docs-structure
 /Documentation/reference-guides/xfrm/ @cilium/ipsec @cilium/docs-structure
 /Documentation/check-build.sh @cilium/docs-structure
@@ -460,6 +461,7 @@ Makefile* @cilium/build
 /Documentation/security/network/proxy/ @cilium/proxy @cilium/docs-structure
 /Documentation/security/policy-creation.rst @cilium/sig-policy @cilium/docs-structure
 /Documentation/security/policy/ @cilium/sig-policy @cilium/docs-structure
+/Documentation/security/standalone-dns-proxy.rst @cilium/fqdn @cilium/docs-structure
 /Documentation/security/threat-model.rst @cilium/security @cilium/docs-structure
 /Documentation/spelling_wordlist.txt @cilium/docs-structure
 /Documentation/update-cmdref.sh @cilium/docs-structure
@@ -487,6 +489,7 @@ Makefile* @cilium/build
 /install/kubernetes/cilium/**/spire @cilium/helm @cilium/sig-servicemesh
 /install/kubernetes/cilium/templates/clustermesh* @cilium/helm @cilium/sig-clustermesh
 /install/kubernetes/cilium/templates/hubble* @cilium/helm @cilium/sig-hubble
+/install/kubernetes/cilium/templates/standalone-dns-proxy* @cilium/helm @cilium/fqdn
 /LICENSE @cilium/contributing
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure

--- a/Documentation/alpha.rst
+++ b/Documentation/alpha.rst
@@ -1,0 +1,5 @@
+.. note::
+
+    This is an alpha feature. Please provide feedback and file a GitHub issue if
+    you experience any problems.
+

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -412,7 +412,7 @@ cilium-agent [flags]
       --service-no-backend-response string                        Response to traffic for a service without backends (default "reject")
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --socket-path string                                        Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")
-      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 40045)
+      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)
       --state-dir string                                          Directory path to store runtime state (default "/var/run/cilium")
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --status-collector-failure-threshold duration               The duration after which a probe is considered failed (default 1m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -255,7 +255,7 @@ cilium-agent hive [flags]
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 40045)
+      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --status-collector-failure-threshold duration               The duration after which a probe is considered failed (default 1m0s)
       --status-collector-interval duration                        The interval between probe invocations (default 5s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -260,7 +260,7 @@ cilium-agent hive dot-graph [flags]
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 40045)
+      --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)
       --static-cnp-path string                                    Directory path to watch and load static cilium network policy yaml files.
       --status-collector-failure-threshold duration               The duration after which a probe is considered failed (default 1m0s)
       --status-collector-interval duration                        The interval between probe invocations (default 5s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3696,6 +3696,50 @@
      - Enable socket LB
      - bool
      - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy`
+     - Standalone DNS Proxy Configuration Note: The standalone DNS proxy uses the agent's dnsProxy.* configuration for DNS settings (proxyPort, enableDnsCompression) to ensure consistency.
+     - object
+     - ``{"annotations":{},"automountServiceAccountToken":false,"debug":false,"enabled":false,"image":{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false},"nodeSelector":{"kubernetes.io/os":"linux"},"rollOutPods":false,"serverPort":10095,"tolerations":[],"updateStrategy":{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}}``
+   * - :spelling:ignore:`standaloneDnsProxy.annotations`
+     - Standalone DNS proxy annotations
+     - object
+     - ``{}``
+   * - :spelling:ignore:`standaloneDnsProxy.automountServiceAccountToken`
+     - Standalone DNS proxy auto mount service account token
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.debug`
+     - Standalone DNS proxy debug mode
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.enabled`
+     - Enable standalone DNS proxy (alpha feature)
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.image`
+     - Standalone DNS proxy image
+     - object
+     - ``{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false}``
+   * - :spelling:ignore:`standaloneDnsProxy.nodeSelector`
+     - Standalone DNS proxy Node Selector
+     - object
+     - ``{"kubernetes.io/os":"linux"}``
+   * - :spelling:ignore:`standaloneDnsProxy.rollOutPods`
+     - Roll out Standalone DNS proxy automatically when configmap is updated.
+     - bool
+     - ``false``
+   * - :spelling:ignore:`standaloneDnsProxy.serverPort`
+     - Standalone DNS proxy server port
+     - int
+     - ``10095``
+   * - :spelling:ignore:`standaloneDnsProxy.tolerations`
+     - Standalone DNS proxy tolerations
+     - list
+     - ``[]``
+   * - :spelling:ignore:`standaloneDnsProxy.updateStrategy`
+     - Standalone DNS proxy update strategy
+     - object
+     - ``{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}``
    * - :spelling:ignore:`startupProbe.failureThreshold`
      - failure threshold of startup probe. Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts).
      - int

--- a/Documentation/security/dns.rst
+++ b/Documentation/security/dns.rst
@@ -170,3 +170,8 @@ Clean-up
 
    kubectl delete -f \ |SCM_WEB|\/examples/kubernetes-dns/dns-sw-app.yaml
    kubectl delete cnp fqdn
+
+Limitations
+===========
+
+By default, Cilium uses an in-agent DNS proxy for DNS policy enforcement. For high availability, consider using the :ref:`standalone_dns_proxy` (alpha feature).

--- a/Documentation/security/index.rst
+++ b/Documentation/security/index.rst
@@ -22,6 +22,7 @@ Securing Networks with Cilium
 
    http
    dns
+   standalone-dns-proxy
    tls-visibility
    kafka
    grpc

--- a/Documentation/security/standalone-dns-proxy.rst
+++ b/Documentation/security/standalone-dns-proxy.rst
@@ -1,0 +1,276 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _standalone_dns_proxy:
+
+***************************************
+Standalone DNS Proxy (alpha)
+***************************************
+
+.. include:: ../alpha.rst
+
+The Standalone DNS Proxy is an independent component that runs as a separate
+DaemonSet in the cluster, providing DNS proxying capabilities independent of
+the Cilium agent. The in-agent proxy runs alongside the Standalone DNS Proxy.
+The load of DNS request is shared between both proxies.
+
+Overview
+========
+
+The Standalone DNS Proxy communicates with the Cilium agent via gRPC to:
+
+1. Receive DNS policy rules from the agent
+2. Report DNS query results for policy enforcement to the agent
+
+Configuration
+=============
+
+To enable the Standalone DNS Proxy, set the following Helm values:
+
+.. code-block:: yaml
+
+   # Enable L7 proxy and configure DNS proxy port
+   l7Proxy: true
+   dnsProxy:
+     proxyPort: 10094  # Must be non-zero when using standalone DNS proxy, choosing 10094 as example
+   
+   # Enable standalone DNS proxy
+   standaloneDnsProxy:
+     enabled: true
+     serverPort: 10095 # Must be non-zero when using standalone DNS proxy, choosing 10095 as example
+
+.. important::
+
+   The standalone DNS proxy uses the agent's DNS configuration to ensure consistency:
+   
+   * ``dnsProxy.proxyPort`` must be explicitly set to a non-zero value (e.g., 10094)
+   * ``dnsProxy.enableDnsCompression`` and other DNS settings will automatically use 
+     the same defaults as the agent (default: true)
+   
+   The Helm chart will fail validation if ``proxyPort`` is not configured correctly.
+
+Testing the Standalone DNS Proxy
+=================================
+
+This section provides steps to test the Standalone DNS Proxy in a development environment.
+To test the standalone DNS proxy feature, you need to build container images from
+source. The following instructions guide you through building and deploying the 
+standalone DNS proxy in a local development environment using kind (Kubernetes in Docker).
+
+Building and Deploying
+----------------------
+
+#. **Build the Standalone DNS Proxy Image**
+
+   Build the standalone DNS proxy container image from source:
+
+   .. code-block:: shell-session
+
+      $ make docker-standalone-dns-proxy-image
+
+   This creates a local image ``quay.io/cilium/standalone-dns-proxy:latest``.
+
+#. **Set Up kind Cluster with Cilium**
+
+   Create a kind cluster and build/install Cilium from source:
+
+   .. code-block:: shell-session
+
+      $ make kind && make kind-image && make kind-install-cilium
+
+#. **Load the Standalone DNS Proxy Image into kind**
+
+   Load the standalone DNS proxy image you built into the kind cluster:
+
+   .. code-block:: shell-session
+
+      $ kind load docker-image quay.io/cilium/standalone-dns-proxy:latest
+
+#. **Upgrade Cilium to Enable Standalone DNS Proxy**
+
+   Enable the standalone DNS proxy and configure it to work with the Cilium agent:
+
+   .. code-block:: shell-session
+
+      $ cilium upgrade \
+          --chart-directory='./install/kubernetes/cilium' \
+          --set='l7Proxy=true' \
+          --set='dnsProxy.proxyPort=10094' \
+          --helm-set='standaloneDnsProxy.enabled=true' \
+          --helm-set='standaloneDnsProxy.image.repository=quay.io/cilium/standalone-dns-proxy' \
+          --helm-set='standaloneDnsProxy.image.tag=latest' \
+          --helm-set='standaloneDnsProxy.image.useDigest=false' \
+          --helm-set='standaloneDnsProxy.image.pullPolicy=Never'
+
+   The configuration flags in this example ensure the standalone proxy is operational by applying the following configurations:
+
+   * ``dnsProxy.proxyPort=10094`` sets the DNS proxy port used by both the agent and standalone DNS proxy
+   * ``l7Proxy=true`` enables L7 proxy support required for DNS policy enforcement
+   * The standalone DNS proxy automatically inherits DNS settings from the agent configuration
+   * ``image.tag=latest`` and ``image.pullPolicy=Never`` are used to reference the locally-built image
+
+#. **Restart Cilium Agent**
+
+   Restart the Cilium agent to apply the configuration changes:
+
+   .. code-block:: shell-session
+
+      $ kubectl rollout restart ds -n kube-system cilium
+
+#. **Verify Deployment**
+
+   Check that the standalone DNS proxy pods are running:
+
+   .. code-block:: shell-session
+
+      $ kubectl -n kube-system get pods -l k8s-app=standalone-dns-proxy
+      NAME                          READY   STATUS    RESTARTS   AGE
+      standalone-dns-proxy-xxxxx    1/1     Running   0          1m
+
+#. **Apply DNS Policy**
+
+   Apply a policy that allows pods with the label ``org: alliance`` to query specific domains
+   (``cilium.io`` and its subdomains) and blocks all other queries:
+
+   .. literalinclude:: ../../examples/policies/l7/dns/dns.yaml
+      :language: yaml
+
+   .. code-block:: shell-session
+
+      $ kubectl apply -f examples/policies/l7/dns/dns.yaml
+
+#. **Deploy Test Pod**
+
+   Create a test pod with the matching label:
+
+   .. code-block:: shell-session
+
+      $ kubectl run test-pod --image=nicolaka/netshoot --labels="org=alliance" -- sleep 3600
+
+#. **Verify DNS Policy Enforcement**
+
+   Test that DNS queries are being intercepted and resolved for allowed domains:
+
+   .. code-block:: shell-session
+
+      $ kubectl exec test-pod -- nslookup cilium.io.
+
+   Queries to ``cilium.io`` should succeed.
+
+   Now test that queries to non-allowed domains are refused:
+
+   .. code-block:: shell-session
+
+      $ kubectl exec test-pod -- nslookup example.com.
+      Server:         10.96.0.10
+      Address:        10.96.0.10#53
+
+      ** server can't find example.com: REFUSED
+
+   The query to ``example.com`` is refused because it's not in the allowed DNS policy rules.
+
+#. **Test Standalone Proxy Resilience**
+
+    Verify that the standalone DNS proxy continues to work even when the Cilium agent is down:
+
+    .. code-block:: shell-session
+
+       # Intentionally break the Cilium agent by using a non-existent image
+       $ kubectl set image -n kube-system ds/cilium cilium-agent=quay.io/cilium/cilium:non-existent-image
+       
+       # Wait for agent pods to enter ImagePullBackOff state
+       $ kubectl wait --for=condition=Ready=false pod -n kube-system -l k8s-app=cilium --timeout=60s
+       
+       # DNS queries for allowed domains should still work via standalone DNS proxy
+       $ kubectl exec test-pod -- nslookup cilium.io
+
+       # Verify that policy enforcement still works - non-allowed domains are still refused
+       $ kubectl exec test-pod -- nslookup example.com
+       Server:         10.96.0.10
+       Address:        10.96.0.10#53
+
+       ** server can't find example.com: REFUSED
+
+    Both queries demonstrate that the standalone DNS proxy continues to enforce DNS policies
+    independently, allowing ``cilium.io`` and refusing ``example.com``, even when the agent is unavailable.
+
+#. **Restore Cilium Agent**
+
+    Restore the Cilium agent to normal operation:
+
+    .. code-block:: shell-session
+
+       $ kubectl rollout undo ds/cilium -n kube-system
+
+For more information on DNS policies, see :ref:`DNS based`.
+
+Limitations
+===========
+
+The Standalone DNS Proxy alpha release has the following known limitations:
+
+* The standalone DNS proxy uses the agent's DNS configuration. The ``dnsProxy.proxyPort`` 
+  must be explicitly set to a non-zero value when the standalone DNS proxy is enabled 
+  (it does not automatically select a free port).
+* Metrics related to DNS are not supported yet. The metrics are currently
+  only available from the in-agent DNS proxy.
+* Standalone DNS proxy depends on Cilium agent to read DNS policies, enforce them and 
+  communicate via gRPC. If there are connectivity issues between the proxy and agent,
+  DNS policy enforcement may be affected.
+* While the standalone DNS proxy can continue to proxy DNS requests when the agent is down,
+  it cannot allocate new identities for domains that haven't been observed before.
+  If an endpoint looks up a new domain (one that hasn't been cached) while the agent is unavailable,
+  the resulting traffic will be dropped because no security identity can be allocated.
+  Only DNS lookups for previously observed domains (with cached identities) will work during agent downtime.
+
+Troubleshooting
+===============
+
+Validation Errors
+-----------------
+
+If the Helm chart fails with a validation error about ``dnsProxy.proxyPort``::
+
+   Error: standaloneDnsProxy requires dnsProxy.proxyPort to be set to a non-zero value (e.g., 10094)
+
+This means you need to explicitly configure the DNS proxy port in your values:
+
+.. code-block:: yaml
+
+   dnsProxy:
+     proxyPort: 10094  # Must be non-zero
+
+Port Configuration Verification
+-------------------------------
+
+To verify that the DNS proxy port is correctly configured:
+
+.. code-block:: shell-session
+
+   $ kubectl -n kube-system get configmap cilium-config -o yaml | grep 'tofqdns-proxy-port'
+   $ kubectl -n kube-system get configmap standalone-dns-proxy-config -o yaml | grep 'tofqdns-proxy-port'
+
+Both ConfigMaps should show the same value from ``dnsProxy.proxyPort``.
+
+gRPC Communication Issues
+-------------------------
+
+If there are communication issues between the proxy and agent, review agent logs for connection errors:
+
+.. code-block:: shell-session
+
+   $ kubectl -n kube-system logs -l k8s-app=cilium --tail=100 | grep -i "fqdn.sdp-grpc-server"
+
+API Reference
+=============
+
+For detailed API documentation, see :ref:`sdpapi_ref`.
+
+Further Reading
+===============
+
+* :ref:`DNS based`
+* :ref:`DNS Proxy`

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -313,6 +313,7 @@ distro
 distros
 dmesg
 dns
+dnsProxy
 dockerd
 dockerhub
 dpaa
@@ -329,6 +330,7 @@ effectful
 egressing
 elfutils
 ena
+enableDnsCompression
 enableSourceIPVerification
 enablement
 endPort
@@ -675,6 +677,7 @@ prometheus
 proto
 protobuf
 proxied
+proxyPort
 proxying
 proxylib
 qdisc
@@ -806,6 +809,7 @@ tiefighter
 tls
 toCIDR
 toCIDRSet
+toFQDN
 toFQDNs
 toGroups
 tofqdns

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -974,6 +974,17 @@ contributors across the globe, there is almost always someone available to help.
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |
+| standaloneDnsProxy | object | `{"annotations":{},"automountServiceAccountToken":false,"debug":false,"enabled":false,"image":{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false},"nodeSelector":{"kubernetes.io/os":"linux"},"rollOutPods":false,"serverPort":10095,"tolerations":[],"updateStrategy":{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}}` | Standalone DNS Proxy Configuration Note: The standalone DNS proxy uses the agent's dnsProxy.* configuration for DNS settings (proxyPort, enableDnsCompression) to ensure consistency. |
+| standaloneDnsProxy.annotations | object | `{}` | Standalone DNS proxy annotations |
+| standaloneDnsProxy.automountServiceAccountToken | bool | `false` | Standalone DNS proxy auto mount service account token |
+| standaloneDnsProxy.debug | bool | `false` | Standalone DNS proxy debug mode |
+| standaloneDnsProxy.enabled | bool | `false` | Enable standalone DNS proxy (alpha feature) |
+| standaloneDnsProxy.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"","tag":"","useDigest":false}` | Standalone DNS proxy image |
+| standaloneDnsProxy.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Standalone DNS proxy Node Selector |
+| standaloneDnsProxy.rollOutPods | bool | `false` | Roll out Standalone DNS proxy automatically when configmap is updated. |
+| standaloneDnsProxy.serverPort | int | `10095` | Standalone DNS proxy server port |
+| standaloneDnsProxy.tolerations | list | `[]` | Standalone DNS proxy tolerations |
+| standaloneDnsProxy.updateStrategy | object | `{"rollingUpdate":{"maxSurge":2,"maxUnavailable":0},"type":"RollingUpdate"}` | Standalone DNS proxy update strategy |
 | startupProbe.failureThreshold | int | `300` | failure threshold of startup probe. Allow Cilium to take up to 600s to start up (300 attempts with 2s between attempts). |
 | startupProbe.periodSeconds | int | `2` | interval between checks of the startup probe |
 | synchronizeK8sNodes | bool | `true` | Synchronize Kubernetes nodes to kvstore and perform CNP GC. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -667,6 +667,13 @@ data:
   enable-l7-proxy: {{ .Values.l7Proxy | quote }}
 {{- end }}
 
+{{- if hasKey .Values "standaloneDnsProxy" }}
+  {{- if .Values.standaloneDnsProxy.enabled }}
+  enable-standalone-dns-proxy: {{ .Values.standaloneDnsProxy.enabled | quote }}
+  standalone-dns-proxy-server-port: {{ .Values.standaloneDnsProxy.serverPort | quote }}
+  {{- end }}
+{{- end }}
+
 {{- if ne $cniChainingMode "none" }}
   # Enable chaining with another CNI plugin
   #

--- a/install/kubernetes/cilium/templates/standalone-dns-proxy/configmap.yaml
+++ b/install/kubernetes/cilium/templates/standalone-dns-proxy/configmap.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.standaloneDnsProxy.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: standalone-dns-proxy-config
+  namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .Values.standaloneDnsProxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  # Use the same L7 proxy and DNS settings as the agent for consistency
+  enable-l7-proxy: {{ .Values.l7Proxy | quote }}
+  debug: {{ .Values.standaloneDnsProxy.debug | quote }}
+  enable-standalone-dns-proxy: {{ .Values.standaloneDnsProxy.enabled | quote }}
+  enable-ipv4: {{ .Values.ipv4.enabled | quote }}
+  enable-ipv6: {{ .Values.ipv6.enabled | quote }}
+  standalone-dns-proxy-server-port: {{ .Values.standaloneDnsProxy.serverPort | quote }}
+  # DNS proxy configuration inherited from agent settings
+  tofqdns-proxy-port: {{ .Values.dnsProxy.proxyPort | quote }}
+  tofqdns-enable-dns-compression: {{ .Values.dnsProxy.enableDnsCompression | quote }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/standalone-dns-proxy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/standalone-dns-proxy/daemonset.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.standaloneDnsProxy.enabled }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: standalone-dns-proxy
+  namespace: {{ include "cilium.namespace" . }}
+  {{- with .Values.standaloneDnsProxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    k8s-app: standalone-dns-proxy
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: standalone-dns-proxy
+    name: standalone-dns-proxy
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  minReadySeconds: 5
+  {{- with .Values.standaloneDnsProxy.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      k8s-app: standalone-dns-proxy
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.standaloneDnsProxy.rollOutPods }}
+        # ensure pods roll when configmap updates
+        cilium.io/standalone-dns-proxy-configmap-checksum: {{ include (print $.Template.BasePath "/standalone-dns-proxy/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+        container.apparmor.security.beta.kubernetes.io/standalone-dns-proxy: "unconfined"
+      labels:
+        k8s-app: standalone-dns-proxy
+        name: standalone-dns-proxy
+        app.kubernetes.io/name: standalone-dns-proxy
+        app.kubernetes.io/part-of: cilium
+        {{- with .Values.commonLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      hostNetwork: true
+      automountServiceAccountToken: {{ .Values.standaloneDnsProxy.automountServiceAccountToken }}
+      {{- with .Values.standaloneDnsProxy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+      - operator: Exists
+      {{- with .Values.standaloneDnsProxy.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: standalone-dns-proxy
+          image: {{ include "cilium.image" .Values.standaloneDnsProxy.image | quote }}
+          args:
+          - --config-dir=/tmp/standalone-dns-proxy/config-map
+          imagePullPolicy: {{ .Values.standaloneDnsProxy.image.pullPolicy }}
+          volumeMounts:
+          - mountPath: /tmp/standalone-dns-proxy/config-map
+            name: standalone-dns-proxy-config-path
+            readOnly: true
+          - mountPath: /var/run/standalone-dns-proxy
+            name: runtime-dir
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN", "NET_RAW"]
+              drop: ["ALL"]
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: standalone-dns-proxy-config
+        name: standalone-dns-proxy-config-path
+      - emptyDir: {}
+        name: runtime-dir
+{{- end }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -220,3 +220,14 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/* validate Standalone DNS Proxy */}}
+{{- if .Values.standaloneDnsProxy.enabled }}
+  {{- if not .Values.dnsProxy.proxyPort }}
+    {{ fail "standaloneDnsProxy requires dnsProxy.proxyPort to be explicitly set (e.g., 10094)" }}
+  {{- end }}
+  {{- if eq (int .Values.dnsProxy.proxyPort) 0 }}
+    {{ fail "standaloneDnsProxy requires dnsProxy.proxyPort to be set to a non-zero value (e.g., 10094). The standalone DNS proxy uses the same DNS configuration as the agent." }}
+  {{- end }}
+{{- end }}
+

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5984,6 +5984,86 @@
       },
       "type": "object"
     },
+    "standaloneDnsProxy": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
+        "debug": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "properties": {
+            "digest": {
+              "type": "string"
+            },
+            "override": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "useDigest": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "nodeSelector": {
+          "properties": {
+            "kubernetes.io/os": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "rollOutPods": {
+          "type": "boolean"
+        },
+        "serverPort": {
+          "type": "integer"
+        },
+        "tolerations": {
+          "items": {},
+          "type": "array"
+        },
+        "updateStrategy": {
+          "properties": {
+            "rollingUpdate": {
+              "properties": {
+                "maxSurge": {
+                  "type": "integer"
+                },
+                "maxUnavailable": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "startupProbe": {
       "properties": {
         "failureThreshold": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -4250,3 +4250,41 @@ authentication:
 enableInternalTrafficPolicy: true
 # -- Enable LoadBalancer IP Address Management
 enableLBIPAM: true
+# -- Standalone DNS Proxy Configuration
+# Note: The standalone DNS proxy uses the agent's dnsProxy.* configuration
+# for DNS settings (proxyPort, enableDnsCompression) to ensure consistency.
+standaloneDnsProxy:
+  # -- Enable standalone DNS proxy (alpha feature)
+  enabled: false
+  # -- Roll out Standalone DNS proxy automatically when configmap is updated.
+  rollOutPods: false
+  # -- Standalone DNS proxy annotations
+  annotations: {}
+  # -- Standalone DNS proxy debug mode
+  debug: false
+  # -- Standalone DNS proxy server port
+  serverPort: 10095
+  # -- Standalone DNS proxy Node Selector
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Standalone DNS proxy tolerations
+  tolerations: []
+  # -- Standalone DNS proxy auto mount service account token
+  automountServiceAccountToken: false
+  # -- Standalone DNS proxy update strategy
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  # -- Standalone DNS proxy image
+  image:
+    # @schema
+    # type: [null, string]
+    # @schema
+    override: ~
+    repository: ""
+    tag: ""
+    digest: ""
+    useDigest: false
+    pullPolicy: "Always"

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -4286,3 +4286,41 @@ authentication:
 enableInternalTrafficPolicy: true
 # -- Enable LoadBalancer IP Address Management
 enableLBIPAM: true
+# -- Standalone DNS Proxy Configuration
+# Note: The standalone DNS proxy uses the agent's dnsProxy.* configuration
+# for DNS settings (proxyPort, enableDnsCompression) to ensure consistency.
+standaloneDnsProxy:
+  # -- Enable standalone DNS proxy (alpha feature)
+  enabled: false
+  # -- Roll out Standalone DNS proxy automatically when configmap is updated.
+  rollOutPods: false
+  # -- Standalone DNS proxy annotations
+  annotations: {}
+  # -- Standalone DNS proxy debug mode
+  debug: false
+  # -- Standalone DNS proxy server port
+  serverPort: 10095
+  # -- Standalone DNS proxy Node Selector
+  nodeSelector:
+    kubernetes.io/os: linux
+  # -- Standalone DNS proxy tolerations
+  tolerations: []
+  # -- Standalone DNS proxy auto mount service account token
+  automountServiceAccountToken: false
+  # -- Standalone DNS proxy update strategy
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  # -- Standalone DNS proxy image
+  image:
+    # @schema
+    # type: [null, string]
+    # @schema
+    override: ~
+    repository: "${STANDALONE_DNS_PROXY_REPO}"
+    tag: "${STANDALONE_DNS_PROXY_VERSION}"
+    digest: "${STANDALONE_DNS_PROXY_DIGEST}"
+    useDigest: ${USE_DIGESTS}
+    pullPolicy: "${PULL_POLICY}"

--- a/pkg/fqdn/service/cell.go
+++ b/pkg/fqdn/service/cell.go
@@ -121,7 +121,7 @@ type FQDNConfig struct {
 
 var DefaultConfig = FQDNConfig{
 	EnableStandaloneDNSProxy:                 false,
-	StandaloneDNSProxyServerPort:             40045,
+	StandaloneDNSProxyServerPort:             10095,
 	ToFQDNsEnableDNSCompression:              true,
 	DNSMaxIPsPerRestoredRule:                 1000,
 	DNSProxyConcurrencyProcessingGracePeriod: 0,


### PR DESCRIPTION
Documentation and templates for testing and installing the standalone DNS proxy as a feature.

```
Standalone DNS Proxy (alpha)
The Standalone DNS Proxy is an independent component that runs as a separate DaemonSet, 
providing DNS proxying capabilities independent of the Cilium agent. This alpha feature 
allows DNS policy enforcement to continue even when the Cilium agent is unavailable.
ref: https://docs.cilium.io/en/stable/security/policy/standalone-dns-proxy/

Note: This is an alpha feature. Please test thoroughly before using in production 
environments and provide feedback via GitHub issues.
```
Fixes: #30984

```release-note
feat(sdp): Documentation and templates for standalone DNS Proxy
```
