### PR TITLE
gateway-api/ingress: add HTTP/3 (QUIC) support for HTTPS listeners

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -270,6 +270,7 @@ data:
 
 {{- if or .Values.envoyConfig.enabled .Values.ingressController.enabled .Values.gatewayAPI.enabled (and (hasKey .Values "loadBalancer") (eq .Values.loadBalancer.l7.backend "envoy")) }}
   enable-envoy-config: "true"
+  enable-envoy-http3: {{ .Values.envoyConfig.enableHttp3 | quote }}
   envoy-config-retry-interval: {{ include "validateDuration" .Values.envoyConfig.retryInterval | quote }}
   {{- if .Values.envoyConfig.enabled }}
   envoy-secrets-namespace: {{ .Values.envoyConfig.secretsNamespace.name | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -935,6 +935,9 @@ envoyConfig:
   # -- Enable CiliumEnvoyConfig CRD
   # CiliumEnvoyConfig CRD can also be implicitly enabled by other options.
   enabled: false
+  # -- Enable HTTP/3 (QUIC) support for both Ingress and Gateway API HTTPS listeners.
+  # When enabled, UDP listeners will be created alongside TCP listeners for HTTPS ports.
+  enableHttp3: false
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve secrets from.
   secretsNamespace:
     # -- Create secrets namespace for CiliumEnvoyConfig CRDs.

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -176,6 +176,9 @@ const (
 	// ProxyStreamIdleTimeoutSeconds is the stream timeout for proxy connections to upstream clusters
 	ProxyStreamIdleTimeoutSeconds = "proxy-stream-idle-timeout-seconds"
 
+	// EnableEnvoyHTTP3 enables HTTP/3 (QUIC) support for Ingress and Gateway API HTTPS listeners
+	EnableEnvoyHTTP3 = "enable-envoy-http3"
+
 	// EnableGatewayAPI enables support of Gateway API
 	// This must be enabled along with enable-envoy-config in cilium agent.
 	EnableGatewayAPI = "enable-gateway-api"
@@ -368,6 +371,9 @@ type OperatorConfig struct {
 	// ProxyStreamIdleTimeoutSeconds is the stream idle timeout for the proxy to upstream cluster
 	ProxyStreamIdleTimeoutSeconds int
 
+	// EnableEnvoyHTTP3 enables HTTP/3 (QUIC) support for Ingress and Gateway API HTTPS listeners
+	EnableEnvoyHTTP3 bool
+
 	// CiliumK8sNamespace is the namespace where Cilium pods are running.
 	CiliumK8sNamespace string
 
@@ -418,6 +424,7 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	if c.ProxyStreamIdleTimeoutSeconds == 0 {
 		c.ProxyStreamIdleTimeoutSeconds = DefaultProxyStreamIdleTimeoutSeconds
 	}
+	c.EnableEnvoyHTTP3 = vp.GetBool(EnableEnvoyHTTP3)
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
 	c.TaintSyncWorkers = vp.GetInt(TaintSyncWorkers)
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -256,6 +256,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
 			XFFNumTrustedHops: params.GatewayApiConfig.GatewayAPIXffNumTrustedHops,
 		},
+		HTTP3Enabled: params.OperatorConfig.EnableEnvoyHTTP3,
 	}
 	cecTranslator := translation.NewCECTranslator(cfg)
 

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -131,6 +131,7 @@ func registerReconciler(params ingressParams) error {
 		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
 			XFFNumTrustedHops: params.IngressConfig.IngressDefaultXffNumTrustedHops,
 		},
+		HTTP3Enabled: params.OperatorConfig.EnableEnvoyHTTP3,
 	})
 
 	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(params.Logger, cecTranslator, params.IngressConfig.IngressHostnetworkEnabled)

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -544,6 +544,27 @@ func (m *Model) AllPorts() []uint32 {
 	return slices.SortedUnique(ports)
 }
 
