### PR TITLE
policy: add metric tracking detached selector policies

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
@@ -1076,6 +1077,9 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 
 	e.PolicyDebug("ApplyPolicyMapChanges")
 
+	if isDetached, t := e.desiredPolicy.SelectorPolicy.IsDetached(); isDetached {
+		metrics.EndpointDetachedSelectorPolicyTimeStats.WithLabelValues("incremental-update").Observe(time.Since(t).Seconds())
+	}
 	return e.applyPolicyMapChangesLocked(&regenerationContext{
 		datapathRegenerationContext: &datapathRegenerationContext{
 			proxyWaitGroup: proxyWaitGroup,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -209,6 +209,14 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 		identity:         e.getIdentity(),
 		identityRevision: e.identityRevision,
 	}
+
+	// If selector policy is detached _before_ endpoint regeneration has started,
+	// we keep track of the timestamp to check how long it ends up in a detached state.
+	if e.desiredPolicy != nil {
+		if isDetached, t := e.desiredPolicy.SelectorPolicy.IsDetached(); isDetached {
+			stats.policyDetachedTimestamp = &t
+		}
+	}
 	e.unlock()
 
 	e.getLogger().Debug("Starting policy recalculation...")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -285,6 +285,10 @@ var (
 	// It must be thread-safe.
 	Endpoint metric.GaugeFunc
 
+	// EndpointDetachedSelectorPolicyTimeStats is tracking the amount of time endpoints have had detached selector
+	// when various updates occur.
+	EndpointDetachedSelectorPolicyTimeStats = NoOpObserverVec
+
 	// EndpointRegenerationTotal is a count of the number of times any endpoint
 	// has been regenerated and success/fail outcome
 	EndpointRegenerationTotal = NoOpCounterVec
@@ -617,80 +621,81 @@ var (
 )
 
 type LegacyMetrics struct {
-	BootstrapTimes                   metric.Vec[metric.Gauge]
-	APIInteractions                  metric.Vec[metric.Observer]
-	NodeHealthConnectivityStatus     metric.Vec[metric.Gauge]
-	NodeHealthConnectivityLatency    metric.Vec[metric.Observer]
-	Endpoint                         metric.GaugeFunc
-	EndpointRegenerationTotal        metric.Vec[metric.Counter]
-	EndpointStateCount               metric.Vec[metric.Gauge]
-	EndpointRegenerationTimeStats    metric.Vec[metric.Observer]
-	EndpointPropagationDelay         metric.Vec[metric.Observer]
-	Policy                           metric.Gauge
-	PolicyRevision                   metric.Gauge
-	PolicyChangeTotal                metric.Vec[metric.Counter]
-	PolicyEndpointStatus             metric.Vec[metric.Gauge]
-	PolicyImplementationDelay        metric.Vec[metric.Observer]
-	PolicyIncrementalUpdateDuration  metric.Vec[metric.Observer]
-	Identity                         metric.Vec[metric.Gauge]
-	IdentityLabelSources             metric.Vec[metric.Gauge]
-	EventTS                          metric.Vec[metric.Gauge]
-	EventLagK8s                      metric.Gauge
-	ProxyRedirects                   metric.Vec[metric.Gauge]
-	ProxyPolicyL7Total               metric.Vec[metric.Counter]
-	ProxyUpstreamTime                metric.Vec[metric.Observer]
-	ProxyDatapathUpdateTimeout       metric.Counter
-	ConntrackGCRuns                  metric.Vec[metric.Counter]
-	ConntrackGCKeyFallbacks          metric.Vec[metric.Counter]
-	ConntrackGCSize                  metric.Vec[metric.Gauge]
-	NatGCSize                        metric.Vec[metric.Gauge]
-	ConntrackGCDuration              metric.Vec[metric.Observer]
-	ConntrackInterval                metric.Vec[metric.Gauge]
-	ConntrackDumpResets              metric.Vec[metric.Counter]
-	SignalsHandled                   metric.Vec[metric.Counter]
-	ServicesEventsCount              metric.Vec[metric.Counter]
-	ServiceImplementationDelay       metric.Vec[metric.Observer]
-	ErrorsWarnings                   metric.Vec[metric.Counter]
-	ControllerRuns                   metric.Vec[metric.Counter]
-	ControllerRunsDuration           metric.Vec[metric.Observer]
-	SubprocessStart                  metric.Vec[metric.Counter]
-	KubernetesEventProcessed         metric.Vec[metric.Counter]
-	KubernetesEventReceived          metric.Vec[metric.Counter]
-	KubernetesAPIInteractions        metric.Vec[metric.Observer]
-	KubernetesAPIRateLimiterLatency  metric.Vec[metric.Observer]
-	KubernetesAPICallsTotal          metric.Vec[metric.Counter]
-	TerminatingEndpointsEvents       metric.Counter
-	IPAMEvent                        metric.Vec[metric.Counter]
-	IPAMCapacity                     metric.Vec[metric.Gauge]
-	KVStoreOperationsDuration        metric.Vec[metric.Observer]
-	KVStoreEventsQueueDuration       metric.Vec[metric.Observer]
-	KVStoreQuorumErrors              metric.Vec[metric.Counter]
-	FQDNGarbageCollectorCleanedTotal metric.Counter
-	FQDNActiveNames                  metric.Vec[metric.Gauge]
-	FQDNActiveIPs                    metric.Vec[metric.Gauge]
-	FQDNAliveZombieConnections       metric.Vec[metric.Gauge]
-	FQDNSelectors                    metric.Gauge
-	FQDNSemaphoreRejectedTotal       metric.Counter
-	IPCacheErrorsTotal               metric.Vec[metric.Counter]
-	IPCacheEventsTotal               metric.Vec[metric.Counter]
-	BPFSyscallDuration               metric.Vec[metric.Observer]
-	BPFMapOps                        metric.Vec[metric.Counter]
-	BPFMapCapacity                   metric.Vec[metric.Gauge]
-	VersionMetric                    metric.Vec[metric.Gauge]
-	APILimiterWaitHistoryDuration    metric.Vec[metric.Observer]
-	APILimiterWaitDuration           metric.Vec[metric.Gauge]
-	APILimiterProcessingDuration     metric.Vec[metric.Gauge]
-	APILimiterRequestsInFlight       metric.Vec[metric.Gauge]
-	APILimiterRateLimit              metric.Vec[metric.Gauge]
-	APILimiterAdjustmentFactor       metric.Vec[metric.Gauge]
-	APILimiterProcessedRequests      metric.Vec[metric.Counter]
-	WorkQueueDepth                   metric.Vec[metric.Gauge]
-	WorkQueueAddsTotal               metric.Vec[metric.Counter]
-	WorkQueueLatency                 metric.Vec[metric.Observer]
-	WorkQueueDuration                metric.Vec[metric.Observer]
-	WorkQueueUnfinishedWork          metric.Vec[metric.Gauge]
-	WorkQueueLongestRunningProcessor metric.Vec[metric.Gauge]
-	WorkQueueRetries                 metric.Vec[metric.Counter]
+	BootstrapTimes                          metric.Vec[metric.Gauge]
+	APIInteractions                         metric.Vec[metric.Observer]
+	NodeHealthConnectivityStatus            metric.Vec[metric.Gauge]
+	NodeHealthConnectivityLatency           metric.Vec[metric.Observer]
+	Endpoint                                metric.GaugeFunc
+	EndpointDetachedSelectorPolicyTimeStats metric.Vec[metric.Observer]
+	EndpointRegenerationTotal               metric.Vec[metric.Counter]
+	EndpointStateCount                      metric.Vec[metric.Gauge]
+	EndpointRegenerationTimeStats           metric.Vec[metric.Observer]
+	EndpointPropagationDelay                metric.Vec[metric.Observer]
+	Policy                                  metric.Gauge
+	PolicyRevision                          metric.Gauge
+	PolicyChangeTotal                       metric.Vec[metric.Counter]
+	PolicyEndpointStatus                    metric.Vec[metric.Gauge]
+	PolicyImplementationDelay               metric.Vec[metric.Observer]
+	PolicyIncrementalUpdateDuration         metric.Vec[metric.Observer]
+	Identity                                metric.Vec[metric.Gauge]
+	IdentityLabelSources                    metric.Vec[metric.Gauge]
+	EventTS                                 metric.Vec[metric.Gauge]
+	EventLagK8s                             metric.Gauge
+	ProxyRedirects                          metric.Vec[metric.Gauge]
+	ProxyPolicyL7Total                      metric.Vec[metric.Counter]
+	ProxyUpstreamTime                       metric.Vec[metric.Observer]
+	ProxyDatapathUpdateTimeout              metric.Counter
+	ConntrackGCRuns                         metric.Vec[metric.Counter]
+	ConntrackGCKeyFallbacks                 metric.Vec[metric.Counter]
+	ConntrackGCSize                         metric.Vec[metric.Gauge]
+	NatGCSize                               metric.Vec[metric.Gauge]
+	ConntrackGCDuration                     metric.Vec[metric.Observer]
+	ConntrackInterval                       metric.Vec[metric.Gauge]
+	ConntrackDumpResets                     metric.Vec[metric.Counter]
+	SignalsHandled                          metric.Vec[metric.Counter]
+	ServicesEventsCount                     metric.Vec[metric.Counter]
+	ServiceImplementationDelay              metric.Vec[metric.Observer]
+	ErrorsWarnings                          metric.Vec[metric.Counter]
+	ControllerRuns                          metric.Vec[metric.Counter]
+	ControllerRunsDuration                  metric.Vec[metric.Observer]
+	SubprocessStart                         metric.Vec[metric.Counter]
+	KubernetesEventProcessed                metric.Vec[metric.Counter]
+	KubernetesEventReceived                 metric.Vec[metric.Counter]
+	KubernetesAPIInteractions               metric.Vec[metric.Observer]
+	KubernetesAPIRateLimiterLatency         metric.Vec[metric.Observer]
+	KubernetesAPICallsTotal                 metric.Vec[metric.Counter]
+	TerminatingEndpointsEvents              metric.Counter
+	IPAMEvent                               metric.Vec[metric.Counter]
+	IPAMCapacity                            metric.Vec[metric.Gauge]
+	KVStoreOperationsDuration               metric.Vec[metric.Observer]
+	KVStoreEventsQueueDuration              metric.Vec[metric.Observer]
+	KVStoreQuorumErrors                     metric.Vec[metric.Counter]
+	FQDNGarbageCollectorCleanedTotal        metric.Counter
+	FQDNActiveNames                         metric.Vec[metric.Gauge]
+	FQDNActiveIPs                           metric.Vec[metric.Gauge]
+	FQDNAliveZombieConnections              metric.Vec[metric.Gauge]
+	FQDNSelectors                           metric.Gauge
+	FQDNSemaphoreRejectedTotal              metric.Counter
+	IPCacheErrorsTotal                      metric.Vec[metric.Counter]
+	IPCacheEventsTotal                      metric.Vec[metric.Counter]
+	BPFSyscallDuration                      metric.Vec[metric.Observer]
+	BPFMapOps                               metric.Vec[metric.Counter]
+	BPFMapCapacity                          metric.Vec[metric.Gauge]
+	VersionMetric                           metric.Vec[metric.Gauge]
+	APILimiterWaitHistoryDuration           metric.Vec[metric.Observer]
+	APILimiterWaitDuration                  metric.Vec[metric.Gauge]
+	APILimiterProcessingDuration            metric.Vec[metric.Gauge]
+	APILimiterRequestsInFlight              metric.Vec[metric.Gauge]
+	APILimiterRateLimit                     metric.Vec[metric.Gauge]
+	APILimiterAdjustmentFactor              metric.Vec[metric.Gauge]
+	APILimiterProcessedRequests             metric.Vec[metric.Counter]
+	WorkQueueDepth                          metric.Vec[metric.Gauge]
+	WorkQueueAddsTotal                      metric.Vec[metric.Counter]
+	WorkQueueLatency                        metric.Vec[metric.Observer]
+	WorkQueueDuration                       metric.Vec[metric.Observer]
+	WorkQueueUnfinishedWork                 metric.Vec[metric.Gauge]
+	WorkQueueLongestRunningProcessor        metric.Vec[metric.Gauge]
+	WorkQueueRetries                        metric.Vec[metric.Counter]
 }
 
 func NewLegacyMetrics() *LegacyMetrics {
@@ -711,6 +716,15 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Name:      "api_process_time_seconds",
 			Help:      "Duration of processed API calls labeled by path, method and return code.",
 		}, []string{LabelPath, LabelMethod, LabelAPIReturnCode}),
+
+		EndpointDetachedSelectorPolicyTimeStats: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: Namespace + "_endpoint_detached_selector_policy_time_stats_seconds",
+
+			Namespace: Namespace,
+			Name:      "endpoint_detached_selector_policy_time_stats_seconds",
+			Help:      "Endpoint detached selector policy time stats labeled by the scope",
+			Buckets:   prometheus.ExponentialBucketsRange(0.01, 60*10, 10),
+		}, []string{LabelScope}),
 
 		EndpointRegenerationTotal: metric.NewCounterVecWithLabels(metric.CounterOpts{
 			ConfigName: Namespace + "_endpoint_regenerations_total",
@@ -1272,6 +1286,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	NodeHealthConnectivityStatus = lm.NodeHealthConnectivityStatus
 	NodeHealthConnectivityLatency = lm.NodeHealthConnectivityLatency
 	Endpoint = lm.Endpoint
+	EndpointDetachedSelectorPolicyTimeStats = lm.EndpointDetachedSelectorPolicyTimeStats
 	EndpointRegenerationTotal = lm.EndpointRegenerationTotal
 	EndpointStateCount = lm.EndpointStateCount
 	EndpointRegenerationTimeStats = lm.EndpointRegenerationTimeStats

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -364,6 +365,14 @@ func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOw
 	}
 
 	return calculatedPolicy
+}
+
+func (p *selectorPolicy) IsDetached() (bool, time.Time) {
+	ptr := p.L4Policy.detachedTime.Load()
+	if ptr == nil {
+		return false, time.Time{}
+	}
+	return true, *ptr
 }
 
 var (


### PR DESCRIPTION
This adds a histogram that tracks the occasions where an endpoint has a selector policy that is detached when its either starting to regenerate, or doing a partial policy map update.

This is interesting, since this means that updates will be missed - and that can result in either permissive policies not being removed, or new identities not being added to the policymap when they should.

This exact issue has caused a lot of issues, and historically we have not had great metrics to catch it. This adds one for the partial policy map updates, as well as full regenerations. Given how the policy engine works, its expected with a short amount of time spent in "detached" state when two or more endpoints share the same identity, and are regenerating. In busy situation, this can extend to a handful of seconds - but if you see this creep above that, there is most likely an issue. This effectively means that if the histogram_quantile(1, ...) is more than ~a handful of sec (or maybe 5-10), there is probably a bug in cilium. If it hits above 1 minute, or 30min+, there is for sure some negative effects. Another trick is to do the _sum / _count value, especially if an endpoint is stuck like this for more than the 30min bucket.

Ideally we avoid doing this detachment, but this metric has helped catch a lot of the bugs around the current implementation, so they could be useful to others. It would also be useful having a counter of endpoints in this state. We used this to catch and fix https://github.com/cilium/cilium/pull/42306, https://github.com/cilium/cilium/pull/42420, https://github.com/cilium/cilium/pull/42418, https://github.com/cilium/cilium/pull/42661 and https://github.com/cilium/cilium/pull/42662.


Here is an example of an endpoint that was stuck in ~a few min in this state;
```bash
$ kubectl get --raw /api/v1/namespaces/kube-system/pods/http:cilium-8ltxq:9962/proxy/metrics  | grep detached
# HELP cilium_endpoint_detached_selector_policy_time_stats_seconds Endpoint detached selector policy time stats labeled by the scope
# TYPE cilium_endpoint_detached_selector_policy_time_stats_seconds histogram
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="0.01"} 2
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="0.03395515321684607"} 2
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="0.1152952429979492"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="0.39148676411688643"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="1.3292993057956153"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="4.513656159933723"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="15.326188647871065"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="52.04030837687489"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="176.70366443887048"} 3
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="600.0000000000001"} 4
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="regeneration",le="+Inf"} 4
cilium_endpoint_detached_selector_policy_time_stats_seconds_sum{scope="regeneration"} 482.608147844
cilium_endpoint_detached_selector_policy_time_stats_seconds_count{scope="regeneration"} 4
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="0.01"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="0.03395515321684607"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="0.1152952429979492"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="0.39148676411688643"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="1.3292993057956153"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="4.513656159933723"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="15.326188647871065"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="52.04030837687489"} 0
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="176.70366443887048"} 1
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="600.0000000000001"} 1
cilium_endpoint_detached_selector_policy_time_stats_seconds_bucket{scope="update",le="+Inf"} 1
cilium_endpoint_detached_selector_policy_time_stats_seconds_sum{scope="update"} 97.594957752
cilium_endpoint_detached_selector_policy_time_stats_seconds_count{scope="update"} 1
```

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
