### PR TITLE
agenthealth: move config flags into hive config

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -11,6 +11,8 @@ cilium-agent hive [flags]
 ### Options
 
 ```
+      --agent-health-port int                                     TCP port for agent health status API (default 9879)
+      --agent-health-require-k8s-connectivity                     Require Kubernetes connectivity in agent health endpoint (default true)
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -17,6 +17,8 @@ cilium-agent hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent-health-port int                                     TCP port for agent health status API (default 9879)
+      --agent-health-require-k8s-connectivity                     Require Kubernetes connectivity in agent health endpoint (default true)
       --agent-labels strings                                      Additional labels to identify this agent in monitor events
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit string                                     API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -155,9 +155,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 
 	hive.RegisterFlags(vp, flags)
 
-	flags.Int(option.AgentHealthPort, defaults.AgentHealthPort, "TCP port for agent health status API")
-	option.BindEnv(vp, option.AgentHealthPort)
-
 	flags.Int(option.ClusterHealthPort, defaults.ClusterHealthPort, "TCP port for cluster-wide network connectivity health API")
 	option.BindEnv(vp, option.ClusterHealthPort)
 
@@ -210,9 +207,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(vp, option.EnableEndpointRoutes)
-
-	flags.Bool(option.AgentHealthRequireK8sConnectivity, true, "Require Kubernetes connectivity in agent health endpoint")
-	option.BindEnv(vp, option.AgentHealthRequireK8sConnectivity)
 
 	flags.Int(option.HealthCheckICMPFailureThreshold, defaults.HealthCheckICMPFailureThreshold, "Number of ICMP requests sent for each run of the health checker. If at least one ICMP response is received, the node or endpoint is marked as healthy.")
 	option.BindEnv(vp, option.HealthCheckICMPFailureThreshold)

--- a/daemon/healthz/agenthealth.go
+++ b/daemon/healthz/agenthealth.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/spf13/pflag"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -26,8 +27,22 @@ var agentHealthzCell = cell.Module(
 	"agent-healthz",
 	"Cilium Agent Healthz endpoint",
 
+	cell.Config(agentHealthConfig{
+		AgentHealthPort:                   9879,
+		AgentHealthRequireK8sConnectivity: true,
+	}),
 	cell.Invoke(registerAgentHealthHTTPService),
 )
+
+type agentHealthConfig struct {
+	AgentHealthPort                   int
+	AgentHealthRequireK8sConnectivity bool
+}
+
+func (r agentHealthConfig) Flags(flags *pflag.FlagSet) {
+	flags.Int("agent-health-port", r.AgentHealthPort, "TCP port for agent health status API")
+	flags.Bool("agent-health-require-k8s-connectivity", r.AgentHealthRequireK8sConnectivity, "Require Kubernetes connectivity in agent health endpoint")
+}
 
 type agentHealthParams struct {
 	cell.In
@@ -35,6 +50,8 @@ type agentHealthParams struct {
 	Logger   *slog.Logger
 	JobGroup job.Group
 
+	Config          agentHealthConfig
+	DaemonConfig    *option.DaemonConfig
 	StatusCollector status.StatusCollector
 }
 
@@ -44,10 +61,10 @@ type agentHealthParams struct {
 // CLI tool reports.
 func registerAgentHealthHTTPService(params agentHealthParams) error {
 	hosts := map[string]string{}
-	if option.Config.EnableIPv4 {
+	if params.DaemonConfig.EnableIPv4 {
 		hosts["ipv4"] = "127.0.0.1"
 	}
-	if option.Config.EnableIPv6 {
+	if params.DaemonConfig.EnableIPv6 {
 		hosts["ipv6"] = "::1"
 	}
 
@@ -63,7 +80,7 @@ func registerAgentHealthHTTPService(params agentHealthParams) error {
 	for name, host := range hosts {
 		params.JobGroup.Add(job.OneShot(fmt.Sprintf("agent-healthz-server-%s", name), func(ctx context.Context, health cell.Health) error {
 			lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
-			addr := net.JoinHostPort(host, fmt.Sprintf("%d", option.Config.AgentHealthPort))
+			addr := net.JoinHostPort(host, fmt.Sprintf("%d", params.Config.AgentHealthPort))
 			ln, err := lc.Listen(context.Background(), "tcp", addr)
 			if errors.Is(err, unix.EADDRNOTAVAIL) {
 				params.Logger.Info("healthz status API server not available", logfields.Address, addr)
@@ -110,11 +127,12 @@ func registerAgentHealthHTTPService(params agentHealthParams) error {
 
 type agentHealthHandler struct {
 	logger          *slog.Logger
+	config          agentHealthConfig
 	statusCollector status.StatusCollector
 }
 
 func (h *agentHealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	requireK8sConnectivity := option.Config.AgentHealthRequireK8sConnectivity
+	requireK8sConnectivity := h.config.AgentHealthRequireK8sConnectivity
 	if v := r.Header.Get("require-k8s-connectivity"); v != "" {
 		res, err := strconv.ParseBool(v)
 		if err != nil {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -20,9 +20,6 @@ const (
 )
 
 const (
-	// AgentHealthPort is the default value for option.AgentHealthPort
-	AgentHealthPort = 9879
-
 	// ClusterHealthPort is the default value for option.ClusterHealthPort
 	ClusterHealthPort = 4240
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -59,9 +59,6 @@ const (
 )
 
 const (
-	// AgentHealthPort is the TCP port for agent health status API
-	AgentHealthPort = "agent-health-port"
-
 	// ClusterHealthPort is the TCP port for cluster-wide network connectivity health API
 	ClusterHealthPort = "cluster-health-port"
 
@@ -190,9 +187,6 @@ const (
 	// EnableK8s operation of Kubernetes-related services/controllers.
 	// Intended for operating cilium with CNI-compatible orchestrators other than Kubernetes. (default is true)
 	EnableK8s = "enable-k8s"
-
-	// AgentHealthRequireK8sConnectivity determines whether the agent health endpoint requires k8s connectivity
-	AgentHealthRequireK8sConnectivity = "agent-health-require-k8s-connectivity"
 
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer = "k8s-api-server"
@@ -1206,17 +1200,11 @@ type DaemonConfig struct {
 	// HiveConfig contains the configuration for daemon hive.
 	HiveConfig HiveConfig
 
-	// AgentHealthPort is the TCP port for agent health status API
-	AgentHealthPort int
-
 	// ClusterHealthPort is the TCP port for cluster-wide network connectivity health API
 	ClusterHealthPort int
 
 	// ClusterMeshHealthPort is the TCP port for ClusterMesh apiserver health API
 	ClusterMeshHealthPort int
-
-	// AgentHealthRequireK8sConnectivity determines whether the agent health endpoint requires k8s connectivity
-	AgentHealthRequireK8sConnectivity bool
 
 	// IPv6ClusterAllocCIDR is the base CIDR used to allocate IPv6 node
 	// CIDRs if allocation is not performed by an orchestration system
@@ -2460,7 +2448,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 
 	c.HiveConfig.Populate(vp)
 
-	c.AgentHealthPort = vp.GetInt(AgentHealthPort)
 	c.ClusterHealthPort = vp.GetInt(ClusterHealthPort)
 	c.ClusterMeshHealthPort = vp.GetInt(ClusterMeshHealthPort)
 	c.AllowICMPFragNeeded = vp.GetBool(AllowICMPFragNeeded)
@@ -2545,7 +2532,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 	c.EnableEgressGateway = vp.GetBool(EnableEgressGateway)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
-	c.AgentHealthRequireK8sConnectivity = vp.GetBool(AgentHealthRequireK8sConnectivity)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
 	c.MonitorAggregation = vp.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)


### PR DESCRIPTION
This commit extracts the config flags `agent-health-port` & `agent-health-require-k8s-connectivity` from the global `DaemonConfig` into a new Hive config struct of the respective Hive cell.

While at it, it also uses an injected instance of `DaemonConfig` to access the global daemonconfig (to check if IPv4/IPv6 is enabled).