### PR TITLE
pkg/bpf: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -110,9 +109,10 @@ var (
 	maxEntries = 16
 )
 
-func mapsEqual(a, b *Map) bool {
-	return a.name == b.name &&
-		reflect.DeepEqual(a.spec, b.spec)
+func mapsEqual(t *testing.T, expected, actual *Map) {
+	t.Helper()
+	require.Equal(t, expected.name, actual.name, "map names should match")
+	require.Equal(t, expected.spec, actual.spec, "map specs should match")
 }
 
 func TestPrivilegedOpen(t *testing.T) {
@@ -152,7 +152,7 @@ func TestPrivilegedOpenMap(t *testing.T) {
 
 	openedMap, err = OpenMap(MapPath(logger, "cilium_test"), &TestKey{}, &TestValue{})
 	require.NoError(t, err)
-	require.True(t, mapsEqual(openedMap, testMap))
+	mapsEqual(t, testMap, openedMap)
 }
 
 func TestPrivilegedOpenOrCreate(t *testing.T) {
@@ -203,7 +203,7 @@ func TestPrivilegedRecreateMap(t *testing.T) {
 	require.Error(t, err)
 
 	// Check OpenMap warning section
-	require.True(t, mapsEqual(parallelMap, testMap))
+	mapsEqual(t, testMap, parallelMap)
 
 	key1 := &TestKey{Key: 101}
 	value1 := &TestValue{Value: 201}


### PR DESCRIPTION
lease ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces usage of `reflect.DeepEqual` in`pkg/bpf/map_linux_test.go`

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/bpf/... -run "TestPrivilegedOpenMap|TestPrivilegedOpenOrCreate" -v
=== RUN   TestPrivilegedOpenMap
--- PASS: TestPrivilegedOpenMap (0.00s)
=== RUN   TestPrivilegedOpenOrCreate
--- PASS: TestPrivilegedOpenOrCreate (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/bpf	0.045s
```

## Follow-up

This is an incremental change affecting the pkg/bpf/ package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768
- #42769
- #43207
- #43208
- #43209
- #43210
- #43386

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/bpf tests for better error messages
```