### PR TITLE
CODEOWNERS: add missing codeowners entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -611,6 +611,7 @@ Makefile* @cilium/build
 /pkg/l2announcer/ @cilium/sig-agent
 /pkg/labels @cilium/sig-policy @cilium/api
 /pkg/labelsfilter @cilium/sig-policy
+/pkg/lbipamconfig @cilium/sig-lb
 /pkg/loadbalancer @cilium/sig-lb
 /pkg/loadinfo/ @cilium/sig-agent
 /pkg/lock @cilium/sig-agent
@@ -640,6 +641,7 @@ Makefile* @cilium/build
 /pkg/node @cilium/sig-agent
 /pkg/node/neighbordiscovery @cilium/sig-agent @cilium/sig-datapath
 /pkg/nodediscovery/ @cilium/sig-agent
+/pkg/nodeipamconfig @cilium/sig-ipam
 /pkg/option @cilium/sig-agent @cilium/cli
 /pkg/pidfile @cilium/sig-agent
 /pkg/policy @cilium/sig-policy


### PR DESCRIPTION
Fixes: 7ff0753e9c3c ("lbipam: split out LBIPAM config into pkg/lbipamconfig")
Fixes: cbe8f4728a7d ("nodeipam: split out NodeIPAMConfig into pkg/nodeipamconfig")