### PR TITLE
selectorcache: test new index in the selector cache id -> selectors

### DIFF
--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -241,3 +241,17 @@ func (s Set[T]) Clone() Set[T] {
 	}
 	return s // singular value or empty Set
 }
+
+func (s Set[T]) All() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		if s.single != nil {
+			yield(*s.single)
+			return
+		}
+		for kv := range s.members {
+			if !yield(kv) {
+				break
+			}
+		}
+	}
+}

--- a/pkg/container/set/set.go
+++ b/pkg/container/set/set.go
@@ -241,17 +241,3 @@ func (s Set[T]) Clone() Set[T] {
 	}
 	return s // singular value or empty Set
 }
-
-func (s Set[T]) All() iter.Seq[T] {
-	return func(yield func(T) bool) {
-		if s.single != nil {
-			yield(*s.single)
-			return
-		}
-		for kv := range s.members {
-			if !yield(kv) {
-				break
-			}
-		}
-	}
-}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1300,11 +1300,11 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, select
 		selections := sel.GetSelectionsAt(selectors)
 
 		// No remote policies would match this rule. Discard it.
-		if len(selections) == 0 {
+		if selections.GetSelections().Len() == 0 {
 			return nil, true
 		}
 
-		r.RemotePolicies = selections.AsUint32Slice()
+		r.RemotePolicies = selections.GetSortedSelections().AsUint32Slice()
 	}
 
 	if l7Rules == nil {
@@ -1410,13 +1410,13 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 				})
 			}
 			selections := sel.GetSelectionsAt(snapshot)
-			if len(selections) == 0 {
+			if selections.Len() == 0 {
 				// No remote policies would match this rule. Discard it.
 				return nil
 			}
 			return append(rules, &cilium.PortNetworkPolicyRule{
 				Deny:           l7.GetDeny(),
-				RemotePolicies: selections.AsUint32Slice(),
+				RemotePolicies: selections.GetSortedSelections().AsUint32Slice(),
 			})
 		}
 	}
@@ -1445,15 +1445,15 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 		}
 
 		selections := sel.GetSelectionsAt(snapshot)
-		if len(selections) == 0 {
+		if selections.Len() == 0 {
 			continue
 		}
 		if l7.GetDeny() {
-			denyCount += len(selections)
-			denySlices = append(denySlices, selections.AsUint32Slice())
+			denyCount += selections.Len()
+			denySlices = append(denySlices, selections.GetSortedSelections().AsUint32Slice())
 		} else {
-			allowCount += len(selections)
-			allowSlices = append(allowSlices, selections.AsUint32Slice())
+			allowCount += selections.Len()
+			allowSlices = append(allowSlices, selections.GetSortedSelections().AsUint32Slice())
 		}
 	}
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1297,14 +1297,14 @@ func (s *xdsServer) getPortNetworkPolicyRule(ep endpoint.EndpointUpdater, select
 	// Optimize the policy if the endpoint selector is a wildcard by
 	// keeping remote policies list empty to match all remote policies.
 	if !wildcard {
-		selections := sel.GetSelectionsAt(selectors)
+		selections := sel.GetSortedSelectionsAt(selectors)
 
 		// No remote policies would match this rule. Discard it.
-		if selections.GetSelections().Len() == 0 {
+		if len(selections) == 0 {
 			return nil, true
 		}
 
-		r.RemotePolicies = selections.GetSortedSelections().AsUint32Slice()
+		r.RemotePolicies = selections.AsUint32Slice()
 	}
 
 	if l7Rules == nil {
@@ -1409,14 +1409,14 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 					Deny: l7.GetDeny(),
 				})
 			}
-			selections := sel.GetSelectionsAt(snapshot)
-			if selections.Len() == 0 {
+			selections := sel.GetSortedSelectionsAt(snapshot)
+			if len(selections) == 0 {
 				// No remote policies would match this rule. Discard it.
 				return nil
 			}
 			return append(rules, &cilium.PortNetworkPolicyRule{
 				Deny:           l7.GetDeny(),
-				RemotePolicies: selections.GetSortedSelections().AsUint32Slice(),
+				RemotePolicies: selections.AsUint32Slice(),
 			})
 		}
 	}
