### PR TITLE
cni: lower default plpmtud setting to "blackhole detected".

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -176,7 +176,6 @@ cilium-agent [flags]
       --enable-no-service-endpoints-routable                      Enable routes when service has 0 endpoints (default true)
       --enable-node-ipam                                          Enable Node IPAM
       --enable-node-selector-labels                               Enable use of node label based identity
-      --enable-packetization-layer-pmtud                          Enables kernel packetization layer path mtu discovery on Pod netns (default true)
       --enable-pmtu-discovery                                     Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                      Enable policy enforcement (default "default")
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
@@ -376,6 +375,7 @@ cilium-agent [flags]
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --only-masquerade-default-pool                              When using multi-pool IPAM, only masquerade flows from the default IP pool. This will preserve source IPs for pods from non-default IP pools. Useful when combining multi-pool IPAM with BGP control plane. This option must be combined with enable-bpf-masquerade.
+      --packetization-layer-pmtud-mode string                     Enables kernel packetization layer path mtu discovery on Pod netns (if empty will use host setting) (default "blackhole")
       --policy-accounting                                         Maintain packet and byte counters for every policy entry (default true)
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
       --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes'

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -94,7 +94,6 @@ cilium-agent hive [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-no-service-endpoints-routable                      Enable routes when service has 0 endpoints (default true)
       --enable-node-ipam                                          Enable Node IPAM
-      --enable-packetization-layer-pmtud                          Enables kernel packetization layer path mtu discovery on Pod netns (default true)
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
@@ -229,6 +228,7 @@ cilium-agent hive [flags]
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --only-masquerade-default-pool                              When using multi-pool IPAM, only masquerade flows from the default IP pool. This will preserve source IPs for pods from non-default IP pools. Useful when combining multi-pool IPAM with BGP control plane. This option must be combined with enable-bpf-masquerade.
+      --packetization-layer-pmtud-mode string                     Enables kernel packetization layer path mtu discovery on Pod netns (if empty will use host setting) (default "blackhole")
       --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-queue-size uint                                    Size of queue for policy-related events (default 100)
       --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -100,7 +100,6 @@ cilium-agent hive dot-graph [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-no-service-endpoints-routable                      Enable routes when service has 0 endpoints (default true)
       --enable-node-ipam                                          Enable Node IPAM
-      --enable-packetization-layer-pmtud                          Enables kernel packetization layer path mtu discovery on Pod netns (default true)
       --enable-policy-secrets-sync                                Enables Envoy secret sync for Secrets used in CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
@@ -234,6 +233,7 @@ cilium-agent hive dot-graph [flags]
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --only-masquerade-default-pool                              When using multi-pool IPAM, only masquerade flows from the default IP pool. This will preserve source IPs for pods from non-default IP pools. Useful when combining multi-pool IPAM with BGP control plane. This option must be combined with enable-bpf-masquerade.
+      --packetization-layer-pmtud-mode string                     Enables kernel packetization layer path mtu discovery on Pod netns (if empty will use host setting) (default "blackhole")
       --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-queue-size uint                                    Size of queue for policy-related events (default 100)
       --policy-secrets-namespace string                           PolicySecretsNamesapce is the namespace having secrets used in CNP and CCNP

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3484,10 +3484,10 @@
      - Enable path MTU discovery to send ICMP fragmentation-needed replies to the client.
      - bool
      - ``false``
-   * - :spelling:ignore:`pmtuDiscovery.packetizationLayerPMTUD`
-     - Enable kernel probing path MTU discovery for Pods which uses different message sizes to search for correct MTU value.
-     - object
-     - ``{"enabled":true}``
+   * - :spelling:ignore:`pmtuDiscovery.packetizationLayerPMTUDMode`
+     - Enable kernel probing path MTU discovery for Pods which uses different message sizes to search for correct MTU value. Valid values are: always, blackhole, disabled and unset (or empty). If value is 'unset' or left empty then will not try to override setting.
+     - string
+     - ``"blackhole"``
    * - :spelling:ignore:`podAnnotations`
      - Annotations to be added to agent pods
      - object

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -595,7 +595,7 @@ Although this provides a more robust way of discovery path MTU, it comes at the 
 initially using sub-optimal MSS resulting in lower network performance.
 In the case where the correct MTU is known, disabling this feature may provide some improved network throughput on TCP connections.
 
-This feature can be disabled via the helm value: ``pmtuDiscovery.packetizationLayerPMTUD.enabled=false``.
+This feature can be disabled via the helm value: ``pmtuDiscovery.packetizationLayerPMTUDMode=disabled``.
 
 Bandwidth Manager
 =================

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -495,8 +495,8 @@ The following options have been introduced in this version of Cilium:
   WireGuard and tunneling to be enabled. When you enable this feature, there
   may be temporary disruption to packet delivery between nodes until the nodes
   are all running with the feature enabled.
-* The agent flag ``enable-endpoint-packet-layer-pmtud`` introduces packet layer
-  path MTU discovery by default for all Cilium-managed endpoints.
+* The agent flag ``packetization-layer-pmtud-mode`` introduces packet layer
+  path MTU discovery on blackhole detected by default for all Cilium-managed endpoints.
 
 Changed Options
 ###############

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -5,6 +5,7 @@ Alibaba
 Aquantia
 Attestor
 Bertin
+blackhole
 Blanco
 Borkmann
 Brenden

--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -60,9 +60,6 @@ type DaemonConfigurationStatus struct {
 	// True if BBR is enabled only in the host network namespace
 	EnableBBRHostNamespaceOnly bool `json:"enableBBRHostNamespaceOnly,omitempty"`
 
-	// Enable PLPMTUD probing on the pod netns
-	EnablePacketizationLayerPMTUD bool `json:"enablePacketizationLayerPMTUD,omitempty"`
-
 	// Enable route MTU for pod netns when CNI chaining is used
 	EnableRouteMTUForCNIChaining bool `json:"enableRouteMTUForCNIChaining,omitempty"`
 
@@ -97,6 +94,9 @@ type DaemonConfigurationStatus struct {
 
 	// Status of the node monitor
 	NodeMonitor *MonitorStatus `json:"nodeMonitor,omitempty"`
+
+	// Specifies what mode PLPMTUD probing on the pod netns should be set to (if empty will do nothing).
+	PacketizationLayerPMTUDMode string `json:"packetizationLayerPMTUDMode,omitempty"`
 
 	// Currently applied configuration
 	Realized *DaemonConfigurationSpec `json:"realized,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2477,9 +2477,9 @@ definitions:
       enableRouteMTUForCNIChaining:
         description: Enable route MTU for pod netns when CNI chaining is used
         type: boolean
-      enablePacketizationLayerPMTUD:
-        description: Enable PLPMTUD probing on the pod netns
-        type: boolean
+      packetizationLayerPMTUDMode:
+        description: Specifies what mode PLPMTUD probing on the pod netns should be set to (if empty will do nothing).
+        type: string
       datapathMode:
         "$ref": "#/definitions/DatapathMode"
       configuredDatapathMode:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2425,10 +2425,6 @@ func init() {
           "description": "True if BBR is enabled only in the host network namespace",
           "type": "boolean"
         },
-        "enablePacketizationLayerPMTUD": {
-          "description": "Enable PLPMTUD probing on the pod netns",
-          "type": "boolean"
-        },
         "enableRouteMTUForCNIChaining": {
           "description": "Enable route MTU for pod netns when CNI chaining is used",
           "type": "boolean"
@@ -2478,6 +2474,10 @@ func init() {
         "nodeMonitor": {
           "description": "Status of the node monitor",
           "$ref": "#/definitions/MonitorStatus"
+        },
+        "packetizationLayerPMTUDMode": {
+          "description": "Specifies what mode PLPMTUD probing on the pod netns should be set to (if empty will do nothing).",
+          "type": "string"
         },
         "realized": {
           "description": "Currently applied configuration",
@@ -7807,10 +7807,6 @@ func init() {
           "description": "True if BBR is enabled only in the host network namespace",
           "type": "boolean"
         },
-        "enablePacketizationLayerPMTUD": {
-          "description": "Enable PLPMTUD probing on the pod netns",
-          "type": "boolean"
-        },
         "enableRouteMTUForCNIChaining": {
           "description": "Enable route MTU for pod netns when CNI chaining is used",
           "type": "boolean"
@@ -7860,6 +7856,10 @@ func init() {
         "nodeMonitor": {
           "description": "Status of the node monitor",
           "$ref": "#/definitions/MonitorStatus"
+        },
+        "packetizationLayerPMTUDMode": {
+          "description": "Specifies what mode PLPMTUD probing on the pod netns should be set to (if empty will do nothing).",
+          "type": "string"
         },
         "realized": {
           "description": "Currently applied configuration",

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -423,7 +423,7 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 		EnableBBRHostNamespaceOnly:          h.bandwidthConfig.EnableBBRHostnsOnly,
 		DeviceHeadroom:                      int64(h.connectorConfig.GetPodDeviceHeadroom()),
 		DeviceTailroom:                      int64(h.connectorConfig.GetPodDeviceTailroom()),
-		EnablePacketizationLayerPMTUD:       h.mtuConfig.IsEnablePacketizationLayerPMTUD(),
+		PacketizationLayerPMTUDMode:         h.mtuConfig.PacketizationLayerPMTUDMode(),
 	}
 
 	cfg := &models.DaemonConfiguration{

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -921,7 +921,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.unmanagedPodWatcher.selector | string | `nil` | Selector for pods that should be restarted when not managed by Cilium. If not set, defaults to built-in selector "k8s-app=kube-dns". Set to empty string to select all pods. @schema type: [null, string] @schema |
 | operator.updateStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"50%"},"type":"RollingUpdate"}` | cilium-operator update strategy |
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
-| pmtuDiscovery.packetizationLayerPMTUD | object | `{"enabled":true}` | Enable kernel probing path MTU discovery for Pods which uses different message sizes to search for correct MTU value. |
+| pmtuDiscovery.packetizationLayerPMTUDMode | string | `"blackhole"` | Enable kernel probing path MTU discovery for Pods which uses different message sizes to search for correct MTU value. Valid values are: always, blackhole, disabled and unset (or empty). If value is 'unset' or left empty then will not try to override setting. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | podSecurityContext | object | `{"appArmorProfile":{"type":"Unconfined"},"seccompProfile":{"type":"Unconfined"}}` | Security Context for cilium-agent pods. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1303,9 +1303,7 @@ data:
   enable-pmtu-discovery: "true"
 {{- end }}
 
-{{- if not .Values.pmtuDiscovery.packetizationLayerPMTUD.enabled }}
-  enable-packetization-layer-pmtud: "false"
-{{- end }}
+  packetization-layer-pmtud-mode: {{ .Values.pmtuDiscovery.packetizationLayerPMTUDMode | quote }}
 
 {{- if not .Values.securityContext.privileged }}
   procfs: "/host/proc"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5404,13 +5404,8 @@
         "enabled": {
           "type": "boolean"
         },
-        "packetizationLayerPMTUD": {
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            }
-          },
-          "type": "object"
+        "packetizationLayerPMTUDMode": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -527,8 +527,9 @@ pmtuDiscovery:
   enabled: false
   # -- Enable kernel probing path MTU discovery for Pods which uses different message
   # sizes to search for correct MTU value.
-  packetizationLayerPMTUD:
-    enabled: true
+  # Valid values are: always, blackhole, disabled and unset (or empty). If value
+  # is 'unset' or left empty then will not try to override setting.
+  packetizationLayerPMTUDMode: "blackhole"
 bpf:
   autoMount:
     # -- Enable automatic mount of BPF filesystem

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -530,8 +530,9 @@ pmtuDiscovery:
   enabled: false
   # -- Enable kernel probing path MTU discovery for Pods which uses different message
   # sizes to search for correct MTU value.
-  packetizationLayerPMTUD:
-    enabled: true
+  # Valid values are: always, blackhole, disabled and unset (or empty). If value
+  # is 'unset' or left empty then will not try to override setting.
+  packetizationLayerPMTUDMode: "blackhole"
 bpf:
   autoMount:
     # -- Enable automatic mount of BPF filesystem

--- a/pkg/datapath/fake/types/mtu.go
+++ b/pkg/datapath/fake/types/mtu.go
@@ -24,6 +24,6 @@ func (*MTU) IsEnableRouteMTUForCNIChaining() bool {
 	return false
 }
 
-func (*MTU) IsEnablePacketizationLayerPMTUD() bool {
-	return false
+func (*MTU) PacketizationLayerPMTUDMode() string {
+	return ""
 }

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -1340,14 +1340,14 @@ const (
 	// Based on recommendation in https://datatracker.ietf.org/doc/html/rfc4821.
 	mtuProbeBaseMSS = 1024
 	mtuProbeFloor   = 48
-	mtuProbeAlways  = 2
 )
 
 // configurePacketPathMTUDiscovery configures netns to use plpmtud for mtu discovery.
 // When using connection based transport protocols such as tcp, this adjusts message
 // size to discover a working MTU for network path in case of a black hole.
 func configurePacketizationLayerPMTUD(logger *slog.Logger, conf *models.DaemonConfigurationStatus, sysctl sysctl.Sysctl) {
-	if !conf.EnablePacketizationLayerPMTUD {
+	// If empty just inherit host setting rather than overriding.
+	if conf.PacketizationLayerPMTUDMode == "" {
 		return
 	}
 
@@ -1360,7 +1360,7 @@ func configurePacketizationLayerPMTUD(logger *slog.Logger, conf *models.DaemonCo
 	}
 	// Note: These setting apply to both IPv4 and IPv6.
 	if err = sysctl.ApplySettings([]tables.Sysctl{
-		{Name: []string{"net", "ipv4", "tcp_mtu_probing"}, Val: strconv.Itoa(mtuProbeAlways)},
+		{Name: []string{"net", "ipv4", "tcp_mtu_probing"}, Val: conf.PacketizationLayerPMTUDMode},
 		{Name: []string{"net", "ipv4", "tcp_mtu_probe_floor"}, Val: strconv.Itoa(mtuProbeFloor)},
 	}); err != nil {
 		logger.Warn("could not enable mtu probing",


### PR DESCRIPTION
Setting this to 2 by default might be too aggressive as it is has been brought up that this may lead to issues in instances with high amounts of ephemeral connections (i.e. multiplying the overhead). Therefore we rework this prior to v1.19 such that cilium can be configured to use any valid value for endpoints or leave it empty to simply inherit from host settings.

Fixes: https://github.com/cilium/cilium/pull/42012

```release-note
Add support for specifying plpmtud (mtu discovery) settings for Pod endpoints, with the default now being "blackhole" (blackhole-detected).
```

