### PR TITLE
licensecheck: Fix license policy link

### DIFF
--- a/tools/licensecheck/main.go
+++ b/tools/licensecheck/main.go
@@ -35,7 +35,7 @@ func main() {
 		for _, l := range allowedLicenses {
 			fmt.Printf("  - %s\n", l)
 		}
-		fmt.Println("\nUnder certain circumstances, exceptions can be made for projects using a different license. For more information, please consult the following resources:\nhttps://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md\nhttps://github.com/cncf/foundation/tree/main/license-exceptions")
+		fmt.Println("\nUnder certain circumstances, exceptions can be made for projects using a different license. For more information, please consult the following resources:\nhttps://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md\nhttps://github.com/cncf/foundation/tree/main/license-exceptions")
 		os.Exit(1)
 	}
 	fmt.Println("Licenses check OK")


### PR DESCRIPTION
The CNCF license policy moved with https://github.com/cncf/foundation/pull/1037 (https://github.com/cncf/foundation/commit/3a0e5c00e9d90d20715392968ecf3771a05f1f41).