### PR TITLE
fix(datapath): disable VF info collection in netlink

### DIFF
--- a/pkg/datapath/linux/bandwidth/ops_test.go
+++ b/pkg/datapath/linux/bandwidth/ops_test.go
@@ -28,7 +28,7 @@ func TestPrivilegedOps(t *testing.T) {
 
 	ns := netns.NewNetNS(t)
 	require.NoError(t, ns.Do(func() error {
-		nlh, err = netlink.NewHandle()
+		nlh, err = safenetlink.NewHandle(nil)
 		return err
 	}))
 

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -718,7 +718,7 @@ type netlinkFuncs struct {
 // makeNetlinkFuncs returns a *netlinkFuncs containing netlink accessors to the
 // network namespace of the calling goroutine's OS thread.
 func makeNetlinkFuncs() (*netlinkFuncs, error) {
-	netlinkHandle, err := netlink.NewHandle(unix.NETLINK_ROUTE)
+	netlinkHandle, err := safenetlink.NewHandle(&safenetlink.HandleConfig{NLFamilies: []int{unix.NETLINK_ROUTE}})
 	if err != nil {
 		return nil, fmt.Errorf("creating netlink handle: %w", err)
 	}

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -75,7 +75,7 @@ func newOps(
 	lifecycle.Append(cell.Hook{
 		OnStart: func(hc cell.HookContext) error {
 			var err error
-			ops.handle, err = netlink.NewHandle()
+			ops.handle, err = safenetlink.NewHandle(nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/datapath/linux/safenetlink/config.go
+++ b/pkg/datapath/linux/safenetlink/config.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package safenetlink
+
+// HandleConfig configures the behavior of NewHandle
+type HandleConfig struct {
+	// EnableVFInfo toggles collection of VF (Virtual Function) information during
+	// link list operations. Disabled by default.
+	EnableVFInfo bool
+
+	// NLFamilies specifies the netlink protocol families to use when creating the handle.
+	// If empty, defaults to NETLINK_ROUTE, NETLINK_XFRM, NETLINK_NETFILTER.
+	NLFamilies []int
+}

--- a/pkg/datapath/linux/safenetlink/netlink_linux.go
+++ b/pkg/datapath/linux/safenetlink/netlink_linux.go
@@ -20,6 +20,25 @@ const (
 	netlinkRetryMax      = 30
 )
 
+// NewHandle wraps netlink.NewHandle with HandleConfig
+func NewHandle(cfg *HandleConfig) (*netlink.Handle, error) {
+	if cfg == nil {
+		cfg = &HandleConfig{}
+	}
+
+	//nolint:forbidigo
+	handle, err := netlink.NewHandle(cfg.NLFamilies...)
+	if err != nil {
+		return nil, err
+	}
+
+	if !cfg.EnableVFInfo {
+		handle.DisableVFInfoCollection()
+	}
+
+	return handle, nil
+}
+
 // WithRetry runs the netlinkFunc. If netlinkFunc returns netlink.ErrDumpInterrupted, the function is retried.
 // If success or any other error is returned, WithRetry returns immediately, propagating the error.
 func WithRetry(netlinkFunc func() error) error {

--- a/pkg/datapath/linux/safenetlink/netlink_unspecified.go
+++ b/pkg/datapath/linux/safenetlink/netlink_unspecified.go
@@ -16,6 +16,10 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+func NewHandle(cfg *HandleConfig) (*netlink.Handle, error) {
+	return nil, netlink.ErrNotImplemented
+}
+
 func AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
 	return nil, netlink.ErrNotImplemented
 }

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -28,7 +28,7 @@ func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	ns := netns.NewNetNS(t)
 
 	ns.Do(func() error {
-		h, err := netlink.NewHandle()
+		h, err := safenetlink.NewHandle(nil)
 		require.NoError(t, err)
 
 		veth0 := &netlink.Veth{

--- a/pkg/datapath/neighbor/neighbor_reconciler.go
+++ b/pkg/datapath/neighbor/neighbor_reconciler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
@@ -43,7 +44,7 @@ func newNetlinkFuncsGetter(lifecycle cell.Lifecycle) *netlinkFuncsGetter {
 				// Get a netlink handle in the current namespace.
 				// Otherwise we default to the namespace at startup. Which is not what we want
 				// during testing where we might currently be in a sub-namespace.
-				handle, err := netlink.NewHandle()
+				handle, err := safenetlink.NewHandle(nil)
 				if err != nil {
 					return fmt.Errorf("creating netlink handle: %w", err)
 				}


### PR DESCRIPTION
<!-- Description of change -->
Disable Virtual Function information collection in netlink handle operations to avoid hold of `rtnl_mutex` on systems with SR-IOV devices.

Fixes: #43516

```release-note
Reduces rtnl_mutex contention on SR-IOV nodes by not requesting VF information in netlink RTM_GETLINK operations
```
