### PR TITLE
mac: add text marshaler/unmarshaler for MAC type

### DIFF
--- a/pkg/mac/mac_test.go
+++ b/pkg/mac/mac_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestParse(t *testing.T) {
@@ -63,6 +64,30 @@ func TestUint64(t *testing.T) {
 	v, err := m.Uint64()
 	require.NoError(t, err)
 	require.Equal(t, Uint64MAC(0x564534231211), v)
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	m := MustParseMAC("11:12:23:34:45:56")
+	w := MAC([]byte{0x11, 0x12, 0x23, 0x34, 0x45, 0xAB})
+	d, err := yaml.Marshal(m)
+	require.NoError(t, err)
+	require.Equal(t, []byte("\"11:12:23:34:45:56\"\n"), d)
+	var t1 MAC
+	err = yaml.Unmarshal([]byte("11:12:23:34:45:AB"), &t1)
+	require.NoError(t, err)
+	require.Equal(t, w, t1)
+	err = yaml.Unmarshal([]byte("11:12:23:34:45:A"), &t1)
+	require.Error(t, err)
+
+	m = MAC([]byte{})
+	w = MAC([]byte{})
+	d, err = yaml.Marshal(m)
+	require.NoError(t, err)
+	require.Equal(t, []byte("\"\"\n"), d)
+	var t2 MAC
+	err = yaml.Unmarshal([]byte(`""`), &t2)
+	require.NoError(t, err)
+	require.Equal(t, w, t2)
 }
 
 func TestUnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
This allows using the string representation (as returned by MAC.String) instead of a list to represent a MAC in YAML.

Before:

```yaml
mac:
- 0x00
- 0x50
- 0x56
- 0xad
- 0x45
- 0xec
```

After:

```yaml
mac: 00:50:56:ad:45:ec
```


This also allows to remove the JSON marshaler/unmarshaler as `json.{Marshal,Unmarshal}` would invoke these methods in case the `{Marshal,Unmarshal}JSON` methods are not implemented for a type.

Suggested by @giorio94.