### PR TITLE
clustermesh: update mcs-api and adapt port conflict checking

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -349,6 +349,8 @@ communicating via the proxy must reconnect to re-establish connections.
   If you have a different configuration, you are not expected to take any action and the
   transition to ``clustermesh.apiserver.tls.authMode=cluster`` should be fully transparent for you.
 * The Socket LB tracing message format has been updated, you might briefly see parsing errors or malformed trace-sock events during the upgrade to Cilium v1.19.
+* The Cilium MCS-API implementation now raise a port conflict when any exported
+  Service has ports that do not exactly match the oldest exported Service.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.22.4
 	sigs.k8s.io/gateway-api v1.4.0-rc.2
-	sigs.k8s.io/mcs-api v0.3.1-0.20251209180531-e481ae73a51f
+	sigs.k8s.io/mcs-api v0.3.1-0.20251217171610-79faa199f7dd
 	sigs.k8s.io/mcs-api/controllers v0.0.0-20251209180531-e481ae73a51f
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I
 sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
 sigs.k8s.io/kustomize/kyaml v0.20.1 h1:PCMnA2mrVbRP3NIB6v9kYCAc38uvFLVs8j/CD567A78=
 sigs.k8s.io/kustomize/kyaml v0.20.1/go.mod h1:0EmkQHRUsJxY8Ug9Niig1pUMSCGHxQ5RklbpV/Ri6po=
-sigs.k8s.io/mcs-api v0.3.1-0.20251209180531-e481ae73a51f h1:cgBhZFv5qdz12tlTq9DLaPL7/8N7ahzIJ4/wXt5JhOQ=
-sigs.k8s.io/mcs-api v0.3.1-0.20251209180531-e481ae73a51f/go.mod h1:zZ5CK8uS6HaLkxY4HqsmcBHfzHuNMrY2uJy8T7jffK4=
+sigs.k8s.io/mcs-api v0.3.1-0.20251217171610-79faa199f7dd h1:s5E2X2Y7W2M2KxV731CBCWAEOsbvqgNsjUSLL4vHXLg=
+sigs.k8s.io/mcs-api v0.3.1-0.20251217171610-79faa199f7dd/go.mod h1:zZ5CK8uS6HaLkxY4HqsmcBHfzHuNMrY2uJy8T7jffK4=
 sigs.k8s.io/mcs-api/controllers v0.0.0-20251209180531-e481ae73a51f h1:TqhC0fHcxg9wEpHkMMmV95JXssNHPMFsl/LvhieB8wA=
 sigs.k8s.io/mcs-api/controllers v0.0.0-20251209180531-e481ae73a51f/go.mod h1:IEVANHiCGLNsCWuPsZCJhCVzeWavUmxpJ8XgpTt9MpM=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/pkg/clustermesh/mcsapi/serviceimport_controller.go
+++ b/pkg/clustermesh/mcsapi/serviceimport_controller.go
@@ -289,7 +289,7 @@ func intersectIPFamilies(orderedSvcExports []*mcsapitypes.MCSAPIServiceSpec) ([]
 	if clusterConflict != "" {
 		// Note that there is no standard export condition reason for this case at this time
 		return ipFamilies,
-			mcsapiv1alpha1.ServiceExportConditionReason("IPFamilyConflict"),
+			mcsapiv1alpha1.ServiceExportReasonIPFamilyConflict,
 			fmt.Sprintf("IPFamilies conflict. Cluster '%s' has no IPFamilies in common.", clusterConflict)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2883,7 +2883,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/internal/k8sgen/pkg/util/validation/field
 sigs.k8s.io/kustomize/kyaml/yaml/merge2
 sigs.k8s.io/kustomize/kyaml/yaml/schema
 sigs.k8s.io/kustomize/kyaml/yaml/walk
-# sigs.k8s.io/mcs-api v0.3.1-0.20251209180531-e481ae73a51f
+# sigs.k8s.io/mcs-api v0.3.1-0.20251217171610-79faa199f7dd
 ## explicit; go 1.23.0
 sigs.k8s.io/mcs-api/config/crd
 sigs.k8s.io/mcs-api/pkg/apis/v1alpha1

--- a/vendor/sigs.k8s.io/mcs-api/pkg/apis/v1alpha1/serviceexport.go
+++ b/vendor/sigs.k8s.io/mcs-api/pkg/apis/v1alpha1/serviceexport.go
@@ -235,10 +235,8 @@ const (
 	ServiceExportConditionConflict ServiceExportConditionType = "Conflict"
 
 	// ServiceExportReasonPortConflict is used with the "Conflict" condition
-	// when the exported service has a conflict related to port configuration.
-	// This includes when ports on resulting imported services would have
-	// duplicated names (including unnamed/empty name) or duplicated
-	// port/protocol pairs.
+	// when the exported service has a conflict related to port configuration
+	// if the ports are not identical in all the constituent Services.
 	ServiceExportReasonPortConflict ServiceExportConditionReason = "PortConflict"
 
 	// ServiceExportReasonTypeConflict is used with the "Conflict" condition
@@ -272,6 +270,13 @@ const (
 	// ServiceExportReasonTrafficDistributionConflict is used with the "Conflict"
 	// condition when the exported service has a conflict related to traffic distribution.
 	ServiceExportReasonTrafficDistributionConflict ServiceExportConditionReason = "TrafficDistributionConflict"
+
+	// ServiceExportReasonIPFamilyConflict is used with the "Conflict" condition
+	// when the exported service has a conflict related to IPFamilies.
+	// The handling of IP families is implementation-specific but this condition
+	// must be used if a conflicting IP family may result in network traffic reaching
+	// only a subset of the backends depending on the IP protocol used.
+	ServiceExportReasonIPFamilyConflict ServiceExportConditionReason = "IPFamilyConflict"
 
 	// ServiceExportReasonNoConflicts is used with the "Conflict" condition
 	// when the condition is False.


### PR DESCRIPTION
Update to the latest change from the MCS-API repo and extend the port conflict condition to reflect the latest MCS KEP change from https://github.com/kubernetes/enhancements/commit/eefb05c986c6eed8e5d63859c42f4003c421792e.

```release-note
clustermesh: MCS now raise a port conflict when exported Service ports are not an exact match
```
