### PR TITLE
health: use localnodestore in healthmanager

### DIFF
--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -226,13 +226,18 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		ip4Address, ip6Address *net.IPNet
 	)
 
-	if healthIPv6 := node.GetEndpointHealthIPv6(h.logger); healthIPv6 != nil {
+	ln, err := h.localNodeStore.Get(baseCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local node: %w", err)
+	}
+
+	if healthIPv6 := ln.IPv6HealthIP; healthIPv6 != nil {
 		info.Addressing.IPV6 = healthIPv6.String()
 		info.Addressing.IPV6PoolName = ipam.PoolDefault().String()
 		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
 		healthIP = healthIPv6
 	}
-	if healthIPv4 := node.GetEndpointHealthIPv4(h.logger); healthIPv4 != nil {
+	if healthIPv4 := ln.IPv4HealthIP; healthIPv4 != nil {
 		info.Addressing.IPV4 = healthIPv4.String()
 		info.Addressing.IPV4PoolName = ipam.PoolDefault().String()
 		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -214,18 +214,6 @@ func GetIPv4(logger *slog.Logger) net.IP {
 	return clone(n.GetNodeIP(false))
 }
 
-// GetInternalIPv4 returns node internal ipv4 address else return nil.
-func GetInternalIPv4(logger *slog.Logger) net.IP {
-	n := getLocalNode(logger)
-	return clone(n.GetNodeInternalIPv4())
-}
-
-// GetInternalIPv6 returns node internal ipv6 address else return nil.
-func GetInternalIPv6(logger *slog.Logger) net.IP {
-	n := getLocalNode(logger)
-	return clone(n.GetNodeInternalIPv6())
-}
-
 // GetCiliumEndpointNodeIP is the node IP that will be referenced by CiliumEndpoints with endpoints
 // running on this node.
 func GetCiliumEndpointNodeIP(logger *slog.Logger) string {


### PR DESCRIPTION
This PR refactors the healthmanager to use the `LocalNodeStore` instead of the global node functions to retrieve IPs. Please review the individual commits.