### PR TITLE
pkg/hubble: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/hubble/metrics/metrics_test.go
+++ b/pkg/hubble/metrics/metrics_test.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -238,7 +237,7 @@ func assertHandlersInDfp(t *testing.T, dfp *DynamicFlowProcessor, cfg *api.Confi
 	for _, m := range dfp.Metrics {
 		_, ok := names[m.Name]
 		assert.True(t, ok)
-		assert.True(t, reflect.DeepEqual(*m.MetricConfig, *(names[m.Name])))
+		assert.Equal(t, *(names[m.Name]), *m.MetricConfig)
 	}
 }
 

--- a/pkg/hubble/parser/seven/kafka_test.go
+++ b/pkg/hubble/parser/seven/kafka_test.go
@@ -4,8 +4,9 @@
 package seven
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
@@ -143,9 +144,7 @@ func Test_decodeKafka(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := decodeKafka(tt.args.flowType, tt.args.kafka, tt.args.opts)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("decodeKafka() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 2 usages of `reflect.DeepEqual` in the `pkg/hubble/` package:

- `pkg/hubble/metrics/metrics_test.go`
- `pkg/hubble/parser/seven/kafka_test.go`

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/hubble/metrics/... ./pkg/hubble/parser/seven/... -v
=== RUN   TestDynamicFlowProcessor
--- PASS: TestDynamicFlowProcessor (0.00s)
=== RUN   Test_decodeKafka
--- PASS: Test_decodeKafka (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/hubble/metrics	0.045s
ok  	github.com/cilium/cilium/pkg/hubble/parser/seven	0.031s
```

## Follow-up

This is an incremental change affecting the pkg/hubble/ package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768
- #42769
- #43207
- #43208
- #43209
- #43210

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/hubble tests for better error messages