### PR TITLE
bpf: wireguard: use set_decrypt_mark()

### DIFF
--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -318,7 +318,7 @@ int cil_from_wireguard(struct __ctx_buff *ctx)
 
 #ifdef ENABLE_IDENTITY_MARK
 	/* mark packet as decrypted by wireguard */
-	ctx->mark |= MARK_MAGIC_DECRYPT;
+	set_decrypt_mark(ctx, 0);
 #endif
 
 #if defined(TUNNEL_MODE) && !(defined(ENABLE_NODEPORT) && defined(ENABLE_NODE_ENCRYPTION))

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -13,14 +13,12 @@
 #include "lib/ipv4.h"
 #include "lib/identity.h"
 
-#if defined(ENABLE_IPSEC) || defined(ENABLE_WIREGUARD)
 static __always_inline void
 set_decrypt_mark(struct __ctx_buff *ctx, __u16 node_id)
 {
 	/* Decrypt "key" is determined by SPI and originating node */
 	ctx->mark = MARK_MAGIC_DECRYPT | node_id << 16;
 }
-#endif /* defined(ENABLE_IPSEC) || defined(ENABLE_WIREGUARD) */
 
 #ifdef ENCRYPTION_STRICT_MODE_EGRESS
 /* strict_allow checks whether the packet is allowed to pass through the strict mode. */


### PR DESCRIPTION
Use the correct helper to format the MARK_MAGIC_DECRYPT info into the skb mark.