### PR TITLE
v1.18 Backports 2025-12-18

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -14,8 +14,7 @@ jobs:
     if: ${{
          github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
          (github.triggering_actor == 'cilium-renovate[bot]' ||
-          github.triggering_actor == 'auto-committer[bot]') &&
-         github.event.requested_reviewer.login == 'ciliumbot'
+          github.triggering_actor == 'auto-committer[bot]')
         }}
     steps:
     - name: Debug
@@ -45,8 +44,7 @@ jobs:
       if: ${{
            github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
            (github.triggering_actor == 'cilium-renovate[bot]' ||
-            github.triggering_actor == 'auto-committer[bot]') &&
-           github.event.requested_reviewer.login == 'ciliumbot'
+            github.triggering_actor == 'auto-committer[bot]')
           }}
       env:
         TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}
@@ -56,10 +54,19 @@ jobs:
         echo ${TOKEN} | gh auth login --with-token
         gh -R ${GITHUB_REPOSITORY} pr review ${PULL_REQUEST_NUMBER} --approve
 
-        echo "Remove other reviewers except ciliumbot to avoid noise"
-        reviewers=$(gh -R ${GITHUB_REPOSITORY} pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
-        for reviewer in $reviewers; do
-          if [ "$reviewer" != "ciliumbot" ]; then
-            gh -R ${GITHUB_REPOSITORY} pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"
-          fi
-        done
+        # Check if ciliumbot was requested by cilium-renovate[bot] from the events list
+        echo "Checking if ciliumbot was requested by cilium-renovate[bot]..."
+        ciliumbot_requested_by_renovate=$(gh api "/repos/${GITHUB_REPOSITORY}/issues/${PULL_REQUEST_NUMBER}/events" --paginate --jq '[.[] | select(.event == "review_requested" and .requested_reviewer.login == "ciliumbot" and .actor.login == "cilium-renovate[bot]")] | length > 0')
+
+        if [ "$ciliumbot_requested_by_renovate" == "true" ]; then
+          echo "ciliumbot was requested by cilium-renovate[bot], removing other reviewers to avoid noise"
+          reviewers=$(gh -R ${GITHUB_REPOSITORY} pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
+          for reviewer in $reviewers; do
+            if [ "$reviewer" != "ciliumbot" ]; then
+              echo "Removing reviewer $reviewer"
+              gh -R ${GITHUB_REPOSITORY} pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"
+            fi
+          done
+        else
+          echo "ciliumbot was not requested by cilium-renovate[bot], keeping all reviewers"
+        fi

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumidentitites.txtar
@@ -16,7 +16,7 @@ kvstore/list -o plain cilium/state/identities identities-1+2.actual
 
 # Update one of the CiliumIdentities
 cp identity-1.yaml identity-1-v2.yaml
-replace 'foo' 'fred' identity-1-v2.yaml
+replace 'baz' 'fred' identity-1-v2.yaml
 k8s/update identity-1-v2.yaml
 
 # Wait for synchronization
@@ -58,32 +58,30 @@ apiVersion: cilium.io/v2
 kind: CiliumIdentity
 metadata:
   name: "199472"
-  labels:
-    io.kubernetes.pod.namespace: foo
 security-labels:
   k8s:app: baz
   k8s:io.cilium.k8s.policy.cluster: cluster3
-  k8s:io.kubernetes.pod.namespace: bar
+  k8s:io.kubernetes.pod.namespace: foo
 
 -- identities-1+2.expected --
 # cilium/state/identities/v1/id/196915
 k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/199472
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=foo;
 -- identities-1+2-v2.expected --
 # cilium/state/identities/v1/id/196915
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=fred;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/199472
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=foo;
 -- identities-1+2+3.expected --
 # cilium/state/identities/v1/id/196915
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=fred;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/199472
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=foo;
 # cilium/state/identities/v1/id/214794
 k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 -- identities-1+3.expected --
 # cilium/state/identities/v1/id/196915
-k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
+k8s:app=fred;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;
 # cilium/state/identities/v1/id/214794
 k8s:app=baz;k8s:io.cilium.k8s.policy.cluster=cluster3;k8s:io.kubernetes.pod.namespace=bar;

--- a/examples/policies/l3/egress-deny/egress-deny.yaml
+++ b/examples/policies/l3/egress-deny/egress-deny.yaml
@@ -1,0 +1,15 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "deny-egress-example"
+spec:
+  endpointSelector:
+    matchLabels:
+      role: frontend
+  egress:
+  - toEntities:
+    - all
+  egressDeny:
+  - toEndpoints:
+    - matchLabels:
+        role: backend

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -477,7 +477,8 @@ func (k *kvstoreBackend) RunGC(
 			continue
 		}
 
-		if identityID, err := strconv.ParseUint(items[len(items)-1], 10, 64); err != nil {
+		identity := items[len(items)-1]
+		if identityID, err := strconv.ParseUint(identity, 10, 64); err != nil {
 			k.logger.Warn(
 				"Parse identity failed, skipping",
 				logfields.Error, err,
@@ -520,8 +521,8 @@ func (k *kvstoreBackend) RunGC(
 		}
 
 		hasUsers := false
-		for prefix := range pairs {
-			if prefixMatchesKey(valueKeyPrefix, prefix) {
+		for prefix, id := range pairs {
+			if prefixMatchesKey(valueKeyPrefix, prefix) && identity == string(id.Data) {
 				hasUsers = true
 				break
 			}


### PR DESCRIPTION
 * [x] #40272 (@syedazeez337) :warning: resolved conflicts
 * [x] #42952 (@aanm)
 * [x] #43287 (@giorio94)
 * [x] #43372 (@giorio94)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 40272 42952 43095 42414 43287 43372
```

Dropped #43095 : multiple issue, set.go in pkg/labels do not exist in v1.18, same for types.Match
Dropped #42414 : was already backported apparently