### PR TITLE
Enable renovate to manage `Documentation` requirements

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,7 @@
     ".github/actions/ipsec/configs.yaml",
     ".github/workflows/**",
     ".github/ISSUE_TEMPLATE/bug_report.yaml",
+    "Documentation/requirements-min/requirements.txt",
     "cilium-cli/**",
     "images/**",
     "examples/hubble/*",
@@ -109,6 +110,7 @@
     "^make -C install/kubernetes$",
     "^make -C Documentation update-helm-values$",
     "^make -C Documentation update-cmdref$",
+    "^make -C Documentation update-requirements$",
     "^make generate-k8s-api$",
     "^make manifests$",
     "^make GO='contrib/scripts/builder.sh go' generate-apis$"
@@ -605,6 +607,30 @@
         ],
         "executionMode": "update"
       }
+    },
+    {
+      "matchFileNames": [
+        "Documentation/requirements-min/requirements.txt"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "make -C Documentation update-requirements"
+        ],
+        "fileFilters": [
+          "Documentation/requirements.txt"
+        ],
+        "executionMode": "update"
+      }
+    },
+    {
+      // Only allow minor and patch updates for Documentation dependencies, no major updates
+      "enabled": false,
+      "matchFileNames": [
+        "Documentation/requirements-min/requirements.txt"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ]
     },
     {
       // k8s dependencies will be updated manually along with tests


### PR DESCRIPTION
I was initially looking to update `Documentation` dependencies in order to bump `urllib3` to get rid of a couple vulnerability warnings ([CVE-2025-66418](https://github.com/advisories/GHSA-gm62-xv2j-4w53) and [CVE-2025-66471](https://github.com/advisories/GHSA-2xpw-w6gg-jr37)) but I figured it would be more efficient to just hook renovate to manage those directly.

CC @cilium/docs-structure 