### PR TITLE
bpf: test: cover network policy with port range

### DIFF
--- a/bpf/tests/hostfw_extended_protocols.c
+++ b/bpf/tests/hostfw_extended_protocols.c
@@ -207,7 +207,7 @@ int hostfw_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(NODE_IP2, 0, HOST_ID, 0, 0);
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
 	ipcache_v4_add_world_entry();
-	policy_add_egress_allow_entry(0, IPPROTO_IGMP, 0);
+	policy_add_egress_allow_l4_entry(IPPROTO_IGMP, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -282,7 +282,7 @@ int hostfw_igmp_ingress_policy_setup(struct __ctx_buff *ctx)
 			      0, (__u8 *)node_mac2, (__u8 *)node_mac2);
 	ipcache_v4_add_entry(NODE_IP2, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
-	policy_add_l4_ingress_deny_entry(0, IPPROTO_IGMP, 0);
+	policy_add_ingress_deny_l4_entry(IPPROTO_IGMP, 0);
 
 	return netdev_receive_packet(ctx);
 }

--- a/bpf/tests/hostfw_extended_protocols.c
+++ b/bpf/tests/hostfw_extended_protocols.c
@@ -207,7 +207,7 @@ int hostfw_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(NODE_IP2, 0, HOST_ID, 0, 0);
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
 	ipcache_v4_add_world_entry();
-	policy_add_egress_allow_l4_entry(IPPROTO_IGMP, 0);
+	policy_add_egress_allow_l4_entry(IPPROTO_IGMP, 0, 0);
 
 	return netdev_send_packet(ctx);
 }
@@ -282,7 +282,7 @@ int hostfw_igmp_ingress_policy_setup(struct __ctx_buff *ctx)
 			      0, (__u8 *)node_mac2, (__u8 *)node_mac2);
 	ipcache_v4_add_entry(NODE_IP2, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
-	policy_add_ingress_deny_l4_entry(IPPROTO_IGMP, 0);
+	policy_add_ingress_deny_l4_entry(IPPROTO_IGMP, 0, 0);
 
 	return netdev_receive_packet(ctx);
 }

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -135,7 +135,8 @@ int overlay_to_lxc_syn_setup(struct __ctx_buff *ctx)
 	 * Apply policy based on the remote "real"
 	 * identity instead of remote-node identity.
 	 */
-	policy_add_ingress_allow_l3_l4_entry(CLIENT_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
+	policy_add_ingress_allow_l3_l4_entry(CLIENT_IDENTITY, IPPROTO_TCP,
+					     BACKEND_PORT, 0);
 
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
 	local_delivery_fill_meta(ctx, CLIENT_IDENTITY, true, false, true, 0);

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -135,7 +135,7 @@ int overlay_to_lxc_syn_setup(struct __ctx_buff *ctx)
 	 * Apply policy based on the remote "real"
 	 * identity instead of remote-node identity.
 	 */
-	policy_add_ingress_allow_entry(CLIENT_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
+	policy_add_ingress_allow_l3_l4_entry(CLIENT_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
 
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
 	local_delivery_fill_meta(ctx, CLIENT_IDENTITY, true, false, true, 0);

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -145,7 +145,7 @@ int lxc_to_overlay_syn_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(BACKEND_IP, BACKEND_CLUSTER_ID, BACKEND_IDENTITY,
 			     BACKEND_NODE_IP, 0);
 
-	policy_add_egress_allow_entry(BACKEND_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
+	policy_add_egress_allow_l3_l4_entry(BACKEND_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
 
 	return pod_send_packet(ctx);
 }

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -145,7 +145,8 @@ int lxc_to_overlay_syn_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(BACKEND_IP, BACKEND_CLUSTER_ID, BACKEND_IDENTITY,
 			     BACKEND_NODE_IP, 0);
 
-	policy_add_egress_allow_l3_l4_entry(BACKEND_IDENTITY, IPPROTO_TCP, BACKEND_PORT);
+	policy_add_egress_allow_l3_l4_entry(BACKEND_IDENTITY, IPPROTO_TCP,
+					    BACKEND_PORT, 0);
 
 	return pod_send_packet(ctx);
 }

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -60,15 +60,15 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 }
 
 static __always_inline void
-policy_add_ingress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
+policy_add_ingress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
 	policy_add_entry(false, sec_label, protocol, dport, false);
 }
 
 static __always_inline void
-policy_add_l4_ingress_deny_entry(__u32 sec_label, __u8 protocol, __u16 dport)
+policy_add_ingress_deny_l4_entry(__u8 protocol, __u16 dport)
 {
-	policy_add_entry(false, sec_label, protocol, dport, true);
+	policy_add_entry(false, 0, protocol, dport, true);
 }
 
 static __always_inline void
@@ -78,14 +78,26 @@ policy_add_ingress_deny_all_entry(void)
 }
 
 static __always_inline void
-policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
+policy_add_egress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
 	policy_add_entry(true, sec_label, protocol, dport, false);
 }
 
+static __always_inline void
+policy_add_egress_allow_l3_entry(__u32 sec_label)
+{
+	policy_add_egress_allow_l3_l4_entry(sec_label, 0, 0);
+}
+
+static __always_inline void
+policy_add_egress_allow_l4_entry(__u8 protocol, __u16 dport)
+{
+	policy_add_egress_allow_l3_l4_entry(0, protocol, dport);
+}
+
 static __always_inline void policy_add_egress_allow_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, false);
+	policy_add_egress_allow_l3_l4_entry(0, 0, 0);
 }
 
 static __always_inline void policy_add_egress_deny_all_entry(void)
@@ -94,12 +106,24 @@ static __always_inline void policy_add_egress_deny_all_entry(void)
 }
 
 static __always_inline void
-policy_delete_egress_entry(__u32 sec_label, __u8 protocol, __u16 dport)
+policy_delete_egress_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
 	policy_delete_entry(true, sec_label, protocol, dport);
 }
 
+static __always_inline void
+policy_delete_egress_l3_entry(__u32 sec_label)
+{
+	policy_delete_egress_l3_l4_entry(sec_label, 0, 0);
+}
+
+static __always_inline void
+policy_delete_egress_l4_entry(__u8 protocol, __u16 dport)
+{
+	policy_delete_egress_l3_l4_entry(0, protocol, dport);
+}
+
 static __always_inline void policy_delete_egress_all_entry(void)
 {
-	policy_delete_egress_entry(0, 0, 0);
+	policy_delete_egress_l3_l4_entry(0, 0, 0);
 }

--- a/bpf/tests/lxc_extended_protocols.c
+++ b/bpf/tests/lxc_extended_protocols.c
@@ -166,7 +166,7 @@ int lxc_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 			      0, (__u8 *)client_mac, (__u8 *)client_mac);
 	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
 	ipcache_v4_add_world_entry();
-	policy_add_egress_allow_l4_entry(IPPROTO_IGMP, 0);
+	policy_add_egress_allow_l4_entry(IPPROTO_IGMP, 0, 0);
 
 	/* Set identity mark for the source pod */
 	set_identity_mark(ctx, LXC_ID, MARK_MAGIC_IDENTITY);
@@ -245,7 +245,7 @@ int lxc_igmp_egress_policy_deny_setup(struct __ctx_buff *ctx)
 			      0, (__u8 *)client_mac, (__u8 *)client_mac);
 	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
 	ipcache_v4_add_world_entry();
-	policy_add_entry(true, 0, IPPROTO_IGMP, 0, true);
+	policy_add_entry(true, 0, IPPROTO_IGMP, 0, 0, true);
 
 	/* Set identity mark for the source pod */
 	set_identity_mark(ctx, LXC_ID, MARK_MAGIC_IDENTITY);

--- a/bpf/tests/lxc_extended_protocols.c
+++ b/bpf/tests/lxc_extended_protocols.c
@@ -166,7 +166,7 @@ int lxc_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 			      0, (__u8 *)client_mac, (__u8 *)client_mac);
 	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
 	ipcache_v4_add_world_entry();
-	policy_add_egress_allow_entry(0, IPPROTO_IGMP, 0);
+	policy_add_egress_allow_l4_entry(IPPROTO_IGMP, 0);
 
 	/* Set identity mark for the source pod */
 	set_identity_mark(ctx, LXC_ID, MARK_MAGIC_IDENTITY);

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -45,11 +45,12 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 		assert(ret == DROP_POLICY);
 	});
 
