### PR TITLE
[v1.16] ci: Use newer lvh image for privileged tests

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -221,6 +221,8 @@ jobs:
           # RuntimeSSHTests Should fail when context times out
           - focus: "agent"
             cliFocus: "RuntimeAgent|RuntimeSSHTests"
+            # TODO: not updated by by renovate, investigate why the tests fail on newer images
+            lvhImage: "6.6-20241218.004849"
 
           ###
           # RuntimeDatapathConntrackInVethModeTest Conntrack-related configuration options for endpoints
@@ -232,6 +234,12 @@ jobs:
           # RuntimeDatapathMonitorTest With Sample Containers delivers the same information to multiple monitors
           - focus: "datapath"
             cliFocus: "RuntimeDatapathConntrackInVethModeTest|RuntimeDatapathMonitorTest"
+            # TODO: not updated by by renovate, investigate why the tests fail on newer images
+            lvhImage: "6.6-20241218.004849"
+
+          - focus: "privileged"
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            lvhImage: "6.6-20241218.004849"
 
     timeout-minutes: 50
     steps:
@@ -273,8 +281,7 @@ jobs:
         with:
           test-name: runtime-tests
           install-dependencies: true
-          # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          image-version: "6.6-20241218.004849"
+          image-version: "${{ matrix.lvhImage }}"
           host-mount: ./
           images-folder-parent: "/tmp"
           cpu: 4


### PR DESCRIPTION
Backport of
* [ ] #41082

To compensate for https://github.com/cilium/cilium/pull/43351 re-enabling the problematic renovate update.


Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 41082
```