### PR TITLE
ipam: unexport allocator fields of `IPAM`

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -308,12 +308,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	// Trigger refresh and update custom resource in the apiserver with all restored endpoints.
 	// Trigger after nodeDiscovery.StartDiscovery to avoid custom resource update conflict.
-	if params.DaemonConfig.EnableIPv6 {
-		params.IPAM.IPv6Allocator.RestoreFinished()
-	}
-	if params.DaemonConfig.EnableIPv4 {
-		params.IPAM.IPv4Allocator.RestoreFinished()
-	}
+	params.IPAM.RestoreFinished()
 
 	// This needs to be done after the node addressing has been configured
 	// as the node address is required as suffix.

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -112,7 +112,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	// Allocate the first 3 IPs
 	for i := 1; i <= 3; i++ {
 		epipv4 := netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))
-		_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault())
+		_, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault())
 		require.NoError(t, err)
 	}
 
@@ -120,7 +120,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
 	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
 	epipv4 := netip.MustParseAddr("1.1.1.4")
-	_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault())
+	_, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault())
 	require.Error(t, err)
 	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
 	sharedNodeStore.updateLocalNodeResource(cn)
@@ -134,8 +134,10 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 
 type ipMasqMapDummy struct{}
 
-func (m ipMasqMapDummy) Update(netip.Prefix) error     { return nil }
-func (m ipMasqMapDummy) Delete(netip.Prefix) error     { return nil }
+func (m ipMasqMapDummy) Update(netip.Prefix) error { return nil }
+
+func (m ipMasqMapDummy) Delete(netip.Prefix) error { return nil }
+
 func (m ipMasqMapDummy) Dump() ([]netip.Prefix, error) { return []netip.Prefix{}, nil }
 
 func TestIPMasq(t *testing.T) {
@@ -176,7 +178,7 @@ func TestIPMasq(t *testing.T) {
 	ipam.ConfigureAllocator()
 
 	epipv4 := netip.MustParseAddr("10.1.1.226")
-	result, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test1", PoolDefault())
+	result, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), "test1", PoolDefault())
 	require.NoError(t, err)
 	// The resulting CIDRs should contain the VPC CIDRs and the default ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
 	require.ElementsMatch(
@@ -239,7 +241,7 @@ func TestAzureIPMasq(t *testing.T) {
 	ipam.ConfigureAllocator()
 
 	epipv4 := netip.MustParseAddr("10.10.1.5")
-	result, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test1", PoolDefault())
+	result, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), "test1", PoolDefault())
 	require.NoError(t, err)
 	// The resulting CIDRs should contain the Azure interface CIDR and the default ip-masq-agent CIDRs
 	require.ElementsMatch(

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -102,38 +102,38 @@ func (ipam *IPAM) ConfigureAllocator() {
 		)
 
 		if ipam.config.IPv6Enabled() {
-			ipam.IPv6Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet)
+			ipam.ipv6Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet)
 		}
 
 		if ipam.config.IPv4Enabled() {
-			ipam.IPv4Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet)
+			ipam.ipv4Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet)
 		}
 	case ipamOption.IPAMMultiPool:
 		ipam.logger.Info("Initializing MultiPool IPAM")
 		manager := newMultiPoolManager(ipam.logger, ipam.config, ipam.nodeResource, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset.CiliumV2().CiliumNodes())
 
 		if ipam.config.IPv6Enabled() {
-			ipam.IPv6Allocator = manager.Allocator(IPv6)
+			ipam.ipv6Allocator = manager.Allocator(IPv6)
 		}
 		if ipam.config.IPv4Enabled() {
-			ipam.IPv4Allocator = manager.Allocator(IPv4)
+			ipam.ipv4Allocator = manager.Allocator(IPv4)
 		}
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		ipam.logger.Info("Initializing CRD-based IPAM")
 		if ipam.config.IPv6Enabled() {
-			ipam.IPv6Allocator = newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
+			ipam.ipv6Allocator = newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
 		}
 
 		if ipam.config.IPv4Enabled() {
-			ipam.IPv4Allocator = newCRDAllocator(ipam.logger, IPv4, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
+			ipam.ipv4Allocator = newCRDAllocator(ipam.logger, IPv4, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
 		}
 	case ipamOption.IPAMDelegatedPlugin:
 		ipam.logger.Info("Initializing no-op IPAM since we're using a CNI delegated plugin")
 		if ipam.config.IPv6Enabled() {
-			ipam.IPv6Allocator = &noOpAllocator{}
+			ipam.ipv6Allocator = &noOpAllocator{}
 		}
 		if ipam.config.IPv4Enabled() {
-			ipam.IPv4Allocator = &noOpAllocator{}
+			ipam.ipv4Allocator = &noOpAllocator{}
 		}
 	default:
 		logging.Fatal(ipam.logger, fmt.Sprintf("Unknown IPAM backend %s", ipam.config.IPAMMode()))

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -134,11 +134,11 @@ func TestLock(t *testing.T) {
 	ipv6 = ipv6.Next()
 
 	// Forcefully release possible allocated IPs
-	ipam.IPv4Allocator.Release(ipv4.AsSlice(), PoolDefault())
-	ipam.IPv6Allocator.Release(ipv6.AsSlice(), PoolDefault())
+	ipam.ipv4Allocator.Release(ipv4.AsSlice(), PoolDefault())
+	ipam.ipv6Allocator.Release(ipv6.AsSlice(), PoolDefault())
 
 	// Let's allocate the IP first so we can see the tests failing
-	result, err := ipam.IPv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault())
+	result, err := ipam.ipv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault())
 	require.NoError(t, err)
 	require.Equal(t, net.IP(ipv4.AsSlice()), result.IP)
 }
