### PR TITLE
Policy pass fixes

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -114,6 +114,9 @@ const (
 	// PolicyEntry is a policy map value
 	PolicyEntry = "policyEntry"
 
+	// PolicyPrecedence is the datapath precedence for a policy Entry
+	PolicyPrecedence = "policyPrecedence"
+
 	// PolicyRevision is the revision of the policy in the repository or of
 	// the object in question
 	PolicyRevision = "policyRevision"

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -465,7 +465,7 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 			logfields.Tier, tier,
 			logfields.Priority, priority,
 		)
-		rulesIngress = append(rulesIngress, wildcardRule(securityIdentity.LabelArray, true /*ingress*/, tier, priority))
+		rulesIngress = append(rulesIngress, wildcardRule(securityIdentity, LabelsAllowAnyIngress, true /*ingress*/, tier, priority))
 	}
 
 	// Same for egress -- synthesize a wildcard rule
@@ -484,22 +484,23 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 			logfields.Tier, tier,
 			logfields.Priority, priority,
 		)
-		rulesEgress = append(rulesEgress, wildcardRule(securityIdentity.LabelArray, false /*egress*/, tier, priority))
+		rulesEgress = append(rulesEgress, wildcardRule(securityIdentity, LabelsAllowAnyEgress, false /*egress*/, tier, priority))
 	}
 
 	return
 }
 
