### PR TITLE
Refactor KVStoreMesh implementation to favor extensibility

### DIFF
--- a/pkg/clustermesh/kvstoremesh/cell.go
+++ b/pkg/clustermesh/kvstoremesh/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
+	"github.com/cilium/cilium/pkg/clustermesh/kvstoremesh/reflector"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
@@ -26,4 +27,6 @@ var Cell = cell.Module(
 	// instead of the more redundant cilium_kvstoremesh_clustermesh_
 	metrics.Metric(common.MetricsProvider("")),
 	metrics.Metric(MetricsProvider),
+
+	reflector.Cell,
 )

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -351,8 +351,8 @@ func TestRemoteClusterRemove(t *testing.T) {
 				return &localClientWrapper{
 					Client: local,
 					errors: map[string]uint{
-						"cilium/cache/identities/v1/foobar/id/": 1,
-						"cilium/cluster-config/baz":             10,
+						"cilium/cache/nodes/v1/foobar/": 1,
+						"cilium/cluster-config/baz":     10,
 					},
 				}
 			}),
@@ -370,10 +370,10 @@ func TestRemoteClusterRemove(t *testing.T) {
 				fmt.Sprintf("cilium/synced/%s/cilium/cache/services/v1", name),
 				fmt.Sprintf("cilium/synced/%s/cilium/cache/identities/v1", name),
 				fmt.Sprintf("cilium/synced/%s/cilium/cache/ip/v1", name),
-				fmt.Sprintf("cilium/cache/nodes/v1/%s/bar", name),
-				fmt.Sprintf("cilium/cache/services/v1/%s/bar", name),
 				fmt.Sprintf("cilium/cache/identities/v1/%s/id/bar", name),
 				fmt.Sprintf("cilium/cache/ip/v1/%s/bar", name),
+				fmt.Sprintf("cilium/cache/nodes/v1/%s/bar", name),
+				fmt.Sprintf("cilium/cache/services/v1/%s/bar", name),
 			}
 		}
 

--- a/pkg/clustermesh/kvstoremesh/reflector/cell.go
+++ b/pkg/clustermesh/kvstoremesh/reflector/cell.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector
+
+import (
+	"path"
+
+	"github.com/cilium/hive/cell"
+
+	mcsapi "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	service "github.com/cilium/cilium/pkg/clustermesh/store"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/kvstore"
+	node "github.com/cilium/cilium/pkg/node/store"
+)
+
+var Cell = cell.Group(
+	cell.Provide(
+		Out(NewFactory(Endpoints, ipcache.IPIdentitiesPath,
+			WithStatePrefixOverride(path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace)),
+		)),
+
+		Out(NewFactory(Identities, cache.IdentitiesPath,
+			WithStatePrefixOverride(path.Join(cache.IdentitiesPath, "id")),
+			WithCachePrefixOverride(path.Join(kvstore.StateToCachePrefix(cache.IdentitiesPath), ClusterNamePlaceHolder, "id")),
+		)),
+
+		Out(NewFactory(Nodes, node.NodeStorePrefix)),
+
+		Out(NewFactory(Services, service.ServiceStorePrefix,
+			WithRevocation(),
+		)),
+
+		Out(NewFactory(ServiceExports, mcsapi.ServiceExportStorePrefix,
+			WithRevocation(),
+			WithEnabledOverride(func(cfg types.CiliumClusterConfig) bool {
+				return cfg.Capabilities.ServiceExportsEnabled != nil
+			}),
+		)),
+	),
+)
+
+type out struct {
+	cell.Out
+
+	Factory Factory `group:"kvstoremesh-reflectors"`
+}
+
+func Out(factory Factory) func() out {
+	return func() out { return out{Factory: factory} }
+}

