### PR TITLE
ipsec,route: Ignore ESRCH errors on delete operations

### DIFF
--- a/contrib/scripts/check-xfrmstate.sh
+++ b/contrib/scripts/check-xfrmstate.sh
@@ -21,6 +21,7 @@ find_match() {
        --exclude \*_test.go \
        --exclude xfrm_state_cache.go \
        --exclude probe_linux.go \
+       --exclude-dir safenetlink \
        -E "$MATCHES_ORED" \
         "$target"
   if [ $? -eq 0 ] ; then

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -811,7 +811,7 @@ func (a *Agent) ipsecDeleteXfrmPolicy(nodeID uint16) error {
 	errs := resiliency.NewErrorSet("failed to delete xfrm policies", len(xfrmPolicyList))
 	for _, p := range xfrmPolicyList {
 		if matchesOnNodeID(p.Mark) && ipsec.GetNodeIDFromXfrmMark(p.Mark) == nodeID {
-			if err := netlink.XfrmPolicyDel(&p); err != nil {
+			if err := safenetlink.XfrmPolicyDel(&p); err != nil {
 				errs.Add(fmt.Errorf("unable to delete xfrm policy %s: %w", p.String(), err))
 			}
 		}
@@ -979,7 +979,7 @@ policy:
 		// if so, delete the policy.
 		for _, tmpl := range p.Tmpls {
 			if reqID == AllReqID || tmpl.Reqid == reqID {
-				if err := netlink.XfrmPolicyDel(&p); err != nil {
+				if err := safenetlink.XfrmPolicyDel(&p); err != nil {
 					ee.Add(err)
 				}
 				continue policy
@@ -1027,7 +1027,7 @@ func (a *Agent) deleteXfrmPolicyOutFamily(nodeID uint16, dst *net.IPNet, family 
 		if !matchesOnNodeID(p.Mark) || ipsec.GetNodeIDFromXfrmMark(p.Mark) != nodeID || !matchesOnDst(p.Dst, dst) {
 			continue
 		}
-		if err := netlink.XfrmPolicyDel(&p); err != nil {
+		if err := safenetlink.XfrmPolicyDel(&p); err != nil {
 			errs.Add(fmt.Errorf("unable to delete xfrm out policy %s: %w", p.String(), err))
 		}
 	}
@@ -1213,7 +1213,7 @@ func (a *Agent) deleteIPsecEncryptRoute() {
 		}
 
 		for _, rt := range routes {
-			if err := netlink.RouteDel(&rt); err != nil {
+			if err := safenetlink.RouteDel(&rt); err != nil {
 				a.log.Warn("Unable to delete ipsec encrypt route",
 					logfields.Route, rt,
 					logfields.Error, err,
@@ -1378,7 +1378,7 @@ func (a *Agent) deleteStaleXfrmPolicies(reclaimTimestamp time.Time) error {
 			logfields.TrafficDirection, getDirFromXfrmMark(p.Mark),
 			logfields.NodeID, getNodeIDAsHexFromXfrmMark(p.Mark),
 		)
-		if err := netlink.XfrmPolicyDel(&p); err != nil {
+		if err := safenetlink.XfrmPolicyDel(&p); err != nil {
 			errs.Add(fmt.Errorf("failed to delete stale xfrm policy spi (%d): %w", policySPI, err))
 		}
 	}

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache.go
@@ -45,7 +45,7 @@ func (c *xfrmStateListCache) XfrmStateList() ([]netlink.XfrmState, error) {
 
 func (c *xfrmStateListCache) XfrmStateDel(state *netlink.XfrmState) error {
 	c.invalidate()
-	return netlink.XfrmStateDel(state)
+	return safenetlink.XfrmStateDel(state)
 }
 
 func (c *xfrmStateListCache) XfrmStateUpdate(state *netlink.XfrmState) error {

--- a/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
+++ b/pkg/datapath/linux/ipsec/xfrm_state_cache_test.go
@@ -100,6 +100,10 @@ func TestPrivilegedXfrmStateListCache(t *testing.T) {
 	stateList, err = xfrmStateCache.XfrmStateList()
 	require.NoError(t, err)
 	require.Empty(t, stateList)
+
+	// Deleting the same state again should succeed (idempotent, ESRCH ignored)
+	err = xfrmStateCache.XfrmStateDel(state)
+	require.NoError(t, err)
 }
 
 func TestPrivilegedXfrmStateListCacheDisabled(t *testing.T) {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -318,7 +318,7 @@ func (n *linuxNodeHandler) deleteDirectRoute(CIDR *cidr.CIDR, nodeIP net.IP) err
 
 	var errs error
 	for _, rt := range routes {
-		if err := netlink.RouteDel(&rt); err != nil {
+		if err := safenetlink.RouteDel(&rt); err != nil {
 			n.log.Warn("Unable to delete direct node route",
 				logfields.CIDR, rt,
 				logfields.Error, err,

--- a/pkg/datapath/linux/safenetlink/netlink_linux.go
+++ b/pkg/datapath/linux/safenetlink/netlink_linux.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
@@ -445,4 +446,40 @@ func XfrmStateList(family int) ([]netlink.XfrmState, error) {
 		//nolint:forbidigo
 		return netlink.XfrmStateList(family)
 	})
+}
+
+// XfrmPolicyDel wraps netlink.XfrmPolicyDel, treating ESRCH as success
+// since it indicates the policy was already deleted.
+func XfrmPolicyDel(policy *netlink.XfrmPolicy) error {
+	if err := netlink.XfrmPolicyDel(policy); err != nil {
+		if errors.Is(err, unix.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// XfrmStateDel wraps netlink.XfrmStateDel, treating ESRCH as success
+// since it indicates the state was already deleted.
+func XfrmStateDel(state *netlink.XfrmState) error {
+	if err := netlink.XfrmStateDel(state); err != nil {
+		if errors.Is(err, unix.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// RouteDel wraps netlink.RouteDel, treating ESRCH and ENOENT as success
+// since they indicate the route was already deleted.
+func RouteDel(route *netlink.Route) error {
+	if err := netlink.RouteDel(route); err != nil {
+		if errors.Is(err, unix.ESRCH) || errors.Is(err, unix.ENOENT) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/pkg/datapath/linux/safenetlink/netlink_linux_test.go
+++ b/pkg/datapath/linux/safenetlink/netlink_linux_test.go
@@ -5,11 +5,15 @@ package safenetlink
 
 import (
 	"io"
+	"net"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/cilium/cilium/pkg/testutils/netns"
 )
 
 func Test_withRetryResult(t *testing.T) {
@@ -47,4 +51,87 @@ func Test_withRetryResult(t *testing.T) {
 	})
 	require.True(t, wait.Interrupted(err))
 	require.Empty(t, out)
+}
+
+func TestPrivilegedIdempotentDel(t *testing.T) {
+	// Can't use testutils.PrivilegedTest due to import cycle
+	// (testutils -> mac -> safenetlink).
+	if os.Getenv("PRIVILEGED_TESTS") == "" {
+		t.Skip("Set PRIVILEGED_TESTS to run this test")
+	}
+
+	t.Run("XfrmPolicyDel", func(t *testing.T) {
+		ns := netns.NewNetNS(t)
+		require.NoError(t, ns.Do(func() error {
+			_, srcNet, _ := net.ParseCIDR("10.0.0.0/24")
+			_, dstNet, _ := net.ParseCIDR("10.0.1.0/24")
+			policy := &netlink.XfrmPolicy{
+				Src: srcNet,
+				Dst: dstNet,
+				Dir: netlink.XFRM_DIR_OUT,
+			}
+
+			require.NoError(t, XfrmPolicyDel(policy))
+
+			require.NoError(t, netlink.XfrmPolicyAdd(policy))
+			require.NoError(t, XfrmPolicyDel(policy))
+			require.NoError(t, XfrmPolicyDel(policy))
+
+			return nil
+		}))
+	})
+
+	t.Run("XfrmStateDel", func(t *testing.T) {
+		ns := netns.NewNetNS(t)
+		require.NoError(t, ns.Do(func() error {
+			state := &netlink.XfrmState{
+				Src:   net.ParseIP("10.0.0.1"),
+				Dst:   net.ParseIP("10.0.0.2"),
+				Proto: netlink.XFRM_PROTO_ESP,
+				Mode:  netlink.XFRM_MODE_TUNNEL,
+				Spi:   1,
+				Auth: &netlink.XfrmStateAlgo{
+					Name: "hmac(sha256)",
+					Key:  make([]byte, 32),
+				},
+				Crypt: &netlink.XfrmStateAlgo{
+					Name: "cbc(aes)",
+					Key:  make([]byte, 16),
+				},
+			}
+
+			require.NoError(t, XfrmStateDel(state))
+
+			require.NoError(t, netlink.XfrmStateAdd(state))
+			require.NoError(t, XfrmStateDel(state))
+			require.NoError(t, XfrmStateDel(state))
+
+			return nil
+		}))
+	})
+
+	t.Run("RouteDel", func(t *testing.T) {
+		ns := netns.NewNetNS(t)
+		require.NoError(t, ns.Do(func() error {
+			//nolint:forbidigo
+			lo, err := netlink.LinkByName("lo")
+			require.NoError(t, err)
+			require.NoError(t, netlink.LinkSetUp(lo))
+
+			_, dst, _ := net.ParseCIDR("192.168.99.0/24")
+			route := &netlink.Route{
+				LinkIndex: lo.Attrs().Index,
+				Dst:       dst,
+				Table:     100,
+			}
+
+			require.NoError(t, RouteDel(route))
+
+			require.NoError(t, netlink.RouteAdd(route))
+			require.NoError(t, RouteDel(route))
+			require.NoError(t, RouteDel(route))
+
+			return nil
+		}))
+	})
 }

--- a/pkg/datapath/linux/safenetlink/netlink_unspecified.go
+++ b/pkg/datapath/linux/safenetlink/netlink_unspecified.go
@@ -139,3 +139,15 @@ func XfrmPolicyList(family int) ([]netlink.XfrmPolicy, error) {
 func XfrmStateList(family int) ([]netlink.XfrmState, error) {
 	return nil, netlink.ErrNotImplemented
 }
+
+func XfrmPolicyDel(policy *netlink.XfrmPolicy) error {
+	return netlink.ErrNotImplemented
+}
+
+func XfrmStateDel(state *netlink.XfrmState) error {
+	return netlink.ErrNotImplemented
+}
+
+func RouteDel(route *netlink.Route) error {
+	return netlink.ErrNotImplemented
+}

--- a/pkg/ztunnel/iptables/inpod.go
+++ b/pkg/ztunnel/iptables/inpod.go
@@ -4,7 +4,6 @@
 package iptables
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -407,11 +406,7 @@ func deleteLoopbackRoute(ipv4Enabled, ipv6Enabled bool) error {
 		}
 
 		if err := route.Delete(ciliumRoute); err != nil {
-			// Ignore ESRCH (no such process) and ENOENT (no such file or directory) errors,
-			// which indicate the route was already deleted
-			if !errors.Is(err, unix.ESRCH) && !errors.Is(err, unix.ENOENT) {
-				return fmt.Errorf("failed to delete route (%+v): %w", ciliumRoute, err)
-			}
+			return fmt.Errorf("failed to delete route (%+v): %w", ciliumRoute, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This fixes flaky tests `TestNodeChurnXFRMLeaksEncryptedOverlay` and `TestNodePodCIDRsChurnIPSec` which intermittently failed when cleanup operations encountered already deleted resources. 


Fixes: #42182
Fixes: #42865