@@ -1444,16 +1444,16 @@ func (s *xdsServer) getWildcardNetworkPolicyRules(snapshot policy.SelectorSnapsh
 			s.logger.Warn("L3-only rule for selector surprisingly requires proxy redirection!", logfields.Selector, sel)
 		}
 
-		selections := sel.GetSelectionsAt(snapshot)
-		if selections.Len() == 0 {
+		selections := sel.GetSortedSelectionsAt(snapshot)
+		if len(selections) == 0 {
 			continue
 		}
 		if l7.GetDeny() {
-			denyCount += selections.Len()
-			denySlices = append(denySlices, selections.GetSortedSelections().AsUint32Slice())
+			denyCount += len(selections)
+			denySlices = append(denySlices, selections.AsUint32Slice())
 		} else {
-			allowCount += selections.Len()
-			allowSlices = append(allowSlices, selections.GetSortedSelections().AsUint32Slice())
+			allowCount += len(selections)
+			allowSlices = append(allowSlices, selections.AsUint32Slice())
 		}
 	}
 

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/statedb/part"
 )
 
 func TestSetPortRulesForID(t *testing.T) {
@@ -200,12 +200,12 @@ type MockCachedSelector struct {
 	key string
 }
 
-func (m MockCachedSelector) GetSelections() set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity]()
+func (m MockCachedSelector) GetSelections() part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity]()
 }
 
-func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity]()
+func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity]()
 }
 
 func (m MockCachedSelector) GetSortedSelections() identity.NumericIdentitySlice {

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -199,11 +200,19 @@ type MockCachedSelector struct {
 	key string
 }
 
-func (m MockCachedSelector) GetSelections() identity.NumericIdentitySlice {
+func (m MockCachedSelector) GetSelections() set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity]()
+}
+
+func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity]()
+}
+
+func (m MockCachedSelector) GetSortedSelections() identity.NumericIdentitySlice {
 	return nil
 }
 
-func (m MockCachedSelector) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (m MockCachedSelector) GetSortedSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
 	return nil
 }
 

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -302,7 +302,7 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 			}
 			ips := make(map[restore.RuleIPOrCIDR]struct{})
 			count := 0
