### PR TITLE
v1.19 Backports 2026-01-19

### DIFF
--- a/.github/actions/cosign/action.yaml
+++ b/.github/actions/cosign/action.yaml
@@ -34,6 +34,16 @@ inputs:
     description: 'Initial delay in seconds before first retry'
     required: false
     default: '10'
+  registry_username:
+    description: 'Registry username for cosign authentication'
+    required: false
+  registry_password:
+    description: 'Registry password for cosign authentication'
+    required: false
+  registry_url:
+    description: 'Registry URL for cosign authentication (e.g., quay.io)'
+    required: false
+    default: 'quay.io'
 
 runs:
   using: 'composite'
@@ -50,6 +60,18 @@ runs:
         output-file: ./sbom_${{ inputs.sbom_name }}.spdx.json
         image: ${{ inputs.image_tag }}
         upload-release-assets: ${{ inputs.upload_sbom_release_assets  }}
+
+    # Login to registry for cosign to authenticate when pushing signatures
+    - name: Login to registry for cosign
+      if: ${{ inputs.registry_username != '' && inputs.registry_password != '' }}
+      shell: bash
+      env:
+        REGISTRY_USERNAME: ${{ inputs.registry_username }}
+        REGISTRY_PASSWORD: ${{ inputs.registry_password }}
+        REGISTRY_URL: ${{ inputs.registry_url }}
+      run: |
+        echo "Logging into ${REGISTRY_URL} for cosign..."
+        echo "${REGISTRY_PASSWORD}" | cosign login "${REGISTRY_URL}" --username "${REGISTRY_USERNAME}" --password-stdin
 
     - name: Sign Container Image
       shell: bash

--- a/.github/actions/gke-create-esp-rule/action.yaml
+++ b/.github/actions/gke-create-esp-rule/action.yaml
@@ -31,5 +31,5 @@ runs:
             --action ALLOW \
             --rules esp \
             --priority 1000 \
-            --source-ranges 0.0.0.0/0 \
+            --source-tags $cluster_node_target_tag \
             --target-tags $cluster_node_target_tag

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -993,15 +993,15 @@ Name                                                 Labels                     
 MCS-API
 ~~~~~~~
 
-========================================= ============================================================ ========== =========================================================
-Name                                      Labels                                                       Default    Description
-========================================= ============================================================ ========== =========================================================
-``mcsapi_serviceexport_info``             ``serviceexport``, ``namespace``                             Enabled    Information about ServiceExport in the local cluster
-``mcsapi_serviceexport_status_condition`` ``serviceexport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceExport in the local cluster
-``mcsapi_serviceimport_info``             ``serviceimport``, ``namespace``                             Enabled    Information about ServiceImport in the local cluster
-``mcsapi_serviceimport_status_condition`` ``serviceimport``, ``namespace``, ``condition``, ``status``  Enabled    Status Condition of ServiceImport in the local cluster
-``mcsapi_serviceimport_status_clusters``  ``serviceimport``, ``namespace``                             Enabled    The number of clusters currently backing a ServiceImport
-========================================= ============================================================ ========== =========================================================
+========================================= ======================================================================== ========== =========================================================
+Name                                      Labels                                                                   Default    Description
+========================================= ======================================================================== ========== =========================================================
+``mcsapi_serviceexport_info``             ``serviceexport``, ``namespace``                                         Enabled    Information about ServiceExport in the local cluster
+``mcsapi_serviceexport_status_condition`` ``serviceexport``, ``namespace``, ``condition``, ``status``, ``reason``  Enabled    Status Condition of ServiceExport in the local cluster
+``mcsapi_serviceimport_info``             ``serviceimport``, ``namespace``                                         Enabled    Information about ServiceImport in the local cluster
+``mcsapi_serviceimport_status_condition`` ``serviceimport``, ``namespace``, ``condition``, ``status``, ``reason``  Enabled    Status Condition of ServiceImport in the local cluster
+``mcsapi_serviceimport_status_clusters``  ``serviceimport``, ``namespace``                                         Enabled    The number of clusters currently backing a ServiceImport
+========================================= ======================================================================== ========== =========================================================
 
 Clustermesh
 ~~~~~~~~~~~

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -459,6 +459,8 @@ Endpoint
 Name                                         Labels                                             Default    Description
 ============================================ ================================================== ========== ========================================================
 ``endpoint``                                                                                    Enabled    Number of endpoints managed by this agent
