### PR TITLE
operator: Fix 'make install' target in quiet mode

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -38,7 +38,7 @@ clean:
 
 install:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
-	$(foreach target,$(TARGETS), $(QUIET)$(INSTALL) -m 0755 $(target) $(DESTDIR)$(BINDIR);)
+	$(QUIET)$(foreach target,$(TARGETS), $(INSTALL) -m 0755 $(target) $(DESTDIR)$(BINDIR);)
 
 install-generic:
 	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
If you ran make 'docker-images-all V=0' for low-verbosity build,
you would encounter this error:

    101.7 make "-s" -C operator install
    101.9 bash: line 1: @install: command not found
    101.9 make[1]: *** [Makefile:41: install] Error 127
    101.9 make: *** [Makefile:220: install-container-binary-operator] Error 2

This is because the quiet character '@' was added in the for loop (part
of the shell expression) and not at the start of the line (interpreted
by make). Fix it by moving it to the start of the line.
