### PR TITLE
Fix GC of possible duplicated identities in kvstore mode

### DIFF
--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -477,7 +477,8 @@ func (k *kvstoreBackend) RunGC(
 			continue
 		}
 
-		if identityID, err := strconv.ParseUint(items[len(items)-1], 10, 64); err != nil {
+		identity := items[len(items)-1]
+		if identityID, err := strconv.ParseUint(identity, 10, 64); err != nil {
 			k.logger.Warn(
 				"Parse identity failed, skipping",
 				logfields.Error, err,
@@ -520,8 +521,8 @@ func (k *kvstoreBackend) RunGC(
 		}
 
 		hasUsers := false
-		for prefix := range pairs {
-			if prefixMatchesKey(valueKeyPrefix, prefix) {
+		for prefix, id := range pairs {
+			if prefixMatchesKey(valueKeyPrefix, prefix) && identity == string(id.Data) {
 				hasUsers = true
 				break
 			}

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -682,4 +682,21 @@ func TestRunGC(t *testing.T) {
 	require.Equal(t, 2, stats.Alive, "Two identities should be alive")
 	require.Equal(t, 1, stats.Deleted, "One identity should have been deleted")
 	require.ElementsMatch(t, getIDs(), []string{"101", "102"}, "Identity 100 should have been deleted")
+
+	// Create a duplicate identity for an already existing set of labels. While this
+	// should never happen thanks to locking, it has been observed in the wild, and
+	// it is better to be robust in this case as well.
+	require.NoError(t, client.Update(ctx, path.Join(base, "id", "103"), []byte("k8s:foo=bar;baz=qux;"), false), "client.Update")
+
+	// The duplicated identity should be treated as stale
+	stale, _, err = backend.RunGC(ctx, rl, make(map[string]uint64), minID, maxID)
+	require.NoError(t, err, "backend.RunGC")
+	require.ElementsMatch(t, slices.Collect(trim(maps.Keys(stale))), []string{"103"}, "Identity 103 should be stale")
+	require.ElementsMatch(t, getIDs(), []string{"101", "102", "103"}, "No identity should have been deleted")
+
+	// Run GC once more, it should remove the stale key
+	stale, _, err = backend.RunGC(ctx, rl, stale, minID, maxID)
+	require.NoError(t, err, "backend.RunGC")
+	require.Empty(t, stale, "No identity should be stale")
+	require.ElementsMatch(t, getIDs(), []string{"101", "102"}, "Identity 103 should have been deleted")
 }

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -6,8 +6,12 @@ package allocator
 import (
 	"context"
 	"fmt"
+	"iter"
+	"maps"
 	"math"
 	"path"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/rate"
+	cslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -606,4 +611,75 @@ func TestRemoteCache(t *testing.T) {
 	for i := range cache {
 		require.Equal(t, 2, cache[i])
 	}
+}
+
+func TestRunGC(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	const (
+		minID = 0
+		maxID = 1000
+	)
+
+	var (
+		ctx    = t.Context()
+		log    = hivetest.Logger(t)
+		client = kvstore.SetupDummyWithConfigOpts(t, "etcd", etcdOpts)
+		base   = randomTestName()
+		rl     = rate.NewLimiter(1*time.Millisecond, 1000)
+	)
+
+	backend, err := NewKVStoreBackend(log, KVStoreBackendConfiguration{base, "", TestAllocatorKey(""), client})
+	require.NoError(t, err, "NewKVStoreBackend")
+
+	for id, label := range map[string]string{
+		"100": "k8s:foo=bar;",
+		"101": "k8s:foo=bar;baz=qux;",
+		"102": "k8s:foo=bar;fred=true;",
+	} {
+		// Create a primary entry for all identities
+		require.NoError(t, client.Update(ctx, path.Join(base, "id", id), []byte(label), false), "client.Update")
+
+		// Create two secondary entries for all identities
+		for _, node := range []string{"node-a", "node-b"} {
+			require.NoError(t, client.Update(ctx, path.Join(base, "value", label, node), []byte(id), false), "client.Update")
+		}
+	}
+
+	var (
+		trim = func(in iter.Seq[string]) iter.Seq[string] {
+			return cslices.MapIter(in, func(in string) string { return strings.TrimPrefix(in, path.Join(base, "id")+"/") })
+		}
+
+		getIDs = func() []string {
+			pairs, err := client.ListPrefix(ctx, path.Join(base, "id")+"/")
+			require.NoError(t, err, "client.ListPrefix")
+			return slices.Collect(trim(maps.Keys(pairs)))
+		}
+	)
+
+	stale, stats, err := backend.RunGC(ctx, rl, make(map[string]uint64), minID, maxID)
+	require.NoError(t, err, "backend.RunGC")
+	require.Empty(t, stale, "No identity should be stale")
+	require.Equal(t, 3, stats.Alive, "All identities should be alive")
+	require.Equal(t, 0, stats.Deleted, "No identity should have been deleted")
+
+	// Remove the secondary keys for one identity
+	require.NoError(t, client.DeletePrefix(ctx, path.Join(base, "value", "k8s:foo=bar;")+"/"))
+
+	// The corresponding identity should be treated as stale
+	stale, stats, err = backend.RunGC(ctx, rl, make(map[string]uint64), minID, maxID)
+	require.NoError(t, err, "backend.RunGC")
+	require.ElementsMatch(t, slices.Collect(trim(maps.Keys(stale))), []string{"100"}, "Identity 100 should be stale")
+	require.Equal(t, 3, stats.Alive, "All identities should be alive")
+	require.Equal(t, 0, stats.Deleted, "No identity should have been deleted")
+	require.ElementsMatch(t, getIDs(), []string{"100", "101", "102"}, "No identity should have been deleted")
+
+	// Run GC once more, it should remove the stale key
+	stale, stats, err = backend.RunGC(ctx, rl, stale, minID, maxID)
+	require.NoError(t, err, "backend.RunGC")
+	require.Empty(t, stale, "No identity should be stale")
+	require.Equal(t, 2, stats.Alive, "Two identities should be alive")
+	require.Equal(t, 1, stats.Deleted, "One identity should have been deleted")
+	require.ElementsMatch(t, getIDs(), []string{"101", "102"}, "Identity 100 should have been deleted")
 }


### PR DESCRIPTION
Currently, the [RunGC] logic does not delete duplicated identities (i.e., pointing to the same labels), as long as at least one of them is actually used. Although duplicated identities should never occur in kvstore mode thanks to locking, this has been observed happening in the wild, and it is better to be robust in this case as well. Hence, let's fine tune the GC logic to consider a given identity as used only if it has any associated secondary key that also matches the actual ID.