### PR TITLE
bpf: Migrate IDENTITY_LEN, IDENTITY_MAX to runtime config

### DIFF
--- a/bpf/lib/clustermesh.h
+++ b/bpf/lib/clustermesh.h
@@ -6,50 +6,41 @@
 
 NODE_CONFIG(__u32, cluster_id, "Cluster ID")
 
-NODE_CONFIG(__u32, cluster_id_max, "Max number of clusters that can be connected in Clustermesh")
-ASSIGN_CONFIG(__u32, cluster_id_max, 255)
+/* Allow to override the assigned value in tests */
+#ifndef DEFAULT_CLUSTER_ID_BITS
+#define DEFAULT_CLUSTER_ID_BITS 8
+#endif
 
-#ifndef get_cluster_id_max
-static __always_inline __u32
-get_cluster_id_max()
-{
-	return CONFIG(cluster_id_max);
-}
-#endif /* get_cluster_id_max() */
+NODE_CONFIG(__u32, cluster_id_bits, "Number of bits of the identity reserved for the Cluster ID")
+ASSIGN_CONFIG(__u32, cluster_id_bits, DEFAULT_CLUSTER_ID_BITS)
+
+/*
+ * Non node-local identity is 24 bits total. cluster_id_bits selects how many
+ * bits are reserved for the Cluster ID; the remainder is the local identity.
+ *
+ * Example identity layout where C is a Cluster ID bit and I is a local
+ * identity bit (default cluster_id_bits=8):
+ * CCCCCCCC IIIIIIII IIIIIIII
+ *
+ * CLUSTER_ID_MAX and IDENTITY_LOCAL_MAX are the masks for the C and I portions.
+ */
+#define IDENTITY_BITS 24
+#define IDENTITY_LOCAL_BITS (IDENTITY_BITS - CONFIG(cluster_id_bits))
+#define CLUSTER_ID_MAX (__u32)((1 << CONFIG(cluster_id_bits)) - 1)
+#define IDENTITY_LOCAL_MAX (__u32)((1 << IDENTITY_LOCAL_BITS) - 1)
 
 #define CLUSTER_ID_LOWER_MASK 0x000000FF
-
-#ifndef __CLUSTERMESH_HELPERS__
-#define __CLUSTERMESH_HELPERS__
-/* these macros allow us to override the values in tests */
-#define IDENTITY_LEN get_identity_len()
-#define IDENTITY_MAX get_max_identity()
-
-static __always_inline __u32
-get_identity_len()
-{
-	return CONFIG(identity_length);
-}
-
-static __always_inline __u32
-get_max_identity()
-{
-	return (__u32)((1 << IDENTITY_LEN) - 1);
-}
-
-#endif /* __CLUSTERMESH_HELPERS__ */
-
 
 static __always_inline __u32
 extract_cluster_id_from_identity(__u32 identity)
 {
-	return (__u32)(identity >> IDENTITY_LEN);
+	return (__u32)(identity >> IDENTITY_LOCAL_BITS);
 }
 
 static __always_inline __maybe_unused __u32
 get_cluster_id_upper_mask()
 {
-	return (get_cluster_id_max() & ~CLUSTER_ID_LOWER_MASK) << (8 + IDENTITY_LEN);
+	return (CLUSTER_ID_MAX & ~CLUSTER_ID_LOWER_MASK) << (8 + IDENTITY_LOCAL_BITS);
 }
 
 static __always_inline __maybe_unused __u32
@@ -64,12 +55,13 @@ ctx_get_cluster_id_mark(const struct __ctx_buff *ctx __maybe_unused)
 /* ctx->mark not available in XDP. */
 #if __ctx_is == __ctx_skb
 	__u32 cluster_id_lower = ctx->mark & CLUSTER_ID_LOWER_MASK;
-	__u32 cluster_id_upper = (ctx->mark & get_cluster_id_upper_mask()) >> (8 + IDENTITY_LEN);
+	__u32 cluster_id_upper = (ctx->mark & get_cluster_id_upper_mask()) >>
+				      (8 + IDENTITY_LOCAL_BITS);
 
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) != MARK_MAGIC_CLUSTER_ID)
 		return 0;
 
