### PR TITLE
renovate: Allow cilium-envoy 1.35.x for v1.18

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -737,7 +737,6 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
       "allowedVersions": "/^v1\\.34\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
-        "v1.18",
         "v1.17",
         "v1.16"
       ]
@@ -756,7 +755,8 @@
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
       "allowedVersions": "/^v1\\.35\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
-        "main"
+        "main",
+        "v1.18"
       ]
     },
     {


### PR DESCRIPTION
Envoy 1.34 will be EOL in 3 months, we should gradually perform the upgrade.

