### PR TITLE
renovate: Allow cilium-envoy minor upgrade for stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -353,8 +353,9 @@
         "!main",
       ],
       "matchDepNames": [
-        // Explicitly allow certgen updates.
+        // Explicitly allow certgen and cilium-envoy updates.
         "!quay.io/cilium/certgen",
+        "!quay.io/cilium/cilium-envoy"
       ]
     },
     {


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/pull/43638
Relates: https://github.com/cilium/cilium/pull/43623