### PR TITLE
daemonconfig: remove unused EnablePacketizationLayerPMTUD

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -997,9 +997,6 @@ const (
 
 	// EnableCiliumNodeCRD is the name of the option to enable use of the CiliumNode CRD
 	EnableCiliumNodeCRDName = "enable-ciliumnode-crd"
-
-	// EnablePacketizationLayerPMTUD enables kernel plpmtud discovery on Pod netns.
-	EnablePacketizationLayerPMTUD = "enable-packetization-layer-pmtud"
 )
 
 // Default string arguments
@@ -1898,9 +1895,6 @@ type DaemonConfig struct {
 
 	// EnableCiliumNodeCRD enables the use of CiliumNode CRD
 	EnableCiliumNodeCRD bool
-
-	// EnablePacketizationLayerPMTUD enables kernel packetization layer path mtu discovery on Pod netns.
-	EnablePacketizationLayerPMTUD bool
 }
 
 var (
@@ -2595,7 +2589,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.BootIDFile = vp.GetString(BootIDFilename)
 	c.EnableExtendedIPProtocols = vp.GetBool(EnableExtendedIPProtocols)
 	c.IPTracingOptionType = vp.GetUint(IPTracingOptionType)
-	c.EnablePacketizationLayerPMTUD = vp.GetBool(EnablePacketizationLayerPMTUD)
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {
 	case ServiceNoBackendResponseReject, ServiceNoBackendResponseDrop:


### PR DESCRIPTION
Checking for recently added global config properties in `DaemonConfig` I stumbled across `EnablePacketizationLayerPMTUD` that has been added but is not used (Note: it has been implemented as hive config in the respective cell). Let's remove it.

Fixes: https://github.com/cilium/cilium/pull/42012