### PR TITLE
v1.18 Backports 2026-01-19

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -307,7 +307,7 @@ jobs:
             --action ALLOW \
             --rules esp \
             --priority 1000 \
-            --source-ranges 0.0.0.0/0 \
+            --source-tags $cluster_node_target_tag \
             --target-tags $cluster_node_target_tag
 
       - name: Get cluster credentials

--- a/pkg/maps/multicast/subscribermap.go
+++ b/pkg/maps/multicast/subscribermap.go
@@ -106,7 +106,7 @@ func NewGroupV4Map(in ParamsIn) ParamsOut {
 		return out
 	}
 
-	out.NodeDefines["ENABLE_MULTICAST"] = "1"
+	out.NodeDefines = defines.Map{"ENABLE_MULTICAST": "1"}
 
 	groupMap := NewGroupV4OuterMap(in.Logger, GroupOuter4MapName)
 


### PR DESCRIPTION
 * [x] #40859 (@ldelossa)
 * [x] #43691 (@marseel) :warning: resolved conflicts
    * :information_source: it looks like that the gke-create-esp-rule action did not exist in v1.18. Hence, I've applied the same changes directly to the corresponding step of the Conformance GKE workflow.

PRs skipped due to conflicts:

 * #43069 (@borkmann)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 40859 43691
```
