### PR TITLE
bpf: host: don't force PACKET_HOST when IPSec is enabled

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1715,12 +1715,6 @@ int cil_to_host(struct __ctx_buff *ctx)
 #endif
 
 #ifdef ENABLE_IPSEC
-	/* Encryption stack needs this when IPSec headers are
-	 * rewritten without FIB helper because we do not yet
-	 * know correct MAC address which will cause the stack
-	 * to mark as PACKET_OTHERHOST and drop.
-	 */
-	ctx_change_type(ctx, PACKET_HOST);
 #if !defined(TUNNEL_MODE)
 	/* Since v1.18 Cilium performs IPsec encryption at the native device,
 	 * before the packet leaves the host.


### PR DESCRIPTION
In the past this part was needed for encrypted packets without valid L2 headers, which got diverted through the cilium_{host,net} veth pair.

But as https://github.com/cilium/cilium/pull/41699 removed this diversion, there shouldn't be any further need for this code. It won't even see any of the targeted IPsec traffic.