### PR TITLE
pkg/azure/api: Add cleanup in case of provision fail in Azure public IP provisionning

### DIFF
--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -110,7 +110,7 @@ func TestFindPublicIPPrefixByTags(t *testing.T) {
 	require.False(t, found)
 }
 
-func TestIsPublicIPProvisionFailedVMSS(t *testing.T) {
+func TestIsPublicIPProvisionFailed(t *testing.T) {
 	tests := []struct {
 		name                 string
 		instanceViewStatuses []*armcompute.InstanceViewStatus
@@ -138,7 +138,7 @@ func TestIsPublicIPProvisionFailedVMSS(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.expected, isPublicIPProvisionFailedVMSS(test.instanceViewStatuses))
+			require.Equal(t, test.expected, isPublicIPProvisionFailed(test.instanceViewStatuses))
 		})
 	}
 }


### PR DESCRIPTION
# Observation

When using public IP assignment with Azure VMSS instances, we have observed a bug that causes instances to fail during provisioning due to exhausted public IP prefixes.

When a public IP prefix is assigned to a node, the prefix is first selected and then the VM update is performed. If multiple nodes are created and a prefix has, for example, only one available IP address, all nodes may see this address as available during the check phase and attempt to acquire it simultaneously.

This scenario should be handled by Azure: only one configuration should be accepted, while the others should be rejected and retried with a different prefix. However, in certain cases, Azure’s API behaves unexpectedly, and we observe the following error message:

```
--------------------------------------------------------------------------------
RESPONSE 200: 200 OK
ERROR CODE: PublicIpPrefixOutOfIpAddressesForVMScaleSet
--------------------------------------------------------------------------------
{
  "startTime": "...",
  "endTime": "...",
  "status": "Failed",
  "error": {
    "code": "PublicIpPrefixOutOfIpAddressesForVMScaleSet",
    "message": "IpPrefix /subscriptions/.../resourceGroups/.../providers/Microsoft.Network/publicIPPrefixes/... can provide 2 public ips at maximum, 1 of them are in use already. Current available public ip Count for this prefix is 1, which is smaller than required number of public ip count 2 for VMScaleSet on this prefix.",
    "target": "..."
  },
  "name": "..."
}
--------------------------------------------------------------------------------
```

The error code 200 suggests that the update was successfully carried out, which is consistent with what we observe on the VM instance. The IP configuration is registered in Azure, but the VM remains in a ProvisionFailed state.

```
"publicIPAddressConfiguration": {
  "name": "cilium-managed-public-ip",
  "properties": {
    "idleTimeoutInMinutes": 4,
    "ipTags": [],
    "publicIPAddressVersion": "IPv4",
    "publicIPPrefix": {
      "id": "/subscriptions/.../resourceGroups/.../providers/Microsoft.Network/publicIPPrefixes/..."
  }
}
```

```
"statuses": [
  {
    "code": "ProvisioningState/failed/PublicIpPrefixOutOfIpAddressesForVMScaleSet",
    "displayStatus": "Provisioning failed",
    "level": "Error",
    "message": "IpPrefix /subscriptions/.../resourceGroups/.../providers/Microsoft.Network/publicIPPrefixes/... can provide 2 public ips at maximum, 2 of them are in use already. Current available public ip Count for this prefix is 0, which is smaller than required number of public ip count 1 for VMScaleSet on this prefix.",
    "time": "2026-01-05T16:33:52.8945842Z"
  },
  ...
]
```
Since the current logic for assigning public IPs considers only the configuration state and not the provisioning status, Cilium assumes that the VM already has a public IP assigned and therefore does not attempt to assign a new one. As a result, the VM never reconciles successfully and never actually receives a public IP.

# How does this fix the problem

To fix the problem, we updated the check logic to be aware of the provisioning status. It now detects when provisioning has failed due to `ProvisioningState/failed/PublicIpPrefixOutOfIpAddressesForVMScaleSet`. In this case, it deletes the erroneous configuration and then proceeds to reassign a new public IP prefix.

We tested this new version of the VMSS public IP assignment on our clusters and it successfully reconciled broken VMs.

```release-note
pkg/azure/api : Fixed an issue where public IP assignment would permanently fail on Azure VMSS VMs.
```
