### PR TITLE
fix(ci): enable module downloads in CIFuzz build

### DIFF
--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -10,15 +10,21 @@ set -eu
 
 
 ln -s "$SRC"/cilium/pkg/policy/distillery_test{,_fuzz}.go
+ln -s "$SRC"/cilium/pkg/policy/l4_filter_deny_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/l4_filter_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/l4_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/mapstate_test{,_fuzz}.go
+ln -s "$SRC"/cilium/pkg/policy/origin_test{,_fuzz}.go
+ln -s "$SRC"/cilium/pkg/policy/repository_deny_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/repository_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/resolve_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/resolve_deny_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/rule_test{,_fuzz}.go
 ln -s "$SRC"/cilium/pkg/policy/selectorcache_test{,_fuzz}.go
 
+# Allow Go to download dependencies not present in the vendor directory.
+# This is needed for go-118-fuzz-build/testing which is required by compile_native_go_fuzzer.
+export GOFLAGS="-mod=mod"
 
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/container/bitlpm FuzzUint8 FuzzUint8
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate FuzzMatchpatternValidate


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] Thanks for contributing!
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)

---

<!-- Description of change -->

The scheduled CIFuzz runs have been failing since the end of September. The December build logs show:
```
cannot find module providing package github.com/AdamKorcz/go-118-fuzz-build/testing: import lookup disabled by -mod=vendor
(Go version in go.mod is at least 1.14 and vendor directory exists.)
```
The `go-118-fuzz-build/testing` package is required by `compile_native_go_fuzzer` but is not present in the vendor directory. When Go runs with `-mod=vendor` (the default when a vendor directory exists), it cannot download missing dependencies from the module proxy.

This change exports `GOFLAGS="-mod=mod"` before running `compile_native_go_fuzzer`, allowing Go to download the required package from the module proxy.

---
Fixes: #43477 

<!-- Release Notes -->
```release-note
ci: Fix CIFuzz build by enabling Go module downloads for dependencies not in vendor directory
```