+``endpoint_restoration_endpoints``           ``phase``, ``outcome``                             Enabled    Number of restored endpoints labeled by phase and outcome
+``endpoint_restoration_duration_seconds``    ``phase``                                          Enabled    Duration of restoration phases in seconds
 ``endpoint_regenerations_total``             ``outcome``                                        Enabled    Count of all endpoint regenerations that have completed
 ``endpoint_regeneration_time_stats_seconds`` ``scope``                                          Enabled    Endpoint regeneration time stats
 ``endpoint_state``                           ``state``                                          Enabled    Count of all endpoints

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1438,7 +1438,7 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 
 	if (lb6_svc_is_l7_punt_proxy(svc) && backend_local) {
-		ctx_skip_nodeport_set(ctx);
+		ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 		*punt_to_stack = true;
 		return CTX_ACT_OK;
 	}
@@ -2839,7 +2839,7 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			return DROP_INVALID;
 
 		if (lb4_svc_is_l7_punt_proxy(svc) && backend_local) {
-			ctx_skip_nodeport_set(ctx);
+			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			*punt_to_stack = true;
 			return CTX_ACT_OK;
 		}

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -543,3 +543,110 @@ int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *
 {
 	return check_reply(ctx);
 }
+
+/* Test that a L7 delegate SVC request
+ * - gets passed up from XDP to TC without DNAT,
+ * - does have XFER_PKT_NO_SVC flag set so that TC does not process it again
+ * if the backend is a local backend
+ */
+PKTGEN("xdp", "xdp_nodeport_l7delegate_local")
+int nodeport_l7delegate_local_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP_ETP_LOCAL,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("xdp", "xdp_nodeport_l7delegate_local")
+int nodeport_l7delegate_local_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	lb_v4_add_service_with_flags(FRONTEND_IP_ETP_LOCAL, FRONTEND_PORT,
+				     IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_LOADBALANCER,
+				     SVC_FLAG_L7_DELEGATE);
+
+	lb_v4_add_backend(FRONTEND_IP_ETP_LOCAL, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, ENDPOINT_F_HOST, 1,
+			      0, NULL, NULL);
+
+	return xdp_receive_packet(ctx);
+}
+
+CHECK("xdp", "xdp_nodeport_l7delegate_local")
+int nodeport_l7delegate_local_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	__u32 *meta;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	status_code = data;
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	meta = (void *)status_code + sizeof(__u32);
+	if ((void *)meta + sizeof(__u32) > data_end)
+		test_fatal("meta out of bounds");
+
+	l2 = (void *)meta + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	assert(*status_code == CTX_ACT_OK);
+
+	assert((*meta & XFER_PKT_NO_SVC) == XFER_PKT_NO_SVC);
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC")
+	if (memcmp(l2->h_dest, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the LB MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != FRONTEND_IP_ETP_LOCAL)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != FRONTEND_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
+}

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -547,7 +547,7 @@ int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *
 /* Test that a L7 delegate SVC request
  * - gets passed up from XDP to TC without DNAT,
  * - does have XFER_PKT_NO_SVC flag set so that TC does not process it again
- * if the backend is a local backend
+ * if the backend is a /local/ backend
  */
 PKTGEN("xdp", "xdp_nodeport_l7delegate_local")
 int nodeport_l7delegate_local_pktgen(struct __ctx_buff *ctx)
@@ -647,6 +647,111 @@ int nodeport_l7delegate_local_check(const struct __ctx_buff *ctx)
 
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("dst port has changed");
+
+	test_finish();
+}
+
+/* Test that a L7 delegate SVC request
+ * - performs DNAT to the remote destination,
+ * - does not have XFER_PKT_NO_SVC flag set
+ * if the backend is a /remote/ backend. Similar test as the
+ * xdp_nodeport_l7delegate_local just that the backend is not
+ * part of the endpoint map.
+ */
+PKTGEN("xdp", "xdp_nodeport_l7delegate_remote")
+int nodeport_l7delegate_remote_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP_REMOTE,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("xdp", "xdp_nodeport_l7delegate_remote")
+int nodeport_l7delegate_remote_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	lb_v4_add_service_with_flags(FRONTEND_IP_REMOTE, FRONTEND_PORT,
+				     IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_LOADBALANCER,
+				     SVC_FLAG_L7_DELEGATE);
+
+	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP_REMOTE, 0, 112233, 0, 0);
+
+	return xdp_receive_packet(ctx);
+}
+
+CHECK("xdp", "xdp_nodeport_l7delegate_remote")
+int nodeport_l7delegate_remote_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(fib_ok(*status_code));
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend MAC")
+
+	if (l3->saddr != LB_IP)
+		test_fatal("src IP hasn't been NATed to LB IP");
+
+	if (l3->daddr != BACKEND_IP_REMOTE)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l3->check != bpf_htons(0xa711))
+		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+
+	if (l4->source == CLIENT_PORT)
+		test_fatal("src port hasn't been NATed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
 
 	test_finish();
 }

