### PR TITLE
lb: Populate all Frontends even if KPR is disabled

### DIFF
--- a/pkg/bgp/test/script_test.go
+++ b/pkg/bgp/test/script_test.go
@@ -62,6 +62,7 @@ const (
 	bgpNoEndpointsRoutableFlag = "bgp-no-endpoints-routable"
 	ipamFlag                   = "ipam"
 	probeTCPMD5Flag            = "probe-tcp-md5"
+	kubeProxyReplacementFlag   = "kube-proxy-replacement"
 )
 
 func TestPrivilegedScript(t *testing.T) {
@@ -91,6 +92,7 @@ func TestPrivilegedScript(t *testing.T) {
 		ipam := flags.String(ipamFlag, ipamOption.IPAMKubernetes, "IPAM used by the test")
 		probeTCPMD5 := flags.Bool(probeTCPMD5Flag, false, "Probe if TCP_MD5SIG socket option is available")
 		noEndpointsRoutable := flags.Bool(bgpNoEndpointsRoutableFlag, true, "")
+		kubeProxyReplacement := flags.Bool(kubeProxyReplacementFlag, true, "")
 		require.NoError(t, flags.Parse(args), "Error parsing test flags")
 
 		if *probeTCPMD5 {
@@ -148,7 +150,7 @@ func TestPrivilegedScript(t *testing.T) {
 				},
 				func() kpr.KPRConfig {
 					return kpr.KPRConfig{
-						KubeProxyReplacement: true,
+						KubeProxyReplacement: *kubeProxyReplacement,
 					}
 				},
 			),

--- a/pkg/bgp/test/testdata/svc-kpr-disabled.txtar
+++ b/pkg/bgp/test/testdata/svc-kpr-disabled.txtar
@@ -1,0 +1,238 @@
+#! --test-peering-ips=10.99.6.101,10.99.6.102 --kube-proxy-replacement=false
+
+# Tests ClusterIP / LoadBalancerIP / ExternalIP advertisements with kube-proxy-replacement disabled.
+
+# Start the hive
+hive start
+
+# Configure gobgp server
+gobgp/add-server test 65010 10.99.6.101 1790
+
+# Configure peers on GoBGP
+gobgp/add-peer 10.99.6.102 65001
+
+# Add k8s services (LB service with eTP=Local)
+k8s/add service-clusterip.yaml service-lb-local.yaml
+
+# Configure BGP on Cilium
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+
+# Wait for peering to be established
+gobgp/wait-state 10.99.6.102 ESTABLISHED
+
+# Add endpoints for the LB service
+k8s/add endpoints-local.yaml
+
+# Validate that all svc IPs are advertised
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-all.expected routes.actual
+
+# Delete endpoints of the LB service
+k8s/delete endpoints-local.yaml
+
+# Validate that only ClusterIP with iTP=Cluster is advertised
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-tp-cluster.expected routes.actual
+
+# Update LB service to eTP=Cluster
+k8s/update service-lb-cluster.yaml
+
+# Validate that all svc IPs are advertised
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-all.expected routes.actual
+
+#####
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  addresses:
+  - ip: 10.99.6.102
+    type: InternalIP
+  ipam:
+    podCIDRs:
+    - 10.244.1.0/24
+
+-- bgp-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor-65001
+    peers:
+    - name: gobgp-peer-1
+      peerASN: 65010
+      peerAddress: 10.99.6.101
+      localAddress: 10.99.6.102
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: gobgp-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    connectRetryTimeSeconds: 1
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: services
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: lb-only
+  labels:
+    advertise: services
+spec:
+  advertisements:
+  - advertisementType: Service
+    service:
+      addresses:
+        - ClusterIP
+        - LoadBalancerIP
+        - ExternalIP
+    selector:
+      matchExpressions:
+        - { key: bgp, operator: In, values: [ advertise ] }
+
+-- service-clusterip.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo2
+  namespace: test
+  labels:
+    bgp: advertise
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  clusterIP: 10.96.50.105
+  clusterIPs:
+  - 10.96.50.105
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+
+-- service-lb-local.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  labels:
+    bgp: advertise
+spec:
+  type: LoadBalancer
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalIPs:
+  - 9.9.9.9
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- service-lb-cluster.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  labels:
+    bgp: advertise
+spec:
+  type: LoadBalancer
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalIPs:
+  - 9.9.9.9
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpoints-local.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.20
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: test-node
+- addresses:
+  - 10.244.2.30
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: other-node
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- gobgp-routes-tp-cluster.expected --
+Prefix            NextHop       Attrs
+10.96.50.105/32   10.99.6.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.6.102}]
+-- gobgp-routes-all.expected --
+Prefix            NextHop       Attrs
+10.96.50.104/32   10.99.6.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.6.102}]
+10.96.50.105/32   10.99.6.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.6.102}]
+172.16.1.1/32     10.99.6.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.6.102}]
+9.9.9.9/32        10.99.6.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.6.102}]

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -220,116 +220,74 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 		}
 	}
 