-	return (cluster_id_upper | cluster_id_lower) & get_cluster_id_max();
+	return (cluster_id_upper | cluster_id_lower) & CLUSTER_ID_MAX;
 #else /* __ctx_is == __ctx_xdp */
 	return 0;
 #endif /* __ctx_is == __ctx_xdp */
@@ -82,7 +74,7 @@ static __always_inline __maybe_unused __u32
 format_cluster_id_mark(__u32 cluster_id)
 {
 	__u32 cluster_id_lower = cluster_id & 0xFF;
-	__u32 cluster_id_upper = (cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LEN);
+	__u32 cluster_id_upper = (cluster_id & 0xFFFFFF00) << (8 + IDENTITY_LOCAL_BITS);
 
 	return cluster_id_lower | cluster_id_upper;
 }

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -31,10 +31,11 @@ get_identity(const struct __ctx_buff *ctx __maybe_unused)
 /* ctx->mark not available in XDP. */
 #if __ctx_is == __ctx_skb
 	__u32 cluster_id_lower = ctx->mark & CLUSTER_ID_LOWER_MASK;
-	__u32 cluster_id_upper = (ctx->mark & get_cluster_id_upper_mask()) >> (8 + IDENTITY_LEN);
-	__u32 identity = (ctx->mark >> 16) & IDENTITY_MAX;
+	__u32 cluster_id_upper = (ctx->mark & get_cluster_id_upper_mask()) >>
+				      (8 + IDENTITY_LOCAL_BITS);
+	__u32 identity = (ctx->mark >> 16) & IDENTITY_LOCAL_MAX;
 
-	return (cluster_id_lower | cluster_id_upper) << IDENTITY_LEN | identity;
+	return (cluster_id_lower | cluster_id_upper) << IDENTITY_LOCAL_BITS | identity;
 #else /* __ctx_is == __ctx_xdp */
 	return 0;
 #endif /* __ctx_is == __ctx_xdp */
@@ -62,11 +63,11 @@ set_identity_mark(struct __ctx_buff *ctx __maybe_unused, __u32 identity __maybe_
 		  __u32 magic __maybe_unused)
 {
 #if __ctx_is == __ctx_skb
-	__u32 cluster_id = (identity >> IDENTITY_LEN) & get_cluster_id_max();
+	__u32 cluster_id = (identity >> IDENTITY_LOCAL_BITS) & CLUSTER_ID_MAX;
 
 	ctx->mark = format_cluster_id_mark(cluster_id);
 	ctx->mark |= magic & MARK_MAGIC_KEY_MASK;
-	ctx->mark |= (identity & IDENTITY_MAX) << 16;
+	ctx->mark |= (identity & IDENTITY_LOCAL_MAX) << 16;
 #endif
 }
 

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -218,12 +218,6 @@ return false;
 # define NAT_46X64_PREFIX_3 0
 #endif
 
-#ifndef __CLUSTERMESH_HELPERS__
-#define __CLUSTERMESH_HELPERS__
-#define IDENTITY_LEN 16
-#define IDENTITY_MAX 65535
-#endif
-
 /*
  *   **** WARNING, THIS FILE IS DEPRECATED, SEE COMMENT AT THE TOP ****
  */

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -1,14 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#ifndef __CLUSTERMESH_HELPERS__
-#define __CLUSTERMESH_HELPERS__
-#define IDENTITY_LEN 8
-#define IDENTITY_MAX 255
-#endif
-
-#define get_cluster_id_max() 255
-
 #include <bpf/ctx/skb.h>
 #include <lib/overloadable.h>
 #include <lib/clustermesh.h>
@@ -17,7 +9,7 @@
 
 #define CLUSTER_LOCAL_IDENTITY 0xAAAA
 #define TEST_CLUSTER_ID 0xFFu
