### PR TITLE
[network-driver]: Add support for allocations restore

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -176,6 +176,13 @@ rules:
 - apiGroups:
   - resource.k8s.io
   resources:
+  - resourceclaims
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
   - resourceclaims/status
   verbs:
   - patch

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -176,6 +176,13 @@ rules:
 - apiGroups:
   - resource.k8s.io
   resources:
+  - resourceclaims
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
   - resourceclaims/status
   verbs:
   - patch

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1860,4 +1860,8 @@ const (
 	DriverName = "driverName"
 
 	VfCount = "vfCount"
+
+	PodUID = "podUID"
+
+	ClaimUID = "claimUID"
 )

--- a/pkg/networkdriver/cell.go
+++ b/pkg/networkdriver/cell.go
@@ -8,16 +8,23 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
+	nodetypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
 )
 
 // Cell implements the Cilium Network Driver for exposing
@@ -26,18 +33,24 @@ var Cell = cell.Module(
 	"network-driver",
 	"Cilium Network Driver",
 
-	cell.ProvidePrivate(ciliumNetworkDriverConfigResource),
+	cell.ProvidePrivate(
+		ciliumNetworkDriverConfigResource,
+		resourceClaimResource,
+		podResource,
+	),
 	cell.Invoke(registerNetworkDriver),
 )
 
 type networkDriverParams struct {
 	cell.In
 
-	Log       *slog.Logger
-	Lifecycle cell.Lifecycle
-	ClientSet k8sClient.Clientset
-	JobGroup  job.Group
-	Configs   resource.Resource[*v2alpha1.CiliumNetworkDriverConfig]
+	Log            *slog.Logger
+	Lifecycle      cell.Lifecycle
+	ClientSet      k8sClient.Clientset
+	JobGroup       job.Group
+	Configs        resource.Resource[*v2alpha1.CiliumNetworkDriverConfig]
+	ResourceClaims resource.Resource[*resourceapi.ResourceClaim]
+	Pods           resource.Resource[*corev1.Pod]
 }
 
 func ciliumNetworkDriverConfigResource(cs k8sClient.Clientset, lc cell.Lifecycle, mp workqueue.MetricsProvider, daemonCfg *option.DaemonConfig) resource.Resource[*v2alpha1.CiliumNetworkDriverConfig] {
@@ -53,11 +66,51 @@ func ciliumNetworkDriverConfigResource(cs k8sClient.Clientset, lc cell.Lifecycle
 	)
 }
 
+func resourceClaimResource(
+	lc cell.Lifecycle,
+	cs k8sClient.Clientset,
+	mp workqueue.MetricsProvider,
+	crdSync promise.Promise[synced.CRDSync],
+) (resource.Resource[*resourceapi.ResourceClaim], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(utils.ListerWatcherFromTyped(cs.ResourceV1().ResourceClaims("")))
+	return resource.New[*resourceapi.ResourceClaim](
+		lc, lw, mp,
+		resource.WithMetric("ResourceClaim"),
+		resource.WithCRDSync(crdSync),
+	), nil
+}
+
+func podResource(
+	lc cell.Lifecycle,
+	cs k8sClient.Clientset,
+	mp workqueue.MetricsProvider,
+	crdSync promise.Promise[synced.CRDSync],
+) (resource.Resource[*corev1.Pod], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped(cs.CoreV1().Pods("")),
+		func(opts *metav1.ListOptions) {
+			opts.FieldSelector = fields.ParseSelectorOrDie("spec.nodeName=" + nodetypes.GetName()).String()
+		},
+	)
+	return resource.New[*corev1.Pod](lc, lw, mp,
+		resource.WithMetric("Pod"),
+		resource.WithCRDSync(crdSync),
+	), nil
+}
+
 func registerNetworkDriver(params networkDriverParams) *Driver {
 	driver := &Driver{
 		logger:         params.Log,
 		lock:           lock.Mutex{},
 		jg:             params.JobGroup,
+		resourceClaims: params.ResourceClaims,
+		pods:           params.Pods,
 		kubeClient:     params.ClientSet,
 		deviceManagers: make(map[types.DeviceManagerType]types.DeviceManager),
 		configCRD:      params.Configs,

--- a/pkg/networkdriver/devicemanagers/managers.go
+++ b/pkg/networkdriver/devicemanagers/managers.go
@@ -34,7 +34,7 @@ func InitManagers(logger *slog.Logger, managerConfigs *v2alpha1.CiliumNetworkDri
 			return nil, err
 		}
 
-		result[types.DeviceManagerTypeSRIOV] = dummyMgr
+		result[types.DeviceManagerTypeDummy] = dummyMgr
 	}
 
 	return result, nil

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -4,6 +4,7 @@
 package dummy
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -118,4 +119,12 @@ func (d DummyDevice) IfName() string {
 
 func (d DummyDevice) KernelIfName() string {
 	return d.Name
+}
+
+func (d DummyDevice) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(d)
+}
+
+func (d *DummyDevice) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, &d)
 }

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -91,10 +91,10 @@ type DummyDevice struct {
 
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
-	result["interface_name"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
-	result["mac_address"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.HWAddr)}
-	result["mtu"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.MTU))}
-	result["flags"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Flags)}
+	result[types.IfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
+	result[types.HWAddrLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.HWAddr)}
+	result[types.MTULabel] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.MTU))}
+	result[types.FlagsLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Flags)}
 
 	return result
 }

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -58,11 +58,11 @@ func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 			continue
 		}
 
