### PR TITLE
redirectpolicy: Allow address-based redirect to override k8s service

### DIFF
--- a/pkg/loadbalancer/backend.go
+++ b/pkg/loadbalancer/backend.go
@@ -151,8 +151,8 @@ func (be *Backend) GetInstancesOfService(name ServiceName) iter.Seq2[BackendInst
 
 func (be *Backend) GetInstanceForFrontend(fe *Frontend) *BackendParams {
 	serviceName := fe.ServiceName
-	if fe.RedirectTo != nil {
-		serviceName = *fe.RedirectTo
+	if fe.Redirect != nil && fe.Redirect.ServiceName != nil {
+		serviceName = *fe.Redirect.ServiceName
 	}
 	return be.GetInstance(serviceName)
 }

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -841,7 +841,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 	}
 
 	svcType := fe.Type
-	if fe.RedirectTo != nil {
+	if fe.Redirect != nil && fe.Redirect.ServiceName != nil {
 		svcType = loadbalancer.SVCTypeLocalRedirect
 	}
 

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -777,7 +777,9 @@ var localRedirectTestCases = []testCase{
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = LocalRedirect
 			svcName := loadbalancer.NewServiceName("bar", "foo")
-			fe.RedirectTo = &svcName
+			fe.Redirect = &loadbalancer.RedirectParams{
+				ServiceName: &svcName,
+			}
 			fe.Address = autoAddr
 			return false, []loadbalancer.Backend{}
 		},

--- a/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-named-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-named-ports.txtar
@@ -69,9 +69,9 @@ Name                              Source
 test/lrp-addr:local-redirect      k8s
 
 -- frontends.table --
-Address                    Type          ServiceName                       Backends            RedirectTo  Status
-169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:50/TCP               Done
-169.254.169.254:5051/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:51/TCP               Done
+Address                    Type          ServiceName                       Backends            Redirect  Status
+169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:50/TCP             Done
+169.254.169.254:5051/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:51/TCP             Done
 
 -- backends.table --
 Address             Instances
@@ -95,12 +95,12 @@ Name                                     Source
 test/lrp-addr-unnamed:local-redirect     k8s
 
 -- frontends-single.table --
-Address                    Type          ServiceName                              Backends            RedirectTo  Status
-169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr-single:local-redirect      10.244.2.1:50/TCP               Done
+Address                    Type          ServiceName                              Backends            Redirect  Status
+169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr-single:local-redirect      10.244.2.1:50/TCP             Done
 
 -- frontends-unnamed.table --
-Address                    Type          ServiceName                              Backends            RedirectTo  Status
-169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr-unnamed:local-redirect     10.244.2.1:50/TCP               Done
+Address                    Type          ServiceName                              Backends            Redirect  Status
+169.254.169.254:5050/TCP   LocalRedirect test/lrp-addr-unnamed:local-redirect     10.244.2.1:50/TCP             Done
 
 -- backends-single.table --
 Address             Instances

--- a/pkg/loadbalancer/redirectpolicy/testdata/address-overlap.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address-overlap.txtar
@@ -1,0 +1,192 @@
+# This tests validates that LRP address matcher can overlap with a k8s
+# service that has the same address as a frontend. On overlap the LRP
+# address matcher wins. If the LRP is removed the k8s service is
+# restored.
+#
+
+hive start
+
+###
+### Service before LRP
+###
+
+k8s/add service.yaml
+db/cmp frontends frontends-before.table
+
+# Now add the pod and LRP. The existing frontend from the service
+# will be replaced by the LRP frontend and the original frontend is
+# stored shadowed in the LRP frontend.
+k8s/add pod.yaml lrp-addr.yaml
+db/cmp frontends frontends-redirected.table
+
+# Update the service to check that the change is remembered
+# when the service is restored. Also add some backends to it.
+sed 'name: tcp' 'name: http' service.yaml
+k8s/update service.yaml
+k8s/add endpointslice.yaml
+
+# This should not affect the current frontend.
+db/cmp frontends frontends-redirected.table
+
+# Removing the LRP restores the original
+k8s/delete lrp-addr.yaml
+
+# Wait for frontend to change to the original
+db/cmp frontends frontends-restored.table
+
+# Cleanup
+k8s/delete service.yaml pod.yaml lrp-addr.yaml
+
+# Wait until empty
+* db/empty frontends services localredirectpolicies
+
+###
+### LRP before Service
+###
+
+# Add the pod and redirect
+k8s/add pod.yaml lrp-addr.yaml
+db/cmp frontends frontends-redirected-no-shadow.table
+
+# Adding the service will update the [Frontend.Redirect.Shadows]
+k8s/add service.yaml endpointslice.yaml
+db/cmp frontends frontends-redirected.table
+
+# Removing the LRP will bring in the k8s frontend
+k8s/delete pod.yaml lrp-addr.yaml
+db/cmp frontends frontends-restored.table
+
+# Add back the pod and redirect
+k8s/add pod.yaml lrp-addr.yaml
+db/cmp frontends frontends-redirected.table
+
+# Removing the service will update the "shadows" and
+# the frontend won't be incorrectly restored on LRP
+# removal.
+k8s/delete service.yaml endpointslice.yaml
+db/cmp frontends frontends-redirected-no-shadow.table
+
+# Removing the LRP will now remove all frontends.
+k8s/delete pod.yaml lrp-addr.yaml
+
+# Frontends should now be empty
+db/show frontends
+* db/empty frontends
+
+# ---
+
+-- frontends-before.table --
+Address                   Type       ServiceName  PortName Redirect  Backends  Status
+169.254.169.254:8080/TCP  ClusterIP  test/echo    tcp                          Done
+
+
+-- frontends-redirected-no-shadow.table --
+Address                   Type          ServiceName                   Redirect  Backends            Status
+169.254.169.254:8080/TCP  LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP   Done
+
+-- frontends-redirected.table --
+Address                   Type          ServiceName                   Redirect              Backends            Status
+169.254.169.254:8080/TCP  LocalRedirect test/lrp-addr:local-redirect  test/echo (shadows)   10.244.2.1:80/TCP   Done
+
+-- frontends-restored.table --
+Address                   Type       ServiceName  PortName Redirect Backends            Status
+169.254.169.254:8080/TCP  ClusterIP  test/echo    http              10.244.1.1:8080/TCP Done
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 169.254.169.254
+  clusterIPs:
+  - 169.254.169.254
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: ClusterIP
+
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+
+
+-- lrp-addr.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: "test"
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.169.254"
+      toPorts:
+        - port: "8080"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: proxy
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: proxy
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: tcp
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  conditions:
+  - status: 'True'
+    type: Ready

--- a/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address.txtar
@@ -85,13 +85,13 @@ Name                              Source
 test/lrp-addr:local-redirect      k8s   
 
 -- frontends.table --
-Address                    Type          ServiceName                       Backends            RedirectTo  Status
-169.254.169.254:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP               Done
-[2001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect [2002::2]:80/TCP                Done
+Address                    Type          ServiceName                       Backends            Redirect  Status
+169.254.169.254:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP             Done
+[2001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect [2002::2]:80/TCP              Done
 
 -- frontends-ipv4.table --
-Address                    Type          ServiceName                       Backends            RedirectTo  Status
-169.254.169.253:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP               Done
+Address                    Type          ServiceName                       Backends            Redirect  Status
+169.254.169.253:8080/TCP   LocalRedirect test/lrp-addr:local-redirect      10.244.2.1:80/TCP             Done
 
 -- backends.table --
 Address             Instances

--- a/pkg/loadbalancer/redirectpolicy/testdata/avoid-recompute.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/avoid-recompute.txtar
@@ -170,6 +170,6 @@ test/echo                     k8s
 test/lrp-svc:local-redirect   k8s   
 
 -- frontends.table --
-Address                  Type          ServiceName                  PortName   Backends              RedirectTo                    Status
+Address                  Type          ServiceName                  PortName   Backends              Redirect                      Status
 1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
 [1001::1]:8080/TCP       ClusterIP     test/echo                    tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done

--- a/pkg/loadbalancer/redirectpolicy/testdata/lrp-single-multiple-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/lrp-single-multiple-ports.txtar
@@ -33,7 +33,7 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 
 -- frontends-empty.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
 
 -- lrp-empty.table --
 Name           Type     FrontendType                Frontends
@@ -42,9 +42,9 @@ Name           Type     FrontendType                Frontends
 Name                          Source
 
 -- frontends.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-192.168.10.10:8080/TCP     ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
+192.168.10.10:8080/TCP     ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect Done
 
 -- lrp.table --
 Name           Type     FrontendType                Frontends

--- a/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/no-target-pods.txtar
@@ -167,12 +167,12 @@ test/lrp-addr:local-redirect  k8s
 test/lrp-svc:local-redirect   k8s   
 
 -- frontends-before.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-1.1.1.1:8080/TCP           ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
+1.1.1.1:8080/TCP           ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                               Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                          Done
 
 -- frontends.table --
-Address                  Type          ServiceName                  PortName   Backends              RedirectTo                    Status
-1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-169.254.169.254:8080/TCP LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP                                   Done
-[1001::1]:8080/TCP       ClusterIP     test/echo                    tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
+Address                  Type          ServiceName                  PortName   Backends              Redirect                    Status
+1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect Done
+169.254.169.254:8080/TCP LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP                                 Done
+[1001::1]:8080/TCP       ClusterIP     test/echo                    tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect Done

--- a/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
@@ -53,10 +53,10 @@ Name                  Source
 kube-system/kube-dns  k8s
 
 -- frontends-before.table --
-Address                    Type        ServiceName           PortName   RedirectTo   Status  Backends
-10.96.0.10:53/TCP          ClusterIP   kube-system/kube-dns  dns-tcp                 Done    10.244.1.51:53/TCP, 10.244.1.68:53/TCP
-10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns                     Done    10.244.1.51:53/UDP, 10.244.1.68:53/UDP
-10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics                 Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP
+Address                    Type        ServiceName           PortName   Redirect   Status  Backends
+10.96.0.10:53/TCP          ClusterIP   kube-system/kube-dns  dns-tcp               Done    10.244.1.51:53/TCP, 10.244.1.68:53/TCP
+10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns                   Done    10.244.1.51:53/UDP, 10.244.1.68:53/UDP
+10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics               Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP
 
 -- services-after.table --
 Name                                     Source
@@ -64,13 +64,13 @@ kube-system/kube-dns                     k8s
 kube-system/nodelocaldns:local-redirect  k8s
 
 -- frontends-after.table --
-Address                    Type        ServiceName           PortName   RedirectTo                               Status  Backends
+Address                    Type        ServiceName           PortName   Redirect                                 Status  Backends
 10.96.0.10:53/TCP          ClusterIP   kube-system/kube-dns  dns-tcp    kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/TCP, 10.244.0.226:53/TCP
 10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns        kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/UDP, 10.244.0.226:53/UDP
 10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics                                             Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP
 
 -- frontends-no-pod2.table --
-Address                    Type        ServiceName           PortName   RedirectTo                               Status  Backends
+Address                    Type        ServiceName           PortName   Redirect                                 Status  Backends
 10.96.0.10:53/TCP          ClusterIP   kube-system/kube-dns  dns-tcp    kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/TCP
 10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns        kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/UDP
 10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics                                             Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP

--- a/pkg/loadbalancer/redirectpolicy/testdata/pod-readiness.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/pod-readiness.txtar
@@ -138,10 +138,10 @@ test/lrp-addr:local-redirect  k8s
 test/lrp-svc:local-redirect   k8s
 
 -- frontends-before.table --
-Address                    Type          ServiceName                   PortName   Backends              RedirectTo                    Status
-1.1.1.1:8080/TCP           ClusterIP     test/echo                     tcp                                                            Done
+Address                    Type          ServiceName                PortName   Backends              Redirect                    Status
+1.1.1.1:8080/TCP           ClusterIP     test/echo                  tcp                                                          Done
 
 -- frontends.table --
-Address                  Type          ServiceName                  PortName   Backends              RedirectTo                    Status
-1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-169.254.169.254:8080/TCP LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP                                   Done
+Address                  Type          ServiceName                  PortName   Backends              Redirect                    Status
+1.1.1.1:8080/TCP         ClusterIP     test/echo                    tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect Done
+169.254.169.254:8080/TCP LocalRedirect test/lrp-addr:local-redirect            10.244.2.1:80/TCP                                 Done

--- a/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service.txtar
@@ -96,24 +96,24 @@ Name                          Source
 test/lrp-svc:local-redirect   k8s   
 
 -- frontends-before.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.1.1:7070/UDP                                 Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
-[1001::1]:7070/UDP         ClusterIP   test/echo     udp                                                            Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
+169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.1.1:7070/UDP                               Done
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                               Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp                                                          Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                          Done
 
 -- frontends.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect   Done
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
+169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect Done
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:80/TCP      test/lrp-svc:local-redirect Done
 -- frontends-no-tcp-redirect.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                                 Done
-[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect   Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                            Done
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
+169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect Done
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                               Done
+[1001::1]:7070/UDP         ClusterIP   test/echo     udp        [2001::1]:70/UDP      test/lrp-svc:local-redirect Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp                                                          Done
 
 -- backends-only-redirects.table --
 Address             Instances                           Shadows   NodeName

--- a/pkg/loadbalancer/redirectpolicy/testdata/skiplb-addr.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/skiplb-addr.txtar
@@ -138,9 +138,9 @@ test/lrp-addr-ipv6:local-redirect  k8s
 test/lrp-addr:local-redirect       k8s
 
 -- frontends.table --
-Address                    Type          ServiceName                       PortName   Backends              RedirectTo                    Status
-169.254.169.255:8080/TCP   LocalRedirect test/lrp-addr:local-redirect                 10.244.2.1:80/TCP                                   Done
-[1001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect            [2002::2]:80/TCP                                    Done
+Address                    Type          ServiceName                       PortName   Backends              Redirect  Status
+169.254.169.255:8080/TCP   LocalRedirect test/lrp-addr:local-redirect                 10.244.2.1:80/TCP               Done
+[1001::1]:8080/TCP         LocalRedirect test/lrp-addr-ipv6:local-redirect            [2002::2]:80/TCP                Done
 
 -- maps-case1.expected --
 BE: ID=1 ADDR=10.244.2.1:80/TCP STATE=active

--- a/pkg/loadbalancer/redirectpolicy/testdata/skiplb.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/skiplb.txtar
@@ -157,14 +157,14 @@ test/echo                     k8s
 test/lrp-svc:local-redirect   k8s   
 
 -- frontends.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2002::2]:80/TCP      test/lrp-svc:local-redirect   Done
+Address                    Type        ServiceName   PortName   Backends              Redirect                    Status
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2002::2]:80/TCP      test/lrp-svc:local-redirect Done
 
 -- frontends-noredirect.table --
-Address                    Type        ServiceName   PortName   Backends              RedirectTo        Status
-169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                     Done
-[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:8080/TCP                      Done
+Address                    Type        ServiceName   PortName   Backends              Redirect        Status
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.1.1:8080/TCP                   Done
+[1001::1]:8080/TCP         ClusterIP   test/echo     tcp        [2001::1]:8080/TCP                    Done
 
 -- maps-case1-pre.expected --
 BE: ID=1 ADDR=10.244.1.1:8080/TCP STATE=active

--- a/pkg/loadbalancer/tests/testdata/file.txtar
+++ b/pkg/loadbalancer/tests/testdata/file.txtar
@@ -43,8 +43,8 @@ Name        Source   PortNames   TrafficPolicy   Flags
 test/echo   api      http=80     Cluster
 
 -- frontends.table --
-Address            Type          ServiceName   PortName   Backends         RedirectTo   Status    Error
-172.16.1.1:80/TCP  LoadBalancer  test/echo     http       2.2.2.2:80/TCP                Done
+Address            Type          ServiceName   PortName   Backends         Status    Error
+172.16.1.1:80/TCP  LoadBalancer  test/echo     http       2.2.2.2:80/TCP   Done
 
 -- backends.table --
 Address          Instances          Shadows   NodeName

--- a/pkg/loadbalancer/tests/testdata/loadbalancer-class-wildcards.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer-class-wildcards.txtar
@@ -51,70 +51,70 @@ test/echo-nodeipam   k8s      http=80, https=443   Cluster         LoadBalancerC
 test/echo-other      k8s      http=80, https=443   Cluster         LoadBalancerClass=other
 
 -- frontends.table --
-Address                Type           ServiceName          PortName   Backends                                   RedirectTo   Status
-0.0.0.0:30780/TCP      NodePort       test/echo-default    http       10.244.1.11:80/TCP, 10.244.1.12:80/TCP                  Done
-0.0.0.0:30781/TCP      NodePort       test/echo-default    https      10.244.1.11:443/TCP, 10.244.1.12:443/TCP                Done
-0.0.0.0:30782/TCP      NodePort       test/echo-bgp        http       10.244.1.13:80/TCP, 10.244.1.14:80/TCP                  Done
-0.0.0.0:30783/TCP      NodePort       test/echo-bgp        https      10.244.1.13:443/TCP, 10.244.1.14:443/TCP                Done
-0.0.0.0:30784/TCP      NodePort       test/echo-l2         http       10.244.1.15:80/TCP, 10.244.1.16:80/TCP                  Done
-0.0.0.0:30785/TCP      NodePort       test/echo-l2         https      10.244.1.15:443/TCP, 10.244.1.16:443/TCP                Done
-0.0.0.0:30786/TCP      NodePort       test/echo-nodeipam   http       10.244.1.17:80/TCP, 10.244.1.18:80/TCP                  Done
-0.0.0.0:30787/TCP      NodePort       test/echo-nodeipam   https      10.244.1.17:443/TCP, 10.244.1.18:443/TCP                Done
-0.0.0.0:30788/TCP      NodePort       test/echo-other      http       10.244.1.19:80/TCP, 10.244.1.20:80/TCP                  Done
-0.0.0.0:30789/TCP      NodePort       test/echo-other      https      10.244.1.19:443/TCP, 10.244.1.20:443/TCP                Done
-10.96.50.101:80/TCP    ClusterIP      test/echo-default    http       10.244.1.11:80/TCP, 10.244.1.12:80/TCP                  Done
-10.96.50.101:443/TCP   ClusterIP      test/echo-default    https      10.244.1.11:443/TCP, 10.244.1.12:443/TCP                Done
-10.96.50.102:80/TCP    ClusterIP      test/echo-bgp        http       10.244.1.13:80/TCP, 10.244.1.14:80/TCP                  Done
-10.96.50.102:443/TCP   ClusterIP      test/echo-bgp        https      10.244.1.13:443/TCP, 10.244.1.14:443/TCP                Done
-10.96.50.103:80/TCP    ClusterIP      test/echo-l2         http       10.244.1.15:80/TCP, 10.244.1.16:80/TCP                  Done
-10.96.50.103:443/TCP   ClusterIP      test/echo-l2         https      10.244.1.15:443/TCP, 10.244.1.16:443/TCP                Done
-10.96.50.104:80/TCP    ClusterIP      test/echo-nodeipam   http       10.244.1.17:80/TCP, 10.244.1.18:80/TCP                  Done
-10.96.50.104:443/TCP   ClusterIP      test/echo-nodeipam   https      10.244.1.17:443/TCP, 10.244.1.18:443/TCP                Done
-10.96.50.105:80/TCP    ClusterIP      test/echo-other      http       10.244.1.19:80/TCP, 10.244.1.20:80/TCP                  Done
-10.96.50.105:443/TCP   ClusterIP      test/echo-other      https      10.244.1.19:443/TCP, 10.244.1.20:443/TCP                Done
-172.16.1.1:80/TCP      LoadBalancer   test/echo-default    http       10.244.1.11:80/TCP, 10.244.1.12:80/TCP                  Done
-172.16.1.1:443/TCP     LoadBalancer   test/echo-default    https      10.244.1.11:443/TCP, 10.244.1.12:443/TCP                Done
-172.16.1.2:80/TCP      LoadBalancer   test/echo-bgp        http       10.244.1.13:80/TCP, 10.244.1.14:80/TCP                  Done
-172.16.1.2:443/TCP     LoadBalancer   test/echo-bgp        https      10.244.1.13:443/TCP, 10.244.1.14:443/TCP                Done
-172.16.1.3:80/TCP      LoadBalancer   test/echo-l2         http       10.244.1.15:80/TCP, 10.244.1.16:80/TCP                  Done
-172.16.1.3:443/TCP     LoadBalancer   test/echo-l2         https      10.244.1.15:443/TCP, 10.244.1.16:443/TCP                Done
-172.16.1.4:80/TCP      LoadBalancer   test/echo-nodeipam   http       10.244.1.17:80/TCP, 10.244.1.18:80/TCP                  Done
-172.16.1.4:443/TCP     LoadBalancer   test/echo-nodeipam   https      10.244.1.17:443/TCP, 10.244.1.18:443/TCP                Done
-172.16.1.5:80/TCP      LoadBalancer   test/echo-other      http       10.244.1.19:80/TCP, 10.244.1.20:80/TCP                  Done
-172.16.1.5:443/TCP     LoadBalancer   test/echo-other      https      10.244.1.19:443/TCP, 10.244.1.20:443/TCP                Done
+Address                Type           ServiceName          PortName   Backends                                   Status
+0.0.0.0:30780/TCP      NodePort       test/echo-default    http       10.244.1.11:80/TCP, 10.244.1.12:80/TCP     Done
+0.0.0.0:30781/TCP      NodePort       test/echo-default    https      10.244.1.11:443/TCP, 10.244.1.12:443/TCP   Done
+0.0.0.0:30782/TCP      NodePort       test/echo-bgp        http       10.244.1.13:80/TCP, 10.244.1.14:80/TCP     Done
+0.0.0.0:30783/TCP      NodePort       test/echo-bgp        https      10.244.1.13:443/TCP, 10.244.1.14:443/TCP   Done
+0.0.0.0:30784/TCP      NodePort       test/echo-l2         http       10.244.1.15:80/TCP, 10.244.1.16:80/TCP     Done
+0.0.0.0:30785/TCP      NodePort       test/echo-l2         https      10.244.1.15:443/TCP, 10.244.1.16:443/TCP   Done
+0.0.0.0:30786/TCP      NodePort       test/echo-nodeipam   http       10.244.1.17:80/TCP, 10.244.1.18:80/TCP     Done
+0.0.0.0:30787/TCP      NodePort       test/echo-nodeipam   https      10.244.1.17:443/TCP, 10.244.1.18:443/TCP   Done
+0.0.0.0:30788/TCP      NodePort       test/echo-other      http       10.244.1.19:80/TCP, 10.244.1.20:80/TCP     Done
+0.0.0.0:30789/TCP      NodePort       test/echo-other      https      10.244.1.19:443/TCP, 10.244.1.20:443/TCP   Done
+10.96.50.101:80/TCP    ClusterIP      test/echo-default    http       10.244.1.11:80/TCP, 10.244.1.12:80/TCP     Done
+10.96.50.101:443/TCP   ClusterIP      test/echo-default    https      10.244.1.11:443/TCP, 10.244.1.12:443/TCP   Done
+10.96.50.102:80/TCP    ClusterIP      test/echo-bgp        http       10.244.1.13:80/TCP, 10.244.1.14:80/TCP     Done
+10.96.50.102:443/TCP   ClusterIP      test/echo-bgp        https      10.244.1.13:443/TCP, 10.244.1.14:443/TCP   Done
+10.96.50.103:80/TCP    ClusterIP      test/echo-l2         http       10.244.1.15:80/TCP, 10.244.1.16:80/TCP     Done
+10.96.50.103:443/TCP   ClusterIP      test/echo-l2         https      10.244.1.15:443/TCP, 10.244.1.16:443/TCP   Done
+10.96.50.104:80/TCP    ClusterIP      test/echo-nodeipam   http       10.244.1.17:80/TCP, 10.244.1.18:80/TCP     Done
+10.96.50.104:443/TCP   ClusterIP      test/echo-nodeipam   https      10.244.1.17:443/TCP, 10.244.1.18:443/TCP   Done
+10.96.50.105:80/TCP    ClusterIP      test/echo-other      http       10.244.1.19:80/TCP, 10.244.1.20:80/TCP     Done
+10.96.50.105:443/TCP   ClusterIP      test/echo-other      https      10.244.1.19:443/TCP, 10.244.1.20:443/TCP   Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo-default    http       10.244.1.11:80/TCP, 10.244.1.12:80/TCP     Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo-default    https      10.244.1.11:443/TCP, 10.244.1.12:443/TCP   Done
+172.16.1.2:80/TCP      LoadBalancer   test/echo-bgp        http       10.244.1.13:80/TCP, 10.244.1.14:80/TCP     Done
+172.16.1.2:443/TCP     LoadBalancer   test/echo-bgp        https      10.244.1.13:443/TCP, 10.244.1.14:443/TCP   Done
+172.16.1.3:80/TCP      LoadBalancer   test/echo-l2         http       10.244.1.15:80/TCP, 10.244.1.16:80/TCP     Done
+172.16.1.3:443/TCP     LoadBalancer   test/echo-l2         https      10.244.1.15:443/TCP, 10.244.1.16:443/TCP   Done
+172.16.1.4:80/TCP      LoadBalancer   test/echo-nodeipam   http       10.244.1.17:80/TCP, 10.244.1.18:80/TCP     Done
+172.16.1.4:443/TCP     LoadBalancer   test/echo-nodeipam   https      10.244.1.17:443/TCP, 10.244.1.18:443/TCP   Done
+172.16.1.5:80/TCP      LoadBalancer   test/echo-other      http       10.244.1.19:80/TCP, 10.244.1.20:80/TCP     Done
+172.16.1.5:443/TCP     LoadBalancer   test/echo-other      https      10.244.1.19:443/TCP, 10.244.1.20:443/TCP   Done
 
 -- frontends_nobackends.table --
-Address                Type           ServiceName          PortName   Backends   RedirectTo   Status
-0.0.0.0:30780/TCP      NodePort       test/echo-default    http                               Done
-0.0.0.0:30781/TCP      NodePort       test/echo-default    https                              Done
-0.0.0.0:30782/TCP      NodePort       test/echo-bgp        http                               Done
-0.0.0.0:30783/TCP      NodePort       test/echo-bgp        https                              Done
-0.0.0.0:30784/TCP      NodePort       test/echo-l2         http                               Done
-0.0.0.0:30785/TCP      NodePort       test/echo-l2         https                              Done
-0.0.0.0:30786/TCP      NodePort       test/echo-nodeipam   http                               Done
-0.0.0.0:30787/TCP      NodePort       test/echo-nodeipam   https                              Done
-0.0.0.0:30788/TCP      NodePort       test/echo-other      http                               Done
-0.0.0.0:30789/TCP      NodePort       test/echo-other      https                              Done
-10.96.50.101:80/TCP    ClusterIP      test/echo-default    http                               Done
-10.96.50.101:443/TCP   ClusterIP      test/echo-default    https                              Done
-10.96.50.102:80/TCP    ClusterIP      test/echo-bgp        http                               Done
-10.96.50.102:443/TCP   ClusterIP      test/echo-bgp        https                              Done
-10.96.50.103:80/TCP    ClusterIP      test/echo-l2         http                               Done
-10.96.50.103:443/TCP   ClusterIP      test/echo-l2         https                              Done
-10.96.50.104:80/TCP    ClusterIP      test/echo-nodeipam   http                               Done
-10.96.50.104:443/TCP   ClusterIP      test/echo-nodeipam   https                              Done
-10.96.50.105:80/TCP    ClusterIP      test/echo-other      http                               Done
-10.96.50.105:443/TCP   ClusterIP      test/echo-other      https                              Done
-172.16.1.1:80/TCP      LoadBalancer   test/echo-default    http                               Done
-172.16.1.1:443/TCP     LoadBalancer   test/echo-default    https                              Done
-172.16.1.2:80/TCP      LoadBalancer   test/echo-bgp        http                               Done
-172.16.1.2:443/TCP     LoadBalancer   test/echo-bgp        https                              Done
-172.16.1.3:80/TCP      LoadBalancer   test/echo-l2         http                               Done
-172.16.1.3:443/TCP     LoadBalancer   test/echo-l2         https                              Done
-172.16.1.4:80/TCP      LoadBalancer   test/echo-nodeipam   http                               Done
-172.16.1.4:443/TCP     LoadBalancer   test/echo-nodeipam   https                              Done
-172.16.1.5:80/TCP      LoadBalancer   test/echo-other      http                               Done
-172.16.1.5:443/TCP     LoadBalancer   test/echo-other      https                              Done
+Address                Type           ServiceName          PortName   Backends   Status
+0.0.0.0:30780/TCP      NodePort       test/echo-default    http                  Done
+0.0.0.0:30781/TCP      NodePort       test/echo-default    https                 Done
+0.0.0.0:30782/TCP      NodePort       test/echo-bgp        http                  Done
+0.0.0.0:30783/TCP      NodePort       test/echo-bgp        https                 Done
+0.0.0.0:30784/TCP      NodePort       test/echo-l2         http                  Done
+0.0.0.0:30785/TCP      NodePort       test/echo-l2         https                 Done
+0.0.0.0:30786/TCP      NodePort       test/echo-nodeipam   http                  Done
+0.0.0.0:30787/TCP      NodePort       test/echo-nodeipam   https                 Done
+0.0.0.0:30788/TCP      NodePort       test/echo-other      http                  Done
+0.0.0.0:30789/TCP      NodePort       test/echo-other      https                 Done
+10.96.50.101:80/TCP    ClusterIP      test/echo-default    http                  Done
+10.96.50.101:443/TCP   ClusterIP      test/echo-default    https                 Done
+10.96.50.102:80/TCP    ClusterIP      test/echo-bgp        http                  Done
+10.96.50.102:443/TCP   ClusterIP      test/echo-bgp        https                 Done
+10.96.50.103:80/TCP    ClusterIP      test/echo-l2         http                  Done
+10.96.50.103:443/TCP   ClusterIP      test/echo-l2         https                 Done
+10.96.50.104:80/TCP    ClusterIP      test/echo-nodeipam   http                  Done
+10.96.50.104:443/TCP   ClusterIP      test/echo-nodeipam   https                 Done
+10.96.50.105:80/TCP    ClusterIP      test/echo-other      http                  Done
+10.96.50.105:443/TCP   ClusterIP      test/echo-other      https                 Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo-default    http                  Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo-default    https                 Done
+172.16.1.2:80/TCP      LoadBalancer   test/echo-bgp        http                  Done
+172.16.1.2:443/TCP     LoadBalancer   test/echo-bgp        https                 Done
+172.16.1.3:80/TCP      LoadBalancer   test/echo-l2         http                  Done
+172.16.1.3:443/TCP     LoadBalancer   test/echo-l2         https                 Done
+172.16.1.4:80/TCP      LoadBalancer   test/echo-nodeipam   http                  Done
+172.16.1.4:443/TCP     LoadBalancer   test/echo-nodeipam   https                 Done
+172.16.1.5:80/TCP      LoadBalancer   test/echo-other      http                  Done
+172.16.1.5:443/TCP     LoadBalancer   test/echo-other      https                 Done
 
 -- backends.table --
 Address               Instances                    Shadows   NodeName

--- a/pkg/loadbalancer/tests/testdata/loadbalancer-multiport.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer-multiport.txtar
@@ -47,22 +47,22 @@ Name        Source   PortNames            TrafficPolicy   Flags
 test/echo   k8s      http=80, https=443   Cluster
 
 -- frontends.table --
-Address                Type           ServiceName   PortName   Backends                                 RedirectTo   Status
-0.0.0.0:30781/TCP      NodePort       test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
-0.0.0.0:30782/TCP      NodePort       test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
-10.96.50.104:80/TCP    ClusterIP      test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
-10.96.50.104:443/TCP   ClusterIP      test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
-172.16.1.1:80/TCP      LoadBalancer   test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
-172.16.1.1:443/TCP     LoadBalancer   test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
+Address                Type           ServiceName   PortName   Backends                                 Status
+0.0.0.0:30781/TCP      NodePort       test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP     Done
+0.0.0.0:30782/TCP      NodePort       test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP   Done
+10.96.50.104:80/TCP    ClusterIP      test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP     Done
+10.96.50.104:443/TCP   ClusterIP      test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP   Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP     Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP   Done
 
 -- frontends_nobackends.table --
-Address                Type           ServiceName   PortName   Backends   RedirectTo   Status
-0.0.0.0:30781/TCP      NodePort       test/echo     http                               Done
-0.0.0.0:30782/TCP      NodePort       test/echo     https                              Done
-10.96.50.104:80/TCP    ClusterIP      test/echo     http                               Done
-10.96.50.104:443/TCP   ClusterIP      test/echo     https                              Done
-172.16.1.1:80/TCP      LoadBalancer   test/echo     http                               Done
-172.16.1.1:443/TCP     LoadBalancer   test/echo     https                              Done
+Address                Type           ServiceName   PortName   Backends   Status
+0.0.0.0:30781/TCP      NodePort       test/echo     http                  Done
+0.0.0.0:30782/TCP      NodePort       test/echo     https                 Done
+10.96.50.104:80/TCP    ClusterIP      test/echo     http                  Done
+10.96.50.104:443/TCP   ClusterIP      test/echo     https                 Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo     http                  Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo     https                 Done
 
 -- backends.table --
 Address              Instances           Shadows   NodeName

--- a/pkg/loadbalancer/tests/testdata/loadbalancer-multiprotocol.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer-multiprotocol.txtar
@@ -47,28 +47,28 @@ Name        Source   PortNames                      TrafficPolicy   Flags
 test/echo   k8s      dtls=443, http=80, https=443   Cluster         
 
 -- frontends.table --
-Address                Type           ServiceName   PortName   Backends                                 RedirectTo   Status
-0.0.0.0:30781/TCP      NodePort       test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
-0.0.0.0:30782/TCP      NodePort       test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
-0.0.0.0:30782/UDP      NodePort       test/echo     dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP                Done
-10.96.50.104:80/TCP    ClusterIP      test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
-10.96.50.104:443/TCP   ClusterIP      test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
-10.96.50.104:443/UDP   ClusterIP      test/echo     dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP                Done
-172.16.1.1:80/TCP      LoadBalancer   test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
-172.16.1.1:443/TCP     LoadBalancer   test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
-172.16.1.1:443/UDP     LoadBalancer   test/echo     dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP                Done
+Address                Type           ServiceName   PortName   Backends                                 Status
+0.0.0.0:30781/TCP      NodePort       test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP     Done
+0.0.0.0:30782/TCP      NodePort       test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP   Done
+0.0.0.0:30782/UDP      NodePort       test/echo     dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP   Done
+10.96.50.104:80/TCP    ClusterIP      test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP     Done
+10.96.50.104:443/TCP   ClusterIP      test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP   Done
+10.96.50.104:443/UDP   ClusterIP      test/echo     dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP   Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo     http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP     Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo     https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP   Done
+172.16.1.1:443/UDP     LoadBalancer   test/echo     dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP   Done
 
 -- frontends_nobackends.table --
-Address                Type           ServiceName   PortName   Backends   RedirectTo   Status
-0.0.0.0:30781/TCP      NodePort       test/echo     http                               Done
-0.0.0.0:30782/TCP      NodePort       test/echo     https                              Done
-0.0.0.0:30782/UDP      NodePort       test/echo     dtls                               Done
-10.96.50.104:80/TCP    ClusterIP      test/echo     http                               Done
-10.96.50.104:443/TCP   ClusterIP      test/echo     https                              Done
-10.96.50.104:443/UDP   ClusterIP      test/echo     dtls                               Done
-172.16.1.1:80/TCP      LoadBalancer   test/echo     http                               Done
-172.16.1.1:443/TCP     LoadBalancer   test/echo     https                              Done
-172.16.1.1:443/UDP     LoadBalancer   test/echo     dtls                               Done
+Address                Type           ServiceName   PortName   Backends   Status
+0.0.0.0:30781/TCP      NodePort       test/echo     http                  Done
+0.0.0.0:30782/TCP      NodePort       test/echo     https                 Done
+0.0.0.0:30782/UDP      NodePort       test/echo     dtls                  Done
+10.96.50.104:80/TCP    ClusterIP      test/echo     http                  Done
+10.96.50.104:443/TCP   ClusterIP      test/echo     https                 Done
+10.96.50.104:443/UDP   ClusterIP      test/echo     dtls                  Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo     http                  Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo     https                 Done
+172.16.1.1:443/UDP     LoadBalancer   test/echo     dtls                  Done
 
 -- backends.table --
 Address              Instances           Shadows   NodeName

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -119,7 +119,7 @@ Address              Instances
     }
   ],
   "ID": 1,
-  "RedirectTo": null
+  "Redirect": null
 }
 {
   "Address": "[2001::1]:80/TCP",
@@ -165,7 +165,7 @@ Address              Instances
     }
   ],
   "ID": 2,
-  "RedirectTo": null
+  "Redirect": null
 }
 -- backends-expected.json --
 {
@@ -275,7 +275,7 @@ healthcheckbackends:
       unhealthy: false
       unhealthyupdatedat: null
 id: 1
-redirectto: null
+redirect: null
 ---
 frontendparams:
     address: '[2001::1]:80/TCP'
@@ -312,7 +312,7 @@ healthcheckbackends:
       unhealthy: false
       unhealthyupdatedat: null
 id: 2
-redirectto: null
+redirect: null
 -- backends-expected.yaml --
 address: 10.244.1.1:8080/TCP
 instances:


### PR DESCRIPTION
Prior to Cilium v1.18 LRP supported address-based redirection of an address that was also referenced by a Kubernetes service. This changed in v1.18 due to the load-balancer control-plane rewrite.

This brings back the support for it by adding [Frontend.Shadows] field to store the frontend shadowed by the LRP frontend. When LRP is removed the original frontend is restored.

Fixes: #43800

```release-note
Fixed regression in local redirect policies that prohibited redirecting addresses already used by Kubernetes services
```
