### PR TITLE
proxy: ensure local routing rule in proxy cell

### DIFF
--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -15,7 +15,6 @@ type bootstrapStatistics struct {
 	k8sInit   spanstat.SpanStat
 	restore   spanstat.SpanStat
 	cleanup   spanstat.SpanStat
-	bpfBase   spanstat.SpanStat
 	ipam      spanstat.SpanStat
 	fqdn      spanstat.SpanStat
 	kvstore   spanstat.SpanStat
@@ -43,7 +42,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"k8sInit":   &b.k8sInit,
 		"restore":   &b.restore,
 		"cleanup":   &b.cleanup,
-		"bpfBase":   &b.bpfBase,
 		"ipam":      &b.ipam,
 		"fqdn":      &b.fqdn,
 		"kvstore":   &b.kvstore,


### PR DESCRIPTION
Currently, the legacy daemon initialization logic is responsible to ensure that the node's local routing rule is updated (lower priority) to make space for proxy related routing rules.

This commit moves this logic into the proxy hive cell where it's executed as a hive lifecycle start hook.

It's still ensured that this modification is performed before the actual L7/proxy related routing rules are installed with `ReinstallRoutingRules`. (It's called by the loader that gets the dependency to the `Proxy` via parameter from the orchestrator. And the orchestrator depends on the `Proxy` which ensures that the ordering is correct (called from a hive job that awaits the lifecycle start hooks of all dependencies)).