### PR TITLE
[v1.17] route: install ingress proxy routes with WireGuard and L7Proxy

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -54,12 +54,7 @@ var (
 // ReinstallRoutingRules ensures the presence of routing rules and tables needed
 // to route packets to and from the L7 proxy.
 func ReinstallRoutingRules(mtu int) error {
-	fromIngressProxy, fromEgressProxy := requireFromProxyRoutes()
-
-	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
-	if !fromIngressProxy || !fromEgressProxy {
-		mtu = 0
-	}
+	fromIngressProxy, fromEgressProxy, mtu := requireFromProxyRoutes(mtu)
 
 	if option.Config.EnableIPv4 {
 		if err := installToProxyRoutesIPv4(); err != nil {
@@ -114,9 +109,14 @@ func ReinstallRoutingRules(mtu int) error {
 	return nil
 }
 
-func requireFromProxyRoutes() (fromIngressProxy, fromEgressProxy bool) {
+func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, mtu int) {
 	fromIngressProxy = (option.Config.EnableEnvoyConfig || option.Config.EnableIPSec) && !option.Config.TunnelingEnabled()
 	fromEgressProxy = option.Config.EnableIPSec && !option.Config.TunnelingEnabled()
+
+	// Use the provided mtu (RouteMTU) only with both ingress and egress proxy.
+	if fromIngressProxy && fromEgressProxy {
+		mtu = mtuIn
+	}
 	return
 }
 

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -117,6 +117,8 @@ func ReinstallRoutingRules(mtu int) error {
 //     hair-pinning traffic in Ingress L7 proxy (i.e. backend is in the same node).
 //   - Native routing + IPSec: install Ingress+Egress routes for (a) the same reason
 //     as above, and also to account for XFRM overhead on proxy-to-proxy connections.
+//   - Native routing + WireGuard: install only Ingress routes to account for WireGuard
+//     overhead on reply packets from Ingress L7 proxy in proxy-to-proxy connections.
 func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, mtu int) {
 	if option.Config.TunnelingEnabled() {
 		return
@@ -128,6 +130,9 @@ func requireFromProxyRoutes(mtuIn int) (fromIngressProxy, fromEgressProxy bool, 
 	case option.Config.EnableIPSec:
 		fromIngressProxy = true
 		fromEgressProxy = true
+		mtu = mtuIn
+	case option.Config.EnableWireguard:
+		fromIngressProxy = true
 		mtu = mtuIn
 	}
 	return


### PR DESCRIPTION
 * #42835 (@smagnani96)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 42835
```