### PR TITLE
feat(cilium-cli): Add -r(estart) parameter to cilium upgrade

### DIFF
--- a/Documentation/cmdref/cilium_upgrade.md
+++ b/Documentation/cmdref/cilium_upgrade.md
@@ -38,6 +38,7 @@ cilium upgrade [flags]
       --repository string         Helm chart repository to download Cilium charts from (default "https://helm.cilium.io")
       --reset-then-reuse-values   When upgrading, reset the values to the ones built into the chart, apply the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' or '--reuse-values' is specified, this is ignored (default true)
       --reset-values              When upgrading, reset the helm values to the ones built into the chart
+  -r, --restart                   Force restart Cilium pods
       --reuse-values              When upgrading, reuse the helm values from the latest release unless any overrides from are set from other flags. This option takes precedence over HelmResetValues
       --set stringArray           Set helm values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
       --set-file stringArray      Set helm values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)

--- a/cilium-cli/cli/install.go
+++ b/cilium-cli/cli/install.go
@@ -214,6 +214,7 @@ to prepare for multi-cluster capabilities.
 		"Write non-default Helm values to stdout; without performing the actual upgrade")
 	cmd.Flags().StringVar(&params.HelmRepository, "repository", defaults.HelmRepository, "Helm chart repository to download Cilium charts from")
 	cmd.Flags().IntVar(&params.HelmMaxHistory, "history-max", defaults.HelmMaxHistory, "limit the maximum number of revisions saved per release. Use 0 for no limit")
+	cmd.Flags().BoolVarP(&params.Restart, "restart", "r", false, "Force restart Cilium pods")
 	return cmd
 }
 

--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -149,6 +149,9 @@ type Parameters struct {
 
 	// NodesWithoutCilium enables the affinities to avoid scheduling Cilium components on nodes labeled with cilium.io/no-schedule
 	NodesWithoutCilium bool
+
+	//Force restart pods after upgrade
+	Restart bool
 }
 
 func (p *Parameters) IsDryRun() bool {


### PR DESCRIPTION
add parameter to force restart pod (cilium and operator) when use cilium upgrade (config but not version)

