### PR TITLE
iptables: detect and validate nf_tables mode for all zero rules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
@@ -100,6 +101,7 @@ type iptablesInterface interface {
 
 	getProg() string
 	getIpset() string
+	getMode() string
 }
 
 type ipt struct {
@@ -107,6 +109,7 @@ type ipt struct {
 	prog     string
 	ipset    string
 	waitArgs []string
+	mode     string
 }
 
 func (ipt *ipt) initLogger(logger *slog.Logger) {
@@ -123,6 +126,11 @@ func (ipt *ipt) initArgs(ctx context.Context, waitSeconds int) {
 			ipt.waitArgs = []string{waitString}
 		}
 	}
+	if mode, err := ipt.getIPtablesMode(ctx); err == nil {
+		ipt.mode = mode
+	} else {
+		ipt.mode = "legacy"
+	}
 }
 
 func (ipt *ipt) getProg() string {
@@ -131,6 +139,10 @@ func (ipt *ipt) getProg() string {
 
 func (ipt *ipt) getIpset() string {
 	return ipt.ipset
+}
+
+func (ipt *ipt) getMode() string {
+	return ipt.mode
 }
 
 func (ipt *ipt) getVersion(ctx context.Context) (semver.Version, error) {
@@ -144,6 +156,17 @@ func (ipt *ipt) getVersion(ctx context.Context) (semver.Version, error) {
 		return semver.Version{}, fmt.Errorf("no iptables version found in string: %s", string(b))
 	}
 	return versioncheck.Version(vString[1])
+}
+
+func (ipt *ipt) getIPtablesMode(ctx context.Context) (string, error) {
+	b, err := exec.CommandContext(ctx, ipt.prog, "--version").CombinedOutput(ipt.logger, false)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(string(b), "nf_tables") {
+		return "nft", nil
+	}
+	return "legacy", nil
 }
 
 func (ipt *ipt) runProgOutput(args []string) (string, error) {
@@ -1419,6 +1442,18 @@ func (m *Manager) installMasqueradeRules(
 	localDeliveryInterface, snatDstExclusionCIDR, allocRange, hostMasqueradeIP string,
 ) error {
 	devices := nativeDevices
+
+	if prog.getMode() == "nft" {
+		if _, exclusionCIDR, err := net.ParseCIDR(snatDstExclusionCIDR); err == nil {
+			maskSize, _ := exclusionCIDR.Mask.Size()
+			if exclusionCIDR.IP.IsUnspecified() && maskSize == 0 {
+				if prog == m.ip6tables {
+					return fmt.Errorf("nf_tables does not support ::/0 exclusion, set --%s=false", option.EnableIPv6Masquerade)
+				}
+				return fmt.Errorf("nf_tables does not support 0.0.0.0/0 exclusion, set --%s=false", option.EnableIPv4Masquerade)
+			}
+		}
+	}
 
 	if m.sharedCfg.NodeIpsetNeeded {
 		cmds := nodeIpsetNATCmds(allocRange, prog.getIpset(), m.sharedCfg.MasqueradeInterfaces)

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -24,6 +24,7 @@ type mockIptables struct {
 	ipset        string
 	expectations []expectation
 	index        int
+	mode         string
 }
 
 func (ipt *mockIptables) getProg() string {
@@ -32,6 +33,10 @@ func (ipt *mockIptables) getProg() string {
 
 func (ipt *mockIptables) getIpset() string {
 	return ipt.ipset
+}
+
+func (ipt *mockIptables) getMode() string {
+	return ipt.mode
 }
 
 func (ipt *mockIptables) runProgOutput(args []string) (out string, err error) {


### PR DESCRIPTION
see commit message



```release-note
generate the proper logs when users put 0.0.0.0/0 as the native routing range for iptable nft mode 
```
