### PR TITLE
[v1.18] ipcache: Fix leak in CIDR metadata consolidation logic

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -514,6 +514,11 @@ type MU struct {
 	IsCIDR   bool
 }
 
+// cidrResourceID is a fixed resource type to represent CIDR metadata entries
+// from policies. This resource type represents entries from the CIDR
+// consolidation optimization logic.
+var cidrResourceID = ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "", "consolidated-prefix")
+
 // UpsertMetadata upserts a given IP and some corresponding information into
 // the ipcache metadata map. See IPMetadata for a list of types that are valid
 // to pass into this function. This will trigger asynchronous calculation of
@@ -532,7 +537,11 @@ func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
 	ipc.metadata.Lock()
 	for _, upd := range updates {
 		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Add(upd.Prefix) {
-			prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, upd.Resource, upd.Metadata...)...)
+			resource := upd.Resource
+			if upd.IsCIDR {
+				resource = cidrResourceID
+			}
+			prefixes = append(prefixes, ipc.metadata.upsertLocked(upd.Prefix, upd.Source, resource, upd.Metadata...)...)
 		}
 	}
 	ipc.metadata.Unlock()
@@ -563,7 +572,11 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 	ipc.metadata.Lock()
 	for _, upd := range updates {
 		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Delete(upd.Prefix) {
-			prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, upd.Resource, upd.Metadata...)...)
+			resource := upd.Resource
+			if upd.IsCIDR {
+				resource = cidrResourceID
+			}
+			prefixes = append(prefixes, ipc.metadata.remove(upd.Prefix, resource, upd.Metadata...)...)
 		}
 	}
 	ipc.metadata.Unlock()

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1466,6 +1466,122 @@ func TestIPCachePodCIDREntries(t *testing.T) {
 	assert.Equal(t, identity.ReservedIdentityWorldIPv4, nid.ID)
 }
 
+// TestIPCacheCIDRResourceConsolidation tests for a leak in the ipcache
+// metadata layer regarding the CIDR resource consolidation.
+func TestIPCacheCIDRResourceConsolidation(t *testing.T) {
+	setupIPCacheTestSuite(t)
+
+	prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/8"))
+	lbls := labels.GetCIDRLabels(prefix.AsPrefix())
+
+	//
+	// Test 1: Regression test of CIDR leak:
+	//
+
+	// CIDR 10.0.0.0/8 is added with resource owner policy-foo. Refcount for
+	// the CIDR is bumped to 1, which means this if statement is true and we
+	// upsert 10.0.0.0/8 with owner policy-foo.
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.UpsertMetadataBatch(MU{
+			Prefix:   prefix,
+			Source:   source.Generated,
+			Resource: types.NewResourceID(types.ResourceKindCNP, "default", "policy-foo"),
+			Metadata: []IPMetadata{lbls},
+			IsCIDR:   true,
+		}),
+	))
+	// CIDR 10.0.0.0/8 is added with resource owner policy-bar. The above if
+	// statement is false, the CIDR is not forwarded to the metadata tracker
+	// (as it should).
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.UpsertMetadataBatch(MU{
+			Prefix:   prefix,
+			Source:   source.Generated,
+			Resource: types.NewResourceID(types.ResourceKindCNP, "default", "policy-bar"),
+			Metadata: []IPMetadata{lbls},
+			IsCIDR:   true,
+		}),
+	))
+	// Policy policy-foo is deleted. This decreases refcount to 1, which means
+	// the deletion would not be forwarded to the metadata tracker (as it
+	// should).
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.RemoveMetadataBatch(MU{
+			Prefix:   prefix,
+			Source:   source.Generated,
+			Resource: types.NewResourceID(types.ResourceKindCNP, "default", "policy-foo"),
+			Metadata: []IPMetadata{lbls},
+			IsCIDR:   true,
+		}),
+	))
+	// Policy policy-bar is deleted. This decreases the refcount to 0. This if
+	// statement is now true, but the deletion event is forwarded with resource
+	// owner policy-bar to the metadata tracker. The metadata tracker never
+	// heard about policy-bar (it still has -foo stored) and therefore ignores
+	// this deletion event. The CIDR is leaked.
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.RemoveMetadataBatch(MU{
+			Prefix:   prefix,
+			Source:   source.Generated,
+			Resource: types.NewResourceID(types.ResourceKindCNP, "default", "policy-bar"),
+			Metadata: []IPMetadata{lbls},
+			IsCIDR:   true,
+		}),
+	))
+	assert.Nil(t, IPIdentityCache.metadata.get(prefix))
+
+	//
+	// Test 2: Mix of CIDRs and FQDN
+	//
+	cidr := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.1/32"))
+	cidrOverlapResource := types.NewResourceID(types.ResourceKindCNP, "default", "policy-fqdn-overlap")
+	fqdnNameManagerResource := types.NewResourceID(types.ResourceKindDaemon, "", "fqdn-name-manager")
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.UpsertMetadataBatch(MU{
+			Prefix:   cidr,
+			Source:   source.Generated,
+			Resource: cidrOverlapResource,
+			Metadata: []IPMetadata{labels.GetCIDRLabels(cidr.AsPrefix())},
+			IsCIDR:   true,
+		}),
+	))
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.UpsertMetadataBatch(MU{
+			Prefix:   cidr,
+			Source:   source.Generated,
+			Resource: fqdnNameManagerResource,
+			Metadata: []IPMetadata{labels.NewLabelsFromSortedList("fqdn:foo.com")},
+			IsCIDR:   false,
+		}),
+	))
+	assert.Len(t, IPIdentityCache.metadata.m[cidr].byResource, 2)
+	// UpsertMetadataBatch() will change the resource by detecting that it is a
+	// CIDR.
+	assert.NotNil(t, IPIdentityCache.metadata.m[cidr].byResource[cidrResourceID])
+	assert.NotNil(t, IPIdentityCache.metadata.m[cidr].byResource[fqdnNameManagerResource])
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.RemoveMetadataBatch(MU{
+			Prefix:   cidr,
+			Source:   source.Generated,
+			Resource: fqdnNameManagerResource,
+			Metadata: []IPMetadata{labels.NewLabelsFromSortedList("fqdn:foo.com")},
+			IsCIDR:   false,
+		}),
+	))
+	assert.Len(t, IPIdentityCache.metadata.m[cidr].byResource, 1)
+	assert.NotNil(t, IPIdentityCache.metadata.m[cidr].byResource[cidrResourceID])
+	assert.NoError(t, IPIdentityCache.WaitForRevision(
+		context.TODO(), IPIdentityCache.RemoveMetadataBatch(MU{
+			Prefix:   cidr,
+			Source:   source.Generated,
+			Resource: cidrOverlapResource,
+			Metadata: []IPMetadata{labels.GetCIDRLabels(cidr.AsPrefix())},
+			IsCIDR:   true,
+		}),
+	))
+	assert.Nil(t, IPIdentityCache.metadata.get(cidr))
+}
+
 func BenchmarkManyResources(b *testing.B) {
 	logger := hivetest.Logger(b)
 	m := newMetadata(logger)


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/43074.