### PR TITLE
Cleanups for ztunnel

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -452,7 +452,6 @@ cilium-agent [flags]
       --vtep-sync-interval duration                               Interval for VTEP sync (default 1m0s)
       --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
-      --ztunnel-zds-unix-addr string                              Unix address for zds server (default "/var/run/cilium/ztunnel.sock")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -281,7 +281,6 @@ cilium-agent hive [flags]
       --vtep-sync-interval duration                               Interval for VTEP sync (default 1m0s)
       --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
-      --ztunnel-zds-unix-addr string                              Unix address for zds server (default "/var/run/cilium/ztunnel.sock")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -286,7 +286,6 @@ cilium-agent hive dot-graph [flags]
       --vtep-sync-interval duration                               Interval for VTEP sync (default 1m0s)
       --wireguard-persistent-keepalive duration                   The Wireguard keepalive interval as a Go duration string
       --write-cni-conf-when-ready string                          Write the CNI configuration to the specified path when agent is ready
-      --ztunnel-zds-unix-addr string                              Unix address for zds server (default "/var/run/cilium/ztunnel.sock")
 ```
 
 ### SEE ALSO

--- a/pkg/ztunnel/config/config.go
+++ b/pkg/ztunnel/config/config.go
@@ -7,13 +7,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	DefaultZtunnelUnixAddress = "/var/run/cilium/ztunnel.sock"
-)
-
 var DefaultConfig = Config{
 	EnableZTunnel: false,
-	ZDSUnixAddr:   DefaultZtunnelUnixAddress,
 }
 
 // Config is a shared config for all ZTunnel module's cells.
@@ -21,10 +16,8 @@ var DefaultConfig = Config{
 // while the agent uses this Config struct for dependency injection.
 type Config struct {
 	EnableZTunnel bool
-	ZDSUnixAddr   string `mapstructure:"ztunnel-zds-unix-addr"`
 }
 
 func (c Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-ztunnel", false, "Use zTunnel as Cilium's encryption infrastructure")
-	flags.String("ztunnel-zds-unix-addr", DefaultZtunnelUnixAddress, "Unix address for zds server")
 }

--- a/pkg/ztunnel/table/enrolled_namespaces.go
+++ b/pkg/ztunnel/table/enrolled_namespaces.go
@@ -67,7 +67,7 @@ func NewEnrolledNamespacesTable(db *statedb.DB) (statedb.RWTable[*EnrolledNamesp
 
 func K8sNamespaceToEnrolledNamespace(ns k8s.Namespace, deleted bool) (*EnrolledNamespace, statedb.DeriveResult) {
 	enrolled := true
-	if mtlsValue, exists := ns.Labels["mtls-enabled"]; !exists || mtlsValue != "true" {
+	if mtlsValue, exists := ns.Labels["io.cilium/mtls-enabled"]; !exists || mtlsValue != "true" {
 		enrolled = false
 	}
 	if deleted || !enrolled {

--- a/pkg/ztunnel/zds/server_test.go
+++ b/pkg/ztunnel/zds/server_test.go
@@ -36,9 +36,10 @@ func setupZDSTestSuite(t *testing.T) *Server {
 	logger := hivetest.Logger(t)
 
 	server := newZDSServer(serverParams{
-		Config:    config.Config{EnableZTunnel: true, ZDSUnixAddr: zdsTestUnixAddress},
-		Lifecycle: hivetest.Lifecycle(t),
-		Logger:    logger,
+		Config:      config.Config{EnableZTunnel: true},
+		ZDSUnixAddr: zdsTestUnixAddress,
+		Lifecycle:   hivetest.Lifecycle(t),
+		Logger:      logger,
 	})
 	require.NotNil(t, server.Server)
 	require.NotNil(t, server.Server.l, "server listener should be initialized")


### PR DESCRIPTION
These are some minor changes we need we discovered while writing/reviewing https://github.com/cilium/cilium/pull/42819. Please see the comments on that PR for further details.

```release-note
ztunnel: Consistently use `io.cilium/mtls-enabled` annotation to enable
```
