### PR TITLE
tools/crdcheck: Use WalkDir and improve error handling

### DIFF
--- a/tools/crdcheck/main.go
+++ b/tools/crdcheck/main.go
@@ -32,8 +32,12 @@ func main() {
 
 	_ = crdv1.AddToScheme(scheme.Scheme)
 
-	if err := filepath.Walk(os.Args[1], func(path string, info os.FileInfo, _ error) error {
-		if info.IsDir() {
+	if err := filepath.WalkDir(os.Args[1], func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("error accessing %s: %w", path, err)
+		}
+
+		if d.IsDir() {
 			return nil
 		}
 
@@ -43,6 +47,9 @@ func main() {
 
 		fileContent, err := os.ReadFile(path)
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 
@@ -68,13 +75,9 @@ func main() {
 }
 
 func checkForCategory(crd *crdv1.CustomResourceDefinition) error {
-	if len(crd.Spec.Names.Categories) == 0 || !sliceContains(crd.Spec.Names.Categories, mandatoryCategory) {
+	if len(crd.Spec.Names.Categories) == 0 || !slices.Contains(crd.Spec.Names.Categories, mandatoryCategory) {
 		return fmt.Errorf("category %s missing for %s", mandatoryCategory, crd.GetName())
 	}
 
 	return nil
-}
-
-func sliceContains(slice []string, item string) bool {
-	return slices.Contains(slice, item)
 }


### PR DESCRIPTION
This patch improves the crdcheck tool by:
- Replacing filepath.Walk with filepath.WalkDir for better performance
- Adding proper error handling in the walk function to gracefully skip errors instead of failing
- Handling file-not-exist errors specifically during file reading
- Removing the unnecessary sliceContains wrapper function and using slices.Contains directly

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This enhancement improves the `crdcheck` tool's performance and robustness:

**Performance improvement**: `filepath.WalkDir` is more efficient than `filepath.Walk` as it doesn't need to call `stat()` for every file - the directory entry already contains type information.

**Better error handling**: The tool now gracefully handles errors during directory traversal and file reading, rather than failing immediately. This makes it more resilient when scanning directories with permission issues or deleted files. In its original version it would abort in case of broken symlinks.

**Code cleanup**: Removed the unnecessary `sliceContains` wrapper function in favour of using `slices.Contains` directly.

```release-note
Improve crdcheck tool performance and error handling