### PR TITLE
Exclude topology.kubernetes.io labels by default

### DIFF
--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -245,6 +245,7 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		`!controller-uid`,                                               // ignore controller-uid
 		`!annotation.*`,                                                 // ignore all annotation labels
 		`!etcd_node`,                                                    // ignore etcd_node label
+		`!topology\.kubernetes\.io`,                                     // ignore all topology.kubernetes.io labels
 	}
 
 	for _, e := range expressions {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -116,6 +116,8 @@ func TestDefaultFilterLabels(t *testing.T) {
 		"apps.kubernetes.io/pod-index":                              "0",
 		"io.cilium.k8s.policy.cluster":                              "default",
 		"io.cilium.k8s.policy.serviceaccount":                       "luke",
+		"topology.kubernetes.io/zone":                               "us-east-1-a",
+		"topology.kubernetes.io/region":                             "us-east-1",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)


### PR DESCRIPTION
Starting from version 1.35 Kuberentes propagetes topology.kubernetes.io labels from nodes to pods. This causes CID duplication and can lead to CID exhaustion.

This patch adds !topology.kubernetes.io label filter to default label filters

Fixes: https://github.com/cilium/cilium/issues/43723

```release-note
Exclude topology.kubernetes.io labels from security labels by default
```
