### PR TITLE
[CFP-39876]: Add namespace filtering to service sync and MCS API service exports

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -56,6 +56,7 @@ import (
 	clustercfgcell "github.com/cilium/cilium/pkg/clustermesh/clustercfg/cell"
 	"github.com/cilium/cilium/pkg/clustermesh/endpointslicesync"
 	"github.com/cilium/cilium/pkg/clustermesh/mcsapi"
+	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
 	cmoperator "github.com/cilium/cilium/pkg/clustermesh/operator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/cmdref"
@@ -298,6 +299,9 @@ var (
 		// secrets namespace that is accessible by the Cilium Agents.
 		// Resources might be K8s `Ingress` or Gateway API `Gateway`.
 		secretsync.Cell,
+
+		// Provide the namespace manager for service and serviceexport synchronizers.
+		cmnamespace.Cell,
 
 		// Synchronizes K8s services to KVStore.
 		cell.Provide(func(cfg *operatorOption.OperatorConfig, dcfg *option.DaemonConfig) operatorWatchers.ServiceSyncConfig {

--- a/operator/watchers/script_test.go
+++ b/operator/watchers/script_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -80,6 +81,7 @@ func TestScript(t *testing.T) {
 			cell.Provide(func() ServiceSyncConfig {
 				return ServiceSyncConfig{Enabled: true}
 			}),
+			cmnamespace.Cell,
 			ServiceSyncCell,
 
 			cell.Provide(

--- a/operator/watchers/testdata/globalnamespace-services.txtar
+++ b/operator/watchers/testdata/globalnamespace-services.txtar
@@ -1,0 +1,244 @@
+#! --cluster-id=3 --cluster-name=cluster3 --clustermesh-default-global-namespace=false
+
+hive/start
+
+# Add two namespaces - ns-alpha (annotated as global), ns-beta (not global)
+k8s/add namespace-alpha.yaml namespace-beta.yaml
+
+# Add two services with shared annotation - one in each namespace
+k8s/add service-alpha.yaml service-beta.yaml
+
+# Add endpoint slices for the services
+k8s/add endpointslice-alpha.yaml endpointslice-beta.yaml
+
+# Assert that the synced key gets created
+kvstore/list -o plain cilium/synced synced.actual
+* grep -q '^# cilium/synced/cluster3/cilium/state/services/v1$' synced.actual
+
+# Wait for synchronization. Only service in ns-alpha should be synced (global namespace)
+# The service in ns-beta should NOT be synced even though it has the service.cilium.io/shared annotation
+kvstore/list -o json cilium/state/services services-1.actual
+* cmp services-1.actual services-1.expected
+
+# Annotate ns-beta as global
+k8s/update namespace-beta-annotated.yaml
+
+# Wait for synchronization. Now both services should be synced
+kvstore/list -o json cilium/state/services services-1+2.actual
+* cmp services-1+2.actual services-1+2.expected
+
+# Remove global annotation from ns-beta
+k8s/update namespace-beta.yaml
+
+# Wait for synchronization. Only service in ns-alpha should remain synced
+kvstore/list -o json cilium/state/services services-1.actual
+* cmp services-1.actual services-1.expected
+
+# Delete the service in ns-alpha
+k8s/delete service-alpha.yaml
+
+# Wait for synchronization. No services should remain synced
+kvstore/list -o json cilium/state/services services-empty.actual
+* empty services-empty.actual
+
+# ---
+
+-- namespace-alpha.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-alpha
+  annotations:
+    clustermesh.cilium.io/global: "true"
+
+-- namespace-beta.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-beta
+
+-- namespace-beta-annotated.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns-beta
+  annotations:
+    clustermesh.cilium.io/global: "true"
+
+-- service-alpha.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-service
+  namespace: ns-alpha
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  clusterIP: 10.96.0.10
+  clusterIPs:
+  - 10.96.0.10
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: echo
+  type: ClusterIP
+
+-- service-beta.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-service
+  namespace: ns-beta
+  annotations:
+    service.cilium.io/global: "true"
+    service.cilium.io/shared: "true"
+spec:
+  clusterIP: 10.96.0.20
+  clusterIPs:
+  - 10.96.0.20
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: echo
+  type: ClusterIP
+
+-- endpointslice-alpha.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo-service
+  name: echo-service-abc12
+  namespace: ns-alpha
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.10
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: worker1
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+
+-- endpointslice-beta.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo-service
+  name: echo-service-def34
+  namespace: ns-beta
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.10
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: worker2
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+
+-- services-1.expected --
+# cilium/state/services/v1/cluster3/ns-alpha/echo-service
+{
+  "cluster": "cluster3",
+  "namespace": "ns-alpha",
+  "name": "echo-service",
+  "frontends": {
+    "10.96.0.10": {
+      "http": {
+        "Protocol": "TCP",
+        "Port": 80
+      }
+    }
+  },
+  "backends": {
+    "10.244.1.10": {
+      "http": {
+        "Protocol": "TCP",
+        "Port": 8080
+      }
+    }
+  },
+  "labels": {},
+  "selector": {
+    "app": "echo"
+  },
+  "includeExternal": true,
+  "shared": true,
+  "clusterID": 3
+}
+-- services-1+2.expected --
+# cilium/state/services/v1/cluster3/ns-alpha/echo-service
+{
+  "cluster": "cluster3",
+  "namespace": "ns-alpha",
+  "name": "echo-service",
+  "frontends": {
+    "10.96.0.10": {
+      "http": {
+        "Protocol": "TCP",
+        "Port": 80
+      }
+    }
+  },
+  "backends": {
+    "10.244.1.10": {
+      "http": {
+        "Protocol": "TCP",
+        "Port": 8080
+      }
+    }
+  },
+  "labels": {},
+  "selector": {
+    "app": "echo"
+  },
+  "includeExternal": true,
+  "shared": true,
+  "clusterID": 3
+}
+# cilium/state/services/v1/cluster3/ns-beta/echo-service
+{
+  "cluster": "cluster3",
+  "namespace": "ns-beta",
+  "name": "echo-service",
+  "frontends": {
+    "10.96.0.20": {
+      "http": {
+        "Protocol": "TCP",
+        "Port": 80
+      }
+    }
+  },
+  "backends": {
+    "10.244.2.10": {
+      "http": {
+        "Protocol": "TCP",
+        "Port": 8080
+      }
+    }
+  },
+  "labels": {},
+  "selector": {
+    "app": "echo"
+  },
+  "includeExternal": true,
+  "shared": true,
+  "clusterID": 3
+}

--- a/operator/watchers/testdata/servicesync.txtar
+++ b/operator/watchers/testdata/servicesync.txtar
@@ -2,6 +2,9 @@
 
 hive/start
 
+# Create the namespace first (required for namespace manager)
+k8s/add namespace.yaml
+
 # 1. Add a service before endpoint slice
 k8s/add service.yaml
 
@@ -107,6 +110,12 @@ kvstore/list -o json cilium/state/services services.actual
 * cmp services.actual services-5.expected
 
 # ----
+
+-- namespace.yaml --
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
 
 -- service.yaml --
 apiVersion: v1


### PR DESCRIPTION
## Description

Follow-up to #42905, continuing the implementation of [CFP-74](https://github.com/cilium/design-cfps/pull/74).

Adds namespace filtering to service sync and MCS-API ServiceExport sync. Services and ServiceExports are only synced to the kvstore when they belong to a "global" namespace.

By default all namespaces are global. Set `--clustermesh-default-global-namespace=false` to require explicit `clustermesh.cilium.io/global="true"` annotation.

## Changes

### operator/watchers/service_sync.go
- Add namespace event watcher to re-sync services when namespace global status changes
- Filter services based on namespace global status before syncing

### pkg/clustermesh/mcsapi/serviceexportsync.go
- Add namespace event watcher to re-sync ServiceExports when namespace global status changes
- Filter ServiceExports based on namespace global status before syncing

### Tests
- `operator/watchers/testdata/globalnamespace-services.txtar`: Script test for service sync filtering (including dynamic namespace changes)
- `pkg/clustermesh/mcsapi/serviceexportsync_test.go`: Unit test for ServiceExport sync filtering

## Manual Testing on Kind Clusters

Tested on two kind clusters with ClusterMesh enabled and `--clustermesh-default-global-namespace=false`:

### Setup
- Two kind clusters using `make kind-clustermesh` and `make kind-clustermesh-images`
- Cilium installed with ClusterMesh enabled, namespace filtering flag, and MCS API enabled

### Service Namespace Filtering Results
| Test | Result |
|------|--------|
| Created global service in default namespace (without namespace annotation) | **NOT synced** to kvstore |
| Annotated namespace with `clustermesh.cilium.io/global=true` | Service **synced** to kvstore |
| Created another global service | **Immediately synced** to kvstore |
| Removed namespace annotation | Services **removed** from kvstore |

### ServiceExport Namespace Filtering Results (MCS API)
| Test | Result |
|------|--------|
| Created ServiceExport in default namespace (without namespace annotation) | **NOT synced** to kvstore |
| Annotated namespace with `clustermesh.cilium.io/global=true` | ServiceExport **synced** to kvstore |
| Removed namespace annotation | ServiceExport **removed** from kvstore |

### Verification Commands Used
```bash
# Check services in kvstore
kubectl exec deploy/clustermesh-apiserver -c kvstoremesh \
    --context=kind-clustermesh1 --namespace=kube-system -- \
    clustermesh-apiserver shell kvstore/list cilium/state/services

# Check serviceexports in kvstore
kubectl exec deploy/clustermesh-apiserver -c kvstoremesh \
    --context=kind-clustermesh1 --namespace=kube-system -- \
    clustermesh-apiserver shell kvstore/list cilium/state/serviceexports
```

---

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

```release-note
Add global namespace filtering support to service sync and MCS API service exports for improved ClusterMesh scalability
```