### PR TITLE
[v1.18] pkg/redirectpolicy: Check for LRP backend pod readiness

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -275,6 +275,9 @@ func (c *lrpController) processRedirectPolicy(wtxn writer.WriteTxn, lrpID lb.Ser
 			// Stop when we hit a different namespace, e.g. prefix search hit a longer name.
 			break
 		}
+		if k8sUtils.GetLatestPodReadiness(pod.Status) != slim_corev1.ConditionTrue {
+			continue
+		}
 		if lrp.BackendSelector.Matches(labels.Set(pod.Labels)) {
 			matchingPods = append(matchingPods, getPodInfo(pod))
 		}
@@ -336,7 +339,7 @@ func (c *lrpController) updateRedirects(wtxn writer.WriteTxn, ws *statedb.WatchS
 						Type:        lb.SVCTypeLocalRedirect,
 						ServiceName: lrpServiceName,
 						ServicePort: feM.feAddr.Port(),
-						//if we only have one frontend mapping, we dont need the frontend port name so it will not check the port name in the backend ports
+						// if we only have one frontend mapping, we dont need the frontend port name so it will not check the port name in the backend ports
 						PortName: func() lb.FEPortName {
 							if len(lrp.FrontendMappings) > 1 {
 								return feM.fePort

--- a/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-named-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-named-ports.txtar
@@ -162,6 +162,7 @@ status:
   conditions:
   - lastProbeTime: null
     type: Ready
+    status: "True"
 
 -- pod-single.yaml --
 apiVersion: v1
@@ -190,3 +191,4 @@ status:
   conditions:
   - lastProbeTime: null
     type: Ready
+    status: "True"

--- a/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
@@ -96,6 +96,11 @@ status:
   - ip: 2001::1
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    type: Ready
+    status: "True"
+
 
 -- service.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/redirectpolicy/testdata/pod-readiness.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/pod-readiness.txtar
@@ -1,25 +1,27 @@
-# Test to check that pod changes that do not change the resulting redirect backends
-# does not update the LB frontends and backends.
+# Tests that pod with non-ready status are not added as LRP backends.
 
 hive/start
 
-# Add all inputs.
-k8s/add service.yaml endpointslice.yaml lrp-svc.yaml pod.yaml
+# Add LRP, service and pods.
+k8s/add service.yaml lrp-svc.yaml lrp-addr.yaml pod-before.yaml
+# Give some time for reconciliation loop to run
+sleep 500ms
+
+# No local-redirect frontends with associated backends as pods are not "ready".
 db/cmp localredirectpolicies lrp.table
 db/cmp services services.table
+db/cmp frontends frontends-before.table
+
+# Update the pod status. The frontends should now be redirected.
+cp pod-before.yaml pod-ready.yaml
+sed 'status: "False"' 'status: "True"' pod-ready.yaml
+k8s/add pod-ready.yaml
 db/cmp frontends frontends.table
 
-db/show frontends -f yaml -o frontends-before.yaml
+# Toggle the pod status back to not being ready.
+k8s/add pod-before.yaml
+db/cmp frontends frontends-before.table
 
-# Add another pod into the namespace of the redirect pod.
-k8s/add pod2.yaml
-sleep 100ms
-
-# The frontend status.id should remain the same when
-# recomputation is skipped.
-db/show frontends -f yaml -o frontends-after.yaml
-cmp frontends-before.yaml frontends-after.yaml
- 
 # -----
 
 -- lrp-svc.yaml --
@@ -42,7 +44,28 @@ spec:
         name: "tcp"
         protocol: TCP
 
--- pod.yaml --
+-- lrp-addr.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod-before.yaml --
 apiVersion: v1
 kind: Pod
 metadata:
@@ -64,48 +87,18 @@ status:
   hostIPs:
   - ip: 172.19.0.3
   phase: Running
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2024-11-21T14:52:24Z"
+    status: "False"
+    type: Ready
   podIP: 10.244.2.1
   podIPs:
   - ip: 10.244.2.1
   - ip: 2001::1
   qosClass: BestEffort
   startTime: "2024-07-10T16:20:42Z"
-  conditions:
-  - lastProbeTime: null
-    type: Ready
-    status: "True"
 
-
--- pod2.yaml --
-apiVersion: v1
-kind: Pod
-metadata:
-  name: other-pod
-  namespace: test
-spec:
-  containers:
-    - name: nginx
-      image: nginx
-      ports:
-        - containerPort: 80
-          name: tcp
-          protocol: TCP
-  nodeName: testnode
-status:
-  hostIP: 172.19.0.3
-  hostIPs:
-  - ip: 172.19.0.3
-  phase: Running
-  podIP: 10.244.2.1
-  podIPs:
-  - ip: 10.244.2.1
-  - ip: 2001::1
-  qosClass: BestEffort
-  startTime: "2024-07-10T16:20:42Z"
-  conditions:
-  - lastProbeTime: null
-    type: Ready
-    status: "True"
 
 -- service.yaml --
 apiVersion: v1
@@ -117,7 +110,6 @@ spec:
   clusterIP: 1.1.1.1
   clusterIPs:
   - 1.1.1.1
-  - 1001::1
   externalTrafficPolicy: Cluster
   internalTrafficPolicy: Cluster
   ipFamilies:
@@ -134,42 +126,22 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 
--- endpointslice.yaml --
-apiVersion: discovery.k8s.io/v1
-kind: EndpointSlice
-metadata:
-  labels:
-    kubernetes.io/service-name: echo
-  name: echo-kvlm2
-  namespace: test
-addressType: IPv4
-endpoints:
-- addresses:
-  - 10.244.1.1
-  conditions:
-    ready: true
-    serving: true
-    terminating: false
-  nodeName: nodeport-worker
-ports:
-- name: tcp
-  port: 8080
-  protocol: TCP
-
 -- lrp.table --
 Name           Type     FrontendType                Frontends
+test/lrp-addr  address  addr-single-port            169.254.169.254:8080/TCP
 test/lrp-svc   service  all
-
--- services-before.table --
-Name                          Source
-test/echo                     k8s   
 
 -- services.table --
 Name                          Source
 test/echo                     k8s
-test/lrp-svc:local-redirect   k8s   
+test/lrp-addr:local-redirect  k8s
+test/lrp-svc:local-redirect   k8s
+
+-- frontends-before.table --
+Address                    Type          ServiceName                   PortName   Backends              RedirectTo                    Status
+1.1.1.1:8080/TCP           ClusterIP     test/echo                     tcp                                                            Done
 
 -- frontends.table --
 Address                  Type          ServiceName                  PortName   Backends              RedirectTo                    Status
 1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-[1001::1]:8080/TCP       ClusterIP     test/echo                    tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
+169.254.169.254:8080/TCP LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP                                   Done


### PR DESCRIPTION
Manual backport of
* [ ] #43095 (resolve a conflict)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43095
```