### PR TITLE
datapath: move device metadata to cilium_devices map

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -1181,6 +1181,7 @@ here.
 | DROP_EP_NOT_READY | 203 | A BPF program wants to tail call some endpoint&#39;s policy program in cilium_call_policy, but the program is not available. |
 | DROP_NO_EGRESS_IP | 204 | An Egress Gateway node matched a packet against an Egress Gateway policy that didn&#39;t select a valid Egress IP. |
 | DROP_PUNT_PROXY | 205 | Punt packet to a user space proxy. |
+| DROP_NO_DEVICE | 206 | A BPF program failed to look up information for a network device. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -652,6 +652,8 @@ const (
 	DropReason_DROP_NO_EGRESS_IP DropReason = 204
 	// Punt packet to a user space proxy.
 	DropReason_DROP_PUNT_PROXY DropReason = 205
+	// A BPF program failed to look up information for a network device.
+	DropReason_DROP_NO_DEVICE DropReason = 206
 )
 
 // Enum value maps for DropReason.
@@ -733,6 +735,7 @@ var (
 		203: "DROP_EP_NOT_READY",
 		204: "DROP_NO_EGRESS_IP",
 		205: "DROP_PUNT_PROXY",
+		206: "DROP_NO_DEVICE",
 	}
 	DropReason_value = map[string]int32{
 		"DROP_REASON_UNKNOWN":                                   0,
@@ -811,6 +814,7 @@ var (
 		"DROP_EP_NOT_READY":                                     203,
 		"DROP_NO_EGRESS_IP":                                     204,
 		"DROP_PUNT_PROXY":                                       205,
+		"DROP_NO_DEVICE":                                        206,
 	}
 )
 
@@ -5916,7 +5920,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
 	"\x06TRACED\x10\x06\x12\x0e\n" +
 	"\n" +
-	"TRANSLATED\x10\a*\xc5\x11\n" +
+	"TRANSLATED\x10\a*\xda\x11\n" +
 	"\n" +
 	"DropReason\x12\x17\n" +
 	"\x13DROP_REASON_UNKNOWN\x10\x00\x12\x1b\n" +
@@ -5997,7 +6001,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x13DROP_HOST_NOT_READY\x10\xca\x01\x12\x16\n" +
 	"\x11DROP_EP_NOT_READY\x10\xcb\x01\x12\x16\n" +
 	"\x11DROP_NO_EGRESS_IP\x10\xcc\x01\x12\x14\n" +
-	"\x0fDROP_PUNT_PROXY\x10\xcd\x01*J\n" +
+	"\x0fDROP_PUNT_PROXY\x10\xcd\x01\x12\x13\n" +
+	"\x0eDROP_NO_DEVICE\x10\xce\x01*J\n" +
 	"\x10TrafficDirection\x12\x1d\n" +
 	"\x19TRAFFIC_DIRECTION_UNKNOWN\x10\x00\x12\v\n" +
 	"\aINGRESS\x10\x01\x12\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -524,6 +524,8 @@ enum DropReason {
     DROP_NO_EGRESS_IP = 204;
     // Punt packet to a user space proxy.
     DROP_PUNT_PROXY = 205;
