### PR TITLE
Fix panic on endpoint controller shutdown

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -43,11 +43,14 @@ var (
 )
 
 func getLocalNode(logger *slog.Logger) LocalNode {
+	// Only expecting errors if we're called after LocalNodeStore has stopped, e.g.
+	// we have a component that uses the legacy getters and setters here and does
+	// not depend on LocalNodeStore.
+	if localNode == nil {
+		logging.Fatal(logger, "getLocalNode called for nil localNode")
+	}
 	n, err := localNode.Get(context.TODO())
 	if err != nil {
-		// Only expecting errors if we're called after LocalNodeStore has stopped, e.g.
-		// we have a component that uses the legacy getters and setters here and does
-		// not depend on LocalNodeStore.
 		logging.Fatal(logger, "getLocalNode: unexpected error", logfields.Error, err)
 	}
 	return n


### PR DESCRIPTION
There is currently a race condition that can happen on daemon shutdown where endpoint controllers keep running after the `LocalNodeStoreCell`'s `OnStop` hook has set `localNode` to `nil`. This causes a panic as in `getLocalNode`, the `.Get()` method gets called on a `nil` node store:

```
Waiting for all endpoints' goroutines to be stopped.
All endpoints' goroutines stopped.
failed to delete reporter status tree
Datapath signal listener exiting
Datapath signal listener done
Signal handler closed. Stopping conntrack garbage collector
Stopped gops server
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1c0 pc=0x177a0b9]
goroutine 116049 [running]:
github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Get(_, {_, _})
/go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:192 +0x79
github.com/cilium/cilium/pkg/node.getLocalNode(_)
/go/src/github.com/cilium/cilium/pkg/node/address.go:45 +0x8d
github.com/cilium/cilium/pkg/node.GetIPv4(0x28?)
/go/src/github.com/cilium/cilium/pkg/node/address.go:231 +0x25
github.com/cilium/cilium/pkg/node.GetCiliumEndpointNodeIP(0x0?)
/go/src/github.com/cilium/cilium/pkg/node/address.go:251 +0x25
github.com/cilium/cilium/pkg/endpoint.getEndpointNetworking(0xc001304270, 0xc01d532a10)
/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint_status.go:38 +0xa5
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).GetCiliumEndpointStatus(0xc010abea08)
/go/src/github.com/cilium/cilium/pkg/endpoint/endpoint_status.go:74 +0x18b
github.com/cilium/cilium/pkg/endpointmanager.(*EndpointSynchronizer).RunK8sCiliumEndpoint
Sync.func1({0x5337190, 0xc016e47450})
/go/src/github.com/cilium/cilium/pkg/endpointmanager/endpointsynchronizer.go:136 +0x376
github.com/cilium/cilium/pkg/controller.(*controller).runController(0xc006e6e9a0)
/go/src/github.com/cilium/cilium/pkg/controller/controller.go:333 +0x1c7
created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in
goroutine 116100
/go/src/github.com/cilium/cilium/pkg/controller/manager.go:124 +0x4ae
```

I initially tried to solve this issue by rearanging the shutdown dependencies to fully wait for endpoint controllers to stop before clearing the local node store (see #42899). But that approach ended up failing a lot of CI checks so probably not the right option.

This PR is slightly more naive: if `localNode` is `nil`, then we crash the agent via `logging.Fatal`. It's fine in this case as the alternative is to get a segment violation panic. The result is that the race condition is still present, but when it occurs, we'll have a slightly better handling of it with a clearer message instead of a panic.
