### PR TITLE
.github/workflows: fix renovate deployment

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -42,7 +42,7 @@ jobs:
           LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
         with:
           # renovate: datasource=github-releases depName=renovatebot/renovate
-          renovate-version: 42.80.3
+          renovate-version: 42.83.0
           docker-user: root
           docker-cmd-file: .github/actions/renovate/entrypoint.sh
           configurationFile: .github/renovate.json5


### PR DESCRIPTION
It seems renovate updated itself with an image tag that doesn't exist and caused it to stop working.

Fixes: 666e29a50d69 ("chore(deps): update all-dependencies")