@@ -196,12 +196,12 @@ func TestIPAMMetadata(t *testing.T) {
 
 	ipam := NewIPAM(hivetest.Logger(t), fakeAddressing, testConfiguration, &ownerMock{}, localNodeStore, &ownerMock{}, &resourceMock{}, &mtuMock, nil, fakeMetadata, nil, nil)
 	ipam.ConfigureAllocator()
-	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
+	ipam.ipv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
 		"test":    "192.168.178.0/24",
 		"special": "172.18.19.0/24",
 	})
-	ipam.IPv6Allocator = newFakePoolAllocator(map[string]string{
+	ipam.ipv6Allocator = newFakePoolAllocator(map[string]string{
 		"default": "fd00:100::/80",
 		"test":    "fc00:100::/96",
 		"special": "fe00:100::/80",

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -95,8 +95,8 @@ type IPAM struct {
 	nodeAddressing types.NodeAddressing
 	config         *option.DaemonConfig
 
-	IPv6Allocator Allocator
-	IPv4Allocator Allocator
+	ipv6Allocator Allocator
+	ipv4Allocator Allocator
 
 	// metadata provides information about a particular IP owner.
 	metadata Metadata
@@ -144,6 +144,16 @@ func (ipam *IPAM) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteCon
 }
 
 func (ipam *IPAM) EndpointRestored(ep *endpoint.Endpoint) {}
+
+// RestoreFinished marks the status of restoration as done
+func (ipam *IPAM) RestoreFinished() {
+	if ipam.config.EnableIPv6 {
+		ipam.ipv6Allocator.RestoreFinished()
+	}
+	if ipam.config.EnableIPv4 {
+		ipam.ipv4Allocator.RestoreFinished()
+	}
+}
 
 // DebugStatus implements debug.StatusObject to provide debug status collection
 // ability


### PR DESCRIPTION
Currently, the legacy daemon initialization logic explicitly notifies IPv4 and IPv6 IPAm allocators that restoration has been finished.

This is unnecessary and leaks logic and the allocators (exported) outside of `IPAM`.

Therefore, this commit introduces the method `IPAM.RestoreFinished` that handles this logic internally. This removes the need to pass whether IPv4/v6 is enabled and the need to have the allocators exported.