### PR TITLE
bpf: fix IPIP DSR to use node tunnel endpoint instead of pod IP as outer destination

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1987,12 +1987,13 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 #endif
 		tuple->daddr = backend->address;
 
-	if (lb4_svc_is_l7_punt_proxy(svc) &&
-	    __lookup_ip4_endpoint(backend->address)) {
+	bool is_local = __lookup_ip4_endpoint(backend->address);
+
+	if (lb4_svc_is_l7_punt_proxy(svc) && is_local) {
 		ctx_skip_nodeport_set(ctx);
 		return LB_PUNT_TO_STACK;
 	}
-	if (skip_xlate)
+	if (skip_xlate && !is_local)
 		return CTX_ACT_OK;
 
 	/* CT tuple contains ports in reverse order: */


### PR DESCRIPTION
<!-- Description of change -->
This fixes IPIP DSR to correctly route
packets through the tunnel interface for decapsulation.

Problem:
When DSR with IPIP encapsulation sends packets to a remote backend, the outer
IP destination was set to the backend pod address. However, the cilium_host
interface has routes for the Pod IP range, causing packets to be routed
directly via cilium_host -> pod interface instead of going through cilium_ipip4.
This bypasses the tunnel interface entirely, and the IPIP packet never gets
decapsulated, resulting in malformed packets reaching the backend pod.

Solution:
Change the destination address of the IPIP outer header from the pod IP to
the node IP (tunnel endpoint) where the pod resides. 

```release-note
bpf: fix IPIP DSR to use node tunnel endpoint instead of pod IP as outer destination
```
