### PR TITLE
fix(gateway-api): add retry with backoff for CRD discovery on transient errors

### DIFF
--- a/operator/pkg/gateway-api/cell_test.go
+++ b/operator/pkg/gateway-api/cell_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "connection refused",
+			err:      syscall.ECONNREFUSED,
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      syscall.ECONNRESET,
+			expected: true,
+		},
+		{
+			name:     "no route to host",
+			err:      syscall.EHOSTUNREACH,
+			expected: true,
+		},
+		{
+			name:     "network unreachable",
+			err:      syscall.ENETUNREACH,
+			expected: true,
+		},
+		{
+			name:     "server timeout",
+			err:      k8serrors.NewServerTimeout(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses"}, "get", 5),
+			expected: true,
+		},
+		{
+			name:     "service unavailable",
+			err:      k8serrors.NewServiceUnavailable("API server is shutting down"),
+			expected: true,
+		},
+		{
+			name:     "too many requests",
+			err:      k8serrors.NewTooManyRequests("rate limited", 5),
+			expected: true,
+		},
+		{
+			name:     "timeout",
+			err:      k8serrors.NewTimeoutError("request timed out", 30),
+			expected: true,
+		},
+		{
+			name:     "not found - permanent error",
+			err:      k8serrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gatewayclasses"}, "cilium"),
+			expected: false,
+		},
+		{
+			name:     "generic error - not transient",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+		{
+			name:     "wrapped connection refused",
+			err:      errors.New("dial tcp: connect: " + syscall.ECONNREFUSED.Error()),
+			expected: false, // string matching won't work, only errors.As
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransientError(tt.err)
+			assert.Equal(t, tt.expected, result, "isTransientError(%v) should return %v", tt.err, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Description

When cilium-operator starts and the Kubernetes API server is temporarily unreachable, Gateway API CRD discovery fails and never recovers. This results in permanent TLS termination failure because TLS secrets are not synchronized to the `cilium-secrets` namespace.

This PR adds retry with exponential backoff for Gateway API CRD discovery:

- **Error classification**: Distinguishes transient errors (network issues, API server overload) from permanent errors (CRDs not installed)
- **Retry loop**: Exponential backoff (1s-2min) for transient errors only
- **Health reporting**: Reports controller status via `cell.Health` for observability
- **Graceful degradation**: Permanent errors (missing CRDs) exit immediately without infinite retries

Fixes: #43130

```release-note
gateway-api: Add retry with exponential backoff for CRD discovery when API server is temporarily unreachable during operator startup
```