-			nids := selRegex.cs.GetSelections()
+			nids := selRegex.cs.GetSortedSelections()
 		Loop:
 			for _, nid := range nids {
 				// Note: p.RLock must not be held during this call to IPCache

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/container/set"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdndns "github.com/cilium/cilium/pkg/fqdn/dns"
@@ -52,6 +51,7 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/statedb/part"
 )
 
 type DNSProxyTestSuite struct {
@@ -1422,11 +1422,11 @@ type selectorMock struct {
 	key string
 }
 
-func (t selectorMock) GetSelections() set.Set[identity.NumericIdentity] {
+func (t selectorMock) GetSelections() part.Set[identity.NumericIdentity] {
 	panic("implement me")
 }
 
-func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) part.Set[identity.NumericIdentity] {
 	panic("implement me")
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/set"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdndns "github.com/cilium/cilium/pkg/fqdn/dns"
@@ -1421,11 +1422,19 @@ type selectorMock struct {
 	key string
 }
 
-func (t selectorMock) GetSelections() identity.NumericIdentitySlice {
+func (t selectorMock) GetSelections() set.Set[identity.NumericIdentity] {
 	panic("implement me")
 }
 
-func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (t selectorMock) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	panic("implement me")
+}
+
+func (t selectorMock) GetSortedSelections() identity.NumericIdentitySlice {
+	panic("implement me")
+}
+
+func (t selectorMock) GetSortedSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
 	panic("implement me")
 }
 

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -594,7 +594,7 @@ func (s *FQDNDataServer) buildDNSPolicyFromL4Filter(l4Filter *policy.L4Filter, p
 
 // buildDNSServers creates the list of DNS servers from L4 filter and cache selector
 func (s *FQDNDataServer) buildDNSServers(l4Filter *policy.L4Filter, cacheSelector policy.CachedSelector) []*pb.DNSServer {
-	if cacheSelector == nil || len(cacheSelector.GetSelections()) == 0 {
+	if cacheSelector == nil || cacheSelector.GetSelections().Len() == 0 {
 		// No cache selector - return single server without identity
 		return []*pb.DNSServer{
 			{
@@ -603,7 +603,7 @@ func (s *FQDNDataServer) buildDNSServers(l4Filter *policy.L4Filter, cacheSelecto
 			},
 		}
 	}
-	selections := cacheSelector.GetSelections()
+	selections := cacheSelector.GetSortedSelections()
 	dnsServers := make([]*pb.DNSServer, 0, len(selections))
 
 	for _, selection := range selections {

--- a/pkg/policy/distillery_precedence_test.go
+++ b/pkg/policy/distillery_precedence_test.go
@@ -214,7 +214,6 @@ func TestOrderedPolicyValidation(t *testing.T) {
 	defer SetPolicyEnabled(oldPolicyEnable)
 
 	SetPolicyEnabled(option.DefaultEnforcement)
-	logger := hivetest.Logger(t)
 
 	// identities used in tests
 	identityWorld := identity.ReservedIdentityWorld
@@ -247,7 +246,6 @@ func TestOrderedPolicyValidation(t *testing.T) {
 		identity1111:      labels1111,
 		identity1100:      labels1100,
 	}
-	selectorCache := testNewSelectorCache(t, logger, identityCache)
 	identity := identity.NewIdentityFromLabelArray(identityFoo, labelsFoo)
 
 	type probe struct {
@@ -748,6 +746,7 @@ func TestOrderedPolicyValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := hivetest.Logger(t)
+			selectorCache := testNewSelectorCache(t, logger, identityCache)
 			repo := newPolicyDistillery(t, selectorCache)
 			for _, entry := range tt.entries {
 				entry.Subject = wildcardSubject

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -519,7 +519,6 @@ func Test_MergeL3(t *testing.T) {
 		identityFoo: labelsFoo,
 		identityBar: labelsBar,
 	}
-	selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 
 	type authResult map[identity.NumericIdentity]AuthTypes
 	tests := []struct {
@@ -678,6 +677,7 @@ func Test_MergeL3(t *testing.T) {
 		Perm(tt.rules, func(rules []*api.Rule) {
 			round++
 
+			selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 			repo := newPolicyDistillery(t, selectorCache)
 			_, _ = repo.MustAddList(rules)
 
@@ -1153,7 +1153,6 @@ func Test_MergeRules(t *testing.T) {
 	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
-	selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
@@ -1216,6 +1215,7 @@ func Test_MergeRules(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 		repo := newPolicyDistillery(t, selectorCache)
 		generatedRule := generateRule(tt.test)
 		for _, r := range tt.rules {
@@ -1268,7 +1268,6 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 	identityCache := identity.IdentityMap{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
-	selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
@@ -1314,6 +1313,7 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, testMapState(t, mapStateMap{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4__Allow, lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 	for _, tt := range tests {
+		selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 		repo := newPolicyDistillery(t, selectorCache)
 		for _, r := range tt.rules {
 			if r != nil {
@@ -1348,7 +1348,6 @@ func Test_AllowAll(t *testing.T) {
 		identityFoo: labelsFoo,
 		identityBar: labelsBar,
 	}
-	selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
@@ -1362,6 +1361,7 @@ func Test_AllowAll(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 		repo := newPolicyDistillery(t, selectorCache)
 		for _, r := range tt.rules {
 			if r != nil {
@@ -1680,7 +1680,6 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		worldIPIdentity:                       lblWorldIP,     // "192.0.2.3/32"
 		worldSubnetIdentity:                   lblWorldSubnet, // "192.0.2.0/24"
 	}
-	selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
@@ -1788,6 +1787,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		selectorCache := testNewSelectorCache(t, hivetest.Logger(t), identityCache)
 		repo := newPolicyDistillery(t, selectorCache)
 		for _, rule := range tt.rules {
 			if rule != nil {

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for id := range idents.All() {
+		for id := range idents.Members() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for id := range idents.Members() {
+		for id := range idents.All() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for _, id := range idents {
+		for id := range idents.GetSelections().All() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -778,7 +778,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, p *EndpointPolicy, features 
 				)
 			}
 		}
-		for id := range idents.GetSelections().All() {
+		for id := range idents.All() {
 			for _, keyToAdd := range keysToAdd {
 				keyToAdd.Identity = id
 				p.policyMapState.insertWithChanges(keyToAdd, entry, features, changes)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -202,15 +202,16 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 				if k.String() == bK.String() {
 					require.True(t, v.Equal(bV), "Expected: %s\nActual: %s", perSelectorPolicyToString(v), perSelectorPolicyToString(bV))
 
-					selActual := bK.(*identitySelector).cachedSelections
-					selExpected := set.NewSet[identity.NumericIdentity]()
-					for id := range k.(*identitySelector).cachedSelections.Members() {
+					selActual := slices.Collect(bK.(*identitySelector).cachedSelections.All())
+					var selExpected []identity.NumericIdentity
+					for id := range k.(*identitySelector).cachedSelections.All() {
 						if slices.Contains(availableIDs, id) {
-							selExpected.Insert(id)
+							selExpected = append(selExpected, id)
 						}
 					}
 
-					require.True(t, selExpected.Equal(selActual), "Expected: %v\nActual: %v", selExpected, selActual)
+					slices.Sort(selExpected)
+					require.True(t, slices.Equal(selExpected, selActual), "Expected: %v\nActual: %v", selExpected, selActual)
 					found = true
 				}
 			}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -204,7 +204,7 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 
 					selActual := bK.(*identitySelector).cachedSelections
 					selExpected := set.NewSet[identity.NumericIdentity]()
-					for id := range k.(*identitySelector).cachedSelections.All() {
+					for id := range k.(*identitySelector).cachedSelections.Members() {
 						if slices.Contains(availableIDs, id) {
 							selExpected.Insert(id)
 						}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -203,14 +203,14 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 					require.True(t, v.Equal(bV), "Expected: %s\nActual: %s", perSelectorPolicyToString(v), perSelectorPolicyToString(bV))
 
 					selActual := bK.(*identitySelector).cachedSelections
-					selExpected := make(map[identity.NumericIdentity]struct{})
-					for id := range k.(*identitySelector).cachedSelections {
+					selExpected := set.NewSet[identity.NumericIdentity]()
+					for id := range k.(*identitySelector).cachedSelections.All() {
 						if slices.Contains(availableIDs, id) {
-							selExpected[id] = struct{}{}
+							selExpected.Insert(id)
 						}
 					}
 
-					require.True(t, maps.Equal(selExpected, selActual), "Expected: %v\nActual: %v", selExpected, selActual)
+					require.True(t, selExpected.Equal(selActual), "Expected: %v\nActual: %v", selExpected, selActual)
 					found = true
 				}
 			}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -520,7 +520,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 	oldRules := maps.Clone(p.rulesByResource[resource]) // need to clone as `p.del()` mutates this
 
 	for key, oldRule := range oldRules {
-		for _, subj := range oldRule.getSubjects() {
+		for subj := range oldRule.getSubjects().All() {
 			affectedIDs.Insert(subj)
 		}
 		p.del(key)
@@ -532,7 +532,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 			newRule := p.newRule(*r, ruleKey{resource: resource, idx: uint(i)})
 			p.insert(newRule)
 
-			for _, subj := range newRule.getSubjects() {
+			for subj := range newRule.getSubjects().All() {
 				affectedIDs.Insert(subj)
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -520,7 +520,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 	oldRules := maps.Clone(p.rulesByResource[resource]) // need to clone as `p.del()` mutates this
 
 	for key, oldRule := range oldRules {
-		for subj := range oldRule.getSubjects().Members() {
+		for subj := range oldRule.getSubjects().All() {
 			affectedIDs.Insert(subj)
 		}
 		p.del(key)
@@ -532,7 +532,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 			newRule := p.newRule(*r, ruleKey{resource: resource, idx: uint(i)})
 			p.insert(newRule)
 
-			for subj := range newRule.getSubjects().Members() {
+			for subj := range newRule.getSubjects().All() {
 				affectedIDs.Insert(subj)
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -520,7 +520,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 	oldRules := maps.Clone(p.rulesByResource[resource]) // need to clone as `p.del()` mutates this
 
 	for key, oldRule := range oldRules {
-		for subj := range oldRule.getSubjects().All() {
+		for subj := range oldRule.getSubjects().Members() {
 			affectedIDs.Insert(subj)
 		}
 		p.del(key)
@@ -532,7 +532,7 @@ func (p *Repository) ReplaceByResource(rules types.PolicyEntries, resource ipcac
 			newRule := p.newRule(*r, ruleKey{resource: resource, idx: uint(i)})
 			p.insert(newRule)
 
-			for subj := range newRule.getSubjects().All() {
+			for subj := range newRule.getSubjects().Members() {
 				affectedIDs.Insert(subj)
 			}
 		}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/statedb/part"
 )
 
 // ruleKey is a synthetic unique identifier for a Rule
@@ -470,9 +470,9 @@ func (r *rule) matchesSubject(securityIdentity *identity.Identity) bool {
 	return r.subjectSelector.Selects(securityIdentity.ID)
 }
 
-func (r *rule) getSubjects() set.Set[identity.NumericIdentity] {
+func (r *rule) getSubjects() part.Set[identity.NumericIdentity] {
 	if r.Node {
-		return set.NewSet(identity.ReservedIdentityHost)
+		return part.NewSet(identity.ReservedIdentityHost)
 	}
 
 	return r.subjectSelector.GetSelections()

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -469,9 +470,9 @@ func (r *rule) matchesSubject(securityIdentity *identity.Identity) bool {
 	return r.subjectSelector.Selects(securityIdentity.ID)
 }
 
-func (r *rule) getSubjects() []identity.NumericIdentity {
+func (r *rule) getSubjects() set.Set[identity.NumericIdentity] {
 	if r.Node {
-		return []identity.NumericIdentity{identity.ReservedIdentityHost}
+		return set.NewSet(identity.ReservedIdentityHost)
 	}
 
 	return r.subjectSelector.GetSelections()

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -303,7 +303,7 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 
 	// iterating selectors requires read lock
 	for key, sel := range sc.selectors.All() {
-		selections := sel.GetSelectionsAt(version).GetSortedSelections()
+		selections := sel.GetSortedSelectionsAt(version)
 		ids := make([]int64, 0, len(selections))
 		for i := range selections {
 			ids = append(ids, int64(selections[i]))

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -29,6 +30,8 @@ type scIdentity struct {
 	NID       identity.NumericIdentity
 	lbls      labels.LabelArray
 	namespace string // value of the namespace label, or ""
+	// TODO this can be made optional, so that not all selectorCaches need it.
+	cachedSelectors set.Set[*identitySelector]
 }
 
 // scIdentityCache is a cache of Identities keyed by the numeric identity
@@ -53,9 +56,10 @@ func newScIdentityCache(ids identity.IdentityMap) scIdentityCache {
 func (c *scIdentityCache) insert(nid identity.NumericIdentity, lbls labels.LabelArray) *scIdentity {
 	namespace, _ := lbls.LookupLabel(&podNamespaceLabel)
 	id := &scIdentity{
-		NID:       nid,
-		lbls:      lbls,
-		namespace: namespace,
+		NID:             nid,
+		lbls:            lbls,
+		namespace:       namespace,
+		cachedSelectors: set.NewSet[*identitySelector](),
 	}
 
 	c.ids[nid] = id
@@ -93,15 +97,15 @@ func (c *scIdentityCache) exists(nid identity.NumericIdentity) bool {
 	return id != nil
 }
 
-func (c *scIdentityCache) selections(sel *identitySelector) iter.Seq[identity.NumericIdentity] {
-	return func(yield func(id identity.NumericIdentity) bool) {
+func (c *scIdentityCache) selections(sel *identitySelector) iter.Seq[*scIdentity] {
+	return func(yield func(id *scIdentity) bool) {
 		namespaces := sel.source.SelectedNamespaces()
 		if len(namespaces) > 0 {
 			// iterate identities in selected namespaces
 			for _, ns := range namespaces {
 				for id := range c.byNamespace[ns] {
 					if sel.source.Matches(id.lbls) {
-						if !yield(id.NID) {
+						if !yield(id) {
 							return
 						}
 					}
@@ -109,9 +113,9 @@ func (c *scIdentityCache) selections(sel *identitySelector) iter.Seq[identity.Nu
 			}
 		} else {
 			// no namespaces selected, iterate through all identities
-			for nid, id := range c.ids {
-				if sel.source.Matches(id.lbls) {
-					if !yield(nid) {
+			for _, scId := range c.ids {
+				if sel.source.Matches(scId.lbls) {
+					if !yield(scId) {
 						return
 					}
 				}
@@ -575,8 +579,9 @@ func (sc *SelectorCache) addSelectorLocked(lbls stringLabels, key string, source
 	sc.selectors.Set(key, sel)
 
 	// Scan the cached set of IDs to determine any new matchers
-	for nid := range sc.idCache.selections(sel) {
-		sel.cachedSelections = sel.cachedSelections.Set(nid)
+	for scId := range sc.idCache.selections(sel) {
+		sel.cachedSelections = sel.cachedSelections.Set(scId.NID)
+		scId.cachedSelectors.Insert(sel)
 	}
 
 	// Note: No notifications are sent for the existing
@@ -699,12 +704,13 @@ func (sc *SelectorCache) updateSelections(sel *identitySelector, added identity.
 		}
 	}
 	for _, numericID := range added {
-		identity, _ := sc.idCache.find(numericID)
-		matches := sel.source.Matches(identity.lbls)
-		exists := sel.cachedSelections.Has(identity.NID)
+		scId, _ := sc.idCache.find(numericID)
+		matches := sel.source.Matches(scId.lbls)
+		exists := sel.cachedSelections.Has(scId.NID)
 		if matches && !exists {
 			adds = append(adds, numericID)
 			sel.cachedSelections = sel.cachedSelections.Set(numericID)
+			scId.cachedSelectors.Insert(sel)
 		} else if !matches && exists {
 			// Identity was mutated and no longer matches, the
 			// identity is deleted from the cached selections,
@@ -715,6 +721,7 @@ func (sc *SelectorCache) updateSelections(sel *identitySelector, added identity.
 			// was never selected by the affected selector.
 			mutated = true
 			sel.cachedSelections = sel.cachedSelections.Delete(numericID)
+			scId.cachedSelectors.Remove(sel)
 		}
 	}
 	if len(dels)+len(adds) > 0 {
@@ -842,4 +849,28 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 		sc.queueNotifiedUsersCommit(readTxn, wg)
 	}
 	return mutated
+}
+
+// GetUsersOfType returns the users of all the selectors selecting the given nid. It will only return users of the
+// type V, so that these can be looped over as a range operation. If the selector cache is made generic, we can
+// do this in a cleaner way directly on the selector cache instead of a separate func.
+// This will also RLock the selector cache while iterating, to avoid allocations when returning a copy.
+func GetUsersOfType[V CachedSelectionUser](sc *SelectorCache, nid identity.NumericIdentity) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		sc.mutex.RLock()
+		defer sc.mutex.RUnlock()
+		id, found := sc.idCache.find(nid)
+		if !found {
+			return
+		}
+		for m := range id.cachedSelectors.Members() {
+			for user := range m.users {
+				is, ok := user.(V)
+				if !ok {
+					continue
+				}
+				yield(is)
+			}
+		}
+	}
 }

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/statedb/part"
 )
 
 type CachedSelector = types.CachedSelector
@@ -64,7 +64,7 @@ type identitySelector struct {
 	key              string
 	id               types.SelectorId
 	users            map[CachedSelectionUser]struct{}
-	cachedSelections set.Set[identity.NumericIdentity]
+	cachedSelections part.Set[identity.NumericIdentity]
 	metadataLbls     stringLabels
 }
 
@@ -77,7 +77,7 @@ func newIdentitySelector(sc *SelectorCache, key string, source Selector, lbls st
 		key:              key,
 		id:               lastSelectorId,
 		users:            make(map[CachedSelectionUser]struct{}),
-		cachedSelections: set.NewSet[identity.NumericIdentity](),
+		cachedSelections: part.NewSet[identity.NumericIdentity](),
 		source:           source,
 		metadataLbls:     lbls,
 	}
@@ -124,7 +124,7 @@ func (i *identitySelector) Equal(b *identitySelector) bool {
 // that case GetSortedSelectionsAt() will return either the old or new version
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
-func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) set.Set[identity.NumericIdentity] {
+func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) part.Set[identity.NumericIdentity] {
 	return i.at(selectors).GetSelections()
 }
 
@@ -143,12 +143,12 @@ func (i *identitySelector) at(selectors SelectorSnapshot) *types.Selections {
 			logfields.Version, selectors,
 			logfields.Stacktrace, hclog.Stacktrace(),
 		)
-		return types.NewSelection(set.NewSet[identity.NumericIdentity]())
+		return types.NewSelection(part.NewSet[identity.NumericIdentity]())
 	}
 	return selectors.Get(i.id)
 }
 
-func (i *identitySelector) GetSelections() set.Set[identity.NumericIdentity] {
+func (i *identitySelector) GetSelections() part.Set[identity.NumericIdentity] {
 	return i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
 }
 func (i *identitySelector) GetSortedSelections() identity.NumericIdentitySlice {
@@ -238,5 +238,5 @@ func (i *identitySelector) updateSelections() {
 		i.selectorCache.writeableSelections.Delete(i.id)
 		return
 	}
-	i.selectorCache.writeableSelections.Set(i.id, types.NewSelection(i.cachedSelections.Clone()))
+	i.selectorCache.writeableSelections.Set(i.id, types.NewSelection(i.cachedSelections))
 }

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -124,7 +124,15 @@ func (i *identitySelector) Equal(b *identitySelector) bool {
 // that case GetSortedSelectionsAt() will return either the old or new version
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
-func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) *types.Selections {
+func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	return i.at(selectors).GetSelections()
+}
+
+func (i *identitySelector) GetSortedSelectionsAt(selectors SelectorSnapshot) identity.NumericIdentitySlice {
+	return i.at(selectors).GetSortedSelections()
+}
+
+func (i *identitySelector) at(selectors SelectorSnapshot) *types.Selections {
 	if !selectors.IsValid() || i.id == 0 {
 		msg := "GetSelectionsAt: Invalid selector snapshot finds nothing"
 		if i.id == 0 {
@@ -140,20 +148,11 @@ func (i *identitySelector) GetSelectionsAt(selectors SelectorSnapshot) *types.Se
 	return selectors.Get(i.id)
 }
 
-func (i *identitySelector) GetSortedSelections() identity.NumericIdentitySlice {
-	r := i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
-	if r == nil {
-		return identity.NumericIdentitySlice{}
-	}
-	return r.GetSortedSelections()
-}
-
 func (i *identitySelector) GetSelections() set.Set[identity.NumericIdentity] {
-	r := i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
-	if r == nil {
-		return set.Set[identity.NumericIdentity]{}
-	}
-	return r.GetSelections()
+	return i.GetSelectionsAt(i.selectorCache.GetSelectorSnapshot())
+}
+func (i *identitySelector) GetSortedSelections() identity.NumericIdentitySlice {
+	return i.GetSortedSelectionsAt(i.selectorCache.GetSelectorSnapshot())
 }
 
 func (i *identitySelector) GetMetadataLabels() labels.LabelArray {

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
@@ -22,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/types"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	"github.com/cilium/statedb/part"
 )
 
 // testNewSelectorCache returns a newly initialized SelectorCache and a function used to
@@ -296,12 +296,12 @@ func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []ide
 
 // CachedSelector interface
 
-func (cs *testCachedSelector) GetSelections() set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](cs.selections...)
+func (cs *testCachedSelector) GetSelections() part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](cs.selections...)
 }
 
-func (cs *testCachedSelector) GetSelectionsAt(SelectorSnapshot) set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](cs.selections...)
+func (cs *testCachedSelector) GetSelectionsAt(SelectorSnapshot) part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](cs.selections...)
 }
 
 func (cs *testCachedSelector) GetSortedSelections() identity.NumericIdentitySlice {
@@ -674,7 +674,7 @@ func TestTransactionalUpdate(t *testing.T) {
 	// New version handle sees the removal
 	txn3 := sc.GetSelectorSnapshot()
 
-	require.Equal(t, identity.NumericIdentitySlice(nil), cs32.GetSortedSelectionsAt(txn3))
+	require.Equal(t, identity.NumericIdentitySlice{}, cs32.GetSortedSelectionsAt(txn3))
 	require.Equal(t, identity.NumericIdentitySlice{li3}, cs24.GetSortedSelectionsAt(txn3))
 	require.Equal(t, identity.NumericIdentitySlice{li2, li3}, cs8.GetSortedSelectionsAt(txn3))
 	require.Equal(t, identity.NumericIdentitySlice{li2, li3, li4}, cs7.GetSortedSelectionsAt(txn3))

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -601,7 +601,7 @@ func (s *SelectorSnapshot) String() string {
 type CachedSelector interface {
 	// GetSelections returns the cached set of numeric identities
 	// selected by the CachedSelector for the latest revision of the
-	// selector cache.  The retuned slice must NOT be modified, as it
+	// selector cache.  The retuned set must NOT be modified, as it
 	// is shared among multiple users.
 	GetSelections() set.Set[identity.NumericIdentity]
 
@@ -612,9 +612,14 @@ type CachedSelector interface {
 	GetSortedSelections() identity.NumericIdentitySlice
 
 	// GetSelectionsAt returns the cached set of numeric identities
+	// selected by the CachedSelector.  The retuned set must NOT
+	// be modified, as it is shared among multiple users.
+	GetSelectionsAt(SelectorSnapshot) set.Set[identity.NumericIdentity]
+
+	// GetSortedSelectionsAt returns the cached set of numeric identities
 	// selected by the CachedSelector.  The retuned slice must NOT
 	// be modified, as it is shared among multiple users.
-	GetSelectionsAt(SelectorSnapshot) *Selections
+	GetSortedSelectionsAt(SelectorSnapshot) identity.NumericIdentitySlice
 
 	// GetMetadataLabels returns metadata labels for additional context
 	// surrounding the selector. These are typically the labels associated with

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -591,12 +592,22 @@ func (d *DNSServerIdentity) IsNone() bool {
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelections() identity.NumericIdentitySlice {
+func (d *DNSServerIdentity) GetSelections() set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity](d.Identities...)
+}
+
+// Not being used in the standalone dns proxy path
+func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
+	return set.NewSet[identity.NumericIdentity](d.Identities...)
+}
+
+// Not being used in the standalone dns proxy path
+func (d *DNSServerIdentity) GetSortedSelections() identity.NumericIdentitySlice {
 	return d.Identities
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
+func (d *DNSServerIdentity) GetSortedSelectionsAt(types.SelectorSnapshot) identity.NumericIdentitySlice {
 	return d.Identities
 }
 

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
-	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
@@ -34,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/statedb/part"
 
 	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
@@ -592,13 +592,13 @@ func (d *DNSServerIdentity) IsNone() bool {
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelections() set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](d.Identities...)
+func (d *DNSServerIdentity) GetSelections() part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](d.Identities...)
 }
 
 // Not being used in the standalone dns proxy path
-func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) set.Set[identity.NumericIdentity] {
-	return set.NewSet[identity.NumericIdentity](d.Identities...)
+func (d *DNSServerIdentity) GetSelectionsAt(types.SelectorSnapshot) part.Set[identity.NumericIdentity] {
+	return part.NewSet[identity.NumericIdentity](d.Identities...)
 }
 
 // Not being used in the standalone dns proxy path

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -244,7 +244,7 @@ func assertDNSRules(t *testing.T, c *GRPCClient, epID uint32, pp restore.PortPro
 	var gotIDs []uint32
 	var gotPatterns []string
 	for k, v := range row.DNSRule {
-		for id := range k.GetSelections().Members() {
+		for id := range k.GetSelections().All() {
 			gotIDs = append(gotIDs, id.Uint32())
 		}
 		if v != nil {

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -244,7 +244,7 @@ func assertDNSRules(t *testing.T, c *GRPCClient, epID uint32, pp restore.PortPro
 	var gotIDs []uint32
 	var gotPatterns []string
 	for k, v := range row.DNSRule {
-		for _, id := range k.GetSelections() {
+		for id := range k.GetSelections().Members() {
 			gotIDs = append(gotIDs, id.Uint32())
 		}
 		if v != nil {


### PR DESCRIPTION
This is still TBD waiting on the split between peer and subject selector
caches, but will be useful to avoid having to loop through all the
rules on every single regeneration. If there are say 10k+ policy rules
but only 100 IDs, this is pretty cheap compared to looping through all
of them.

This is still proof-of-concept and will require more benchmarking to
figure out if its workable or not.

Built on top of https://github.com/cilium/cilium/pull/43368, and waiting for https://github.com/cilium/cilium/pull/42580.

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
