### PR TITLE
bpf/tests: fix off-by-one error in ASSERT_CTX_BUF_OFF macro

### DIFF
--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -169,7 +169,7 @@ static struct scapy_assert __scapy_assert = {0};
 		if (!_ok) {								\
 			__scapy_assert.len = LEN;					\
 			scapy_memcpy(__scapy_assert.exp_buf, _BUF, LEN);		\
-			if (__DATA + (LEN) < __DATA_END) {				\
+			if (__DATA + (LEN) <= __DATA_END) {				\
 				scapy_memcpy(__scapy_assert.got_buf, __DATA, LEN);	\
 			}								\
 			scapy_strncpy(__scapy_assert.name, NAME, sizeof(NAME));		\


### PR DESCRIPTION
The ASSERT_CTX_BUF_OFF macro had an off-by-one error when copying packet data for error reporting. When a packet ended exactly at the expected length (no extra padding), the condition to copy data to got_buf would fail, leaving it as zeros.

This means:
- If __DATA + LEN > __DATA_END: correctly detected as not enough data
- If __DATA + LEN == __DATA_END: valid packet with exact length, but the condition fails, so got_buf remains zeros in error reports
- If __DATA + LEN < __DATA_END: works correctly with extra padding

The fix changes the condition to use <= instead of <, allowing the macro to correctly handle packets that end exactly at the expected boundary. This is common for fixed-size packets without payload padding, such as minimal TCP packets.