### PR TITLE
[v1.18] bpf: tests: egressgw improvements

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1071,7 +1071,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 {
 	struct icmphdr icmphdr __align_stack_8;
 	struct ipv4_nat_entry *state = NULL;
-	struct ipv4_ct_tuple tuple = {};
+	struct ipv4_ct_tuple tuple __align_stack_8 = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
 	fraginfo_t fraginfo;

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -73,10 +73,10 @@ ipcache_v4_add_entry_with_mask_size(__be32 addr, __u8 cluster_id, __u32 sec_iden
 static __always_inline void
 __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 		       const union v6addr *tunnel_ep, __u8 spi, bool flag_skip_tunnel,
-		       bool ipv6_underlay)
+		       bool ipv6_underlay, __u32 mask_size)
 {
 	struct ipcache_key key __align_stack_8 = {
-		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(V6_CACHE_KEY_LEN),
+		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(mask_size),
 		.cluster_id = cluster_id,
 		.family = ENDPOINT_KEY_IPV6,
 	};
@@ -106,7 +106,7 @@ ipcache_v6_add_world_entry()
 	union v6addr tunnel_ep = {0};
 
 	__ipcache_v6_add_entry((union v6addr *)v6_all, 0, WORLD_IPV6_ID,
-			       &tunnel_ep, false, false, 0);
+			       &tunnel_ep, 0, false, false, 0);
 }
 
 static __always_inline void
@@ -114,14 +114,15 @@ ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_identi
 		     __u32 tunnel_ep, __u8 spi)
 {
 	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
-			       false, false);
+			       false, false, V6_CACHE_KEY_LEN);
 }
 
 static __always_inline void
 ipcache_v6_add_entry_ipv6_underlay(const union v6addr *addr, __u8 cluster_id, __u32 sec_identity,
 				   const union v6addr *tunnel_ep, __u8 spi)
 {
-	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, true);
+	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, tunnel_ep, spi, false, true,
+			       V6_CACHE_KEY_LEN);
 }
 
 static __always_inline void
@@ -129,5 +130,5 @@ ipcache_v6_add_entry_with_flags(const union v6addr *addr, __u8 cluster_id, __u32
 				__u32 tunnel_ep, __u8 spi, bool flag_skip_tunnel)
 {
 	__ipcache_v6_add_entry(addr, cluster_id, sec_identity, (union v6addr *)&tunnel_ep, spi,
-			       flag_skip_tunnel, false);
+			       flag_skip_tunnel, false, V6_CACHE_KEY_LEN);
 }

--- a/bpf/tests/lib/ipcache.h
+++ b/bpf/tests/lib/ipcache.h
@@ -75,7 +75,7 @@ __ipcache_v6_add_entry(const union v6addr *addr, __u8 cluster_id, __u32 sec_iden
 		       const union v6addr *tunnel_ep, __u8 spi, bool flag_skip_tunnel,
 		       bool ipv6_underlay)
 {
-	struct ipcache_key key = {
+	struct ipcache_key key __align_stack_8 = {
 		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(V6_CACHE_KEY_LEN),
 		.cluster_id = cluster_id,
 		.family = ENDPOINT_KEY_IPV6,

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -255,7 +255,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
@@ -300,7 +300,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_EXCL_CIDR));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
@@ -354,7 +354,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_NO_GATEWAY,
 				     &egress_ip);
@@ -419,7 +419,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 
-	ipcache_v6_add_entry(&ext_svc_ip, 0, WORLD_IPV6_ID, 0, 0);
+	ipcache_v6_add_world_entry();
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
 	create_ct_entry_v6(ctx, client_port(TEST_DROP_NO_EGRESS_IP));

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -48,7 +48,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_redirect")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
@@ -85,7 +85,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 {
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_EXCL_CIDR));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
@@ -131,7 +131,7 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 	};
 
 	map_delete_elem(&cilium_metrics, &key);
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY,
 				  EGRESS_IP);
@@ -191,7 +191,7 @@ int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 	};
 
 	map_delete_elem(&cilium_metrics, &key);
-	ipcache_v4_add_entry_with_mask_size(v4_all, 0, WORLD_IPV4_ID, 0, 0, 0);
+	ipcache_v4_add_world_entry();
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
 	create_ct_entry(ctx, client_port(TEST_DROP_NO_EGRESS_IP));

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -6,12 +6,13 @@
 #include "pktgen.h"
 
 /* Enable code paths under test */
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_NODEPORT
-#define ENABLE_EGRESS_GATEWAY
-#define ENABLE_MASQUERADE_IPV4
-#define ENABLE_MASQUERADE_IPV6
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_EGRESS_GATEWAY		1
+#define ENABLE_MASQUERADE_IPV4		1
+#define ENABLE_MASQUERADE_IPV6		1
+#define ENABLE_HOST_FIREWALL		1
 #define ENCAP_IFINDEX 0
 
 #include "bpf_host.c"
@@ -52,6 +53,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	create_ct_entry(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
 				  EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
@@ -91,6 +93,7 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 				  EGRESS_IP);
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR,
 				  EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
@@ -256,6 +259,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT));
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);
@@ -302,6 +306,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 				     &egress_ip);
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, 128, EGRESS_GATEWAY_EXCLUDED_CIDR,
 				     &egress_ip);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, TO_NETDEV);

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -6,12 +6,13 @@
 #include "pktgen.h"
 
 /* Enable code paths under test */
-#define ENABLE_IPV4
-#define ENABLE_IPV6
-#define ENABLE_NODEPORT
-#define ENABLE_EGRESS_GATEWAY
-#define ENABLE_MASQUERADE_IPV4
-#define ENABLE_MASQUERADE_IPV6
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_EGRESS_GATEWAY		1
+#define ENABLE_MASQUERADE_IPV4		1
+#define ENABLE_MASQUERADE_IPV6		1
+#define ENABLE_HOST_FIREWALL		1
 #define ENCAP_IFINDEX		42
 #define SECONDARY_IFACE_IFINDEX	44
 
@@ -90,6 +91,7 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -192,6 +194,7 @@ int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP);
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -227,6 +230,7 @@ int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP3);
+	ipcache_v4_add_entry(EGRESS_IP3, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -384,6 +388,7 @@ int egressgw_fib_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
 				  GATEWAY_NODE_IP, EGRESS_IP2);
+	ipcache_v4_add_entry(EGRESS_IP2, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -427,6 +432,7 @@ int egressgw_snat1_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -538,6 +544,7 @@ int egressgw_tuple_collision1_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -580,6 +587,7 @@ int egressgw_tuple_collision2_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -750,6 +758,7 @@ int egressgw_fib_redirect_setup_v6(struct __ctx_buff *ctx)
 
 	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
 				     &egress_ip);
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
 
 	/* Jump into the entrypoint */
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);


### PR DESCRIPTION
Manual backport of
* [ ] #42955
* [ ] #42988

Along with one `v1.18`-only patch to let us pass the verifier.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42955 42988
```

