### PR TITLE
[41867] Part 3: Add subnet config watcher with stateDB and BPF map sync

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -674,6 +674,7 @@ Makefile* @cilium/build
 /pkg/source @cilium/ipcache
 /pkg/spanstat/ @cilium/sig-agent
 /pkg/status/ @cilium/sig-agent
+/pkg/subnet/ @cilium/sig-datapath
 /pkg/svcrouteconfig/ @cilium/sig-datapath @cilium/sig-bgp
 /pkg/testutils/ @cilium/ci-structure
 /pkg/testutils/scriptnet @cilium/sig-foundations

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -84,6 +84,7 @@ import (
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/cilium/cilium/pkg/subnet"
 	"github.com/cilium/cilium/pkg/svcrouteconfig"
 	"github.com/cilium/cilium/pkg/ztunnel"
 )
@@ -366,6 +367,9 @@ var (
 
 		// Instantiates an xDS server used for zTunnel integration.
 		ztunnel.Cell,
+
+		// Subnet topology watcher and management.
+		subnet.Cell,
 	)
 )
 

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/maps/subnet"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
@@ -140,6 +142,9 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 				return &loadbalancer.TestConfig{}
 			},
 			func() *server.Server { return nil },
+			func() statedb.RWTable[subnet.SubnetTableEntry] {
+				return nil
+			},
 		),
 		fakeDatapath.Cell,
 		neighbor.ForwardableIPCell,

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
+	"github.com/cilium/cilium/pkg/maps/subnet"
 	"github.com/cilium/cilium/pkg/maps/vtep"
 )
 
@@ -97,6 +98,9 @@ var Cell = cell.Module(
 
 	// Provides access to the vtep map.
 	vtep.Cell,
+
+	// Provides access to the subnet map.
+	subnet.Cell,
 )
 
 type mapApiHandlerOut struct {

--- a/pkg/maps/subnet/cell.go
+++ b/pkg/maps/subnet/cell.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell manages subnet routing information for hybrid routing mode.
+//
+// This cell provides:
+//   - A BPF map that stores subnet-to-identity mappings
+//   - A StateDB table for tracking subnet configurations from users
+//   - A reconciler that syncs the table to the BPF map
+//
+// The BPF map is used by the datapath to look up subnets and determine
+// whether to use tunnel (encapsulation) or native (direct) routing for
+// packets sent to those subnets. This enables different subnets to use
+// different routing modes in the same cluster.
+// The cell is only active when routing mode is set to hybrid.
+var Cell = cell.Module(
+	"subnet-map",
+	"Manages the subnet to identity BPF map",
+
+	cell.Provide(
+		newSubnetMap,        // eBPF map
+		newSubnetEntryTable, // StateDB table
+		statedb.RWTable[SubnetTableEntry].ToTable,
+
+		scriptCommands, // Script commands
+	),
+	cell.Invoke(
+		registerReconciler,
+		bpf.RegisterTablePressureMetricsJob[SubnetTableEntry, subnetMap],
+	),
+)
+
+func registerReconciler(cfg *option.DaemonConfig, params reconciler.Params, st statedb.RWTable[SubnetTableEntry], m subnetMap) error {
+	if cfg.RoutingMode != option.RoutingModeHybrid {
+		params.Log.Debug("Routing mode is not hybrid, skipping subnet map reconciler registration")
+		return nil
+	}
+	params.Log = params.Log.With(
+		logfields.BPFMapName, MapName,
+		logfields.Table, TableName,
+	)
+
+	ops := bpf.NewMapOps[SubnetTableEntry](m.Map)
+	_, err := reconciler.Register(
+		params,
+		st,
+		SubnetTableEntry.clone,
+		SubnetTableEntry.setStatus,
+		SubnetTableEntry.getStatus,
+		ops, // Reconciliation operations.
+		nil, // No batch ops defined.
+	)
+	params.Log.Info("Registered reconciler")
+	return err
+}

--- a/pkg/maps/subnet/cmds.go
+++ b/pkg/maps/subnet/cmds.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+)
+
+type scriptCommandsParams struct {
+	cell.In
+
+	SubnetMap subnetMap
+}
+
+func scriptCommands(p scriptCommandsParams) hive.ScriptCmdsOut {
+	cmds := map[string]script.Cmd{
+		"subnet/map-dump": subnetMapDumpCommand(p.SubnetMap),
+	}
+
+	return hive.NewScriptCmds(cmds)
+}
+
+func subnetMapDumpCommand(m subnetMap) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Dump the subnet BPF map",
+			Args:    "(output file)",
+			Detail: []string{
+				"This dumps the subnet BPF map either to stdout or to a file.",
+				"Each BPF map key-value is shown as one line, e.g.:",
+				"PREFIX=10.0.0.1/24 IDENTITY=1234",
+				"This command is for testing and debugging purposes only.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				out := dumpSubnetMap(m)
+				if len(args) == 1 {
+					err = os.WriteFile(s.Path(args[0]), []byte(out), 0644)
+				} else {
+					stdout = out
+				}
+				return
+			}, nil
+		},
+	)
+}
+
+func dumpSubnetMap(m subnetMap) string {
+	// Iterate through all map entries.
+	data := make(map[string][]string)
+	m.Map.DumpIfExists(data)
+
+	// Sort by IP prefix for stable output.
+	keys := slices.Sorted(maps.Keys(data))
+
+	var result strings.Builder
+	for _, k := range keys {
+		result.WriteString(fmt.Sprintf("PREFIX=%s IDENTITY=%s\n", k, data[k][0]))
+	}
+	return result.String()
+}

