### PR TITLE
infra ip allocation: use `LocalNodeStore`

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -179,6 +179,8 @@ cilium-agent hive [flags]
       --ipsec-key-rotation-duration duration                      Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
+      --ipv4-service-loopback-address string                      IPv4 source address to use for SNAT when a Pod talks to itself over a Service. (default "169.254.42.1")
+      --ipv6-service-loopback-address string                      IPv6 source address to use for SNAT when a Pod talks to itself over a Service. (default "fe80::1")
       --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -184,6 +184,8 @@ cilium-agent hive dot-graph [flags]
       --ipsec-key-rotation-duration duration                      Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
+      --ipv4-service-loopback-address string                      IPv4 source address to use for SNAT when a Pod talks to itself over a Service. (default "169.254.42.1")
+      --ipv6-service-loopback-address string                      IPv6 source address to use for SNAT when a Pod talks to itself over a Service. (default "fe80::1")
       --k8s-api-server-urls strings                               Kubernetes API server URLs
       --k8s-client-burst int                                      Burst value allowed for the K8s client (default 20)
       --k8s-client-connection-keep-alive duration                 Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -231,7 +231,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	// We must do this after IPAM because we must wait until the
 	// K8s resources have been synced.
-	if err := params.InfraIPAllocator.AllocateIPs(ctx, restoredRouterIPs); err != nil { // will log errors/fatal internally
+	if err := params.InfraIPAllocator.AllocateIPs(ctx, restoredRouterIPs); err != nil {
 		return err
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -479,14 +479,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.LogSystemLoadConfigName, false, "Enable periodic logging of system load")
 	option.BindEnv(vp, option.LogSystemLoadConfigName)
 
-	flags.String(option.ServiceLoopbackIPv4, defaults.ServiceLoopbackIPv4, "IPv4 source address to use for SNAT "+
-		"when a Pod talks to itself over a Service.")
-	option.BindEnv(vp, option.ServiceLoopbackIPv4)
-
-	flags.String(option.ServiceLoopbackIPv6, defaults.ServiceLoopbackIPv6, "IPv6 source address to use for SNAT "+
-		"when a Pod talks to itself over a Service.")
-	option.BindEnv(vp, option.ServiceLoopbackIPv6)
-
 	flags.Bool(option.EnableIPv4Masquerade, true, "Masquerade IPv4 traffic from endpoints leaving the host")
 	option.BindEnv(vp, option.EnableIPv4Masquerade)
 

--- a/daemon/infraendpoints/cell.go
+++ b/daemon/infraendpoints/cell.go
@@ -3,7 +3,10 @@
 
 package infraendpoints
 
-import "github.com/cilium/hive/cell"
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+)
 
 // Cell is responsible to initialize the Cilium Agent "infrastructure"
 // (host, health, ingress) endpoints. This includes IP allocation and
@@ -12,7 +15,21 @@ var Cell = cell.Module(
 	"agent-infra-endpoints",
 	"Cilium Agent infrastructure endpoints",
 
+	cell.Config(config{
+		ServiceLoopbackIPv4: "169.254.42.1",
+		ServiceLoopbackIPv6: "fe80::1",
+	}),
 	cell.Provide(newInfraIPAllocator),
 	cell.Invoke(registerIngressEndpoint),
 	cell.Invoke(registerHostEndpoint),
 )
