### PR TITLE
.github/workflows: add missing permissions for cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,8 @@ on:
 permissions:
   # To be able to access the repository with `actions/checkout`
   contents: read
+  # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.version }}-${{ inputs.step }}


### PR DESCRIPTION
Fixes: 7494f7cd633a ("workflows/release: release helm charts as OCI packages")