### PR TITLE
loader: Add -Wno-unused-command-line-argument on compiler tests.

### DIFF
--- a/pkg/datapath/loader/compile_test.go
+++ b/pkg/datapath/loader/compile_test.go
@@ -22,6 +22,7 @@ func TestPrivilegedCompile(t *testing.T) {
 		cpy := *p
 		cpy.Output = cpy.Source
 		cpy.OutputType = outputSource
+		cpy.Options = append(cpy.Options, "-Wno-unused-command-line-argument")
 		return &cpy
 	}
 


### PR DESCRIPTION
When upgrading from Rocky Linux 9.6 to 9.7, the distributed LLVM toolchain was jumped from 19.1 to 20.1. Since then, the datapath compiler test has failed with the following message for both bpf_lxc.c and bpf_host.c:

```
=== RUN   TestPrivilegedCompile
=== RUN   TestPrivilegedCompile/obj:bpf_lxc.o
=== RUN   TestPrivilegedCompile/obj:bpf_host.o
=== RUN   TestPrivilegedCompile/c:bpf_lxc.c
    logger.go:256: time=2025-12-12T16:40:58.313Z level=ERROR source=/home/ajm/cilium/pkg/datapath/loader/compile.go:219 msg="Failed to compile bpf_lxc.c: exit status 1" compilerPID=33313
    logger.go:256: time=2025-12-12T16:40:58.330Z level=WARN source=/home/ajm/cilium/pkg/datapath/loader/compile.go:227 msg="clang: error: argument unused during compilation: '-c' [-Werror,-Wunused-command-line-argument]"
    compile_test.go:39:
        	Error Trace:	/home/ajm/cilium/pkg/datapath/loader/compile_test.go:39
        	Error:      	Received unexpected error:
        	            	Failed to compile bpf_lxc.c: exit status 1
        	Test:       	TestPrivilegedCompile/c:bpf_lxc.c
=== RUN   TestPrivilegedCompile/c:bpf_host.c
    logger.go:256: time=2025-12-12T16:40:59.132Z level=ERROR source=/home/ajm/cilium/pkg/datapath/loader/compile.go:219 msg="Failed to compile bpf_host.c: exit status 1" compilerPID=33314
    logger.go:256: time=2025-12-12T16:40:59.173Z level=WARN source=/home/ajm/cilium/pkg/datapath/loader/compile.go:227 msg="clang: error: argument unused during compilation: '-c' [-Werror,-Wunused-command-line-argument]"
    compile_test.go:39:
        	Error Trace:	/home/ajm/cilium/pkg/datapath/loader/compile_test.go:39
        	Error:      	Received unexpected error:
        	            	Failed to compile bpf_host.c: exit status 1
        	Test:       	TestPrivilegedCompile/c:bpf_host.c
--- FAIL: TestPrivilegedCompile (12.88s)
    --- PASS: TestPrivilegedCompile/obj:bpf_lxc.o (5.51s)
    --- PASS: TestPrivilegedCompile/obj:bpf_host.o (5.84s)
    --- FAIL: TestPrivilegedCompile/c:bpf_lxc.c (0.62s)
    --- FAIL: TestPrivilegedCompile/c:bpf_host.c (0.83s)
```

This is also true for Ubuntu 25.10 which also ships with LLVM 20.1, and goes away if downgraded back to 19.1.

This commit adds the -Wno-unused-command-line-argument flag to the test to suppress this fault, which is only observed when running privileged tests. It does not appear when running Cilium and running a workload.

No functional change.

```release-note
Add -Wno-unused-command-line-argument to loader/compiler unit test to mitigate test fault with LLVM 20.1.
```
