### PR TITLE
endpoint/synchronizer: use `LocalNodeStore` to retrieve node IPs

### DIFF
--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -242,6 +242,7 @@ type endpointSynchronizerParams struct {
 	Clientset           client.Clientset
 	CiliumEndpoint      resource.Resource[*types.CiliumEndpoint]
 	CiliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	LocalNodeStore      *node.LocalNodeStore
 }
 
 func newEndpointSynchronizer(p endpointSynchronizerParams) EndpointResourceSynchronizer {
@@ -249,5 +250,6 @@ func newEndpointSynchronizer(p endpointSynchronizerParams) EndpointResourceSynch
 		Clientset:           p.Clientset,
 		CiliumEndpoint:      p.CiliumEndpoint,
 		CiliumEndpointSlice: p.CiliumEndpointSlice,
+		localNodeStore:      p.LocalNodeStore,
 	}
 }

--- a/pkg/endpointmanager/endpointsynchronizer_test.go
+++ b/pkg/endpointmanager/endpointsynchronizer_test.go
@@ -98,7 +98,7 @@ func Test_updateCEPUID(t *testing.T) {
 		// but the endpoint snapshot is lost on reboot. The endpoint UID will
 		// remain empty, but the CEP object will have a UID and a wrong nodeIP.
 		// It is to counter this case that we check the pods hostIP against the
-		// nodeIP instaed of the CEP's node IP.
+		// nodeIP instead of the CEP's node IP.
 		"take ownership of cep due to empty CiliumEndpointUID ref": {
 			ep:            epWithUID("", podWithHostIP(testIP)),
 			nodeIP:        testIP,
@@ -114,23 +114,20 @@ func Test_updateCEPUID(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-			var err error
-			node.WithTestLocalNodeStore(func() {
-				node.UpdateLocalNodeInTest(func(n *node.LocalNode) {
-					n.SetNodeInternalIP(net.ParseIP(test.nodeIP))
-				})
-				err = updateCEPUID(logger, test.ep, test.cep)
-			})
+			ln := node.LocalNode{}
+			ln.SetNodeInternalIP(net.ParseIP(test.nodeIP))
+			eps := &EndpointSynchronizer{
+				localNodeStore: node.NewTestLocalNodeStore(ln),
+			}
+			err := eps.updateCEPUID(t.Context(), logger, test.ep, test.cep)
 			if test.err == nil {
-				assert.NoError(err)
+				assert.NoError(t, err)
 			} else {
-				assert.ErrorContains(err, test.err.Error())
+				assert.ErrorContains(t, err, test.err.Error())
 			}
 			if test.expectedEPUID != nil {
-				assert.Equal(*test.expectedEPUID, test.ep.GetCiliumEndpointUID())
+				assert.Equal(t, *test.expectedEPUID, test.ep.GetCiliumEndpointUID())
 			}
 		})
-
 	}
 }

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -387,12 +387,3 @@ func SetTestLocalNodeStore() {
 func UnsetTestLocalNodeStore() {
 	localNode = nil
 }
-
-// UpdateLocalNodeInTest provides access to modifying the local node
-// information from tests that are not yet using hive and the LocalNodeStoreCell.
-func UpdateLocalNodeInTest(mod func(n *LocalNode)) {
-	if localNode == nil {
-		panic("localNode not set, use node.LocalNodeStoreCell or WithTestLocalNodeStore()?")
-	}
-	localNode.Update(mod)
-}


### PR DESCRIPTION
Currently, the `EndpointSynchronizer` uses the global node functions to retrieve the local node IPs.

In preparation to eventually get rid of the global node functions and the necessary testing utilities, this commit refactors the `EndpointSynchronizer` to use the injected `LocalNodeStore` to retrieve the local node IPs.