### PR TITLE
Add support for multilevel subdomain prefix wildcard in DNS match pattern

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -351,6 +351,10 @@ communicating via the proxy must reconnect to re-establish connections.
 * The Socket LB tracing message format has been updated, you might briefly see parsing errors or malformed trace-sock events during the upgrade to Cilium v1.19.
 * The Cilium MCS-API implementation now raise a port conflict when any exported
   Service has ports that do not exactly match the oldest exported Service.
+* DNS Policies match pattern now support a wildcard prefix(``**.``) to match multilevel subdomains as pattern prefix. For usage see :ref:`DNS based` policies.
+  This change introduces a difference in behavior for existing policies with ``**.`` wildcard prefix in match patterns.
+  This pattern now selects all cascaded subdomains in prefix as opposed to just a single level. For example: ``**.cilium.io`` now selects both ``app.cilium.io`` and ``test.app.cilium.io`` as
+  opposed to just ``app.cilium.io`` previously.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -528,6 +528,9 @@ IPs to be allowed are selected via:
     ``part-extra-ial.com``.
   * ``*`` alone matches all names, and inserts all cached DNS IPs into this
     rule.
+  * ``**.`` is a special prefix supported in DNS match pattern to wildcard all cascaded
+    subdomains in the prefix. For example: ``**.cilium.io`` pattern will match both
+    ``app.cilium.io`` and ``test.app.cilium.io`` but not ``cilium.io``.
 
 The example below allows all DNS traffic on port 53 to the DNS service and
 intercepts it via the `DNS Proxy`_. If using a non-standard DNS port for
@@ -1340,5 +1343,5 @@ Host Policies known issues
   Policies on service addresses rather than the service endpoints. For details,
   refer to :gh-issue:`12545`.
 
-- Host Firewall and thus Host Policies do not work together with IPsec. 
+- Host Firewall and thus Host Policies do not work together with IPsec.
   For details, refer to :gh-issue:`41854`.

--- a/pkg/fqdn/matchpattern/matchpattern.go
+++ b/pkg/fqdn/matchpattern/matchpattern.go
@@ -4,7 +4,6 @@
 package matchpattern
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -13,11 +12,33 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/re"
 )
 
-const allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
+const (
+	// allowedDNSCharsREGroup is the regex group to match allowed characters in a DNS name.
+	allowedDNSCharsREGroup = "[-a-zA-Z0-9_]"
 
-// allowedPatternChars tests that the MatchPattern field contains only the
-// characters we want in our wildcard scheme.
-var allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
+	// dnsWildcardREGroup is the regex pattern for DNS wildcard specifier which matches one ore more
+	// entire DNS labels. This regex group matches following cases:
+	// * <dns-label>
+	// * <dns-label-1>.<dns-label-2>.<dns-label-3>
+	dnsWildcardREGroup = "(" + allowedDNSCharsREGroup + "+" + "([.]" + allowedDNSCharsREGroup + "+){0,})[.]"
+)
+
+var (
+	// dnsWildcardRegex is regular expression to match a DNS wildcard.
+	// For example this pattern will match: '*', '**', '**.', '***', '***.'
+	dnsWildcardRegex = regexp.MustCompile("^[*]{1,}[.]?$")
+
+	// allowedPatternChars tests that the MatchPattern field contains only the
+	// characters we want in our wildcard scheme.
+	allowedPatternChars = regexp.MustCompile("^[-a-zA-Z0-9_.*]+$") // the * inside the [] is a literal *
+
+	// subdomainWildcardSpecifierPrefix is the regular expression to match subdomain wildcard prefix in dns patterns.
+	// This regex will match '**[.]', '****[.]' and so on.
+	subdomainWildcardSpecifierPrefix = regexp.MustCompile(`^[*]{2,}\[\.\]`)
+
+	// wildcardSpecifier is the regular expression to match wildcard in DNS pattern.
+	wildcardSpecifier = regexp.MustCompile("[*]{1,}")
+)
 
 // MatchAllAnchoredPattern is the simplest pattern that match all inputs. This resulting
 // parsed regular expression is the same as an empty string regex (""), but this
