### PR TITLE
v1.18 Backports:  envoy: Allow customize per cluster connections / requests limit

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -351,6 +351,8 @@ cilium-agent [flags]
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-admin-port int                                      Port to serve Envoy admin interface on.
+      --proxy-cluster-max-connections uint32                      Maximum number of connections on Envoy clusters (default 1024)
+      --proxy-cluster-max-requests uint32                         Maximum number of requests on Envoy clusters (default 1024)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -189,6 +189,8 @@ cilium-agent hive [flags]
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-admin-port int                                      Port to serve Envoy admin interface on.
+      --proxy-cluster-max-connections uint32                      Maximum number of connections on Envoy clusters (default 1024)
+      --proxy-cluster-max-requests uint32                         Maximum number of requests on Envoy clusters (default 1024)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -194,6 +194,8 @@ cilium-agent hive dot-graph [flags]
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-admin-port int                                      Port to serve Envoy admin interface on.
+      --proxy-cluster-max-connections uint32                      Maximum number of connections on Envoy clusters (default 1024)
+      --proxy-cluster-max-requests uint32                         Maximum number of requests on Envoy clusters (default 1024)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)
       --proxy-idle-timeout-seconds int                            Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s (default 60)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1316,6 +1316,14 @@
      - ADVANCED OPTION: Bring your own custom Envoy bootstrap ConfigMap. Provide the name of a ConfigMap with a ``bootstrap-config.json`` key. When specified, Envoy will use this ConfigMap instead of the default provided by the chart. WARNING: Use of this setting has the potential to prevent cilium-envoy from starting up, and can cause unexpected behavior (e.g. due to syntax error or semantically incorrect configuration). Before submitting an issue, please ensure you have disabled this feature, as support cannot be provided for custom Envoy bootstrap configs. @schema type: [null, string] @schema
      - string
      - ``nil``
+   * - :spelling:ignore:`envoy.clusterMaxConnections`
+     - Maximum number of connections on Envoy clusters
+     - int
+     - ``1024``
+   * - :spelling:ignore:`envoy.clusterMaxRequests`
+     - Maximum number of requests on Envoy clusters
+     - int
+     - ``1024``
    * - :spelling:ignore:`envoy.connectTimeoutSeconds`
      - Time in seconds after which a TCP connection attempt times out
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -379,6 +379,8 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.annotations | object | `{}` | Annotations to be added to all top-level cilium-envoy objects (resources under templates/cilium-envoy) |
 | envoy.baseID | int | `0` |  Set Envoy'--base-id' to use when allocating shared memory regions. Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0' |
 | envoy.bootstrapConfigMap | string | `nil` | ADVANCED OPTION: Bring your own custom Envoy bootstrap ConfigMap. Provide the name of a ConfigMap with a `bootstrap-config.json` key. When specified, Envoy will use this ConfigMap instead of the default provided by the chart. WARNING: Use of this setting has the potential to prevent cilium-envoy from starting up, and can cause unexpected behavior (e.g. due to syntax error or semantically incorrect configuration). Before submitting an issue, please ensure you have disabled this feature, as support cannot be provided for custom Envoy bootstrap configs. @schema type: [null, string] @schema |
+| envoy.clusterMaxConnections | int | `1024` | Maximum number of connections on Envoy clusters |
+| envoy.clusterMaxRequests | int | `1024` | Maximum number of requests on Envoy clusters |
 | envoy.connectTimeoutSeconds | int | `2` | Time in seconds after which a TCP connection attempt times out |
 | envoy.debug.admin.enabled | bool | `false` | Enable admin interface for cilium-envoy. This is useful for debugging and should not be enabled in production. |
 | envoy.debug.admin.port | int | `9901` | Port number (bound to loopback interface). kubectl port-forward can be used to access the admin interface. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1374,6 +1374,8 @@ data:
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}
   proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
   proxy-max-concurrent-retries: {{ .Values.envoy.maxConcurrentRetries | quote }}
