### PR TITLE
policy: Allow IPCache to be decorated

### DIFF
--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -31,6 +31,7 @@ var Cell = cell.Module(
 	cell.Provide(newPolicyUpdater),
 	cell.Provide(newPolicyImporter),
 	cell.Provide(newIdentityUpdater),
+	cell.Provide(newIPCacher),
 	cell.Config(defaultConfig),
 	metrics.Metric(newIdentityUpdaterMetrics),
 )

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -44,7 +44,7 @@ type policyImporterParams struct {
 
 	Repo            policy.PolicyRepository
 	EndpointManager endpointmanager.EndpointManager
-	IPCache         *ipcache.IPCache
+	IPCache         IPCacher
 	MonitorAgent    agent.Agent
 }
 
@@ -52,7 +52,7 @@ type policyImporter struct {
 	log          *slog.Logger
 	repo         policy.PolicyRepository
 	epm          epmanager
-	ipc          ipcacher
+	ipc          IPCacher
 	monitorAgent agent.Agent
 
 	// prefixesByResources is the list of prefixes
@@ -63,10 +63,14 @@ type policyImporter struct {
 	q chan *policytypes.PolicyUpdate
 }
 
-type ipcacher interface {
+type IPCacher interface {
 	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	WaitForRevision(ctx context.Context, rev uint64) error
+}
+
+func newIPCacher(ipc *ipcache.IPCache) IPCacher {
+	return ipc
 }
 
 type epmanager interface {

--- a/pkg/policy/k8s/cell.go
+++ b/pkg/policy/k8s/cell.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/ipcache"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -45,11 +44,6 @@ var Cell = cell.Module(
 	cell.Invoke(startK8sPolicyWatcher),
 )
 
-type ipc interface {
-	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
-	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
-}
-
 type PolicyWatcherParams struct {
 	cell.In
 
@@ -67,7 +61,7 @@ type PolicyWatcherParams struct {
 	Services statedb.Table[*loadbalancer.Service]
 	Backends statedb.Table[*loadbalancer.Backend]
 
-	IPCache        *ipcache.IPCache
+	IPCache        policycell.IPCacher
 	PolicyImporter policycell.PolicyImporter
 
 	CiliumNetworkPolicies            resource.Resource[*cilium_v2.CiliumNetworkPolicy]

--- a/pkg/policy/k8s/watcher.go
+++ b/pkg/policy/k8s/watcher.go
@@ -42,7 +42,7 @@ type policyWatcher struct {
 
 	serviceEvents stream.Observable[serviceEvent]
 
-	ipCache ipc
+	ipCache policycell.IPCacher
 
 	// Number of outstanding requests still pending in the PolicyImporter
 	// This is only used during initial sync; we will increment these


### PR DESCRIPTION
This commit makes `pkg/policy` use its own interface for IPCache in the policy K8s watcher and the policy ingestor. This allows the use of `cell.DecorateAll` to overwrite the IPCache implementation in tests.
