### PR TITLE
kvstore: let WatchStoreManager.Run only return once the context expires

### DIFF
--- a/pkg/kvstore/store/watchstoremgr.go
+++ b/pkg/kvstore/store/watchstoremgr.go
@@ -140,5 +140,7 @@ func (mgr *wsmImmediate) Run(ctx context.Context) {
 	for prefix := range mgr.functions {
 		mgr.ready(ctx, prefix)
 	}
+
+	<-ctx.Done()
 	mgr.wait()
 }


### PR DESCRIPTION
Currently, [wsmImmediate.Run] does not fully comply with the corresponding godoc, as it actually returns before the context has expired, in case no prefix is registered. While we never hit this case given the current usage, let's still address that, and add a test to validate the expected behavior.