### PR TITLE
clustermesh: add missing reason in mcs condition metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -993,15 +993,15 @@ Name                                                 Labels                     
 MCS-API
 ~~~~~~~
 
-========================================= ============================================================ ========== =========================================================
-Name                                      Labels                                                       Default    Description
-========================================= ============================================================ ========== =========================================================
-``mcsapi_serviceexport_info``             ``serviceexport``, ``namespace``                             Enabled    Information about ServiceExport in the local cluster
-``mcsapi_serviceexport_status_condition`` ``serviceexport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceExport in the local cluster
-``mcsapi_serviceimport_info``             ``serviceimport``, ``namespace``                             Enabled    Information about ServiceImport in the local cluster
-``mcsapi_serviceimport_status_condition`` ``serviceimport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceImport in the local cluster
-``mcsapi_serviceimport_status_clusters``  ``serviceimport``, ``namespace``                             Enabled    The number of clusters currently backing a ServiceImport
-========================================= ============================================================ ========== =========================================================
+========================================= ======================================================================== ========== =========================================================
+Name                                      Labels                                                                   Default    Description
+========================================= ======================================================================== ========== =========================================================
+``mcsapi_serviceexport_info``             ``serviceexport``, ``namespace``                                         Enabled    Information about ServiceExport in the local cluster
+``mcsapi_serviceexport_status_condition`` ``serviceexport``, ``namespace``, ``condition``, ``status``, ``reason``  Enabled    Status Condition of ServiceExport in the local cluster
+``mcsapi_serviceimport_info``             ``serviceimport``, ``namespace``                                         Enabled    Information about ServiceImport in the local cluster
+``mcsapi_serviceimport_status_condition`` ``serviceimport``, ``namespace``, ``condition``, ``status``, ``reason``  Enabled    Status Condition of ServiceImport in the local cluster
+``mcsapi_serviceimport_status_clusters``  ``serviceimport``, ``namespace``                                         Enabled    The number of clusters currently backing a ServiceImport
+========================================= ======================================================================== ========== =========================================================
 
 Clustermesh
 ~~~~~~~~~~~

--- a/pkg/clustermesh/mcsapi/metrics.go
+++ b/pkg/clustermesh/mcsapi/metrics.go
@@ -29,7 +29,7 @@ func registerMCSAPICollector(registry *metrics.Registry, logger *slog.Logger, cl
 		serviceExportStatusCondition: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceexport_status_condition"),
 			"Status Condition of ServiceExport in the local cluster",
-			[]string{"serviceexport", "namespace", "condition", "status"}, nil),
+			[]string{"serviceexport", "namespace", "condition", "status", "reason"}, nil),
 		serviceImportInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceimport_info"),
 			"Information about ServiceImport in the local cluster",
@@ -37,7 +37,7 @@ func registerMCSAPICollector(registry *metrics.Registry, logger *slog.Logger, cl
 		serviceImportStatusCondition: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceimport_status_condition"),
 			"Status Condition of ServiceImport in the local cluster",
-			[]string{"serviceimport", "namespace", "condition", "status"}, nil),
+			[]string{"serviceimport", "namespace", "condition", "status", "reason"}, nil),
 		serviceImportStatusClusters: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceimport_status_clusters"),
 			"The number of clusters currently backing a ServiceImport",
@@ -89,7 +89,7 @@ func (c *mcsAPICollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				1,
 				svcExport.Name, svcExport.Namespace,
-				string(condition.Type), string(condition.Status),
+				string(condition.Type), string(condition.Status), condition.Reason,
 			)
 			if err != nil {
 				c.logger.Error("Failed to generate ServiceExport metrics", logfields.Error, err)
@@ -134,7 +134,7 @@ func (c *mcsAPICollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				1,
 				svcImport.Name, svcImport.Namespace,
-				string(condition.Type), string(condition.Status),
+				string(condition.Type), string(condition.Status), condition.Reason,
 			)
 			if err != nil {
 				c.logger.Error("Failed to generate ServiceImport metrics", logfields.Error, err)


### PR DESCRIPTION
Reason is a field defined with a fixed possible set of values so it makes a good candidate to be added in those metrics.

I have marked this for backport in 1.19 as it's a small addition to the existing metrics and allows users to have more info about the condition (for instance the the type of conflict in some alerts) and also those metrics are net new from 1.19 (as it doesn't really count as a bug fix if you feel it isn't reasonable to backport this please say so, it could also wait for 1.20 ~)

```release-note
clustermesh: add missing reason in mcs condition metrics
```
