### PR TITLE
operator: Move unmanagedpod logic to dedicated cell

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -144,7 +144,7 @@ cilium-operator-alibabacloud [flags]
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information
 ```

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -104,6 +104,7 @@ cilium-operator-alibabacloud hive [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -109,6 +109,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -152,7 +152,7 @@ cilium-operator-aws [flags]
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information
 ```

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -104,6 +104,7 @@ cilium-operator-aws hive [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -109,6 +109,7 @@ cilium-operator-aws hive dot-graph [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -147,7 +147,7 @@ cilium-operator-azure [flags]
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information
 ```

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -104,6 +104,7 @@ cilium-operator-azure hive [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -109,6 +109,7 @@ cilium-operator-azure hive dot-graph [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -143,7 +143,7 @@ cilium-operator-generic [flags]
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information
 ```

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -104,6 +104,7 @@ cilium-operator-generic hive [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -109,6 +109,7 @@ cilium-operator-generic hive dot-graph [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -157,7 +157,7 @@ cilium-operator [flags]
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
       --version                                              Print version information
 ```

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -104,6 +104,7 @@ cilium-operator hive [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -109,6 +109,7 @@ cilium-operator hive dot-graph [flags]
       --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
 ```
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -396,6 +396,26 @@ Agent Options
 ~~~~~~~~~~~~~
 
 
+Operator Options
+~~~~~~~~~~~~~~~~
+
+* The ``--unmanaged-pod-watcher-interval`` flag type has been changed from ``int`` (seconds)
+  to ``time.Duration`` for improved usability and consistency with other Cilium configuration
+  options. If you have this flag explicitly configured, update your configuration to use
+  duration format (e.g., ``15s``, ``1m``, ``90s``). The default value remains 15 seconds.
+
+  .. code-block:: bash
+
+      # Before (deprecated):
+      --unmanaged-pod-watcher-interval=15
+
+      # After:
+      --unmanaged-pod-watcher-interval=15s
+
+  Note: When using Helm, the ``operator.unmanagedPodWatcher.intervalSeconds`` value now
+  accepts both integers (for backward compatibility) and duration strings. Numeric values
+  will be automatically converted to duration strings (e.g., ``15`` becomes ``"15s"``).
+
 Cluster Mesh API Server Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1343,7 +1343,12 @@ data:
 {{- end }}
 
 {{- if .Values.operator.unmanagedPodWatcher.restart }}
-  unmanaged-pod-watcher-interval: {{ .Values.operator.unmanagedPodWatcher.intervalSeconds | quote }}
+  {{- $interval := .Values.operator.unmanagedPodWatcher.intervalSeconds }}
+  {{- if kindIs "float64" $interval }}
+  unmanaged-pod-watcher-interval: {{ printf "%ds" (int $interval) | quote }}
+  {{- else }}
+  unmanaged-pod-watcher-interval: {{ $interval | quote }}
+  {{- end }}
 {{- else }}
   unmanaged-pod-watcher-interval: "0"
 {{- end }}

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -210,9 +210,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(vp, operatorOption.SyncK8sServices)
 
-	flags.Int(operatorOption.UnmanagedPodWatcherInterval, 15, "Interval to check for unmanaged kube-dns pods (0 to disable)")
-	option.BindEnv(vp, operatorOption.UnmanagedPodWatcherInterval)
-
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(vp, option.Version)
 

--- a/operator/unmanagedpods/cell.go
+++ b/operator/unmanagedpods/cell.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package unmanagedpods
+
+import (
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+// Cell is a cell that implements a controller for restarting pods without
+// CiliumEndpoint CRDs. This is primarily used to restart kube-dns pods that
+// may have started before Cilium was ready.
+var Cell = cell.Module(
+	"unmanaged-pods-gc",
+	"Garbage collector for pods without CiliumEndpoints",
+
+	cell.Config(defaultConfig),
+	cell.Invoke(registerController),
+	metrics.Metric(NewMetrics),
+)
+
+const (
+	// UnmanagedPodWatcherInterval is the interval to check for unmanaged kube-dns pods (0 to disable)
+	UnmanagedPodWatcherInterval = "unmanaged-pod-watcher-interval"
+)
+
+type Config struct {
+	// Interval is the interval between checks for unmanaged pods (0 to disable)
+	Interval time.Duration `mapstructure:"unmanaged-pod-watcher-interval"`
+}
+
+var defaultConfig = Config{
+	Interval: 15 * time.Second,
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Duration(UnmanagedPodWatcherInterval, def.Interval, "Interval to check for unmanaged kube-dns pods (0 to disable)")
+}
+
+// SharedConfig contains the configuration that is shared between this module and others.
+type SharedConfig struct {
+	// DisableCiliumEndpointCRD disables the use of CiliumEndpoint CRD
+	DisableCiliumEndpointCRD bool
+
+	// K8sEnabled indicates whether Kubernetes support is enabled
+	K8sEnabled bool
+}

--- a/operator/unmanagedpods/metrics.go
+++ b/operator/unmanagedpods/metrics.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package unmanagedpods
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+// Metrics holds the metrics for the unmanaged pods controller.
+type Metrics struct {
+	// UnmanagedPods records the pods that are unmanaged by Cilium.
+	// This includes Running pods not using hostNetwork, which do not have a corresponding CiliumEndpoint object.
+	UnmanagedPods metric.Gauge
+}
+
+// NewMetrics creates a new Metrics instance.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		UnmanagedPods: metric.NewGauge(
+			metric.GaugeOpts{
+				Namespace: metrics.CiliumOperatorNamespace,
+				Name:      "unmanaged_pods",
+				Help:      "The total number of pods observed to be unmanaged by Cilium operator",
+			},
+		),
+	}
+}


### PR DESCRIPTION
Move the operator's unmanaged pod controller out of the `legacy` hive cell and into a dedicated `unmanagedpod` cell.

This PR also updates the `unmanaged-pod-watcher-interval` flag to be of type `duration` instead of `int` to be consistent with other `-interval` flags.

Note: I kept the helm value `operator.unmanagedPodWatcher.intervalSeconds` as an int and not a duration as if we want to also replace this one with a duration we'd need to rename it to `operator.unmanagedPodWatcher.interval` for consistency and that'd be a larger breaking change. Happy to change it though if reviewers feel like that's better this way.

Related issue: #23425

```release-note
operator: Refactor unmanaged kube-dns pods management into a separate cell. The `unmanaged-pod-watcher-interval` flag now expects a duration value.
```
