### PR TITLE
docs: adjust URL to latest stable Hubble CLI version

### DIFF
--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -110,7 +110,7 @@ Select the tab for your platform below and install the latest release of Hubble 
 
       .. code-block:: shell-session
 
-         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/main/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "aarch64" ]; then HUBBLE_ARCH=arm64; fi
          curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
@@ -124,7 +124,7 @@ Select the tab for your platform below and install the latest release of Hubble 
 
       .. code-block:: shell-session
 
-         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/main/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "arm64" ]; then HUBBLE_ARCH=arm64; fi
          curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
@@ -138,7 +138,7 @@ Select the tab for your platform below and install the latest release of Hubble 
 
       .. code-block:: shell-session
 
-         curl -LO "https://raw.githubusercontent.com/cilium/hubble/master/stable.txt"
+         curl -LO "https://raw.githubusercontent.com/cilium/hubble/main/stable.txt"
          set /p HUBBLE_VERSION=<stable.txt
          curl -L --fail -O "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz"
          curl -L --fail -O "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz.sha256sum"


### PR DESCRIPTION
Adjust the branch name in the URL to get the latest stable Hubble CLI version.