### PR TITLE
cmapisrv/test: miscellaneous fixes to the ciliumidentities script test

### DIFF
--- a/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
@@ -16,7 +16,7 @@ kvstore/list -o plain cilium/state/identities identities-1+2.actual
 
 # Update one of the CiliumIdentities
 cp identity-1.yaml identity-1-v2.yaml
-replace 'foo' 'fred' identity-1-v2.yaml
+replace 'baz' 'fred' identity-1-v2.yaml
 k8s/update identity-1-v2.yaml
 
 # Wait for synchronization
@@ -58,32 +58,30 @@ apiVersion: cilium.io/v2
 kind: CiliumIdentity
 metadata:
   name: "199472"
-  labels:
-    io.kubernetes.pod.namespace: foo
 security-labels:
   k8s:app: baz
   k8s:io.cilium.k8s.policy.cluster: cluster3
-  k8s:io.kubernetes.pod.namespace: bar
+  k8s:io.kubernetes.pod.namespace: foo
 
 -- identities-1+2.expected --
 # cilium/state/identities/v1/id/196915
 k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/199472
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=foo;
 -- identities-1+2-v2.expected --
 # cilium/state/identities/v1/id/196915
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=fred;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/199472
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=foo;
 -- identities-1+2+3.expected --
 # cilium/state/identities/v1/id/196915
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=fred;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/199472
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=foo;
 # cilium/state/identities/v1/id/214794
 k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 -- identities-1+3.expected --
 # cilium/state/identities/v1/id/196915
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=fred;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/214794
 k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;


### PR DESCRIPTION
It appears that the ciliumidentities.txtar test is affected by two issues. First, the update performed at line 19 is ineffective, because none of the security labels contain the 'foo' token. Second, the namespace labels of the second identity are inconsistent. Let's get them fixed, and update the namespace labels to be different between the two identities.