### PR TITLE
[network-driver]: Add support for allocations restore

### DIFF
--- a/pkg/networkdriver/cell.go
+++ b/pkg/networkdriver/cell.go
@@ -5,6 +5,7 @@ package networkdriver
 
 import (
 	"log/slog"
+	"path/filepath"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -14,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Cell implements the Cilium Network Driver for exposing
@@ -32,6 +34,7 @@ type networkDriverParams struct {
 	Lifecycle cell.Lifecycle
 	ClientSet k8sClient.Clientset
 	JobGroup  job.Group
+	DaemonCfg *option.DaemonConfig
 }
 
 // getNetworkDriverConfig returns the network driver configuration.
@@ -88,6 +91,8 @@ func registerNetworkDriver(params networkDriverParams) *Driver {
 		kubeClient:     params.ClientSet,
 		deviceManagers: make(map[types.DeviceManagerType]types.DeviceManager),
 		config:         *cfg,
+		stateDir:       params.DaemonCfg.StateDir,
+		filePath:       filepath.Join(params.DaemonCfg.StateDir, defaultDriverStoreFileName),
 		allocations:    make(map[kube_types.UID]map[kube_types.UID][]allocation),
 	}
 

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -56,7 +56,7 @@ func (d *Driver) unprepareResourceClaim(ctx context.Context, claim kubeletplugin
 	}
 
 	if !found {
-		d.logger.DebugContext(
+		d.logger.WarnContext(
 			ctx, "no allocation found for claim",
 			logfields.UID, claim.UID,
 			logfields.K8sNamespace, claim.Namespace,

--- a/pkg/networkdriver/driver_test.go
+++ b/pkg/networkdriver/driver_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package networkdriver
+
+import (
+	"path/filepath"
+	"testing"
+
+	kube_types "k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/networkdriver/dummy"
+	"github.com/cilium/cilium/pkg/networkdriver/sriov"
+)
+
+func TestDriverStoreAndReload(t *testing.T) {
+	allocations := map[kube_types.UID]map[kube_types.UID][]allocation{
+		kube_types.UID("6bd2a7f7-baf8-4358-a88e-2975f600f0dc"): {
+			kube_types.UID("bcf84ccd-99b9-4bad-9f57-2b607f822b3e"): {
+				allocation{
+					Device: &sriov.PciDevice{
+						Addr:            "test-addr-1",
+						Driver:          "test-driver-1",
+						Vendor:          "test-vendor-1",
+						DeviceID:        "test-device-id-1",
+						PfName:          "phys-name-1",
+						VfID:            1,
+						KernelIfaceName: "test-name-1",
+					},
+				},
+				allocation{
+					Device: &sriov.PciDevice{
+						Addr:            "test-addr-2",
+						Driver:          "test-driver-2",
+						Vendor:          "test-vendor-2",
+						DeviceID:        "test-device-id-2",
+						PfName:          "phys-name-2",
+						VfID:            2,
+						KernelIfaceName: "test-name-2",
+					},
+				},
+			},
+			kube_types.UID("f2b841c6-14c5-46f7-856d-ff563f113352"): {
+				allocation{
+					Device: &dummy.DummyDevice{
+						Name:   "test-name-3",
+						HWAddr: "test-hw-addr-3",
+						MTU:    1500,
+						Flags:  "up|running",
+					},
+				},
+			},
+		},
+		kube_types.UID("7ee48615-8bb3-4f09-acac-fa13e84edaca"): {
+			kube_types.UID("e139427b-b920-4a85-8713-b6e549f32051"): {
+				allocation{
+					Device: &dummy.DummyDevice{
+						Name:   "test-name-4",
+						HWAddr: "test-hw-addr-4",
+						MTU:    1250,
+						Flags:  "up|running",
+					},
+				},
+			},
+		},
+	}
+
+	driver := Driver{
+		filePath:    filepath.Join(t.TempDir(), defaultDriverStoreFileName),
+		allocations: allocations,
+	}
+	assert.NoError(t, driver.storeState())
+
+	driver.allocations = nil
+	assert.NoError(t, driver.reloadState())
+
+	assert.Equal(t, allocations, driver.allocations)
+}

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -65,11 +65,11 @@ func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 			continue
 		}
 
-		devices = append(devices, DummyDevice{
-			name:   link.Attrs().Name,
-			hwAddr: link.Attrs().HardwareAddr.String(),
-			mtu:    link.Attrs().MTU,
-			flags:  link.Attrs().Flags.String(),
+		devices = append(devices, &DummyDevice{
+			Name:   link.Attrs().Name,
+			HWAddr: link.Attrs().HardwareAddr.String(),
+			MTU:    link.Attrs().MTU,
+			Flags:  link.Attrs().Flags.String(),
 		})
 	}
 
@@ -77,18 +77,18 @@ func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 }
 
 type DummyDevice struct {
-	name   string
-	hwAddr string
-	mtu    int
-	flags  string
+	Name   string
+	HWAddr string
+	MTU    int
+	Flags  string
 }
 
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result["interface_name"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
-	result["mac_address"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.hwAddr)}
-	result["mtu"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.mtu))}
-	result["flags"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.flags)}
+	result["mac_address"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.HWAddr)}
+	result["mtu"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.MTU))}
+	result["flags"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Flags)}
 
 	return result
 }
@@ -114,9 +114,9 @@ func (d DummyDevice) Match(filter types.DeviceFilter) bool {
 }
 
 func (d DummyDevice) IfName() string {
-	return d.name
+	return d.Name
 }
 
 func (d DummyDevice) KernelIfName() string {
-	return d.name
+	return d.Name
 }

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -83,6 +83,10 @@ type DummyDevice struct {
 	Flags  string
 }
 
+func (d DummyDevice) Type() string {
+	return "dummy"
+}
+
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result["interface_name"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}

--- a/pkg/networkdriver/sriov/sriov.go
+++ b/pkg/networkdriver/sriov/sriov.go
@@ -54,6 +54,10 @@ type PciDevice struct {
 	KernelIfaceName string
 }
 
+func (p PciDevice) Type() string {
+	return "sr-iov"
+}
+
 func (p PciDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result["driver"] = resourceapi.DeviceAttribute{StringValue: ptr.To(p.Driver)}

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -72,6 +72,7 @@ func (d *DeviceManagerType) UnmarshalText(text []byte) error {
 }
 
 type Device interface {
+	Type() string
 	GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute
 	Setup(cfg DeviceConfig) error
 	Free(cfg DeviceConfig) error


### PR DESCRIPTION
Add support for saving and restoring the driver allocations to persistent storage. This allows to avoid leaking resources after an agent/plugin restart.

The format used to save the allocations is JSON, therefore we require each Device concrete types to be JSON serializable.
