### PR TITLE
gh: cilium-config: encryption-strict-egress is also supported for IPsec

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -38,7 +38,7 @@ inputs:
     description: 'Enable node-to-node encryption (WireGuard only)'
     default: 'false'
   encryption-strict-egress:
-    description: 'Enable strict mode egress encryption (WireGuard only)'
+    description: 'Enable strict mode egress encryption'
     default: ''
   encryption-strict-ingress:
     description: 'Enable strict mode ingress encryption (WireGuard only)'


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/42115 added the necessary bits for IPsec. Also update the parameter description in the cilium-config action.