### PR TITLE
datapath: ipsec: remove clean up code for encrypt IP rule 

### DIFF
--- a/pkg/datapath/fake/types/mtu.go
+++ b/pkg/datapath/fake/types/mtu.go
@@ -15,11 +15,6 @@ func (*MTU) GetRouteMTU() int {
 	return 1500
 }
 
-// GetRoutePostEncryptMTU implements mtu.MTU.
-func (*MTU) GetRoutePostEncryptMTU() int {
-	return 1420
-}
-
 func (*MTU) IsEnableRouteMTUForCNIChaining() bool {
 	return false
 }

--- a/pkg/datapath/linux/ipsec.go
+++ b/pkg/datapath/linux/ipsec.go
@@ -725,31 +725,6 @@ func (n *linuxNodeHandler) subnetEncryption() bool {
 	return len(n.nodeConfig.IPv4PodSubnets) > 0 || len(n.nodeConfig.IPv6PodSubnets) > 0
 }
 
-func (n *linuxNodeHandler) removeEncryptRules() error {
-	rule := route.Rule{
-		Priority: 1,
-		Mask:     linux_defaults.RouteMarkMask,
-		Table:    linux_defaults.RouteTableIPSec,
-		Protocol: linux_defaults.RTProto,
-	}
-
-	rule.Mark = linux_defaults.RouteMarkEncrypt
-	if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("delete previous IPv4 encrypt rule failed: %w", err)
-		}
-	}
-
-	rule.Mark = linux_defaults.RouteMarkEncrypt
-	if err := route.DeleteRule(netlink.FAMILY_V6, rule); err != nil {
-		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
-			return fmt.Errorf("delete previous IPv6 encrypt rule failed: %w", err)
-		}
-	}
-	return nil
-
-}
-
 func (n *linuxNodeHandler) removeDecryptRules() error {
 	rule := route.Rule{
 		Priority: 1,

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -700,11 +700,6 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig datapath.LocalNode
 		return fmt.Errorf("failed to update or remove node routes: %w", err)
 	}
 
-	// Clean up stale IP rules for IPsec. This can be removed in the v1.20 release.
-	if err := n.removeEncryptRules(); err != nil {
-		n.log.Warn("Cannot cleanup previous encryption rule state.", logfields.Error, err)
-	}
-
 	if newConfig.EnableIPSec {
 		// For the ENI ipam mode on EKS, this will be the interface that
 		// the router (cilium_host) IP is associated to.

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -20,7 +20,6 @@ import (
 type MTUConfiguration interface {
 	GetDeviceMTU() int
 	GetRouteMTU() int
-	GetRoutePostEncryptMTU() int
 }
 
 // LocalNodeConfiguration represents the configuration of the local node

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -51,10 +51,6 @@ func (f *fakeMTU) GetRouteMTU() int {
 	return 1500
 }
 
-func (f *fakeMTU) GetRoutePostEncryptMTU() int {
-	return 1500
-}
-
 var mtuMock = fakeMTU{}
 
 func TestAllocatedIPDump(t *testing.T) {

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -37,7 +37,6 @@ var Cell = cell.Module(
 type MTU interface {
 	GetDeviceMTU() int
 	GetRouteMTU() int
-	GetRoutePostEncryptMTU() int
 	IsEnableRouteMTUForCNIChaining() bool
 	IsEnablePacketizationLayerPMTUD() bool
 }
@@ -166,12 +165,6 @@ func (m *LatestMTUGetter) GetRouteMTU() int {
 	rtx := m.db.ReadTxn()
 	mtu, _, _ := m.tbl.Get(rtx, MTURouteIndex.Query(DefaultPrefixV4))
 	return mtu.RouteMTU
-}
-
-func (m *LatestMTUGetter) GetRoutePostEncryptMTU() int {
-	rtx := m.db.ReadTxn()
-	mtu, _, _ := m.tbl.Get(rtx, MTURouteIndex.Query(DefaultPrefixV4))
-	return mtu.RoutePostEncryptMTU
 }
 
 func (m *LatestMTUGetter) IsEnableRouteMTUForCNIChaining() bool {


### PR DESCRIPTION
Now that we branched off `v1.19`, clean up the remaining bits from https://github.com/cilium/cilium/pull/41699.
