### PR TITLE
[draft] fix: Validate IP when device drops

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -140,8 +140,12 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 	if option.Config.EnableIPv4 {
 		ipv4GW := cfg.CiliumInternalIPv4
-		cDefinesMap["IPV4_GATEWAY"] = fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(ipv4GW))
-
+		if ipv4GW == nil && len(ipv4GW.To4()) != 4 {
+			h.log.Warn("CiliumInternalIPv4 is nil or invalid, using fallback value for IPV4_GATEWAY", "ip", ipv4GW)
+			cDefinesMap["IPV4_GATEWAY"] = "0"
+		} else {
+			cDefinesMap["IPV4_GATEWAY"] = fmt.Sprintf("%#x", byteorder.NetIPv4ToHost32(ipv4GW))
+		}
 		if option.Config.EnableIPv4FragmentsTracking {
 			cDefinesMap["ENABLE_IPV4_FRAGMENTS"] = "1"
 		}


### PR DESCRIPTION
Validation should be done at the orchestrator level within pkg/datapath/orchestrator/localnodeconfig.go I imagine. When trying to implement I was unable to catch the invalid IP. Error is coming from reconciliation. Repro with `systemctl restart systemd-networkd`

Bug brought in with https://github.com/cilium/cilium/commit/8fae439710fd4b426beae9190957d2380a96bed6#diff-06474c2745f844b5604a889717c7dc45f1328db43bf72ae18397c01ffb643d36 as part of #40430

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
