### PR TITLE
cilium, bigtcp: BIG TCP for tunnels

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -183,6 +183,7 @@ cilium-agent [flags]
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
+      --enable-tunnel-big-tcp                                     Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
       --enable-unreachable-routes                                 Add unreachable routes on pod deletion
       --enable-vtep                                               Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -96,6 +96,7 @@ cilium-agent hive [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
+      --enable-tunnel-big-tcp                                     Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                          Enable WireGuard
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -102,6 +102,7 @@ cilium-agent hive dot-graph [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
+      --enable-tunnel-big-tcp                                     Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                          Enable WireGuard
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1320,6 +1320,10 @@
      - Enable Non-Default-Deny policies
      - bool
      - ``true``
+   * - :spelling:ignore:`enableTunnelBIGTCP`
+     - Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
+     - bool
+     - ``false``
    * - :spelling:ignore:`enableXTSocketFallback`
      - Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -380,6 +380,7 @@ contributors across the globe, there is almost always someone available to help.
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |
 | enableNoServiceEndpointsRoutable | bool | `true` | Enable routing to a service that has zero endpoints |
 | enableNonDefaultDenyPolicies | bool | `true` | Enable Non-Default-Deny policies |
+| enableTunnelBIGTCP | bool | `false` | Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.ipsec.encryptedOverlay | bool | `false` | Enable IPsec encrypted overlay |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -706,6 +706,7 @@ data:
   enable-ipv4-big-tcp: {{ .Values.enableIPv4BIGTCP | quote }}
   enable-ipv6-big-tcp: {{ .Values.enableIPv6BIGTCP | quote }}
   enable-ipv6-masquerade: {{ .Values.enableIPv6Masquerade | quote }}
+  enable-tunnel-big-tcp: {{ .Values.enableTunnelBIGTCP | quote }}
 
 {{- if hasKey .Values.bpf "enableTCX" }}
   enable-tcx: {{ .Values.bpf.enableTCX | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1892,6 +1892,9 @@
     "enableNonDefaultDenyPolicies": {
       "type": "boolean"
     },
+    "enableTunnelBIGTCP": {
+      "type": "boolean"
+    },
     "enableXTSocketFallback": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2279,6 +2279,8 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
+# -- Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
+enableTunnelBIGTCP: false
 nat:
   # -- Number of the top-k SNAT map connections to track in Cilium statedb.
   mapStatsEntries: 32

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2301,6 +2301,8 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
+# -- Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
+enableTunnelBIGTCP: false
 
 nat:
   # -- Number of the top-k SNAT map connections to track in Cilium statedb.

--- a/pkg/datapath/fake/types/bigtcp.go
+++ b/pkg/datapath/fake/types/bigtcp.go
@@ -10,6 +10,9 @@ type BigTCPUserConfig struct {
 
 	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
 	EnableIPv4BIGTCP bool
+
+	// EnableTunnelBIGTCP enables BIG TCP (larger GSO/GRO limits) in tunneling mode for VXLAN and GENEVE tunnels.
+	EnableTunnelBIGTCP bool
 }
 
 func (def BigTCPUserConfig) IsIPv4Enabled() bool {
@@ -18,4 +21,8 @@ func (def BigTCPUserConfig) IsIPv4Enabled() bool {
 
 func (def BigTCPUserConfig) IsIPv6Enabled() bool {
 	return def.EnableIPv6BIGTCP
+}
+
+func (def BigTCPUserConfig) IsTunnelEnabled() bool {
+	return def.EnableTunnelBIGTCP
 }

--- a/pkg/datapath/fake/types/loader.go
+++ b/pkg/datapath/fake/types/loader.go
@@ -39,7 +39,7 @@ func (f *FakeLoader) ReinitializeHostDev(ctx context.Context, mtu int) error {
 }
 
 // Reinitialize does nothing.
-func (f *FakeLoader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+func (f *FakeLoader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr datapath.IptablesManager, p datapath.Proxy, bigtcp datapath.BigTCPConfiguration) error {
 	return nil
 }
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -329,7 +329,7 @@ func (l *loader) ReinitializeHostDev(ctx context.Context, mtu int) error {
 // BPF programs, netfilter rule configuration and reserving routes in IPAM for
 // locally detected prefixes. It may be run upon initial Cilium startup, after
 // restore from a previous Cilium run, or during regular Cilium operation.
-func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr datapath.IptablesManager, p datapath.Proxy, bigtcp datapath.BigTCPConfiguration) error {
 	sysSettings := []tables.Sysctl{
 		{Name: []string{"net", "core", "bpf_jit_enable"}, Val: "1", IgnoreErr: true, Warn: "Unable to ensure that BPF JIT compilation is enabled. This can be ignored when Cilium is running inside non-host network namespace (e.g. with kind or minikube)"},
 		{Name: []string{"net", "ipv4", "conf", "all", "rp_filter"}, Val: "0", IgnoreErr: false},
@@ -384,7 +384,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 	}
 
 	if err := setupTunnelDevice(l.logger, l.sysctl, tunnelConfig.EncapProtocol(), tunnelConfig.Port(),
-		tunnelConfig.SrcPortLow(), tunnelConfig.SrcPortHigh(), lnc.DeviceMTU); err != nil {
+		tunnelConfig.SrcPortLow(), tunnelConfig.SrcPortHigh(), lnc.DeviceMTU, bigtcp); err != nil {
 		return fmt.Errorf("failed to setup %s tunnel device: %w", tunnelConfig.EncapProtocol(), err)
 	}
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -74,6 +75,7 @@ type Params struct {
 	DB                 *statedb.DB
 	Devices            statedb.Table[*tables.Device]
 	EPRestorer         promise.Promise[endpointstate.Restorer]
+	BIGTCPConfig       *bigtcp.Configuration
 
 	// Force map initialisation before loader. You should not use these otherwise.
 	// Some of the entries in this slice may be nil.

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -14,10 +14,12 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	btcp "github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
@@ -179,11 +181,14 @@ func addHostDeviceAddr(hostDev netlink.Link, ipv4, ipv6 net.IP) error {
 
 // setupTunnelDevice ensures the cilium_{mode} device is created and
 // unused leftover devices are cleaned up in case mode changes.
-func setupTunnelDevice(logger *slog.Logger, sysctl sysctl.Sysctl, mode tunnel.EncapProtocol, port, srcPortLow, srcPortHigh uint16, mtu int) error {
+func setupTunnelDevice(logger *slog.Logger, sysctl sysctl.Sysctl, mode tunnel.EncapProtocol, port, srcPortLow, srcPortHigh uint16, mtu int, bigtcp types.BigTCPConfiguration) error {
 	switch mode {
 	case tunnel.Geneve:
 		if err := setupGeneveDevice(logger, sysctl, port, srcPortLow, srcPortHigh, mtu); err != nil {
 			return fmt.Errorf("setting up geneve device: %w", err)
+		}
+		if err := setupTunnelGSOGRO(logger, defaults.GeneveDevice, bigtcp); err != nil {
+			return fmt.Errorf("setting up GSO/GRO on GENEVE netdev: %w", err)
 		}
 		if err := removeDevice(defaults.VxlanDevice); err != nil {
 			return fmt.Errorf("removing %s: %w", defaults.VxlanDevice, err)
@@ -192,6 +197,9 @@ func setupTunnelDevice(logger *slog.Logger, sysctl sysctl.Sysctl, mode tunnel.En
 	case tunnel.VXLAN:
 		if err := setupVxlanDevice(logger, sysctl, port, srcPortLow, srcPortHigh, mtu); err != nil {
 			return fmt.Errorf("setting up vxlan device: %w", err)
+		}
+		if err := setupTunnelGSOGRO(logger, defaults.VxlanDevice, bigtcp); err != nil {
+			return fmt.Errorf("setting up GSO/GRO on VXLAN netdev: %w", err)
 		}
 		if err := removeDevice(defaults.GeneveDevice); err != nil {
 			return fmt.Errorf("removing %s: %w", defaults.GeneveDevice, err)
@@ -318,6 +326,42 @@ func setupVxlanDevice(logger *slog.Logger, sysctl sysctl.Sysctl, port, srcPortLo
 			logfields.Range, fmt.Sprintf("(%d-%d)", vxlan.PortLow, vxlan.PortHigh),
 			logfields.Device, defaults.VxlanDevice,
 		)
+	}
+	return nil
+}
+
+func setupTunnelGSOGRO(logger *slog.Logger, device string, bigtcp types.BigTCPConfiguration) error {
+	// IPv6 goes first, because {gso,gro}_ipv4_max_size gets auto-adjusted
+	// if the new size of {gso,gro}_max_size isn't greater than 64KB for
+	// backwards compatibility.
+	if bigtcp.GetGROIPv6MaxSize() != 0 && bigtcp.GetGSOIPv6MaxSize() != 0 {
+		logger.Info("Setting IPv6",
+			logfields.Device, device,
+			logfields.GsoMaxSize, bigtcp.GetGSOIPv6MaxSize(),
+			logfields.GroMaxSize, bigtcp.GetGROIPv6MaxSize(),
+		)
+		err := btcp.SetGROGSOIPv6MaxSize(logger, device, bigtcp.GetGROIPv6MaxSize(), bigtcp.GetGSOIPv6MaxSize())
+		if err != nil {
+			logger.Warn("Could not modify IPv6 gro_max_size and gso_max_size",
+				logfields.Device, device,
+				logfields.Error, err)
+			return err
+		}
+	}
+	if bigtcp.GetGROIPv4MaxSize() != 0 && bigtcp.GetGSOIPv4MaxSize() != 0 {
+		logger.Info("Setting IPv4",
+			logfields.Device, device,
+			logfields.GsoMaxSize, bigtcp.GetGSOIPv4MaxSize(),
+			logfields.GroMaxSize, bigtcp.GetGROIPv4MaxSize(),
+		)
+		err := btcp.SetGROGSOIPv4MaxSize(logger, device, bigtcp.GetGROIPv4MaxSize(), bigtcp.GetGSOIPv4MaxSize())
+		if err != nil {
+			logger.Warn("Could not modify IPv4 gro_ipv4_max_size and gso_ipv4_max_size",
+				logfields.Device, device,
+				logfields.Error, err,
+			)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -31,6 +31,25 @@ var lo = &netlink.GenericLink{
 	LinkType:  "loopback",
 }
 
+type mockBigTCP struct {
+}
+
+func (c mockBigTCP) GetGROIPv6MaxSize() int {
+	return 65536
+}
+
+func (c mockBigTCP) GetGSOIPv6MaxSize() int {
+	return 65536
+}
+
+func (c mockBigTCP) GetGROIPv4MaxSize() int {
+	return 65536
+}
+
+func (c mockBigTCP) GetGSOIPv4MaxSize() int {
+	return 65536
+}
+
 func mustXDPProgram(t *testing.T, name string) *ebpf.Program {
 	p, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Type: ebpf.XDP,
@@ -118,7 +137,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 		ns := netns.NewNetNS(t)
 
 		ns.Do(func() error {
-			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.GeneveDevice)
@@ -140,10 +159,10 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 		ns := netns.NewNetNS(t)
 
 		ns.Do(func() error {
-			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.Geneve, 12345, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.Geneve, 12345, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.GeneveDevice)
@@ -165,7 +184,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 		ns := netns.NewNetNS(t)
 
 		ns.Do(func() error {
-			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.GeneveDevice)
@@ -174,7 +193,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			// Ensure the ifindex does not change when specifying a different MTU.
 			ifindex := link.Attrs().Index
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu-1)
+			err = setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu-1, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err = safenetlink.LinkByName(defaults.GeneveDevice)
@@ -194,7 +213,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 		ns := netns.NewNetNS(t)
 
 		ns.Do(func() error {
-			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
@@ -216,10 +235,10 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 		ns := netns.NewNetNS(t)
 
 		ns.Do(func() error {
-			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, 12345, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, 12345, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
@@ -253,10 +272,10 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			err = netlink.LinkSetUp(externallyMangedVxlan)
 			require.NoError(t, err)
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, mockBigTCP{})
 			require.Error(t, err)
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, 12345, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, 12345, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
@@ -278,7 +297,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 		ns := netns.NewNetNS(t)
 
 		ns.Do(func() error {
-			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
@@ -287,7 +306,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			// Ensure the ifindex does not change when specifying a different MTU.
 			ifindex := link.Attrs().Index
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu-1)
+			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu-1, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err = safenetlink.LinkByName(defaults.VxlanDevice)
@@ -310,7 +329,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			srcMin := uint16(1000)
 			srcMax := uint16(2000)
 
-			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, 4567, srcMin, srcMax, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, 4567, srcMin, srcMax, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
@@ -337,7 +356,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			srcMin := uint16(1000)
 			srcMax := uint16(2000)
 
-			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
@@ -348,7 +367,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			require.Equal(t, 0, vxlan.PortLow)
 			require.Equal(t, 0, vxlan.PortHigh)
 
-			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, srcMin, srcMax, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, srcMin, srcMax, mtu, mockBigTCP{})
 			require.NoError(t, err)
 
 			link, err = safenetlink.LinkByName(defaults.VxlanDevice)
@@ -372,7 +391,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 
 		ns.Do(func() error {
 			// Start with a Geneve tunnel.
-			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu)
+			err := setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 			_, err = safenetlink.LinkByName(defaults.GeneveDevice)
 			require.NoError(t, err)
@@ -380,7 +399,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			require.Error(t, err)
 
 			// Switch to vxlan mode.
-			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 			_, err = safenetlink.LinkByName(defaults.GeneveDevice)
 			require.Error(t, err)
@@ -388,7 +407,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			require.NoError(t, err)
 
 			// Switch back to Geneve.
-			err = setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.Geneve, defaults.TunnelPortGeneve, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 			_, err = safenetlink.LinkByName(defaults.GeneveDevice)
 			require.NoError(t, err)
@@ -396,7 +415,7 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			require.Error(t, err)
 
 			// Disable tunneling.
-			err = setupTunnelDevice(logger, sysctl, tunnel.Disabled, 0, 0, 0, mtu)
+			err = setupTunnelDevice(logger, sysctl, tunnel.Disabled, 0, 0, 0, mtu, mockBigTCP{})
 			require.NoError(t, err)
 			_, err = safenetlink.LinkByName(defaults.VxlanDevice)
 			require.Error(t, err)

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -90,6 +91,9 @@ func newTestLoader(tb testing.TB) *loader {
 				&manager.NodeConfigNotifier{},
 				promise,
 				&FakePreFilter{}
+		}),
+		cell.Provide(func() *bigtcp.Configuration {
+			return &bigtcp.Configuration{}
 		}),
 	).Populate(hivetest.Logger(tb))
 	if err != nil {

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -114,6 +115,7 @@ type orchestratorParams struct {
 	MaglevConfig        maglev.Config
 	WgAgent             wgTypes.WireguardAgent
 	IPsecConfig         datapath.IPsecConfig
+	BIGTCPConfig        *bigtcp.Configuration
 }
 
 func newOrchestrator(params orchestratorParams) *orchestrator {
@@ -285,6 +287,7 @@ func (o *orchestrator) reinitialize(ctx context.Context, req reinitializeRequest
 		o.params.TunnelConfig,
 		o.params.IPTablesManager,
 		o.params.Proxy,
+		o.params.BIGTCPConfig,
 	)
 	if err != nil {
 		if req.errChan != nil {

--- a/pkg/datapath/types/bigtcp.go
+++ b/pkg/datapath/types/bigtcp.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	EnableIPv4BIGTCPFlag = "enable-ipv4-big-tcp"
-	EnableIPv6BIGTCPFlag = "enable-ipv6-big-tcp"
+	EnableIPv4BIGTCPFlag   = "enable-ipv4-big-tcp"
+	EnableIPv6BIGTCPFlag   = "enable-ipv6-big-tcp"
+	EnableTunnelBIGTCPFlag = "enable-tunnel-big-tcp"
 )
 
 // BigTCPUserConfig are the configuration flags that the user can modify.
@@ -19,11 +20,15 @@ type BigTCPUserConfig struct {
 
 	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
 	EnableIPv4BIGTCP bool
+
+	// EnableTunnelBIGTCP enables BIG TCP (larger GSO/GRO limits) in tunneling mode for VXLAN and GENEVE tunnels.
+	EnableTunnelBIGTCP bool
 }
 
 func (def BigTCPUserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(EnableIPv4BIGTCPFlag, def.EnableIPv4BIGTCP, "Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4")
 	flags.Bool(EnableIPv6BIGTCPFlag, def.EnableIPv6BIGTCP, "Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6")
+	flags.Bool(EnableTunnelBIGTCPFlag, def.EnableTunnelBIGTCP, "Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels")
 }
 
 func (def BigTCPUserConfig) IsIPv4Enabled() bool {
@@ -34,7 +39,19 @@ func (def BigTCPUserConfig) IsIPv6Enabled() bool {
 	return def.EnableIPv6BIGTCP
 }
 
+func (def BigTCPUserConfig) IsTunnelEnabled() bool {
+	return def.EnableTunnelBIGTCP
+}
+
 type BigTCPConfig interface {
 	IsIPv4Enabled() bool
 	IsIPv6Enabled() bool
+	IsTunnelEnabled() bool
+}
+
+type BigTCPConfiguration interface {
+	GetGROIPv6MaxSize() int
+	GetGSOIPv6MaxSize() int
+	GetGROIPv4MaxSize() int
+	GetGSOIPv4MaxSize() int
 }

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -22,7 +22,7 @@ type Loader interface {
 	ReloadDatapath(ctx context.Context, ep Endpoint, cfg *LocalNodeConfiguration, stats *metrics.SpanStat) (string, error)
 	EndpointHash(cfg EndpointConfiguration, lnCfg *LocalNodeConfiguration) (string, error)
 	ReinitializeHostDev(ctx context.Context, mtu int) error
-	Reinitialize(ctx context.Context, cfg *LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr IptablesManager, p Proxy) error
+	Reinitialize(ctx context.Context, cfg *LocalNodeConfiguration, tunnelConfig tunnel.Config, iptMgr IptablesManager, p Proxy, bigtcp BigTCPConfiguration) error
 	WriteEndpointConfig(w io.Writer, cfg EndpointConfiguration, lnCfg *LocalNodeConfiguration) error
 }
 

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -56,8 +56,9 @@ func (m mockFeaturesParams) IsDynamicConfigSourceKindNodeConfig() bool {
 }
 
 type bigTCPMock struct {
-	ipv4Enabled bool
-	ipv6Enabled bool
+	ipv4Enabled   bool
+	ipv6Enabled   bool
+	tunnelEnabled bool
 }
 
 func (b bigTCPMock) IsIPv4Enabled() bool {
@@ -66,6 +67,10 @@ func (b bigTCPMock) IsIPv4Enabled() bool {
 
 func (b bigTCPMock) IsIPv6Enabled() bool {
 	return b.ipv6Enabled
+}
+
+func (b bigTCPMock) IsTunnelEnabled() bool {
+	return b.tunnelEnabled
 }
 
 func TestUpdateNetworkMode(t *testing.T) {
@@ -1211,6 +1216,7 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 		name             string
 		enableIPv4       bool
 		enableIPv6       bool
+		enableTunnel     bool
 		expectedProtocol string
 	}{
 		{
@@ -1249,8 +1255,9 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
 				bigTCPMock: bigTCPMock{
-					ipv4Enabled: tt.enableIPv4,
-					ipv6Enabled: tt.enableIPv6,
+					ipv4Enabled:   tt.enableIPv4,
+					ipv6Enabled:   tt.enableIPv6,
+					tunnelEnabled: tt.enableTunnel,
 				},
 			}
 


### PR DESCRIPTION
Don't fail hard when BIG TCP is requested in tunneling mode. Rather probe tso_max_size on the tunnel interface to check whether the kernel support for BIG TCP for UDP tunnels has landed. If so, set gso_max_size and co on the cilium_vxlan or cilium_geneve netdev as well.

```release-note
Support BIG TCP in tunneling mode, provided that kernel supports BIG TCP for UDP tunnels.
```
