### PR TITLE
Add static IP tags discovery on all IPAM modes

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -387,6 +387,12 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 
 	nodeResource.Spec.BootID = ln.BootID
 
+	if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
+		if len(c.IPAM.StaticIPTags) > 0 {
+			nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
+		}
+	}
+
 	switch option.Config.IPAM {
 	case ipamOption.IPAMENI:
 		// set ENI field in the node only when the ENI ipam is specified
@@ -435,10 +441,6 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 
 			if c.IPAM.PreAllocate != 0 {
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			}
-
-			if len(c.IPAM.StaticIPTags) > 0 {
-				nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
 			}
 
 			if c.ENI.FirstInterfaceIndex != nil {
@@ -511,9 +513,6 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 			}
 			if c.IPAM.PreAllocate != 0 {
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			}
-			if len(c.IPAM.StaticIPTags) > 0 {
-				nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
 			}
 			if c.Azure.InterfaceName != "" {
 				nodeResource.Spec.Azure.InterfaceName = c.Azure.InterfaceName
@@ -589,10 +588,6 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 
 			if c.IPAM.PreAllocate != 0 {
 				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			}
-
-			if len(c.IPAM.StaticIPTags) > 0 {
-				nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
 			}
 		}
 	}


### PR DESCRIPTION
This moves static IP tags discovery from the CNI custom net config file outside the IPAM specific sections. This makes it possible to set static IP tags through custom net configs on all IPAM modes. Previously the parsing only occured in ENI, Azure or AlibabaCloud IPAM modes.

Static IP tags will not alter the behavior of Cilium in IPAM modes which do not implement static IP allocation. However, this change allows users to leverage this CiliumNode flag with custom logic to implement static IP allocation on Cloud Providers not natively supported by Cilium, such as GCP.

```release-note
Static IP tags are parsed from the CNI custom net configuration file on all IPAM modes
```
