### PR TITLE
gh: introduce testing with kernel 6.18

### DIFF
--- a/.github/actions/e2e/kernel-versions.yml
+++ b/.github/actions/e2e/kernel-versions.yml
@@ -11,3 +11,5 @@ kernels:
   6.6: '6.6-20260105.013422'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   6.12: '6.12-20260105.013422'
+  # renovate: datasource=docker depName=quay.io/lvh-images/kind
+  6.18: '6.18-20260109.091250'

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,7 +6,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.35.0@sha256:a36285a50bb7ee33d44b6d7938dca10e34f8a9294873ae4b0b04f9d21619d44c"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "6.12-20260105.013422"
+    kernel: "6.18-20260109.091250"
     kernel-type: "latest"
 
   - k8s-version: "1.34"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -201,7 +201,7 @@ jobs:
 
           - focus: "privileged"
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            lvhImage: "6.12-20260105.013422"
+            lvhImage: "6.18-20260109.091250"
 
     timeout-minutes: 50
     steps:

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -100,6 +100,9 @@ jobs:
           - kernel: '6.12'
             kernel-name: '612'
             ci-kernel: '61'
+          - kernel: '6.18'
+            kernel-name: '618'
+            ci-kernel: '61'
           - kernel: 'bpf-next'
             kernel-name: 'bpf-next'
             ci-kernel: 'netnext'
@@ -143,6 +146,8 @@ jobs:
             "6.6") FULL_KERNEL="6.6-20260105.013422" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "6.12") FULL_KERNEL="6.12-20260105.013422" ;;
+            # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
+            "6.18") FULL_KERNEL="6.18-20260109.091250" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "bpf-next") FULL_KERNEL="bpf-next-20260105.013422" ;;
             *) FULL_KERNEL="$KERNEL" ;;


### PR DESCRIPTION
Kernel 6.18 is the lastest LTS kernel. Start populating the CI with it.