### PR TITLE
.github/renovate: add go mod commands after updating go deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,7 +114,9 @@
     "^make -C Documentation update-requirements$",
     "^make generate-k8s-api$",
     "^make manifests$",
-    "^make GO='contrib/scripts/builder.sh go' generate-apis$"
+    "^make GO='contrib/scripts/builder.sh go' generate-apis$",
+    "^go mod tidy$",
+    "^go mod vendor$"
   ],
   "assignAutomerge": true,
   "packageRules": [
@@ -230,6 +232,13 @@
         // update source import paths on major updates
         "gomodUpdateImportPaths"
       ],
+      "postUpgradeTasks": {
+        "commands": [
+          "go mod tidy",
+          "go mod vendor"
+        ],
+        "executionMode": "update"
+      },
       "matchBaseBranches": [
         "main"
       ]


### PR DESCRIPTION
It seems renovate is not doing this step after it updates the golang dependencies. Adding these two commands explicitly to see if it helps.