### PR TITLE
policy: introduce lazy ordered/sorted selections

### DIFF
--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -241,3 +241,17 @@ func (s Set[T]) Clone() Set[T] {
 	}
 	return s // singular value or empty Set
 }
+
+func (s Set[T]) All() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		if s.single != nil {
+			yield(*s.single)
+			return
+		}
+		for kv := range s.members {
+			if !yield(kv) {
+				break
+			}
+		}
+	}
+}

--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -241,17 +241,3 @@ func (s Set[T]) Clone() Set[T] {
 	}
 	return s // singular value or empty Set
 }
-
-func (s Set[T]) All() iter.Seq[T] {
-	return func(yield func(T) bool) {
-		if s.single != nil {
-			yield(*s.single)
-			return
-		}
-		for kv := range s.members {
-			if !yield(kv) {
-				break
-			}
-		}
-	}
-}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1300,11 +1300,11 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, select
 		selections := sel.GetSelectionsAt(selectors)
 
 		// No remote policies would match this rule. Discard it.
-		if len(selections) == 0 {
+		if selections.GetSelections().Len() == 0 {
 			return nil, true
 		}
 
-		r.RemotePolicies = selections.AsUint32Slice()
+		r.RemotePolicies = selections.GetSortedSelections().AsUint32Slice()
 	}
 
 	if l7Rules == nil {
@@ -1410,13 +1410,13 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 				})
 			}
 			selections := sel.GetSelectionsAt(snapshot)
-			if len(selections) == 0 {
+			if selections.Len() == 0 {
 				// No remote policies would match this rule. Discard it.
 				return nil
 			}
 			return append(rules, &cilium.PortNetworkPolicyRule{
 				Deny:           l7.GetDeny(),
-				RemotePolicies: selections.AsUint32Slice(),
+				RemotePolicies: selections.GetSortedSelections().AsUint32Slice(),
 			})
 		}
 	}
@@ -1445,15 +1445,15 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 		}
 
 		selections := sel.GetSelectionsAt(snapshot)
-		if len(selections) == 0 {
+		if selections.Len() == 0 {
 			continue
 		}
 		if l7.GetDeny() {
-			denyCount += len(selections)
-			denySlices = append(denySlices, selections.AsUint32Slice())
+			denyCount += selections.Len()
+			denySlices = append(denySlices, selections.GetSortedSelections().AsUint32Slice())
 		} else {
-			allowCount += len(selections)
-			allowSlices = append(allowSlices, selections.AsUint32Slice())
+			allowCount += selections.Len()
+			allowSlices = append(allowSlices, selections.GetSortedSelections().AsUint32Slice())
 		}
 	}
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1297,14 +1297,14 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, select
 	// Optimize the policy if the endpoint selector is a wildcard by
 	// keeping remote policies list empty to match all remote policies.
 	if !wildcard {
-		selections := sel.GetSelectionsAt(selectors)
+		selections := sel.GetSortedSelectionsAt(selectors)
 
 		// No remote policies would match this rule. Discard it.
-		if selections.GetSelections().Len() == 0 {
+		if len(selections) == 0 {
 			return nil, true
 		}
 
-		r.RemotePolicies = selections.GetSortedSelections().AsUint32Slice()
+		r.RemotePolicies = selections.AsUint32Slice()
 	}
 
 	if l7Rules == nil {
@@ -1409,14 +1409,14 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 					Deny: l7.GetDeny(),
 				})
 			}
-			selections := sel.GetSelectionsAt(snapshot)
-			if selections.Len() == 0 {
+			selections := sel.GetSortedSelectionsAt(snapshot)
+			if len(selections) == 0 {
 				// No remote policies would match this rule. Discard it.
 				return nil
 			}
 			return append(rules, &cilium.PortNetworkPolicyRule{
 				Deny:           l7.GetDeny(),
-				RemotePolicies: selections.GetSortedSelections().AsUint32Slice(),
+				RemotePolicies: selections.AsUint32Slice(),
 			})
 		}
 	}
@@ -1444,16 +1444,16 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 			s.logger.Warn("L3-only rule for selector surprisingly requires proxy redirection!", logfields.Selector, sel)
 		}
 