+    // A BPF program failed to look up information for a network device.
+    DROP_NO_DEVICE = 206;
 }
 
 enum TrafficDirection {

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -211,6 +211,7 @@ const DropReason_DROP_HOST_NOT_READY = flow.DropReason_DROP_HOST_NOT_READY
 const DropReason_DROP_EP_NOT_READY = flow.DropReason_DROP_EP_NOT_READY
 const DropReason_DROP_NO_EGRESS_IP = flow.DropReason_DROP_NO_EGRESS_IP
 const DropReason_DROP_PUNT_PROXY = flow.DropReason_DROP_PUNT_PROXY
+const DropReason_DROP_NO_DEVICE = flow.DropReason_DROP_NO_DEVICE
 
 var DropReason_name = flow.DropReason_name
 var DropReason_value = flow.DropReason_value

--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -111,3 +111,6 @@ add_type(struct node_value);
 #include "lib/lrp.h"
 add_type(struct skip_lb4_key);
 add_type(struct skip_lb6_key);
+
+#include "lib/network_device.h"
+add_type(struct device_state);

--- a/bpf/lib/drop_reasons.h
+++ b/bpf/lib/drop_reasons.h
@@ -86,3 +86,4 @@
 #define DROP_EP_NOT_READY	-203
 #define DROP_NO_EGRESS_IP	-204
 #define DROP_PUNT_PROXY		-205 /* Mapped as drop code, though drop not necessary. */
+#define DROP_NO_DEVICE		-206

--- a/bpf/lib/network_device.h
+++ b/bpf/lib/network_device.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <linux/bpf.h>
+#include <bpf/section.h>
+#include <bpf/loader.h>
+
+#include "eth.h"
+
+struct device_state {
+	union macaddr mac;
+	__u8 l3:1;
+	__u8 pad0:7;
+	__u8 pad1;
+	__u16 pad2;
+	__u32 pad3;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, __u32);
+	__type(value, struct device_state);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, 4096);
+} cilium_devices __section_maps_btf;
+
+static __always_inline struct device_state *
+device_state_lookup(__u32 ifindex)
+{
+	return map_lookup_elem(&cilium_devices, &ifindex);
+}
+
+static __always_inline bool
+device_is_l3(__u32 ifindex)
+{
+	struct device_state *state = device_state_lookup(ifindex);
+
+	return state ? state->l3 : false;
+}
+
+static __always_inline union macaddr
+*device_mac(__u32 ifindex)
+{
+	struct device_state *state;
+
+	state = device_state_lookup(ifindex);
+	if (!state)
+		return NULL;
+	return &state->mac;
+}

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -16,7 +16,6 @@
 
 #define CILIUM_NET_IFINDEX 1
 #define CILIUM_HOST_IFINDEX 1
-#define NATIVE_DEV_MAC_BY_IFINDEX(_) { .addr = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 } }
 
 #define LRU_MEM_FLAVOR 0
 
@@ -160,10 +159,6 @@
 #  define IPV6_RSS_PREFIX IPV6_DIRECT_ROUTING
 #  define IPV6_RSS_PREFIX_BITS 128
 # endif
-#endif
-
-#ifndef IS_L3_DEV
-# define IS_L3_DEV(ifindex) false
 #endif
 
 #define LB4_SRC_RANGE_MAP_SIZE	1000

--- a/bpf/tests/lib/network_device.h
+++ b/bpf/tests/lib/network_device.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+static __always_inline void
+cilium_device_add_entry(__u32 ifindex, const __u8 *mac, __u8 l3)
+{
+	struct device_state state = {
+		.l3 = l3,
+	};
+
+	if (mac)
+		memcpy(&state.mac, mac, ETH_ALEN);
+
+	map_update_elem(&cilium_devices, &ifindex, &state, BPF_ANY);
+}

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -28,6 +28,8 @@
 #define BACKEND_IP_REMOTE	v4_pod_two
 #define BACKEND_PORT		__bpf_htons(8080)
 
+#define DEFAULT_IFACE	24
+
 #define fib_lookup mock_fib_lookup
 
 static volatile const __u8 *client_mac = mac_one;
@@ -61,8 +63,10 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 	__u32 key = 0;
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
 
-	if (settings && settings->fail_fib)
+	if (settings && settings->fail_fib) {
+		params->ifindex = DEFAULT_IFACE;
 		return BPF_FIB_LKUP_RET_NO_NEIGH;
+	}
 
 	params->ifindex = 0;
 
