### PR TITLE
Add support for extra observers in Cluster Mesh

### DIFF
--- a/pkg/clustermesh/observer/observer.go
+++ b/pkg/clustermesh/observer/observer.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package observer
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+)
+
+// Name represents the name of an observer.
+type Name string
+
+// Observer knows how to watch a prefix from a given etcd instance.
+type Observer interface {
+	// Name returns the name of the observer.
+	Name() Name
+
+	// Status returns the status of the observer.
+	Status() Status
+
+	// Register registers the observer with the given [store.WatchStoreManager], to
+	// watch the desired prefix. If the observer is not enabled (e.g., as not supported
+	// according to the remote cluster capabilities), it drains possibly stale data.
+	Register(mgr store.WatchStoreManager, backend kvstore.BackendOperations, cfg types.CiliumClusterConfig)
+
+	// Drain emits a deletion event for all previously observed entries, upon
+	// disconnection from the target remote cluster.
+	Drain()
+
+	// Revoke possibly emits a deletion event for all previously observed entries,
+	// if connectivity to the target remote cluster is lost.
+	Revoke()
+}
+
+// Status summarizes the status of an observer.
+type Status struct {
+	// Enabled represents whether the observer is currently enabled.
+	Enabled bool
+
+	// Synced represents whether the observer retrieved the initial list of entries from etcd.
+	Synced bool
+
+	// Entries is the number of entries observed by the given observer.
+	Entries uint64
+}
+
+// Factory is the signature of the observer factory.
+type Factory func(cluster string, onSync func()) Observer
+
+// NewFactoryOut provides the given factory via Hive.
+func NewFactoryOut(factory Factory) FactoryOut {
+	return FactoryOut{Factory: factory}
+}
+
+type FactoryOut struct {
+	cell.Out
+
+	Factory Factory `group:"clustermesh-observers"`
+}

