### PR TITLE
gh/actions: Move BGP e2e tests from lb to misc category to re-enable them

### DIFF
--- a/.github/actions/e2e/lb.yaml
+++ b/.github/actions/e2e/lb.yaml
@@ -24,7 +24,6 @@
   host-fw: 'true'
   lb-acceleration: 'testing-only'
   ingress-controller: 'true'
-  bgp-control-plane: 'true'
   # L7 testing: SNAT load balancer mode + Ingress controller requires L7 proxy for HTTP routing
   test-l7: 'true'
 - name: 'lb-3'

--- a/.github/actions/e2e/misc.yaml
+++ b/.github/actions/e2e/misc.yaml
@@ -21,6 +21,7 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  bgp-control-plane: 'true'
   # L7 testing: Ingress covered in lb.yaml, can skip
   test-l7: 'false'
 - name: 'misc-3'
@@ -33,6 +34,7 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  bgp-control-plane: 'true'
   # L7 testing: Ingress covered in lb.yaml, can skip
   test-l7: 'false'
 - name: 'misc-4'


### PR DESCRIPTION
As of 9750fc3f755fa415dfd298b0f9460304876ecda3 we are not running BGP e2e tests, as they were enabled only as part of the "lb" e2e category, for which we are running only L7 tests now. As BGP tests do not fall under these, they were not executed. Let's move them into "misc" category running L3-L4 tests instead.

BGP CP is quite independent of any other cilium configuration as it only advertises k8s prefixes over BGP, but let's enable it at least once in the vxlan tunnel mode and once with tunneling disabled.