### PR TITLE
node: remove global function `SetIPsecKeyIdentity`

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1242,7 +1242,9 @@ func (a *Agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, 
 			// This will set addrs.ipsecKeyIdentity in the node
 			// package, and eventually trigger an update to
 			// publish the updated information to k8s/kvstore.
-			node.SetIPsecKeyIdentity(spi)
+			a.localNode.Update(func(ln *node.LocalNode) {
+				ln.EncryptionKey = spi
+			})
 
 			// AllNodeValidateImplementation will eventually call
 			// nodeUpdate(), which is responsible for updating the

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -476,14 +476,6 @@ func ExtractCiliumHostIPFromFS(logger *slog.Logger) (ipv4GW, ipv6Router net.IP) 
 	return getCiliumHostIPsFromNetDev(logger, defaults.HostDevice)
 }
 
-// SetIPsecKeyIdentity sets the IPsec key identity an opaque value used to
-// identity encryption keys used on the node.
-func SetIPsecKeyIdentity(id uint8) {
-	localNode.Update(func(n *LocalNode) {
-		n.EncryptionKey = id
-	})
-}
-
 func GetOptOutNodeEncryption(logger *slog.Logger) bool {
 	return getLocalNode(logger).Local.OptOutNodeEncryption
 }


### PR DESCRIPTION
This commit removes the global function `node.SetipSecKeyIdentity` in favor of directly using `LocalNodeStore.Update` in the IPSec `Agent`.