--- a/pkg/clustermesh/kvstoremesh/reflector/reflector.go
+++ b/pkg/clustermesh/kvstoremesh/reflector/reflector.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"sync/atomic"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// Name represents the name of a reflector.
+type Name string
+
+const (
+	Endpoints      Name = "endpoints"
+	Identities     Name = "identities"
+	Nodes          Name = "nodes"
+	Services       Name = "services"
+	ServiceExports Name = "service exports"
+)
+
+// Reflector knows how to watch a prefix from a given etcd instance, and
+// propagate all changes into a different instance.
+type Reflector interface {
+	// Name returns the name of the reflector.
+	Name() Name
+
+	// Status returns the status of the reflector.
+	Status() Status
+
+	// Run starts the synchronization process. It blocks until the context is canceled.
+	Run(ctx context.Context)
+
+	// Register registers the reflector with the given [store.WatchStoreManager], to
+	// watch the desired prefix. If reflection is not enabled (e.g., as not supported
+	// according to the remote cluster capabilities), it drains possibly stale data.
+	Register(mgr store.WatchStoreManager, remote kvstore.BackendOperations, cfg types.CiliumClusterConfig)
+
+	// DeleteCache deletes all previously cached data from the local kvstore, possibly
+	// at once. It shall be invoked only once the synchronization process has already been
+	// aborted, and under the assumption that all Cilium agents have already stopped watching
+	// the prefix.
+	DeleteCache(ctx context.Context) error
+
+	// RevokeCache revokes all previously cached data, if revocation is enabled.
+	// It shall be invoked when synchronization is still in progress, and it is expected
+	// that Cilium agents may be potentially watching the prefix.
+	RevokeCache(ctx context.Context)
+}
+
+// Status summarizes the status of a reflector.
+type Status struct {
+	// Enabled represents whether the reflector is currently enabled.
+	Enabled bool
+
+	// Synced represents whether the reflector retrieved the initial list of entries from etcd.
+	Synced bool
+
+	// Entries is the number of entries synchronized by the given reflector.
+	Entries uint64
+}
+
+type opt func(*reflector)
+
+// ClusterNamePlaceHolder is the placeholder for the cluster name in prefix overrides.
+const ClusterNamePlaceHolder = "<cluster-name>"
+
+// WithStatePrefixOverride allows to override the state prefix, for non-standard paths.
+// [ClusterNamePlaceHolder] gets automatically replaced with the actual cluster name.
+func WithStatePrefixOverride(prefix string) opt {
+	return func(r *reflector) {
+		r.statePrefix = strings.ReplaceAll(prefix, ClusterNamePlaceHolder, r.cluster)
+	}
+}
+
+// WithCachePrefixOverride allows to override the cache prefix, for non-standard paths.
+// [ClusterNamePlaceHolder] gets automatically replaced with the actual cluster name.
+func WithCachePrefixOverride(prefix string) opt {
+	return func(r *reflector) {
+		r.cachePrefix = strings.ReplaceAll(prefix, ClusterNamePlaceHolder, r.cluster)
+	}
+}
+
+// WithEnabledOverride configures a function that determines whether reflection
+// of a resource should be enabled, depending on the remote cluster configuration.
+// Reflection is enabled by default if not configured otherwise.
+func WithEnabledOverride(enabled func(types.CiliumClusterConfig) bool) opt {
+	return func(r *reflector) {
+		r.shouldRegister = enabled
+	}
+}
+
+// WithRevocation enables the revocation of all previously cached data, in
+// case connectivity to the source cluster is lost.
+func WithRevocation() opt {
+	return func(r *reflector) {
+		r.shouldRevoke = true
+	}
+}
+
+// Factory is the signature of the reflector factory.
+type Factory func(local kvstore.Client, sf store.Factory, cluster string, onSync func()) Reflector
+
+// NewFactory returns a new factory for the given reflector.
+func NewFactory(name Name, prefix string, opts ...opt) Factory {
+	return func(local kvstore.Client, sf store.Factory, cluster string, onSync func()) Reflector {
+		var rfl = reflector{
+			name:    name,
+			cluster: cluster,
+
+			basePrefix:  prefix,
+			statePrefix: path.Join(prefix, cluster),
+			cachePrefix: path.Join(kvstore.StateToCachePrefix(prefix), cluster),
+
+			shouldRegister: func(types.CiliumClusterConfig) bool { return true },
+			shouldRevoke:   false,
+
+			local: local,
+		}
+
+		for _, opt := range opts {
+			opt(&rfl)
+		}
+
+		rfl.syncer = syncer{
+			SyncStore: sf.NewSyncStore(
+				cluster, local, rfl.cachePrefix,
+				store.WSSWithSyncedKeyOverride(kvstore.StateToCachePrefix(rfl.basePrefix)),
+			),
+			syncedDone: onSync,
+		}
+
+		rfl.watcher = sf.NewWatchStore(
+			cluster, store.KVPairCreator, &rfl.syncer,
+			store.RWSWithOnSyncCallback(rfl.syncer.OnSync),
+		)
+
+		return &rfl
+	}
+}
+
+type reflector struct {
+	name    Name
+	cluster string
+
+	statePrefix string
+	cachePrefix string
+	basePrefix  string
+
+	shouldRegister func(types.CiliumClusterConfig) bool
+	shouldRevoke   bool
+
+	local   kvstore.Client
+	watcher store.WatchStore
+	syncer  syncer
+
+	enabled atomic.Bool
+}
+
+func (rfl *reflector) Name() Name {
+	return rfl.name
+}
+
+func (rfl *reflector) Run(ctx context.Context) {
+	rfl.syncer.Run(ctx)
+}
+
+func (rfl *reflector) Register(mgr store.WatchStoreManager, backend kvstore.BackendOperations, cfg types.CiliumClusterConfig) {
+	if rfl.shouldRegister(cfg) {
+		var syncPrefix, watchPrefix = rfl.basePrefix, rfl.statePrefix
+		if cfg.Capabilities.Cached {
+			syncPrefix, watchPrefix = kvstore.StateToCachePrefix(syncPrefix), rfl.cachePrefix
+		}
+
+		rfl.enabled.Store(true)
+		mgr.Register(syncPrefix, func(ctx context.Context) {
+			rfl.watcher.Watch(ctx, backend, watchPrefix)
+		})
+	} else {
+		rfl.enabled.Store(false)
+
+		// Let's drain the watcher in case the given reflector is not enabled,
+		// to remove possibly state data if previously enabled.
+		rfl.watcher.Drain()
+		// Additionally, pretend that synchronization completed, to ensure that
+		// the synced key is written, and eventually invoke the onSync callback.
+		rfl.syncer.OnSync(context.Background())
+	}
+}
+
+func (rfl *reflector) DeleteCache(ctx context.Context) error {
+	if err := rfl.local.DeletePrefix(ctx, rfl.cachePrefix+"/"); err != nil {
+		return fmt.Errorf("deleting prefix %q: %w", rfl.cachePrefix+"/", err)
+	}
+
+	return nil
+}
+
+func (rfl *reflector) RevokeCache(context.Context) {
+	if rfl.shouldRevoke {
+		rfl.watcher.Drain()
+	}
+}
+
+func (rfl *reflector) Status() Status {
+	return Status{
+		Enabled: rfl.enabled.Load(),
+		Synced:  rfl.watcher.Synced(),
+		Entries: rfl.watcher.NumEntries(),
+	}
+}
+
+type syncer struct {
+	store.SyncStore
+	syncedDone lock.DoneFunc
+}
+
+func (o *syncer) OnUpdate(key store.Key) {
+	o.UpsertKey(context.Background(), key)
+}
+
+func (o *syncer) OnDelete(key store.NamedKey) {
+	o.DeleteKey(context.Background(), key)
+}
+
+func (o *syncer) OnSync(ctx context.Context) {
+	o.Synced(ctx, func(context.Context) { o.syncedDone() })
+}

