### PR TITLE
Add the selector type in the cilium-dbg

### DIFF
--- a/api/v1/models/selector_identity_mapping.go
+++ b/api/v1/models/selector_identity_mapping.go
@@ -31,6 +31,9 @@ type SelectorIdentityMapping struct {
 	// string form of selector
 	Selector string `json:"selector,omitempty"`
 
+	// usage of selector
+	Usage string `json:"usage,omitempty"`
+
 	// number of users of this selector in the cache
 	Users int64 `json:"users,omitempty"`
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2683,6 +2683,9 @@ definitions:
       users:
         description: number of users of this selector in the cache
         type: integer
+      usage:
+        description: usage of selector
+        type: string
   Srv6:
     description: |-
       Status of the SRv6
@@ -3894,3 +3897,4 @@ definitions:
     type: array
     items:
       "$ref": "#/definitions/Label"
+

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4487,6 +4487,10 @@ func init() {
           "description": "string form of selector",
           "type": "string"
         },
+        "usage": {
+          "description": "usage of selector",
+          "type": "string"
+        },
         "users": {
           "description": "number of users of this selector in the cache",
           "type": "integer"
@@ -10226,6 +10230,10 @@ func init() {
         },
         "selector": {
           "description": "string form of selector",
+          "type": "string"
+        },
+        "usage": {
+          "description": "usage of selector",
           "type": "string"
         },
         "users": {

--- a/cilium-dbg/cmd/policy_selectors.go
+++ b/cilium-dbg/cmd/policy_selectors.go
@@ -36,7 +36,7 @@ var policyCacheGetCmd = &cobra.Command{
 			sort.Slice(resp, func(i, j int) bool {
 				return resp[i].Selector < resp[j].Selector
 			})
-			fmt.Fprintf(w, "SELECTOR\tLABELS\tUSERS\tIDENTITIES\n")
+			fmt.Fprintf(w, "SELECTOR\tLABELS\tUSAGE\tUSERS\tIDENTITIES\n")
 
 			for _, mapping := range resp {
 				lbls := constructLabelsArrayFromAPIType(mapping.Labels)
@@ -52,6 +52,7 @@ var policyCacheGetCmd = &cobra.Command{
 				} else {
 					fmt.Fprintf(w, "\t%s", getNameAndNamespaceFromLabels(lbls))
 				}
+				fmt.Fprintf(w, "\t%s", mapping.Usage)
 				fmt.Fprintf(w, "\t%d", mapping.Users)
 				if len(mapping.Identities) == 0 {
 					fmt.Fprintf(w, "\t\n")
@@ -61,7 +62,7 @@ var policyCacheGetCmd = &cobra.Command{
 						fmt.Fprintf(w, "\t%d\t\n", idty)
 						first = false
 					} else {
-						fmt.Fprintf(w, "\t\t\t%d\t\n", idty)
+						fmt.Fprintf(w, "\t\t\t\t%d\t\n", idty)
 					}
 				}
 			}

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -318,6 +318,7 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 			Identities: ids,
 			Users:      int64(sel.numUsers()),
 			Labels:     labelArrayToModel(sel.GetMetadataLabels()),
+			Usage:      sel.Usage(),
 		}
 		selCacheMdl = append(selCacheMdl, selMdl)
 	}

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -226,6 +226,28 @@ func (i *identitySelector) numUsers() int {
 	return len(i.users)
 }
 
+func (i *identitySelector) Usage() string {
+	var hasPeer, hasSubject bool
+	for user := range i.users {
+		if user.IsPeerSelector() {
+			hasPeer = true
+		} else {
+			hasSubject = true
+		}
+	}
+
+	switch {
+	case hasPeer && hasSubject:
+		return "peer and subject"
+	case hasPeer:
+		return "peer"
+	case hasSubject:
+		return "subject"
+	default:
+		return ""
+	}
+}
+
 // updateSelections updates the immutable slice representation of the
 // cached selections after the cached selections have been changed.
 //


### PR DESCRIPTION
Add the selector type in the cilium-dbg so people have better visibility.

details in the commits msg

```release-note
Add the selector type in the cilium-dbg for selector cache
```
