### PR TITLE
daemon: split daemonCell

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -141,9 +141,6 @@ var (
 		// Provides cilium_bpf_ratelimit_dropped_total Prometheus metric.
 		ratelimitmap.Cell,
 
-		// Provide option.Config via hive so cells can depend on the agent config.
-		cell.Provide(func() *option.DaemonConfig { return option.Config }),
-
 		// Cilium API served over UNIX sockets. Accessed by the 'cilium' utility (not cilium-cli).
 		server.Cell,
 		cell.Invoke(configureAPIServer),
@@ -178,6 +175,12 @@ var (
 
 		// IP allocation and creation of agents infrastructure endpoints (host, health & ingress)
 		infraendpoints.Cell,
+
+		// Syncs local host entries to the lxc/endpoints BPF map and IPCache
+		hostIPSyncCell,
+
+		// Endpoint restoration at agent startup
+		endpointRestoreCell,
 
 		// LocalNodeStore holds onto the information about the local node and allows
 		// observing changes to it.
@@ -222,6 +225,9 @@ var (
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,
+
+		// daemonConfigCell wraps legacy daemonconfig initialization and provides *option.DaemonConfig and Promise[*option.DaemonConfig]
+		daemonConfigCell,
 
 		// Maglev table computtations
 		maglev.Cell,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1175,14 +1175,26 @@ var daemonCell = cell.Module(
 	"daemon",
 	"Legacy Daemon",
 
+	cell.Provide(daemonLegacyInitialization),
+	cell.Invoke(func(_ legacy.DaemonInitialization) {}), // Force initialization.
+)
+
+// daemonConfigCell provides the DaemonConfig that contains properties
+// that haven't yet been refactored to use module specific configs.
+var daemonConfigCell = cell.Module(
+	"daemonconfig",
+	"Provides and initializes global DaemonConfig",
+
 	cell.Provide(
+		// Initialize unsafe daemonconfig properties that depend on values of other configs.
 		daemonConfigInitialization,
-		daemonLegacyInitialization,
+		// Provide promise that can be used to await initialization of unsafe daemonconfig properties.
 		promise.New[*option.DaemonConfig],
-		newSyncHostIPs,
+		// Provide option.Config via hive so cells can depend on the agent config.
+		// It's not safe to access unsafe daemonconfig properties. Either use the promise or depend on legacy.DaemonConfigInitialization.
+		func() *option.DaemonConfig { return option.Config },
 	),
-	cell.Invoke(func(_ legacy.DaemonInitialization) {}), // Force instantiation.
-	endpointRestoreCell,
+	cell.Invoke(func(_ legacy.DaemonConfigInitialization) {}), // Force initialization.
 )
 
 type daemonConfigParams struct {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -132,7 +132,6 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 			},
 			func() kvstore.Config { return kvstore.Config{KVStore: kvstore.EtcdBackendName} },
 			func() kvstore.Client { return client },
-			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() ctmap.GCRunner { return ctmap.NewFakeGCRunner() },
 			func() policymap.Factory { return nil },

--- a/daemon/cmd/hostips-sync.go
+++ b/daemon/cmd/hostips-sync.go
@@ -29,6 +29,13 @@ import (
 
 const syncHostIPsInterval = time.Minute
 
+var hostIPSyncCell = cell.Module(
+	"hostip-sync",
+	"Syncs local host entries to the endpoints BPF map and IPCache",
+
+	cell.Provide(newSyncHostIPs),
+)
+
 type syncHostIPsParams struct {
 	cell.In
 

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -74,7 +74,6 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 			func() (_ statedbReconciler.Reconciler[*reconciler.DesiredRoute]) { return nil },
 			func() k8sClient.Clientset { return clientset },
 			func() k8sClient.Config { return clientset.Config() },
-			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
 			func() ctmap.GCRunner { return ctmap.NewFakeGCRunner() },
 			func() policymap.Factory { return nil },


### PR DESCRIPTION
This commit splits the daemonCell.

* separate cell for `DaemonConfig` aspects (init, provide config & promise)
* introduce `hostIPSyncCell` and register directly in agent controlplane cell
* register `endpointRestoreCell` directly in agent controlplane cell

Follow up of https://github.com/cilium/cilium/pull/42625 that separated the daemonconfig init/validation logic from the legacy daemon init logic