-		selections := sel.GetSelectionsAt(snapshot)
-		if selections.Len() == 0 {
+		selections := sel.GetSortedSelectionsAt(snapshot)
+		if len(selections) == 0 {
 			continue
 		}
 		if l7.GetDeny() {
-			denyCount += selections.Len()
-			denySlices = append(denySlices, selections.GetSortedSelections().AsUint32Slice())
+			denyCount += len(selections)
+			denySlices = append(denySlices, selections.AsUint32Slice())
 		} else {
-			allowCount += selections.Len()
-			allowSlices = append(allowSlices, selections.GetSortedSelections().AsUint32Slice())
+			allowCount += len(selections)
+			allowSlices = append(allowSlices, selections.AsUint32Slice())
 		}
 	}
 

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/cilium/statedb/part"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -200,12 +200,12 @@ type MockCachedSelector struct {
 	key string
 }
 
-func (m MockCachedSelector) GetSelections() set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity]()
+func (m MockCachedSelector) GetSelections() part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity]()
 }
 
-func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity]()
+func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity]()
 }
 
 func (m MockCachedSelector) GetSortedSelections() identity.NumericIdentitySlice {

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -199,11 +200,19 @@ type MockCachedSelector struct {
 	key string
 }
 
-func (m MockCachedSelector) GetSelections() identity.NumericIdentitySlice {
+func (m MockCachedSelector) GetSelections() set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity]()
+}
+
+func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity]()
+}
+
+func (m MockCachedSelector) GetSortedSelections() identity.NumericIdentitySlice {
 	return nil
 }
 
-func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (m MockCachedSelector) GetSortedSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
 	return nil
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -302,7 +302,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 			}
 			ips := make(map[restore.RuleIPOrCIDR]struct{})
 			count := 0