+	/* Allow access to UDP port 80, at REMOTE_IDENTITY. */
 	TEST("L3+L4 policy", {
 		int ret;
 
-		policy_add_egress_allow_entry(REMOTE_IDENTITY, IPPROTO_UDP,
-					      __bpf_htons(80));
+		policy_add_egress_allow_l3_l4_entry(REMOTE_IDENTITY, IPPROTO_UDP,
+						    __bpf_htons(80));
 
 		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
 					  __bpf_htons(80));
@@ -62,14 +63,15 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 					  __bpf_htons(80));
 		assert(ret == DROP_POLICY);
 
-		policy_delete_egress_entry(REMOTE_IDENTITY, IPPROTO_UDP,
-					   __bpf_htons(80));
+		policy_delete_egress_l3_l4_entry(REMOTE_IDENTITY, IPPROTO_UDP,
+						 __bpf_htons(80));
 	});
 
-	TEST("wildcarded L4", {
+	/* Allow access to all UDP ports, at REMOTE_IDENTITY. */
+	TEST("L3 + wildcarded L4 policy", {
 		int ret;
 
-		policy_add_egress_allow_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
+		policy_add_egress_allow_l3_l4_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
 
 		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
 					  __bpf_htons(80));
@@ -79,13 +81,14 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 					  __bpf_htons(80));
 		assert(ret == DROP_POLICY);
 
-		policy_delete_egress_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
+		policy_delete_egress_l3_l4_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
 	});
 
-	TEST("wildcarded L3+L4", {
+	/* Allow full L3 access, at REMOTE_IDENTITY. */
+	TEST("L3 policy", {
 		int ret;
 
-		policy_add_egress_allow_entry(REMOTE_IDENTITY, 0, 0);
+		policy_add_egress_allow_l3_entry(REMOTE_IDENTITY);
 
 		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
 					  __bpf_htons(80));
@@ -95,14 +98,14 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 					  __bpf_htons(80));
 		assert(ret == CTX_ACT_OK);
 
-		policy_delete_egress_entry(REMOTE_IDENTITY, 0, 0);
+		policy_delete_egress_l3_entry(REMOTE_IDENTITY);
 	});
 
-	TEST("L3+L4 policy, any identity", {
+	/* Allow access to UDP port 80, at all dst endpoints. */
+	TEST("L4-only policy", {
 		int ret;
 
-		policy_add_egress_allow_entry(0, IPPROTO_UDP,
-					      __bpf_htons(80));
+		policy_add_egress_allow_l4_entry(IPPROTO_UDP, __bpf_htons(80));
 
 		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
 					  __bpf_htons(80));
@@ -115,14 +118,14 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 					  __bpf_htons(80));
 		assert(ret == DROP_POLICY);
 
-		policy_delete_egress_entry(0, IPPROTO_UDP,
-					   __bpf_htons(80));
+		policy_delete_egress_l4_entry(IPPROTO_UDP, __bpf_htons(80));
 	});
 
-	TEST("wildcarded L4, any-identity", {
+	/* Allow access to all UDP ports, at all dst endpoints. */
+	TEST("wildcarded L4-only policy", {
 		int ret;
 
-		policy_add_egress_allow_entry(0, IPPROTO_UDP, 0);
+		policy_add_egress_allow_l4_entry(IPPROTO_UDP, 0);
 
 		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
 					  __bpf_htons(80));
@@ -132,13 +135,14 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 					  __bpf_htons(80));
 		assert(ret == DROP_POLICY);
 
-		policy_delete_egress_entry(0, IPPROTO_UDP, 0);
+		policy_delete_egress_l4_entry(IPPROTO_UDP, 0);
 	});
 
-	TEST("wildcarded L3+L4, any identity [allow-all]", {
+	/* Allow full L3 access, at all dst endpoints. */
+	TEST("allow-all", {
 		int ret;
 
-		policy_add_egress_allow_entry(0, 0, 0);
+		policy_add_egress_allow_all_entry();
 
 		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
 					  __bpf_htons(80));
@@ -148,7 +152,7 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 					  __bpf_htons(80));
 		assert(ret == CTX_ACT_OK);
 
-		policy_delete_egress_entry(0, 0, 0);
+		policy_delete_egress_all_entry();
 	});
 
 	test_finish();


### PR DESCRIPTION
```
Test the behavior for policy entries where the `port` part is partially
wild-carded.
```