### PR TITLE
operator: Move policy derivative watchers into dedicated cell

### DIFF
--- a/operator/policyderivative/ccnp_watcher.go
+++ b/operator/policyderivative/ccnp_watcher.go
@@ -1,20 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package policyderivative
 
 import (
 	"context"
-	"log/slog"
-	"sync"
-	"time"
 
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
@@ -29,35 +25,35 @@ func k8sEventMetric(scope, action string) {
 	metrics.EventTS.WithLabelValues(metrics.LabelEventSourceK8s, scope, action).SetToCurrentTime()
 }
 
-// enableCCNPWatcher is similar to enableCNPWatcher but handles the watch events for
+// startCCNPWatcher is similar to startCNPWatcher but handles the watch events for
 // clusterwide policies. Since, internally Clusterwide policies are implemented
 // using CiliumNetworkPolicy itself, the entire implementation uses the methods
 // associated with CiliumNetworkPolicy.
-func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset, clusterName string) {
-	logger.InfoContext(ctx, "Starting CCNP derivative handler")
+func (c *policyDerivativeController) startCCNPWatcher() {
+	c.logger.Info("Starting CCNP derivative handler")
 
 	ccnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	ciliumV2Controller := informer.NewInformerWithStore(
-		utils.ListerWatcherFromTyped[*cilium_v2.CiliumClusterwideNetworkPolicyList](clientset.CiliumV2().CiliumClusterwideNetworkPolicies()),
+		utils.ListerWatcherFromTyped[*cilium_v2.CiliumClusterwideNetworkPolicyList](c.clientset.CiliumV2().CiliumClusterwideNetworkPolicies()),
 		&cilium_v2.CiliumClusterwideNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricCreate)
-				if cnp := informer.CastInformerEvent[types.SlimCNP](logger, obj); cnp != nil {
+				if cnp := informer.CastInformerEvent[types.SlimCNP](c.logger, obj); cnp != nil {
 					// We need to deepcopy this structure because we are writing
 					// fields.
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativePolicyIfNeeded(logger, clientset, clusterName, cnpCpy.CiliumNetworkPolicy, true)
+					groups.AddDerivativePolicyIfNeeded(c.logger, c.clientset, c.clusterName, cnpCpy.CiliumNetworkPolicy, true)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj any) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricUpdate)
-				if oldCNP := informer.CastInformerEvent[types.SlimCNP](logger, oldObj); oldCNP != nil {
-					if newCNP := informer.CastInformerEvent[types.SlimCNP](logger, newObj); newCNP != nil {
+				if oldCNP := informer.CastInformerEvent[types.SlimCNP](c.logger, oldObj); oldCNP != nil {
+					if newCNP := informer.CastInformerEvent[types.SlimCNP](c.logger, newObj); newCNP != nil {
 						if oldCNP.DeepEqual(newCNP) {
 							return
 						}
@@ -68,13 +64,13 @@ func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGr
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativePolicyIfNeeded(logger, clientset, clusterName, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, true)
+						groups.UpdateDerivativePolicyIfNeeded(c.logger, c.clientset, c.clusterName, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, true)
 					}
 				}
 			},
 			DeleteFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCCNP, resources.MetricDelete)
-				cnp := informer.CastInformerEvent[types.SlimCNP](logger, obj)
+				cnp := informer.CastInformerEvent[types.SlimCNP](c.logger, obj)
 				if cnp == nil {
 					return
 				}
@@ -88,21 +84,19 @@ func enableCCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGr
 	)
 	mgr := controller.NewManager()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ciliumV2Controller.Run(ctx.Done())
+	c.wg.Go(func() {
+		ciliumV2Controller.Run(c.ctx.Done())
 		mgr.RemoveAllAndWait()
-	}()
+	})
 
 	mgr.UpdateController(
 		"ccnp-to-groups",
 		controller.ControllerParams{
 			Group: ccnpToGroupsControllerGroup,
 			DoFunc: func(ctx context.Context) error {
-				groups.UpdateCNPInformation(logger, clientset, clusterName)
+				groups.UpdateCNPInformation(c.logger, c.clientset, c.clusterName)
 				return nil
 			},
-			RunInterval: 5 * time.Minute,
+			RunInterval: c.updateInterval,
 		})
 }

