### PR TITLE
operator: Remove dummy ingress endpoint

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -66,9 +66,6 @@ metadata:
     {{- toYaml .Values.ingressController.service.annotations | nindent 4 }}
   {{- end }}
 addressType: IPv4
-endpoints:
-- addresses:
-  - "192.192.192.192"
-ports:
-- port: 9999
+endpoints: []
+ports: []
 {{- end }}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -327,19 +327,8 @@ func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedR
 			},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Port: ptr.To[int32](9999), // dummy
-			},
-		},
+		Endpoints:   nil,
+		Ports:       nil,
 	}
 }
 

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -175,18 +175,7 @@ func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.Endpoi
 			},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Port: ptr.To[int32](9999), // dummy
-			},
-		},
+		Endpoints:   nil,
+		Ports:       nil,
 	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -214,15 +214,8 @@ func Test_getEndpointForIngress(t *testing.T) {
 			},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port
+		Endpoints:   nil,
+		Ports:       nil,
 	}, res)
 }
 

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -8,7 +8,7 @@
 hive/start
 
 # Add the objects
-k8s/add svc-ingress.yaml eps-ingress.yaml cec.yaml
+k8s/add svc-ingress.yaml cec.yaml
 k8s/add svc-details.yaml eps-details.yaml
 k8s/add svc-productpage.yaml eps-productpage.yaml
 
@@ -108,39 +108,6 @@ spec:
   type: LoadBalancer
 status:
   loadBalancer: {}
-
--- eps-ingress.yaml --
-addressType: IPv4
-apiVersion: discovery.k8s.io/v1
-endpoints:
-- addresses:
-  - 192.192.192.192
-  conditions:
-    ready: true
-kind: EndpointSlice
-metadata:
-  creationTimestamp: "2025-03-25T10:13:20Z"
-  generateName: cilium-ingress-basic-ingress-
-  generation: 1
-  labels:
-    cilium.io/ingress: "true"
-    endpointslice.kubernetes.io/managed-by: endpointslicemirroring-controller.k8s.io
-    kubernetes.io/service-name: cilium-ingress-basic-ingress
-  name: cilium-ingress-basic-ingress-gjh2c
-  namespace: default
-  ownerReferences:
-  - apiVersion: v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Endpoints
-    name: cilium-ingress-basic-ingress
-    uid: 9465c03a-ea0e-42bf-bd8d-56aabc86fcc2
-  resourceVersion: "126851"
-  uid: d93afa57-70a6-4b66-8906-16e53df84b3f
-ports:
-- name: ""
-  port: 9999
-  protocol: TCP
 
 -- cec.yaml --
 apiVersion: cilium.io/v2

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -33,19 +33,7 @@ import (
 var (
 	zeroV4 = cmtypes.MustParseAddrCluster("0.0.0.0")
 	zeroV6 = cmtypes.MustParseAddrCluster("::")
-
-	ingressDummyAddress = cmtypes.MustParseAddrCluster("192.192.192.192")
-	ingressDummyPort    = uint16(9999)
 )
-
-func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
-	// The ingress and gateway-api controllers (operator/pkg/model/translation/{gateway-api,ingress}) create
-	// a dummy endpoint to force Cilium to reconcile the service. This is no longer required with this new
-	// control-plane, but due to rolling upgrades we cannot remove it immediately. Hence we have the
-	// special handling here to just ignore this endpoint to avoid populating the tables with unnecessary
-	// data.
-	return l3n4Addr.AddrCluster() == ingressDummyAddress && l3n4Addr.Port() == ingressDummyPort
-}
 
 func getAnnotationServiceForwardingMode(cfg loadbalancer.Config, svc *slim_corev1.Service) (loadbalancer.SVCForwardingMode, error) {
 	if value, ok := annotation.Get(svc, annotation.ServiceForwardingMode); ok {
@@ -415,9 +403,6 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					l4Addr.Port,
 					loadbalancer.ScopeExternal,
 				)
-				if isIngressDummyEndpoint(l3n4Addr) {
-					continue
-				}
 
 				// Filter out the unnamed port, if present
 				if idx := slices.Index(portNames, ""); idx != -1 {

--- a/pkg/loadbalancer/tests/testdata/ingress.txtar
+++ b/pkg/loadbalancer/tests/testdata/ingress.txtar
@@ -1,7 +1,5 @@
 #! --lb-test-fault-probability=0.0
 # Test the handling for the ingress service created by the operator.
-# The control-plane should ignore the dummy ingress endpoint (192.192.192.192:9999), but
-# still process the service.
 # An extended version of this test that include CiliumEnvoyConfig processing can be found
 # from pkg/ciliumenvoyconfig/testdata/ingress.yaml.
 # Based on https://docs.cilium.io/en/stable/network/servicemesh/http/
@@ -78,11 +76,7 @@ status:
 -- eps-ingress.yaml --
 addressType: IPv4
 apiVersion: discovery.k8s.io/v1
-endpoints:
-- addresses:
-  - 192.192.192.192
-  conditions:
-    ready: true
+endpoints: []
 kind: EndpointSlice
 metadata:
   creationTimestamp: "2025-03-25T10:13:20Z"
@@ -103,9 +97,4 @@ metadata:
     uid: 9465c03a-ea0e-42bf-bd8d-56aabc86fcc2
   resourceVersion: "126851"
   uid: d93afa57-70a6-4b66-8906-16e53df84b3f
-ports:
-- name: ""
-  port: 9999
-  protocol: TCP
-
-
+ports: []


### PR DESCRIPTION
Now that v1.18 is out with the new LB control-plane we can finally remove the dummy ingress endpoint.

Fixes: #19262

```release-note
The dummy endpoint (192.192.192.192:9999) is no longer created for Ingress and Gateway API.
```