--- a/pkg/maps/subnet/subnet.go
+++ b/pkg/maps/subnet/subnet.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"unsafe"
+
+	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+const (
+	// MapName is the name of the subnet map.
+	MapName = "cilium_subnet_map"
+
+	// MaxEntries is the maximum number of keys that can be present in the
+	// subnet map.
+	MaxEntries = 1024
+
+	SubnetKeyIPv4 uint8 = 1
+	SubnetKeyIPv6 uint8 = 2
+)
+
+// SubnetMapKey implements the bpf.MapKey interface.
+// Must be in sync with struct subnet_key in <bpf/lib/subnet.h>
+type SubnetMapKey struct {
+	Prefixlen uint32     `align:"lpm_key"`
+	Pad0      uint16     `align:"pad0"`
+	Pad1      uint8      `align:"pad1"`
+	Family    uint8      `align:"family"`
+	IP        types.IPv6 `align:"$union0"`
+}
+
+// getStaticPrefixBits returns the number of bits in the Prefixlen field
+// that are not part of the actual subnet prefix, i.e., the bits used for
+// static fields in the SubnetMapKey struct.
+func getStaticPrefixBits() uint32 {
+	staticMatchSize := unsafe.Sizeof(SubnetMapKey{})
+	staticMatchSize -= unsafe.Sizeof(SubnetMapKey{}.Prefixlen)
+	staticMatchSize -= unsafe.Sizeof(SubnetMapKey{}.IP)
+	return uint32(staticMatchSize) * 8
+}
+
+func (k SubnetMapKey) String() string {
+	var (
+		addr netip.Addr
+		ok   bool
+	)
+
+	switch k.Family {
+	case SubnetKeyIPv4:
+		addr, ok = netip.AddrFromSlice(k.IP[:net.IPv4len])
+		if !ok {
+			return "<unknown>"
+		}
+	case SubnetKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	default:
+		return "<unknown>"
+	}
+
+	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
+	return netip.PrefixFrom(addr, prefixLen).String()
+}
+
+func (k *SubnetMapKey) New() bpf.MapKey { return &SubnetMapKey{} }
+
+func (k SubnetMapKey) Prefix() netip.Prefix {
+	var addr netip.Addr
+	prefixLen := int(k.Prefixlen - getStaticPrefixBits())
+	switch k.Family {
+	case SubnetKeyIPv4:
+		addr = netip.AddrFrom4(*(*[4]byte)(k.IP[:4]))
+	case SubnetKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	}
+	return netip.PrefixFrom(addr, prefixLen)
+}
+
+// getPrefixLen determines the length that should be set inside the Key so that
+// the lookup prefix is correct in the BPF map key. The specified 'prefixBits'
+// indicates the number of bits in the IP that must match to match the entry in
+// the BPF subnet map.
+func getPrefixLen(prefixBits int) uint32 {
+	return getStaticPrefixBits() + uint32(prefixBits)
+}
+
+// SubnetMapValue implements the bpf.MapValue interface.
+// Must be in sync with struct subnet_value in <bpf/lib/subnet.h>
+type SubnetMapValue struct {
+	Identity uint32 `align:"identity"`
+}
+
+func (v *SubnetMapValue) String() string {
+	return fmt.Sprintf("identity=%d", v.Identity)
+}
+
+func (v *SubnetMapValue) New() bpf.MapValue { return &SubnetMapValue{} }
+
+// NewValue returns a Value based on the provided identity.
+func NewValue(identity uint32) SubnetMapValue {
+	return SubnetMapValue{
+		Identity: identity,
+	}
+}
+
+type subnetMap struct {
+	*bpf.Map
+}
+
+// SubnetMap constructs the cilium_subnet_map. Direct use of this
+// outside of this package is solely for cilium-dbg.
+func SubnetMap() *bpf.Map {
+	return bpf.NewMap(
+		MapName,
+		ebpf.LPMTrie,
+		&SubnetMapKey{},
+		&SubnetMapValue{},
+		MaxEntries,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG,
+	)
+}
+
+func newSubnetMap(cfg *option.DaemonConfig, lc cell.Lifecycle) (out bpf.MapOut[subnetMap]) {
+	m := subnetMap{SubnetMap()}
+	if cfg.RoutingMode == option.RoutingModeHybrid {
+		lc.Append(cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				// We want to recreate the map in case schema has changed.
+				return m.Recreate()
+			},
+			OnStop: func(cell.HookContext) error {
+				return m.Close()
+			},
+		})
+	}
+	return bpf.NewMapOut(m)
+}