-		devices = append(devices, DummyDevice{
-			name:   link.Attrs().Name,
-			hwAddr: link.Attrs().HardwareAddr.String(),
-			mtu:    link.Attrs().MTU,
-			flags:  link.Attrs().Flags.String(),
+		devices = append(devices, &DummyDevice{
+			Name:   link.Attrs().Name,
+			HWAddr: link.Attrs().HardwareAddr.String(),
+			MTU:    link.Attrs().MTU,
+			Flags:  link.Attrs().Flags.String(),
 		})
 	}
 
@@ -70,18 +70,18 @@ func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 }
 
 type DummyDevice struct {
-	name   string
-	hwAddr string
-	mtu    int
-	flags  string
+	Name   string
+	HWAddr string
+	MTU    int
+	Flags  string
 }
 
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result["interface_name"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
-	result["mac_address"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.hwAddr)}
-	result["mtu"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.mtu))}
-	result["flags"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.flags)}
+	result["mac_address"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.HWAddr)}
+	result["mtu"] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.MTU))}
+	result["flags"] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Flags)}
 
 	return result
 }
@@ -113,9 +113,9 @@ func (d DummyDevice) Match(filter v2alpha1.CiliumNetworkDriverDeviceFilter) bool
 }
 
 func (d DummyDevice) IfName() string {
-	return d.name
+	return d.Name
 }
 
 func (d DummyDevice) KernelIfName() string {
-	return d.name
+	return d.Name
 }

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -38,6 +38,10 @@ func NewManager(logger *slog.Logger, cfg *v2alpha1.DummyDeviceManagerConfig) (*D
 	return mgr, mgr.init()
 }
 
+func (mgr *DummyManager) Type() types.DeviceManagerType {
+	return types.DeviceManagerTypeDummy
+}
+
 func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 	links, err := safenetlink.LinkList()
 	if err != nil {
@@ -68,6 +72,14 @@ func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 	}
 
 	return devices, errors.Join(errs...)
