### PR TITLE
endpoint/restore: introduce metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -459,6 +459,8 @@ Endpoint
 Name                                         Labels                                             Default    Description
 ============================================ ================================================== ========== ========================================================
 ``endpoint``                                                                                    Enabled    Number of endpoints managed by this agent
+``endpoint_restoration_endpoints``           ``phase``, ``outcome``                             Enabled    Number of restored endpoints labeled by phase and outcome
+``endpoint_restoration_duration_seconds``    ``phase``                                          Enabled    Duration of restoration phases in seconds
 ``endpoint_regenerations_total``             ``outcome``                                        Enabled    Count of all endpoint regenerations that have completed
 ``endpoint_regeneration_time_stats_seconds`` ``scope``                                          Enabled    Endpoint regeneration time stats
 ``endpoint_state``                           ``state``                                          Enabled    Count of all endpoints

--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -13,7 +13,6 @@ type bootstrapStatistics struct {
 	overall   spanstat.SpanStat
 	earlyInit spanstat.SpanStat
 	k8sInit   spanstat.SpanStat
-	restore   spanstat.SpanStat
 	ipam      spanstat.SpanStat
 	kvstore   spanstat.SpanStat
 }
@@ -38,7 +37,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"overall":   &b.overall,
 		"earlyInit": &b.earlyInit,
 		"k8sInit":   &b.k8sInit,
-		"restore":   &b.restore,
 		"ipam":      &b.ipam,
 		"kvstore":   &b.kvstore,
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -202,13 +202,10 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	// Configure and start IPAM without using the configuration yet.
 	configureAndStartIPAM(ctx, params)
 
-	bootstrapStats.restore.Start()
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
-	err := params.EndpointRestorer.RestoreOldEndpoints()
-	bootstrapStats.restore.EndError(err)
-	if err != nil {
+	if err := params.EndpointRestorer.RestoreOldEndpoints(); err != nil {
 		return err
 	}
 

--- a/daemon/cmd/endpoint_restore_metrics.go
+++ b/daemon/cmd/endpoint_restore_metrics.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	metricsSubsystem = "endpoint_restoration"
+)
+
+const (
+	labelPhase   = "phase"
+	labelOutcome = "outcome"
+)
+
+const (
+	phaseRead                = "read_from_disk"
+	phaseRestoration         = "restoration"
+	phasePrepareRegeneration = "prepare_regeneration"
+	phasePolicyComputation   = "initial_policy_computation"
+	phaseRegeneration        = "regeneration"
+)
+
+const (
+	outcomeTotal      = "total"
+	outcomeSuccessful = "successful"
+	outcomeSkipped    = "skipped"
+	outcomeFailed     = "failed"
+)
+
+type endpointRestoreMetrics struct {
+	Endpoints metric.Vec[metric.Gauge]
+	Duration  metric.Vec[metric.Gauge]
+}
+
+func newEndpointRestoreMetrics() *endpointRestoreMetrics {
+	return &endpointRestoreMetrics{
+		Endpoints: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "endpoints",
+			Help:      "Number of restored endpoints labelled by phase and outcome",
+		}, []string{labelPhase, labelOutcome}),
+		Duration: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "duration_seconds",
+			Help:      "Duration of restoration phases in seconds",
+		}, []string{labelPhase}),
+	}
+}

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -4,7 +4,6 @@
 package endpoint
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"log/slog"
@@ -66,7 +65,7 @@ func (s *EndpointSuite) endpointCreator(t testing.TB, id uint16, secID identity.
 	identity.Sanitize()
 
 	model := newTestEndpointModel(int(id), StateReady)
-	ep, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
+	ep, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -138,7 +137,7 @@ func TestReadEPsFromDirNames(t *testing.T) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	eps := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
+	eps, _ := ReadEPsFromDirNames(t.Context(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
 	require.Len(t, eps, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -201,7 +200,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	epResult := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epNames)
+	epResult, _ := ReadEPsFromDirNames(t.Context(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epNames)
 	require.Len(t, epResult, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -254,7 +253,7 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	}
 
 	for b.Loop() {
-		eps := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
+		eps, _ := ReadEPsFromDirNames(b.Context(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
 		require.Len(b, eps, len(epsWanted))
 	}
 }


### PR DESCRIPTION
In the past, the metric `agent_bootstrap_seconds` with label `scope=restore` was used to publish some endpoint restoration related metrics.

With the modularization of the legacy daemon init logic, some of the endpoint restoration logic no longer reported its duration to that metric.

In addition to this, the label `scope=restore` was pretty generic, because other restoration logic was using the same label (e.g. identity restoration). And the metric didn't take into account that the actual regeneration of the restored endpoints was executed asynchronously.

To shed some more light into the endpoint restoration process, this commit introduces two endpoint restoration specific metrics.

* `endpoint_restoration_endpoints` - with label `phase` & `outcome`
* `endpoint_restoration_duration_seconds` - with label `phase`

The following phases of the endpoint restoration process report the metric.

* `read_from_disk`: Reads old endpoints from state dir
* `restoration`: Restore old endpoints. includes validation & IP re-allocation
* `prepare_regeneration`: Trigger asynchronous regeneration (and node endpoint restoration)
* `initial_policy_computation`: Initial policy computation for all restored endpoints
* `regeneration`: Regeneration of restored endpoints

e.g.

```
root@kind-control-plane:/home/cilium# cilium-dbg shell metrics endpoint_restoration
Metric                                         Labels                                                Value
cilium_endpoint_restoration_duration_seconds   phase=initial_policy_computation                      0.006262
cilium_endpoint_restoration_duration_seconds   phase=prepare_regeneration                            2.506187
cilium_endpoint_restoration_duration_seconds   phase=read_from_disk                                  0.002105
cilium_endpoint_restoration_duration_seconds   phase=regeneration                                    2.270423
cilium_endpoint_restoration_duration_seconds   phase=restoration                                     0.101983
cilium_endpoint_restoration_endpoints          outcome=failed phase=read_from_disk                   0.000000
cilium_endpoint_restoration_endpoints          outcome=failed phase=regeneration                     0.000000
cilium_endpoint_restoration_endpoints          outcome=failed phase=restoration                      1.000000
cilium_endpoint_restoration_endpoints          outcome=skipped phase=restoration                     1.000000
cilium_endpoint_restoration_endpoints          outcome=successful phase=initial_policy_computation   4.000000
cilium_endpoint_restoration_endpoints          outcome=successful phase=prepare_regeneration         4.000000
cilium_endpoint_restoration_endpoints          outcome=successful phase=read_from_disk               6.000000
cilium_endpoint_restoration_endpoints          outcome=successful phase=regeneration                 4.000000
cilium_endpoint_restoration_endpoints          outcome=successful phase=restoration                  4.000000
cilium_endpoint_restoration_endpoints          outcome=total phase=initial_policy_computation        4.000000
cilium_endpoint_restoration_endpoints          outcome=total phase=prepare_regeneration              4.000000
cilium_endpoint_restoration_endpoints          outcome=total phase=read_from_disk                    6.000000
cilium_endpoint_restoration_endpoints          outcome=total phase=regeneration                      4.000000
cilium_endpoint_restoration_endpoints          outcome=total phase=restoration                       6.000000

```

Related PR: https://github.com/cilium/cilium/pull/43348 (deprecation of metric `agent_bootstrap_seconds`) cc @gandro 