### PR TITLE
docs: Add IPv6 limitation note to L2 announcements page

### DIFF
--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -12,6 +12,10 @@ L2 Announcements / L2 Aware LB (Beta)
 
 .. include:: ../beta.rst
 
+.. note::
+   IPv6 is not currently supported for L2 announcements. Only ARP (IPv4)
+   messages are sent; Neighbor Discovery (IPv6) is not implemented.
+
 L2 Announcements is a feature which makes services visible and reachable on 
 the local area network. This feature is primarily intended for on-premises
 deployments within networks without BGP based routing such as office or 


### PR DESCRIPTION
Users with IPv6-only clusters were wasting time debugging L2 announcements before discovering the feature doesn't support IPv6. The limitation was previously only mentioned at the bottom of the page.

This adds a prominent note at the top of the page, immediately after the beta warning, to inform users upfront that IPv6 is not currently supported (only ARP/IPv4, no NDP/IPv6).

Fixes: #43529




```release-note
docs: Add IPv6 limitation note to L2 announcements documentation
```
