### PR TITLE
cgroup: use hive jobs instead of raw go routines

### DIFF
--- a/pkg/cgroups/manager/cell.go
+++ b/pkg/cgroups/manager/cell.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -24,8 +25,8 @@ var Cell = cell.Module(
 type cgroupManagerParams struct {
 	cell.In
 
-	Logger    *slog.Logger
-	Lifecycle cell.Lifecycle
+	Logger   *slog.Logger
+	JobGroup job.Group
 
 	AgentConfig *option.DaemonConfig
 }
@@ -48,16 +49,7 @@ func newCGroupManager(params cgroupManagerParams) CGroupManager {
 
 	cm := newManager(params.Logger, cgroupImpl{}, pathProvider, podEventsChannelSize)
 
-	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(hookContext cell.HookContext) error {
-			go cm.processPodEvents()
-			return nil
-		},
-		OnStop: func(cell.HookContext) error {
-			cm.Close()
-			return nil
-		},
-	})
+	params.JobGroup.Add(job.OneShot("process-pod-events", cm.processPodEvents))
 
 	params.Logger.Info("Cgroup metadata manager is enabled")
 

--- a/pkg/cgroups/manager/manager.go
+++ b/pkg/cgroups/manager/manager.go
@@ -4,11 +4,14 @@
 package manager
 
 import (
+	"context"
 	"log/slog"
 	"maps"
 	"os"
 	"slices"
 	"strings"
+
+	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/cgroups"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -61,8 +64,6 @@ type cgroupManager struct {
 	podEventsDone chan podEventStatus
 	// Cgroup path provider
 	pathProvider cgroupPathProvider
-	// Channel to shut down manager
-	shutdown chan struct{}
 	// Interface to do cgroups related operations
 	cgroupsChecker cgroup
 	// Cache indexed by cgroup id to store pod metadata
@@ -151,11 +152,6 @@ func (m *cgroupManager) DumpPodMetadata() []*FullPodMetadata {
 	return <-allMetaOut
 }
 
-// Close should only be called once from daemon close.
-func (m *cgroupManager) Close() {
-	close(m.shutdown)
-}
-
 type podUID = string
 
 type podMetadata struct {
@@ -206,14 +202,13 @@ func newManager(logger *slog.Logger, cg cgroup, pathProvider cgroupPathProvider,
 		podMetadataById:           make(map[string]*podMetadata),
 		containerMetadataByCgrpId: make(map[uint64]*containerMetadata),
 		podEvents:                 make(chan podEvent, channelSize),
-		shutdown:                  make(chan struct{}),
 		metadataCache:             map[uint64]PodMetadata{},
 		cgroupsChecker:            cg,
 		pathProvider:              pathProvider,
 	}
 }
 
-func (m *cgroupManager) processPodEvents() {
+func (m *cgroupManager) processPodEvents(ctx context.Context, _ cell.Health) error {
 	for {
 		select {
 		case ev := <-m.podEvents:
@@ -241,11 +236,11 @@ func (m *cgroupManager) processPodEvents() {
 			case podDumpMetadataEvent:
 				m.dumpPodMetadata(ev.allMetadataOut)
 			}
-		case <-m.shutdown:
+		case <-ctx.Done():
 			if m.podEventsDone != nil {
 				close(m.podEventsDone)
 			}
-			return
+			return nil
 		}
 	}
 }

--- a/pkg/cgroups/manager/manager_test.go
+++ b/pkg/cgroups/manager/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/stretchr/testify/require"
 
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -128,8 +129,7 @@ func newCgroupManagerTest(t testing.TB, pMock providerMock, cg cgroup, events ch
 
 	tcm.podEventsDone = events
 
-	go tcm.processPodEvents()
-	t.Cleanup(tcm.Close)
+	go tcm.processPodEvents(t.Context(), &cell.SimpleHealth{})
 
 	return tcm
 }


### PR DESCRIPTION
This commit refactors the cgroup metadata manager to use hive jobs for processing pod events.