### PR TITLE
k8s/annotate: move k8s node annotation logic into `NodeDiscovery`

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -227,17 +227,6 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	// PodCIDR range and allocation of the health IPs.
 	if params.Clientset.IsEnabled() && params.DaemonConfig.AnnotateK8sNode {
 		bootstrapStats.k8sInit.Start()
-		params.Logger.Info("Annotating k8s node",
-			logfields.V4Prefix, node.GetIPv4AllocRange(params.Logger),
-			logfields.V6Prefix, node.GetIPv6AllocRange(params.Logger),
-			logfields.V4HealthIP, node.GetEndpointHealthIPv4(params.Logger),
-			logfields.V6HealthIP, node.GetEndpointHealthIPv6(params.Logger),
-			logfields.V4IngressIP, node.GetIngressIPv4(params.Logger),
-			logfields.V6IngressIP, node.GetIngressIPv6(params.Logger),
-			logfields.V4CiliumHostIP, node.GetInternalIPv4Router(params.Logger),
-			logfields.V6CiliumHostIP, node.GetIPv6Router(params.Logger),
-		)
-
 		latestLocalNode, err := params.LocalNodeStore.Get(ctx)
 		if err == nil {
 			_, err = k8s.AnnotateNode(

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -223,7 +223,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
-	params.NodeDiscovery.AnnotateK8sNode(ctx, params.IPsecAgent.SPI())
+	params.NodeDiscovery.AnnotateK8sNode(ctx)
 
 	// Trigger refresh and update custom resource in the apiserver with all restored endpoints.
 	// Trigger after nodeDiscovery.StartDiscovery to avoid custom resource update conflict.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -14,10 +14,8 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
-	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
@@ -225,24 +223,8 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
-	if params.Clientset.IsEnabled() && params.DaemonConfig.AnnotateK8sNode {
-		bootstrapStats.k8sInit.Start()
-		latestLocalNode, err := params.LocalNodeStore.Get(ctx)
-		if err == nil {
-			_, err = k8s.AnnotateNode(
-				params.Logger,
-				params.Clientset,
-				nodeTypes.GetName(),
-				latestLocalNode.Node,
-				params.IPsecAgent.SPI())
-		}
-		if err != nil {
-			params.Logger.Warn("Cannot annotate k8s node with CIDR range", logfields.Error, err)
-		}
-
-		bootstrapStats.k8sInit.End(true)
-	} else if !params.DaemonConfig.AnnotateK8sNode {
-		params.Logger.Debug("Annotate k8s node is disabled.")
+	if err = params.NodeDiscovery.AnnotateK8sNode(ctx, params.IPsecAgent.SPI()); err != nil {
+		params.Logger.Warn("Cannot annotate k8s node with CIDR range", logfields.Error, err)
 	}
 
 	// Trigger refresh and update custom resource in the apiserver with all restored endpoints.

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -223,9 +223,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	// Annotation of the k8s node must happen after discovery of the
 	// PodCIDR range and allocation of the health IPs.
-	if err = params.NodeDiscovery.AnnotateK8sNode(ctx, params.IPsecAgent.SPI()); err != nil {
-		params.Logger.Warn("Cannot annotate k8s node with CIDR range", logfields.Error, err)
-	}
+	params.NodeDiscovery.AnnotateK8sNode(ctx, params.IPsecAgent.SPI())
 
 	// Trigger refresh and update custom resource in the apiserver with all restored endpoints.
 	// Trigger after nodeDiscovery.StartDiscovery to avoid custom resource update conflict.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -59,7 +59,6 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -1232,7 +1231,6 @@ type daemonParams struct {
 	Clientset           k8sClient.Clientset
 	KVStoreClient       kvstore.Client
 	WGAgent             wgTypes.WireguardAgent
-	LocalNodeStore      *node.LocalNodeStore
 	LocalNodeRes        k8s.LocalNodeResource
 	LocalCiliumNodeRes  k8s.LocalCiliumNodeResource
 	K8sWatcher          *watchers.K8sWatcher

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -69,22 +69,22 @@ func updateNodeAnnotation(c kubernetes.Interface, nodeName string, annotation no
 // AnnotateNode writes v4 and v6 CIDRs and health IPs in the given k8s node name.
 // In case of failure while updating the node, this function while spawn a go
 // routine to retry the node update indefinitely.
-func AnnotateNode(logger *slog.Logger, cs kubernetes.Interface, nodeName string, nd nodeTypes.Node, encryptKey uint8) (nodeAnnotation, error) {
+func AnnotateNode(logger *slog.Logger, cs kubernetes.Interface, nodeName string, localNode nodeTypes.Node, encryptKey uint8) (nodeAnnotation, error) {
 	scopedLog := logger.With(
 		logfields.NodeName, nodeName,
-		logfields.V4Prefix, nd.IPv4AllocCIDR,
-		logfields.V6Prefix, nd.IPv6AllocCIDR,
-		logfields.V4HealthIP, nd.IPv4HealthIP,
-		logfields.V6HealthIP, nd.IPv6HealthIP,
-		logfields.V4IngressIP, nd.IPv4IngressIP,
-		logfields.V6IngressIP, nd.IPv6IngressIP,
-		logfields.V4CiliumHostIP, nd.GetCiliumInternalIP(false),
-		logfields.V6CiliumHostIP, nd.GetCiliumInternalIP(true),
+		logfields.V4Prefix, localNode.IPv4AllocCIDR,
+		logfields.V6Prefix, localNode.IPv6AllocCIDR,
+		logfields.V4HealthIP, localNode.IPv4HealthIP,
+		logfields.V6HealthIP, localNode.IPv6HealthIP,
+		logfields.V4IngressIP, localNode.IPv4IngressIP,
+		logfields.V6IngressIP, localNode.IPv6IngressIP,
+		logfields.V4CiliumHostIP, localNode.GetCiliumInternalIP(false),
+		logfields.V6CiliumHostIP, localNode.GetCiliumInternalIP(true),
 		logfields.Key, encryptKey,
 	)
-	scopedLog.Debug("Updating node annotations with node CIDRs")
+	scopedLog.Info("Annotating k8s Node with node information")
 
-	annotation := prepareNodeAnnotation(nd, encryptKey)
+	annotation := prepareNodeAnnotation(localNode, encryptKey)
 	controller.NewManager().UpdateController("update-k8s-node-annotations",
 		controller.ControllerParams{
 			Group: nodeAnnotationControllerGroup,

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -297,16 +297,6 @@ func GetEndpointEncryptKeyIndex(localNode LocalNode, wgEnabled, ipsecEnabled boo
 	return 0
 }
 
-// WithTestLocalNodeStore sets the 'localNode' to a temporary instance and
-// runs the given test. Afterwards the 'localNode' is restored to nil.
-// This is a temporary workaround for tests until the LocalNodeStoreCell can be
-// used.
-func WithTestLocalNodeStore(runTest func()) {
-	SetTestLocalNodeStore()
-	defer UnsetTestLocalNodeStore()
-	runTest()
-}
-
 func SetTestLocalNodeStore() {
 	if localNode != nil {
 		panic("localNode already set")

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -184,16 +184,6 @@ func clone(ip net.IP) net.IP {
 	return dup
 }
 
-// GetIPv4AllocRange returns the IPv4 allocation prefix of this node
-func GetIPv4AllocRange(logger *slog.Logger) *cidr.CIDR {
-	return getLocalNode(logger).IPv4AllocCIDR.DeepCopy()
-}
-
-// GetIPv6AllocRange returns the IPv6 allocation prefix of this node
-func GetIPv6AllocRange(logger *slog.Logger) *cidr.CIDR {
-	return getLocalNode(logger).IPv6AllocCIDR.DeepCopy()
-}
-
 // GetIPv4 returns one of the IPv4 node address available with the following
 // priority:
 // - NodeInternalIP
@@ -213,14 +203,6 @@ func GetCiliumEndpointNodeIP(logger *slog.Logger) string {
 		return n.GetNodeIP(false).String()
 	}
 	return n.GetNodeIP(true).String()
-}
-
-// GetInternalIPv4Router returns the cilium internal IPv4 node address. This must not be conflated with
-// k8s internal IP as this IP address is only relevant within the Cilium-managed network (this means
-// within the node for direct routing mode and on the overlay for tunnel mode).
-func GetInternalIPv4Router(logger *slog.Logger) net.IP {
-	n := getLocalNode(logger)
-	return n.GetCiliumInternalIP(false)
 }
 
 // GetRouterInfo returns additional information for the router, the cilium_host interface.
@@ -295,33 +277,6 @@ func ValidatePostInit(logger *slog.Logger) error {
 func GetIPv6(logger *slog.Logger) net.IP {
 	n := getLocalNode(logger)
 	return clone(n.GetNodeIP(true))
-}
-
-// GetIPv6Router returns the IPv6 address of the router, e.g. address
-// of cilium_host device.
-func GetIPv6Router(logger *slog.Logger) net.IP {
-	n := getLocalNode(logger)
-	return clone(n.GetCiliumInternalIP(true))
-}
-
-// GetEndpointHealthIPv4 returns the IPv4 cilium-health endpoint address.
-func GetEndpointHealthIPv4(logger *slog.Logger) net.IP {
-	return getLocalNode(logger).IPv4HealthIP
-}
-
-// GetEndpointHealthIPv6 returns the IPv6 cilium-health endpoint address.
-func GetEndpointHealthIPv6(logger *slog.Logger) net.IP {
-	return getLocalNode(logger).IPv6HealthIP
-}
-
-// GetIngressIPv4 returns the local IPv4 source address for Cilium Ingress.
-func GetIngressIPv4(logger *slog.Logger) net.IP {
-	return getLocalNode(logger).IPv4IngressIP
-}
-
-// GetIngressIPv6 returns the local IPv6 source address for Cilium Ingress.
-func GetIngressIPv6(logger *slog.Logger) net.IP {
-	return getLocalNode(logger).IPv6IngressIP
 }
 
 // GetEndpointEncryptKeyIndex returns the encryption key value for an endpoint

--- a/pkg/nodediscovery/k8s_node_annotate.go
+++ b/pkg/nodediscovery/k8s_node_annotate.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -110,30 +108,4 @@ func (n *NodeDiscovery) annotateK8sNode(ctx context.Context, cs kubernetes.Inter
 			},
 			Context: ctx,
 		})
-}
-
-func prepareRemoveNodeAnnotationsPayload(annotation nodeAnnotation) ([]byte, error) {
-	deleteAnnotations := []k8s.JSONPatch{}
-
-	for key := range annotation {
-		deleteAnnotations = append(deleteAnnotations, k8s.JSONPatch{
-			OP:   "remove",
-			Path: "/metadata/annotations/" + encodeJsonElement(key),
-		})
-	}
-
-	return json.Marshal(deleteAnnotations)
-}
-
-func RemoveNodeAnnotations(c kubernetes.Interface, nodeName string, annotation nodeAnnotation) error {
-	patch, err := prepareRemoveNodeAnnotationsPayload(annotation)
-	if err != nil {
-		return err
-	}
-	_, err = c.CoreV1().Nodes().Patch(context.TODO(), nodeName, k8sTypes.JSONPatchType, patch, metav1.PatchOptions{}, "status")
-	return err
-}
-
-func encodeJsonElement(element string) string {
-	return strings.ReplaceAll(element, "/", "~1")
 }

--- a/pkg/nodediscovery/k8s_node_annotate_test.go
+++ b/pkg/nodediscovery/k8s_node_annotate_test.go
@@ -105,9 +105,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 		// IPv6 Node range is not checked because it shouldn't be changed.
 
 		n := &NodeDiscovery{logger: logger}
-		_, err := n.annotateK8sNode(fakeK8sClient, "node1", *node1Cilium, 0)
-
-		require.NoError(t, err)
+		n.annotateK8sNode(t.Context(), fakeK8sClient, "node1", *node1Cilium, 0)
 
 		select {
 		case <-patchChan:
@@ -165,9 +163,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 		require.Equal(t, "10.254.0.0/16", node.GetIPv4AllocRange(logger).String())
 		require.Equal(t, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96", node.GetIPv6AllocRange(logger).String())
 
-		_, err = n.annotateK8sNode(fakeK8sClient, "node2", *node2Cilium, 0)
-
-		require.NoError(t, err)
+		n.annotateK8sNode(t.Context(), fakeK8sClient, "node2", *node2Cilium, 0)
 
 		select {
 		case <-patchChan:

--- a/pkg/nodediscovery/k8s_node_annotate_test.go
+++ b/pkg/nodediscovery/k8s_node_annotate_test.go
@@ -105,7 +105,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 		// IPv6 Node range is not checked because it shouldn't be changed.
 
 		n := &NodeDiscovery{logger: logger}
-		n.annotateK8sNode(t.Context(), fakeK8sClient, "node1", *node1Cilium, 0)
+		n.annotateK8sNode(t.Context(), fakeK8sClient, *node1Cilium)
 
 		select {
 		case <-patchChan:
@@ -163,7 +163,7 @@ func TestPatchingCIDRAnnotation(t *testing.T) {
 		require.Equal(t, "10.254.0.0/16", node.GetIPv4AllocRange(logger).String())
 		require.Equal(t, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96", node.GetIPv6AllocRange(logger).String())
 
-		n.annotateK8sNode(t.Context(), fakeK8sClient, "node2", *node2Cilium, 0)
+		n.annotateK8sNode(t.Context(), fakeK8sClient, *node2Cilium)
 
 		select {
 		case <-patchChan:

--- a/pkg/nodediscovery/k8s_node_annotate_test.go
+++ b/pkg/nodediscovery/k8s_node_annotate_test.go
@@ -22,129 +22,116 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
 func TestPatchingCIDRAnnotation(t *testing.T) {
 	logger := hivetest.Logger(t)
-	node.WithTestLocalNodeStore(func() {
-		prevAnnotateK8sNode := option.Config.AnnotateK8sNode
-		option.Config.AnnotateK8sNode = true
-		defer func() {
-			option.Config.AnnotateK8sNode = prevAnnotateK8sNode
-		}()
 
-		// Test IPv4
-		node1 := v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node1",
-				Annotations: map[string]string{
-					annotation.V4CIDRName:   "10.254.0.0/16",
-					annotation.CiliumHostIP: "10.254.0.1",
-				},
+	prevAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	defer func() {
+		option.Config.AnnotateK8sNode = prevAnnotateK8sNode
+	}()
+
+	// Test IPv4
+	node1 := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Annotations: map[string]string{
+				annotation.V4CIDRName:   "10.254.0.0/16",
+				annotation.CiliumHostIP: "10.254.0.1",
 			},
-			Spec: v1.NodeSpec{
-				PodCIDR: "10.2.0.0/16",
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "10.2.0.0/16",
+		},
+	}
+
+	// set buffer to 2 to prevent blocking when calling UseNodeCIDR
+	// and we need to wait for the response of the channel.
+	patchChan := make(chan bool, 2)
+	fakeK8sClient := &fake.Clientset{}
+	fakeK8sClient.AddReactor("patch", "nodes",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			n1copy := node1.DeepCopy()
+			n1copy.Annotations[annotation.V4CIDRName] = "10.2.0.0/16"
+			raw, err := json.Marshal(n1copy.Annotations)
+			if err != nil {
+				require.NoError(t, err)
+			}
+			patchWanted := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
+
+			patchReceived := action.(k8stesting.PatchAction).GetPatch()
+			require.Equal(t, string(patchWanted), string(patchReceived))
+			patchChan <- true
+			return true, n1copy, nil
+		})
+
+	node1Cilium := k8s.ParseNode(logger, toSlimNode(node1.DeepCopy()), source.Unspec)
+	node1Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
+
+	n := &NodeDiscovery{logger: logger}
+	n.annotateK8sNode(t.Context(), fakeK8sClient, *node1Cilium)
+
+	select {
+	case <-patchChan:
+	case <-time.Tick(10 * time.Second):
+		t.Errorf("d.fakeK8sClient.CoreV1().Nodes().Update() was not called")
+		t.FailNow()
+	}
+
+	// Test IPv6
+	node2 := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node2",
+			Annotations: map[string]string{
+				annotation.V4CIDRName:   "10.254.0.0/16",
+				annotation.CiliumHostIP: "10.254.0.1",
 			},
-		}
+		},
+		Spec: v1.NodeSpec{
+			PodCIDR: "aaaa:aaaa:aaaa:aaaa:beef:beef::/96",
+		},
+	}
 
-		// set buffer to 2 to prevent blocking when calling UseNodeCIDR
-		// and we need to wait for the response of the channel.
-		patchChan := make(chan bool, 2)
-		fakeK8sClient := &fake.Clientset{}
-		fakeK8sClient.AddReactor("patch", "nodes",
-			func(action k8stesting.Action) (bool, runtime.Object, error) {
-				n1copy := node1.DeepCopy()
-				n1copy.Annotations[annotation.V4CIDRName] = "10.2.0.0/16"
-				raw, err := json.Marshal(n1copy.Annotations)
-				if err != nil {
-					require.NoError(t, err)
-				}
-				patchWanted := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
+	failAttempts := 0
 
-				patchReceived := action.(k8stesting.PatchAction).GetPatch()
-				require.Equal(t, string(patchWanted), string(patchReceived))
-				patchChan <- true
-				return true, n1copy, nil
-			})
+	fakeK8sClient = &fake.Clientset{}
+	fakeK8sClient.AddReactor("patch", "nodes",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			// first call will be a patch for annotations
+			if failAttempts == 0 {
+				failAttempts++
+				return true, nil, fmt.Errorf("failing on purpose")
+			}
+			n2Copy := node2.DeepCopy()
+			n2Copy.Annotations[annotation.V4CIDRName] = "10.254.0.0/16"
+			n2Copy.Annotations[annotation.V6CIDRName] = "aaaa:aaaa:aaaa:aaaa:beef:beef::/96"
+			raw, err := json.Marshal(n2Copy.Annotations)
+			if err != nil {
+				require.NoError(t, err)
+			}
+			patchWanted := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
 
-		node1Cilium := k8s.ParseNode(logger, toSlimNode(node1.DeepCopy()), source.Unspec)
-		node1Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
-		node.SetIPv4AllocRange(node1Cilium.IPv4AllocCIDR)
+			patchReceived := action.(k8stesting.PatchAction).GetPatch()
+			require.Equal(t, string(patchWanted), string(patchReceived))
+			patchChan <- true
+			return true, n2Copy, nil
+		})
 
-		require.Equal(t, "10.2.0.0/16", node.GetIPv4AllocRange(logger).String())
-		// IPv6 Node range is not checked because it shouldn't be changed.
+	node2Cilium := k8s.ParseNode(hivetest.Logger(t), toSlimNode(node2.DeepCopy()), source.Unspec)
+	node2Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
 
-		n := &NodeDiscovery{logger: logger}
-		n.annotateK8sNode(t.Context(), fakeK8sClient, *node1Cilium)
+	n.annotateK8sNode(t.Context(), fakeK8sClient, *node2Cilium)
 
-		select {
-		case <-patchChan:
-		case <-time.Tick(10 * time.Second):
-			t.Errorf("d.fakeK8sClient.CoreV1().Nodes().Update() was not called")
-			t.FailNow()
-		}
-
-		// Test IPv6
-		node2 := v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "node2",
-				Annotations: map[string]string{
-					annotation.V4CIDRName:   "10.254.0.0/16",
-					annotation.CiliumHostIP: "10.254.0.1",
-				},
-			},
-			Spec: v1.NodeSpec{
-				PodCIDR: "aaaa:aaaa:aaaa:aaaa:beef:beef::/96",
-			},
-		}
-
-		failAttempts := 0
-
-		fakeK8sClient = &fake.Clientset{}
-		fakeK8sClient.AddReactor("patch", "nodes",
-			func(action k8stesting.Action) (bool, runtime.Object, error) {
-				// first call will be a patch for annotations
-				if failAttempts == 0 {
-					failAttempts++
-					return true, nil, fmt.Errorf("failing on purpose")
-				}
-				n2Copy := node2.DeepCopy()
-				n2Copy.Annotations[annotation.V4CIDRName] = "10.254.0.0/16"
-				n2Copy.Annotations[annotation.V6CIDRName] = "aaaa:aaaa:aaaa:aaaa:beef:beef::/96"
-				raw, err := json.Marshal(n2Copy.Annotations)
-				if err != nil {
-					require.NoError(t, err)
-				}
-				patchWanted := fmt.Appendf(nil, `{"metadata":{"annotations":%s}}`, raw)
-
-				patchReceived := action.(k8stesting.PatchAction).GetPatch()
-				require.Equal(t, string(patchWanted), string(patchReceived))
-				patchChan <- true
-				return true, n2Copy, nil
-			})
-
-		node2Cilium := k8s.ParseNode(hivetest.Logger(t), toSlimNode(node2.DeepCopy()), source.Unspec)
-		node2Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
-		node.SetIPv4AllocRange(node2Cilium.IPv4AllocCIDR)
-		node.SetIPv6NodeRange(node2Cilium.IPv6AllocCIDR)
-
-		// We use the node's annotation for the IPv4 and the PodCIDR for the
-		// IPv6.
-		require.Equal(t, "10.254.0.0/16", node.GetIPv4AllocRange(logger).String())
-		require.Equal(t, "aaaa:aaaa:aaaa:aaaa:beef:beef::/96", node.GetIPv6AllocRange(logger).String())
-
-		n.annotateK8sNode(t.Context(), fakeK8sClient, *node2Cilium)
-
-		select {
-		case <-patchChan:
-		case <-time.Tick(10 * time.Second):
-			t.Errorf("d.fakeK8sClient.CoreV1().Nodes().Update() was not called")
-			t.FailNow()
-		}
-	})
+	select {
+	case <-patchChan:
+	case <-time.Tick(10 * time.Second):
+		t.Errorf("d.fakeK8sClient.CoreV1().Nodes().Update() was not called")
+		t.FailNow()
+	}
 }
 
 func convertToAddress(v1Addrs []v1.NodeAddress) []slim_corev1.NodeAddress {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -68,6 +68,7 @@ type NodeDiscovery struct {
 	clientset        client.Clientset
 	kvstoreClient    kvstore.Client
 	ctrlmgr          *controller.Manager
+	daemonConfig     *option.DaemonConfig
 	config           config
 }
 
@@ -80,6 +81,7 @@ func NewNodeDiscovery(
 	lns *node.LocalNodeStore,
 	cniConfigManager cni.CNIConfigManager,
 	k8sNodeWatcher *watchers.K8sCiliumNodeWatcher,
+	daemonConfig *option.DaemonConfig,
 	c config,
 ) *NodeDiscovery {
 	if !option.Config.EnableCiliumNodeCRD {
@@ -97,6 +99,7 @@ func NewNodeDiscovery(
 		kvstoreClient:    kvstoreClient,
 		ctrlmgr:          controller.NewManager(),
 		k8sGetters:       k8sNodeWatcher,
+		daemonConfig:     daemonConfig,
 		config:           c,
 	}
 }


### PR DESCRIPTION
This PR moves the logic that annotates the K8s Node resource with local node information into the `NodeDiscovery` cell.

Please review the individual commits.