### PR TITLE
feat(helm) cilium-operator run as non-root

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3263,7 +3263,7 @@
    * - :spelling:ignore:`operator.podSecurityContext`
      - Security context to be added to cilium-operator pods
      - object
-     - ``{"seccompProfile":{"type":"RuntimeDefault"}}``
+     - ``{"runAsGroup":65000,"runAsNonRoot":true,"runAsUser":65000,"seccompProfile":{"type":"RuntimeDefault"}}``
    * - :spelling:ignore:`operator.pprof.address`
      - Configure pprof listen address for cilium-operator
      - string

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -82,11 +82,10 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=gops /out /
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-${OPERATOR_VARIANT} /usr/bin/cilium-${OPERATOR_VARIANT}
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
-WORKDIR /
 # Configure gops directory to prevent permission
 # issues depending on the UID configured to run the entrypoint.
-COPY --chmod=777 --from=scratch / /home/gops
-ENV GOPS_CONFIG_DIR=/home/gops
+ENV GOPS_CONFIG_DIR=/tmp
+WORKDIR /tmp
 CMD ["/usr/bin/cilium-${OPERATOR_VARIANT}"]
 
 FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS debug-tools

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -865,7 +865,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | operator.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `nil` | How are unhealthy, but running, pods counted for eviction |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
-| operator.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to be added to cilium-operator pods |
+| operator.podSecurityContext | object | `{"runAsGroup":65000,"runAsNonRoot":true,"runAsUser":65000,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context to be added to cilium-operator pods |
 | operator.pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-operator |
 | operator.pprof.blockProfileRate | int | `0` | Enable goroutine blocking profiling for cilium-operator and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead]) |
 | operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -222,6 +222,10 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 5
         volumeMounts:
+        - name: tmp-volume
+          mountPath: /tmp
+        - name: var-run-cilium-volume
+          mountPath: /var/run/cilium
         - name: cilium-config-path
           mountPath: /tmp/cilium/config-map
           readOnly: true
@@ -327,9 +331,15 @@ spec:
       {{- if hasKey .Values "agentNotReadyTaintKey" }}
         - key: {{ .Values.agentNotReadyTaintKey }}
           operator: Exists
-      {{ end}}
-      {{- end}}
+      {{ end }}
+      {{- end }}
       volumes:
+      - name: tmp-volume
+        emptyDir:
+          sizeLimit: 256Mi
+      - name: var-run-cilium-volume
+        emptyDir:
+          sizeLimit: 256Mi
         # To read the configuration from the config map
       - name: cilium-config-path
         configMap:

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4948,6 +4948,15 @@
         },
         "podSecurityContext": {
           "properties": {
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            },
             "seccompProfile": {
               "properties": {
                 "type": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3078,6 +3078,9 @@ operator:
   hostUsers: true
   # -- Security context to be added to cilium-operator pods
   podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65000
+    runAsGroup: 65000
     seccompProfile:
       type: RuntimeDefault
   # -- Annotations to be added to cilium-operator pods
@@ -3121,8 +3124,6 @@ operator:
       drop:
         - ALL
     allowPrivilegeEscalation: false
-  # runAsUser: 0
-
   # -- Interval for endpoint garbage collection.
   endpointGCInterval: "5m0s"
   # -- Interval for cilium node garbage collection.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3106,6 +3106,9 @@ operator:
   hostUsers: true
   # -- Security context to be added to cilium-operator pods
   podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65000
+    runAsGroup: 65000
     seccompProfile:
       type: RuntimeDefault
   # -- Annotations to be added to cilium-operator pods
@@ -3149,7 +3152,6 @@ operator:
       drop:
       - ALL
     allowPrivilegeEscalation: false
-  # runAsUser: 0
 
   # -- Interval for endpoint garbage collection.
   endpointGCInterval: "5m0s"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

The cilium-operator deployment can run as non-root in a pss-restricted compatible security context.

Tested on bare-metal with kubernetes 1.35 on Fedora 34. Probably needs more eyes across more deployments to be well tested/reviewed.

```release-note
cilium-operator pod hardened to match pss-restricted security settings
```
