### PR TITLE
helm: Add hubble-ui backend health probes

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -133,6 +133,12 @@ spec:
           grpc:
             port: 8090
         {{- end }}
+        startupProbe:
+          grpc:
+            port: 8090
+          initialDelaySeconds: 5
+          failureThreshold: 20
+          periodSeconds: 3
         ports:
         - name: grpc
           containerPort: 8090

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -125,14 +125,12 @@ spec:
         {{- end }}
         {{- if .Values.hubble.ui.backend.livenessProbe.enabled }}
         livenessProbe:
-          httpGet:
-            path: /healthz
+          grpc:
             port: 8090
         {{- end }}
         {{- if .Values.hubble.ui.backend.readinessProbe.enabled }}
         readinessProbe:
-          httpGet:
-            path: /healthz
+          grpc:
             port: 8090
         {{- end }}
         ports:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1856,10 +1856,10 @@ hubble:
       # -- Additional hubble-ui backend volumeMounts.
       extraVolumeMounts: []
       livenessProbe:
-        # -- Enable gRPC liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        # -- Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       readinessProbe:
-        # -- Enable gRPC readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1856,10 +1856,10 @@ hubble:
       # -- Additional hubble-ui backend volumeMounts.
       extraVolumeMounts: []
       livenessProbe:
-        # -- Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        # -- Enable gRPC liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       readinessProbe:
-        # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        # -- Enable gRPC readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
         enabled: false
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}


### PR DESCRIPTION
The hubble-ui-backend is a gRPC server that doesn't expose HTTP endpoints. The `livenessProbe` and `readinessProbe` were incorrectly configured to use httpGet to `/healthz`, causing `CrashLoopBackOff `when probes are enabled. 
This fix changes the probe type from `httpGet` to `grpc`

Fixes: #43501



```release-note
helm: Add hubble-ui backend health probes
```
