### PR TITLE
ztunnel: ensure xDS uses Kubernetes pod UID, not CEP UID

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -142,6 +142,8 @@ func TransformToCiliumEndpoint(obj any) (any, error) {
 				// they are not used by the CEP handlers.
 				Labels:      nil,
 				Annotations: nil,
+				// OwnerReferences is needed for ztunnel xDS to extract Pod UID.
+				OwnerReferences: slim_metav1.SlimOwnerReferences(concreteObj.ObjectMeta.OwnerReferences),
 			},
 			Encryption: func() *cilium_v2.EncryptionSpec {
 				enc := concreteObj.Status.Encryption
@@ -178,6 +180,8 @@ func TransformToCiliumEndpoint(obj any) (any, error) {
 					// they are not used by the CEP handlers.
 					Labels:      nil,
 					Annotations: nil,
+					// OwnerReferences is needed for ztunnel xDS to extract Pod UID.
+					OwnerReferences: slim_metav1.SlimOwnerReferences(ciliumEndpoint.ObjectMeta.OwnerReferences),
 				},
 				Encryption: func() *cilium_v2.EncryptionSpec {
 					enc := ciliumEndpoint.Status.Encryption

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -1193,6 +1193,16 @@ func Test_TransformToCiliumEndpoint(t *testing.T) {
 						// they are not used by the CEP handlers.
 						Labels:      nil,
 						Annotations: nil,
+						// OwnerReferences is preserved for ztunnel xDS to extract Pod UID.
+						OwnerReferences: []slim_metav1.OwnerReference{
+							{
+								Kind:       "Pod",
+								APIVersion: "v1",
+								Name:       "foo",
+								UID:        "65dasd54d45",
+								Controller: nil,
+							},
+						},
 					},
 					Identity: &v2.EndpointIdentity{
 						ID: 9654,

--- a/pkg/ztunnel/xds/endpoint_event_test.go
+++ b/pkg/ztunnel/xds/endpoint_event_test.go
@@ -59,7 +59,8 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 		require.NotNil(t, workload, "Address should contain Workload")
 
 		// Validate all required field mappings from endpoint to workload
-		require.Equal(t, ep.K8sUID, workload.Uid, "Workload.Uid should match endpoint.K8sUID")
+		// The workload UID comes from OwnerReferences (Pod UID)
+		require.Equal(t, ep.K8sUID, workload.Uid, "Workload.Uid should match Pod UID from OwnerReferences")
 		require.Equal(t, ep.K8sPodName, workload.Name, "Workload.Name should match endpoint.K8sPodName")
 		require.Equal(t, ep.K8sNamespace, workload.Namespace, "Workload.Namespace should match endpoint.K8sNamespace")
 		// TODO(hemanthmalla): Currently we're setting zTunnel node name to host IP due to lack of nodename in CEP.
@@ -123,7 +124,8 @@ func TestEndpointEventToXDSAddress(t *testing.T) {
 		require.NotNil(t, workload, "Address should contain Workload")
 
 		// Validate all required field mappings from endpoint to workload
-		require.Equal(t, ep.K8sUID, workload.Uid, "Workload.Uid should match endpoint.K8sUID")
+		// The workload UID comes from OwnerReferences (Pod UID)
+		require.Equal(t, ep.K8sUID, workload.Uid, "Workload.Uid should match Pod UID from OwnerReferences")
 		require.Equal(t, ep.K8sPodName, workload.Name, "Workload.Name should match endpoint.K8sPodName")
 		require.Equal(t, ep.K8sNamespace, workload.Namespace, "Workload.Namespace should match endpoint.K8sNamespace")
 		// TODO(hemanthmalla): Currently we're setting zTunnel node name to host IP due to lack of nodename in CEP.
@@ -156,7 +158,12 @@ func endpointToCiliumEndpoint(ep *endpoint.Endpoint) *types.CiliumEndpoint {
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      ep.K8sPodName,
 			Namespace: ep.K8sNamespace,
-			UID:       apimachineryTypes.UID(ep.K8sUID),
+			OwnerReferences: []slim_metav1.OwnerReference{
+				{
+					Kind: "Pod",
+					UID:  apimachineryTypes.UID(ep.K8sUID),
+				},
+			},
 		},
 
 		Networking: &v2.EndpointNetworking{

--- a/pkg/ztunnel/xds/stream_processor_test.go
+++ b/pkg/ztunnel/xds/stream_processor_test.go
@@ -389,6 +389,7 @@ func TestStreamProcessorDeltaDiscoveryRequest(t *testing.T) {
 			return nil
 		}
 
+		// These UIDs must match what MockEndpointEventSource.ListAllEndpoints returns
 		expectedUIDs := []string{
 			"12345678-1234-1234-1234-123456789abc", // ep1
 			"87654321-4321-4321-4321-cba987654321", // ep2


### PR DESCRIPTION
The xDS server was utilizing CiliumEndpoint UIDs while both ztunnel and
our ZDS implemenation refer to Kubernetes pod UID.

We must make the K8s Pod UID available to xDS by way of the
CiliumEndpoint. Introduce the required plumbing to carry forward the
K8sUID into CiliumEndoint via the OwnerReference structure.

```release-note
ztunnel,endpoint: make kubernetes pod UID available to CiliumEndpoint API via OwnerReference.
```