### PR TITLE
node/address: always prefer public addresses in `firstGlobalAddr`

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -19,8 +19,6 @@ import (
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
-const preferPublicIP bool = true
-
 var (
 	addrs addresses
 
@@ -80,7 +78,7 @@ func setDefaultPrefix(logger *slog.Logger, cfg *option.DaemonConfig, device stri
 	if cfg.EnableIPv4 {
 		isIPv6 := false
 
-		ip, err := firstGlobalV4Addr(device, node.GetCiliumInternalIP(isIPv6), preferPublicIP)
+		ip, err := firstGlobalV4Addr(device, node.GetCiliumInternalIP(isIPv6))
 		if err != nil {
 			return
 		}
@@ -129,7 +127,7 @@ func setDefaultPrefix(logger *slog.Logger, cfg *option.DaemonConfig, device stri
 
 		if node.GetNodeIP(isIPv6) == nil {
 			// Find a IPv6 node address first
-			addr, _ := firstGlobalV6Addr(device, node.GetCiliumInternalIP(isIPv6), preferPublicIP)
+			addr, _ := firstGlobalV6Addr(device, node.GetCiliumInternalIP(isIPv6))
 			if addr == nil {
 				addr = makeIPv6HostIP(logger)
 			}

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 )
 
-func firstGlobalAddr(intf string, preferredIP net.IP, family int, preferPublic bool) (net.IP, error) {
+func firstGlobalAddr(intf string, preferredIP net.IP, family int) (net.IP, error) {
 	var link netlink.Link
 	var ipLen int
 	var err error
@@ -80,10 +80,6 @@ retryScope:
 		}
 	}
 
-	if hasPreferred && !preferPublic {
-		return preferredIP, nil
-	}
-
 	if len(ipsPublic) != 0 {
 		if hasPreferred && ip.IsPublicAddr(preferredIP) {
 			return preferredIP, nil
@@ -139,8 +135,8 @@ retryScope:
 // IPs belonging to that interface are considered.
 //
 // If preferredIP is present in the IP list it is returned irrespective of
-// the sort order. However, if preferPublic is true and preferredIP is a
-// private IP, a public IP will be returned if it is assigned to the intf
+// the sort order. However, if preferredIP is a private IP, a public IP will
+// be returned if it is assigned to the intf
 //
 // Passing intf and preferredIP will only return preferredIP if it is in
 // the IPs that belong to intf.
@@ -154,12 +150,12 @@ retryScope:
 // universe scope again (and then falling back to reduced scope).
 //
 // In case none of the above helped, we bail out with error.
-func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
-	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V4, preferPublic)
+func firstGlobalV4Addr(intf string, preferredIP net.IP) (net.IP, error) {
+	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V4)
 }
 
 // firstGlobalV6Addr returns first IPv6 global IP of an interface, see
 // firstGlobalV4Addr for more details.
-func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
-	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V6, preferPublic)
+func firstGlobalV6Addr(intf string, preferredIP net.IP) (net.IP, error) {
+	return firstGlobalAddr(intf, preferredIP, netlink.FAMILY_V6)
 }

--- a/pkg/node/address_linux_test.go
+++ b/pkg/node/address_linux_test.go
@@ -28,7 +28,6 @@ func TestPrivilegedFirstGlobalV4Addr(t *testing.T) {
 		name           string
 		ipsOnInterface []string
 		preferredIP    string
-		preferPublic   bool
 		want           string
 	}{
 		{
@@ -37,21 +36,8 @@ func TestPrivilegedFirstGlobalV4Addr(t *testing.T) {
 			want:           "21.0.0.1",
 		},
 		{
-			name:           "prefer IP when not preferPublic",
+			name:           "prefer public IP over preferred IP",
 			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
-			preferredIP:    "192.168.0.1",
-			want:           "192.168.0.1",
-		},
-		{
-			name:           "preferPublic when not prefer IP",
-			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
-			preferPublic:   true,
-			want:           "21.0.0.1",
-		},
-		{
-			name:           "preferPublic when prefer IP",
-			ipsOnInterface: []string{"192.168.0.1", "21.0.0.1"},
-			preferPublic:   true,
 			preferredIP:    "192.168.0.1",
 			want:           "21.0.0.1",
 		},
@@ -60,13 +46,19 @@ func TestPrivilegedFirstGlobalV4Addr(t *testing.T) {
 			ipsOnInterface: []string{"192.168.0.2", "192.168.0.1"},
 			want:           "192.168.0.2",
 		},
+		{
+			name:           "preferred IP if defined",
+			ipsOnInterface: []string{"192.168.0.2", "192.168.0.1"},
+			preferredIP:    "192.168.0.1",
+			want:           "192.168.0.1",
+		},
 	}
 	const ifName = "dummy_iface"
 	for _, tc := range testCases {
 		err := setupDummyDevice(ifName, tc.ipsOnInterface...)
 		require.NoError(t, err)
 
-		got, err := firstGlobalV4Addr(ifName, net.ParseIP(tc.preferredIP), tc.preferPublic)
+		got, err := firstGlobalV4Addr(ifName, net.ParseIP(tc.preferredIP))
 		require.NoError(t, err)
 		require.Equal(t, tc.want, got.String())
 		removeDevice(ifName)

--- a/pkg/node/address_other.go
+++ b/pkg/node/address_other.go
@@ -9,15 +9,15 @@ import (
 	"net"
 )
 
-func firstGlobalAddr(intf string, preferredIP net.IP, family int, preferPublic bool) (net.IP, error) {
+func firstGlobalAddr(intf string, preferredIP net.IP, family int) (net.IP, error) {
 	return net.IP{}, nil
 }
 
-func firstGlobalV4Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
+func firstGlobalV4Addr(intf string, preferredIP net.IP) (net.IP, error) {
 	return net.IP{}, nil
 }
 
-func firstGlobalV6Addr(intf string, preferredIP net.IP, preferPublic bool) (net.IP, error) {
+func firstGlobalV6Addr(intf string, preferredIP net.IP) (net.IP, error) {
 	return net.IP{}, nil
 }
 


### PR DESCRIPTION
This commit removes the nowadays unnecessary constant `node.preferPublicIP` and changes the function `firstGlobalAddr` to always prefer public addresses (`true` was always passed anyway - except for tests).