--- a/pkg/maps/subnet/subnet_test.go
+++ b/pkg/maps/subnet/subnet_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+func TestKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		key            SubnetMapKey
+		expectedString string
+		expectedPrefix netip.Prefix
+	}{
+		{
+			name: "IPv4 /24",
+			key: SubnetMapKey{
+				Prefixlen: getPrefixLen(24),
+				Family:    bpf.EndpointKeyIPv4,
+				IP:        types.IPv6{192, 168, 1, 0},
+			},
+			expectedString: "192.168.1.0/24",
+			expectedPrefix: netip.MustParsePrefix("192.168.1.0/24"),
+		},
+		{
+			name: "IPv4 /32",
+			key: SubnetMapKey{
+				Prefixlen: getPrefixLen(32),
+				Family:    bpf.EndpointKeyIPv4,
+				IP:        types.IPv6{10, 0, 0, 1},
+			},
+			expectedString: "10.0.0.1/32",
+			expectedPrefix: netip.MustParsePrefix("10.0.0.1/32"),
+		},
+		{
+			name: "IPv4 /16",
+			key: SubnetMapKey{
+				Prefixlen: getPrefixLen(16),
+				Family:    bpf.EndpointKeyIPv4,
+				IP:        types.IPv6{10, 20, 0, 0},
+			},
+			expectedString: "10.20.0.0/16",
+			expectedPrefix: netip.MustParsePrefix("10.20.0.0/16"),
+		},
+		{
+			name: "IPv6 /64",
+			key: SubnetMapKey{
+				Prefixlen: getPrefixLen(64),
+				Family:    bpf.EndpointKeyIPv6,
+				IP:        types.IPv6{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			},
+			expectedString: "2001:db8::/64",
+			expectedPrefix: netip.MustParsePrefix("2001:db8::/64"),
+		},
+		{
+			name: "IPv6 /128",
+			key: SubnetMapKey{
+				Prefixlen: getPrefixLen(128),
+				Family:    bpf.EndpointKeyIPv6,
+				IP:        types.IPv6{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			},
+			expectedString: "2001:db8::1/128",
+			expectedPrefix: netip.MustParsePrefix("2001:db8::1/128"),
+		},
+		{
+			name: "Unknown family",
+			key: SubnetMapKey{
+				Prefixlen: getPrefixLen(24),
+				Family:    99,
+				IP:        types.IPv6{192, 168, 1, 0},
+			},
+			expectedString: "<unknown>",
+			expectedPrefix: netip.Prefix{}, // zero value for unknown family
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedString, tt.key.String())
+			assert.Equal(t, tt.expectedPrefix, tt.key.Prefix())
+		})
+	}
+}