-	// NOTE: We always want to do ClusterIP services even when full kube-proxy replacement is disabled.
-	// See https://github.com/cilium/cilium/issues/16197 for context.
+	// NodePort
+	if (svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer) &&
+		expType.CanExpose(slim_corev1.ServiceTypeNodePort) {
 
-	if extCfg.KubeProxyReplacement {
-		// NodePort
-		if (svc.Spec.Type == slim_corev1.ServiceTypeNodePort || svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer) &&
-			expType.CanExpose(slim_corev1.ServiceTypeNodePort) {
-
-			for _, scope := range scopes {
-				for _, family := range getIPFamilies(svc) {
-					if (!extCfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
-						(!extCfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
-						log().Debug(
-							"Skipping NodePort due to disabled IP family",
-							logfields.IPv4, extCfg.EnableIPv4,
-							logfields.IPv6, extCfg.EnableIPv6,
-							logfields.Family, family,
-						)
-						continue
-					}
-					for _, port := range svc.Spec.Ports {
-						if port.NodePort == 0 {
-							continue
-						}
-
-						fe := loadbalancer.FrontendParams{
-							Type:        loadbalancer.SVCTypeNodePort,
-							PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
-							ServiceName: name,
-							ServicePort: uint16(port.Port),
-						}
-
-						switch family {
-						case slim_corev1.IPv4Protocol:
-							fe.Address = loadbalancer.NewL3n4Addr(
-								loadbalancer.L4Type(port.Protocol),
-								zeroV4,
-								uint16(port.NodePort),
-								scope,
-							)
-						case slim_corev1.IPv6Protocol:
-							fe.Address = loadbalancer.NewL3n4Addr(
-								loadbalancer.L4Type(port.Protocol),
-								zeroV6,
-								uint16(port.NodePort),
-								scope,
-							)
-						default:
-							continue
-						}
-
-						fes = append(fes, fe)
-					}
-				}
-			}
-		}
-
-		// LoadBalancer
-		if svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && expType.CanExpose(slim_corev1.ServiceTypeLoadBalancer) {
-			for _, ip := range svc.Status.LoadBalancer.Ingress {
-				if ip.IP == "" ||
-					(ip.IPMode != nil && *ip.IPMode != slim_corev1.LoadBalancerIPModeVIP) /* KEP-1860, skip non-VIP */ {
-					continue
-				}
-
-				addr, err := cmtypes.ParseAddrCluster(ip.IP)
-				if err != nil {
-					continue
-				}
-				if (!extCfg.EnableIPv6 && addr.Is6()) || (!extCfg.EnableIPv4 && addr.Is4()) {
+		for _, scope := range scopes {
+			for _, family := range getIPFamilies(svc) {
+				if (!extCfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
+					(!extCfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
 					log().Debug(
-						"Skipping LoadBalancer due to disabled IP family",
+						"Skipping NodePort due to disabled IP family",
 						logfields.IPv4, extCfg.EnableIPv4,
 						logfields.IPv6, extCfg.EnableIPv6,
-						logfields.Address, addr,
+						logfields.Family, family,
 					)
 					continue
 				}
+				for _, port := range svc.Spec.Ports {
+					if port.NodePort == 0 {
+						continue
+					}
 
-				for _, scope := range scopes {
-					for _, port := range svc.Spec.Ports {
-						fe := loadbalancer.FrontendParams{
-							Type:        loadbalancer.SVCTypeLoadBalancer,
-							PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
-							ServiceName: name,
-							ServicePort: uint16(port.Port),
-						}
+					fe := loadbalancer.FrontendParams{
+						Type:        loadbalancer.SVCTypeNodePort,
+						PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
+						ServiceName: name,
+						ServicePort: uint16(port.Port),
+					}
 
+					switch family {
+					case slim_corev1.IPv4Protocol:
 						fe.Address = loadbalancer.NewL3n4Addr(
 							loadbalancer.L4Type(port.Protocol),
-							addr,
-							uint16(port.Port),
+							zeroV4,
+							uint16(port.NodePort),
 							scope,
 						)
-						fes = append(fes, fe)
+					case slim_corev1.IPv6Protocol:
+						fe.Address = loadbalancer.NewL3n4Addr(
+							loadbalancer.L4Type(port.Protocol),
+							zeroV6,
+							uint16(port.NodePort),
+							scope,
+						)
+					default:
+						continue
 					}
-				}
 
+					fes = append(fes, fe)
+				}
 			}
 		}
+	}
 
-		// ExternalIP
-		for _, ip := range svc.Spec.ExternalIPs {
-			addr, err := cmtypes.ParseAddrCluster(ip)
+	// LoadBalancer
+	if svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && expType.CanExpose(slim_corev1.ServiceTypeLoadBalancer) {
+		for _, ip := range svc.Status.LoadBalancer.Ingress {
+			if ip.IP == "" ||
+				(ip.IPMode != nil && *ip.IPMode != slim_corev1.LoadBalancerIPModeVIP) /* KEP-1860, skip non-VIP */ {
+				continue
+			}
+
+			addr, err := cmtypes.ParseAddrCluster(ip.IP)
 			if err != nil {
 				continue
 			}
 			if (!extCfg.EnableIPv6 && addr.Is6()) || (!extCfg.EnableIPv4 && addr.Is4()) {
 				log().Debug(
-					"Skipping ExternalIP due to disabled IP family",
+					"Skipping LoadBalancer due to disabled IP family",
 					logfields.IPv4, extCfg.EnableIPv4,
 					logfields.IPv6, extCfg.EnableIPv6,
 					logfields.Address, addr,
@@ -337,21 +295,58 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 				continue
 			}
 
-			for _, port := range svc.Spec.Ports {
-				fe := loadbalancer.FrontendParams{
-					Type:        loadbalancer.SVCTypeExternalIPs,
-					PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
-					ServiceName: name,
-					ServicePort: uint16(port.Port),
+			for _, scope := range scopes {
+				for _, port := range svc.Spec.Ports {
+					fe := loadbalancer.FrontendParams{
+						Type:        loadbalancer.SVCTypeLoadBalancer,
+						PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
+						ServiceName: name,
+						ServicePort: uint16(port.Port),
+					}
+
+					fe.Address = loadbalancer.NewL3n4Addr(
+						loadbalancer.L4Type(port.Protocol),
+						addr,
+						uint16(port.Port),
+						scope,
+					)
+					fes = append(fes, fe)
 				}
-				fe.Address = loadbalancer.NewL3n4Addr(
-					loadbalancer.L4Type(port.Protocol),
-					addr,
-					uint16(port.Port),
-					loadbalancer.ScopeExternal,
-				)
-				fes = append(fes, fe)
 			}
+
+		}
+	}
+
+	// ExternalIP
+	for _, ip := range svc.Spec.ExternalIPs {
+		addr, err := cmtypes.ParseAddrCluster(ip)
+		if err != nil {
+			continue
+		}
+		if (!extCfg.EnableIPv6 && addr.Is6()) || (!extCfg.EnableIPv4 && addr.Is4()) {
+			log().Debug(
+				"Skipping ExternalIP due to disabled IP family",
+				logfields.IPv4, extCfg.EnableIPv4,
+				logfields.IPv6, extCfg.EnableIPv6,
+				logfields.Address, addr,
+			)
+			continue
+		}
+
+		for _, port := range svc.Spec.Ports {
+			fe := loadbalancer.FrontendParams{
+				Type:        loadbalancer.SVCTypeExternalIPs,
+				PortName:    loadbalancer.FEPortName(cache.Strings.Get(port.Name)),
+				ServiceName: name,
+				ServicePort: uint16(port.Port),
+			}
+			fe.Address = loadbalancer.NewL3n4Addr(
+				loadbalancer.L4Type(port.Protocol),
+				addr,
+				uint16(port.Port),
+				loadbalancer.ScopeExternal,
+			)
+			fes = append(fes, fe)
 		}
 	}
 


### PR DESCRIPTION
Multiple subsystems now depend on the `Frontends` statedb table as the source of truth instead of the `Resource[*slim_corev1.Service]` (e.g. BGP CP as of https://github.com/cilium/cilium/pull/40916, l2announcer and more as of https://github.com/cilium/cilium/pull/42440), and they need to have the `Frontends` table populated with all types of frontends (including `LoadBalancer`, `ExternalIP`) even if KPR is disabled.

To make sure the `Frontends` table always reflects the state in k8s, remove the KPR conditional preventing full population of the table that was existing most likely just to save some resources when KPR is disabled.

This resolves BGP LoadBalancer service advertisement issue with KPR disabled.

cc @joamaki 