--- a/pkg/clustermesh/kvstoremesh/reflector/reflector_test.go
+++ b/pkg/clustermesh/kvstoremesh/reflector/reflector_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reflector_test
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/kvstoremesh/reflector"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+type (
+	Config       = types.CiliumClusterConfig
+	Capabilities = types.CiliumClusterConfigCapabilities
+)
+
+const (
+	tick    = 10 * time.Millisecond
+	timeout = 3 * time.Second
+
+	name    = reflector.Name("burro")
+	cluster = "ape"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}
+
+func TestReflector(t *testing.T) {
+	tests := []struct {
+		name    string
+		factory reflector.Factory
+		cfg     Config
+		revoke  bool
+
+		keys     []string
+		synced   string
+		expected []string
+	}{
+		{
+			name:    "vanilla",
+			factory: reflector.NewFactory(name, "cilium/state/foo/bar"),
+			cfg:     Config{Capabilities: Capabilities{SyncedCanaries: true}},
+
+			keys: []string{
+				"cilium/synced/ape/cilium/state/foo/bar",
+				"cilium/state/foo/bar/ape/impala",
+				"cilium/state/foo/bar/ape/lacewing",
+				"cilium/state/foo/bar/walrus/lacewing",
+			},
+			synced: "cilium/synced/ape/cilium/cache/foo/bar",
+			expected: []string{
+				"cilium/cache/foo/bar/ape/impala",
+				"cilium/cache/foo/bar/ape/lacewing",
+			},
+		},
+		{
+			name:    "cached",
+			factory: reflector.NewFactory(name, "cilium/state/foo/bar"),
+			cfg:     Config{Capabilities: Capabilities{SyncedCanaries: true, Cached: true}},
+
+			keys: []string{
+				"cilium/synced/ape/cilium/cache/foo/bar",
+				"cilium/cache/foo/bar/ape/impala",
+				"cilium/cache/foo/bar/ape/lacewing",
+				"cilium/cache/foo/bar/walrus/lacewing",
+			},
+			synced: "cilium/synced/ape/cilium/cache/foo/bar",
+			expected: []string{
+				"cilium/cache/foo/bar/ape/impala",
+				"cilium/cache/foo/bar/ape/lacewing",
+			},
+		},
+		{
+			name: "with prefix overrides",
+			factory: reflector.NewFactory(name, "cilium/state/foo/bar",
+				reflector.WithStatePrefixOverride("cilium/state/foo/"+reflector.ClusterNamePlaceHolder+"/bar"),
+				reflector.WithCachePrefixOverride("cilium/cache/foo/"+reflector.ClusterNamePlaceHolder+"/baz"),
+			),
+			cfg: Config{Capabilities: Capabilities{SyncedCanaries: true}},
+
+			keys: []string{
+				"cilium/synced/ape/cilium/state/foo/bar",
+				"cilium/state/foo/ape/bar/impala",
+				"cilium/state/foo/ape/bar/lacewing",
+				"cilium/state/foo/walrus/baz/lacewing",
+			},
+			synced: "cilium/synced/ape/cilium/cache/foo/bar",
+			expected: []string{
+				"cilium/cache/foo/ape/baz/impala",
+				"cilium/cache/foo/ape/baz/lacewing",
+			},
+		},
+		{
+			name:    "with revocation",
+			factory: reflector.NewFactory(name, "cilium/state/foo/bar", reflector.WithRevocation()),
+			cfg:     Config{Capabilities: Capabilities{SyncedCanaries: true}},
+			revoke:  true,
+
+			keys: []string{
+				"cilium/synced/ape/cilium/state/foo/bar",
+				"cilium/state/foo/bar/ape/impala",
+				"cilium/state/foo/bar/ape/lacewing",
+				"cilium/state/foo/bar/walrus/lacewing",
+			},
+			synced: "cilium/synced/ape/cilium/cache/foo/bar",
+			expected: []string{
+				"cilium/cache/foo/bar/ape/impala",
+				"cilium/cache/foo/bar/ape/lacewing",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				synced atomic.Bool
+
+				db     = statedb.New()
+				local  = kvstore.NewInMemoryClient(db, "__local__")
+				remote = kvstore.NewInMemoryClient(db, "__remote__")
+				sf     = store.NewFactory(hivetest.Logger(t), store.MetricsProvider())
+				mgr    = sf.NewWatchStoreManager(remote, cluster)
+			)
+
+			rfl := tt.factory(local, sf, cluster, func() { synced.Store(true) })
+
+			require.Equal(t, name, rfl.Name())
+			require.Equal(t, reflector.Status{}, rfl.Status())
+
+			// Start the reflector.
+			var rwg sync.WaitGroup
+			rctx, rcancel := context.WithCancel(t.Context())
+			defer func() { rcancel(); rwg.Wait() }()
+			rwg.Go(func() { rfl.Run(rctx) })
+
+			// Populate the content of the remote instance.
+			for _, key := range tt.keys {
+				require.NoError(t, remote.Update(t.Context(), key, []byte("value"), false), "remote.Update")
+			}
+
+			rfl.Register(mgr, remote, tt.cfg)
+			require.Equal(t, reflector.Status{Enabled: true}, rfl.Status())
+
+			// Start the WatchStoreManager
+			var mwg sync.WaitGroup
+			mctx, mcancel := context.WithCancel(t.Context())
+			defer func() { mcancel(); mwg.Wait() }()
+			mwg.Go(func() { mgr.Run(mctx) })
+
+			// Wait for initial synchronization to complete.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.True(c, synced.Load())
+			}, timeout, tick)
+
+			// The expected keys should have been reflected.
+			var all = append([]string{tt.synced}, tt.expected...)
+			kvs, err := local.ListPrefix(t.Context(), "")
+			require.NoError(t, err, "local.ListPrefix")
+			require.ElementsMatch(t, all, slices.Collect(maps.Keys(kvs)))
+
+			require.Equal(t, reflector.Status{
+				Enabled: true,
+				Synced:  true,
+				Entries: uint64(len(tt.expected)),
+			}, rfl.Status())
+
+			// Stop the manager.
+			mcancel()
+			mwg.Wait()
+
+			rfl.RevokeCache(t.Context())
+
+			if tt.revoke {
+				// All keys should be eventually removed, except the synced prefix.
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					kvs, err := local.ListPrefix(t.Context(), "")
+					assert.NoError(c, err, "local.ListPrefix")
+					assert.ElementsMatch(c, []string{tt.synced}, slices.Collect(maps.Keys(kvs)))
+				}, timeout, tick)
+
+				require.Equal(t, reflector.Status{Enabled: true}, rfl.Status())
+			} else {
+				// No key should have been removed.
+				time.Sleep(tick)
+
+				kvs, err := local.ListPrefix(t.Context(), "")
+				require.NoError(t, err, "local.ListPrefix")
+				require.ElementsMatch(t, all, slices.Collect(maps.Keys(kvs)))
+
+				require.Equal(t, reflector.Status{
+					Enabled: true,
+					Entries: uint64(len(tt.expected)),
+				}, rfl.Status())
+			}
+
+			// Stop the reflector.
+			rcancel()
+			rwg.Wait()
+
+			require.NoError(t, rfl.DeleteCache(t.Context()), "rfl.DeleteCache")
+
+			// All keys should be removed, except the synced prefix.
+			kvs, err = local.ListPrefix(t.Context(), "")
+			assert.NoError(t, err, "local.ListPrefix")
+			assert.ElementsMatch(t, []string{tt.synced}, slices.Collect(maps.Keys(kvs)))
+		})
+	}
+}
+
+func TestReflectorEnabled(t *testing.T) {
+	var (
+		synced atomic.Bool
+
+		db     = statedb.New()
+		log    = hivetest.Logger(t)
+		local  = kvstore.NewInMemoryClient(db, "__local__")
+		remote = kvstore.NewInMemoryClient(db, "__remote__")
+		sf     = store.NewFactory(log, store.MetricsProvider())
+	)
+
+	rfl := reflector.NewFactory(name, "cilium/state/foo",
+		reflector.WithEnabledOverride(func(cfg Config) bool {
+			return cfg.Capabilities.MaxConnectedClusters == 22
+		}),
+	)(local, sf, cluster, func() { synced.Store(true) })
+
+	// Start the reflector.
+	var rwg sync.WaitGroup
+	rctx, rcancel := context.WithCancel(t.Context())
+	defer func() { rcancel(); rwg.Wait() }()
+	rwg.Go(func() { rfl.Run(rctx) })
+
+	// Populate the content of the remote instance.
+	for _, key := range []string{"cilium/state/foo/ape/bar", "cilium/state/foo/ape/baz"} {
+		require.NoError(t, remote.Update(t.Context(), key, []byte("value"), false), "remote.Update")
+	}
+
+	tests := []struct {
+		capabilities Capabilities
+		expected     int
+	}{
+		{capabilities: Capabilities{MaxConnectedClusters: 11}, expected: 0},
+		{capabilities: Capabilities{MaxConnectedClusters: 22}, expected: 2},
+		{capabilities: Capabilities{MaxConnectedClusters: 11}, expected: 0},
+	}
+
+	for _, tt := range tests {
+		func() {
+			var (
+				mwg sync.WaitGroup
+				mgr = store.NewWatchStoreManagerImmediate(log)
+			)
+
+			mctx, mcancel := context.WithCancel(t.Context())
+			defer func() { mcancel(); mwg.Wait() }()
+
+			rfl.Register(mgr, remote, Config{Capabilities: tt.capabilities})
+			require.Equal(t, tt.expected != 0, rfl.Status().Enabled)
+
+			mwg.Go(func() { mgr.Run(mctx) })
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				// The onSync callback should have been invoked regardless.
+				assert.True(c, synced.Load())
+
+				// The synced canary should have been created regardless.
+				kvs, err := local.ListPrefix(t.Context(), "cilium/synced")
+				assert.NoError(c, err, "local.ListPrefix")
+				assert.Len(c, kvs, 1)
+
+				// The actual keys should be synchronized only when enabled.
+				kvs, err = local.ListPrefix(t.Context(), "cilium/cache")
+				assert.NoError(c, err, "local.ListPrefix")
+				assert.Len(c, kvs, tt.expected)
+
+				assert.Equal(c, reflector.Status{
+					Enabled: tt.expected != 0,
+					Synced:  tt.expected != 0,
+					Entries: uint64(tt.expected),
+				}, rfl.Status())
+			}, timeout, tick)
+		}()
+	}
+}

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -73,15 +73,9 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		close(rc.synced.connected)
 	}
 