+}
+
+func (mgr *DummyManager) RestoreDevice(data []byte) (types.Device, error) {
+	var dev DummyDevice
+	if err := dev.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &dev, nil
 }
 
 type DummyDevice struct {

--- a/pkg/networkdriver/sriov/sriov.go
+++ b/pkg/networkdriver/sriov/sriov.go
@@ -210,6 +210,10 @@ func NewManager(logger *slog.Logger, cfg *v2alpha1.SRIOVDeviceManagerConfig, opt
 	return mgr, mgr.init()
 }
 
+func (mgr *SRIOVManager) Type() types.DeviceManagerType {
+	return types.DeviceManagerTypeSRIOV
+}
+
 func (mgr *SRIOVManager) pciDevicesPath() string {
 	return path.Join(mgr.sysPath, pciDevicesPath)
 }
@@ -262,6 +266,14 @@ func (mgr *SRIOVManager) ListDevices() ([]types.Device, error) {
 	}
 
 	return result, nil
+}
+
+func (mgr *SRIOVManager) RestoreDevice(data []byte) (types.Device, error) {
+	var dev PciDevice
+	if err := dev.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return &dev, nil
 }
 
 const (

--- a/pkg/networkdriver/sriov/sriov.go
+++ b/pkg/networkdriver/sriov/sriov.go
@@ -4,6 +4,7 @@
 package sriov
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -154,6 +155,14 @@ func (d PciDevice) Match(filter v2alpha1.CiliumNetworkDriverDeviceFilter) bool {
 	}
 
 	return true
+}
+
+func (d PciDevice) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(d)
+}
+
+func (d *PciDevice) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, &d)
 }
 
 type SRIOVManager struct {

--- a/pkg/networkdriver/sriov/sriov_test.go
+++ b/pkg/networkdriver/sriov/sriov_test.go
@@ -90,13 +90,13 @@ func TestSriov(t *testing.T) {
 		require.NotNil(t, device)
 
 		expectedDevice := PciDevice{
-			addr:         "0000:02:00.1",
-			pfName:       "mypf",
-			driver:       "mydriver",
-			vfID:         1,
-			kernelIfName: "myvf",
-			deviceID:     "mydeviceid",
-			vendor:       "myvendor",
+			Addr:            "0000:02:00.1",
+			PfName:          "mypf",
+			Driver:          "mydriver",
+			VfID:            1,
+			KernelIfaceName: "myvf",
+			DeviceID:        "mydeviceid",
+			Vendor:          "myvendor",
 		}
 
 		require.Equal(t, expectedDevice, *device)

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"encoding"
 	"encoding/json"
 	"errors"
 	"net/netip"
@@ -108,6 +109,9 @@ func (d *DeviceManagerType) UnmarshalText(text []byte) error {
 }
 
 type Device interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+
 	GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute
 	Setup(cfg DeviceConfig) error
 	Free(cfg DeviceConfig) error

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -121,7 +121,9 @@ type Device interface {
 }
 
 type DeviceManager interface {
+	Type() DeviceManagerType
 	ListDevices() ([]Device, error)
+	RestoreDevice([]byte) (Device, error)
 }
 
 type DeviceManagerConfig interface {
@@ -142,4 +144,10 @@ func (d *DeviceConfig) Empty() bool {
 	return d.Ipv4Addr == (netip.Prefix{}) &&
 		d.Routes == nil &&
 		d.Vlan == 0
+}
+
+type SerializedDevice struct {
+	Manager DeviceManagerType
+	Dev     json.RawMessage
+	Config  DeviceConfig
 }

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -42,6 +42,12 @@ const (
 	DeviceIDLabel = "deviceID"
 	// DriverLabel identifies a device's driver.
 	DriverLabel = "driver"
+	// HWAddrLabel contains the MAC address of the device.
+	HWAddrLabel = "mac_address"
+	// MTULabel contains the MTU value set for the device.
+	MTULabel = "mtu"
+	// FlagsLabel contains the flags set for the device.
+	FlagsLabel = "flags"
 	// DeviceManagerLabel identifies which Device Manager
 	// published the device.
 	DeviceManagerLabel = "deviceManager"


### PR DESCRIPTION
Add support for device allocations restore after a restart.

This is done writing in the ResourceClaim Status (namely in the Status.AllocatedDeviceStatus[].Data field) the binary serialization of each allocated device and, after an agent restart, listing all the ResourceClaims referenced by the local pods and unmarshalling all the allocations found.

Moreover, the interface name and IP addresses of each allocated device is also written in Status.AllocatedDeviceStatus[].NetworkData for improved visibility of the configuration parameters.

Notes for reviewers: please review each commit individually

---

To test the PR locally:

1) Create the cluster and add a dummy device in kind-worker node

```
make kind-debug

$ docker exec -ti kind-worker bash
# ip link add dummy0 type dummy && ip link set dummy0 up
```

2) Enable the Cilium network driver for dummy devices:

```
cat <<EOF | kubectl apply -f -
apiVersion: cilium.io/v2alpha1
kind: CiliumNetworkDriverConfig
metadata:
  name: dummy-config
spec:
  draRegistrationRetryInterval: 1
  draRegistrationTimeout: 600
  publishInterval: 10
  driverName: "dummy.cilium.k8s.io"
  pools:
    - name: "dummy-pool"
      filter:
        deviceManagers:
          - "dummy"
  deviceManagerConfigs:
    dummy:
      enabled: true
EOF
```

3) Apply the DeviceClass and the ResourceClaimTemplate:

```
cat <<EOF | kubectl apply -f -
apiVersion: resource.k8s.io/v1
kind: DeviceClass
metadata:
  name: dummy.cilium.k8s.io
  namespace: kube-system
spec:
  selectors:
  - cel:
      expression: device.driver == "dummy.cilium.k8s.io"
---
apiVersion: resource.k8s.io/v1
kind: ResourceClaimTemplate
metadata:
  name: dummy
spec:
  spec:
    devices:
      requests:
      - name: dummy
        exactly:
          deviceClassName: dummy.cilium.k8s.io
      config:
        - requests:
          - dummy
          opaque:
            driver: dummy.cilium.k8s.io
            parameters:
              ipv4Addr: 192.168.1.1/24 
EOF
```

4) Run a pod referencing the `dummy` ResourceClaimTemplate:

```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: dummy-pod
spec:
  securityContext:
    runAsUser: 0
  containers:
  - name: app
    image: busybox
    command: ["sleep", "inf"]
  resourceClaims:
  - name: dummy
    resourceClaimTemplateName: dummy
EOF
```

The pod will be scheduled on kind-worker where the dummy interface is available. After a Cilium agent restart, the network driver is able to reload the allocation status relying on the Status of the ResourceClaim:

```
$ kubectl -n kube-system rollout restart ds/cilium
$ kubectl -n kube-system logs ds/cilium
...
time=2026-01-12T19:54:56.429117187Z level=debug source=/go/src/github.com/cilium/cilium/pkg/networkdriver/driver.go:401 msg="allocation device restored" module=agent.controlplane.network-driver podUID=09378de5-8a9a-468b-9fab-57fc24ec8916 claimUID=b54a3307-ae42-4b12-abfa-6a2873f348d3 device=dummy0 config="{Ipv4Addr:192.168.1.1/24 Routes:map[] Vlan:0}"
...
```

~Blocked on https://github.com/cilium/cilium/pull/43265~