### PR TITLE
bpf: consistently use proto extracted from packet as __be16

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1012,7 +1012,7 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
 #endif /* ENABLE_IPV4 */
 
 static __always_inline int
-do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 identity,
+do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 	  enum trace_point obs_point,  const bool __maybe_unused from_host)
 {
 	struct trace_ctx trace = {
@@ -1327,7 +1327,7 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
-	__be16 __maybe_unused proto = 0;
+	__be16 proto = 0;
 	__u32 vlan_id;
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
@@ -1668,7 +1668,7 @@ __section_entry
 int cil_to_host(struct __ctx_buff *ctx)
 {
 	__u32 magic = ctx_load_meta(ctx, CB_PROXY_MAGIC);
-	__u16 __maybe_unused proto = 0;
+	__be16 proto = 0;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1650,7 +1650,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 __section_entry
 int cil_from_container(struct __ctx_buff *ctx)
 {
-	__u16 proto = 0;
+	__be16 proto = 0;
 	__u32 sec_label = SECLABEL;
 	__s8 ext_err = 0;
 	int ret;
@@ -2355,7 +2355,7 @@ int cil_lxc_policy(struct __ctx_buff *ctx)
 	__u32 src_label = ctx_load_meta(ctx, CB_SRC_LABEL);
 	__u32 sec_label = SECLABEL;
 	__s8 ext_err = 0;
-	__u16 proto;
+	__be16 proto;
 	int ret;
 
 	if (!validate_ethertype(ctx, &proto)) {
@@ -2408,7 +2408,7 @@ __section_entry
 int cil_lxc_policy_egress(struct __ctx_buff *ctx __maybe_unused)
 {
 #if defined(ENABLE_L7_LB)
-	__u16 proto;
+	__be16 proto;
 	int ret;
 	__u32 sec_label = SECLABEL;
 	__s8 ext_err = 0;
@@ -2465,7 +2465,7 @@ int cil_to_container(struct __ctx_buff *ctx)
 	__u32 magic, identity = 0;
 	__u32 sec_label = SECLABEL;
 	__s8 ext_err = 0;
-	__u16 proto;
+	__be16 proto;
 	int ret;
 
 	if (!validate_ethertype(ctx, &proto)) {

--- a/bpf/bpf_network.c
+++ b/bpf/bpf_network.c
@@ -19,7 +19,7 @@ int cil_from_network(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
 
-	__u16 proto __maybe_unused;
+	__be16 proto __maybe_unused;
 	__u32 ingress_ifindex = ctx->ingress_ifindex;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -518,7 +518,7 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 {
 	__u32 src_sec_identity = 0;
 	__s8 ext_err = 0;
-	__u16 proto;
+	__be16 proto;
 	int ret;
 
 	bpf_clear_meta(ctx);
@@ -632,7 +632,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	__u32 src_sec_identity = UNKNOWN_ID;
 	int ret = TC_ACT_OK;
 	__u32 cluster_id __maybe_unused = 0;
-	__be16 __maybe_unused proto = 0;
+	__be16 proto = 0;
 	__s8 ext_err = 0;
 
 	bpf_clear_meta(ctx);

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -309,7 +309,7 @@ int cil_from_wireguard(struct __ctx_buff *ctx)
 	int __maybe_unused ret;
 	__u32 __maybe_unused identity = UNKNOWN_ID;
 	__s8 __maybe_unused ext_err = 0;
-	__u16 proto = ctx_get_protocol(ctx);
+	__be16 proto = ctx_get_protocol(ctx);
 
 	ctx_skip_nodeport_clear(ctx);
 
@@ -397,8 +397,8 @@ int cil_to_wireguard(struct __ctx_buff *ctx)
 {
 	int __maybe_unused ret;
 	__s8 __maybe_unused ext_err = 0;
-	__u16 __maybe_unused proto = ctx_get_protocol(ctx);
-	__u32 __maybe_unused src_sec_identity = UNKNOWN_ID;
+	__be16 proto = ctx_get_protocol(ctx);
+	__u32 src_sec_identity = UNKNOWN_ID;
 	__u32 magic = ctx->mark & MARK_MAGIC_HOST_MASK;
 
 	struct trace_ctx __maybe_unused trace = {

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -117,7 +117,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 			struct genevehdr geneve;
 			__sum16	udp_csum;
 			__be16 dport;
-			__u16 proto;
+			__be16 proto;
 
 			if (ip4->protocol != IPPROTO_UDP)
 				goto no_encap;
@@ -329,7 +329,7 @@ static __always_inline int check_v6(struct __ctx_buff *ctx)
 static __always_inline int check_filters(struct __ctx_buff *ctx)
 {
 	int ret = CTX_ACT_OK;
-	__u16 proto;
+	__be16 proto;
 
 	if (!validate_ethertype(ctx, &proto))
 		return CTX_ACT_OK;

--- a/bpf/include/bpf/ctx/skb.h
+++ b/bpf/include/bpf/ctx/skb.h
@@ -136,10 +136,10 @@ ctx_load_and_clear_meta(struct __sk_buff *ctx, const __u32 off)
 	return val;
 }
 
-static __always_inline __maybe_unused __u16
+static __always_inline __maybe_unused __be16
 ctx_get_protocol(const struct __sk_buff *ctx)
 {
-	return (__u16)ctx->protocol;
+	return (__be16)ctx->protocol;
 }
 
 static __always_inline __maybe_unused __u32

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -433,7 +433,7 @@ ctx_load_and_clear_meta(const struct xdp_md *ctx __maybe_unused, const __u64 off
 	return 0;
 }
 
-static __always_inline __maybe_unused __u16
+static __always_inline __maybe_unused __be16
 ctx_get_protocol(const struct xdp_md *ctx)
 {
 	void *data_end = ctx_data_end(ctx);

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -70,7 +70,7 @@ union v4addr {
 #define THIS_IS_L3_DEV		(ETH_HLEN == 0)
 
 static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
-						      int l2_off, __u16 *proto)
+						      int l2_off, __be16 *proto)
 {
 	const __u64 tot_len = l2_off + ETH_HLEN;
 	void *data_end = ctx_data_end(ctx);
@@ -96,7 +96,7 @@ static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 }
 
 static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
-					       __u16 *proto)
+					       __be16 *proto)
 {
 	return validate_ethertype_l2_off(ctx, 0, proto);
 }
@@ -135,7 +135,7 @@ static __always_inline __u32 get_tunnel_id(__u32 identity)
 	return identity;
 }
 
-static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __u16 proto  __maybe_unused)
+static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __be16 proto  __maybe_unused)
 {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
 	if (tunnel_id == WORLD_ID) {

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -101,7 +101,7 @@ static __always_inline int eth_store_daddr(struct __ctx_buff *ctx,
 }
 
 static __always_inline int eth_store_proto(struct __ctx_buff *ctx,
-					   const __u16 proto, int off)
+					   const __be16 proto, int off)
 {
 	return ctx_store_bytes(ctx, off + ETH_ALEN + ETH_ALEN,
 			       &proto, sizeof(proto), 0);

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -20,9 +20,9 @@ neigh_resolver_without_nh_available()
 }
 
 static __always_inline int
-add_l2_hdr(struct __ctx_buff *ctx __maybe_unused)
+add_l2_hdr(struct __ctx_buff *ctx)
 {
-	__u16 proto = ctx_get_protocol(ctx);
+	__be16 proto = ctx_get_protocol(ctx);
 
 	if (ctx_change_head(ctx, __ETH_HLEN, 0))
 		return DROP_INVALID;

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -243,7 +243,7 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = HOST_ID;
 	} else {
 #if defined ENABLE_IPV4 && defined ENABLE_IPV6
-		__u16 proto = ctx_get_protocol(ctx);
+		__be16 proto = ctx_get_protocol(ctx);
 
 		if (proto == bpf_htons(ETH_P_IP))
 			*identity = WORLD_IPV4_ID;

--- a/bpf/lib/ip_options.h
+++ b/bpf/lib/ip_options.h
@@ -166,7 +166,7 @@ trace_id_from_ctx(struct __ctx_buff *ctx, __s64 *value, __u8 ip_opt_type_value)
 	void *data, *data_end;
 	__s64 trace_id = 0;
 	struct iphdr *ip4;
-	__u16 proto;
+	__be16 proto;
 	int ret;
 
 	if (!validate_ethertype(ctx, &proto))

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -111,7 +111,7 @@ set_ipsec_encrypt(struct __ctx_buff *ctx,
 }
 
 static __always_inline int
-do_decrypt(struct __ctx_buff *ctx, __u16 proto)
+do_decrypt(struct __ctx_buff *ctx, __be16 proto)
 {
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
@@ -318,7 +318,7 @@ overlay_encrypt:
 }
 #else
 static __always_inline int
-do_decrypt(struct __ctx_buff __maybe_unused *ctx, __u16 __maybe_unused proto)
+do_decrypt(struct __ctx_buff __maybe_unused *ctx, __be16 __maybe_unused proto)
 {
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -291,7 +291,7 @@ static __always_inline int
 ctx_redirect_to_proxy_first_tproxy(struct __ctx_buff *ctx, __be16 proxy_port)
 {
 	int ret = CTX_ACT_OK;
-	__u16 proto;
+	__be16 proto;
 
 	/**
 	 * For reply traffic to egress proxy for a local endpoint, we skip the

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -110,7 +110,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		int l4_off;
 		struct ct_state ct_state = {};
 		struct ct_state ct_state_new = {};
-		__u16 proto;
+		__be16 proto;
 		__u32 monitor = 0;
 		int ret;
 
@@ -169,7 +169,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		struct iphdr *ip4;
 		int l3_off = ETH_HLEN;
 		int l4_off;
-		__u16 proto;
+		__be16 proto;
 		__u32 monitor = 0;
 
 		bpf_clear_meta(ctx);

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -221,7 +221,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	void *data;
 	void *data_end;
 
@@ -335,7 +335,7 @@ int test_nat4_icmp_error_tcp_rfc1191(__maybe_unused struct __ctx_buff *ctx)
 	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	void *data;
 	void *data_end;
 
@@ -453,7 +453,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	void *data;
 	void *data_end;
 
@@ -566,7 +566,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	void *data;
 	void *data_end;
 
@@ -744,7 +744,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	int l3_off;
 	struct icmphdr icmphdr __align_stack_8;
 
@@ -863,7 +863,7 @@ int test_nat4_icmp_error_tcp_egress_rfc1191(__maybe_unused struct __ctx_buff *ct
 			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	int l3_off;
 	struct icmphdr icmphdr __align_stack_8;
 
@@ -986,7 +986,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	int l3_off;
 	struct icmphdr icmphdr __align_stack_8;
 
@@ -1104,7 +1104,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	int l3_off;
 	struct icmphdr icmphdr __align_stack_8;
 
@@ -1211,7 +1211,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 			  l4_off, &target, &trace, NULL);
 	assert(ret == 0);
 
-	__u16 proto;
+	__be16 proto;
 	int l3_off;
 	struct icmphdr icmphdr __align_stack_8;
 


### PR DESCRIPTION
In these cases, proto is always in network byte order extracted from the packet using `validate_ethertype()` and used as such inside the functions. Consistently declare it as `__be16` to make this obvious to the reader.
