### PR TITLE
bpf: nodeport: dsr: don't create NAT entries for RevDNAT

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -817,9 +817,6 @@ create_ct:
 
 		ret = ct_create6(get_ct_map6(tuple), NULL, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, ext_err);
-		if (!IS_ERR(ret))
-			ret = snat_v6_create_dsr(tuple, addr, port, ext_err);
-
 		if (IS_ERR(ret))
 			return ret;
 		break;
@@ -2224,10 +2221,6 @@ create_ct:
 
 		ret = ct_create4(get_ct_map4(tuple), NULL, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, ext_err);
-		if (!IS_ERR(ret))
-			/* TODO remove this in v1.20 */
-			ret = snat_v4_create_dsr(tuple, addr, port, ext_err);
-
 		if (IS_ERR(ret))
 			return ret;
 		break;

--- a/bpf/tests/tc_geneve_dsr_v4_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_v4_legacy.c
@@ -94,21 +94,11 @@ int tc_geneve_dsr_v4_legacy_check(struct __ctx_buff *ctx)
 	void *data, *data_end;
 	__u32 *status_code;
 	struct ct_entry *ct_entry;
-	struct ipv4_nat_entry *nat_entry;
 	struct ipv4_ct_tuple expected_tuple_for_ct = {
 		.saddr   = BACKEND_IP,
 		.daddr   = CLIENT_IP,
 		.sport   = CLIENT_PORT,
 		.dport   = BACKEND_PORT,
-		.nexthdr = IPPROTO_TCP,
-		.flags   = TUPLE_F_OUT,
-	};
-
-	struct ipv4_ct_tuple expected_tuple_for_nat = {
-		.saddr   = BACKEND_IP,
-		.daddr   = CLIENT_IP,
-		.sport   = BACKEND_PORT,
-		.dport   = CLIENT_PORT,
 		.nexthdr = IPPROTO_TCP,
 		.flags   = TUPLE_F_OUT,
 	};
@@ -129,11 +119,6 @@ int tc_geneve_dsr_v4_legacy_check(struct __ctx_buff *ctx)
 	ct_entry = map_lookup_elem(&cilium_ct4_global, &expected_tuple_for_ct);
 	if (!ct_entry)
 		test_fatal("No entry in conntrack map");
-
-	/* Verify that the datapath inserted the SNAT entry */
-	nat_entry = snat_v4_lookup(&expected_tuple_for_nat);
-	if (!nat_entry)
-		test_fatal("No entry in SNAT map");
 
 	test_finish();
 }

--- a/bpf/tests/tc_geneve_dsr_v6_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_v6_legacy.c
@@ -98,7 +98,6 @@ int tc_geneve_dsr_v6_legacy_check(struct __ctx_buff *ctx)
 	void *data, *data_end;
 	__u32 *status_code;
 	struct ct_entry *ct_entry;
-	struct ipv6_nat_entry *nat_entry;
 
 	union v6addr backend_ip = BACKEND_IP;
 	union v6addr client_ip  = CLIENT_IP;
@@ -107,15 +106,6 @@ int tc_geneve_dsr_v6_legacy_check(struct __ctx_buff *ctx)
 		.daddr   = client_ip,
 		.sport   = CLIENT_PORT,
 		.dport   = BACKEND_PORT,
-		.nexthdr = IPPROTO_TCP,
-		.flags   = TUPLE_F_OUT,
-	};
-
-	struct ipv6_ct_tuple expected_tuple_for_nat = {
-		.saddr   = backend_ip,
-		.daddr   = client_ip,
-		.sport   = BACKEND_PORT,
-		.dport   = CLIENT_PORT,
 		.nexthdr = IPPROTO_TCP,
 		.flags   = TUPLE_F_OUT,
 	};
@@ -136,11 +126,6 @@ int tc_geneve_dsr_v6_legacy_check(struct __ctx_buff *ctx)
 	ct_entry = map_lookup_elem(&cilium_ct6_global, &expected_tuple_for_ct);
 	if (!ct_entry)
 		test_fatal("No entry in conntrack map");
