### PR TITLE
infraipallocation: include router ip restoration

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cilium/cilium/daemon/infraendpoints"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
@@ -192,15 +191,6 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	params.K8sWatcher.InitK8sSubsystem(ctx)
 	bootstrapStats.k8sInit.End(true)
 
-	// Fetch the router (`cilium_host`) IPs in case they were set a priori from
-	// the Kubernetes or CiliumNode resource in the K8s subsystem from call
-	// k8s.WaitForNodeInformation(). These will be used later after starting
-	// IPAM initialization to finish off the `cilium_host` IP restoration.
-	var restoredRouterIPs infraendpoints.RestoredIPs
-	restoredRouterIPs.IPv4FromK8s, restoredRouterIPs.IPv6FromK8s = node.GetInternalIPv4Router(params.Logger), node.GetIPv6Router(params.Logger)
-	// Fetch the router IPs from the filesystem in case they were set a priori
-	restoredRouterIPs.IPv4FromFS, restoredRouterIPs.IPv6FromFS = node.ExtractCiliumHostIPFromFS(params.Logger)
-
 	// Configure and start IPAM without using the configuration yet.
 	configureAndStartIPAM(ctx, params)
 
@@ -216,7 +206,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 
 	// We must do this after IPAM because we must wait until the
 	// K8s resources have been synced.
-	if err := params.InfraIPAllocator.AllocateIPs(ctx, restoredRouterIPs); err != nil {
+	if err := params.InfraIPAllocator.AllocateIPs(ctx); err != nil {
 		return err
 	}
 

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -584,7 +584,7 @@ func (r *infraIPAllocator) extractCiliumHostIPFromFS() (net.IP, net.IP) {
 		return ipv4GW, ipv6Router
 	}
 
-	ipv4GW, ipv6Router = node.GetCiliumHostIPsFromNetDev(defaults.HostDevice)
+	ipv4GW, ipv6Router = getCiliumHostIPsFromNetDev(defaults.HostDevice)
 
 	if ipv4GW != nil || ipv6Router != nil {
 		r.logger.Info(

--- a/daemon/infraendpoints/netdev_linux.go
+++ b/daemon/infraendpoints/netdev_linux.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package infraendpoints
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+)
+
+// getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns it
+func getCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
+	hostDev, err := safenetlink.LinkByName(devName)
+	if err != nil {
+		return nil, nil
+	}
+	addrs, err := safenetlink.AddrList(hostDev, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, nil
+	}
+	for _, addr := range addrs {
+		if addr.IP.To4() != nil {
+			if addr.Scope == int(netlink.SCOPE_LINK) {
+				ipv4GW = addr.IP
+			}
+		} else {
+			if addr.Scope != int(netlink.SCOPE_LINK) {
+				ipv6Router = addr.IP
+			}
+		}
+	}
+
+	return ipv4GW, ipv6Router
+}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -332,7 +332,7 @@ func GetNodeAddressing(logger *slog.Logger) *models.NodeAddressing {
 	return a
 }
 
-func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
+func GetCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 	// ipLen is the length of the IP address stored in the node_config.h
 	// it has the same length for both IPv4 and IPv6.
 	const ipLen = net.IPv6len
@@ -392,24 +392,6 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 		}
 	}
 	return ipv4GW, ipv6Router
-}
-
-// ExtractCiliumHostIPFromFS returns the Cilium IPv4 gateway and router IPv6 address from
-// the node_config.h file if is present; or by deriving it from
-// defaults.HostDevice interface, on which only the IPv4 is possible to derive.
-func ExtractCiliumHostIPFromFS(logger *slog.Logger) (ipv4GW, ipv6Router net.IP) {
-	nodeConfig := option.Config.GetNodeConfigPath()
-	ipv4GW, ipv6Router = getCiliumHostIPsFromFile(nodeConfig)
-	if ipv4GW != nil || ipv6Router != nil {
-		logger.Info(
-			"Restored router address from node_config",
-			logfields.IPv4, ipv4GW,
-			logfields.IPv6, ipv6Router,
-			logfields.File, nodeConfig,
-		)
-		return ipv4GW, ipv6Router
-	}
-	return getCiliumHostIPsFromNetDev(logger, defaults.HostDevice)
 }
 
 // GetEndpointHealthIPv4 returns the IPv4 cilium-health endpoint address.

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -7,7 +7,6 @@ package node
 
 import (
 	"fmt"
-	"log/slog"
 	"net"
 	"sort"
 
@@ -16,7 +15,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/ip"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 func firstGlobalAddr(intf string, preferredIP net.IP, family int, preferPublic bool) (net.IP, error) {
@@ -166,9 +164,9 @@ func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.
 	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V6, preferPublic)
 }
 
-// getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
+// GetCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
 // it
-func getCiliumHostIPsFromNetDev(logger *slog.Logger, devName string) (ipv4GW, ipv6Router net.IP) {
+func GetCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
 	hostDev, err := safenetlink.LinkByName(devName)
 	if err != nil {
 		return nil, nil
@@ -187,15 +185,6 @@ func getCiliumHostIPsFromNetDev(logger *slog.Logger, devName string) (ipv4GW, ip
 				ipv6Router = addr.IP
 			}
 		}
-	}
-
-	if ipv4GW != nil || ipv6Router != nil {
-		logger.Info(
-			"Restored router address from device",
-			logfields.IPv4, ipv4GW,
-			logfields.IPv6, ipv6Router,
-			logfields.Device, devName,
-		)
 	}
 
 	return ipv4GW, ipv6Router

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -163,29 +163,3 @@ func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.
 func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
 	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V6, preferPublic)
 }
-
-// GetCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
-// it
-func GetCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
-	hostDev, err := safenetlink.LinkByName(devName)
-	if err != nil {
-		return nil, nil
-	}
-	addrs, err := safenetlink.AddrList(hostDev, netlink.FAMILY_ALL)
-	if err != nil {
-		return nil, nil
-	}
-	for _, addr := range addrs {
-		if addr.IP.To4() != nil {
-			if addr.Scope == int(netlink.SCOPE_LINK) {
-				ipv4GW = addr.IP
-			}
-		} else {
-			if addr.Scope != int(netlink.SCOPE_LINK) {
-				ipv6Router = addr.IP
-			}
-		}
-	}
-
-	return ipv4GW, ipv6Router
-}

--- a/pkg/node/address_other.go
+++ b/pkg/node/address_other.go
@@ -28,9 +28,3 @@ func initMasqueradeV4Addrs(masqAddrs map[string]net.IP, masqIPFromDevice string,
 func initMasqueradeV6Addrs(masqAddrs map[string]net.IP, masqIPFromDevice string, devices []string, logfield string) error {
 	return nil
 }
-
-// GetCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
-// it
-func GetCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
-	return net.IP{}, net.IP{}
-}

--- a/pkg/node/address_other.go
+++ b/pkg/node/address_other.go
@@ -6,7 +6,6 @@
 package node
 
 import (
-	"log/slog"
 	"net"
 )
 
@@ -30,8 +29,8 @@ func initMasqueradeV6Addrs(masqAddrs map[string]net.IP, masqIPFromDevice string,
 	return nil
 }
 
-// getCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
+// GetCiliumHostIPsFromNetDev returns the first IPv4 link local and returns
 // it
-func getCiliumHostIPsFromNetDev(_ *slog.Logger, devName string) (ipv4GW, ipv6Router net.IP) {
+func GetCiliumHostIPsFromNetDev(devName string) (ipv4GW, ipv6Router net.IP) {
 	return net.IP{}, net.IP{}
 }

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -84,7 +84,7 @@ func Test_getCiliumHostIPsFromFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotIpv4GW, gotIpv6Router := getCiliumHostIPsFromFile(tt.args.nodeConfig)
+			gotIpv4GW, gotIpv6Router := GetCiliumHostIPsFromFile(tt.args.nodeConfig)
 			require.Equal(t, tt.wantIpv4GW, gotIpv4GW)
 			require.Equal(t, tt.wantIpv6Router, gotIpv6Router)
 		})


### PR DESCRIPTION
Currently, the router ip is restored in the legacy daemon init logic and passed to the `infraIPAllocator`.

This PR includes the router ip restoration logic into the `infraIPAllocator` itself.

Follow up of https://github.com/cilium/cilium/pull/43444