--- a/pkg/maps/subnet/table.go
+++ b/pkg/maps/subnet/table.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"encoding"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+const TableName = "subnet-identities"
+
+type SubnetTableEntry struct {
+	Key netip.Prefix
+
+	// Identity is the uint64 identifier associated with this subnet.
+	Value uint32
+
+	// Status represents the reconciliation status of the subnet entry.
+	Status reconciler.Status
+}
+
+func NewSubnetEntry(key netip.Prefix, value uint32) SubnetTableEntry {
+	return SubnetTableEntry{
+		Key:    key,
+		Value:  value,
+		Status: reconciler.StatusPending(),
+	}
+}
+
+// TableHeader returns the header for the table representation of SubnetEntry.
+func (s SubnetTableEntry) TableHeader() []string {
+	return []string{"Prefix", "Identity"}
+}
+
+// TableRow returns the row representation of SubnetEntry.
+func (s SubnetTableEntry) TableRow() []string {
+	return []string{s.Key.String(), fmt.Sprintf("%d", s.Value)}
+}
+
+// clone returns a shallow copy of the SubnetTableEntry.
+func (s SubnetTableEntry) clone() SubnetTableEntry {
+	return SubnetTableEntry{
+		Key:    s.Key,
+		Value:  s.Value,
+		Status: s.Status,
+	}
+}
+
+// setStatus sets the reconciliation status and returns the updated entry.
+func (s SubnetTableEntry) setStatus(status reconciler.Status) SubnetTableEntry {
+	s.Status = status
+	return s
+}
+
+// getStatus returns the current reconciliation status.
+func (s SubnetTableEntry) getStatus() reconciler.Status {
+	return s.Status
+}
+
+// BinaryKey returns the binary representation of the subnet prefix for the eBPF map key.
+func (s SubnetTableEntry) BinaryKey() encoding.BinaryMarshaler {
+	var ip types.IPv6
+	var family uint8
+
+	// Convert netip.Prefix to SubnetMapKey
+	addr := s.Key.Addr()
+
+	// Copy the IP address bytes into the IPv6 array
+	if addr.Is4() {
+		// For IPv4, copy to the last 4 bytes (IPv4-mapped IPv6 format)
+		ipv4 := addr.As4()
+		copy(ip[:], ipv4[:])
+		family = bpf.EndpointKeyIPv4
+	} else {
+		// For IPv6, copy all 16 bytes
+		ipv6 := addr.As16()
+		copy(ip[:], ipv6[:])
+		family = bpf.EndpointKeyIPv6
+	}
+
+	k := SubnetMapKey{
+		Prefixlen: getStaticPrefixBits() + uint32(s.Key.Bits()),
+		Family:    family,
+		IP:        ip,
+	}
+	return bpf.StructBinaryMarshaler{Target: &k}
+}
+
+// BinaryValue returns the binary representation of the identity for the eBPF map value.
+func (s SubnetTableEntry) BinaryValue() encoding.BinaryMarshaler {
+	v := SubnetMapValue{
+		Identity: s.Value,
+	}
+	return bpf.StructBinaryMarshaler{Target: &v}
+}
+
+// SubnetIndex is the primary index for SubnetEntry, indexing by Prefix.
+var SubnetIndex = statedb.Index[SubnetTableEntry, netip.Prefix]{
+	Name: "prefix",
+	FromObject: func(s SubnetTableEntry) index.KeySet {
+		return index.NewKeySet(index.NetIPPrefix(s.Key))
+	},
+	FromKey:    index.NetIPPrefix,
+	FromString: index.NetIPPrefixString,
+	Unique:     true,
+}
+
+// newSubnetEntryTable creates and registers the subnet entry table in stateDB.
+func newSubnetEntryTable(db *statedb.DB) (statedb.RWTable[SubnetTableEntry], error) {
+	return statedb.NewTable(
+		db,
+		TableName,
+		SubnetIndex,
+	)
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1009,6 +1009,9 @@ const (
 
 	// RoutingModeTunnel specifies tunneling mode
 	RoutingModeTunnel = "tunnel"
+
+	// RoutingModeHybrid specifies hybrid mode
+	RoutingModeHybrid = "hybrid"
 )
 
 const (

--- a/pkg/subnet/cell.go
+++ b/pkg/subnet/cell.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/dynamicconfig"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides the subnet watcher functionality
+var Cell = cell.Module(
+	"subnet",
+	"Subnet watcher and management",
+
+	cell.Config(DefaultConfig),
+
+	cell.Provide(
+		newSubnetWatcher,
+	),
+
+	cell.Invoke(
+		registerSubnetWatcher,
+	),
+)
+
+func registerSubnetWatcher(cfg *option.DaemonConfig, sw *SubnetWatcher) {
+	if cfg.RoutingMode != option.RoutingModeHybrid {
+		sw.logger.Debug("Routing mode is not hybrid, skipping subnet watcher")
+		return
+	}
+	sw.jobGroup.Add(job.OneShot("subnet-watcher", func(ctx context.Context, health cell.Health) error {
+		sw.logger.Info("Starting subnet topology dynamic config watcher")
+		for {
+			entry, found, w := dynamicconfig.WatchKey(sw.db.ReadTxn(), sw.dynamicConfigTable, SubnetTopologyConfigKey)
+			if found {
+				sw.logger.Info("Detected change in subnet-topology dynamic config")
+				if err := sw.processSubnetConfigEntry(entry); err != nil {
+					sw.logger.Error("Failed to process subnet-topology dynamic config", logfields.Error, err)
+					health.Degraded("Failed to process subnet-topology dynamic config", err)
+				} else {
+					health.OK("subnet-topology dynamic config processed successfully")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-w:
+				continue
+			}
+		}
+	}))
+}

--- a/pkg/subnet/config.go
+++ b/pkg/subnet/config.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import "github.com/spf13/pflag"
+
+const (
+	SubnetTopologyConfigKey = "subnet-topology"
+)
+
+var DefaultConfig = Config{
+	Subnets: "",
+}
+
+type Config struct {
+	Subnets string `json:"subnet-topology,omitempty"`
+}
+
+func (cfg Config) Flags(flags *pflag.FlagSet) {
+	flags.String(
+		SubnetTopologyConfigKey,
+		cfg.Subnets,
+		"Comma and/or semicolon separated list of subnets in CIDR notation representing the subnet topology.",
+	)
+	flags.MarkHidden(SubnetTopologyConfigKey)
+}

--- a/pkg/subnet/script_test.go
+++ b/pkg/subnet/script_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"context"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/dynamicconfig"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/hive"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/maps/subnet"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestPrivilegedScript(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	setup := func(t testing.TB, args []string) *script.Engine {
+		h := hive.New(
+			k8sClient.FakeClientCell(),
+
+			dynamicconfig.Cell,
+			cell.Provide(
+				func() *option.DaemonConfig {
+					return &option.DaemonConfig{
+						RoutingMode: option.RoutingModeHybrid,
+					}
+				},
+				regeneration.NewFence,
+			),
+			subnet.Cell,
+			Cell,
+			metrics.Cell,
+		)
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h.RegisterFlags(flags)
+		require.NoError(t, flags.Parse(args), "parse args")
+
+		log := hivetest.Logger(t)
+
+		t.Cleanup(func() {
+			assert.NoError(t, h.Stop(log, context.TODO()))
+		})
+		cmds, err := h.ScriptCommands(log)
+		require.NoError(t, err, "ScriptCommands")
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{
+			Cmds:             cmds,
+			RetryInterval:    1 * time.Second,
+			MaxRetryInterval: 30 * time.Second, // For bpf map pressure metrics which run every 30s.
+		}
+	}
+
+	scripttest.Test(t,
+		t.Context(),
+		setup,
+		[]string{},
+		"testdata/*.txtar")
+}

--- a/pkg/subnet/testdata/subnet.txtar
+++ b/pkg/subnet/testdata/subnet.txtar
@@ -1,0 +1,69 @@
+# Test subnet config sync to map
+
+hive/start
+
+# Add cilium-config without subnet-topology first
+k8s/add cilium-config-no-subnet.yaml
+
+# Ensure no subnet identities exist
+* db/empty subnet-identities
+
+# Ensure subnet map is empty
+subnet/map-dump subnetmap.empty
+* empty subnetmap.empty
+
+# Add subnet topology config
+k8s/add cilium-config-1.yaml
+
+# Wait for Cilium to pick up the config
+db/cmp subnet-identities subnet.table
+
+# Dump the subnet map.
+subnet/map-dump subnetmap.actual
+* cmp subnetmap.actual subnetmap.expected
+
+# Check pressure metrics. There are 4 entries
+# and max entries is 1024 (default).
+# So map pressure should be 4/1024 = 0.003906.
+metrics --out=metrics.actual cilium_bpf_map_pressure
+* cmp metrics.expected metrics.actual
+
+####
+
+-- cilium-config-1.yaml --
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: cilium-config
+  namespace: kube-system
+data:
+    subnet-topology: "10.0.0.1/24,10.10.0.1/24;10.20.0.1/24;2001:0db8:85a3::/64"
+
+-- cilium-config-no-subnet.yaml --
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: cilium-config
+  namespace: kube-system
+data:
+    subnet-topology: ""
+ 
+-- subnet.table --
+Prefix               Identity
+10.0.0.1/24          1
+10.10.0.1/24         1
+10.20.0.1/24         2
+2001:db8:85a3::/64   3
+
+-- subnetmap.expected --
+PREFIX=10.0.0.1/24 IDENTITY=identity=1
+PREFIX=10.10.0.1/24 IDENTITY=identity=1
+PREFIX=10.20.0.1/24 IDENTITY=identity=2
+PREFIX=2001:db8:85a3::/64 IDENTITY=identity=3
+-- metrics.expected --
+Metric                    Labels                Value
+cilium_bpf_map_pressure   map_name=subnet_map   0.003906

--- a/pkg/subnet/watcher.go
+++ b/pkg/subnet/watcher.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package subnet
+
+import (
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/dynamicconfig"
+	subnetTable "github.com/cilium/cilium/pkg/maps/subnet"
+)
+
+type watcherParams struct {
+	cell.In
+
+	Logger             *slog.Logger
+	DynamicConfigTable statedb.Table[dynamicconfig.DynamicConfig]
+	SubnetTable        statedb.RWTable[subnetTable.SubnetTableEntry]
+	DB                 *statedb.DB
+	JobGroup           job.Group
+}
+
+type SubnetWatcher struct {
+	logger             *slog.Logger
+	dynamicConfigTable statedb.Table[dynamicconfig.DynamicConfig]
+	subnetTable        statedb.RWTable[subnetTable.SubnetTableEntry]
+	db                 *statedb.DB
+	jobGroup           job.Group
+}
+
+func newSubnetWatcher(params watcherParams) *SubnetWatcher {
+	return &SubnetWatcher{
+		logger:             params.Logger,
+		dynamicConfigTable: params.DynamicConfigTable,
+		subnetTable:        params.SubnetTable,
+		db:                 params.DB,
+		jobGroup:           params.JobGroup,
+	}
+}
+
+func (w *SubnetWatcher) processSubnetConfigEntry(entry dynamicconfig.DynamicConfig) error {
+	subnetEntries, err := decodeJson(entry.Value)
+	if err != nil {
+		return fmt.Errorf("failed to decode subnet-topology dynamic config value: %w", err)
+	}
+
+	// Write to the subnet table.
+	// Reset the table and write all entries afresh.
+	wTx := w.db.WriteTxn(w.subnetTable)
+	defer wTx.Abort()
+
+	if err := w.subnetTable.DeleteAll(wTx); err != nil {
+		return fmt.Errorf("failed to reset subnet table: %w", err)
+	}
+	for _, entry := range subnetEntries {
+		if _, _, err := w.subnetTable.Insert(wTx, entry); err != nil {
+			return fmt.Errorf("failed to upsert subnet entry %v: %w", entry, err)
+		}
+	}
+	wTx.Commit()
+	return nil
+}
+
+// decodeJson decodes a JSON string into a slice of SubnetTableEntry.
+// Ex: data=10.0.0.1/24,10.10.0.1/24;10.20.0.1/24;2001:0db8:85a3::/64
+// would decode into four SubnetTableEntry objects.
+// | Key | Value |
+// |------|-----------|
+// | 10.0.0.1/24 | 1  |
+// | 10.10.0.1/24 | 1 |
+// | 10.20.0.1/24 | 2 |
+// | 2001:0db8:85a3::/64 | 3 |
+func decodeJson(data string) ([]subnetTable.SubnetTableEntry, error) {
+	data = strings.TrimSpace(data)
+	if data == "" {
+		return []subnetTable.SubnetTableEntry{}, nil
+	}
+
+	var entries []subnetTable.SubnetTableEntry
+
+	// Split by semicolons to get groups
+	groups := strings.Split(data, ";")
+
+	for groupID, group := range groups {
+		group = strings.TrimSpace(group)
+		if group == "" {
+			continue
+		}
+
+		// Split by commas to get individual subnets within a group
+		subnets := strings.SplitSeq(group, ",")
+
+		for subnet := range subnets {
+			subnet = strings.TrimSpace(subnet)
+			if subnet == "" {
+				continue
+			}
+
+			// Validate CIDR format
+			prefix, err := netip.ParsePrefix(subnet)
+			if err != nil {
+				return nil, fmt.Errorf("invalid CIDR %q: %w", subnet, err)
+			}
+
+			// Identity is groupID + 1 to avoid using identity 0.
+			entries = append(entries, subnetTable.NewSubnetEntry(prefix, uint32(groupID+1)))
+		}
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no valid subnets found in data")
+	}
+
+	return entries, nil
+}

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/maps/subnet"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
@@ -79,6 +80,9 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 			func() policymap.Factory { return nil },
 			func() *server.Server { return nil },
 			func() *loadbalancer.TestConfig { return &loadbalancer.TestConfig{} },
+			func() statedb.RWTable[subnet.SubnetTableEntry] {
+				return nil
+			},
 			k8sSynced.RejectedCRDSyncPromise,
 		),
 		kvstore.Cell(kvstore.DisabledBackendName),


