### PR TITLE
fix(helm): add missing proxy-stream-idle-timeout-seconds to configmap template

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1468,6 +1468,7 @@ data:
   proxy-max-requests-per-connection: {{ .Values.envoy.maxRequestsPerConnection | quote }}
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}
   proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
+  proxy-stream-idle-timeout-seconds: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}
   proxy-max-concurrent-retries: {{ .Values.envoy.maxConcurrentRetries | quote }}
   proxy-use-original-source-address: {{ .Values.envoy.useOriginalSourceAddress | quote }}
   proxy-cluster-max-connections: {{ .Values.envoy.clusterMaxConnections | quote }}


### PR DESCRIPTION
Added missing proxy-stream-idle-timeout-seconds entry in cilium configmap template related to envoy streamIdleTimeout config.

<!-- Description of change -->

Fixes: #43814

```release-note
fix(helm): add missing proxy-stream-idle-timeout-seconds to configmap template
```
