### PR TITLE
test: Fix 'make fuzz'

### DIFF
--- a/test/fuzzing/go-fuzz.sh
+++ b/test/fuzzing/go-fuzz.sh
@@ -20,6 +20,7 @@ declare -A ALL_TESTS
 # find_fuzzers populates 'ALL_TESTS' and 'TEST_COUNT' from oss-fuzz-build.sh.
 find_fuzzers() {
     local test_count
+    test_count=0
 
     packages="$(grep compile_native_go_fuzzer "$FUZZ_BUILD" \
                 | awk '{ print $2 }' \
@@ -48,7 +49,7 @@ run_tests() {
 }
 
 main() {
-    if [ "$TIMEOUT" -le 0 ]; then
+    if [ "$FUZZ_TIME" -le 0 ]; then
         >&2 echo "Timeout $FUZZ_TIME must be >= 0."
         exit 1
     fi


### PR DESCRIPTION
This command was a bit broken due to renamed and uninitialized
variables. It also required environment variables to be passed on the
command line in order to run. Fix up a couple of variables so it's now
possible to run `make fuzz` by itself, to just validate the fuzzers by
running them each for one second. Optionally you can run `make fuzz
FUZZ_TIME=x` to run each fuzzer for x seconds.
