### PR TITLE
node: remove global function `node.GetOptOutNodeEncryption`

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -424,10 +424,6 @@ func ExtractCiliumHostIPFromFS(logger *slog.Logger) (ipv4GW, ipv6Router net.IP) 
 	return getCiliumHostIPsFromNetDev(logger, defaults.HostDevice)
 }
 
-func GetOptOutNodeEncryption(logger *slog.Logger) bool {
-	return getLocalNode(logger).Local.OptOutNodeEncryption
-}
-
 // GetEndpointHealthIPv4 returns the IPv4 cilium-health endpoint address.
 func GetEndpointHealthIPv4(logger *slog.Logger) net.IP {
 	return getLocalNode(logger).IPv4HealthIP

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -17,6 +17,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -84,21 +85,22 @@ type NodeManager interface {
 
 func newAllNodeManager(in struct {
 	cell.In
-	Logger      *slog.Logger
-	TunnelConf  tunnel.Config
-	Lifecycle   cell.Lifecycle
-	IPCache     *ipcache.IPCache
-	IPSetMgr    ipset.Manager
-	IPSetFilter IPSetFilterFn `optional:"true"`
-	NodeMetrics *nodeMetrics
-	Health      cell.Health
-	JobGroup    job.Group
-	DB          *statedb.DB
-	Devices     statedb.Table[*tables.Device]
-	WGConfig    wgTypes.WireguardConfig
+	Logger         *slog.Logger
+	TunnelConf     tunnel.Config
+	Lifecycle      cell.Lifecycle
+	IPCache        *ipcache.IPCache
+	IPSetMgr       ipset.Manager
+	IPSetFilter    IPSetFilterFn `optional:"true"`
+	NodeMetrics    *nodeMetrics
+	Health         cell.Health
+	JobGroup       job.Group
+	DB             *statedb.DB
+	Devices        statedb.Table[*tables.Device]
+	WGConfig       wgTypes.WireguardConfig
+	LocalNodeStore *node.LocalNodeStore
 },
 ) (NodeManager, error) {
-	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig)
+	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, in.LocalNodeStore)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -35,7 +36,7 @@ func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	option.Config.IPv6ServiceRange = "auto"
 
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{})
+	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeTypes.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakeTypes.WireguardConfig{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{


### PR DESCRIPTION
This commit removes the global function `node.GetOptOutNodeEncryption` and refactors the usage in the nodemanager to retrieve the info from the `LocalNodeStore`.