+
+type config struct {
+	ServiceLoopbackIPv4 string `mapstructure:"ipv4-service-loopback-address"`
+	ServiceLoopbackIPv6 string `mapstructure:"ipv6-service-loopback-address"`
+}
+
+func (r config) Flags(flags *pflag.FlagSet) {
+	flags.String("ipv4-service-loopback-address", r.ServiceLoopbackIPv4, "IPv4 source address to use for SNAT when a Pod talks to itself over a Service.")
+	flags.String("ipv6-service-loopback-address", r.ServiceLoopbackIPv6, "IPv6 source address to use for SNAT when a Pod talks to itself over a Service.")
+}

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -40,6 +40,7 @@ type infraIPAllocatorParams struct {
 	Logger         *slog.Logger
 	JobGroup       job.Group
 	DaemonConfig   *option.DaemonConfig
+	Config         config
 	DB             *statedb.DB
 	Routes         statedb.Table[*datapathTables.Route]
 	NodeAddrs      statedb.Table[datapathTables.NodeAddress]
@@ -61,6 +62,7 @@ type infraIPAllocator struct {
 	logger         *slog.Logger
 	jobGroup       job.Group
 	daemonConfig   *option.DaemonConfig
+	config         config
 	db             *statedb.DB
 	routes         statedb.Table[*datapathTables.Route]
 	nodeAddressing datapath.NodeAddressing
@@ -85,6 +87,7 @@ func newInfraIPAllocator(params infraIPAllocatorParams) InfraIPAllocator {
 		logger:         params.Logger,
 		jobGroup:       params.JobGroup,
 		daemonConfig:   params.DaemonConfig,
+		config:         params.Config,
 		db:             params.DB,
 		routes:         params.Routes,
 		nodeAddressing: params.NodeAddressing,
@@ -562,9 +565,9 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context, restoredRouterIPs Re
 func (r *infraIPAllocator) allocateServiceLoopbackIPs() error {
 	if r.daemonConfig.EnableIPv6 {
 		// Allocate IPv6 service loopback IP
-		serviceLoopbackIPv6 := net.ParseIP(r.daemonConfig.ServiceLoopbackIPv6)
+		serviceLoopbackIPv6 := net.ParseIP(r.config.ServiceLoopbackIPv6)
 		if serviceLoopbackIPv6 == nil {
-			return fmt.Errorf("invalid IPv6 service loopback address %s", r.daemonConfig.ServiceLoopbackIPv6)
+			return fmt.Errorf("invalid IPv6 service loopback address %s", r.config.ServiceLoopbackIPv6)
 		}
 		r.localNodeStore.Update(func(n *node.LocalNode) { n.Local.ServiceLoopbackIPv6 = serviceLoopbackIPv6 })
 		r.logger.Debug("Allocated IPv6 service loopback address", logfields.IPAddr, serviceLoopbackIPv6)
@@ -572,9 +575,9 @@ func (r *infraIPAllocator) allocateServiceLoopbackIPs() error {
 
 	if r.daemonConfig.EnableIPv4 {
 		// Allocate IPv4 service loopback IP
-		serviceLoopbackIPv4 := net.ParseIP(r.daemonConfig.ServiceLoopbackIPv4)
+		serviceLoopbackIPv4 := net.ParseIP(r.config.ServiceLoopbackIPv4)
 		if serviceLoopbackIPv4 == nil {
-			return fmt.Errorf("invalid IPv4 service loopback address %s", r.daemonConfig.ServiceLoopbackIPv4)
+			return fmt.Errorf("invalid IPv4 service loopback address %s", r.config.ServiceLoopbackIPv4)
 		}
 		r.localNodeStore.Update(func(n *node.LocalNode) { n.Local.ServiceLoopbackIPv4 = serviceLoopbackIPv4 })
 		r.logger.Debug("Allocated IPv4 service loopback address", logfields.IPAddr, serviceLoopbackIPv4)

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -121,35 +121,35 @@ func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 	invalidFromK8s := net.ParseIP("172.16.0.41")
 
 	// no restoration needed
-	result := infraIPAllocator.reallocateDatapathIPs(nil, nil)
+	result := infraIPAllocator.reallocateOldRouterIPs(nil, nil)
 	assert.Nil(t, result)
 
 	// fromK8s if fromFS is not available
-	result = infraIPAllocator.reallocateDatapathIPs(fromK8s, nil)
+	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, nil)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromK8s)
 
 	// fromFS if fromK8s is not available
-	result = infraIPAllocator.reallocateDatapathIPs(nil, fromFS)
+	result = infraIPAllocator.reallocateOldRouterIPs(nil, fromFS)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromFS)
 
 	// fromFS should be preferred
-	result = infraIPAllocator.reallocateDatapathIPs(fromK8s, fromFS)
+	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, fromFS)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromFS)
 
 	// reject restoration if the IP is not in the allocation CIDR
-	result = infraIPAllocator.reallocateDatapathIPs(invalidFromFS, invalidFromK8s)
+	result = infraIPAllocator.reallocateOldRouterIPs(invalidFromFS, invalidFromK8s)
 	assert.Nil(t, result)
 
 	// fromFS with invalid fromK8s
-	result = infraIPAllocator.reallocateDatapathIPs(invalidFromK8s, fromFS)
+	result = infraIPAllocator.reallocateOldRouterIPs(invalidFromK8s, fromFS)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromFS)
 
 	// fromFS with invalid fromK8s
-	result = infraIPAllocator.reallocateDatapathIPs(fromK8s, invalidFromFS)
+	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, invalidFromFS)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromK8s)
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -289,12 +289,6 @@ const (
 	// connection tracking garbage collection
 	ConntrackGCStartingInterval = 5 * time.Minute
 
-	// ServiceLoopbackIPv4 is the default address for service loopback
-	ServiceLoopbackIPv4 = "169.254.42.1"
-
-	// ServiceLoopbackIPv6 is the default address for service loopback
-	ServiceLoopbackIPv6 = "fe80::1"
-
 	// EnableEndpointRoutes is the value for option.EnableEndpointRoutes.
 	// It is disabled by default for backwards compatibility.
 	EnableEndpointRoutes = false

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -23,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/option"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -195,30 +193,6 @@ func clone(ip net.IP) net.IP {
 	return dup
 }
 
