### PR TITLE
kpr: remove dependency to IPSec agent in kpr initializer

### DIFF
--- a/pkg/kpr/initializer/cell.go
+++ b/pkg/kpr/initializer/cell.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -43,7 +42,6 @@ type kprInitializerParams struct {
 	LBConfig     loadbalancer.Config
 	KPRCfg       kpr.KPRConfig
 	WireguardCfg wgTypes.WireguardConfig
-	IPSecAgent   datapath.IPsecAgent
 }
 
 func newKPRInitializer(params kprInitializerParams) KPRInitializer {
@@ -54,6 +52,5 @@ func newKPRInitializer(params kprInitializerParams) KPRInitializer {
 		lbConfig:     params.LBConfig,
 		kprCfg:       params.KPRCfg,
 		wgCfg:        params.WireguardCfg,
-		ipsecAgent:   params.IPSecAgent,
 	}
 }

--- a/pkg/kpr/initializer/kube_proxy_replacement.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging"
@@ -41,7 +40,6 @@ type kprInitializer struct {
 	lbConfig     loadbalancer.Config
 	kprCfg       kpr.KPRConfig
 	wgCfg        wgTypes.WireguardConfig
-	ipsecAgent   datapath.IPsecAgent
 }
 
 func (r *kprInitializer) InitKubeProxyReplacementOptions() error {

--- a/pkg/kpr/initializer/kube_proxy_replacement_test.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement_test.go
@@ -17,7 +17,6 @@ import (
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
@@ -91,7 +90,7 @@ func errorMatch(err error, regex string) assert.Comparison {
 	}
 }
 
-func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, tc tunnel.Config, wgCfg wgTypes.WireguardConfig, ipsecAgent datapath.IPsecAgent) {
+func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, tc tunnel.Config, wgCfg wgTypes.WireguardConfig) {
 	logger := hivetest.Logger(t)
 	kprManager := &kprInitializer{
 		logger:       logger,
@@ -100,7 +99,6 @@ func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg 
 		lbConfig:     lbConfig,
 		kprCfg:       kprCfg,
 		wgCfg:        wgCfg,
-		ipsecAgent:   ipsecAgent,
 	}
 	err := kprManager.InitKubeProxyReplacementOptions()
 	if err != nil || cfg.expectedErrorRegex != "" {
@@ -111,7 +109,6 @@ func (cfg *kprConfig) verify(t *testing.T, lbConfig loadbalancer.Config, kprCfg 
 		}
 	}
 	require.Equal(t, cfg.enableSocketLB, kprCfg.EnableSocketLB)
-	require.Equal(t, cfg.enableIPSec, ipsecAgent.Enabled())
 	require.Equal(t, cfg.enableHostLegacyRouting, option.Config.EnableHostLegacyRouting)
 	require.Equal(t, cfg.installNoConntrackIptRules, option.Config.InstallNoConntrackIptRules)
 	require.Equal(t, cfg.enableBPFMasquerade, option.Config.EnableBPFMasquerade)
@@ -346,7 +343,7 @@ func TestInitKubeProxyReplacementOptions(t *testing.T) {
 		cfg := def
 		testCase.mod(&cfg)
 		require.NoError(t, cfg.set())
-		testCase.out.verify(t, cfg.lbConfig, cfg.kprConfig, tunnel.NewTestConfig(cfg.tunnelProtocol), fakeTypes.WireguardConfig{}, &fakeTypes.IPsecAgent{EnableIPsec: cfg.enableIPSec})
+		testCase.out.verify(t, cfg.lbConfig, cfg.kprConfig, tunnel.NewTestConfig(cfg.tunnelProtocol), fakeTypes.WireguardConfig{})
 		def.set()
 	}
 }


### PR DESCRIPTION
This commit removes the unused dependency to the `IPSecAgent` from the KPR initializer.

Follow up of: https://github.com/cilium/cilium/pull/41997