### PR TITLE
pkg/endpoint: replace reflect.DeepEqual in tests

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -588,9 +587,8 @@ func TestEndpoint_GetK8sPodLabels(t *testing.T) {
 				mutex:  lock.RWMutex{},
 				labels: tt.labels,
 			}
-			if got := e.getK8sPodLabels(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Endpoint.getK8sPodLabels() = %v, want %v", got, tt.want)
-			}
+			got := e.getK8sPodLabels()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This PR continues the incremental work to address issue #40562, which aims to replace all uses of `reflect.DeepEqual` in test code with `assert.Equal` from the `github.com/stretchr/testify/assert` package.

## Motivation

The problem with `reflect.DeepEqual` is that when tests fail, it's difficult to discern which specific fields differ between the expected and actual values. Using `assert.Equal` provides much clearer error messages that show exactly what differs.

## Changes

This PR focuses on a small, reviewable scope as suggested in the feedback from PR #40651. It replaces 1 usage of `reflect.DeepEqual` in `pkg/endpoint/endpoint_test.go`

## Testing

All existing tests continue to pass:

```bash
$ go test ./pkg/endpoint -run "TestEndpoint_GetK8sPodLabels" -v
=== RUN   TestEndpoint_GetK8sPodLabels
=== RUN   TestEndpoint_GetK8sPodLabels/has_all_k8s_labels
=== RUN   TestEndpoint_GetK8sPodLabels/the_namespace_labels,_service_account_and_namespace_should_be_ignored_as_they_don't_belong_to_pod_labels
=== RUN   TestEndpoint_GetK8sPodLabels/labels_with_other_source_than_k8s_should_also_be_ignored
--- PASS: TestEndpoint_GetK8sPodLabels (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/endpoint	0.044s
```

## Follow-up

This is an incremental change affecting the pkg/endpoint/ package. Once merged, similar changes can be made to other packages across the codebase.

Previous PRs in this series:
- #42185
- #42222
- #42323
- #42324
- #42768
- #42769
- #43207
- #43208
- #43209
- #43210
- #43386
- #43387

Related: #40562

```release-note
Testing: Replace reflect.DeepEqual with assert.Equal in pkg/endpoint tests for better error messages
```