### PR TITLE
[CI - e2e-upgrade]: Continue on failures for agent restart L7 traffic disruption test

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -571,6 +571,7 @@ jobs:
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 
       - name: Test Cilium ${{ matrix.skip-upgrade != 'true' && 'after agent restart' }}
+        continue-on-error: true
         if: ${{ matrix.skip-upgrade != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-check
         with:


### PR DESCRIPTION
Temporarily ignore failures in L7 traffic disruption tests on cilium-agent restart, while we work on root causing the underlying reason for test flakiness.
Fixes #43770