### PR TITLE
bpf: wireguard: remove dependency on tc_index for proxy detection

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -10,7 +10,6 @@
 #include "overloadable.h"
 #include "identity.h"
 
-#include "lib/proxy.h"
 #include "lib/l4.h"
 
 #include "linux/icmpv6.h"
@@ -148,13 +147,6 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	if (magic == MARK_MAGIC_PROXY_INGRESS ||
 	    magic == MARK_MAGIC_SKIP_TPROXY)
 		goto maybe_encrypt;
-#if defined(TUNNEL_MODE)
-	/* In tunneling mode the mark might have been reset. Check TC index instead.
-	 * TODO: remove this in v1.20, once we can rely on MARK_MAGIC_SKIP_TPROXY.
-	 */
-	if (tc_index_from_ingress_proxy(ctx) || tc_index_from_egress_proxy(ctx))
-		goto maybe_encrypt;
-#endif /* TUNNEL_MODE */
 
 	/* Unless node encryption is enabled, we don't want to encrypt
 	 * traffic from the hostns (an exception - L7 proxy traffic).


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/41851 allowed for the detection of from-proxy traffic even when it is diverted via cilium_host, without relying on the fragile skb->tc_index.

The marking with MARK_MAGIC_SKIP_TPROXY landed in v1.19, therefore we can rely on it in v1.20 and remove the tc_index-related code.