### PR TITLE
chore(helm): liveness and readiness Probes use port by name

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -83,14 +83,14 @@ spec:
             {{- end }}
           readinessProbe:
             grpc:
-              port: 4222
+              port: grpc
             timeoutSeconds: 3
           # livenessProbe will kill the pod, we should be very conservative
           # here on failures since killing the pod should be a last resort, and
           # we should provide enough time for relay to retry before killing it.
           livenessProbe:
             grpc:
-              port: 4222
+              port: grpc
             timeoutSeconds: 10
             # Give relay time to establish connections and make a few retries
             # before starting livenessProbes.
@@ -105,7 +105,7 @@ spec:
             failureThreshold: 12
           startupProbe:
             grpc:
-              port: 4222
+              port: grpc
             # Give relay time to get it's certs and establish connections and
             # make a few retries before starting startupProbes.
             initialDelaySeconds: 10

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -127,13 +127,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8090
+            port: grpc
         {{- end }}
         {{- if .Values.hubble.ui.backend.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 8090
+            port: grpc
         {{- end }}
         ports:
         - name: grpc


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

It shifts the health checks to use the ports by name rather than number (dentified by the kubernetes linter popeyecli.io). Based on the use of httpGet for hubble-ui, I'm not actually sure the port name `grpc` is an accurate name for the port itself...

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
