### PR TITLE
v1.18 Backports 2026-01-15

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -249,6 +249,10 @@ jobs:
   call-publish-helm:
     if: github.repository_owner == 'cilium'
     name: Publish Helm Chart
+    permissions:
+      contents: read
+      # Required to generate OIDC tokens for `sigstore/cosign-installer` authentication
+      id-token: write
     uses: cilium/cilium/.github/workflows/release.yaml@main
     needs: image-digests
     with:

--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -112,7 +112,7 @@ Select the tab for your platform below and install the latest release of Hubble 
 
       .. code-block:: shell-session
 
-         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/main/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "aarch64" ]; then HUBBLE_ARCH=arm64; fi
          curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
@@ -126,7 +126,7 @@ Select the tab for your platform below and install the latest release of Hubble 
 
       .. code-block:: shell-session
 
-         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
+         HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/main/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "arm64" ]; then HUBBLE_ARCH=arm64; fi
          curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
@@ -140,7 +140,7 @@ Select the tab for your platform below and install the latest release of Hubble 
 
       .. code-block:: shell-session
 
-         curl -LO "https://raw.githubusercontent.com/cilium/hubble/master/stable.txt"
+         curl -LO "https://raw.githubusercontent.com/cilium/hubble/main/stable.txt"
          set /p HUBBLE_VERSION=<stable.txt
          curl -L --fail -O "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz"
          curl -L --fail -O "https://github.com/cilium/hubble/releases/download/%HUBBLE_VERSION%/hubble-windows-amd64.tar.gz.sha256sum"

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -245,6 +245,7 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 		`!controller-uid`,                                               // ignore controller-uid
 		`!annotation.*`,                                                 // ignore all annotation labels
 		`!etcd_node`,                                                    // ignore etcd_node label
+		`!topology\.kubernetes\.io`,                                     // ignore all topology.kubernetes.io labels
 	}
 
 	for _, e := range expressions {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -116,6 +116,8 @@ func TestDefaultFilterLabels(t *testing.T) {
 		"apps.kubernetes.io/pod-index":                              "0",
 		"io.cilium.k8s.policy.cluster":                              "default",
 		"io.cilium.k8s.policy.serviceaccount":                       "luke",
+		"topology.kubernetes.io/zone":                               "us-east-1-a",
+		"topology.kubernetes.io/region":                             "us-east-1",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)

--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -91,13 +91,14 @@ type BackendInstanceKey struct {
 }
 
 func (k BackendInstanceKey) Key() []byte {
+	const separator = ' '
 	if k.SourcePriority == 0 {
-		return k.ServiceName.Key()
+		return append(k.ServiceName.Key(), separator)
 	}
 	sk := k.ServiceName.Key()
 	buf := make([]byte, 0, 2+len(sk))
 	buf = append(buf, sk...)
-	return append(buf, ' ', k.SourcePriority)
+	return append(buf, separator, k.SourcePriority)
 }
 
 func (be *Backend) GetInstance(name ServiceName) *BackendParams {
@@ -264,7 +265,6 @@ func (be *Backend) PreferredInstances() iter.Seq2[BackendInstanceKey, BackendPar
 				}
 			} // Skip instances with the same ServiceName but lower (numerically larger) priorities.
 		}
-
 	}
 }
 

--- a/pkg/loadbalancer/backend_test.go
+++ b/pkg/loadbalancer/backend_test.go
@@ -16,7 +16,14 @@ func TestBackendInstanceKey(t *testing.T) {
 		ServiceName:    name,
 		SourcePriority: 0,
 	}
-	assert.True(t, bytes.Equal(key.Key(), name.Key()), "BackendInstanceKey with prio 0 is the ServiceName key")
+	nameExtended := NewServiceNameInCluster("foo", "bar", "baz-extended")
+	keyExtended := BackendInstanceKey{
+		ServiceName:    nameExtended,
+		SourcePriority: 0,
+	}
+
+	assert.True(t, bytes.Equal(key.Key(), append(name.Key(), ' ')), "BackendInstanceKey with prio 0 is the ServiceName key + ' '")
+	assert.False(t, bytes.HasPrefix(key.Key(), keyExtended.Key()), "BackendInstanceKey with prio 0 should not have the the same prefix if the prefix of one service is the name of another service")
 	key.SourcePriority = 1
 	assert.True(t, bytes.HasPrefix(key.Key(), name.Key()), "BackendInstanceKey with prio 1 has ServiceName key as prefix")
 


### PR DESCRIPTION
 * [ ] #43620 (@imroc)
 * [x] #43717 (@aanm)
 * [x] #43725 (@moscicky)
 * [x] #43745 (@tklauser)

PRs skipped due to conflicts:

 * #43598 (@41ks)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43620 43717 43725 43745
```
