### PR TITLE
clustermesh: fix unlikely race condition in status propagation

### DIFF
--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -419,7 +419,7 @@ func (rc *remoteCluster) status() *models.RemoteCluster {
 		Ready:       rc.isReadyLocked(),
 		Connected:   rc.backend != nil,
 		Status:      backendStatus,
-		Config:      rc.config,
+		Config:      rc.config.DeepCopy(),
 		NumFailures: int64(rc.failures),
 		LastFailure: strfmt.DateTime(rc.lastFailure),
 	}


### PR DESCRIPTION
The [status] function populates the initial content of the [RemoteCluster] model. However, it is currently affected by a possible race condition, because it propagates a pointer to [RemoteClusterConfig], and the struct it points to can then be potentially modified in parallel with a consumer subsequently accessing it. Let's get this fixed by returning a deep-copy of the object, to ensure that it does never get mutated.

Fixes: e206c4704112 ("clustermesh: propagate cluster config in remote cluster status")

Labeling as `release-note/misc`, as I'm not aware of any possible consequence, besides it being possibly flagged by the race detector (which doesn't even seem to happen with the current integration tests form). 