@@ -82,6 +86,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
+#include "lib/network_device.h"
 
 /* Test that a SVC request to a local backend
  * - gets DNATed (but not SNATed)
@@ -534,6 +539,8 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 
 	if (settings)
 		settings->fail_fib = true;
+
+	cilium_device_add_entry(DEFAULT_IFACE, (__u8 *)lb_mac, 0);
 
 	return xdp_receive_packet(ctx);
 }

--- a/pkg/datapath/alignchecker/alignchecker.go
+++ b/pkg/datapath/alignchecker/alignchecker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+	"github.com/cilium/cilium/pkg/maps/netdev"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/ratelimitmap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
@@ -93,6 +94,7 @@ var (
 		"debug_capture_msg":       {monitor.DebugCapture{}},
 		"policy_verdict_notify":   {monitor.PolicyVerdictNotify{}},
 		"trace_sock_notify":       {monitor.TraceSockNotify{}},
+		"device_state":            {netdev.DeviceState{}},
 	}
 	toCheckSizes = map[string][]any{
 		"__u16": {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -398,13 +398,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["LB4_SRC_RANGE_MAP_SIZE"] = fmt.Sprintf("%d", cfg.LBConfig.LBSourceRangeMapEntries)
 	cDefinesMap["LB6_SRC_RANGE_MAP_SIZE"] = fmt.Sprintf("%d", cfg.LBConfig.LBSourceRangeMapEntries)
 
-	macByIfIndexMacro, isL3DevMacro, err := devMacros(nativeDevices)
-	if err != nil {
-		return fmt.Errorf("generating device macros: %w", err)
-	}
-	cDefinesMap["NATIVE_DEV_MAC_BY_IFINDEX(IFINDEX)"] = macByIfIndexMacro
-	cDefinesMap["IS_L3_DEV(ifindex)"] = isL3DevMacro
-
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---
 
 	const (
@@ -695,54 +688,6 @@ return false;`))
 
 		return vlanFilterMacro.String(), nil
 	}
-}
-
-// devMacros generates NATIVE_DEV_MAC_BY_IFINDEX and IS_L3_DEV macros which
-// are written to node_config.h.
-func devMacros(devs []*tables.Device) (string, string, error) {
-	var (
-		macByIfIndexMacro, isL3DevMacroBuf bytes.Buffer
-		isL3DevMacro                       string
-	)
-	macByIfIndex := make(map[int]string)
-	l3DevIfIndices := make([]int, 0)
-
-	for _, dev := range devs {
-		if len(dev.HardwareAddr) != 6 {
-			l3DevIfIndices = append(l3DevIfIndices, dev.Index)
-		}
-		macByIfIndex[dev.Index] = mac.CArrayString(net.HardwareAddr(dev.HardwareAddr))
-	}
-
-	macByIfindexTmpl := template.Must(template.New("macByIfIndex").Parse(
-		`({ \
-union macaddr __mac = {.addr = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0}}; \
-switch (IFINDEX) { \
-{{range $idx,$mac := .}} case {{$idx}}: {union macaddr __tmp = {.addr = {{$mac}}}; __mac=__tmp;} break; \
-{{end}}} \
-__mac; })`))
-
-	if err := macByIfindexTmpl.Execute(&macByIfIndexMacro, macByIfIndex); err != nil {
-		return "", "", fmt.Errorf("failed to execute template: %w", err)
-	}
-
-	if len(l3DevIfIndices) == 0 {
-		isL3DevMacro = "false"
-	} else {
-		isL3DevTmpl := template.Must(template.New("isL3Dev").Parse(
-			`({ \
-bool is_l3 = false; \
-switch (ifindex) { \
-{{range $idx := .}} case {{$idx}}: is_l3 = true; break; \
-{{end}}} \
-is_l3; })`))
-		if err := isL3DevTmpl.Execute(&isL3DevMacroBuf, l3DevIfIndices); err != nil {
-			return "", "", fmt.Errorf("failed to execute template: %w", err)
-		}
-		isL3DevMacro = isL3DevMacroBuf.String()
-	}
-
-	return macByIfIndexMacro.String(), isL3DevMacro, nil
 }
 
 func (h *HeaderfileWriter) writeNetdevConfig(w io.Writer, opts *option.IntOptions) {

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/multicast"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
+	"github.com/cilium/cilium/pkg/maps/netdev"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
@@ -44,6 +45,9 @@ var Cell = cell.Module(
 
 	// ConfigMap stores runtime configuration state for the Cilium datapath.
 	configmap.Cell,
+
+	// Provides access to eBPF map which stores network devices properties for datapath usage.
+	netdev.Cell,
 
 	// Receives datapath signals for GC fill-up events
 	// Note that we can't import this from ctmap package, as gc needs to import ctmap.

--- a/pkg/maps/netdev/cell.go
+++ b/pkg/maps/netdev/cell.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package netdev
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+// Cell initializes and manages the network devices map.
+var Cell = cell.Module(
+	"netdev-map",
+	"eBPF map contains information about network devices for Cilium datapath",
+
+	cell.Provide(newMap),
+
+	// Synchronizes selected network devices into the cilium_devices BPF map.
+	NetDevMapSyncCell,
+)
+
+func newMap(lifecycle cell.Lifecycle) bpf.MapOut[Map] {
+	netDevMap := newNetDevMap()
+
+	lifecycle.Append(cell.Hook{
+		OnStart: func(startCtx cell.HookContext) error {
+			return netDevMap.init()
+		},
+		OnStop: func(stopCtx cell.HookContext) error {
+			return netDevMap.close()
+		},
+	})
+
+	return bpf.NewMapOut(Map(netDevMap))
+}

--- a/pkg/maps/netdev/doc.go
+++ b/pkg/maps/netdev/doc.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package contains information about network devices for Cilium datapath.
+// +groupName=maps
+package netdev

--- a/pkg/maps/netdev/netdev.go
+++ b/pkg/maps/netdev/netdev.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package netdev
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+// Map provides access to the eBPF map cilium_devices.
+type Map interface {
+	Upsert(ifindex uint32, state DeviceState) error
+
+	Lookup(ifindex uint32) (*DeviceState, error)
+
+	IterateWithCallback(cb IterateCallback) error
+
+	Clear(ifindex uint32) error
+}
+
+type netDevMap struct {
+	*bpf.Map
+}
+
+func newNetDevMap() *netDevMap {
+	var index Index
+	return &netDevMap{
+		Map: bpf.NewMap(
+			"cilium_devices",
+			ebpf.Array,
+			&index,
+			&DeviceState{},
+			4096,
+			0,
+		),
+	}
+}
+
+func (m *netDevMap) Upsert(ifindex uint32, state DeviceState) error {
+	key := Index(ifindex)
+	return m.Map.Update(&key, &state)
+}
+
+func (m *netDevMap) Lookup(ifindex uint32) (*DeviceState, error) {
+	key := Index(ifindex)
+	state, err := m.Map.Lookup(&key)
+	if err != nil {
+		return nil, err
+	}
+	return state.(*DeviceState), nil
+}
+
+// IterateCallback represents the signature of the callback used for iteration.
+type IterateCallback func(*Index, *DeviceState)
+
+func (m *netDevMap) IterateWithCallback(cb IterateCallback) error {
+	return m.Map.DumpWithCallback(func(k bpf.MapKey, v bpf.MapValue) {
+		cb(k.(*Index), v.(*DeviceState))
+	})
+}
+
+var zeroDeviceState = DeviceState{}
+
+// Clear resets an entry to the zero value.
+func (m *netDevMap) Clear(ifindex uint32) error {
+	key := Index(ifindex)
+	return m.Map.Update(&key, &zeroDeviceState)
+}
+
+func (m *netDevMap) init() error {
+	if err := m.Map.OpenOrCreate(); err != nil {
+		return fmt.Errorf("failed to init bpf map: %w", err)
+	}
+	return nil
+}
+
+func (m *netDevMap) close() error {
+	if err := m.Map.Close(); err != nil {
+		return fmt.Errorf("failed to close bpf map: %w", err)
+	}
+	return nil
+}
+
+// Index matches the BPF map key (__u32 ifindex).
+type Index uint32
+
+func (k *Index) New() bpf.MapKey {
+	return new(Index)
+}
+
+func (k *Index) String() string {
+	return fmt.Sprintf("%d", uint32(*k))
+}
+
+// DeviceState matches struct device_state in bpf/lib/network_device.h.
+type DeviceState struct {
+	MAC types.MACAddr `align:"mac"`
+	_   uint16
+	L3  DeviceStateL3 `align:"l3"`
+	_   uint8         `align:"pad1"`
+	_   uint16        `align:"pad2"`
+	_   uint32        `align:"pad3"`
+}
+
+func NewDeviceState(mac net.HardwareAddr) DeviceState {
+	state := DeviceState{}
+	if len(mac) == len(state.MAC) {
+		copy(state.MAC[:], mac)
+	}
+	if len(mac) != 6 {
+		state.SetL3(true)
+	}
+	return state
+}
+
+// DeviceStateL3 represents device L3 states.
+type DeviceStateL3 uint8
+
+const deviceStateL3Mask DeviceStateL3 = 1 << iota
+
+func (s *DeviceState) New() bpf.MapValue {
+	return &DeviceState{}
+}
+
+func (s *DeviceState) String() string {
+	return fmt.Sprintf("%s %b", s.MAC.String(), s.L3)
+}
+
+func (s *DeviceState) IsL3() bool {
+	return s.L3&deviceStateL3Mask != 0
+}
+
+func (s *DeviceState) SetL3(enabled bool) {
+	if enabled {
+		s.L3 |= deviceStateL3Mask
+		return
+	}
+	s.L3 &^= deviceStateL3Mask
+}

--- a/pkg/maps/netdev/netdev_sync.go
+++ b/pkg/maps/netdev/netdev_sync.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package netdev
+
+import (
+	"context"
+	"log/slog"
+	"net"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// NetDevMapSyncCell keeps the cilium_devices map in sync with the selected devices.
+var NetDevMapSyncCell = cell.Module(
+	"netdev-map-sync",
+	"Synchronizes network devices state into the cilium_devices BPF map",
+	cell.Invoke(registerNetDevMapSync),
+)
+
+type netDevMapSyncParams struct {
+	cell.In
+
+	JobGroup  job.Group
+	Logger    *slog.Logger
+	DB        *statedb.DB
+	Devices   statedb.Table[*tables.Device]
+	DeviceMap Map
+}
+
+func registerNetDevMapSync(p netDevMapSyncParams) {
+	p.JobGroup.Add(job.OneShot(
+		"netdev-map-sync",
+		func(ctx context.Context, _ cell.Health) error {
+			return syncNetDevMap(p, ctx)
+		},
+	))
+}
+
+func syncNetDevMap(p netDevMapSyncParams, ctx context.Context) error {
+	limiter := rate.NewLimiter(50*time.Millisecond, 1)
+	defer limiter.Stop()
+
+	ticker := time.NewTicker(time.Minute * 5)
+	defer ticker.Stop()
+
+	for {
+		rx := p.DB.ReadTxn()
+		devices, watch := tables.SelectedDevices(p.Devices, rx)
+		desired := desiredState(devices)
+
+		upsertDesiredDevices(p, desired)
+		pruneStaleDevices(p, desired)
+
+		select {
+		case <-watch:
+		case <-ticker.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func desiredState(devices []*tables.Device) map[uint32]DeviceState {
+	desired := make(map[uint32]DeviceState, len(devices))
+	for _, dev := range devices {
+		desired[uint32(dev.Index)] = NewDeviceState(net.HardwareAddr(dev.HardwareAddr))
+	}
+	return desired
+}
+
+func pruneStaleDevices(p netDevMapSyncParams, desired map[uint32]DeviceState) {
+	var stale []uint32
+	err := p.DeviceMap.IterateWithCallback(func(k *Index, _ *DeviceState) {
+		key := uint32(*k)
+		if _, ok := desired[key]; ok {
+			return
+		}
+		stale = append(stale, key)
+	})
+	if err != nil {
+		p.Logger.Warn("Failed to iterate network devices map", logfields.Error, err)
+	}
+	for _, ifindex := range stale {
+		if err := p.DeviceMap.Clear(ifindex); err != nil {
+			p.Logger.Warn("Failed to clear stale network devices map entry",
+				logfields.Error, err,
+				logfields.Interface, ifindex,
+			)
+		}
+	}
+}
+
+func upsertDesiredDevices(p netDevMapSyncParams, desired map[uint32]DeviceState) {
+	for ifindex, state := range desired {
+		if err := p.DeviceMap.Upsert(ifindex, state); err != nil {
+			p.Logger.Warn("Failed to upsert network devices map entry",
+				logfields.Error, err,
+				logfields.Interface, ifindex,
+			)
+		}
+	}
+}

--- a/pkg/maps/netdev/netdev_test.go
+++ b/pkg/maps/netdev/netdev_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package netdev
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+func setup(tb testing.TB) {
+	tb.Helper()
+	testutils.PrivilegedTest(tb)
+	logger := hivetest.Logger(tb)
+
+	bpf.CheckOrMountFS(logger, "")
+	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to set memlock rlimit")
+}
+
+func TestNewDeviceState(t *testing.T) {
+	t.Run("mac copied and l3 unset for valid length", func(t *testing.T) {
+		mac := net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+		state := NewDeviceState(mac)
+
+		require.False(t, state.IsL3())
+		require.Equal(t, types.MACAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, state.MAC)
+	})
+
+	t.Run("l3 set when mac length invalid", func(t *testing.T) {
+		mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee}
+		state := NewDeviceState(mac)
+
+		require.True(t, state.IsL3())
+		require.Equal(t, types.MACAddr{}, state.MAC)
+	})
+}
+
+func TestPrivilegedNetDevMap(t *testing.T) {
+	setup(t)
+
+	dm := newNetDevMap()
+	require.NoError(t, dm.Map.CreateUnpinned())
+
+	t.Cleanup(func() {
+		require.NoError(t, dm.close())
+	})
+
+	state1 := NewDeviceState(net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55})
+	state2 := NewDeviceState(net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01})
+
+	require.NoError(t, dm.Upsert(1, state1))
+	require.NoError(t, dm.Upsert(2, state2))
+
+	got1, err := dm.Lookup(1)
+	require.NoError(t, err)
+	require.Equal(t, state1, *got1)
+
+	got2, err := dm.Lookup(2)
+	require.NoError(t, err)
+	require.Equal(t, state2, *got2)
+
+	seen := map[uint32]DeviceState{}
+	require.NoError(t, dm.IterateWithCallback(func(k *Index, v *DeviceState) {
+		if uint32(*k) == 1 || uint32(*k) == 2 {
+			seen[uint32(*k)] = *v
+		}
+	}))
+	require.Len(t, seen, 2)
+	require.Equal(t, state1, seen[1])
+	require.Equal(t, state2, seen[2])
+
+	require.NoError(t, dm.Clear(2))
+	got2, err = dm.Lookup(2)
+	require.NoError(t, err)
+	require.Equal(t, DeviceState{}, *got2)
+}

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -105,6 +105,7 @@ var errors = map[uint8]string{
 	203: "Endpoint policy program not available",
 	204: "No Egress IP configured",
 	205: "Punt to proxy",
+	206: "No device",
 }
 
 func extendedReason(extError int8) string {


### PR DESCRIPTION
Introduce a new cilium_devices BPF map and a sync job that keeps it aligned with SelectedDevices, and wire it into the datapath cells. Replace node_config macros for device MAC/L3 lookup with BPF helpers backed by the map, and add the devices map cell and size define. Remove the legacy macro generator.

Fixes: https://github.com/cilium/cilium/issues/39116
Related: https://github.com/cilium/cilium/issues/38370
