### PR TITLE
datapath/localnodeconfig: read loopback ip from local node

### DIFF
--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 
 	"github.com/cilium/statedb"
 
@@ -42,7 +41,6 @@ const (
 // is never mutated in-place.
 func newLocalNodeConfig(
 	ctx context.Context,
-	logger *slog.Logger,
 	config *option.DaemonConfig,
 	localNode node.LocalNode,
 	txn statedb.ReadTxn,
@@ -113,8 +111,8 @@ func newLocalNodeConfig(
 		AllocCIDRIPv6:                localNode.IPv6AllocCIDR,
 		NativeRoutingCIDRIPv4:        datapath.RemoteSNATDstAddrExclusionCIDRv4(localNode),
 		NativeRoutingCIDRIPv6:        datapath.RemoteSNATDstAddrExclusionCIDRv6(localNode),
-		ServiceLoopbackIPv4:          node.GetServiceLoopbackIPv4(logger),
-		ServiceLoopbackIPv6:          node.GetServiceLoopbackIPv6(logger),
+		ServiceLoopbackIPv4:          localNode.Local.ServiceLoopbackIPv4,
+		ServiceLoopbackIPv6:          localNode.Local.ServiceLoopbackIPv6,
 		Devices:                      nativeDevices,
 		NodeAddresses:                statedb.Collect(nodeAddrsIter),
 		DirectRoutingDevice:          directRoutingDevice,

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -198,7 +198,6 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 	for {
 		localNodeConfig, localNodeConfigWatch, err := newLocalNodeConfig(
 			ctx,
-			o.params.Log,
 			option.Config,
 			localNode,
 			o.params.DB.ReadTxn(),


### PR DESCRIPTION
This commit changes the construction of the `LocalNodeConfiguration` to read the service loopback ips from the `localNode` instance rather than using the global function. This way we can eventually get rid of the global funcs.