### PR TITLE
policy: add new benchmarks for identity updates and large policy repository

### DIFF
--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -725,3 +725,25 @@ func TestSelectorManagerCanGetBeforeSet(t *testing.T) {
 	selections := sel.GetSelections()
 	require.Empty(t, selections)
 }
+
+func BenchmarkSelectorCacheIdentityUpdates(b *testing.B) {
+	td := newTestData(b, hivetest.Logger(b))
+	td.bootstrapRepo(GenerateMatchAllRules, 1, b)
+	ids := generateNumIdentities(10000)
+	wg := &sync.WaitGroup{}
+	for k, v := range ids {
+		td.sc.UpdateIdentities(identity.IdentityMap{k: v}, nil, wg)
+	}
+
+	wg.Wait()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		wg := &sync.WaitGroup{}
+		td.sc.UpdateIdentities(nil, identity.IdentityMap{fooIdentity.ID: fooIdentity.LabelArray}, wg)
+		wg.Wait()
+		td.sc.UpdateIdentities(identity.IdentityMap{fooIdentity.ID: fooIdentity.LabelArray}, nil, wg)
+		wg.Wait()
+
+	}
+}


### PR DESCRIPTION
This adds two distinct new benchmarks. One testing the `resolvePolicyLocked` function when no/a low number of rules are selected, but when the repository has a lot of rules. The other one tests `UpdateIdentities` calls when a selector has a lot of identities selected.

These benchmarks are useful for selectorcache refactors and changes like https://github.com/cilium/cilium/pull/43376 and https://github.com/cilium/cilium/pull/43368.

```
/mnt/code/pkg/policy# go test -bench="BenchmarkSelectorCacheIdentityUpdates|BenchmarkResolveNoMatchingRules" . -run="^$" -v -count=5

goos: linux
goarch: arm64
pkg: github.com/cilium/cilium/pkg/policy
BenchmarkResolveNoMatchingRules
BenchmarkResolveNoMatchingRules-12                   690           1615507 ns/op          161072 B/op      20025 allocs/op
BenchmarkResolveNoMatchingRules-12                   759           1582734 ns/op          161072 B/op      20025 allocs/op
BenchmarkResolveNoMatchingRules-12                   687           1673607 ns/op          161072 B/op      20025 allocs/op
BenchmarkResolveNoMatchingRules-12                   705           1757171 ns/op          161072 B/op      20025 allocs/op
BenchmarkResolveNoMatchingRules-12                   745           2318819 ns/op          161072 B/op      20025 allocs/op
BenchmarkSelectorCacheIdentityUpdates
BenchmarkSelectorCacheIdentityUpdates-12             580           1994185 ns/op          168811 B/op         51 allocs/op
BenchmarkSelectorCacheIdentityUpdates-12             602           1933765 ns/op          168687 B/op         55 allocs/op
BenchmarkSelectorCacheIdentityUpdates-12             619           1935440 ns/op          168864 B/op         51 allocs/op
BenchmarkSelectorCacheIdentityUpdates-12             624           1934987 ns/op          168968 B/op         51 allocs/op
BenchmarkSelectorCacheIdentityUpdates-12             616           1937497 ns/op          168928 B/op         51 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/policy     57.810s
```
