### PR TITLE
gh: e2e: enable additional configs for downgrade-testing with v1.19

### DIFF
--- a/.github/actions/e2e/ipsec.yaml
+++ b/.github/actions/e2e/ipsec.yaml
@@ -79,7 +79,6 @@
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
-  skip-upgrade: 'true'
   # L7 testing: IPsec encryption has complex interaction with L7 proxy
   test-l7: 'true'
 - name: 'ipsec-8'
@@ -108,7 +107,6 @@
   encryption: 'ipsec'
   key-one: 'rfc4106-gcm-aes'
   key-two: 'rfc4106-gcm-aes'
-  skip-upgrade: 'true'
   # L7 testing: IPsec encryption has complex interaction with L7 proxy
   test-l7: 'true'
 - name: 'ipsec-10'

--- a/.github/actions/e2e/ipsec.yaml
+++ b/.github/actions/e2e/ipsec.yaml
@@ -120,7 +120,5 @@
   encryption-strict-mode: 'true'
   key-one: 'cbc-aes-sha256'
   key-two: 'cbc-aes-sha256'
-  # no strict mode on v1.18
-  skip-upgrade: 'true'
   # L7 testing: IPsec strict mode especially critical - affects proxy traffic encryption
   test-l7: 'true'

--- a/.github/actions/e2e/kube-proxy.yaml
+++ b/.github/actions/e2e/kube-proxy.yaml
@@ -31,7 +31,7 @@
   kpr: 'false'
   tunnel: 'geneve'
   endpoint-routes: 'true'
-  misc: 'socketLB.enabled=false,nodePort.enabled=true,bpf.masquerade=true'
+  misc: 'socketLB.enabled=false,bpf.masquerade=true'
   local-redirect-policy: 'true'
   node-local-dns: 'true'
   skip-include-conn-disrupt-test-ns-traffic: 'true'

--- a/.github/actions/e2e/kube-proxy.yaml
+++ b/.github/actions/e2e/kube-proxy.yaml
@@ -68,6 +68,5 @@
   tunnel: 'vxlan'
   underlay: 'ipv6'
   encryption: 'wireguard'
-  skip-upgrade: 'true'
   # L7 testing: IPv6-only configuration - covered by other wireguard tests, can skip
   test-l7: 'false'

--- a/.github/actions/e2e/misc.yaml
+++ b/.github/actions/e2e/misc.yaml
@@ -85,6 +85,5 @@
   ipv4: 'false'
   tunnel: 'vxlan'
   underlay: 'ipv6'
-  skip-upgrade: 'true'
   # L7 testing: Basic IPv6-only configuration, can skip
   test-l7: 'false'

--- a/.github/actions/e2e/wireguard.yaml
+++ b/.github/actions/e2e/wireguard.yaml
@@ -88,7 +88,5 @@
   # bpf program attachment ordering issue as the root cause. So for now combine encryption-strict-egress and
   # encryption-strict-ingress in CI.
   encryption-strict-egress: 'true'
-  # Upgrades would fail no-unexpected-packet-drops as older cilium versions don't set the decrypted mark
-  skip-upgrade: 'true'
   # L7 testing: WireGuard encryption + Ingress controller requires L7 proxy for HTTP routing
   test-l7: 'true'

--- a/.github/actions/e2e/wireguard.yaml
+++ b/.github/actions/e2e/wireguard.yaml
@@ -71,7 +71,6 @@
   lb-mode: 'snat'
   ingress-controller: 'true'
   encryption: 'wireguard'
-  skip-upgrade: 'true'
   # L7 testing: WireGuard encryption + Ingress controller requires L7 proxy for HTTP routing
   test-l7: 'true'
 - name: 'wireguard-6'


### PR DESCRIPTION
There's some e2e configs that didn't test downgrades to the v1.18 release, since that release doesn't contain some needed functionality (eg. a new config option).

But now that the v1.19 branch exists, we can enable downgrade-testing for all these e2e configs.