### PR TITLE
cli: add status output hooks

### DIFF
--- a/cilium-cli/api/api.go
+++ b/cilium-cli/api/api.go
@@ -78,3 +78,17 @@ func (*NopHooks) AddConnectivityTests(...*check.ConnectivityTest) error         
 func (*NopHooks) DetectFeatures(context.Context, *check.ConnectivityTest) error   { return nil }
 func (*NopHooks) SetupAndValidate(context.Context, *check.ConnectivityTest) error { return nil }
 func (*NopHooks) InitializeCommand(*cobra.Command)                                {}
+
+// StatusOutputHooks allows downstreams to modify the rendered status output
+// without changing status.Status.
+type StatusOutputHooks interface {
+	TransformSummary(string) string
+	TransformJSON([]byte) ([]byte, error)
+}
+
+type NopStatusOutputHooks struct{}
+
+var _ StatusOutputHooks = &NopStatusOutputHooks{}
+
+func (*NopStatusOutputHooks) TransformSummary(s string) string       { return s }
+func (*NopStatusOutputHooks) TransformJSON(b []byte) ([]byte, error) { return b, nil }

--- a/cilium-cli/cli/cmd.go
+++ b/cilium-cli/cli/cmd.go
@@ -122,7 +122,7 @@ Perform a connectivity test
 		newCmdEncrypt(),
 		newCmdHubble(),
 		newCmdMulticast(),
-		newCmdStatus(),
+		newCmdStatus(&api.NopStatusOutputHooks{}),
 		newCmdSysdump(hooks),
 		newCmdVersion(),
 		newCmdInstallWithHelm(),


### PR DESCRIPTION
Introduce StatusOutputHooks to let downstreams transform the status summary and JSON output without touching status.Status. Wire the hooks through the status command and provide a no-op implementation, ensuring error paths still emit the formatted status.