-#define IDENTITY (0x00000000u | (TEST_CLUSTER_ID << IDENTITY_LEN) | CLUSTER_LOCAL_IDENTITY)
+#define IDENTITY (0x00000000u | (TEST_CLUSTER_ID << IDENTITY_LOCAL_BITS) | CLUSTER_LOCAL_IDENTITY)
 
 CHECK("tc", "set_and_get_identity")
 int check_get_identity(struct __ctx_buff *ctx)

--- a/bpf/tests/bpf_skb_511_tests.c
+++ b/bpf/tests/bpf_skb_511_tests.c
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#ifndef __CLUSTERMESH_HELPERS__
-#define __CLUSTERMESH_HELPERS__
-#define IDENTITY_LEN 15
-#define IDENTITY_MAX 32767
-#endif
-
-#define get_cluster_id_max() 511
+#define DEFAULT_CLUSTER_ID_BITS 9
 
 #include <bpf/ctx/skb.h>
 #include <lib/overloadable.h>
@@ -17,7 +11,7 @@
 
 #define CLUSTER_LOCAL_IDENTITY 0x5555
 #define TEST_CLUSTER_ID 0x1FFu
-#define IDENTITY (0x00000000u | (TEST_CLUSTER_ID << IDENTITY_LEN) | CLUSTER_LOCAL_IDENTITY)
+#define IDENTITY (0x00000000u | (TEST_CLUSTER_ID << IDENTITY_LOCAL_BITS) | CLUSTER_LOCAL_IDENTITY)
 
 CHECK("tc", "set_and_get_identity")
 int check_get_identity(struct __ctx_buff *ctx)
@@ -54,4 +48,3 @@ int check_ctx_get_cluster_id_mark(struct __ctx_buff *ctx)
 
 	test_finish();
 }