--- a/daemon/cmd/bootstrap_statistics.go
+++ b/daemon/cmd/bootstrap_statistics.go
@@ -13,7 +13,6 @@ type bootstrapStatistics struct {
 	overall   spanstat.SpanStat
 	earlyInit spanstat.SpanStat
 	k8sInit   spanstat.SpanStat
-	restore   spanstat.SpanStat
 	ipam      spanstat.SpanStat
 	kvstore   spanstat.SpanStat
 }
@@ -38,7 +37,6 @@ func (b *bootstrapStatistics) getMap() map[string]*spanstat.SpanStat {
 		"overall":   &b.overall,
 		"earlyInit": &b.earlyInit,
 		"k8sInit":   &b.k8sInit,
-		"restore":   &b.restore,
 		"ipam":      &b.ipam,
 		"kvstore":   &b.kvstore,
 	}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -202,13 +202,10 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 	// Configure and start IPAM without using the configuration yet.
 	configureAndStartIPAM(ctx, params)
 
-	bootstrapStats.restore.Start()
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.
-	err := params.EndpointRestorer.RestoreOldEndpoints()
-	bootstrapStats.restore.EndError(err)
-	if err != nil {
+	if err := params.EndpointRestorer.RestoreOldEndpoints(); err != nil {
 		return err
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -327,15 +327,15 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.L2AnnouncerRetryPeriod)
 
 	flags.Bool(option.EnableEncryptionStrictMode, false, "Enable encryption strict mode")
-	flags.MarkDeprecated(option.EnableEncryptionStrictMode, "Please use --enable-encryption-strict-mode-egress instead. This option will be removed in v1.19")
+	flags.MarkDeprecated(option.EnableEncryptionStrictMode, "Please use --enable-encryption-strict-mode-egress instead. This option will be removed in v1.20")
 	option.BindEnv(vp, option.EnableEncryptionStrictMode)
 
 	flags.String(option.EncryptionStrictModeCIDR, "", "In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped.")
-	flags.MarkDeprecated(option.EncryptionStrictModeCIDR, "Please use --encryption-strict-egress-cidr instead. This option will be removed in v1.19")
+	flags.MarkDeprecated(option.EncryptionStrictModeCIDR, "Please use --encryption-strict-egress-cidr instead. This option will be removed in v1.20")
 	option.BindEnv(vp, option.EncryptionStrictModeCIDR)
 
 	flags.Bool(option.EncryptionStrictModeAllowRemoteNodeIdentities, false, "Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.")
-	flags.MarkDeprecated(option.EncryptionStrictModeAllowRemoteNodeIdentities, "Please use --encryption-strict-egress-allow-remote-node-identities instead. This option will be removed in v1.19")
+	flags.MarkDeprecated(option.EncryptionStrictModeAllowRemoteNodeIdentities, "Please use --encryption-strict-egress-allow-remote-node-identities instead. This option will be removed in v1.20")
 	option.BindEnv(vp, option.EncryptionStrictModeAllowRemoteNodeIdentities)
 
 	flags.Bool(option.EnableEncryptionStrictModeEgress, false, "Enable strict mode encryption enforcement for egress traffic")

--- a/daemon/cmd/endpoint_restore_metrics.go
+++ b/daemon/cmd/endpoint_restore_metrics.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	metricsSubsystem = "endpoint_restoration"
+)
+
+const (
+	labelPhase   = "phase"
+	labelOutcome = "outcome"
+)
+
+const (
+	phaseRead                = "read_from_disk"
+	phaseRestoration         = "restoration"
+	phasePrepareRegeneration = "prepare_regeneration"
+	phasePolicyComputation   = "initial_policy_computation"
+	phaseRegeneration        = "regeneration"
+)
+
+const (
+	outcomeTotal      = "total"
+	outcomeSuccessful = "successful"
+	outcomeSkipped    = "skipped"
+	outcomeFailed     = "failed"
+)
+
+type endpointRestoreMetrics struct {
+	Endpoints metric.Vec[metric.Gauge]
+	Duration  metric.Vec[metric.Gauge]
+}
+
+func newEndpointRestoreMetrics() *endpointRestoreMetrics {
+	return &endpointRestoreMetrics{
+		Endpoints: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "endpoints",
+			Help:      "Number of restored endpoints labelled by phase and outcome",
+		}, []string{labelPhase, labelOutcome}),
+		Duration: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metricsSubsystem,
+			Name:      "duration_seconds",
+			Help:      "Duration of restoration phases in seconds",
+		}, []string{labelPhase}),
+	}
+}