@@ -52,19 +73,11 @@ func ValidateWithoutCache(pattern string) (matcher *regexp.Regexp, err error) {
 }
 
 func prevalidate(pattern string) error {
-	if len(pattern) > MaxFQDNLength {
+	if len(strings.TrimSpace(pattern)) > MaxFQDNLength {
 		return fmt.Errorf("Invalid MatchPattern: %q. Must be <= %d characters long.", pattern, MaxFQDNLength)
 	}
 	if len(pattern) > 0 && !allowedPatternChars.MatchString(pattern) {
-		return fmt.Errorf("Invalid characters in MatchPattern: \"%s\". Only 0-9, a-z, A-Z and ., - and * characters are allowed", pattern)
-	}
-
-	pattern = strings.TrimSpace(pattern)
-	pattern = strings.ToLower(pattern)
-
-	// error check
-	if strings.ContainsAny(pattern, "[]+{},") {
-		return errors.New(`Only alphanumeric ASCII characters, the hyphen "-", underscore "_", "." and "*" are allowed in a matchPattern`)
+		return fmt.Errorf("Invalid characters in MatchPattern: \"%s\". Only 0-9, a-z, A-Z and ., -, _ and * characters are allowed", pattern)
 	}
 
 	return nil
@@ -72,7 +85,7 @@ func prevalidate(pattern string) error {
 
 // Sanitize canonicalized the pattern for use by ToAnchoredRegexp
 func Sanitize(pattern string) string {
-	if pattern == "*" {
+	if dnsWildcardRegex.MatchString(pattern) {
 		return pattern
 	}
 
@@ -88,7 +101,7 @@ func ToAnchoredRegexp(pattern string) string {
 	pattern = strings.ToLower(pattern)
 
 	// handle the * match-all case. This will filter down to the end.
-	if pattern == "*" {
+	if dnsWildcardRegex.MatchString(pattern) {
 		return "(^(" + allowedDNSCharsREGroup + "+[.])+$)|(^[.]$)"
 	}
 
@@ -105,20 +118,27 @@ func ToAnchoredRegexp(pattern string) string {
 func ToUnAnchoredRegexp(pattern string) string {
 	pattern = strings.TrimSpace(pattern)
 	pattern = strings.ToLower(pattern)
+
 	// handle the * match-all case. This will filter down to the end.
-	if pattern == "*" {
+	if dnsWildcardRegex.MatchString(pattern) {
 		return MatchAllUnAnchoredPattern
 	}
+
 	pattern = escapeRegexpCharacters(pattern)
 	return pattern
 }
 
 func escapeRegexpCharacters(pattern string) string {
-	// base case. "." becomes a literal .
+	// Convert '.' in the match pattern as literal '.' for regex pattern.
 	pattern = strings.ReplaceAll(pattern, ".", "[.]")
 
-	// base case. * becomes .*, but only for DNS valid characters
-	// NOTE: this only works because the case above does not leave the *
-	pattern = strings.ReplaceAll(pattern, "*", allowedDNSCharsREGroup+"*")
+	// '**.' in match pattern prefix is a subdomain wildcard specifier which matches one ore more
+	// entire labels.
+	pattern = subdomainWildcardSpecifierPrefix.ReplaceAllString(pattern, dnsWildcardREGroup)
+
+	// Base case: * becomes .*, but only for DNS valid characters
+	// `*` wildcard matches all DNS characters within the subdomain boundary(doesn't include '.' literal)
+	pattern = wildcardSpecifier.ReplaceAllString(pattern, allowedDNSCharsREGroup+"*")
+
 	return pattern
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -448,17 +448,19 @@ spec:
                               the pattern. As a special case a "*" as the leftmost character, without a
                               following "." matches all subdomains as well as the name to the right.
                               A trailing "." is automatically added when missing.
+                              - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                               Examples:
-                              `*.cilium.io` matches subdomains of cilium at that level
+                              1. `*.cilium.io` matches subdomains of cilium at that level
                                 www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                              `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                              2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                 except those containing "." separator, subcilium.io and sub-cilium.io match,
                                 www.cilium.io and blog.cilium.io does not
-                              sub*.cilium.io matches subdomains of cilium where the subdomain component
-                              begins with "sub"
-                                sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                              3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                 blog.cilium.io, cilium.io and google.com do not
+                              4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                             maxLength: 255
                             pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                             type: string
@@ -764,17 +766,19 @@ spec:
                                         the pattern. As a special case a "*" as the leftmost character, without a
                                         following "." matches all subdomains as well as the name to the right.
                                         A trailing "." is automatically added when missing.
+                                        - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                         Examples:
-                                        `*.cilium.io` matches subdomains of cilium at that level
+                                        1. `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                        `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                        2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
                                           www.cilium.io and blog.cilium.io does not
-                                        sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                        begins with "sub"
-                                          sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                        3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                          begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                        4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                          "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                       maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
@@ -2417,17 +2421,19 @@ spec:
                                         the pattern. As a special case a "*" as the leftmost character, without a
                                         following "." matches all subdomains as well as the name to the right.
                                         A trailing "." is automatically added when missing.
+                                        - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                         Examples:
-                                        `*.cilium.io` matches subdomains of cilium at that level
+                                        1. `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                        `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                        2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
                                           www.cilium.io and blog.cilium.io does not
-                                        sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                        begins with "sub"
-                                          sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                        3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                          begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                        4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                          "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                       maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
@@ -3686,17 +3692,19 @@ spec:
                                 the pattern. As a special case a "*" as the leftmost character, without a
                                 following "." matches all subdomains as well as the name to the right.
                                 A trailing "." is automatically added when missing.
+                                - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                 Examples:
-                                `*.cilium.io` matches subdomains of cilium at that level
+                                1. `*.cilium.io` matches subdomains of cilium at that level
                                   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                   except those containing "." separator, subcilium.io and sub-cilium.io match,
                                   www.cilium.io and blog.cilium.io does not
-                                sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                begins with "sub"
-                                  sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                  begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                   blog.cilium.io, cilium.io and google.com do not
+                                4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                  "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                               maxLength: 255
                               pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                               type: string
@@ -4002,17 +4010,19 @@ spec:
                                           the pattern. As a special case a "*" as the leftmost character, without a
                                           following "." matches all subdomains as well as the name to the right.
                                           A trailing "." is automatically added when missing.
+                                          - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                           Examples:
-                                          `*.cilium.io` matches subdomains of cilium at that level
+                                          1. `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                          `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                          2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,
                                             www.cilium.io and blog.cilium.io does not
-                                          sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                          begins with "sub"
-                                            sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                          3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                            begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                          4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                            "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                         maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string
@@ -5657,17 +5667,19 @@ spec:
                                           the pattern. As a special case a "*" as the leftmost character, without a
                                           following "." matches all subdomains as well as the name to the right.
                                           A trailing "." is automatically added when missing.
+                                          - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                           Examples:
-                                          `*.cilium.io` matches subdomains of cilium at that level
+                                          1. `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                          `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                          2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,
                                             www.cilium.io and blog.cilium.io does not
-                                          sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                          begins with "sub"
-                                            sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                          3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                            begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                          4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                            "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                         maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -451,17 +451,19 @@ spec:
                               the pattern. As a special case a "*" as the leftmost character, without a
                               following "." matches all subdomains as well as the name to the right.
                               A trailing "." is automatically added when missing.
+                              - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                               Examples:
-                              `*.cilium.io` matches subdomains of cilium at that level
+                              1. `*.cilium.io` matches subdomains of cilium at that level
                                 www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                              `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                              2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                 except those containing "." separator, subcilium.io and sub-cilium.io match,
                                 www.cilium.io and blog.cilium.io does not
-                              sub*.cilium.io matches subdomains of cilium where the subdomain component
-                              begins with "sub"
-                                sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                              3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                 blog.cilium.io, cilium.io and google.com do not
+                              4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                             maxLength: 255
                             pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                             type: string
@@ -767,17 +769,19 @@ spec:
                                         the pattern. As a special case a "*" as the leftmost character, without a
                                         following "." matches all subdomains as well as the name to the right.
                                         A trailing "." is automatically added when missing.
+                                        - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                         Examples:
-                                        `*.cilium.io` matches subdomains of cilium at that level
+                                        1. `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                        `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                        2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
                                           www.cilium.io and blog.cilium.io does not
-                                        sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                        begins with "sub"
-                                          sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                        3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                          begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                        4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                          "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                       maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
@@ -2420,17 +2424,19 @@ spec:
                                         the pattern. As a special case a "*" as the leftmost character, without a
                                         following "." matches all subdomains as well as the name to the right.
                                         A trailing "." is automatically added when missing.
+                                        - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                         Examples:
-                                        `*.cilium.io` matches subdomains of cilium at that level
+                                        1. `*.cilium.io` matches subdomains of cilium at that level
                                           www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                        `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                        2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                           except those containing "." separator, subcilium.io and sub-cilium.io match,
                                           www.cilium.io and blog.cilium.io does not
-                                        sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                        begins with "sub"
-                                          sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                        3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                          begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                           blog.cilium.io, cilium.io and google.com do not
+                                        4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                          "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                       maxLength: 255
                                       pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                       type: string
@@ -3689,17 +3695,19 @@ spec:
                                 the pattern. As a special case a "*" as the leftmost character, without a
                                 following "." matches all subdomains as well as the name to the right.
                                 A trailing "." is automatically added when missing.
+                                - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                 Examples:
-                                `*.cilium.io` matches subdomains of cilium at that level
+                                1. `*.cilium.io` matches subdomains of cilium at that level
                                   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                   except those containing "." separator, subcilium.io and sub-cilium.io match,
                                   www.cilium.io and blog.cilium.io does not
-                                sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                begins with "sub"
-                                  sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                  begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                   blog.cilium.io, cilium.io and google.com do not
+                                4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                  "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                               maxLength: 255
                               pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                               type: string
@@ -4005,17 +4013,19 @@ spec:
                                           the pattern. As a special case a "*" as the leftmost character, without a
                                           following "." matches all subdomains as well as the name to the right.
                                           A trailing "." is automatically added when missing.
+                                          - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                           Examples:
-                                          `*.cilium.io` matches subdomains of cilium at that level
+                                          1. `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                          `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                          2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,
                                             www.cilium.io and blog.cilium.io does not
-                                          sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                          begins with "sub"
-                                            sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                          3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                            begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                          4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                            "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                         maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string
@@ -5660,17 +5670,19 @@ spec:
                                           the pattern. As a special case a "*" as the leftmost character, without a
                                           following "." matches all subdomains as well as the name to the right.
                                           A trailing "." is automatically added when missing.
+                                          - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 
                                           Examples:
-                                          `*.cilium.io` matches subdomains of cilium at that level
+                                          1. `*.cilium.io` matches subdomains of cilium at that level
                                             www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-                                          `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+                                          2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
                                             except those containing "." separator, subcilium.io and sub-cilium.io match,
                                             www.cilium.io and blog.cilium.io does not
-                                          sub*.cilium.io matches subdomains of cilium where the subdomain component
-                                          begins with "sub"
-                                            sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+                                          3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+                                            begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
                                             blog.cilium.io, cilium.io and google.com do not
+                                          4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+                                            "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
                                         maxLength: 255
                                         pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
                                         type: string

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -45,17 +45,19 @@ type FQDNSelector struct {
 	// the pattern. As a special case a "*" as the leftmost character, without a
 	// following "." matches all subdomains as well as the name to the right.
 	// A trailing "." is automatically added when missing.
+	// - "**." is a special prefix which matches all multilevel subdomains in the prefix.
 	//
 	// Examples:
-	// `*.cilium.io` matches subdomains of cilium at that level
+	// 1. `*.cilium.io` matches subdomains of cilium at that level
 	//   www.cilium.io and blog.cilium.io match, cilium.io and google.com do not
-	// `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
+	// 2. `*cilium.io` matches cilium.io and all subdomains ends with "cilium.io"
 	//   except those containing "." separator, subcilium.io and sub-cilium.io match,
 	//   www.cilium.io and blog.cilium.io does not
-	// sub*.cilium.io matches subdomains of cilium where the subdomain component
-	// begins with "sub"
-	//   sub.cilium.io and subdomain.cilium.io match, www.cilium.io,
+	// 3. `sub*.cilium.io` matches subdomains of cilium where the subdomain component
+	//   begins with "sub". sub.cilium.io and subdomain.cilium.io match while www.cilium.io,
 	//   blog.cilium.io, cilium.io and google.com do not
+	// 4. `**.cilium.io` matches all multilevel subdomains of cilium.io.
+	//   "app.cilium.io" and "test.app.cilium.io" match but not "cilium.io"
 	//
 	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern=`^([-a-zA-Z0-9_*]+[.]?)+$`
@@ -100,7 +102,7 @@ func (s *FQDNSelector) sanitize() error {
 		return fmt.Errorf("only one of MatchName or MatchPattern is allowed in an FQDNSelector")
 	}
 	if len(s.MatchName) > 0 && !allowedMatchNameChars.MatchString(s.MatchName) {
-		return fmt.Errorf("Invalid characters in MatchName: \"%s\". Only 0-9, a-z, A-Z and . and - characters are allowed", s.MatchName)
+		return fmt.Errorf("Invalid characters in MatchName: \"%s\". Only 0-9, a-z, A-Z and ., -, _ characters are allowed", s.MatchName)
 	}
 
 	_, err := matchpattern.Validate(s.MatchPattern)


### PR DESCRIPTION
See commit message for more details.

Original PR - https://github.com/cilium/cilium/pull/42871

```release-note
DNS Policies match pattern now support a wildcard prefix(`**.`) to match multilevel subdomain as pattern prefix. For example: `**.cilium.io` now selects both `app.cilium.io`` and `test.app.cilium.io`
```
