### PR TITLE
feat(install) mount-cgroup container can pull limits from initResources

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -551,9 +551,12 @@ spec:
           value: {{ .Values.cgroup.hostRoot }}
         - name: BIN_PATH
           value: {{ .Values.cni.binPath }}
-        {{- with .Values.cgroup.autoMount.resources }}
+        {{- if .Values.cgroup.autoMount.resources }}
         resources:
-          {{- toYaml . | trim | nindent 10 }}
+          {{- toYaml .Values.cgroup.autoMount.resources | trim | nindent 10 }}
+        {{- else if .Values.initResources }}
+        resources:
+          {{- toYaml .Values.initResources | trim | nindent 10 }}
         {{- end }}
         command:
         - sh


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

I may be misunderstanding it, but the `mount-cgroups` part of the daemonset seems like it is part of the initialization of the node. So shouldn't the `initResources` also work for that? It isn't an initContainer, but....