-// GetServiceLoopbackIPv4 returns the service loopback IPv4 address of this node.
-func GetServiceLoopbackIPv4(logger *slog.Logger) net.IP {
-	return getLocalNode(logger).Local.ServiceLoopbackIPv4
-}
-
-// GetServiceLoopbackIPv6 returns the service loopback IPv6 address of this node.
-func GetServiceLoopbackIPv6(logger *slog.Logger) net.IP {
-	return getLocalNode(logger).Local.ServiceLoopbackIPv6
-}
-
-// SetIPv4Loopback sets the service loopback IPv4 address of this node.
-func SetServiceLoopbackIPv4(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.Local.ServiceLoopbackIPv4 = ip
-	})
-}
-
-// SetServiceLoopbackIPv6 sets the service loopback IPv6 address of this node.
-func SetServiceLoopbackIPv6(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.Local.ServiceLoopbackIPv6 = ip
-	})
-}
-
 // GetIPv4AllocRange returns the IPv4 allocation prefix of this node
 func GetIPv4AllocRange(logger *slog.Logger) *cidr.CIDR {
 	return getLocalNode(logger).IPv4AllocCIDR.DeepCopy()
@@ -227,14 +201,6 @@ func GetIPv4AllocRange(logger *slog.Logger) *cidr.CIDR {
 // GetIPv6AllocRange returns the IPv6 allocation prefix of this node
 func GetIPv6AllocRange(logger *slog.Logger) *cidr.CIDR {
 	return getLocalNode(logger).IPv6AllocCIDR.DeepCopy()
-}
-
-// IsNodeIP determines if addr is one of the node's IP addresses,
-// and returns which type of address it is. "" is returned if addr
-// is not one of the node's IP addresses.
-func IsNodeIP(logger *slog.Logger, addr netip.Addr) addressing.AddressType {
-	n := getLocalNode(logger)
-	return n.IsNodeIP(addr)
 }
 
 // GetIPv4 returns one of the IPv4 node address available with the following
@@ -268,16 +234,6 @@ func GetCiliumEndpointNodeIP(logger *slog.Logger) string {
 		return GetIPv4(logger).String()
 	}
 	return GetIPv6(logger).String()
-}
-
-// SetInternalIPv4Router sets the cilium internal IPv4 node address, it is allocated from the node prefix.
-// This must not be conflated with k8s internal IP as this IP address is only relevant within the
-// Cilium-managed network (this means within the node for direct routing mode and on the overlay
-// for tunnel mode).
-func SetInternalIPv4Router(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.SetCiliumInternalIP(ip)
-	})
 }
 
 // GetInternalIPv4Router returns the cilium internal IPv4 node address. This must not be conflated with
@@ -363,14 +319,6 @@ func GetIPv6(logger *slog.Logger) net.IP {
 func GetIPv6Router(logger *slog.Logger) net.IP {
 	n := getLocalNode(logger)
 	return clone(n.GetCiliumInternalIP(true))
-}
-
-// SetIPv6Router sets the IPv6 address of the router address, e.g. address
-// of cilium_host device.
-func SetIPv6Router(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.SetCiliumInternalIP(ip)
-	})
 }
 
 // GetNodeAddressing returns the NodeAddressing model for the local IPs.
@@ -488,23 +436,9 @@ func GetOptOutNodeEncryption(logger *slog.Logger) bool {
 	return getLocalNode(logger).Local.OptOutNodeEncryption
 }
 
-// SetEndpointHealthIPv4 sets the IPv4 cilium-health endpoint address.
-func SetEndpointHealthIPv4(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.IPv4HealthIP = ip
-	})
-}
-
 // GetEndpointHealthIPv4 returns the IPv4 cilium-health endpoint address.
 func GetEndpointHealthIPv4(logger *slog.Logger) net.IP {
 	return getLocalNode(logger).IPv4HealthIP
-}
-
-// SetEndpointHealthIPv6 sets the IPv6 cilium-health endpoint address.
-func SetEndpointHealthIPv6(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.IPv6HealthIP = ip
-	})
 }
 
 // GetEndpointHealthIPv6 returns the IPv6 cilium-health endpoint address.
@@ -512,23 +446,9 @@ func GetEndpointHealthIPv6(logger *slog.Logger) net.IP {
 	return getLocalNode(logger).IPv6HealthIP
 }
 
