### PR TITLE
clean up the endpoints from the previous round of scanning at first

### DIFF
--- a/pkg/endpointmanager/gc.go
+++ b/pkg/endpointmanager/gc.go
@@ -13,6 +13,17 @@ import (
 // EndpointCheckerFunc can verify whether an endpoint is currently healthy.
 type EndpointCheckerFunc func(*endpoint.Endpoint) error
 
+// isMarkedEndpoint returns whether the endpoint with the given id exists in markedEndpoints
+func (mgr *endpointManager) isMarkedEndpoint(id uint16) bool {
+	_, ok := mgr.markedEndpoints[id]
+	return ok
+}
+
+// setMarkedEndpoints replaces markedEndpoints with the provided map.
+func (mgr *endpointManager) setMarkedEndpoints(candidates map[uint16]struct{}) {
+	mgr.markedEndpoints = candidates
+}
+
 // markAndSweep performs a two-phase garbage collection of endpoints using the
 // configured EndpointChecker.
 //
@@ -23,50 +34,21 @@ type EndpointCheckerFunc func(*endpoint.Endpoint) error
 // components in the system, then we will not flag warnings about the system
 // getting out-of-sync.
 func (mgr *endpointManager) markAndSweep(ctx context.Context) error {
-	marked := mgr.markEndpoints()
+	gcCandidates := make(map[uint16]struct{})
+	toSweep := []*endpoint.Endpoint{}
 
-	mgr.mutex.Lock()
-	toSweep := mgr.markedEndpoints
-	mgr.markedEndpoints = marked
-	mgr.mutex.Unlock()
-
-	// Avoid returning an error which would cause the calling controller to
-	// re-run the garbage collection more frequently than the RunInterval.
-	mgr.sweepEndpoints(toSweep)
-	return nil
-}
-
-// markEndpoints runs all endpoints in the manager against the configured
-// EndpointChecker and returns a slice of endpoint ids that require garbage
-// collection.
-func (mgr *endpointManager) markEndpoints() []uint16 {
 	mgr.mutex.RLock()
-	defer mgr.mutex.RUnlock()
-
-	needsGC := make([]uint16, 0, len(mgr.endpoints))
 	for eid, ep := range mgr.endpoints {
 		if err := mgr.checkHealth(ep); err != nil {
-			needsGC = append(needsGC, eid)
+			// Only collect previously marked endpoints for cleanup.
+			if mgr.isMarkedEndpoint(eid) {
+				toSweep = append(toSweep, ep)
+			} else {
+				gcCandidates[eid] = struct{}{}
+			}
 		}
 	}
-	return needsGC
-}
-
-// sweepEndpoints iterates through the specified list of endpoints marked for
-// deletion and attempts to garbage-collect them if they still exist.
-func (mgr *endpointManager) sweepEndpoints(markedEndpoints []uint16) {
-	toSweep := make([]*endpoint.Endpoint, 0, len(markedEndpoints))
-
-	// 'markedEndpoints' were marked during the previous mark round, so
-	// they may no longer be valid endpoints. Narrow the list to only the
-	// endpoints that remain. Then, release the lock so RemoveEndpoint()
-	// below can independently grab it.
-	mgr.mutex.RLock()
-	for _, id := range markedEndpoints {
-		if ep, ok := mgr.endpoints[id]; ok {
-			toSweep = append(toSweep, ep)
-		}
-	}
+	mgr.setMarkedEndpoints(gcCandidates)
 	mgr.mutex.RUnlock()
 
 	for _, ep := range toSweep {
@@ -90,4 +72,5 @@ func (mgr *endpointManager) sweepEndpoints(markedEndpoints []uint16) {
 			}
 		}
 	}
+	return nil
 }

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -26,6 +26,11 @@ func fakeCheck(ep *endpoint.Endpoint) error {
 	return nil
 }
 
