### PR TITLE
chore(install): don't mount any token if account not enabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -122,6 +122,8 @@ spec:
       {{- if .Values.serviceAccounts.nodeinit.enabled }}
       serviceAccountName: {{ .Values.serviceAccounts.nodeinit.name | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.nodeinit.automount }}
+      {{- else }}
+      automountServiceAccountToken: false
       {{- end }}
       {{- with .Values.nodeinit.extraVolumes }}
       volumes:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

If the service account is not enabled for node-init, explicitly do not mount any service account tokens.

```release-note
The nodeinit pods no longer get a default service account if the nodeinit service account is disabled.
```