### PR TITLE
ci: bump eks cluster pool cleanup timeout

### DIFF
--- a/.github/workflows/eks-cluster-pool-manager.yaml
+++ b/.github/workflows/eks-cluster-pool-manager.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: generate-cleanup-matrix
     if: ${{ needs.generate-cleanup-matrix.outputs.empty == 'false' }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix: ${{ fromJson(needs.generate-cleanup-matrix.outputs.matrix) }}
       fail-fast: false


### PR DESCRIPTION
Cloudformation can be slow sometimes to delete clusters. Bumping the timeout from 30 to 45 minutes will avoid cancellation before removing all the clusters needed to be cleaned up.

Example : https://github.com/cilium/cilium/actions/runs/20894891020/job/60031839677