### PR TITLE
chore(helm): setup startupProbes for hubble-ui containers

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -75,6 +75,10 @@ spec:
           httpGet:
             path: /healthz
             port: http
+        startupProbe:
+          httpGet:
+            path: /
+            port: http
         readinessProbe:
           httpGet:
             path: /
@@ -123,6 +127,9 @@ spec:
         {{- with .Values.hubble.ui.backend.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}
+        startupProbe:
+          grpc:
+            port: grpc
         {{- if .Values.hubble.ui.backend.livenessProbe.enabled }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This adds a starupProbe for the hubble-ui containers. The missing probe was identified by the kubernetes linter popeyecli.io.