### PR TITLE
node: remove node.GetNodeAddressing

### DIFF
--- a/pkg/health/health_manager.go
+++ b/pkg/health/health_manager.go
@@ -68,6 +68,7 @@ type ciliumHealthManager struct {
 	ctrlMgr      *controller.Manager
 	ciliumHealth *CiliumHealth
 
+	daemonConfig *option.DaemonConfig
 	healthConfig healthconfig.CiliumHealthConfig
 }
 
@@ -88,6 +89,7 @@ type ciliumHealthParams struct {
 	K8sClientSet           k8sClient.Clientset
 	InfraIPAllocator       infraendpoints.InfraIPAllocator
 	LocalNodeStore         *node.LocalNodeStore
+	DaemonConfig           *option.DaemonConfig
 	Config                 healthconfig.CiliumHealthConfig
 }
 
@@ -105,6 +107,7 @@ func newCiliumHealthManager(params ciliumHealthParams) CiliumHealthManager {
 		k8sClientSet:     params.K8sClientSet,
 		infraIPAllocator: params.InfraIPAllocator,
 		localNodeStore:   params.LocalNodeStore,
+		daemonConfig:     params.DaemonConfig,
 		healthConfig:     params.Config,
 	}
 	if !params.Config.IsHealthCheckingEnabled() {

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -120,7 +120,9 @@ type ipamAPIHandlerParams struct {
 	cell.In
 
 	Logger          *slog.Logger
+	DaemonConfig    *option.DaemonConfig
 	IPAM            *ipam.IPAM
+	LocalNodeStore  *node.LocalNodeStore
 	EndpointManager endpointmanager.EndpointManager
 }
 
@@ -139,8 +141,10 @@ func newIPAMAPIHandler(params ipamAPIHandlerParams) ipamAPIHandlerOut {
 			EndpointManager: params.EndpointManager,
 		},
 		IpamPostIpamHandler: &ipamapi.IpamPostIpamHandler{
-			Logger: params.Logger,
-			IPAM:   params.IPAM,
+			DaemonConfig:   params.DaemonConfig,
+			Logger:         params.Logger,
+			IPAM:           params.IPAM,
+			LocalNodeStore: params.LocalNodeStore,
 		},
 		IpamPostIpamIPHandler: &ipamapi.IpamPostIpamIPHandler{
 			IPAM: params.IPAM,

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net"
 
-	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -301,29 +300,6 @@ func GetIPv6(logger *slog.Logger) net.IP {
 func GetIPv6Router(logger *slog.Logger) net.IP {
 	n := getLocalNode(logger)
 	return clone(n.GetCiliumInternalIP(true))
-}
-
-// GetNodeAddressing returns the NodeAddressing model for the local IPs.
-func GetNodeAddressing(logger *slog.Logger) *models.NodeAddressing {
-	a := &models.NodeAddressing{}
-
-	if option.Config.EnableIPv6 {
-		a.IPV6 = &models.NodeAddressingElement{
-			Enabled:    option.Config.EnableIPv6,
-			IP:         GetIPv6Router(logger).String(),
-			AllocRange: GetIPv6AllocRange(logger).String(),
-		}
-	}
-
-	if option.Config.EnableIPv4 {
-		a.IPV4 = &models.NodeAddressingElement{
-			Enabled:    option.Config.EnableIPv4,
-			IP:         GetInternalIPv4Router(logger).String(),
-			AllocRange: GetIPv4AllocRange(logger).String(),
-		}
-	}
-
-	return a
 }
 
 // GetEndpointHealthIPv4 returns the IPv4 cilium-health endpoint address.


### PR DESCRIPTION
Currently, the global helper function `node.GetNodeAddressing` comes with the cost of using other global node functions and the global daemonconfig field. In addition, its name isn't really clear that the node addressing struct is built with the router IPs as IPs.

Therefore, this commit removes the function completely and refactors the usages to build the struct themselves by using dependencies to `LocalNodeStore` and `DaemonConfig`.  The decision to have a little bit more boilerplate code instead
of having yet another central helper function was made deliberately.