### PR TITLE
clustermesh: misc MCS cleanup

### DIFF
--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
@@ -360,7 +360,7 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) SetupWithManager(mgr ctrl.Manager)
 		// We need to enqueue the "other" EndpointSlice to allow derived
 		// EndpointSlice initial creation.
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-			svcImportOwner := getOwnerReferenceName(obj.GetOwnerReferences(), mcsapiv1alpha1.GroupVersion.String(), kindServiceImport)
+			svcImportOwner := getOwnerReferenceName(obj.GetOwnerReferences(), mcsapiv1alpha1.GroupVersion.String(), mcsapiv1alpha1.ServiceImportKindName)
 			if svcImportOwner != "" {
 				return r.getEndpointSliceFromServiceRequests(ctx, types.NamespacedName{Name: svcImportOwner, Namespace: obj.GetNamespace()})
 			}

--- a/pkg/clustermesh/mcsapi/service_controller.go
+++ b/pkg/clustermesh/mcsapi/service_controller.go
@@ -28,11 +28,6 @@ import (
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
 )
 
-const (
-	kindServiceImport = "ServiceImport"
-	kindServiceExport = "ServiceExport"
-)
-
 // mcsAPIServiceReconciler is a controller that creates a derived service from
 // a ServiceImport object. The derived Service is created with the Cilium
 // annotations to mark it as a global Service so that we can take advantage of
@@ -283,7 +278,7 @@ func (r *mcsAPIServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&mcsapiv1alpha1.ServiceExport{}, &handler.EnqueueRequestForObject{}).
 		// Watch for changes to Services
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
-			svcImportOwner := getOwnerReferenceName(obj.GetOwnerReferences(), mcsapiv1alpha1.GroupVersion.String(), kindServiceImport)
+			svcImportOwner := getOwnerReferenceName(obj.GetOwnerReferences(), mcsapiv1alpha1.GroupVersion.String(), mcsapiv1alpha1.ServiceImportKindName)
 			if svcImportOwner == "" {
 				return []ctrl.Request{{NamespacedName: types.NamespacedName{
 					Name: obj.GetName(), Namespace: obj.GetNamespace(),

--- a/pkg/clustermesh/mcsapi/service_controller_test.go
+++ b/pkg/clustermesh/mcsapi/service_controller_test.go
@@ -290,7 +290,6 @@ func Test_mcsDerivedService_Reconcile(t *testing.T) {
 			require.Len(t, svc.Spec.Ports, 2)
 			require.Equal(t, "my-port-1", svc.Spec.Ports[0].Name)
 			require.Equal(t, "my-port-target-port", svc.Spec.Ports[1].Name)
-			require.Equal(t, "test-target-port", svc.Spec.Ports[1].TargetPort.String())
 
 			svcImport := &mcsapiv1alpha1.ServiceImport{}
 			err = c.Get(context.Background(), key, svcImport)


### PR DESCRIPTION
Two relatively small MCS cleanup:
- remove targetPort unused since we now have a controller that mirror the EndpointSlice instead of relying on selector (and targetPort); there's slightly more detail on the commit itself
- remove kind const in MCS code to rely mcs-api lib (we also already rely on similar const for the crd install process)