+  proxy-cluster-max-connections: {{ .Values.envoy.clusterMaxConnections | quote }}
+  proxy-cluster-max-requests: {{ .Values.envoy.clusterMaxRequests | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
   http-stream-idle-timeout: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2011,6 +2011,12 @@
             "string"
           ]
         },
+        "clusterMaxConnections": {
+          "type": "integer"
+        },
+        "clusterMaxRequests": {
+          "type": "integer"
+        },
         "connectTimeoutSeconds": {
           "type": "integer"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2439,6 +2439,10 @@ envoy:
   initialFetchTimeoutSeconds: 30
   # -- Maximum number of concurrent retries on Envoy clusters
   maxConcurrentRetries: 128
+  # -- Maximum number of connections on Envoy clusters
+  clusterMaxConnections: 1024
+  # -- Maximum number of requests on Envoy clusters
+  clusterMaxRequests: 1024
   # -- Maximum number of retries for each HTTP request
   httpRetryCount: 3
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2460,6 +2460,10 @@ envoy:
   initialFetchTimeoutSeconds: 30
   # -- Maximum number of concurrent retries on Envoy clusters
   maxConcurrentRetries: 128
+  # -- Maximum number of connections on Envoy clusters
+  clusterMaxConnections: 1024
+  # -- Maximum number of requests on Envoy clusters
+  clusterMaxRequests: 1024
   # -- Maximum number of retries for each HTTP request
   httpRetryCount: 3
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -600,6 +600,8 @@ func TestCiliumEnvoyConfigMulti(t *testing.T) {
 		logger:                      hivetest.Logger(t),
 		portAllocator:               NewMockPortAllocator(),
 		defaultMaxConcurrentRetries: 128,
+		defaultMaxConnections:       2048,
+		defaultMaxRequests:          4096,
 	}
 
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigMulti))
@@ -673,6 +675,8 @@ func TestCiliumEnvoyConfigMulti(t *testing.T) {
 	assert.NotNil(t, cb)
 	assert.Len(t, cb.Thresholds, 1)
 	assert.Equal(t, uint32(128), cb.Thresholds[0].MaxRetries.Value)
+	assert.Equal(t, uint32(2048), cb.Thresholds[0].MaxConnections.Value)
+	assert.Equal(t, uint32(4096), cb.Thresholds[0].MaxRequests.Value)
 	//
 	// Check that missing EDS config source is automatically filled in
 	//

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -477,6 +477,12 @@ clusters:default/cilium-ingress-default-basic-ingress/default:details:9080:
   }
   circuit_breakers: {
     thresholds: {
+      max_connections: {
+        value: 1024
+      }
+      max_requests: {
+        value: 1024
+      }
       max_retries: {
         value: 128
       }
@@ -542,6 +548,12 @@ clusters:default/cilium-ingress-default-basic-ingress/default:productpage:9080:
   }
   circuit_breakers: {
     thresholds: {
+      max_connections: {
+        value: 1024
+      }
+      max_requests: {
+        value: 1024
+      }
       max_retries: {
         value: 128
       }

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -228,6 +228,12 @@ clusters:test/listener-a/test:echo:80:
   }
   circuit_breakers: {
     thresholds: {
+      max_connections: {
+        value: 1024
+      }
+      max_requests: {
+        value: 1024
+      }
       max_retries: {
         value: 128
       }
@@ -268,6 +274,12 @@ clusters:test/listener-b/test:echo:80:
   }
   circuit_breakers: {
     thresholds: {
+      max_connections: {
+        value: 1024
+      }
+      max_requests: {
+        value: 1024
+      }
       max_retries: {
         value: 128
       }
@@ -359,6 +371,12 @@ clusters:test/listener-b/test:echo:80:
   }
   circuit_breakers: {
     thresholds: {
+      max_connections: {
+        value: 1024
+      }
+      max_requests: {
+        value: 1024
+      }
       max_retries: {
         value: 128
       }

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -141,6 +141,8 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			maxConnectionDuration:    time.Duration(params.EnvoyProxyConfig.ProxyMaxConnectionDurationSeconds) * time.Second,
 			idleTimeout:              time.Duration(params.EnvoyProxyConfig.ProxyIdleTimeoutSeconds) * time.Second,
 			maxConcurrentRetries:     params.EnvoyProxyConfig.ProxyMaxConcurrentRetries,
+			maxConnections:           params.EnvoyProxyConfig.ProxyClusterMaxConnections,
+			maxRequests:              params.EnvoyProxyConfig.ProxyClusterMaxRequests,
 		}, nil
 	}
 

--- a/pkg/envoy/config/config.go
+++ b/pkg/envoy/config/config.go
@@ -25,6 +25,8 @@ type ProxyConfig struct {
 	ProxyMaxConnectionDurationSeconds int
 	ProxyIdleTimeoutSeconds           int
 	ProxyMaxConcurrentRetries         uint32
+	ProxyClusterMaxConnections        uint32
+	ProxyClusterMaxRequests           uint32
 	HTTPNormalizePath                 bool
 	HTTPRequestTimeout                uint
 	HTTPIdleTimeout                   uint
@@ -55,6 +57,8 @@ func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
 	flags.Int("proxy-max-connection-duration-seconds", 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
 	flags.Int("proxy-idle-timeout-seconds", 60, "Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s")
 	flags.Uint32("proxy-max-concurrent-retries", 128, "Maximum number of concurrent retries on Envoy clusters")
+	flags.Uint32("proxy-cluster-max-connections", 1024, "Maximum number of connections on Envoy clusters")
+	flags.Uint32("proxy-cluster-max-requests", 1024, "Maximum number of requests on Envoy clusters")
 	flags.Bool("http-normalize-path", true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
 	flags.Uint("http-request-timeout", 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
 	flags.Uint("http-idle-timeout", 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -113,6 +113,8 @@ type embeddedEnvoyConfig struct {
 	maxConnectionDuration    time.Duration
 	idleTimeout              time.Duration
 	maxConcurrentRetries     uint32
+	maxConnections           uint32
+	maxRequests              uint32
 }
 
 // startEmbeddedEnvoyInternal starts an Envoy proxy instance.
@@ -146,6 +148,8 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConf
 		maxConnectionDuration:    config.maxConnectionDuration,
 		idleTimeout:              config.idleTimeout,
 		maxConcurrentRetries:     config.maxConcurrentRetries,
+		maxConnections:           config.maxConnections,
+		maxRequests:              config.maxRequests,
 	})
 
 	o.logger.Debug("Envoy: Starting embedded Envoy")
@@ -366,6 +370,8 @@ type bootstrapConfig struct {
 	maxConnectionDuration    time.Duration
 	idleTimeout              time.Duration
 	maxConcurrentRetries     uint32
+	maxConnections           uint32
+	maxRequests              uint32
 }
 
 func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
@@ -412,7 +418,9 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 
 	clusterRetryLimits := &envoy_config_cluster.CircuitBreakers{
 		Thresholds: []*envoy_config_cluster.CircuitBreakers_Thresholds{{
-			MaxRetries: &wrapperspb.UInt32Value{Value: config.maxConcurrentRetries},
+			MaxRetries:     &wrapperspb.UInt32Value{Value: config.maxConcurrentRetries},
+			MaxConnections: &wrapperspb.UInt32Value{Value: config.maxConnections},
+			MaxRequests:    &wrapperspb.UInt32Value{Value: config.maxRequests},
 		}},
 	}
 

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -30,6 +30,8 @@ type onDemandXdsStarter struct {
 	maxConnectionDuration    time.Duration
 	idleTimeout              time.Duration
 	maxConcurrentRetries     uint32
+	maxConnections           uint32
+	maxRequests              uint32
 
 	envoyOnce sync.Once
 }
@@ -82,6 +84,8 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 			maxConnectionDuration:    o.maxConnectionDuration,
 			idleTimeout:              o.idleTimeout,
 			maxConcurrentRetries:     o.maxConcurrentRetries,
+			maxConnections:           o.maxConnections,
+			maxRequests:              o.maxRequests,
 		})
 
 		// Add Prometheus listener if the port is (properly) configured


### PR DESCRIPTION
[x] upstream pr #43049
