### PR TITLE
[v1.18] route: install ingress proxy routes with WireGuard and L7Proxy

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -55,12 +55,7 @@ var (
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
 func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu int) error {
-	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
-
-	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
-	if !fromIngressProxy || !fromEgressProxy {
-		mtu = 0
-	}
+	fromIngressProxy, fromEgressProxy, mtu := requireFromProxyRoutes(mtu)
 
 	if option.Config.EnableIPv4 {
 		if err := installToProxyRoutesIPv4(logger); err != nil {
@@ -115,9 +110,14 @@ func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu in
 	return nil
 }
 
-func requireFromProxyRoutes() (fromIngressProxy, fromEgressProxy bool) {
+func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, mtu int) {
 	fromIngressProxy = (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
 	fromEgressProxy = option.Config.EnableIPSec && !option.Config.TunnelingEnabled()
+
+	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
+	if fromIngressProxy && fromEgressProxy {
+		mtu = mtuIn
+	}
 	return
 }
 

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -118,6 +118,8 @@ func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu in
 //     hair-pinning traffic in Ingress L7 proxy (i.e. backend is in the same node).
 //   - Native routing + IPSec: install Ingress+Egress routes for (a) the same reason
 //     as above, and also to account for XFRM overhead on proxy-to-proxy connections.
+//   - Native routing + WireGuard: install only Ingress routes to account for WireGuard
+//     overhead on reply packets from Ingress L7 proxy in proxy-to-proxy connections.
 func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, mtu int) {
 	if option.Config.TunnelingEnabled() {
 		return
@@ -129,6 +131,9 @@ func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, 
 	case option.Config.EnableIPSec:
 		fromIngressProxy = true
 		fromEgressProxy = true
+		mtu = mtuIn
+	case option.Config.EnableWireguard:
+		fromIngressProxy = true
 		mtu = mtuIn
 	}
 	return

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -110,12 +110,25 @@ func ReinstallRoutingRules(logger *slog.Logger, localNode node.LocalNode, mtu in
 	return nil
 }
 
+// requireFromProxyRoutes determines whether routes from the proxy are needed,
+// and selects the appropriate MTU to set on those routes.
+//
+// Conditions for proxy routes:
+//   - Native routing + Envoy: install only Ingress routes to handle reply packet of
+//     hair-pinning traffic in Ingress L7 proxy (i.e. backend is in the same node).
+//   - Native routing + IPSec: install Ingress+Egress routes for (a) the same reason
+//     as above, and also to account for XFRM overhead on proxy-to-proxy connections.
 func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, mtu int) {
-	fromIngressProxy = (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
-	fromEgressProxy = option.Config.EnableIPSec && !option.Config.TunnelingEnabled()
-
-	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
-	if fromIngressProxy && fromEgressProxy {
+	if option.Config.TunnelingEnabled() {
+		return
+	}
+	if option.Config.EnableEnvoyConfig {
+		fromIngressProxy = true
+	}
+	switch {
+	case option.Config.EnableIPSec:
+		fromIngressProxy = true
+		fromEgressProxy = true
 		mtu = mtuIn
 	}
 	return


### PR DESCRIPTION
 * #42835 (@smagnani96)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42835
```