### PR TITLE
clustermesh: exclude back non ready/non serving endpoints

### DIFF
--- a/operator/watchers/service_sync.go
+++ b/operator/watchers/service_sync.go
@@ -236,6 +236,9 @@ func (d DefaultClusterServiceConverter) Convert(k8sService *slim_corev1.Service,
 	svc.Backends = map[string]serviceStore.PortConfiguration{}
 	for _, ep := range getEndpoints(svc.Namespace, svc.Name) {
 		for addrCluster, backend := range ep.Backends {
+			if !backend.Conditions.IsReady() && !backend.Conditions.IsServing() {
+				continue
+			}
 			addrString := addrCluster.Addr().String()
 			svc.Backends[addrString] = backend.ToPortConfiguration()
 			if backend.Hostname != "" {

--- a/operator/watchers/testdata/servicesync.txtar
+++ b/operator/watchers/testdata/servicesync.txtar
@@ -151,6 +151,13 @@ endpoints:
   hints:
     forZones:
     - name: zone1
+- addresses:
+  - 10.244.1.2
+  conditions:
+    ready: false
+    serving: false
+    terminating: false
+  nodeName: nodeport-worker
 ports:
 - name: http
   port: 8080


### PR DESCRIPTION
This adds back a check to skip some endpoints that should not receive anyvtraffic in the ClusterMesh context.

Before the fixed commit this filtering was done through the resource / ParseEndpointSliceV1 but this was removed so that everything can be kept it in he backend maps while backends are excluded correctly at the datapath level.

However as ClusterMesh doesn't retain any info on the Endpoint conditions, those are essentially lost and we would propagate them like any fully ready backends unfortunately.

```release-note
clustermesh: correctly phase out not ready/not service endpoints from global services
```
