### PR TITLE
docs: Update Gateway API conformance link to v1.4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -353,9 +353,9 @@ and the `2-Clause BSD License <bsd-license_>`__
     :alt: FOSSA Status
     :target: https://app.fossa.com/projects/custom%2B162%2Fgit%40github.com%3Acilium%2Fcilium.git?ref=badge_shield
 
-.. |gateway-api| image:: https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.2.0-Cilium-green
+.. |gateway-api| image:: https://img.shields.io/badge/Gateway%20API%20Conformance%20v1.4.0-Cilium-green
     :alt: Gateway API Status
-    :target: https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports/v1.2.0/cilium-cilium
+    :target: https://github.com/kubernetes-sigs/gateway-api/tree/main/conformance/reports/v1.4.0/cilium
 
 .. |codespaces| image:: https://img.shields.io/badge/Open_in_GitHub_Codespaces-gray?logo=github
     :alt: Github Codespaces


### PR DESCRIPTION
While reading the [docs](https://gateway-api.sigs.k8s.io/implementations/) for gateway API I noticed there is a difference in the conformance badge shown on their website and the one on the repo.
This PR bumps the badge on the repo to match the one on the docs.