### PR TITLE
fix(helm): add missing proxy-stream-idle-timeout-seconds to configmap template

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1373,6 +1373,7 @@ data:
   proxy-max-requests-per-connection: {{ .Values.envoy.maxRequestsPerConnection | quote }}
   proxy-max-connection-duration-seconds: {{ .Values.envoy.maxConnectionDurationSeconds | quote }}
   proxy-idle-timeout-seconds: {{ .Values.envoy.idleTimeoutDurationSeconds | quote }}
+  proxy-stream-idle-timeout-seconds: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}
   proxy-max-concurrent-retries: {{ .Values.envoy.maxConcurrentRetries | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
   http-stream-idle-timeout: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}


### PR DESCRIPTION
Added missing proxy-stream-idle-timeout-seconds entry in cilium configmap template related to envoy streamIdleTimeout config.

<!-- Description of change -->

Fixes: #43814

```release-note
fix(helm): add missing proxy-stream-idle-timeout-seconds to configmap template
```
