### PR TITLE
Makefile: use container's make for run_bpf_tests target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,7 @@ BPF_TEST_VERBOSE ?= 0
 
 run_bpf_tests: ## Build and run the BPF unit tests using the cilium-builder container image.
 	DOCKER_ARGS="--privileged -v /sys:/sys" RUN_AS_ROOT=1 contrib/scripts/builder.sh \
-		$(MAKE) $(SUBMAKEOPTS) -j$(shell nproc) -C bpf/tests/ run \
+		make $(SUBMAKEOPTS) -j$(shell nproc) -C bpf/tests/ run \
 			"BPF_TEST=$(BPF_TEST)" \
 			"BPF_TEST_DUMP_CTX=$(BPF_TEST_DUMP_CTX)" \
 			"LOG_CODEOWNERS=$(LOG_CODEOWNERS)" \


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

builder.sh executes commands inside a Docker container, so the make path should refer to the container's binary, not the host's.

When $(MAKE) is used, it expands to the host system's make path before being passed to builder.sh. On macOS, this results in paths like /Library/Developer/CommandLineTools/usr/bin/make, which don't exist inside the Linux container.

Use 'make' directly so that the container resolves it from its own PATH.

```
+ docker run --rm -v /Users/user/Library/Caches/go-build:/Users/user/Library/Caches/go-build -v /Users/user/go/pkg/mod:/Users/user/go/pkg/mod -v /tmp/.ccache:/tmp/.ccache -v /Users/user/cilium:/go/src/github.com/cilium/cilium -w /go/src/github.com/cilium/cilium --privileged -v /sys:/sys quay.io/cilium/cilium-builder:b937a6488e6baf994203fbce48ede4dde777142c@sha256:6d85c4863b721217f3977c921b7708b7c49c4fa0ee2f4463802eac6e97958d47 /Library/Developer/CommandLineTools/usr/bin/make -j12 -C bpf/tests/ run BPF_TEST= BPF_TEST_DUMP_CTX= LOG_CODEOWNERS= JUNIT_PATH= V=0
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/Library/Developer/CommandLineTools/usr/bin/make": stat /Library/Developer/CommandLineTools/usr/bin/make: no such file or directory
```