-	dstcfg := types.CiliumClusterConfig{
-		ID: srccfg.ID,
-		Capabilities: types.CiliumClusterConfigCapabilities{
-			SyncedCanaries:        true,
-			Cached:                true,
-			MaxConnectedClusters:  srccfg.Capabilities.MaxConnectedClusters,
-			ServiceExportsEnabled: srccfg.Capabilities.ServiceExportsEnabled,
-		},
-	}
+	var dstcfg = srccfg
+	dstcfg.Capabilities.SyncedCanaries = true
+	dstcfg.Capabilities.Cached = true
 
 	stopAndWait, err := clustercfg.Enforce(ctx, rc.name, dstcfg, rc.localBackend, rc.logger)
 	defer stopAndWait()


### PR DESCRIPTION
Currently, KVStoreMesh already relies on the concept of reflector when referring to the logic that is responsible for synchronizing a given prefix from a remote cluster into the local cache. However, while all reflectors are supposed to operate similarly, it still treats them mostly as pets, as each is associated with some small differences. 

This approach has the downside of making the introduction of new reflectors more difficult, and possibly error prone, in case one forgets to account for the new prefix in certain pieces of the logic. 

This commit refactors the general approach extracting and formalizing the concept of Reflector, and letting the common remote cluster logic operate on a generic set of Reflectors only. Each reflector is self contained, and knows how to handle the specific prefix, with all possible associated caveats (e.g., whether it needs to be only enabled in certain cases, it has special suffixes, and so on). 

The set of reflector factories is now also provided via hive, to simplify introducing the reflection of new prefixes, both in-tree and by downstream projects. 

The status collection logic still partially treats the reflectors as pet, due to the fixed API structure. This limitation is intended to be lifted in a future patch, possibly migrating to a script-command based approach, to not further increase the scope of this one. 

The TestRemoteClusterRemove test is slightly amended to account for the different prefix ordering during the drain process (they are now sorted lexicographically); no functional changes are present otherwise.