### PR TITLE
helm: add default CiliumNetworkPolicy for hubble-relay and hubble-ui

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2268,6 +2268,14 @@
      - Log level for hubble-relay. Valid values are: debug, info, warn, error.
      - string
      - info
+   * - :spelling:ignore:`hubble.relay.networkPolicy`
+     - Network policy configuration for hubble-relay
+     - object
+     - ``{"enabled":false}``
+   * - :spelling:ignore:`hubble.relay.networkPolicy.enabled`
+     - Enable default CiliumNetworkPolicy for hubble-relay
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.relay.nodeSelector`
      - Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
@@ -2596,6 +2604,14 @@
      - Additional labels to be added to 'hubble-ui' deployment object
      - object
      - ``{}``
+   * - :spelling:ignore:`hubble.ui.networkPolicy`
+     - Network policy configuration for hubble-ui
+     - object
+     - ``{"enabled":false}``
+   * - :spelling:ignore:`hubble.ui.networkPolicy.enabled`
+     - Enable default CiliumNetworkPolicy for hubble-ui
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.ui.nodeSelector`
      - Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -617,6 +617,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.logOptions | object | `{"format":null,"level":null}` | Logging configuration for hubble-relay. |
 | hubble.relay.logOptions.format | string | text-ts | Log format for hubble-relay. Valid values are: text, text-ts, json, json-ts. |
 | hubble.relay.logOptions.level | string | info | Log level for hubble-relay. Valid values are: debug, info, warn, error. |
+| hubble.relay.networkPolicy | object | `{"enabled":false}` | Network policy configuration for hubble-relay |
+| hubble.relay.networkPolicy.enabled | bool | `false` | Enable default CiliumNetworkPolicy for hubble-relay |
 | hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
 | hubble.relay.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -699,6 +701,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"labels":{},"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.labels | object | `{}` | Additional labels to be added to 'hubble-ui' deployment object |
+| hubble.ui.networkPolicy | object | `{"enabled":false}` | Network policy configuration for hubble-ui |
+| hubble.ui.networkPolicy.enabled | bool | `false` | Enable default CiliumNetworkPolicy for hubble-ui |
 | hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/install/kubernetes/cilium/templates/hubble-relay/networkpolicy.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/networkpolicy.yaml
@@ -1,0 +1,53 @@
+﻿{{- if and .Values.hubble.enabled .Values.hubble.relay.enabled .Values.hubble.relay.networkPolicy.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hubble-relay
+  namespace: {{ include "cilium.namespace" . }}
+  labels:
+    k8s-app: hubble-relay
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  ingress:
+    # Allow gRPC from any source (hubble-ui, hubble CLI, external clients)
+    - toPorts:
+        - ports:
+            - port: {{ .Values.hubble.relay.listenPort | quote }}
+              protocol: TCP
+    {{- if .Values.hubble.relay.prometheus.enabled }}
+    # Allow Prometheus metrics scraping
+    - toPorts:
+        - ports:
+            - port: {{ .Values.hubble.relay.prometheus.port | quote }}
+              protocol: TCP
+    {{- end }}
+  egress:
+    # Allow connection to cilium-agent (runs on host network)
+    - toEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: {{ .Values.hubble.peerService.targetPort | quote }}
+              protocol: TCP
+    # Allow DNS resolution
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+{{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/networkpolicy.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/networkpolicy.yaml
@@ -1,0 +1,46 @@
+﻿{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.hubble.ui.networkPolicy.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: hubble-ui
+  namespace: {{ include "cilium.namespace" . }}
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  ingress:
+    # Allow HTTP from any source (users via Service/Ingress)
+    - toPorts:
+        - ports:
+            - port: "8081"
+              protocol: TCP
+  egress:
+    # Allow connection to hubble-relay
+    - toServices:
+        - k8sService:
+            serviceName: hubble-relay
+            namespace: {{ include "cilium.namespace" . }}
+    # Allow connection to kube-apiserver for namespace listing
+    - toEntities:
+        - kube-apiserver
+    # Allow DNS resolution
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+{{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3476,6 +3476,14 @@
               },
               "type": "object"
             },
+            "networkPolicy": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
             "nodeSelector": {
               "properties": {
                 "kubernetes.io/os": {
@@ -3990,6 +3998,14 @@
               "type": "object"
             },
             "labels": {
+              "type": "object"
+            },
+            "networkPolicy": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
               "type": "object"
             },
             "nodeSelector": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1918,6 +1918,10 @@ hubble:
       # -- Log level for hubble-relay. Valid values are: debug, info, warn, error.
       # @default -- info
       level: ~
+    # -- Network policy configuration for hubble-relay
+    networkPolicy:
+      # -- Enable default CiliumNetworkPolicy for hubble-relay
+      enabled: false
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: false
@@ -2112,6 +2116,10 @@ hubble:
     # emptyDir:
     #   # sizeLimit: "100Mi"
     #   # medium: "Memory"
+    # -- Network policy configuration for hubble-ui
+    networkPolicy:
+      # -- Enable default CiliumNetworkPolicy for hubble-ui
+      enabled: false
   # -- Hubble flows export.
   export:
     # --- Static exporter configuration.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1930,6 +1930,10 @@ hubble:
       # -- Log level for hubble-relay. Valid values are: debug, info, warn, error.
       # @default -- info
       level: ~
+    # -- Network policy configuration for hubble-relay
+    networkPolicy:
+      # -- Enable default CiliumNetworkPolicy for hubble-relay
+      enabled: false
   ui:
     # -- Whether to enable the Hubble UI.
     enabled: false
@@ -2125,6 +2129,10 @@ hubble:
       # emptyDir:
       #   # sizeLimit: "100Mi"
       #   # medium: "Memory"
+    # -- Network policy configuration for hubble-ui
+    networkPolicy:
+      # -- Enable default CiliumNetworkPolicy for hubble-ui
+      enabled: false
 
   # -- Hubble flows export.
   export:


### PR DESCRIPTION
Add `CiliumNetworkPolicy` templates for `hubble-relay` and `hubble-ui` components. The policies are disabled by default and can be enabled via `hubble.relay.networkPolicy.enabled` and `hubble.ui.networkPolicy.enabled` Helm values.

Fixes: #43502




```release-note
helm: Add CiliumNetworkPolicy for hubble-relay and hubble-ui components, controlled by `hubble.relay.networkPolicy.enabled` and `hubble.ui.networkPolicy.enabled` Helm values
```