+// HasHTTPSPort returns true if the model has an HTTPS listener on the specified port.
+func (m *Model) HasHTTPSPort(port uint32) bool {
+	for _, l := range m.HTTP {
+		if l.Port == port && len(l.TLS) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// HTTPSPorts returns a list of unique ports for HTTPS listeners (HTTP listeners with TLS).
+func (m *Model) HTTPSPorts() []uint32 {
+	var ports []uint32
+	for _, l := range m.HTTP {
+		if len(l.TLS) > 0 {
+			ports = append(ports, l.Port)
+		}
+	}
+	return slices.SortedUnique(ports)
+}
+
 // TLSBackendsToHostnames returns a map of TLS backends to hostnames.
 // This is only for TLS Passthrough listeners.
 func (m *Model) TLSBackendsToHostnames() map[string][]string {

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -78,6 +78,10 @@ type Config struct {
 	ClusterConfig             ClusterConfig             `json:"cluster_config"`
 	RouteConfig               RouteConfig               `json:"route_config"`
 	OriginalIPDetectionConfig OriginalIPDetectionConfig `json:"original_ip_detection_config"`
+
+	// HTTP3Enabled enables HTTP/3 (QUIC) support for HTTPS listeners.
+	// When enabled, UDP listeners will be created alongside TCP listeners for HTTPS ports.
+	HTTP3Enabled bool `json:"http3_enabled,omitempty"`
 }
 
 // cecTranslator is the translator from model to CiliumEnvoyConfig

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -247,3 +247,180 @@ func Test_withHostNetworkPortSorted(t *testing.T) {
 		t.Errorf("Modified Envoy Listeners did not match for different order of http listener ports:\n%s\n", diffOutput)
 	}
 }
+
+func Test_getListenerAddresses(t *testing.T) {
+	testCases := []struct {
+		desc                       string
+		ports                      []uint32
+		protocol                   envoy_config_core_v3.SocketAddress_Protocol
+		ipv4Enabled                bool
+		ipv6Enabled                bool
+		expectedPrimaryAddress     *envoy_config_core_v3.Address
+		expectedAdditionalAdresses []*envoy_config_listener.AdditionalAddress
+	}{
+		{
+			desc:                       "No ports - no address",
+			protocol:                   envoy_config_core_v3.SocketAddress_UDP,
+			ipv4Enabled:                true,
+			ipv6Enabled:                true,
+			expectedPrimaryAddress:     nil,
+			expectedAdditionalAdresses: nil,
+		},
+		{
+			desc:        "UDP IPv4 only",
+			ports:       []uint32{443},
+			protocol:    envoy_config_core_v3.SocketAddress_UDP,
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedPrimaryAddress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_UDP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 443,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: nil,
+		},
+		{
+			desc:        "UDP IPv4 & IPv6",
+			ports:       []uint32{443},
+			protocol:    envoy_config_core_v3.SocketAddress_UDP,
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+			expectedPrimaryAddress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_UDP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 443,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: []*envoy_config_listener.AdditionalAddress{
+				{
+					Address: &envoy_config_core_v3.Address{
+						Address: &envoy_config_core_v3.Address_SocketAddress{
+							SocketAddress: &envoy_config_core_v3.SocketAddress{
+								Protocol: envoy_config_core_v3.SocketAddress_UDP,
+								Address:  "::",
+								PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+									PortValue: 443,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:        "Fallback to IPv4 when neither enabled",
+			ports:       []uint32{443},
+			protocol:    envoy_config_core_v3.SocketAddress_UDP,
+			ipv4Enabled: false,
+			ipv6Enabled: false,
+			expectedPrimaryAddress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol: envoy_config_core_v3.SocketAddress_UDP,
+						Address:  "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+							PortValue: 443,
+						},
+					},
+				},
+			},
+			expectedAdditionalAdresses: nil,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			primaryAddress, additionalAddresses := getListenerAddresses(tC.ports, tC.protocol, tC.ipv4Enabled, tC.ipv6Enabled)
+
+			assert.Equal(t, tC.expectedPrimaryAddress, primaryAddress)
+			assert.Equal(t, tC.expectedAdditionalAdresses, additionalAddresses)
+		})
+	}
+}
+
+func Test_buildTLSSdsConfigs(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		namespace     string
+		secrets       []model.TLSSecret
+		expectedNames []string
+	}{
+		{
+			desc:          "Empty secrets",
+			namespace:     "cilium-secrets",
+			secrets:       nil,
+			expectedNames: nil,
+		},
+		{
+			desc:      "Single secret",
+			namespace: "cilium-secrets",
+			secrets: []model.TLSSecret{
+				{Namespace: "default", Name: "my-cert"},
+			},
+			expectedNames: []string{"cilium-secrets/default-my-cert"},
+		},
+		{
+			desc:      "Multiple secrets are sorted",
+			namespace: "cilium-secrets",
+			secrets: []model.TLSSecret{
+				{Namespace: "ns-b", Name: "cert-2"},
+				{Namespace: "ns-a", Name: "cert-1"},
+			},
+			expectedNames: []string{
+				"cilium-secrets/ns-a-cert-1",
+				"cilium-secrets/ns-b-cert-2",
+			},
+		},
+		{
+			desc:      "Duplicate secrets are deduplicated",
+			namespace: "cilium-secrets",
+			secrets: []model.TLSSecret{
+				{Namespace: "default", Name: "cert"},
+				{Namespace: "default", Name: "cert"},
+			},
+			expectedNames: []string{"cilium-secrets/default-cert"},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			configs := buildTLSSdsConfigs(tC.namespace, tC.secrets)
+
+			var names []string
+			for _, c := range configs {
+				names = append(names, c.Name)
+			}
+
+			assert.Equal(t, tC.expectedNames, names)
+		})
+	}
+}
+
+func Test_toTransportSocket(t *testing.T) {
+	socket, err := toTransportSocket("cilium-secrets", []model.TLSSecret{
+		{Namespace: "default", Name: "test-cert"},
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, socket)
+	assert.Equal(t, "envoy.transport_sockets.tls", socket.Name)
+}
+
+func Test_toQuicTransportSocket(t *testing.T) {
+	socket, err := toQuicTransportSocket("cilium-secrets", []model.TLSSecret{
+		{Namespace: "default", Name: "test-cert"},
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, socket)
+	assert.Equal(t, "envoy.transport_sockets.quic", socket.Name)
+}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -372,7 +372,7 @@ func Test_getService(t *testing.T) {
 					ExternalTrafficPolicy: tt.args.externalTrafficPolicy,
 				},
 			}}
