### PR TITLE
hubble-relay: Expose and validate support for encrypted flow filtering

### DIFF
--- a/Documentation/observability/hubble/hubble-cli.rst
+++ b/Documentation/observability/hubble/hubble-cli.rst
@@ -87,6 +87,23 @@ dropped:
 Feel free to further inspect the traffic. To get help for the ``observe``
 command, use ``hubble help observe``.
 
+Filtering Encrypted Traffic
+===========================
+
+You can filter flows based on whether they are encrypted (via WireGuard or IPsec) or not.
+
+To see only encrypted flows:
+
+.. code-block:: shell-session
+
+    $ hubble observe --encrypted
+
+To see only unencrypted flows:
+
+.. code-block:: shell-session
+
+    $ hubble observe --unencrypted
+
 Next Steps
 ==========
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

## Description

This PR addresses issue #43238 by validating (via tests) and documenting the support for encrypted flow filtering in Hubble Relay.

The `encrypted` field was already present in the `FlowFilter` protobuf definition, but it was not explicitly validated in the Relay tests or documented in the user guide.

Changes included in this PR:
- **Tests**: Added a new test case `Observe encrypted flows` to `TestGetFlows` in `pkg/hubble/relay/observer/server_test.go`. This test verifies that when a client requests flows with `Encrypted: true`, the Relay correctly forwards this filter to the backend peers.
- **Documentation**: Updated `Documentation/observability/hubble/hubble-cli.rst` to include a section "Filtering Encrypted Traffic", documenting how to use `hubble observe --encrypted` and `hubble observe --encrypted=false`.

## Testing

- Added a unit test in `pkg/hubble/relay/observer/server_test.go` to verify the filter propagation.
- The test ensures that the `Encrypted` field in the `FlowFilter` is correctly passed from the Relay to the Hubble peers.

## Documentation

- Updated `Documentation/observability/hubble/hubble-cli.rst` to explain how to filter encrypted and unencrypted flows using the Hubble CLI.

Fixes: #43238

```release-note
Hubble: Documented support for filtering encrypted flows via `hubble observe --encrypted`.
```