-// SetIngressIPv4 sets the local IPv4 source address for Cilium Ingress.
-func SetIngressIPv4(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.IPv4IngressIP = ip
-	})
-}
-
 // GetIngressIPv4 returns the local IPv4 source address for Cilium Ingress.
 func GetIngressIPv4(logger *slog.Logger) net.IP {
 	return getLocalNode(logger).IPv4IngressIP
-}
-
-// SetIngressIPv6 sets the local IPv6 source address for Cilium Ingress.
-func SetIngressIPv6(ip net.IP) {
-	localNode.Update(func(n *LocalNode) {
-		n.IPv6IngressIP = ip
-	})
 }
 
 // GetIngressIPv6 returns the local IPv6 source address for Cilium Ingress.

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -192,7 +192,7 @@ type Node struct {
 	IPv4AllocCIDR *cidr.CIDR
 
 	// IPv4SecondaryAllocCIDRs contains additional IPv4 CIDRs from which this
-	//node allocates IPs for its local endpoints from
+	// node allocates IPs for its local endpoints from
 	IPv4SecondaryAllocCIDRs []*cidr.CIDR
 
 	// IPv6AllocCIDR if set, is the IPv6 address pool out of which the node
@@ -380,6 +380,9 @@ func (n *Node) GetCiliumInternalIP(ipv6 bool) net.IP {
 
 // SetCiliumInternalIP sets the CiliumInternalIP e.g. the IP associated
 // with cilium_host on the node.
+// This must not be conflated with k8s internal IP as this IP address is only relevant within the
+// Cilium-managed network (this means within the node for direct routing mode and on the overlay
+// for tunnel mode).
 func (n *Node) SetCiliumInternalIP(newAddr net.IP) {
 	n.setAddress(addressing.NodeCiliumInternalIP, newAddr)
 }
@@ -430,7 +433,6 @@ func (n *Node) setAddress(typ addressing.AddressType, newIP net.IP) {
 		return
 	}
 	n.IPAddresses = append(n.IPAddresses, newAddr)
-
 }
 
 func (n *Node) GetIPByType(addrType addressing.AddressType, ipv6 bool) net.IP {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -734,12 +734,6 @@ const (
 	// EndpointRegenInterval is the interval of the periodic endpoint regeneration loop.
 	EndpointRegenInterval = "endpoint-regen-interval"
 
-	// ServiceLoopbackIPv4 is the address to use for service loopback SNAT
-	ServiceLoopbackIPv4 = "ipv4-service-loopback-address"
-
-	// ServiceLoopbackIPv6 is the address to use for service loopback SNAT
-	ServiceLoopbackIPv6 = "ipv6-service-loopback-address"
-
 	// LocalRouterIPv4 is the link-local IPv4 address to use for Cilium router device
 	LocalRouterIPv4 = "local-router-ipv4"
 
@@ -1522,12 +1516,6 @@ type DaemonConfig struct {
 	// events, specifically those which cause many regenerations.
 	EndpointQueueSize int
 
-	// ServiceLoopbackIPv4 is the address to use for service loopback SNAT
-	ServiceLoopbackIPv4 string
-
-	// ServiceLoopbackIPv6 is the address to use for service loopback SNAT
-	ServiceLoopbackIPv6 string
-
 	// LocalRouterIPv4 is the link-local IPv4 address used for Cilium's router device
 	LocalRouterIPv4 string
 
@@ -1855,8 +1843,6 @@ var (
 		IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriodK8s,
 		FixedIdentityMapping:            make(map[string]string),
 		LogOpt:                          make(map[string]string),
-		ServiceLoopbackIPv4:             defaults.ServiceLoopbackIPv4,
-		ServiceLoopbackIPv6:             defaults.ServiceLoopbackIPv6,
 		EnableEndpointRoutes:            defaults.EnableEndpointRoutes,
 		AnnotateK8sNode:                 defaults.AnnotateK8sNode,
 		AutoCreateCiliumNodeResource:    defaults.AutoCreateCiliumNodeResource,
@@ -2458,8 +2444,6 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.Labels = vp.GetStringSlice(Labels)
 	c.LibDir = vp.GetString(LibDir)
 	c.LogSystemLoadConfig = vp.GetBool(LogSystemLoadConfigName)
-	c.ServiceLoopbackIPv4 = vp.GetString(ServiceLoopbackIPv4)
-	c.ServiceLoopbackIPv6 = vp.GetString(ServiceLoopbackIPv6)
 	c.LocalRouterIPv4 = vp.GetString(LocalRouterIPv4)
 	c.LocalRouterIPv6 = vp.GetString(LocalRouterIPv6)
 	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)


### PR DESCRIPTION
This PR refactors the Agent infrastructure IP allocation (loopback, router, health & ingress) to use the `LocalNodeStore` instead of the global node functions (`node.xxx`) to read and update the local node.

The main goal is to get rid of some of these global node functions.

Please review the individual commits.