### PR TITLE
chore: comment job to use generated token instead of PAT (pull_request_target)

### DIFF
--- a/.github/workflows/build-images-ci-v1.16.yaml
+++ b/.github/workflows/build-images-ci-v1.16.yaml
@@ -397,9 +397,15 @@ jobs:
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
         }}
     steps:
+      - name: Generate Github App Token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:
-          TOKEN: ${{ secrets.AUTO_COMMENT_TOKEN }}
+          TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -419,9 +419,15 @@ jobs:
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
         }}
     steps:
+      - name: Generate Github App Token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:
-          TOKEN: ${{ secrets.AUTO_COMMENT_TOKEN }}
+          TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -445,9 +445,15 @@ jobs:
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME
         }}
     steps:
+      - name: Generate Github App Token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:
-          TOKEN: ${{ secrets.AUTO_COMMENT_TOKEN }}
+          TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |


### PR DESCRIPTION
This is the follow-up PR for pull_request_target workflows.

Previous PR: https://github.com/cilium/cilium/pull/43148