### PR TITLE
ci:wireguard: enable Host Firewall in native routing e2e tests

### DIFF
--- a/.github/actions/e2e/wireguard.yaml
+++ b/.github/actions/e2e/wireguard.yaml
@@ -43,6 +43,7 @@
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
+  host-fw: 'true'
   # L7 testing: WireGuard strict mode + Ingress controller - critical for proxy traffic encryption
   test-l7: 'true'
 - name: 'wireguard-4'


### PR DESCRIPTION
This enabled Host Firewall in the `wireguard-3` config.
This helps us validating that host-related packets go through the host
firewall hook in `cilium_host` when WireGuard is enabled in native routing.
In overlay, even if we'd miss a redirect we'd see the packet in bpf_overlay,
which will then redirect the packet to bpf_host for HostFW validation.

Fixes: #43374.