### PR TITLE
datapath: mark read-only to node, lrp, and lb maps from datapath

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -194,7 +194,7 @@ struct {
 	__type(value, struct lb6_service);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_SERVICE_MAP_MAX_ENTRIES);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb6_services_v2 __section_maps_btf;
 
 struct {
@@ -221,7 +221,7 @@ struct {
 	__type(value, __u8);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, LB6_SRC_RANGE_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb6_source_range __section_maps_btf;
 
 struct {
@@ -240,7 +240,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_MAGLEV_MAP_MAX_ENTRIES);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 	/* Maglev inner map definition */
 	__array(values, struct {
 		__uint(type, BPF_MAP_TYPE_ARRAY);
@@ -266,7 +266,7 @@ struct {
 	__type(value, struct lb4_service);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_SERVICE_MAP_MAX_ENTRIES);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb4_services_v2 __section_maps_btf;
 
 struct {
@@ -293,7 +293,7 @@ struct {
 	__type(value, __u8);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, LB4_SRC_RANGE_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb4_source_range __section_maps_btf;
 
 struct {
@@ -312,7 +312,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_MAGLEV_MAP_MAX_ENTRIES);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 	/* Maglev inner map definition */
 	__array(values, struct {
 		__uint(type, BPF_MAP_TYPE_ARRAY);

--- a/bpf/lib/lrp.h
+++ b/bpf/lib/lrp.h
@@ -24,7 +24,7 @@ struct {
 	__type(value, __u8);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_SKIP_MAP_MAX_ENTRIES);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_skip_lb6 __section_maps_btf;
 
 struct {
@@ -33,7 +33,7 @@ struct {
 	__type(value, __u8);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_SKIP_MAP_MAX_ENTRIES);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_skip_lb4 __section_maps_btf;
 
 DECLARE_CONFIG(bool, enable_lrp, "Enable support for Local Redirect Policy")

--- a/bpf/lib/node.h
+++ b/bpf/lib/node.h
@@ -36,7 +36,7 @@ struct {
 	__type(value, struct node_value);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, NODE_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_node_map_v2 __section_maps_btf;
 
 static __always_inline const struct node_value *

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
+	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/bpf/analyze"
@@ -213,6 +215,13 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 		return nil, nil, fmt.Errorf("replacing maps from registry: %w", err)
 	}
 
+	// Handle BPF_F_RDONLY_PROG flag compatibility for pinned maps before loading.
+	// This ensures BPF programs can reuse existing pinned maps during upgrades
+	// where the flag state differs between old and new versions.
+	if err := adjustMapFlagsForUpgrade(logger, spec, &opts.CollectionOptions); err != nil {
+		return nil, nil, fmt.Errorf("adjusting map flags for upgrade: %w", err)
+	}
+
 	if err := renameMaps(spec, opts.MapRenames); err != nil {
 		return nil, nil, fmt.Errorf("renaming maps: %w", err)
 	}
@@ -307,6 +316,63 @@ func patchMaps(coll *ebpf.CollectionSpec, reg *registry.MapRegistry) error {
 		}
 
 		patch.Apply(spec)
+	}
+
+	return nil
+}
+
+// adjustMapFlagsForUpgrade modifies map specs in the CollectionSpec to handle
+// BPF_F_RDONLY_PROG flag mismatches between spec and pinned maps.
+//
+// On upgrade (no flag -> flag): remove BPF_F_RDONLY_PROG from spec to reuse the
+// existing map, since the datapath functions correctly with a more privileged
+// (read-write) map.
+//
+// On downgrade (flag -> no flag): unpin the existing map to force recreation
+// without the flag, since BPF programs need write access.
+func adjustMapFlagsForUpgrade(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *ebpf.CollectionOptions) error {
+	if opts.Maps.PinPath == "" {
+		return nil
+	}
+
+	const bpfFRdonlyProg = unix.BPF_F_RDONLY_PROG
+
+	for name, mapSpec := range spec.Maps {
+		if mapSpec.Pinning == 0 {
+			continue
+		}
+
+		pinPath := path.Join(opts.Maps.PinPath, name)
+
+		existing, err := ebpf.LoadPinnedMap(pinPath, nil)
+		if err != nil {
+			continue
+		}
+
+		info, err := existing.Info()
+		if err != nil {
+			existing.Close()
+			continue
+		}
+
+		switch {
+		case mapSpec.Flags&bpfFRdonlyProg != 0 && info.Flags&bpfFRdonlyProg == 0:
+			// Upgrade: strip flag from spec to reuse existing map.
+			logger.Debug("Removing BPF_F_RDONLY_PROG flag for upgrade compatibility",
+				logfields.BPFMapName, name,
+				logfields.Path, pinPath,
+			)
+			mapSpec.Flags &^= bpfFRdonlyProg
+		case mapSpec.Flags&bpfFRdonlyProg == 0 && info.Flags&bpfFRdonlyProg != 0:
+			// Downgrade: unpin to force recreation without the flag.
+			logger.Debug("Unpinning map with BPF_F_RDONLY_PROG for downgrade compatibility",
+				logfields.BPFMapName, name,
+				logfields.Path, pinPath,
+			)
+			existing.Unpin()
+		}
+
+		existing.Close()
 	}
 
 	return nil

--- a/pkg/datapath/maps/maps_generated.go
+++ b/pkg/datapath/maps/maps_generated.go
@@ -507,7 +507,7 @@ func newCiliumLb4MaglevSpec(btf *btf.Spec) *ebpf.MapSpec {
 		Value:      anyTypeByName(btf, "__u32"),
 		InnerMap:   newCiliumLb4MaglevInnerSpec(btf),
 		MaxEntries: 65536,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -561,7 +561,7 @@ func newCiliumLb4ServicesV2Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  12,
 		Value:      anyTypeByName(btf, "lb4_service"),
 		MaxEntries: 65536,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -575,7 +575,7 @@ func newCiliumLb4SourceRangeSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  1,
 		Value:      anyTypeByName(btf, "__u8"),
 		MaxEntries: 1000,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -632,7 +632,7 @@ func newCiliumLb6MaglevSpec(btf *btf.Spec) *ebpf.MapSpec {
 		Value:      anyTypeByName(btf, "__u32"),
 		InnerMap:   newCiliumLb6MaglevInnerSpec(btf),
 		MaxEntries: 65536,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -686,7 +686,7 @@ func newCiliumLb6ServicesV2Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  12,
 		Value:      anyTypeByName(btf, "lb6_service"),
 		MaxEntries: 65536,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -700,7 +700,7 @@ func newCiliumLb6SourceRangeSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  1,
 		Value:      anyTypeByName(btf, "__u8"),
 		MaxEntries: 1000,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -797,7 +797,7 @@ func newCiliumNodeMapV2Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  4,
 		Value:      anyTypeByName(btf, "node_value"),
 		MaxEntries: 16384,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -1109,7 +1109,7 @@ func newCiliumSkipLb4Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  1,
 		Value:      anyTypeByName(btf, "__u8"),
 		MaxEntries: 100,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -1123,7 +1123,7 @@ func newCiliumSkipLb6Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  1,
 		Value:      anyTypeByName(btf, "__u8"),
 		MaxEntries: 100,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }

--- a/pkg/loadbalancer/maps/lbmaps.go
+++ b/pkg/loadbalancer/maps/lbmaps.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -156,7 +157,7 @@ func NewService4Map(maxEntries int) *bpf.Map {
 		&Service4Key{},
 		&Service4Value{},
 		maxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	)
 }
 
@@ -167,7 +168,7 @@ func NewService6Map(maxEntries int) *bpf.Map {
 		&Service6Key{},
 		&Service6Value{},
 		maxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	)
 }
 
@@ -255,7 +256,7 @@ func NewSourceRange4Map(maxEntries int) *bpf.Map {
 		&SourceRangeKey4{},
 		&SourceRangeValue{},
 		maxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	)
 }
 
@@ -266,7 +267,7 @@ func NewSourceRange6Map(maxEntries int) *bpf.Map {
 		&SourceRangeKey6{},
 		&SourceRangeValue{},
 		maxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	)
 }
 
@@ -299,7 +300,7 @@ func NewMaglevOuterMap(name string, maxEntries int, innerSpec *ebpf.MapSpec) *bp
 		&MaglevOuterKey{},
 		&MaglevOuterVal{},
 		maxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 		innerSpec.Copy(),
 	)
 }

--- a/pkg/loadbalancer/maps/skiplb.go
+++ b/pkg/loadbalancer/maps/skiplb.go
@@ -47,7 +47,7 @@ func NewSkipLBMap(logger *slog.Logger) (SkipLBMap, error) {
 			KeySize:    uint32(unsafe.Sizeof(SkipLB4Key{})),
 			ValueSize:  uint32(unsafe.Sizeof(SkipLB4Value{})),
 			MaxEntries: SkipLBMapMaxEntries,
-			Flags:      unix.BPF_F_NO_PREALLOC,
+			Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 			Pinning:    pinning,
 		})
 	}
@@ -58,7 +58,7 @@ func NewSkipLBMap(logger *slog.Logger) (SkipLBMap, error) {
 			KeySize:    uint32(unsafe.Sizeof(SkipLB6Key{})),
 			ValueSize:  uint32(unsafe.Sizeof(SkipLB6Value{})),
 			MaxEntries: SkipLBMapMaxEntries,
-			Flags:      unix.BPF_F_NO_PREALLOC,
+			Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 			Pinning:    pinning,
 		})
 	}