--- a/pkg/clustermesh/mcsapi/metrics.go
+++ b/pkg/clustermesh/mcsapi/metrics.go
@@ -29,7 +29,7 @@ func registerMCSAPICollector(registry *metrics.Registry, logger *slog.Logger, cl
 		serviceExportStatusCondition: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceexport_status_condition"),
 			"Status Condition of ServiceExport in the local cluster",
-			[]string{"serviceexport", "namespace", "condition", "status"}, nil),
+			[]string{"serviceexport", "namespace", "condition", "status", "reason"}, nil),
 		serviceImportInfo: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceimport_info"),
 			"Information about ServiceImport in the local cluster",
@@ -37,7 +37,7 @@ func registerMCSAPICollector(registry *metrics.Registry, logger *slog.Logger, cl
 		serviceImportStatusCondition: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceimport_status_condition"),
 			"Status Condition of ServiceImport in the local cluster",
-			[]string{"serviceimport", "namespace", "condition", "status"}, nil),
+			[]string{"serviceimport", "namespace", "condition", "status", "reason"}, nil),
 		serviceImportStatusClusters: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.CiliumOperatorNamespace, subsystem, "serviceimport_status_clusters"),
 			"The number of clusters currently backing a ServiceImport",
@@ -89,7 +89,7 @@ func (c *mcsAPICollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				1,
 				svcExport.Name, svcExport.Namespace,
-				string(condition.Type), string(condition.Status),
+				string(condition.Type), string(condition.Status), condition.Reason,
 			)
 			if err != nil {
 				c.logger.Error("Failed to generate ServiceExport metrics", logfields.Error, err)
@@ -134,7 +134,7 @@ func (c *mcsAPICollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				1,
 				svcImport.Name, svcImport.Namespace,
-				string(condition.Type), string(condition.Status),
+				string(condition.Type), string(condition.Status), condition.Reason,
 			)
 			if err != nil {
 				c.logger.Error("Failed to generate ServiceImport metrics", logfields.Error, err)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -4,7 +4,6 @@
 package endpoint
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 	"log/slog"
@@ -66,7 +65,7 @@ func (s *EndpointSuite) endpointCreator(t testing.TB, id uint16, secID identity.
 	identity.Sanitize()
 
 	model := newTestEndpointModel(int(id), StateReady)
-	ep, err := NewEndpointFromChangeModel(context.TODO(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
+	ep, err := NewEndpointFromChangeModel(t.Context(), hivetest.Logger(t), nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -138,7 +137,7 @@ func TestReadEPsFromDirNames(t *testing.T) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	eps := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
+	eps, _ := ReadEPsFromDirNames(t.Context(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
 	require.Len(t, eps, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -201,7 +200,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	epResult := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epNames)
+	epResult, _ := ReadEPsFromDirNames(t.Context(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epNames)
 	require.Len(t, epResult, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -254,7 +253,7 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	}
 
 	for b.Loop() {
-		eps := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
+		eps, _ := ReadEPsFromDirNames(b.Context(), logger, &fakeParser{logger: logger, orchestrator: s.orchestrator, policyRepo: s.repo}, tmpDir, epsNames)
 		require.Len(b, eps, len(epsWanted))
 	}
 }


### PR DESCRIPTION
 * [x] #43790 (@mhofstetter)
 * [x] #43776 (@mhofstetter)
 * [x] #43731 (@rgo3)
 * [x] #43782 (@aanm) :warning: resolved conflicts
    * :information_source: skipped the release.yaml hunk, as the target file doesn't exist in v1.19. I've preserved the cosign action hunk instead, to keep the two branches aligned. Let me know if you'd prefer me to skip the commit entirely instead.
 * [x] #43691 (@marseel)
 * [x] #43069 (@borkmann)
 * [x] #43775 (@MrFreezeex)
 * [x] #43748 (@mhofstetter) :warning: resolved conflicts
   * :information_source: hit minor conflict in `pkg/endpoint/restore_test.go` due to changes in surrounding context, resolved accepting combination.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43790 43776 43731 43782 43691 43069 43775 43748
```
