### PR TITLE
kvstore: start local identity watcher in hive cell as job

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -344,16 +344,6 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		return err
 	}
 
-	// Start watcher for endpoint IP --> identity mappings in key-value store.
-	// this needs to be done *after* that the ipcache map has been recreated
-	// by initMaps.
-	if params.IPIdentityWatcher.IsEnabled() {
-		go func() {
-			params.Logger.Info("Starting IP identity watcher")
-			params.IPIdentityWatcher.Watch(ctx)
-		}()
-	}
-
 	if err := params.IPsecAgent.StartBackgroundJobs(params.NodeHandler); err != nil {
 		params.Logger.Error("Unable to start IPsec key watcher", logfields.Error, err)
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -43,7 +43,6 @@ import (
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/ipcache"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
@@ -1235,7 +1234,6 @@ type daemonParams struct {
 	DB                  *statedb.DB
 	Devices             statedb.Table[*datapathTables.Device]
 	DirectRoutingDevice datapathTables.DirectRoutingDevice
-	IPIdentityWatcher   *ipcache.LocalIPIdentityWatcher
 	IPsecAgent          datapath.IPsecAgent
 	SyncHostIPs         *syncHostIPs
 	NodeDiscovery       *nodediscovery.NodeDiscovery


### PR DESCRIPTION
This commit extracts the start of the kvstore local identity watcher from the legacy daemon init logic into the hive cell. The watch itself is started as hive oneshot job.

Note: With https://github.com/cilium/cilium/pull/42874 merged, the Identity restoration & IPCache BPF map recreation is handled by a lifecycle start hook of the IPCache cell. Due to the dependency from the KVStore local identity watcher on the `IPCache` it's ensured that the restoration/recreation runs before the watch starts.