### PR TITLE
k8s: cleanup agent k8s resource convenience structs

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -163,7 +163,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 			params.NodeDiscovery.UpdateCiliumNodeResource()
 		}
 
-		if err := agentK8s.WaitForNodeInformation(ctx, params.Logger, params.Resources.LocalNode, params.Resources.LocalCiliumNode); err != nil {
+		if err := agentK8s.WaitForNodeInformation(ctx, params.Logger, params.LocalNodeRes, params.LocalCiliumNodeRes); err != nil {
 			return fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
 		}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/cmd/legacy"
 	"github.com/cilium/cilium/daemon/infraendpoints"
-	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/common"
@@ -1228,7 +1228,8 @@ type daemonParams struct {
 	KVStoreClient       kvstore.Client
 	WGAgent             wgTypes.WireguardAgent
 	LocalNodeStore      *node.LocalNodeStore
-	Resources           agentK8s.Resources
+	LocalNodeRes        k8s.LocalNodeResource
+	LocalCiliumNodeRes  k8s.LocalCiliumNodeResource
 	K8sWatcher          *watchers.K8sWatcher
 	NodeHandler         datapath.NodeHandler
 	EndpointManager     endpointmanager.EndpointManager

--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -12,12 +12,9 @@ import (
 	envoy "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
-	"github.com/cilium/cilium/pkg/k8s/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -89,26 +86,3 @@ type LocalNodeResource resource.Resource[*slim_corev1.Node]
 // LocalCiliumNodeResource is a resource.Resource[*cilium_api_v2.CiliumNode] but one which will only stream updates for the
 // CiliumNode object associated with the node we are currently running on.
 type LocalCiliumNodeResource resource.Resource[*cilium_api_v2.CiliumNode]
-
-// Resources is a convenience struct to group all the agent k8s resources as cell constructor parameters.
-type Resources struct {
-	cell.In
-
-	LocalNode                        LocalNodeResource
-	LocalCiliumNode                  LocalCiliumNodeResource
-	NetworkPolicies                  resource.Resource[*slim_networkingv1.NetworkPolicy]
-	CiliumNetworkPolicies            resource.Resource[*cilium_api_v2.CiliumNetworkPolicy]
-	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy]
-	CiliumCIDRGroups                 resource.Resource[*cilium_api_v2.CiliumCIDRGroup]
-	CiliumSlimEndpoint               resource.Resource[*types.CiliumEndpoint]
-	CiliumEndpointSlice              resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
-	CiliumNode                       resource.Resource[*cilium_api_v2.CiliumNode]
-}
-
-// LocalNodeResources is a convenience struct to group CiliumNode and Node resources as cell constructor parameters.
-type LocalNodeResources struct {
-	cell.In
-
-	LocalNode       LocalNodeResource
-	LocalCiliumNode LocalCiliumNodeResource
-}

--- a/pkg/k8s/watchers/cilium_endpoint_slice.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice.go
@@ -31,7 +31,7 @@ func (k *K8sCiliumEndpointsWatcher) ciliumEndpointSliceInit(ctx context.Context)
 	k.k8sAPIGroups.AddAPI(k8sAPIGroupCiliumEndpointSliceV2Alpha1)
 
 	go func() {
-		events := k.resources.CiliumEndpointSlice.Events(ctx)
+		events := k.ciliumEndpointSlice.Events(ctx)
 		cache := make(map[resource.Key]*cilium_api_v2a1.CiliumEndpointSlice)
 		for event := range events {
 			switch event.Kind {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
-
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -69,7 +68,6 @@ type k8sPodWatcherParams struct {
 	K8sEventReporter *K8sEventReporter
 
 	Clientset          k8sClient.Clientset
-	Resources          agentK8s.Resources
 	K8sResourceSynced  *k8sSynced.Resources
 	K8sAPIGroups       *k8sSynced.APIGroups
 	EndpointManager    endpointmanager.EndpointManager
@@ -96,7 +94,6 @@ func newK8sPodWatcher(params k8sPodWatcherParams) *K8sPodWatcher {
 		policyManager:      params.PolicyUpdater,
 		ipcache:            params.IPCache,
 		cgroupManager:      params.CGroupManager,
-		resources:          params.Resources,
 		db:                 params.DB,
 		pods:               params.Pods,
 		nodeAddrs:          params.NodeAddrs,
@@ -126,7 +123,6 @@ type K8sPodWatcher struct {
 	policyManager      policyManager
 	ipcache            ipcacheManager
 	cgroupManager      cgroupManager
-	resources          agentK8s.Resources
 	db                 *statedb.DB
 	pods               statedb.Table[agentK8s.LocalPod]
 	nodeAddrs          statedb.Table[datapathTables.NodeAddress]


### PR DESCRIPTION
This commit removes the agent k8s convenience structs. Modules that still use k8s `Resource` directly depend on the required types. For new code it's recommended to use statedb where possible - otherwise depend on the required resources too.
