### PR TITLE
add option to wait for cloud-init completion

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3116,6 +3116,10 @@
      - node-init update strategy
      - object
      - ``{"type":"RollingUpdate"}``
+   * - :spelling:ignore:`nodeinit.waitForCloudInit`
+     - wait for Cloud init to finish on the host and assume the node has cloud init installed
+     - bool
+     - ``false``
    * - :spelling:ignore:`operator.affinity`
      - Affinity for cilium-operator
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -829,6 +829,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.startup | object | `{"postScript":"","preScript":""}` | startup offers way to customize startup nodeinit script (pre and post position) |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
+| nodeinit.waitForCloudInit | bool | `false` | wait for Cloud init to finish on the host and assume the node has cloud init installed |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |
 | operator.annotations | object | `{}` | Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator) |
 | operator.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for cilium-operator grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -156,6 +156,14 @@ fi
 iptables -w -t nat -D POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ || true
 {{- end }}
 
+{{- if .Values.nodeinit.waitForCloudInit }}
+echo "Waiting for cloud-init..."
+if command -v cloud-init >/dev/null 2>&1; then
+  cloud-init status --wait
+  echo "cloud-init completed!"
+fi
+{{- end }}
+
 {{- if not (eq .Values.nodeinit.bootstrapFile "") }}
 mkdir -p {{ .Values.nodeinit.bootstrapFile | dir | quote }}
 date > {{ .Values.nodeinit.bootstrapFile | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4679,6 +4679,9 @@
             }
           },
           "type": "object"
+        },
+        "waitForCloudInit": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3263,6 +3263,8 @@ nodeinit:
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
   bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
+  # -- wait for Cloud init to finish on the host and assume the node has cloud init installed
+  waitForCloudInit: false
   # -- startup offers way to customize startup nodeinit script (pre and post position)
   startup:
     preScript: ""

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3291,6 +3291,8 @@ nodeinit:
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
   bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
+  # -- wait for Cloud init to finish on the host and assume the node has cloud init installed
+  waitForCloudInit: false
   # -- startup offers way to customize startup nodeinit script (pre and post position)
   startup:
     preScript: ""


### PR DESCRIPTION
In aws enviroment, aws could consider the NIC is managed by networkd if cilium adds the NIC to the instance during the cloud init
(https://github.com/awslabs/amazon-eks-ami/blob/4c653a2903ec8604a9fdfdeaf779f8ad8292d70b/nodeadm/cmd/nodeadm-internal/udev/broker.go#L28-L40) . This will cause a race between cilium and networkd.

This PR will add cloud init wait option to node init so we can let the cilium agent not running before cloud init finish the setup to avoid the race between cilium and networkd.


Here is the test result from my test cluster.

Helm value:
```
nodeinit:
  enabled: true
  bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
  waitForCloudInit: true
```

cluster status

```
NAMESPACE     NAME                               READY   STATUS     RESTARTS   AGE     IP             NODE       NOMINATED NODE   READINESS GATES
kube-system   cilium-4h9dg                       0/1     Init:4/7   0          113s    192.168.1.31   workers1   <none>           <none>
kube-system   cilium-6xtzf                       0/1     Init:4/7   0          113s    192.168.1.30   workers0   <none>           <none>
kube-system   cilium-d94sh                       1/1     Running    0          113s    192.168.1.20   masters0   <none>           <none>
kube-system   cilium-envoy-bs76s                 1/1     Running    0          113s    192.168.1.31   workers1   <none>           <none>
kube-system   cilium-envoy-tzgw7                 1/1     Running    0          113s    192.168.1.30   workers0   <none>           <none>
kube-system   cilium-envoy-zkq7d                 1/1     Running    0          113s    192.168.1.20   masters0   <none>           <none>
kube-system   cilium-node-init-4svg5             1/1     Running    0          113s    192.168.1.20   masters0   <none>           <none>
kube-system   cilium-node-init-7jp2n             1/1     Running    0          113s    192.168.1.31   workers1   <none>           <none>
kube-system   cilium-node-init-fw9ns             1/1     Running    0          113s    192.168.1.30   workers0   <none>           <none>
```
agents on 1.31 and 1.30 can't be scheduled because the node init is waiting for the cloud init

logs on cilium-node-init-7jp2n
```
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
    inet6 fd03::31/128 scope global
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:feaa:bbb1/64 scope link
       valid_lft forever preferred_lft forever
Waiting for cloud-init...
```

release notes:

```release-note
Add wait for cloud init in the node init script option
```