--- a/pkg/clustermesh/operator/cell.go
+++ b/pkg/clustermesh/operator/cell.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/clustermesh/observer"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/dial"
@@ -58,6 +59,9 @@ type clusterMeshParams struct {
 
 	// ServiceResolver, if not nil, is used to create a custom dialer for service resolution.
 	ServiceResolver dial.Resolver
+
+	// ObserverFactories is the list of factories to instantiate additional observers.
+	ObserverFactories []observer.Factory `group:"clustermesh-observers"`
 }
 
 // ClusterMeshConfig contains the configuration for ClusterMesh inside the operator.

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cilium/hive/hivetest"
@@ -19,6 +20,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	"github.com/cilium/cilium/pkg/clustermesh/observer"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -225,4 +227,155 @@ func TestRemoteClusterHooks(t *testing.T) {
 
 	rc.Remove(ctx)
 	require.EqualValues(t, 1, clusterRemoveCalledCount.Load(), "cluster remove called once")
+}
+
+type fakeCMObserver struct {
+	name       observer.Name
+	onRegister func(store.WatchStoreManager, kvstore.BackendOperations, types.CiliumClusterConfig)
+	enabled    bool
+
+	cluster string
+	onSync  func()
+
+	synced     atomic.Bool
+	registered atomic.Bool
+	revoked    atomic.Bool
+	drained    atomic.Bool
+}
+
+func (f *fakeCMObserver) Name() observer.Name { return f.name }
+func (f *fakeCMObserver) Revoke()             { f.revoked.Store(true) }
+func (f *fakeCMObserver) Drain()              { f.drained.Store(true) }
+
+func (f *fakeCMObserver) Register(mgr store.WatchStoreManager, backend kvstore.BackendOperations, cfg types.CiliumClusterConfig) {
+	f.registered.Store(true)
+	if f.onRegister != nil {
+		f.onRegister(mgr, backend, cfg)
+	}
+}
+
+func (f *fakeCMObserver) Status() observer.Status {
+	return observer.Status{Enabled: f.enabled, Synced: f.synced.Load()}
+}
+
+func TestRemoteClusterExtraObservers(t *testing.T) {
+	var (
+		logger = hivetest.Logger(t)
+		remote = kvstore.NewInMemoryClient(statedb.New(), "__remote__")
+
+		cfg = types.CiliumClusterConfig{
+			ID: 10, Capabilities: types.CiliumClusterConfigCapabilities{
+				MaxConnectedClusters: 123, ServiceExportsEnabled: ptr.To(true),
+			},
+		}
+
+		onRegister = func(mgr store.WatchStoreManager, backend kvstore.BackendOperations, got types.CiliumClusterConfig) {
+			require.NotNil(t, mgr, "Received invalid [store.WatchStoreManager]")
+			require.NotNil(t, backend, "Received invalid [kvstore.BackendOperations]")
+			require.Equal(t, cfg, got, "Received mismatching [types.CiliumClusterConfig]")
+		}
+
+		fooobs = fakeCMObserver{name: "foo", onRegister: onRegister, enabled: true}
+		barobs = fakeCMObserver{name: "bar", onRegister: onRegister, enabled: false}
+
+		factory = func(obs *fakeCMObserver) observer.Factory {
+			return func(cluster string, onSync func()) observer.Observer {
+				obs.cluster = cluster
+				obs.onSync = func() {
+					onSync()
+					obs.synced.Store(true)
+				}
+				return obs
+			}
+		}
+	)
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	cm := clusterMesh{
+		logger:            logger,
+		metrics:           NewMetrics(),
+		observerFactories: []observer.Factory{factory(&fooobs), factory(&barobs)},
+		storeFactory:      store.NewFactory(logger, store.MetricsProvider()),
+	}
+
+	rc := cm.newRemoteCluster("foo", func() *models.RemoteCluster {
+		return &models.RemoteCluster{Ready: true}
+	}).(*remoteCluster)
+
+	require.False(t, rc.Status().Ready, "Status should not be ready before [Run] is invoked")
+
+	ready := make(chan error)
+	wg.Go(func() { rc.Run(ctx, remote, cfg, ready) })
+
+	require.NoError(t, <-ready, "rc.Run() failed")
+
+	require.True(t, fooobs.registered.Swap(false), "[Register] should have been invoked")
+	require.True(t, barobs.registered.Swap(false), "[Register] should have been invoked")
+	require.False(t, fooobs.revoked.Load(), "[Revoke] should not have been invoked")
+	require.False(t, fooobs.drained.Load(), "[Drain] should not have been invoked")
+
+	require.False(t, rc.Status().Ready, "Status should not be ready before all enabled observers are synced")
+	fooobs.onSync()
+	require.True(t, rc.Status().Ready, "Status should be ready once all enabled observers are synced")
+
+	cancel()
+	wg.Wait()
+
+	rc.RevokeCache(ctx)
+	require.True(t, fooobs.revoked.Swap(false), "[Revoke] should have been invoked")
+	require.True(t, barobs.revoked.Swap(false), "[Revoke] should have been invoked")
+	require.False(t, fooobs.registered.Load(), "[Register] should not have been invoked")
+	require.False(t, fooobs.drained.Load(), "[Drain] should not have been invoked")
+
+	rc.Remove(ctx)
+	require.True(t, fooobs.drained.Swap(false), "[Drain] should have been invoked")
+	require.True(t, barobs.drained.Swap(false), "[Drain] should have been invoked")
+	require.False(t, fooobs.registered.Load(), "[Register] should not have been invoked")
+	require.False(t, fooobs.revoked.Load(), "[Revoke] should not have been invoked")
+}
+
+func TestRemoteClusterExtraObserversSynced(t *testing.T) {
+	// Make use of synctest to leverage [synctest.Wait], which allows waiting
+	// until all goroutines are durably blocked, which is not otherwise possible.
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			obs    = fakeCMObserver{name: "foo"}
+			logger = hivetest.Logger(t)
+		)
+
+		cm := clusterMesh{
+			logger:  logger,
+			metrics: NewMetrics(),
+			observerFactories: []observer.Factory{
+				func(cluster string, onSync func()) observer.Observer {
+					obs.onSync = onSync
+					return &obs
+				},
+			},
+			storeFactory: store.NewFactory(logger, store.MetricsProvider()),
+		}
+
+		rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
+
+		var ch = make(chan error, 1)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		go func() { ch <- rc.synced.Observer(ctx, obs.name) }()
+
+		synctest.Wait()
+		cancel()
+
+		require.ErrorIs(t, <-ch, context.Canceled, "The observer should not be synced")
+
+		obs.onSync()
+		require.NoError(t, rc.synced.Observer(t.Context(), obs.name), "The observer should be now synced")
+
+		require.ErrorIs(t, rc.synced.Observer(ctx, "non-existing"), ErrObserverNotRegistered)
+	})
 }

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
@@ -35,9 +36,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRemoteClusterStatus(t *testing.T) {
-	testutils.IntegrationTest(t)
-
-	client := kvstore.SetupDummy(t, "etcd")
+	client := kvstore.NewInMemoryClient(statedb.New(), "__remote__")
 	kvsService := map[string]string{
 		"cilium/state/services/v1/foo/baz/bar": `{"name": "bar", "namespace": "baz", "cluster": "foo", "clusterID": 1}`,
 	}
@@ -88,8 +87,6 @@ func TestRemoteClusterStatus(t *testing.T) {
 			t.Cleanup(func() {
 				cancel()
 				wg.Wait()
-
-				require.NoError(t, client.DeletePrefix(context.Background(), kvstore.BaseKeyPrefix))
 			})
 
 			logger := hivetest.Logger(t)
@@ -179,9 +176,7 @@ func TestRemoteClusterStatus(t *testing.T) {
 }
 
 func TestRemoteClusterHooks(t *testing.T) {
-	testutils.IntegrationTest(t)
-
-	client := kvstore.SetupDummy(t, "etcd")
+	client := kvstore.NewInMemoryClient(statedb.New(), "__remote__")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup


### PR DESCRIPTION
Currently, the list of prefixes watched for each remote cluster, and the logic to handle the corresponding watch events is strongly coupled with the clustermesh implementation itself. However, this has the downside of increasing the overall complexity, and making it difficult to add the support for new prefixes, both in-tree and by downstream projects.

As an initial effort towards decoupling, let's introduce the [Observer] interface, and extend the clustermesh implementation in both the agent and operator to support providing extra observers through hive.

Existing observers are not refactored contextually to leverage the new [Observer] interface, because they are way too coupled with the current structure, and that would lead to a way too large refactoring. I think it there is value in migrating to the approach over time for better separation, but that needs to be a more gradual process given all the possible implications. 

Please refer to the individual commits for additional details.