--- a/operator/policyderivative/cell.go
+++ b/operator/policyderivative/cell.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policyderivative
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell is a cell that implements watchers for CiliumNetworkPolicy and
+// CiliumClusterwideNetworkPolicy derivative policies. These watchers monitor
+// policy CRD events and manage derivative policies for network policy groups.
+var Cell = cell.Module(
+	"policy-derivative",
+	"CNP and CCNP derivative policy watcher",
+
+	cell.Invoke(registerWatchers),
+)
+
+// SharedConfig contains the configuration that is shared between this module and others.
+type SharedConfig struct {
+	// EnableCiliumNetworkPolicy indicates whether CNP support is enabled
+	EnableCiliumNetworkPolicy bool
+
+	// EnableCiliumClusterwideNetworkPolicy indicates whether CCNP support is enabled
+	EnableCiliumClusterwideNetworkPolicy bool
+
+	// ClusterName is the name of the cluster
+	ClusterName string
+
+	// K8sEnabled indicates whether Kubernetes support is enabled
+	K8sEnabled bool
+}

--- a/operator/policyderivative/cnp_watcher.go
+++ b/operator/policyderivative/cnp_watcher.go
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package cmd
+package policyderivative
 
 import (
 	"context"
-	"log/slog"
-	"sync"
-	"time"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -15,7 +12,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/utils"
@@ -23,9 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/groups"
 )
 
