### PR TITLE
endpoint/policy: prevent panic when retrieving local node

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -25,7 +25,6 @@ import (
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
@@ -1047,7 +1046,8 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 
 				ln, err := e.localNodeStore.Get(ctx)
 				if err != nil {
-					logging.Fatal(logger, "getLocalNode: unexpected error", logfields.Error, err)
+					e.runlock()
+					return controller.NewExitReason("Failed to get local node")
 				}
 
 				ID := e.SecurityIdentity.ID


### PR DESCRIPTION
The refactoring to retrieve the local node via `LocalNodeStore` introduced an issue where retrieving the local node store panics if the context of the endpoint is cancelled (e.g. when removing endpoint).

Seen in `ci-integration` test (https://github.com/cilium/cilium/actions/runs/21060507113/attempts/2)

```
time=2026-01-16T09:23:23.694457811Z level=debug msg="stopping EventQueue" ciliumEndpointName=/ k8sPodName=/ ipv4=10.232.125.252 containerID="" desiredPolicyRevision=0 ipv6=f00d::ae8:0:0:296f endpointID=625 datapathPolicyRevision=0 containerInterface="" subsys=endpoint name=endpoint-625
time=2026-01-16T09:23:23.694679188Z level=fatal msg="getLocalNode: unexpected error" identity=5 ciliumEndpointName=/ k8sPodName=/ ipv4=10.232.125.252 containerID="" desiredPolicyRevision=0 ipv6=f00d::ae8:0:0:296f endpointID=625 datapathPolicyRevision=0 containerInterface="" subsys=endpoint error="context canceled"
```

Therefore, this commit changes the errorhandling to stop the controller by returning an error instead of panicing. (context cancellation is the only case where the method returns an error anyway).

Fixes: https://github.com/cilium/cilium/pull/43606 (as mentioned in the commit messages it seemed fine to fatal if proper error handling isn't ready. BUT only in combination with `context.TODO()`.

Note: `release-note/misc` instead of bug because the PR introducing this issue only landed in `main`