### PR TITLE
v1.18 Backports 2025-12-12

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1483,8 +1483,6 @@ const (
 
 	EgressAlive = "egressAlive"
 
-	CTMapIPVersion = "ctMapIPVersion"
-
 	ExpectedPrevInterval = "expectedPrevInterval"
 
 	ActualPrevInterval = "actualPrevInterval"

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -574,6 +574,12 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 		return nil
 	}
 
+	if err := natMap.Open(); err != nil {
+		natMap.Logger.Error("Unable to open NAT map", logfields.Error, err)
+		return nil
+	}
+	defer natMap.Close()
+
 	family := gcFamilyIPv4
 	if ctMapTCP.mapType.isIPv6() {
 		family = gcFamilyIPv6

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -543,14 +543,33 @@ func GC(m *Map, filter GCFilter, next4, next6 func(GCEvent)) (int, error) {
 // CT GC to remove corresponding SNAT entries.
 // See the unit test TestPrivilegedOrphanNatGC for more examples.
 func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
+	var natMap *nat.Map
+
 	// Both CT maps should point to the same natMap, so use the first one
 	// to determine natMap
-	ctMap := mapInfo[ctMapTCP.mapType]
-	if ctMap.natMapLock != nil {
-		ctMap.natMapLock.Lock()
-		defer ctMap.natMapLock.Unlock()
+	if ctMapTCP.clusterID == 0 {
+		// global map handling
+		ctMap := mapInfo[ctMapTCP.mapType]
+		if ctMap.natMapLock != nil {
+			ctMap.natMapLock.Lock()
+			defer ctMap.natMapLock.Unlock()
+		}
+		natMap = ctMap.natMap
+	} else {
+		// per-cluster map handling
+		var family = nat.IPv4
+		if ctMapTCP.mapType.isIPv6() {
+			family = nat.IPv6
+		}
+
+		natm, err := nat.GetClusterNATMap(ctMapTCP.clusterID, family)
+		if err != nil {
+			ctMapTCP.Logger.Error("Unable to get per-cluster NAT map", logfields.Error, err)
+		} else {
+			natMap = natm
+		}
 	}
-	natMap := ctMap.natMap
+
 	if natMap == nil {
 		return nil
 	}
@@ -559,7 +578,7 @@ func PurgeOrphanNATEntries(ctMapTCP, ctMapAny *Map) *NatGCStats {
 	if ctMapTCP.mapType.isIPv6() {
 		family = gcFamilyIPv6
 	}
-	stats := newNatGCStats(natMap, family)
+	stats := newNatGCStats(natMap, family, ctMapTCP.clusterID)
 	defer stats.finish()
 	egressEntriesToDelete := make([]nat.NatKey, 0)
 	ingressEntriesToDelete := make([]nat.NatKey, 0)

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -57,25 +57,3 @@ func TestGetInterval(t *testing.T) {
 	option.Config.ConntrackGCMaxInterval = oldMaxInterval
 	require.Equal(t, time.Minute, GetInterval(logger, actualLast, expectedLast, 0.1))
 }
-
-func TestFilterMapsByProto(t *testing.T) {
-	maps := []*Map{
-		newMap("tcp4", mapTypeIPv4TCPGlobal),
-		newMap("any4", mapTypeIPv4AnyGlobal),
-		newMap("tcp6", mapTypeIPv6TCPGlobal),
-		newMap("any6", mapTypeIPv6AnyGlobal),
-	}
-
-	ctMapTCP, ctMapAny := FilterMapsByProto(maps, CTMapIPv4)
-	require.Equal(t, mapTypeIPv4TCPGlobal, ctMapTCP.mapType)
-	require.Equal(t, mapTypeIPv4AnyGlobal, ctMapAny.mapType)
-
-	ctMapTCP, ctMapAny = FilterMapsByProto(maps, CTMapIPv6)
-	require.Equal(t, mapTypeIPv6TCPGlobal, ctMapTCP.mapType)
-	require.Equal(t, mapTypeIPv6AnyGlobal, ctMapAny.mapType)
-
-	maps = maps[0:2] // remove ipv6 maps
-	ctMapTCP, ctMapAny = FilterMapsByProto(maps, CTMapIPv6)
-	require.Nil(t, ctMapTCP)
-	require.Nil(t, ctMapAny)
-}

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -93,6 +93,8 @@ func New(params parameters) *GC {
 		signalHandler:    params.SignalManager,
 
 		controllerManager: controller.NewManager(),
+
+		perClusterCTMapsRetriever: params.PerClusterCTMapsRetriever,
 	}
 
 	gc.observable4, gc.next4, gc.complete4 = stream.Multicast[ctmap.GCEvent]()

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -4,6 +4,7 @@
 package gc
 
 import (
+	"cmp"
 	"log/slog"
 	"net/netip"
 	"os"
@@ -49,6 +50,9 @@ type parameters struct {
 	NodeAddressing  types.NodeAddressing
 	SignalManager   SignalHandler
 
+	// PerClusterCTMapsRetriever is an optional function that, if provided, is
+	// used to retrieve the per-cluster CT maps. The slice of maps returned by
+	// the function must contain consecutive (TCP, ANY) pairs.
 	PerClusterCTMapsRetriever PerClusterCTMapsRetriever `optional:"true"`
 }
 
@@ -363,17 +367,13 @@ func (gc *GC) runGC(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (
 	}
 
 	if triggeredBySignal {
-		vsns := []ctmap.CTMapIPVersion{}
-		if ipv4 {
-			vsns = append(vsns, ctmap.CTMapIPv4)
-		}
-		if ipv6 {
-			vsns = append(vsns, ctmap.CTMapIPv6)
-		}
-
-		for _, vsn := range vsns {
+		// This works under the assumption that [maps] contains consecutive pairs
+		// of CT maps, respectively of TCP and ANY type, which is currently true
+		// both for global and per-cluster maps.
+		for i := 0; i+1 < len(maps); i += 2 {
 			startTime := time.Now()
-			ctMapTCP, ctMapAny := ctmap.FilterMapsByProto(maps, vsn)
+
+			ctMapTCP, ctMapAny := maps[i], maps[i+1]
 			stats := ctmap.PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
 			if stats != nil && (stats.EgressDeleted != 0 || stats.IngressDeleted != 0) {
 				gc.logger.Info(
@@ -382,7 +382,8 @@ func (gc *GC) runGC(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (
 					logfields.EgressDeleted, stats.EgressDeleted,
 					logfields.IngressAlive, stats.IngressAlive,
 					logfields.EgressAlive, stats.EgressAlive,
-					logfields.CTMapIPVersion, vsn,
+					logfields.Family, stats.Family,
+					logfields.ClusterID, cmp.Or(stats.ClusterID, option.Config.ClusterID),
 					logfields.Duration, time.Since(startTime),
 				)
 			}

--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -148,7 +148,8 @@ type NatGCStats struct {
 	*bpf.DumpStats
 
 	// family is the address family
-	Family gcFamily
+	Family    gcFamily
+	ClusterID uint32
 
 	IngressAlive   uint32
 	IngressDeleted uint32
@@ -156,10 +157,11 @@ type NatGCStats struct {
 	EgressAlive    uint32
 }
 
-func newNatGCStats(m *nat.Map, family gcFamily) NatGCStats {
+func newNatGCStats(m *nat.Map, family gcFamily, clusterID uint32) NatGCStats {
 	return NatGCStats{
 		DumpStats: m.DumpStats(),
 		Family:    family,
+		ClusterID: clusterID,
 	}
 }
 

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -156,37 +156,6 @@ func (m mapType) maxEntries() int {
 	}
 }
 
-type CTMapIPVersion int
-
-const (
-	CTMapIPv4 CTMapIPVersion = iota
-	CTMapIPv6
-)
-
-// FilterMapsByProto filters the given CT maps by the given IP version, and
-// returns two maps - one for TCP and one for any protocol.
-func FilterMapsByProto(maps []*Map, ipVsn CTMapIPVersion) (ctMapTCP *Map, ctMapAny *Map) {
-	for _, m := range maps {
-		switch ipVsn {
-		case CTMapIPv4:
-			switch m.mapType {
-			case mapTypeIPv4TCPLocal, mapTypeIPv4TCPGlobal:
-				ctMapTCP = m
-			case mapTypeIPv4AnyLocal, mapTypeIPv4AnyGlobal:
-				ctMapAny = m
-			}
-		case CTMapIPv6:
-			switch m.mapType {
-			case mapTypeIPv6TCPLocal, mapTypeIPv6TCPGlobal:
-				ctMapTCP = m
-			case mapTypeIPv6AnyLocal, mapTypeIPv6AnyGlobal:
-				ctMapAny = m
-			}
-		}
-	}
-	return
-}
-
 type CtKey interface {
 	bpf.MapKey
 


### PR DESCRIPTION
 * [x] #43160 (@giorio94) :warning: resolved conflicts
    * :information_source: Hit minor conflicts due to different surrounding context, and because https://github.com/cilium/cilium/commit/a1a4e9eadfcebe5090f7d923150cb458c24e314e ("ctmap: remove local ctmap types") is not present in v1.18. Resolved as appropriate.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43160
```
