### PR TITLE
xds: fix nil-pointer in `processRequestStream`

### DIFF
--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -437,8 +437,10 @@ func (s *Server) processRequestStream(ctx context.Context, streamLog *slog.Logge
 
 		default: // Pending watch response.
 			state := &typeStates[chosen]
-			state.pendingWatchCancel()
-			state.pendingWatchCancel = nil
+			if state.pendingWatchCancel != nil {
+				state.pendingWatchCancel()
+				state.pendingWatchCancel = nil
+			}
 
 			if !recvOK {
 				// chosen channel was closed. If context has an error (e.g.,


### PR DESCRIPTION
In CI `processRequestStream` sometimes fails with a nil-pointer error. There's one occurrence where`state.PendingWatchCancel` gets called without checking whether it's nil or not - all other cases check.

Therefore, this commit adds the additional nil-check for this case too.

Note: I haven't looked deeper into the potential use-case when this error/flake occurs. I though it's best to add the missing nil-check.

Fixes: https://github.com/cilium/cilium/issues/43608