### PR TITLE
endpoint/restore: explicitly skip validation for ingress endpoint

### DIFF
--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -301,34 +301,35 @@ func (r *endpointRestorer) validateDatapathModeCompatibility(endpoints map[uint1
 //
 // Returns true to indicate that the endpoint is valid to restore, and an
 // optional error.
-func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error) {
+func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, cleanup bool, err error) {
 	if ep.IsProperty(endpoint.PropertyFakeEndpoint) {
-		return true, nil
+		return true, false, nil
 	}
 
-	// On each restart, the health endpoint is supposed to be recreated.
-	// Hence we need to clean health endpoint state unconditionally.
-	if ep.HasLabels(labels.LabelHealth) {
-		// Ignore health endpoint and don't report
+	// On each restart, the health and ingress endpoints are supposed to be recreated.
+	// Hence we need to clean endpoint state unconditionally.
+	if ep.HasLabels(labels.LabelHealth) || ep.HasLabels(labels.LabelIngress) {
+		// Ignore endpoint and don't report
 		// it as not restored. But we need to clean up the old
 		// state files, so do this now.
-		healthStateDir := ep.StateDirectoryPath()
-		r.logger.Debug("Removing old health endpoint state directory",
+		epStateDir := ep.StateDirectoryPath()
+		r.logger.Debug("Removing old endpoint state directory",
 			logfields.EndpointID, ep.ID,
-			logfields.Path, healthStateDir,
+			logfields.Path, epStateDir,
 		)
-		if err := os.RemoveAll(healthStateDir); err != nil {
-			r.logger.Warn("Cannot clean up old health state directory",
+		if err := os.RemoveAll(epStateDir); err != nil {
+			r.logger.Warn("Cannot clean up old state directory",
 				logfields.EndpointID, ep.ID,
-				logfields.Path, healthStateDir,
+				logfields.Path, epStateDir,
 			)
 		}
-		return false, nil
+
+		return false, false, nil
 	}
 
 	if ep.K8sPodName != "" && ep.K8sNamespace != "" && r.clientset.IsEnabled() {
 		if err := r.getPodForEndpoint(ep); err != nil {
-			return false, err
+			return false, true, err
 		}
 
 		// Initialize the endpoint's event queue because the following call to
@@ -341,16 +342,16 @@ func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, 
 	}
 
 	if err := ep.ValidateConnectorPlumbing(r.checkLink); err != nil {
-		return false, err
+		return false, true, err
 	}
 
 	if !ep.DatapathConfiguration.ExternalIpam {
 		if err := r.allocateIPsLocked(ep); err != nil {
-			return false, fmt.Errorf("Failed to re-allocate IP of endpoint: %w", err)
+			return false, true, fmt.Errorf("Failed to re-allocate IP of endpoint: %w", err)
 		}
 	}
 
-	return true, nil
+	return true, false, nil
 }
 
 func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
@@ -471,7 +472,7 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 			scopedLog = scopedLog.With(logfields.CEPName, ep.GetK8sNamespaceAndCEPName())
 		}
 
-		restore, err := r.validateEndpoint(ep)
+		restore, cleanup, err := r.validateEndpoint(ep)
 		if err != nil {
 			// Disconnected EPs are not failures, clean them silently below
 			if !ep.IsDisconnecting() {
@@ -486,7 +487,9 @@ func (r *endpointRestorer) RestoreOldEndpoints() error {
 			if err == nil {
 				skipped++
 			}
-			r.restoreState.toClean = append(r.restoreState.toClean, ep)
+			if cleanup {
+				r.restoreState.toClean = append(r.restoreState.toClean, ep)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Currently, Ingress endpoint restoration fails in the "link check"
because the Ingress endpoint doesn't have an `ifName` configured.

```
msg="Unable to restore endpoint, ignoring" module=agent.controlplane.daemon.endpoint-restore endpointID=791 ciliumEndpointName=/ error="interface  could not be found"
```

Even though the Ingress endpoint is re-created shortly after this with
the same IP(s), this leads us with a short amount of time where the endpoint
is deleted - which can lead to issues.

Therefore, with this commit, the validation is skipped for the ingress endpoint -
similar to what we are already doing for the health endpoint.

In addition to this, the skipped endpoints should not be cleaned
up - it should be silently skipped (we already cleanup the state dir).

Reported-by: Sebastian Wicki <sebastian@isovalent.com>