### PR TITLE
ci: add k8s 1.34 for aks

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -8,10 +8,13 @@ include:
     location: westus2
     index: 2
   - version: "1.32"
-    location: eastus2
+    location: westus
     index: 3
   - version: "1.33"
+    location: eastus2
+    index: 4
+  - version: "1.34"
     location: eastus
     default: true
     preview: true
-    index: 4
+    index: 5


### PR DESCRIPTION
Adding k8s 1.34 for AKS, should be available since nov 2025 cf [doc](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli)