### PR TITLE
feat(sdp): Readiness cmd for standalone dns proxy

### DIFF
--- a/standalone-dns-proxy/cmd/readiness.go
+++ b/standalone-dns-proxy/cmd/readiness.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+)
+
+// ReadinessCell provides readiness check commands for the shell
+var ReadinessCell = cell.Module(
+	"readiness",
+	"Readiness check commands for the standalone DNS proxy",
+	cell.Provide(
+		readinessCommands,
+	),
+)
+
+// readinessCommands returns script commands for readiness checking.
+func readinessCommands(provider ReadinessStatusProvider) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"readiness-check": readinessCheckCommand(provider),
+	})
+}
+
+func readinessCheckCommand(provider ReadinessStatusProvider) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Check readiness status of standalone DNS proxy",
+			Args:    "",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(s *script.State) (stdout, stderr string, err error) {
+				// Check if the proxy is ready
+				if !provider.IsReady() {
+					return "", "", fmt.Errorf("standalone DNS proxy is not ready or not started")
+				}
+				return "OK\n", "", nil
+			}, nil
+		},
+	)
+}

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -74,6 +74,7 @@ func setupTestEnv(t *testing.T) *StandaloneDNSProxy {
 			bootstrap.Cell,
 			lookup.Cell,
 			messagehandler.Cell,
+			ReadinessCell,
 			cell.Provide(
 				func() *option.DaemonConfig {
 					return &option.DaemonConfig{
@@ -82,6 +83,7 @@ func setupTestEnv(t *testing.T) *StandaloneDNSProxy {
 					}
 				},
 				NewStandaloneDNSProxy,
+				NewReadinessStatusProvider,
 			)),
 		cell.Invoke(func(_s *StandaloneDNSProxy) {
 			sdp = _s

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
@@ -28,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 
 	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"

--- a/standalone-dns-proxy/pkg/defaults/defaults.go
+++ b/standalone-dns-proxy/pkg/defaults/defaults.go
@@ -10,6 +10,5 @@ const (
 	RuntimePath = "/var/run/standalone-dns-proxy"
 
 	// ShellSockPath is the path to the UNIX domain socket exposing the debug shell
-	// and health checking for the standalone DNS proxy.
 	ShellSockPath = RuntimePath + "/shell.sock"
 )

--- a/standalone-dns-proxy/pkg/lookup/lookup_test.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"net/netip"
 	"testing"
-	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
 )
 


### PR DESCRIPTION
 Readiness cmd for standalone dns proxy. The health cmd returns healthy if the `onStart` hook for the standalone dns proxy is able to run without any error.

In the future, the health status can be enhanced to reflect the actual runtime state of the proxy (for example, whether the proxy process is actively running).

Usage:
 ```
azureuser@vipul-vm:~/ws/cilium$ k exec -it -n kube-system standalone-dns-proxy-tq8jx  -- standalone-dns-proxy shell readiness-check
OK
``` 
Note: This PR is created on top of the #43204 

```release-note
feat(sdp): Readiness cmd for standalone dns proxy
```