-

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -6,12 +6,13 @@ package config
 import (
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func NodeConfig(lnc *datapath.LocalNodeConfiguration) Node {
 	node := *NewNode()
-	node.ClusterIDMax = option.Config.MaxConnectedClusters
+	node.ClusterIDBits = identity.GetClusterIDBits()
 
 	if lnc.ServiceLoopbackIPv4 != nil {
 		node.ServiceLoopbackIPv4 = [4]byte(lnc.ServiceLoopbackIPv4.To4())

--- a/pkg/datapath/config/node_config.go
+++ b/pkg/datapath/config/node_config.go
@@ -11,8 +11,8 @@ package config
 type Node struct {
 	// Cluster ID.
 	ClusterID uint32 `config:"cluster_id"`
-	// Max number of clusters that can be connected in Clustermesh.
-	ClusterIDMax uint32 `config:"cluster_id_max"`
+	// Number of bits of the identity reserved for the Cluster ID.
+	ClusterIDBits uint32 `config:"cluster_id_bits"`
 	// Index of the interface used to connect nodes in the cluster.
 	DirectRoutingDevIfIndex uint32 `config:"direct_routing_dev_ifindex"`
 	// Use jiffies (count of timer ticks since boot).
@@ -38,7 +38,7 @@ type Node struct {
 }
 
 func NewNode() *Node {
-	return &Node{0x0, 0xff, 0x0, false, 0x0, false,
+	return &Node{0x0, 0x8, 0x0, false, 0x0, false,
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -602,10 +602,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENCAP6_IFINDEX"] = "0"
 	}
 
-	// Write Identity related macros.
-	fmt.Fprint(fw, declareConfig("identity_length", identity.GetClusterIDShift(), "Identity length in bits"))
-	fmt.Fprint(fw, assignConfig("identity_length", identity.GetClusterIDShift()))
-
 	fmt.Fprint(fw, declareConfig("interface_ifindex", uint32(0), "ifindex of the interface the bpf program is attached to"))
 
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---

--- a/pkg/datapath/linux/config/utils.go
+++ b/pkg/datapath/linux/config/utils.go
@@ -36,20 +36,3 @@ func declareConfig(name string, value any, description string) string {
 	}
 	return fmt.Sprintf("DECLARE_CONFIG(%s, %s, \"%s\");\n", t, name, description)
 }
-
-// assignConfig writes the C macro for assigning a value to the given config variable at compile
-// time. This value can be overridden at runtime.
-func assignConfig(name string, value any) string {
-	var t string
-	switch value.(type) {
-	case uint16:
-		t = "__u16"
-	case uint32:
-		t = "__u32"
-	case uint64:
-		t = "__u64"
-	default:
-		return fmt.Sprintf("/* BUG: %s has invalid type for ASSIGN_CONFIG: %T/*\n", name, value)
-	}
-	return fmt.Sprintf("ASSIGN_CONFIG(%s, %s, %v);\n", t, name, value)
-}

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -83,9 +83,13 @@ const (
 )
 
 var (
-	// clusterIDInit ensures that clusterIDLen and clusterIDShift can only be
+	// clusterIDInit ensures that clusterIDBits and clusterIDShift can only be
 	// set once, and only if we haven't used either value elsewhere already.
 	clusterIDInit sync.Once
+
+	// clusterIDBits is the number of bits that represent a cluster ID in a
+	// numeric identity
+	clusterIDBits uint32
 
 	// clusterIDShift is the number of bits to shift a cluster ID in a numeric
 	// identity and is equal to the number of bits that represent a cluster-local identity.
@@ -328,13 +332,20 @@ func GetClusterIDShift() uint32 {
 	return clusterIDShift
 }
 
+// GetClusterIDBits returns the number of bits that represent a cluster ID in a numeric identity
+// A sync.Once is used to ensure we only initialize clusterIDBits once.
+func GetClusterIDBits() uint32 {
+	clusterIDInit.Do(initClusterIDShift)
+	return clusterIDBits
+}
+
 // initClusterIDShift sets variables that control the bit allocation of cluster
 // ID in a numeric identity.
 func initClusterIDShift() {
 	// ClusterIDLen is the number of bits that represent a cluster ID in a numeric identity
-	clusterIDLen := uint32(math.Log2(float64(cmtypes.ClusterIDMax + 1)))
+	clusterIDBits = uint32(math.Log2(float64(cmtypes.ClusterIDMax + 1)))
 	// ClusterIDShift is the number of bits to shift a cluster ID in a numeric identity
-	clusterIDShift = NumericIdentityBitlength - clusterIDLen
+	clusterIDShift = NumericIdentityBitlength - clusterIDBits
 }
 
 // GetMinimalNumericIdentity returns the minimal numeric identity not used for

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -87,16 +87,19 @@ func TestGetClusterIDShift(t *testing.T) {
 		name                   string
 		maxConnectedClusters   uint32
 		expectedClusterIDShift uint32
+		expectedClusterIDBits  uint32
 	}{
 		{
 			name:                   "clustermesh255",
 			maxConnectedClusters:   255,
 			expectedClusterIDShift: 16,
+			expectedClusterIDBits:  8,
 		},
 		{
 			name:                   "clustermesh511",
 			maxConnectedClusters:   511,
 			expectedClusterIDShift: 15,
+			expectedClusterIDBits:  9,
 		},
 	}
 
@@ -109,6 +112,7 @@ func TestGetClusterIDShift(t *testing.T) {
 			cinfo := cmtypes.ClusterInfo{MaxConnectedClusters: tt.maxConnectedClusters}
 			cinfo.InitClusterIDMax()
 			assert.Equal(t, tt.expectedClusterIDShift, GetClusterIDShift())
+			assert.Equal(t, tt.expectedClusterIDBits, GetClusterIDBits())
 
 			// ensure we cannot change the clusterIDShift after it has been initialized
 			for _, tc := range tests {
@@ -119,6 +123,7 @@ func TestGetClusterIDShift(t *testing.T) {
 				newCinfo := cmtypes.ClusterInfo{MaxConnectedClusters: tc.maxConnectedClusters}
 				newCinfo.InitClusterIDMax()
 				assert.NotEqual(t, tc.expectedClusterIDShift, GetClusterIDShift())
+				assert.NotEqual(t, tc.expectedClusterIDBits, GetClusterIDBits())
 			}
 		})
 	}


### PR DESCRIPTION
Migrate IDENTITY_LEN, IDENTITY_MAX to runtime config.

Please see description per-commit.

Related: #38370