### PR TITLE
fix: azure aks apiserver hardening

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -56,5 +56,6 @@ runs:
           --node-count ${{ inputs.node_count }} \
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
-          --generate-ssh-keys
+          --generate-ssh-keys \
+          --api-server-authorized-ip-ranges $(curl api.ipify.org)/32
 


### PR DESCRIPTION
This change ensures that AKS Kube API Server is only accessible from the github runner.