### PR TITLE
bpf: correct comments in cil_from_netdev function

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1173,10 +1173,7 @@ drop_err_ingress: __maybe_unused
 
 /*
  * from-netdev is attached as a tc ingress filter to one or more physical devices
- * managed by Cilium (e.g., eth0). This program is only attached when:
- * - the host firewall is enabled, or
- * - BPF NodePort is enabled, or
- * - L2 announcements are enabled
+ * managed by Cilium (e.g., eth0).
  */
 __section_entry
 int cil_from_netdev(struct __ctx_buff *ctx)


### PR DESCRIPTION
Removing conditions from the comment block describing the cil_from_netdev function since the logic has been changed.

with the current codebase, we dont have the condition to attach the cil_from_netdev for certain features.


In my test environment I dont have BPF Nodeport, Host firewall nor L2 announcements.

```
KubeProxyReplacement Details:
  Status:               False
  Socket LB:            Disabled
  Socket LB Tracing:    Disabled
  Socket LB Coverage:   Full
  Session Affinity:     Enabled
  NAT46/64 Support:     Disabled
  Services:
  - ClusterIP:      Enabled                                                                                                                                                                  - NodePort:       Disabled
  - LoadBalancer:   Disabled
  - externalIPs:    Disabled
  - HostPort:       Disabled

Host firewall:          Disabled


kn logs cilium-9ch6s | grep l2
time=2026-01-18T19:15:00.128901398Z level=info msg="  --enable-l2-announcements='false'"
time=2026-01-18T19:15:00.128904315Z level=info msg="  --enable-l2-neigh-discovery='false'"
time=2026-01-18T19:15:00.128907898Z level=info msg="  --enable-l2-pod-announcements='false'"
```

but I still have 

```
root@kind-worker3:/home/cilium# bpftool net list
xdp:

tc:
eth0(13) clsact/ingress cil_from_netdev-eth0 id 1266
```

when I check the loader, I can see it's just going through the devices without condition like others

https://github.com/liyihuang/cilium/blob/db2182352aae62a0178a1e3c1f858e570c847bb8/pkg/datapath/loader/host.go#L254-L257


