### PR TITLE
cgroup: don't start watch if KPRConfig.EnableSocketLB is disabled

### DIFF
--- a/pkg/cgroups/manager/cell.go
+++ b/pkg/cgroups/manager/cell.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -28,10 +29,11 @@ type cgroupManagerParams struct {
 	Lifecycle cell.Lifecycle
 
 	AgentConfig *option.DaemonConfig
+	KPRConfig   kpr.KPRConfig
 }
 
 func newCGroupManager(params cgroupManagerParams) CGroupManager {
-	if !params.AgentConfig.EnableSocketLBTracing {
+	if !params.KPRConfig.EnableSocketLB || !params.AgentConfig.EnableSocketLBTracing {
 		return &noopCGroupManager{}
 	}
 


### PR DESCRIPTION
Currently, the cgroup manager is started if `EnableSocketLBTracing` is enabled even though the overall feature `EnableSocketLB` is disabled.

Even though `EnableSocketLBTracing` get set to `false` if `EnableSocketLB` is `false`, this might happen after the cgroup manager already has been started. (KPR config runs as hive lifecycle hook while the cgroup start decision runs in the hive config phase).

See https://github.com/cilium/cilium/blob/main/pkg/kpr/initializer/kube_proxy_replacement.go#L245-L245

Therefore, this commit changes the cgroup manager to only start if both `KPRConfig.EnableSocketLB` & `DaemonConfig.EnableSocketLBTracing` are enabled.

Reported-by: Marcel Zieba <marcel.zieba@isovalent.com> :pray: 

Fixes: https://github.com/cilium/cilium/pull/32799