### PR TITLE
metrics: deprecate `agent_bootstrap_seconds`

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -733,7 +733,7 @@ Agent
 ================================ ================================ ========== ========================================================
 Name                             Labels                           Default    Description
 ================================ ================================ ========== ========================================================
-``agent_bootstrap_seconds``      ``scope``, ``outcome``           Enabled    Duration of various bootstrap phases
+``agent_bootstrap_seconds``      ``scope``, ``outcome``           Enabled    Deprecated, will be removed in Cilium 1.20 - use ``cilium_hive_jobs_oneshot_last_run_duration_seconds`` of respective job instead. Duration of various bootstrap phases
 ``api_process_time_seconds``                                      Enabled    Processing time of all the API calls made to the cilium-agent, labeled by API method, API path and returned HTTP code.
 ================================ ================================ ========== ========================================================
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -454,6 +454,7 @@ The following metrics no longer reports a ``source_cluster`` and a ``source_node
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~
 
+* ``cilium_agent_bootstrap_seconds`` is now deprecated. Please use ``cilium_hive_jobs_oneshot_last_run_duration_seconds`` of respective job instead.
 
 Advanced
 ========


### PR DESCRIPTION
This commit deprecates the metric `agent_bootstrap_seconds`.

With the ongoing modularization of the legacy daemon initialization logic - the metric will eventually be deleted.

Most of the long-running bootstrap tasks are/will be replaced with hive jobs. Therefore it's recommended to use the metric `cilium_hive_jobs_oneshot_last_run_duration_seconds` of the respective job instead. If this isn't enough we have to introduce specific metrics in the scope of the respective modules.

Short-running tasks are/will be handled directly in hive lifecycle start hooks and reported in the log if they exceed a given max time (`--hive-log-threshold` (default 100ms))

Related PR that updates the hive job metrics documentation: https://github.com/cilium/cilium/pull/43347