+// fakeCheckHealthy detects endpoints as healthy
+func fakeCheckHealthy(ep *endpoint.Endpoint) error {
+	return nil
+}
+
 func TestMarkAndSweep(t *testing.T) {
 	logger := hivetest.Logger(t)
 	s := setupEndpointManagerSuite(t)
@@ -66,6 +71,131 @@ func TestMarkAndSweep(t *testing.T) {
 	require.False(t, mgr.EndpointExists(endpointIDToDelete))
 	require.NoError(t, err)
 	require.Len(t, mgr.GetEndpoints(), len(healthyEndpointIDs))
+}
+
+// TestMarkAndSweepNoDoubleSweep verifies that the sweep-first-then-mark logic ensures
+// an endpoint is only swept once.
+func TestMarkAndSweepNoDoubleSweep(t *testing.T) {
+	logger := hivetest.Logger(t)
+	s := setupEndpointManagerSuite(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	mgr.checkHealth = fakeCheck
+	mgr.deleteEndpoint = endpointDeleteFunc(mgr.waitEndpointRemoved)
+
+	timeout := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	testEPID := 256
+
+	// Create an unhealthy endpoint (even ID)
+	unhealthyID := uint16(testEPID)
+	model := newTestEndpointModel(int(unhealthyID), endpoint.StateReady)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	require.NoError(t, err)
+	ep.Start(unhealthyID)
+	t.Cleanup(ep.Stop)
+	err = mgr.expose(ep)
+	require.NoError(t, err)
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Round 1 GC: sweep is empty, mark tags the unhealthy endpoint
+	err = mgr.markAndSweep(ctx)
+	require.NoError(t, err)
+	require.True(t, mgr.EndpointExists(unhealthyID), "endpoint should still exist after round 1 GC")
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Round 2 GC: sweep deletes the previously marked endpoint,
+	// mark re-checks (endpoint has been deleted at this point)
+	err = mgr.markAndSweep(ctx)
+	require.NoError(t, err)
+	require.False(t, mgr.EndpointExists(unhealthyID), "endpoint should be deleted after round 2 GC")
+	require.Empty(t, mgr.GetEndpoints(), "endpoint should be deleted after round 2 GC")
+
+	// Verify that markedEndpoints is correctly cleared after sweep.
+	// Since we sweep first then mark, after round 2 sweep executes,
+	// the endpoint no longer exists during the mark phase,
+	// so markedEndpoints should be empty.
+	require.False(t, mgr.isMarkedEndpoint(unhealthyID), "markedEndpoints should be empty after endpoint is deleted")
+
+	// Simulate endpoint ID reuse: create a new healthy endpoint.
+	// Since fakeCheck marks even IDs as unhealthy, we use an odd ID
+	// to simulate a healthy endpoint.
+	healthyID := uint16(testEPID)
+	model2 := newTestEndpointModel(int(healthyID), endpoint.StateReady)
+	ep2, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model2, nil)
+	require.NoError(t, err)
+	ep2.Start(healthyID)
+	t.Cleanup(ep2.Stop)
+	err = mgr.expose(ep2)
+	require.NoError(t, err)
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Round 3 GC: since markedEndpoints is empty, sweep won't delete any endpoint.
+	// The newly created healthy endpoint should not be incorrectly deleted.
+	err = mgr.markAndSweep(ctx)
+	require.NoError(t, err)
+	require.True(t, mgr.EndpointExists(healthyID), "healthy endpoint should still exist after round 3 GC")
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Verify that healthyID (256, even) is now marked in markedEndpoints after round 3.
+	require.True(t, mgr.isMarkedEndpoint(healthyID), "healthyID should be marked in markedEndpoints after round 3 GC")
+
+	// Round 4 GC: sweep should delete the previously marked endpoint (healthyID).
+	err = mgr.markAndSweep(ctx)
+	require.NoError(t, err)
+	require.False(t, mgr.EndpointExists(healthyID), "endpoint should be deleted after round 4 GC")
+	require.Empty(t, mgr.GetEndpoints(), "no endpoints should exist after round 4 GC")
+}
+
+// TestMarkAndSweepEndpointIDRecover verifies that if an endpoint is marked as a GC
+// candidate in one round but recovers (becomes healthy) before the next sweep,
+// it will not be deleted and will be removed from markedEndpoints.
+func TestMarkAndSweepEndpointIDRecover(t *testing.T) {
+	logger := hivetest.Logger(t)
+	s := setupEndpointManagerSuite(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	mgr.checkHealth = fakeCheck
+	mgr.deleteEndpoint = endpointDeleteFunc(mgr.waitEndpointRemoved)
+
+	timeout := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Create an unhealthy endpoint (even ID, fakeCheck returns error for even IDs)
+	unhealthyID := uint16(256)
+	model := newTestEndpointModel(int(unhealthyID), endpoint.StateReady)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	require.NoError(t, err)
+	ep.Start(unhealthyID)
+	t.Cleanup(ep.Stop)
+	err = mgr.expose(ep)
+	require.NoError(t, err)
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Round 1 GC: sweep is empty (nothing to delete), mark tags the unhealthy endpoint.
+	err = mgr.markAndSweep(ctx)
+	require.NoError(t, err)
+	require.True(t, mgr.EndpointExists(unhealthyID), "endpoint should still exist after round 1 GC")
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Verify that unhealthyID is now marked in markedEndpoints after round 1.
+	require.True(t, mgr.isMarkedEndpoint(unhealthyID), "unhealthyID should be marked in markedEndpoints after round 1 GC")
+
+	// Simulate endpoint recovery: switch checkHealth to fakeCheckHealthy so the
+	// endpoint is now considered healthy before the next sweep executes.
+	mgr.checkHealth = fakeCheckHealthy
+
+	// Round 2 GC: sweep would normally delete the marked endpoint, but since the
+	// endpoint is now healthy, it should NOT be deleted. Instead, it should be
+	// removed from markedEndpoints because it passes the health check.
+	err = mgr.markAndSweep(ctx)
+	require.NoError(t, err)
+	require.True(t, mgr.EndpointExists(unhealthyID), "recovered endpoint should NOT be deleted in round 2 GC")
+	require.Len(t, mgr.GetEndpoints(), 1)
+
+	// Verify that unhealthyID is no longer in markedEndpoints after recovery.
+	require.False(t, mgr.isMarkedEndpoint(unhealthyID), "recovered endpoint should be removed from markedEndpoints after round 2 GC")
 }
 
 func newTestEndpointModel(id int, state endpoint.State) *models.EndpointChangeRequest {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -88,7 +88,7 @@ type endpointManager struct {
 	// This is configured via WithPeriodicEndpointGC() and will mark
 	// endpoints for removal on one run of the controller, then in the
 	// subsequent controller run will remove the endpoints.
-	markedEndpoints []uint16
+	markedEndpoints map[uint16]struct{}
 
 	// controllers associated with the endpoint manager.
 	controllers *controller.Manager


### PR DESCRIPTION
clean up the endpoints from the previous round of scanning at first , then proceed with the next round of scanning

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #43577 

```release-note
Fix bug where a newly created endpoint could be incorrectly garbage collected if the endpoint ID is reused from a recently deleted endpoint
```