-			got := trans.desiredService(nil, tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
+			got := trans.desiredService(nil, tt.args.resource, tt.args.allPorts, nil, tt.args.labels, tt.args.annotations)
 			assert.Equalf(t, tt.want, got, "desiredService(%v, %v, %v, %v)", tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
 			assert.LessOrEqual(t, len(got.Name), 63, "Service name is too long")
 		})


### PR DESCRIPTION
Hi Cilium team, @youngnick ! 👋

I understand that this PR in its current form may not be ready for merging as-is, and the architecture likely needs to be discussed. I'm opening this PR primarily to **start a conversation** about how HTTP/3 support could be properly integrated into Cilium.

I need this feature **ASAP** for my own projects, so I've implemented a working solution. I'm happy to iterate on the implementation based on your feedback and align it with Cilium's architectural guidelines.

Fixes: #28497

---

This PR adds HTTP/3 (QUIC) support for Cilium Ingress and Gateway API HTTPS listeners.

## Changes

When `envoyConfig.enableHttp3` is enabled in Helm values (or `--enable-envoy-http3` flag), 
UDP listeners are automatically created alongside TCP listeners for all HTTPS ports. This enables 
HTTP/3 protocol support via Envoy's QUIC implementation.

### Key implementation details:

- Added new Helm value `envoyConfig.enableHttp3` (default: false)
- Added operator flag `--enable-envoy-http3`
- For each HTTPS listener (HTTP listener with TLS), a corresponding UDP listener is created
- UDP listeners use the same port number as TCP listeners
- Alt-Svc header is automatically added to HTTP responses to advertise HTTP/3 availability
- Extended CiliumEnvoyConfig resource parser to handle UDP listener protocol

### Files changed:

- `install/kubernetes/cilium/values.yaml` - Added `enableHttp3` option
- `install/kubernetes/cilium/templates/cilium-configmap.yaml` - Pass config to operator
- `operator/option/config.go` - Added EnableEnvoyHTTP3 config option
- `operator/pkg/gateway-api/cell.go` - Pass HTTP3 config to translator
- `operator/pkg/ingress/cell.go` - Pass HTTP3 config to translator
- `operator/pkg/model/model.go` - Added HTTPSPorts() and HasHTTPSPort() helpers
- `operator/pkg/model/translation/cec_translator.go` - Pass HTTP3 flag
- `operator/pkg/model/translation/envoy_listener.go` - Core HTTP/3 listener implementation
- `operator/pkg/model/translation/envoy_listener_test.go` - Unit tests for HTTP/3
- `operator/pkg/model/translation/gateway-api/translator.go` - Pass HTTP3 config and HTTPS ports
- `pkg/ciliumenvoyconfig/cec_resource_parser.go` - Handle UDP protocol for listeners

## Testing

- Unit tests added for HTTP/3 listener generation
- Manual testing with Gateway API and Ingress resources

## Usage

Enable HTTP/3 support in Helm values:

```yaml
envoyConfig:
  enabled: true
  enableHttp3: true
```

Or via CLI flag:
```
--enable-envoy-http3=true
```

```release-note
Add HTTP/3 (QUIC) support for Ingress and Gateway API HTTPS listeners. Enable with `envoyConfig.enableHttp3: true` in Helm values.
```