### PR TITLE
bpf: ipsec: cleanups for CB_ENCRYPT_IDENTITY

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1354,7 +1354,7 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPSEC
 	if (magic == MARK_MAGIC_ENCRYPT)
 		send_trace_notify(ctx, TRACE_FROM_STACK,
-				  ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY), UNKNOWN_ID,
+				  get_encrypt_identity_meta(ctx), UNKNOWN_ID,
 				  TRACE_EP_ID_UNKNOWN, ctx->ingress_ifindex,
 				  TRACE_REASON_ENCRYPTED, 0, proto);
 #endif /* ENABLE_IPSEC */
@@ -1705,7 +1705,7 @@ int cil_to_host(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPSEC
 	else if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
 		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
-		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+		src_id = get_encrypt_identity_meta(ctx);
 	}
 #endif
 

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -83,11 +83,10 @@ set_ipsec_encrypt(struct __ctx_buff *ctx,
 		  __u32 seclabel, bool use_meta)
 {
 	/* IPSec is performed by the stack on any packets with the
-	 * MARK_MAGIC_ENCRYPT bit set. During the process though we
-	 * lose the lxc context (seclabel and tunnel endpoint). The
-	 * tunnel endpoint can be looked up from daddr but the sec
-	 * label is stashed in the mark or cb, and extracted in
-	 * bpf_host to send ctx onto tunnel for encap.
+	 * MARK_MAGIC_ENCRYPT bit set.
+	 *
+	 * The source's security identity in CB_ENCRYPT_IDENTITY is
+	 * preserved across the XFRM traversal.
 	 */
 
 	const struct node_value *node_value = NULL;

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -102,7 +102,7 @@ set_ipsec_encrypt(struct __ctx_buff *ctx,
 
 	mark = ipsec_encode_encryption_mark(spi, node_value->id);
 
-	set_identity_meta(ctx, seclabel);
+	set_encrypt_identity_meta(ctx, seclabel);
 	if (use_meta)
 		ctx->cb[CB_ENCRYPT_MAGIC] = mark;
 	ctx->mark = mark;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -50,9 +50,15 @@ get_epid(const struct __sk_buff *ctx)
 }
 
 static __always_inline __maybe_unused void
-set_identity_meta(struct __sk_buff *ctx, __u32 identity)
+set_encrypt_identity_meta(struct __sk_buff *ctx, __u32 identity)
 {
 	ctx->cb[CB_ENCRYPT_IDENTITY] = identity;
+}
+
+static __always_inline __maybe_unused __u32
+get_encrypt_identity_meta(const struct __sk_buff *ctx)
+{
+	return ctx->cb[CB_ENCRYPT_IDENTITY];
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -35,12 +35,6 @@ ctx_load_meta_ipv6(const struct xdp_md *ctx __maybe_unused,
 	build_bug_on((off + 4) * sizeof(__u32) > META_PIVOT);
 }
 
-static __always_inline __maybe_unused void
-set_identity_meta(struct xdp_md *ctx __maybe_unused,
-		__u32 identity __maybe_unused)
-{
-}
-
 static __always_inline __maybe_unused int
 redirect_self(struct xdp_md *ctx __maybe_unused)
 {


### PR DESCRIPTION
I was poking around a bit to see whether `CB_ENCRYPT_IDENTITY` is even still used today, and who is relying on it.

Land some resulting cleanups.