### PR DESCRIPTION
# Description

The motivation behind adding a new routing mode is discussed in this [CFP](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-32810-hybrid-routing-mode.md) .

Part-1 : https://github.com/cilium/cilium/pull/41868
Part-2 : https://github.com/cilium/cilium/pull/43631

This PR introduces subnet-to-identity mapping infrastructure in control plane to support hybrid 
routing mode in Cilium. We introduce a StateDB for caching and reconciliation, with a 
Kubernetes ConfigMap-driven configuration model. The stateDB data is sync'd to already introduce eBPF map.

# Key Changes

This PR adds infrastructure for subnet-to-identity mapping in hybrid routing mode:

- Add `RoutingModeHybrid` constant to routing mode options
- Implement `cilium_subnet_map` under `pkg/maps`
  - Support for both IPv4 and IPv6 address families
  - SubnetMapKey/SubnetMapValue structures synced with bpf/lib/subnet.h
- Add `subnet-identities` StateDB table to cache subnet topology
  - Register reconciler to sync table entries to BPF map
  - Integration with maps cell module
- Implement subnet ConfigMap watcher in pkg/subnet
  - Parse and validate subnet configuration from ConfigMap
  - Automatic propagation of changes to StateDB
- Add script commands for map dumping and debugging

# Testing Done

- Unit tests for BPF map key/value serialization and operations
- E2e script-based tests validating full flow: ConfigMap → StateDB → BPF map
- Verified subnet entry reconciliation and status tracking manually
- Tested both IPv4 and IPv6 subnet configurations

```bash
$ PRIVILEGED_TESTS=true go test -v -exec "sudo -E" ./pkg/subnet
=== RUN   TestPrivilegedScript
=== RUN   TestPrivilegedScript/subnet.txtar
...
--- PASS: TestPrivilegedScript (0.00s)
    --- PASS: TestPrivilegedScript/subnet.txtar (0.05s)
PASS
ok      github.com/cilium/cilium/pkg/subnet     0.092s
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/41867