### PR TITLE
Correctly handle CiliumGatewayClassConfig as namespaced

### DIFF
--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -27,7 +27,8 @@ var (
 	cgwccFixture = []client.Object{
 		&v2alpha1.CiliumGatewayClassConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "dummy-gateway-class-config",
+				Name:      "dummy-gateway-class-config",
+				Namespace: "default",
 			},
 			Spec: v2alpha1.CiliumGatewayClassConfigSpec{},
 		},
@@ -62,9 +63,10 @@ var (
 			Spec: gatewayv1.GatewayClassSpec{
 				ControllerName: "io.cilium/gateway-controller",
 				ParametersRef: &gatewayv1.ParametersReference{
-					Group: "cilium.io",
-					Kind:  "CiliumGatewayClassConfig",
-					Name:  "dummy-gateway-class-config",
+					Group:     "cilium.io",
+					Kind:      "CiliumGatewayClassConfig",
+					Name:      "dummy-gateway-class-config",
+					Namespace: ptr.To(gatewayv1.Namespace("default")),
 				},
 			},
 		},

--- a/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
@@ -10,7 +10,6 @@ import (
 )
 
 // +genclient
-// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories={cilium},singular="ciliumgatewayclassconfig",path="ciliumgatewayclassconfigs",scope="Namespaced",shortName={cgcc}
 // +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="Accepted")].status`

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/cilium.io_client.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/cilium.io_client.go
@@ -62,8 +62,8 @@ func (c *CiliumV2alpha1Client) CiliumEndpointSlices() CiliumEndpointSliceInterfa
 	return newCiliumEndpointSlices(c)
 }
 
