### PR TITLE
proxy/accesslogger: use `LocalNodeStore` to retrieve node IPs

### DIFF
--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -250,7 +250,7 @@ func TestEnvoyNACK(t *testing.T) {
 
 type proxyAccessLoggerMock struct{}
 
-func (p *proxyAccessLoggerMock) NewLogRecord(t accesslog.FlowType, ingress bool, tags ...accesslog.LogTag) *accesslog.LogRecord {
+func (p *proxyAccessLoggerMock) NewLogRecord(ctx context.Context, t accesslog.FlowType, ingress bool, tags ...accesslog.LogTag) (*accesslog.LogRecord, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -232,7 +232,7 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 	// requests because an identity isn't in the local cache yet.
 	logContext, lcncl := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer lcncl()
-	record := h.proxyAccessLogger.NewLogRecord(flowType, false,
+	record, err := h.proxyAccessLogger.NewLogRecord(logContext, flowType, false,
 		func(lr *accesslog.LogRecord, _ accesslog.EndpointInfoRegistry) {
 			lr.TransportProtocol = accesslog.TransportProtocol(protoID)
 		},
@@ -249,6 +249,10 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 			AnswerTypes:       recordTypes,
 		}),
 	)
+	if err != nil {
+		return fmt.Errorf("failed create log record: %w", err)
+	}
+
 	h.proxyAccessLogger.Log(record)
 
 	return nil

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -93,7 +92,6 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 		Logger:     logger,
 	})
 	policyRepo.GetSelectorCache().SetLocalIdentityNotifier(nm)
-	node.SetTestLocalNodeStore()
 	option.Config.DNSProxyLockTimeout = defaults.DNSProxyLockTimeout
 	option.Config.FQDNProxyResponseMaxDelay = defaults.FQDNProxyResponseMaxDelay
 
@@ -101,7 +99,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 		DNSMessageHandlerParams{
 			Logger:            logger,
 			NameManager:       nm,
-			ProxyAccessLogger: accesslog.NewProxyAccessLogger(logger, accesslog.ProxyAccessLoggerConfig{}, &noopNotifier{}, &dummyInfoRegistry{}),
+			ProxyAccessLogger: accesslog.NewProxyAccessLogger(logger, accesslog.ProxyAccessLoggerConfig{}, &noopNotifier{}, &dummyInfoRegistry{}, nil),
 		})
 
 	// Register rules (simulates applied policies).

--- a/pkg/proxy/accesslog/proxy_access_logger_test.go
+++ b/pkg/proxy/accesslog/proxy_access_logger_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/payload"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -162,68 +161,60 @@ var benchCases = []struct {
 }
 
 func benchWithoutListeners(b *testing.B, notifier LogRecordNotifier) {
-	accessLogger := NewProxyAccessLogger(hivetest.Logger(b), ProxyAccessLoggerConfig{}, notifier, nil)
-	node.WithTestLocalNodeStore(func() {
-		record := mockLogRecord(accessLogger)
-		for _, bm := range benchCases {
-			b.Run(bm.name, func(b *testing.B) {
-				b.ReportAllocs()
-				for b.Loop() {
-					// Each goroutine will deliver a single notification concurrently.
-					// This is done to simulate what happens when a high rate of DNS
-					// related events trigger one `notifyOnDNSMsg` callback each and
-					// consequently the event logging.
-					var wg sync.WaitGroup
-					for range bm.nRecords {
-						wg.Add(1)
-						go func() {
-							defer wg.Done()
-							accessLogger.Log(record)
-						}()
-					}
-					wg.Wait()
+	accessLogger := NewProxyAccessLogger(hivetest.Logger(b), ProxyAccessLoggerConfig{}, notifier, nil, nil)
+	record := mockLogRecord(accessLogger)
+	for _, bm := range benchCases {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				// Each goroutine will deliver a single notification concurrently.
+				// This is done to simulate what happens when a high rate of DNS
+				// related events trigger one `notifyOnDNSMsg` callback each and
+				// consequently the event logging.
+				var wg sync.WaitGroup
+				for range bm.nRecords {
+					wg.Go(func() {
+						accessLogger.Log(record)
+					})
 				}
-			})
-		}
-	})
+				wg.Wait()
+			}
+		})
+	}
 }
 
 func benchWithListeners(accessLogger ProxyAccessLogger, listener *MockMonitorListener, b *testing.B) {
-	node.WithTestLocalNodeStore(func() {
-		record := mockLogRecord(accessLogger)
-		for _, bm := range benchCases {
-			b.Run(bm.name, func(b *testing.B) {
-				ctx, cancel := context.WithCancel(context.Background())
+	record := mockLogRecord(accessLogger)
+	for _, bm := range benchCases {
+		b.Run(bm.name, func(b *testing.B) {
+			ctx, cancel := context.WithCancel(context.Background())
 
-				var wg sync.WaitGroup
-				wg.Add(1)
-				listener.Drain(ctx, &wg)
+			var wg sync.WaitGroup
+			wg.Add(1)
+			listener.Drain(ctx, &wg)
 
-				b.ReportAllocs()
-				b.ResetTimer()
-				for b.Loop() {
-					// Each goroutine will deliver a single notification concurrently.
-					// This is done to simulate what happens when a high rate of DNS
-					// related events trigger one `notifyOnDNSMsg` callback each and
-					// consequently the event logging.
-					var logWg sync.WaitGroup
-					for range bm.nRecords {
-						logWg.Add(1)
-						go func() {
-							defer logWg.Done()
-							accessLogger.Log(record)
-						}()
-					}
-					logWg.Wait()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				// Each goroutine will deliver a single notification concurrently.
+				// This is done to simulate what happens when a high rate of DNS
+				// related events trigger one `notifyOnDNSMsg` callback each and
+				// consequently the event logging.
+				var logWg sync.WaitGroup
+				for range bm.nRecords {
+					logWg.Go(func() {
+						accessLogger.Log(record)
+					})
 				}
-				b.StopTimer()
+				logWg.Wait()
+			}
+			b.StopTimer()
 
-				// wait for listener cleanup
-				cancel()
-				wg.Wait()
-			})
-		}
-	})
+			// wait for listener cleanup
+			cancel()
+			wg.Wait()
+		})
+	}
 }
 
 func BenchmarkLogNotifierWithNoListeners(b *testing.B) {
@@ -261,7 +252,7 @@ func BenchmarkLogNotifierWithListeners(b *testing.B) {
 		listener := NewMockMonitorListener(cfg.MonitorQueueSize)
 		notifier := NewMockLogNotifier(monitor)
 		notifier.RegisterNewListener(listener)
-		accessLogger := NewProxyAccessLogger(hivetest.Logger(b), ProxyAccessLoggerConfig{}, notifier, nil)
+		accessLogger := NewProxyAccessLogger(hivetest.Logger(b), ProxyAccessLoggerConfig{}, notifier, nil, nil)
 
 		lc.Append(cell.Hook{
 			OnStart: func(ctx cell.HookContext) error {


### PR DESCRIPTION
Please review the individual commits.