### PR TITLE
Replace Index{,Byte} with Cut,Contains

### DIFF
--- a/cilium-cli/features/status.go
+++ b/cilium-cli/features/status.go
@@ -308,8 +308,8 @@ type statusPrinter interface {
 
 // parseNameAndLabels splits the key into name and labels based on the first ";" separator
 func parseNameAndLabels(key string) (string, string) {
-	if idx := strings.Index(key, ";"); idx != -1 {
-		return key[:idx], key[idx+1:]
+	if before, after, found := strings.Cut(key, ";"); found {
+		return before, after
 	}
 	return key, ""
 }

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2310,11 +2310,11 @@ func (c *Collector) SubmitTetragonBugtoolTasks(pods []*corev1.Pod, tetragonAgent
 // you think it does.
 func removeTopDirectory(path string) (string, error) {
 	// file separator hardcoded because sysdump always created on Linux OS
-	index := strings.IndexByte(path, '/')
-	if index < 0 {
+	_, after, found := strings.Cut(path, "/")
+	if !found {
 		return "", fmt.Errorf("invalid path %q", path)
 	}
-	return path[index+1:], nil
+	return after, nil
 }
 
 func untar(src string, dst string) error {

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -113,8 +113,8 @@ func NewCNIAttachmentID(containerID, containerIfName string) string {
 
 // splitID splits ID into prefix and id. No validation is performed on prefix.
 func splitID(id string) (PrefixType, string) {
-	if idx := strings.IndexByte(id, ':'); idx > -1 {
-		return PrefixType(id[:idx]), id[idx+1:]
+	if before, after, found := strings.Cut(id, ":"); found {
+		return PrefixType(before), after
 	}
 
 	// default prefix

--- a/pkg/hubble/filters/nodename.go
+++ b/pkg/hubble/filters/nodename.go
@@ -26,7 +26,7 @@ func filterByNodeNames(nodeNames []string) (FilterFunc, error) {
 			return false
 		}
 		// ensure that the node name always includes a cluster name
-		if strings.IndexByte(nodeName, '/') == -1 {
+		if !strings.Contains(nodeName, "/") {
 			nodeName = ciliumDefaults.ClusterName + "/" + nodeName
 		}
 		return nodeNameRegexp.MatchString(nodeName)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -528,9 +528,8 @@ func GetExtendedKeyFrom(str string) string {
 		src = LabelSourceAny
 	}
 	// Remove an eventually value
-	i := strings.IndexByte(next, '=')
-	if i >= 0 {
-		return src + PathDelimiter + next[:i]
+	if before, _, found := strings.Cut(next, "="); found {
+		return src + PathDelimiter + before
 	}
 	return src + PathDelimiter + next
 }

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -79,10 +79,10 @@ func (p LabelPrefix) matches(l labels.Label) (bool, int) {
 // parseLabelPrefix returns a LabelPrefix created from the string label parameter.
 func parseLabelPrefix(label string) (*LabelPrefix, error) {
 	labelPrefix := LabelPrefix{}
-	i := strings.IndexByte(label, ':')
-	if i >= 0 {
-		labelPrefix.Source = label[:i]
-		labelPrefix.Prefix = label[i+1:]
+	before, after, found := strings.Cut(label, ":")
+	if found {
+		labelPrefix.Source = before
+		labelPrefix.Prefix = after
 	} else {
 		labelPrefix.Prefix = label
 	}


### PR DESCRIPTION
The latest golangci-lint reports that these code patterns can be
modernized to use Go 1.18 feature 'Cut()' in the strings,bytes
libraries. Update these patterns to simplify the code and appease the
linter.