-func (c *CiliumV2alpha1Client) CiliumGatewayClassConfigs() CiliumGatewayClassConfigInterface {
-	return newCiliumGatewayClassConfigs(c)
+func (c *CiliumV2alpha1Client) CiliumGatewayClassConfigs(namespace string) CiliumGatewayClassConfigInterface {
+	return newCiliumGatewayClassConfigs(c, namespace)
 }
 
 func (c *CiliumV2alpha1Client) CiliumL2AnnouncementPolicies() CiliumL2AnnouncementPolicyInterface {

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/ciliumgatewayclassconfig.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/ciliumgatewayclassconfig.go
@@ -19,7 +19,7 @@ import (
 // CiliumGatewayClassConfigsGetter has a method to return a CiliumGatewayClassConfigInterface.
 // A group's client should implement this interface.
 type CiliumGatewayClassConfigsGetter interface {
-	CiliumGatewayClassConfigs() CiliumGatewayClassConfigInterface
+	CiliumGatewayClassConfigs(namespace string) CiliumGatewayClassConfigInterface
 }
 
 // CiliumGatewayClassConfigInterface has methods to work with CiliumGatewayClassConfig resources.
@@ -43,13 +43,13 @@ type ciliumGatewayClassConfigs struct {
 }
 
 // newCiliumGatewayClassConfigs returns a CiliumGatewayClassConfigs
-func newCiliumGatewayClassConfigs(c *CiliumV2alpha1Client) *ciliumGatewayClassConfigs {
+func newCiliumGatewayClassConfigs(c *CiliumV2alpha1Client, namespace string) *ciliumGatewayClassConfigs {
 	return &ciliumGatewayClassConfigs{
 		gentype.NewClientWithList[*ciliumiov2alpha1.CiliumGatewayClassConfig, *ciliumiov2alpha1.CiliumGatewayClassConfigList](
 			"ciliumgatewayclassconfigs",
 			c.RESTClient(),
 			scheme.ParameterCodec,
-			"",
+			namespace,
 			func() *ciliumiov2alpha1.CiliumGatewayClassConfig { return &ciliumiov2alpha1.CiliumGatewayClassConfig{} },
 			func() *ciliumiov2alpha1.CiliumGatewayClassConfigList {
 				return &ciliumiov2alpha1.CiliumGatewayClassConfigList{}

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/fake/fake_cilium.io_client.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/fake/fake_cilium.io_client.go
@@ -43,8 +43,8 @@ func (c *FakeCiliumV2alpha1) CiliumEndpointSlices() v2alpha1.CiliumEndpointSlice
 	return newFakeCiliumEndpointSlices(c)
 }
 
-func (c *FakeCiliumV2alpha1) CiliumGatewayClassConfigs() v2alpha1.CiliumGatewayClassConfigInterface {
-	return newFakeCiliumGatewayClassConfigs(c)
+func (c *FakeCiliumV2alpha1) CiliumGatewayClassConfigs(namespace string) v2alpha1.CiliumGatewayClassConfigInterface {
+	return newFakeCiliumGatewayClassConfigs(c, namespace)
 }
 
 func (c *FakeCiliumV2alpha1) CiliumL2AnnouncementPolicies() v2alpha1.CiliumL2AnnouncementPolicyInterface {

--- a/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/fake/fake_ciliumgatewayclassconfig.go
+++ b/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1/fake/fake_ciliumgatewayclassconfig.go
@@ -17,11 +17,11 @@ type fakeCiliumGatewayClassConfigs struct {
 	Fake *FakeCiliumV2alpha1
 }
 
-func newFakeCiliumGatewayClassConfigs(fake *FakeCiliumV2alpha1) ciliumiov2alpha1.CiliumGatewayClassConfigInterface {
+func newFakeCiliumGatewayClassConfigs(fake *FakeCiliumV2alpha1, namespace string) ciliumiov2alpha1.CiliumGatewayClassConfigInterface {
 	return &fakeCiliumGatewayClassConfigs{
 		gentype.NewFakeClientWithList[*v2alpha1.CiliumGatewayClassConfig, *v2alpha1.CiliumGatewayClassConfigList](
 			fake.Fake,
-			"",
+			namespace,
 			v2alpha1.SchemeGroupVersion.WithResource("ciliumgatewayclassconfigs"),
 			v2alpha1.SchemeGroupVersion.WithKind("CiliumGatewayClassConfig"),
 			func() *v2alpha1.CiliumGatewayClassConfig { return &v2alpha1.CiliumGatewayClassConfig{} },

--- a/pkg/k8s/client/informers/externalversions/cilium.io/v2alpha1/ciliumgatewayclassconfig.go
+++ b/pkg/k8s/client/informers/externalversions/cilium.io/v2alpha1/ciliumgatewayclassconfig.go
@@ -29,44 +29,45 @@ type CiliumGatewayClassConfigInformer interface {
 type ciliumGatewayClassConfigInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
 }
 
 // NewCiliumGatewayClassConfigInformer constructs a new informer for CiliumGatewayClassConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewCiliumGatewayClassConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredCiliumGatewayClassConfigInformer(client, resyncPeriod, indexers, nil)
+func NewCiliumGatewayClassConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredCiliumGatewayClassConfigInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredCiliumGatewayClassConfigInformer constructs a new informer for CiliumGatewayClassConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredCiliumGatewayClassConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredCiliumGatewayClassConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CiliumV2alpha1().CiliumGatewayClassConfigs().List(context.Background(), options)
+				return client.CiliumV2alpha1().CiliumGatewayClassConfigs(namespace).List(context.Background(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CiliumV2alpha1().CiliumGatewayClassConfigs().Watch(context.Background(), options)
+				return client.CiliumV2alpha1().CiliumGatewayClassConfigs(namespace).Watch(context.Background(), options)
 			},
 			ListWithContextFunc: func(ctx context.Context, options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CiliumV2alpha1().CiliumGatewayClassConfigs().List(ctx, options)
+				return client.CiliumV2alpha1().CiliumGatewayClassConfigs(namespace).List(ctx, options)
 			},
 			WatchFuncWithContext: func(ctx context.Context, options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CiliumV2alpha1().CiliumGatewayClassConfigs().Watch(ctx, options)
+				return client.CiliumV2alpha1().CiliumGatewayClassConfigs(namespace).Watch(ctx, options)
 			},
 		},
 		&apisciliumiov2alpha1.CiliumGatewayClassConfig{},
@@ -76,7 +77,7 @@ func NewFilteredCiliumGatewayClassConfigInformer(client versioned.Interface, res
 }
 
 func (f *ciliumGatewayClassConfigInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredCiliumGatewayClassConfigInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredCiliumGatewayClassConfigInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *ciliumGatewayClassConfigInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/k8s/client/informers/externalversions/cilium.io/v2alpha1/interface.go
+++ b/pkg/k8s/client/informers/externalversions/cilium.io/v2alpha1/interface.go
@@ -85,7 +85,7 @@ func (v *version) CiliumEndpointSlices() CiliumEndpointSliceInformer {
 
 // CiliumGatewayClassConfigs returns a CiliumGatewayClassConfigInformer.
 func (v *version) CiliumGatewayClassConfigs() CiliumGatewayClassConfigInformer {
-	return &ciliumGatewayClassConfigInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
+	return &ciliumGatewayClassConfigInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // CiliumL2AnnouncementPolicies returns a CiliumL2AnnouncementPolicyInformer.

--- a/pkg/k8s/client/listers/cilium.io/v2alpha1/ciliumgatewayclassconfig.go
+++ b/pkg/k8s/client/listers/cilium.io/v2alpha1/ciliumgatewayclassconfig.go
@@ -18,9 +18,8 @@ type CiliumGatewayClassConfigLister interface {
 	// List lists all CiliumGatewayClassConfigs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*ciliumiov2alpha1.CiliumGatewayClassConfig, err error)
-	// Get retrieves the CiliumGatewayClassConfig from the index for a given name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*ciliumiov2alpha1.CiliumGatewayClassConfig, error)
+	// CiliumGatewayClassConfigs returns an object that can list and get CiliumGatewayClassConfigs.
+	CiliumGatewayClassConfigs(namespace string) CiliumGatewayClassConfigNamespaceLister
 	CiliumGatewayClassConfigListerExpansion
 }
 
@@ -32,4 +31,27 @@ type ciliumGatewayClassConfigLister struct {
 // NewCiliumGatewayClassConfigLister returns a new CiliumGatewayClassConfigLister.
 func NewCiliumGatewayClassConfigLister(indexer cache.Indexer) CiliumGatewayClassConfigLister {
 	return &ciliumGatewayClassConfigLister{listers.New[*ciliumiov2alpha1.CiliumGatewayClassConfig](indexer, ciliumiov2alpha1.Resource("ciliumgatewayclassconfig"))}
+}
+
+// CiliumGatewayClassConfigs returns an object that can list and get CiliumGatewayClassConfigs.
+func (s *ciliumGatewayClassConfigLister) CiliumGatewayClassConfigs(namespace string) CiliumGatewayClassConfigNamespaceLister {
+	return ciliumGatewayClassConfigNamespaceLister{listers.NewNamespaced[*ciliumiov2alpha1.CiliumGatewayClassConfig](s.ResourceIndexer, namespace)}
+}
+
+// CiliumGatewayClassConfigNamespaceLister helps list and get CiliumGatewayClassConfigs.
+// All objects returned here must be treated as read-only.
+type CiliumGatewayClassConfigNamespaceLister interface {
+	// List lists all CiliumGatewayClassConfigs in the indexer for a given namespace.
+	// Objects returned here must be treated as read-only.
+	List(selector labels.Selector) (ret []*ciliumiov2alpha1.CiliumGatewayClassConfig, err error)
+	// Get retrieves the CiliumGatewayClassConfig from the indexer for a given namespace and name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*ciliumiov2alpha1.CiliumGatewayClassConfig, error)
+	CiliumGatewayClassConfigNamespaceListerExpansion
+}
+
+// ciliumGatewayClassConfigNamespaceLister implements the CiliumGatewayClassConfigNamespaceLister
+// interface.
+type ciliumGatewayClassConfigNamespaceLister struct {
+	listers.ResourceIndexer[*ciliumiov2alpha1.CiliumGatewayClassConfig]
 }

--- a/pkg/k8s/client/listers/cilium.io/v2alpha1/expansion_generated.go
+++ b/pkg/k8s/client/listers/cilium.io/v2alpha1/expansion_generated.go
@@ -37,6 +37,10 @@ type CiliumEndpointSliceListerExpansion interface{}
 // CiliumGatewayClassConfigLister.
 type CiliumGatewayClassConfigListerExpansion interface{}
 
+// CiliumGatewayClassConfigNamespaceListerExpansion allows custom methods to be added to
+// CiliumGatewayClassConfigNamespaceLister.
+type CiliumGatewayClassConfigNamespaceListerExpansion interface{}
+
 // CiliumL2AnnouncementPolicyListerExpansion allows custom methods to be added to
 // CiliumL2AnnouncementPolicyLister.
 type CiliumL2AnnouncementPolicyListerExpansion interface{}


### PR DESCRIPTION
So, it turns out that in #42172, @oblazek fixed handling of CGCCs to cluster-scoped, rather than namespaced, because there are tags in the API defs that indicate CGCC is not namespaced.

However, those tags only control the typed client, the actual YAML that is generated _is_ namespaced. So, although @oblazek was doing the right thing, as we all saw it, that change actually caused #42956.

Specifically, there is a `// +genclient:nonNamespaced` directive, which tells the typed client generation to treat CGCC as a non-namespaced (that is, cluster-scoped) resource, but there is also:

```
// +kubebuilder:resource:categories={cilium},singular="ciliumgatewayclassconfig",path="ciliumgatewayclassconfigs",scope="Namespaced",shortName={cgcc}
```

So, the actual CRD that gets created _is_ namespaced after all, but the generated client is _not_ namespaced.

This PR reverts #42172 and also fixes the typed client generation so that this shouldn't happen again.

Fixes: #42956

```release-note
gateway-api: correctly handle CiliumGatewayClassConfig as a namespaced resource.
```
