### PR TITLE
workflows: Add id-token permission to call-publish-helm job

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -240,6 +240,10 @@ jobs:
   call-publish-helm:
     if: github.repository_owner == 'cilium'
     name: Publish Helm Chart
+    permissions:
+      contents: read
+      # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+      id-token: write
     uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests
     with:


### PR DESCRIPTION
The call-publish-helm job calls a reusable workflow (release.yaml) which needs to sign Helm charts using cosign with GitHub Actions OIDC tokens.

According to GitHub Actions documentation[1]:

> If jobs.<job_id>.permissions is not specified in the calling job, the
  called workflow will have the default permissions for the GITHUB_TOKEN.

Since the default permissions don't include 'id-token: write', cosign was unable to obtain OIDC tokens and fell back to device flow, which then failed with expired_token errors.

[1]: https://docs.github.com/en/actions/using-workflows/reusing-workflows

Fixes: 32d801791fdd ("workflows: Add id-token permission to call-publish-helm job")