-			nids := selRegex.cs.GetSelections()
+			nids := selRegex.cs.GetSortedSelections()
 		Loop:
 			for _, nid := range nids {
 				// Note: p.RLock must not be held during this call to IPCache

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/cilium/dns"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb/part"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/container/set"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdndns "github.com/cilium/cilium/pkg/fqdn/dns"
@@ -1422,11 +1422,11 @@ type selectorMock struct {
 	key string
 }
 
-func (t selectorMock) GetSelections() set.Set[identity.NumericIdentity] {
+func (t selectorMock) GetSelections() part.Set[identity.NumericIdentity] {
 	panic("implement me")
 }
 
-func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) part.Set[identity.NumericIdentity] {
 	panic("implement me")
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/set"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdndns "github.com/cilium/cilium/pkg/fqdn/dns"
@@ -1421,11 +1422,19 @@ type selectorMock struct {
 	key string
 }
 
-func (t selectorMock) GetSelections() identity.NumericIdentitySlice {
+func (t selectorMock) GetSelections() set.Set[identity.NumericIdentity] {
 	panic("implement me")
 }
 
-func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	panic("implement me")
+}
+
+func (t selectorMock) GetSortedSelections() identity.NumericIdentitySlice {
+	panic("implement me")
+}
+
+func (t selectorMock) GetSortedSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
 	panic("implement me")
 }
 

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -594,7 +594,7 @@ func (s *FQDNDataServer) buildDNSPolicyFromL4Filter(l4Filter *policy.L4Filter, p
 
 // buildDNSServers creates the list of DNS servers from L4 filter and cache selector
 func (s *FQDNDataServer) buildDNSServers(l4Filter *policy.L4Filter, cacheSelector policy.CachedSelector) []*pb.DNSServer {
-	if cacheSelector == nil || len(cacheSelector.GetSelections()) == 0 {
+	if cacheSelector == nil || cacheSelector.GetSelections().Len() == 0 {
 		// No cache selector - return single server without identity
 		return []*pb.DNSServer{
 			{
@@ -603,7 +603,7 @@ func (s *FQDNDataServer) buildDNSServers(l4Filter *policy.L4Filter, cacheSelecto
 			},
 		}
 	}
-	selections := cacheSelector.GetSelections()
+	selections := cacheSelector.GetSortedSelections()
 	dnsServers := make([]*pb.DNSServer, 0, len(selections))
 
 	for _, selection := range selections {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for id := range idents.All() {
+		for id := range idents.Members() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for id := range idents.Members() {
+		for id := range idents.All() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for _, id := range idents {
+		for id := range idents.GetSelections().All() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for id := range idents.GetSelections().All() {
+		for id := range idents.All() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -202,15 +202,16 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 				if k.String() == bK.String() {
 					require.True(t, v.Equal(bV), "Expected: %s\nActual: %s", perSelectorPolicyToString(v), perSelectorPolicyToString(bV))
 
-					selActual := bK.(*identitySelector).cachedSelections
-					selExpected := set.NewSet[identity.NumericIdentity]()
-					for id := range k.(*identitySelector).cachedSelections.Members() {
+					selActual := slices.Collect(bK.(*identitySelector).cachedSelections.All())
+					var selExpected []identity.NumericIdentity
+					for id := range k.(*identitySelector).cachedSelections.All() {
 						if slices.Contains(availableIDs, id) {
-							selExpected.Insert(id)
+							selExpected = append(selExpected, id)
 						}
 					}
 
-					require.True(t, selExpected.Equal(selActual), "Expected: %v\nActual: %v", selExpected, selActual)
+					slices.Sort(selExpected)
+					require.True(t, slices.Equal(selExpected, selActual), "Expected: %v\nActual: %v", selExpected, selActual)
 					found = true
 				}
 			}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -204,7 +204,7 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 
 					selActual := bK.(*identitySelector).cachedSelections
 					selExpected := set.NewSet[identity.NumericIdentity]()
-					for id := range k.(*identitySelector).cachedSelections.All() {
+					for id := range k.(*identitySelector).cachedSelections.Members() {
 						if slices.Contains(availableIDs, id) {
 							selExpected.Insert(id)
 						}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -203,14 +203,14 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 					require.True(t, v.Equal(bV), "Expected: %s\nActual: %s", perSelectorPolicyToString(v), perSelectorPolicyToString(bV))
 
 					selActual := bK.(*identitySelector).cachedSelections
-					selExpected := make(map[identity.NumericIdentity]struct{})
-					for id := range k.(*identitySelector).cachedSelections {
+					selExpected := set.NewSet[identity.NumericIdentity]()
+					for id := range k.(*identitySelector).cachedSelections.All() {
 						if slices.Contains(availableIDs, id) {
-							selExpected[id] = struct{}{}
+							selExpected.Insert(id)
 						}
 					}
 
-					require.True(t, maps.Equal(selExpected, selActual), "Expected: %v\nActual: %v", selExpected, selActual)
+					require.True(t, selExpected.Equal(selActual), "Expected: %v\nActual: %v", selExpected, selActual)
 					found = true
 				}
 			}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -520,7 +520,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 	oldRules := maps.Clone(p.rulesByResource[resource]) // need to clone as `p.del()` mutates this
 
 	for key, oldRule := range oldRules {
-		for _, subj := range oldRule.getSubjects() {
+		for subj := range oldRule.getSubjects().All() {
 			affectedIDs.Insert(subj)
 		}
 		p.del(key)
@@ -532,7 +532,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 			newRule := p.newRule(*r, ruleKey{resource: resource, idx: uint(i)})
 			p.insert(newRule)
 
-			for _, subj := range newRule.getSubjects() {
+			for subj := range newRule.getSubjects().All() {
 				affectedIDs.Insert(subj)
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -520,7 +520,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 	oldRules := maps.Clone(p.rulesByResource[resource]) // need to clone as `p.del()` mutates this
 
 	for key, oldRule := range oldRules {
-		for subj := range oldRule.getSubjects().Members() {
+		for subj := range oldRule.getSubjects().All() {
 			affectedIDs.Insert(subj)
 		}
 		p.del(key)
@@ -532,7 +532,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 			newRule := p.newRule(*r, ruleKey{resource: resource, idx: uint(i)})
 			p.insert(newRule)
 
-			for subj := range newRule.getSubjects().Members() {
+			for subj := range newRule.getSubjects().All() {
 				affectedIDs.Insert(subj)
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -520,7 +520,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 	oldRules := maps.Clone(p.rulesByResource[resource]) // need to clone as `p.del()` mutates this
 
 	for key, oldRule := range oldRules {
-		for subj := range oldRule.getSubjects().All() {
+		for subj := range oldRule.getSubjects().Members() {
 			affectedIDs.Insert(subj)
 		}
 		p.del(key)
@@ -532,7 +532,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 			newRule := p.newRule(*r, ruleKey{resource: resource, idx: uint(i)})
 			p.insert(newRule)
 
-			for subj := range newRule.getSubjects().All() {
+			for subj := range newRule.getSubjects().Members() {
 				affectedIDs.Insert(subj)
 			}
 		}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -8,8 +8,8 @@ import (
 	"log/slog"
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
+	"github.com/cilium/statedb/part"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -470,9 +470,9 @@ func (r *rule) matchesSubject(securityIdentity *identity.Identity) bool {
 	return r.subjectSelector.Selects(securityIdentity.ID)
 }
 
-func (r *rule) getSubjects() set.Set[identity.NumericIdentity] {
+func (r *rule) getSubjects() part.Set[identity.NumericIdentity] {
 	if r.Node {
-		return set.NewSet(identity.ReservedIdentityHost)
+		return part.NewSet(identity.ReservedIdentityHost)
 	}
 
 	return r.subjectSelector.GetSelections()

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -469,9 +470,9 @@ func (r *rule) matchesSubject(securityIdentity *identity.Identity) bool {
 	return r.subjectSelector.Selects(securityIdentity.ID)
 }
 
-func (r *rule) getSubjects() []identity.NumericIdentity {
+func (r *rule) getSubjects() set.Set[identity.NumericIdentity] {
 	if r.Node {
-		return []identity.NumericIdentity{identity.ReservedIdentityHost}
+		return set.NewSet(identity.ReservedIdentityHost)
 	}
 
 	return r.subjectSelector.GetSelections()

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -303,7 +303,7 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 
 	// iterating selectors requires read lock
 	for key, sel := range sc.selectors.All() {
-		selections := sel.GetSelectionsAt(version).GetSortedSelections()
+		selections := sel.GetSortedSelectionsAt(version)
 		ids := make([]int64, 0, len(selections))
 		for i := range selections {
 			ids = append(ids, int64(selections[i]))

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -124,7 +124,15 @@ func (i *identitySelector) Equal(b *identitySelector) bool {
 // that case GetSortedSelectionsAt() will return either the old or new version
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
-func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) *types.Selections {
+func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	return i.at(selectors).GetSelections()
+}
+
+func (i *identitySelector) GetSortedSelectionsAt(selectors SelectorSnapshot) identity.NumericIdentitySlice {
+	return i.at(selectors).GetSortedSelections()
+}
+
+func (i *identitySelector) at(selectors SelectorSnapshot) *types.Selections {
 	if !selectors.IsValid() || i.id == 0 {
 		msg := "GetSelectionsAt: Invalid selector snapshot finds nothing"
 		if i.id == 0 {
@@ -140,20 +148,11 @@ func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) *types.Se
 	return selectors.Get(i.id)
 }
 
-func (i *identitySelector) GetSortedSelections() identity.NumericIdentitySlice {
-	r := i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
-	if r == nil {
-		return identity.NumericIdentitySlice{}
-	}
-	return r.GetSortedSelections()
-}
-
 func (i *identitySelector) GetSelections() set.Set[identity.NumericIdentity] {
-	r := i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
-	if r == nil {
-		return set.Set[identity.NumericIdentity]{}
-	}
-	return r.GetSelections()
+	return i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
+}
+func (i *identitySelector) GetSortedSelections() identity.NumericIdentitySlice {
+	return i.GetSortedSelectionsAt(i.selectorCache.GetSelectorSnapshot())
 }
 
 func (i *identitySelector) GetMetadataLabels() labels.LabelArray {

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb/part"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -296,12 +296,12 @@ func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []ide
 
 // CachedSelector interface
 
-func (cs *testCachedSelector) GetSelections() set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](cs.selections...)
+func (cs *testCachedSelector) GetSelections() part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](cs.selections...)
 }
 
-func (cs *testCachedSelector) GetSelectionsAt(SelectorSnapshot) set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](cs.selections...)
+func (cs *testCachedSelector) GetSelectionsAt(SelectorSnapshot) part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](cs.selections...)
 }
 
 func (cs *testCachedSelector) GetSortedSelections() identity.NumericIdentitySlice {
@@ -674,7 +674,7 @@ func TestTransactionalUpdate(t *testing.T) {
 	// New version handle sees the removal
 	txn3 := sc.GetSelectorSnapshot()
 
-	require.Equal(t, identity.NumericIdentitySlice(nil), cs32.GetSortedSelectionsAt(txn3))
+	require.Equal(t, identity.NumericIdentitySlice{}, cs32.GetSortedSelectionsAt(txn3))
 	require.Equal(t, identity.NumericIdentitySlice{li3}, cs24.GetSortedSelectionsAt(txn3))
 	require.Equal(t, identity.NumericIdentitySlice{li2, li3}, cs8.GetSortedSelectionsAt(txn3))
 	require.Equal(t, identity.NumericIdentitySlice{li2, li3, li4}, cs7.GetSortedSelectionsAt(txn3))

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -601,7 +601,7 @@ func (s *SelectorSnapshot) String() string {
 type CachedSelector interface {
 	// GetSelections returns the cached set of numeric identities
 	// selected by the CachedSelector for the latest revision of the
-	// selector cache.  The retuned slice must NOT be modified, as it
+	// selector cache.  The retuned set must NOT be modified, as it
 	// is shared among multiple users.
 	GetSelections() set.Set[identity.NumericIdentity]
 
@@ -612,9 +612,14 @@ type CachedSelector interface {
 	GetSortedSelections() identity.NumericIdentitySlice
 
 	// GetSelectionsAt returns the cached set of numeric identities
+	// selected by the CachedSelector.  The retuned set must NOT
+	// be modified, as it is shared among multiple users.
+	GetSelectionsAt(SelectorSnapshot) set.Set[identity.NumericIdentity]
+
+	// GetSortedSelectionsAt returns the cached set of numeric identities
 	// selected by the CachedSelector.  The retuned slice must NOT
 	// be modified, as it is shared among multiple users.
-	GetSelectionsAt(SelectorSnapshot) *Selections
+	GetSortedSelectionsAt(SelectorSnapshot) identity.NumericIdentitySlice
 
 	// GetMetadataLabels returns metadata labels for additional context
 	// surrounding the selector. These are typically the labels associated with

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -18,13 +18,13 @@ import (
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/part"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -592,13 +592,13 @@ func (d *DNSServerIdentity) IsNone() bool {
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelections() set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](d.Identities...)
+func (d *DNSServerIdentity) GetSelections() part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](d.Identities...)
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](d.Identities...)
+func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](d.Identities...)
 }
 
 // Not being used in the standalone dns proxy path

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -591,12 +592,22 @@ func (d *DNSServerIdentity) IsNone() bool {
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelections() identity.NumericIdentitySlice {
+func (d *DNSServerIdentity) GetSelections() set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity](d.Identities...)
+}
+
+// Not being used in the standalone dns proxy path
+func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity](d.Identities...)
+}
+
+// Not being used in the standalone dns proxy path
+func (d *DNSServerIdentity) GetSortedSelections() identity.NumericIdentitySlice {
 	return d.Identities
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (d *DNSServerIdentity) GetSortedSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
 	return d.Identities
 }
 

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -244,7 +244,7 @@ func assertDNSRules(t *testing.T, c *GRPCClient, epID uint32, pp restore.PortPro
 	var gotIDs []uint32
 	var gotPatterns []string
 	for k, v := range row.DNSRule {
-		for id := range k.GetSelections().Members() {
+		for id := range k.GetSelections().All() {
 			gotIDs = append(gotIDs, id.Uint32())
 		}
 		if v != nil {

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -244,7 +244,7 @@ func assertDNSRules(t *testing.T, c *GRPCClient, epID uint32, pp restore.PortPro
 	var gotIDs []uint32
 	var gotPatterns []string
 	for k, v := range row.DNSRule {
-		for _, id := range k.GetSelections() {
+		for id := range k.GetSelections().Members() {
 			gotIDs = append(gotIDs, id.Uint32())
 		}
 		if v != nil {


### PR DESCRIPTION
This introduces a separate sorted structure that can be used by the components that need it. Previously all selections were sorted. This very cosly in the hotpath of the selection updates, as sorting 10k+ slices is pretty expensive. This still creates a copy of the selections, but it does not sort it.

This can in theory result in higher memory usage since we now keep a set (thats in practice a map), and the sorted slice if asked for. In practice not many things need the sorted version, noteably the dnsproxy as well as some l7/xds configs. Its also not totally sure that those always need it either - and in the cases they need it, they also end up keeping it in memory - so the diff is pretty small in practice. Most of the datapath is also using updates, so its not relying on the sorted version all the time.

Its a bit hard to benchmark this directly without cherry-picking results, but a simple test-case where a single selector selects say 20k identities (eg. the 'cluster' entity), that are updated say 5 times/sec - results in a lot of cpu cycles spent on sorting that slice.

Fixes: #issue-number

```release-note
n/a
```