--- a/pkg/maps/nodemap/node_map_v2.go
+++ b/pkg/maps/nodemap/node_map_v2.go
@@ -4,9 +4,11 @@
 package nodemap
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"os"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -61,7 +63,7 @@ func newMapV2(logger *slog.Logger, mapName string, conf Config) *nodeMapV2 {
 			KeySize:    uint32(unsafe.Sizeof(NodeKey{})),
 			ValueSize:  uint32(unsafe.Sizeof(NodeValueV2{})),
 			MaxEntries: conf.NodeMapMax,
-			Flags:      unix.BPF_F_NO_PREALLOC,
+			Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 			Pinning:    ebpf.PinByName,
 		}),
 	}
@@ -173,6 +175,13 @@ func LoadNodeMapV2(logger *slog.Logger) (MapV2, error) {
 }
 
 func (m *nodeMapV2) init() error {
+	if existing, err := ebpf.LoadRegisterMap(m.logger, MapNameV2); err == nil {
+		m.bpfMap = existing
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		m.logger.Debug("Falling back to recreate node map", logfields.Error, err)
+	}
+
 	if err := m.bpfMap.OpenOrCreate(); err != nil {
 		return fmt.Errorf("failed to init bpf map: %w", err)
 	}


### PR DESCRIPTION
Follow up for [pr](https://github.com/cilium/cilium/pull/43076)

```release-note
datapath: mark read-only to node, lrp, and lb maps from datapath
```