-var (
-	cnpToGroupsControllerGroup = controller.NewGroup("cilium-network-policy-to-groups")
-)
+var cnpToGroupsControllerGroup = controller.NewGroup("cilium-network-policy-to-groups")
 
 func init() {
 	runtime.ErrorHandlers = []runtime.ErrorHandler{
@@ -33,32 +27,32 @@ func init() {
 	}
 }
 
-// enableCNPWatcher waits for the CiliumNetworkPolicy CRD availability and then
-// garbage collects stale CiliumNetworkPolicy status field entries.
-func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGroup, clientset k8sClient.Clientset, clusterName string) {
-	logger.InfoContext(ctx, "Starting CNP derivative handler")
+// startCNPWatcher waits for the CiliumNetworkPolicy CRD availability and then
+// manages derivative policies for CNPs.
+func (c *policyDerivativeController) startCNPWatcher() {
+	c.logger.Info("Starting CNP derivative handler")
 	cnpStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	ciliumV2Controller := informer.NewInformerWithStore(
-		utils.ListerWatcherFromTyped[*cilium_v2.CiliumNetworkPolicyList](clientset.CiliumV2().CiliumNetworkPolicies("")),
+		utils.ListerWatcherFromTyped[*cilium_v2.CiliumNetworkPolicyList](c.clientset.CiliumV2().CiliumNetworkPolicies("")),
 		&cilium_v2.CiliumNetworkPolicy{},
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricCreate)
-				if cnp := informer.CastInformerEvent[types.SlimCNP](logger, obj); cnp != nil {
+				if cnp := informer.CastInformerEvent[types.SlimCNP](c.logger, obj); cnp != nil {
 					// We need to deepcopy this structure because we are writing
 					// fields.
 					// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
 					cnpCpy := cnp.DeepCopy()
 
-					groups.AddDerivativePolicyIfNeeded(logger, clientset, clusterName, cnpCpy.CiliumNetworkPolicy, false)
+					groups.AddDerivativePolicyIfNeeded(c.logger, c.clientset, c.clusterName, cnpCpy.CiliumNetworkPolicy, false)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj any) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricUpdate)
-				if oldCNP := informer.CastInformerEvent[types.SlimCNP](logger, oldObj); oldCNP != nil {
-					if newCNP := informer.CastInformerEvent[types.SlimCNP](logger, newObj); newCNP != nil {
+				if oldCNP := informer.CastInformerEvent[types.SlimCNP](c.logger, oldObj); oldCNP != nil {
+					if newCNP := informer.CastInformerEvent[types.SlimCNP](c.logger, newObj); newCNP != nil {
 						if oldCNP.DeepEqual(newCNP) {
 							return
 						}
@@ -69,13 +63,13 @@ func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGro
 						newCNPCpy := newCNP.DeepCopy()
 						oldCNPCpy := oldCNP.DeepCopy()
 
-						groups.UpdateDerivativePolicyIfNeeded(logger, clientset, clusterName, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, false)
+						groups.UpdateDerivativePolicyIfNeeded(c.logger, c.clientset, c.clusterName, newCNPCpy.CiliumNetworkPolicy, oldCNPCpy.CiliumNetworkPolicy, false)
 					}
 				}
 			},
 			DeleteFunc: func(obj any) {
 				k8sEventMetric(resources.MetricCNP, resources.MetricDelete)
-				cnp := informer.CastInformerEvent[types.SlimCNP](logger, obj)
+				cnp := informer.CastInformerEvent[types.SlimCNP](c.logger, obj)
 				if cnp == nil {
 					return
 				}
@@ -90,20 +84,18 @@ func enableCNPWatcher(ctx context.Context, logger *slog.Logger, wg *sync.WaitGro
 
 	mgr := controller.NewManager()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ciliumV2Controller.Run(ctx.Done())
+	c.wg.Go(func() {
+		ciliumV2Controller.Run(c.ctx.Done())
 		mgr.RemoveAllAndWait()
-	}()
+	})
 
 	mgr.UpdateController("cnp-to-groups",
 		controller.ControllerParams{
 			Group: cnpToGroupsControllerGroup,
 			DoFunc: func(ctx context.Context) error {
-				groups.UpdateCNPInformation(logger, clientset, clusterName)
+				groups.UpdateCNPInformation(c.logger, c.clientset, c.clusterName)
 				return nil
 			},
-			RunInterval: 5 * time.Minute,
+			RunInterval: c.updateInterval,
 		})
 }

--- a/operator/policyderivative/controller.go
+++ b/operator/policyderivative/controller.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policyderivative
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/cilium/hive/cell"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+)
+
+type params struct {
+	cell.In
+
+	Lifecycle            cell.Lifecycle
+	SharedCfg            SharedConfig
+	Clientset            k8sClient.Clientset
+	Logger               *slog.Logger
+	CfgClusterMeshPolicy cmtypes.PolicyConfig
+}
+
+func registerWatchers(p params) {
+	// Check if watchers should be enabled
+	if !p.SharedCfg.K8sEnabled {
+		p.Logger.Info("Policy derivative watchers disabled due to kubernetes support not enabled")
+		return
+	}
+
+	if !p.SharedCfg.EnableCiliumNetworkPolicy && !p.SharedCfg.EnableCiliumClusterwideNetworkPolicy {
+		p.Logger.Info("Policy derivative watchers disabled as both CNP and CCNP are disabled")
+		return
+	}
+
+	clusterNamePolicy := cmtypes.LocalClusterNameForPolicies(p.CfgClusterMeshPolicy, p.SharedCfg.ClusterName)
+
+	c := &policyDerivativeController{
+		clientset:      p.Clientset,
+		logger:         p.Logger,
+		updateInterval: 5 * time.Minute,
+		clusterName:    clusterNamePolicy,
+		enableCNP:      p.SharedCfg.EnableCiliumNetworkPolicy,
+		enableCCNP:     p.SharedCfg.EnableCiliumClusterwideNetworkPolicy,
+	}
+
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: c.onStart,
+		OnStop:  c.onStop,
+	})
+}
+
+type policyDerivativeController struct {
+	clientset      k8sClient.Clientset
+	logger         *slog.Logger
+	updateInterval time.Duration
+	clusterName    string
+	enableCNP      bool
+	enableCCNP     bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func (c *policyDerivativeController) onStart(ctx cell.HookContext) error {
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+
+	if c.enableCNP {
+		c.wg.Go(func() {
+			c.startCNPWatcher()
+		})
+	}
+
+	if c.enableCCNP {
+		c.wg.Go(func() {
+			c.startCCNPWatcher()
+		})
+	}
+
+	return nil
+}
+
+func (c *policyDerivativeController) onStop(_ cell.HookContext) error {
+	c.cancel()
+	c.wg.Wait()
+	return nil
+}


### PR DESCRIPTION
Move the operator's CNP and CCNP derivative policy watchers out of the `legacy` hive cell and into a dedicated `policyderivative` cell.

Related issue: #23425

See similar PR: #43344