-// wildcardRule generates a wildcard rule that only selects the given identity.
-func wildcardRule(lbls labels.LabelArray, ingress bool, tier types.Tier, priority float64) *rule {
+// wildcardRule generates a wildcard rule that only selects the given subject identity.
+func wildcardRule(subject *identity.Identity, lbls labels.LabelArray, ingress bool, tier types.Tier, priority float64) *rule {
 	return &rule{
 		PolicyEntry: types.PolicyEntry{
 			Tier:     tier,
 			Priority: priority,
 			Verdict:  types.Allow,
 			Ingress:  ingress,
-			Subject:  types.NewLabelSelectorFromLabels(lbls...),
+			Subject:  types.NewLabelSelectorFromLabels(subject.LabelArray...),
 			L3:       types.WildcardSelectors,
+			Labels:   lbls,
 		},
 	}
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -473,6 +473,12 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 		// User the lowest tier and priority
 		lastRule := rulesEgress[len(rulesEgress)-1]
 		tier, priority := lastRule.Tier, lastRule.Priority
+		// Keep the tier and priority as zeroes for backwards compatibility if the last rule
+		// is at tier and priority 0.
+		if tier > 0 || priority > 0 {
+			tier++
+			priority = 0
+		}
 		p.logger.Debug("Only default-allow policies, synthesizing egress wildcard-allow rule",
 			logfields.Identity, securityIdentity,
 			logfields.Tier, tier,

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -339,7 +339,9 @@ func (resMap *L4PolicyMap) addFilter(policyCtx PolicyContext, entry *types.Polic
 	if err != nil {
 		return 0, err
 	}
-	// TODO: do not return 1 if the filter was skipped due to priority!
+
+	// Currently we return '1' here even if all of the filterToMerge was skipped due to priority
+	// in mergePortProto called by addL4Filter.
 	return 1, err
 }
 

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -31,11 +31,72 @@ func roundUp(n int, to int) int {
 	return ((n + (to - 1)) / to) * to
 }
 
+// ensureSlice makes sure slice 's' can be indexed at 'index'.
+//
+// We avoid cloning and append in a loop since:
+// - 's' may have unused capacity, and
+// - 'index' is typically the same between invocations, and
+// - 'index' usually grows by one when not the same as before.
+// This way we avoid unnecessary allocations in typical cases.
 func ensureSlice[E any, S ~[]E, I ~uint | ~uint8](s *S, index I) {
 	for len(*s) <= int(index) {
 		var e E
 		*s = append(*s, e)
 	}
+}
+
+// computeTierPriorities determines how many priority levels are needed for each tier,
+// considering that PASS verdicts require priority space after them for all the rules
+// in the lower tiers.
+// 'rules' is already sorted by tier/priority
+func (rules ruleSlice) computeTierPriorities() ([]int, error) {
+	lastTier := types.Tier(0)
+	tierPriorityLevels := make([]int, 1)
+	numPassVerdicts := make([]int, 1)
+
+	lastPrio := rules[0].Priority
+	levels := 1 // each tier occupies at least one priority level
+	for _, r := range rules {
+		if r.Tier != lastTier {
+			if r.Tier < lastTier {
+				return nil, ErrUnorderedTiers
+			}
+			// Keep the needed priority levels for the previous tier,
+			// rounding up to next 10 to reduce policy map churn.
+			ensureSlice(&tierPriorityLevels, lastTier)
+			tierPriorityLevels[lastTier] = roundUp(levels, 10)
+
+			ensureSlice(&numPassVerdicts, r.Tier)
+
+			// reset counting priority levels for the next tier
+			lastTier = r.Tier
+			lastPrio = r.Priority
+			levels = 1
+		} else if r.Priority != lastPrio {
+			if r.Priority < lastPrio {
+				return nil, ErrUnorderedRules
+			}
+			levels++
+			lastPrio = r.Priority
+		}
+
+		// count the number of pass verdicts on each tier
+		if r.Verdict == types.Pass {
+			numPassVerdicts[lastTier]++
+		}
+	}
+	// for the last tier
+	ensureSlice(&tierPriorityLevels, lastTier)
+	tierPriorityLevels[lastTier] = roundUp(levels, 10)
+
+	// Compute the whole priority range needed for each tier by adding the lower tier priorities
+	// for each pass verdict so that when computing mapstate we can elevate priority of each
+	// passed-to entry to the priority of the pass verdict.
+	for tier := int(lastTier) - 1; tier >= 0; tier-- {
+		tierPriorityLevels[tier] += numPassVerdicts[tier] * tierPriorityLevels[tier+1]
+	}
+
+	return tierPriorityLevels, nil
 }
 
 func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPolicy, error) {
@@ -50,58 +111,14 @@ func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPoli
 		return result, nil
 	}
 
-	// 'rules' is already sorted by tier/priority
-	// Here we determine how many priority levels are needed for each tier,
-	// considering that PASS verdicts require priority space after them for all the rules
-	// in the lower tiers.
-	lastTier := types.Tier(0)
-	var tierPriorityLevels []int
-	numPassVerdicts := make([]int, 1)
-	{
-		lastPrio := rules[0].Priority
-		levels := 1 // each tier occupies at least one priority level
-		for _, r := range rules {
-			if r.Tier != lastTier {
-				if r.Tier < lastTier {
-					return result, ErrUnorderedTiers
-				}
-				// Keep the needed priority levels for the previous tier,
-				// rounding up to next 10 to reduce policy map churn.
-				ensureSlice(&tierPriorityLevels, lastTier)
-				tierPriorityLevels[lastTier] = roundUp(levels, 10)
-
-				ensureSlice(&numPassVerdicts, r.Tier)
-
-				// reset counting priority levels for the next tier
-				lastTier = r.Tier
-				lastPrio = r.Priority
-				levels = 1
-			} else if r.Priority != lastPrio {
-				if r.Priority < lastPrio {
-					return result, ErrUnorderedRules
-				}
-				levels++
-				lastPrio = r.Priority
-			}
-
-			// count the number of pass verdicts on each tier
-			if r.Verdict == types.Pass {
-				numPassVerdicts[lastTier]++
-			}
-		}
-		// for the last tier
-		ensureSlice(&tierPriorityLevels, lastTier)
-		tierPriorityLevels[lastTier] = roundUp(levels, 10)
+	// compute how many priotity levels are needed for each tier.
+	tierPriorityLevels, err := rules.computeTierPriorities()
+	if err != nil {
+		return result, err
 	}
+	result.tierBasePriority = make([]types.Priority, len(tierPriorityLevels))
 
-	result.tierBasePriority = make([]types.Priority, lastTier+1)
-
-	// Compute the whole priority range needed for each tier by adding the lower tier priorities
-	// for each pass verdict so that when computing mapstate we can elevate priority of each
-	// passed-to entry to the priority of the pass verdict.
-	for tier := int(lastTier) - 1; tier >= 0; tier-- {
-		tierPriorityLevels[tier] += numPassVerdicts[tier] * tierPriorityLevels[tier+1]
-	}
+	lastTier := types.Tier(len(tierPriorityLevels) - 1)
 
 	// add rules, computing the absolute priority for each rule,
 	// making sufficient gaps after each pass verdict


### PR DESCRIPTION
Address the remaining comments at #42896 that did not get to the initial merge:

- policy: Remove panics, XXX & TODO comments
- policy: Bump tier for egress default allow like for ingress
- policy: Factor out ruleSlice.computeTierPriorities()
- policy: Add precedence test with default allow

Fixes: #42896
