### PR TITLE
fqdn: Add extra metrics to UpdateOnDNSMsg

### DIFF
--- a/pkg/fqdn/dnsproxy/types.go
+++ b/pkg/fqdn/dnsproxy/types.go
@@ -80,6 +80,9 @@ type ProxyRequestContext struct {
 	PolicyCheckTime      spanstat.SpanStat
 	PolicyGenerationTime spanstat.SpanStat
 	DataplaneTime        spanstat.SpanStat
+	QnameLockTime        spanstat.SpanStat
+	UpdateEpCacheTime    spanstat.SpanStat
+	UpdateNmCacheTime    spanstat.SpanStat
 	Success              bool
 	Err                  error
 	DataSource           accesslog.DNSDataSource


### PR DESCRIPTION
This commit adds some extra processing time metrics to UpdateOnDNSMsg, specifically latency for the query name lock and endpoint/namemanager cache updates.

These metrics have proven useful for catching/debugging/improving performance regressions in the fqdn query hot path.
