### PR TITLE
network driver: collect CiliumNetworkDriverConfigs in sysdump

### DIFF
--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -117,6 +117,7 @@ const (
 	referenceGrantsFileName                  = "gatewayapi-referencegrants-<ts>.yaml"
 	ingressClassesFileName                   = "ingressclasses-<ts>.yaml"
 	k8sResourceFileName                      = "%s-<ts>.yaml"
+	ciliumNetworkDriverConfigFileName        = "cilium-network-driver-configs-<ts>.yaml"
 )
 
 const (

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1484,6 +1484,21 @@ func (c *Collector) Run() error {
 				return fmt.Errorf("could not find running Cilium Pod")
 			},
 		},
+		{
+			Description: "Collecting CiliumNetworkDriverConfig resources",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				return c.GatherResourceUnstructured(
+					ctx,
+					schema.GroupVersionResource{
+						Group:    "cilium.io",
+						Resource: "ciliumnetworkdriverconfigs",
+						Version:  "v2alpha1",
+					},
+					ciliumNetworkDriverConfigFileName,
+				)
+			},
+		},
 	}
 	ciliumTasks = append(ciliumTasks, collectCiliumV2OrV2Alpha1Resource(c, "ciliumloadbalancerippools", "Cilium LoadBalancer IP Pools"))
 


### PR DESCRIPTION
collect the CRD for the network driver configuration with the sysdump command

```
» cat cilium-sysdump-20251218-152137/cilium-network-driver-configs-20251218-152137.yaml
apiVersion: cilium.io/v2alpha1
items:
- apiVersion: cilium.io/v2alpha1
  kind: CiliumNetworkDriverConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cilium.io/v2alpha1","kind":"CiliumNetworkDriverConfig","metadata":{"annotations":{},"name":"cilium-network-driver-config"},"spec":{"driverName":"sriov.cilium.k8s.io"}}
    creationTimestamp: "2025-12-18T15:21:33Z"
    generation: 1
    managedFields:
    - apiVersion: cilium.io/v2alpha1
      fieldsType: FieldsV1
      fieldsV1:
        f:metadata:
          f:annotations:
            .: {}
            f:kubectl.kubernetes.io/last-applied-configuration: {}
        f:spec:
          .: {}
          f:driverName: {}
      manager: kubectl-client-side-apply
      operation: Update
      time: "2025-12-18T15:21:33Z"
    name: cilium-network-driver-config
    resourceVersion: "1723"
    uid: ba412313-2aac-49ed-b69e-477b3d7f33a7
  spec:
    driverName: sriov.cilium.k8s.io
kind: CiliumNetworkDriverConfigList
metadata:
  resourceVersion: "1738"
```

```release-note
Collect CiliumNetworkDriverConfig on sysdump
```
