### PR TITLE
loadbalancer: Fix GetInstancesOfService to avoid removing endpoint from Service A cause requests to Service B fail if the name of Service A is the prefix of Service B

### DIFF
--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -126,13 +126,14 @@ type BackendInstanceKey struct {
 }
 
 func (k BackendInstanceKey) Key() []byte {
+	const separator = ' '
 	if k.SourcePriority == 0 {
-		return k.ServiceName.Key()
+		return append(k.ServiceName.Key(), separator)
 	}
 	sk := k.ServiceName.Key()
 	buf := make([]byte, 0, 2+len(sk))
 	buf = append(buf, sk...)
-	return append(buf, ' ', k.SourcePriority)
+	return append(buf, separator, k.SourcePriority)
 }
 
 func (be *Backend) GetInstance(name ServiceName) *BackendParams {
@@ -299,7 +300,6 @@ func (be *Backend) PreferredInstances() iter.Seq2[BackendInstanceKey, BackendPar
 				}
 			} // Skip instances with the same ServiceName but lower (numerically larger) priorities.
 		}
-
 	}
 }
 

--- a/pkg/loadbalancer/backend_test.go
+++ b/pkg/loadbalancer/backend_test.go
@@ -16,7 +16,14 @@ func TestBackendInstanceKey(t *testing.T) {
 		ServiceName:    name,
 		SourcePriority: 0,
 	}
-	assert.True(t, bytes.Equal(key.Key(), name.Key()), "BackendInstanceKey with prio 0 is the ServiceName key")
+	nameExtended := NewServiceNameInCluster("foo", "bar", "baz-extended")
+	keyExtended := BackendInstanceKey{
+		ServiceName:    nameExtended,
+		SourcePriority: 0,
+	}
+
+	assert.True(t, bytes.Equal(key.Key(), append(name.Key(), ' ')), "BackendInstanceKey with prio 0 is the ServiceName key + ' '")
+	assert.False(t, bytes.HasPrefix(key.Key(), keyExtended.Key()), "BackendInstanceKey with prio 0 should not have the the same prefix if the prefix of one service is the name of another service")
 	key.SourcePriority = 1
 	assert.True(t, bytes.HasPrefix(key.Key(), name.Key()), "BackendInstanceKey with prio 1 has ServiceName key as prefix")
 


### PR DESCRIPTION
The current `GetInstancesOfService` function returns all Services that prefix with the specified name, which can lead to removing endpoint from Service A cause requests to Service B fail if the name of Service A is the prefix of Service B (#43619).

This patch will fix the matching logic of GetInstancesOfService, ensuring an exact match for the service.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

When an endpoint is removed from EndpointSlice, it will proceed to the `backendRelease` function to release the corresponding backend:
```go
// pkg/loadbalancer/writer/writer.go
func backendRelease(be *loadbalancer.Backend, name loadbalancer.ServiceName) (*loadbalancer.Backend, bool) {
	instances := be.Instances
	if be.Instances.Len() == 1 {
		for k := range be.Instances.All() {
			if k.ServiceName == name {
				return nil, true
			}
		}
	}
	// delete instances if the service name is matched
	for k := range be.GetInstancesOfService(name) {
		instances = instances.Delete(k)
	}
	beCopy := *be
	beCopy.Instances = instances
	return &beCopy, beCopy.Instances.Len() == 0
}
```

Let's take a look at the `GetInstancesOfService`:
```go
// pkg/loadbalancer/backend.go
func (be *Backend) GetInstancesOfService(name ServiceName) iter.Seq2[BackendInstanceKey, BackendParams] {
	return be.Instances.Prefix(BackendInstanceKey{ServiceName: name, SourcePriority: 0})
}

type BackendInstanceKey struct {
	ServiceName    ServiceName
	SourcePriority uint8
}

func (k BackendInstanceKey) Key() []byte {
	if k.SourcePriority == 0 {
		return k.ServiceName.Key()
	}
	sk := k.ServiceName.Key()
	buf := make([]byte, 0, 2+len(sk))
	buf = append(buf, sk...)
	return append(buf, ' ', k.SourcePriority)
}
```

The  returned []byte of `BackendInstanceKey.Key` always starts with the service name.
It means that Service B will be matched if its' name starts with Service A when GetInstancesOfService(Service A).

This is also the root cause described in  #43619

This PR fixes the `GetInstancesOfService`,  use the exact match for service instead of prefix match.

Fixes: #43619 

```release-note
loadbalancer: Fix GetInstancesOfService to avoid removing an endpoint from Service A causes all requests to Service B to fail if the name of Service A is the prefix of Service B
```
