### PR TITLE
.github/actions: login with cosign to sign helm OCI charts

### DIFF
--- a/.github/actions/cosign/action.yaml
+++ b/.github/actions/cosign/action.yaml
@@ -34,6 +34,16 @@ inputs:
     description: 'Initial delay in seconds before first retry'
     required: false
     default: '10'
+  registry_username:
+    description: 'Registry username for cosign authentication'
+    required: false
+  registry_password:
+    description: 'Registry password for cosign authentication'
+    required: false
+  registry_url:
+    description: 'Registry URL for cosign authentication (e.g., quay.io)'
+    required: false
+    default: 'quay.io'
 
 runs:
   using: 'composite'
@@ -50,6 +60,18 @@ runs:
         output-file: ./sbom_${{ inputs.sbom_name }}.spdx.json
         image: ${{ inputs.image_tag }}
         upload-release-assets: ${{ inputs.upload_sbom_release_assets  }}
+
+    # Login to registry for cosign to authenticate when pushing signatures
+    - name: Login to registry for cosign
+      if: ${{ inputs.registry_username != '' && inputs.registry_password != '' }}
+      shell: bash
+      env:
+        REGISTRY_USERNAME: ${{ inputs.registry_username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry_password }}
+        REGISTRY_URL: ${{ inputs.registry_url }}
+      run: |
+        echo "Logging into ${REGISTRY_URL} for cosign..."
+        echo "${REGISTRY_PASSWORD}" | cosign login "${REGISTRY_URL}" --username "${REGISTRY_USERNAME}" --password-stdin
 
     - name: Sign Container Image
       shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -357,3 +357,6 @@ jobs:
           image: "quay.io/${{ github.repository_owner }}/charts/cilium@${{ steps.helm_digests.outputs.quay_digest }}"
           generate_sbom: 'false'
           attach_sbom: 'false'
+          registry_username: ${{ secrets.QUAY_USERNAME_HELM_RELEASE_USERNAME }}
+          registry_password: ${{ secrets.QUAY_PASSWORD_HELM_RELEASE_PASSWORD }}
+          registry_url: 'quay.io'


### PR DESCRIPTION
As helm uses a different file to login into the registries, we also need to use cosign login so the oci helm charts can be properly signed by cosign.

Fixes: 7494f7cd633a ("workflows/release: release helm charts as OCI packages")