-
-	/* Verify that the datapath inserted the SNAT entry */
-	nat_entry = snat_v6_lookup(&expected_tuple_for_nat);
-	if (!nat_entry)
-		test_fatal("No entry in NAT map");
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -264,19 +264,10 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 		test_fatal("no CT entry for DSR found");
 	if (!ct_entry->dsr_internal)
 		test_fatal("CT entry doesn't have the .dsr_internal flag set");
-
-	struct ipv4_nat_entry *nat_entry;
-
-	tuple.sport = BACKEND_PORT;
-	tuple.dport = CLIENT_PORT;
-
-	nat_entry = snat_v4_lookup(&tuple);
-	if (!nat_entry)
-		test_fatal("no SNAT entry for DSR found");
-	if (nat_entry->to_saddr != FRONTEND_IP)
-		test_fatal("SNAT entry has wrong address");
-	if (nat_entry->to_sport != FRONTEND_PORT)
-		test_fatal("SNAT entry has wrong port");
+	if (ct_entry->nat_addr.p4 != FRONTEND_IP)
+		test_fatal("CT entry has wrong RevDNAT address");
+	if (ct_entry->nat_port != FRONTEND_PORT)
+		test_fatal("CT entry has wrong RevDNAT port");
 
 	test_finish();
 }
@@ -382,41 +373,6 @@ int nodeport_dsr_backend_reply_setup(struct __ctx_buff *ctx)
 
 CHECK("tc", "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_check(const struct __ctx_buff *ctx)
-{
-	return check_reply(ctx);
-}
-
-/* Test that the backend node revDNATs a reply from the
- * DSR backend, and sends the reply back to the client.
- * Even without the NAT entry.
- */
-PKTGEN("tc", "tc_nodeport_dsr_backend_reply2_no_nat_entry")
-int nodeport_dsr_backend_reply2_no_nat_entry_pktgen(struct __ctx_buff *ctx)
-{
-	return build_reply(ctx);
-}
-
-SETUP("tc", "tc_nodeport_dsr_backend_reply2_no_nat_entry")
-int nodeport_dsr_backend_reply2_no_nat_entry_setup(struct __ctx_buff *ctx)
-{
-	struct ipv4_ct_tuple tuple = {
-		.daddr = CLIENT_IP,
-		.saddr = BACKEND_IP,
-		.dport = CLIENT_PORT,
-		.sport = BACKEND_PORT,
-		.nexthdr = IPPROTO_TCP,
-		.flags = CT_EGRESS,
-	};
-
-	/* Delete the NAT entry, fall back to the NAT info in the CT entry. */
-	if (map_delete_elem(&cilium_snat_v4_external, &tuple))
-		return TEST_ERROR;
-
-	return netdev_send_packet(ctx);
-}
-
-CHECK("tc", "tc_nodeport_dsr_backend_reply2_no_nat_entry")
-int nodeport_dsr_backend_reply2_no_nat_entry_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
 }
@@ -570,19 +526,6 @@ int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 		test_fatal("no CT entry for DSR found");
 	if (!ct_entry->dsr_internal)
 		test_fatal("CT entry doesn't have the .dsr_internal flag set");
-
-	struct ipv4_nat_entry *nat_entry;
-
-	tuple.sport = BACKEND_PORT;
-	tuple.dport = CLIENT_PORT;
-
-	nat_entry = snat_v4_lookup(&tuple);
-	if (!nat_entry)
-		test_fatal("no SNAT entry for DSR found");
-	if (nat_entry->to_saddr != FRONTEND_IP)
-		test_fatal("SNAT entry has wrong address");
-	if (nat_entry->to_sport != FRONTEND_PORT)
-		test_fatal("SNAT entry has wrong port");
 
 	test_finish();
 }


### PR DESCRIPTION
The infrastructure for CT entry-based RevDNAT
(https://github.com/cilium/cilium/pull/43017) landed in v1.19. And thus v1.20 can rely on it for downgrade purposes, and stop creating NAT entries.

Fixes: #43339