### PR TITLE
bpf: Correct refinement of inner packet L4 checksum detection

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -859,7 +859,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 
 	/* Check if the inner L4 header has checksum */
 	if (tuple.nexthdr == IPPROTO_TCP &&
-	    total_inner_len < iphdr.ihl + TCP_CSUM_OFF + sizeof(__u16))
+	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + sizeof(__u16))
 		icmp_has_inner_l4_csum = false;
 
 	/* We found SNAT entry to NAT embedded packet. The destination addr
@@ -1084,7 +1084,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 
 	/* Check if the inner L4 header has checksum */
 	if (tuple.nexthdr == IPPROTO_TCP &&
-	    total_inner_len < iphdr.ihl + TCP_CSUM_OFF + sizeof(__u16))
+	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + sizeof(__u16))
 		icmp_has_inner_l4_csum = false;
 
 	/* For UDP, a checksum value of zero means that no checksum */

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -286,6 +286,12 @@ int test_nat4_icmp_error_tcp_rfc1191(__maybe_unused struct __ctx_buff *ctx)
 
 		memcpy(data, pkt, pkt_size);
 	}
+	/* We also need to set the packet size in ctx, since that's what
+	 * the BPF code now checks for this condition.  The verifier prevents
+	 * us from directly writing the len field of the context,
+	 * but there is a BPF helper function for this.
+	 */
+	ctx_change_tail(ctx, pkt_size, 0);
 
 	test_init();
 	/* The test is validating that the function snat_v4_rev_nat()
@@ -804,6 +810,12 @@ int test_nat4_icmp_error_tcp_egress_rfc1191(__maybe_unused struct __ctx_buff *ct
 
 		memcpy(data, pkt, pkt_size);
 	}
+	/* We also need to set the packet size in ctx, since that's what
+	 * the BPF code now checks for this condition.  The verifier prevents
+	 * us from directly writing the len field of the context,
+	 * but there is a BPF helper function for this.
+	 */
+	ctx_change_tail(ctx, pkt_size, 0);
 
 	test_init();
 	/* The test is validating that the function snat_v4_nat()


### PR DESCRIPTION
The previous commit updating short ICMP error packet NAT handling improperly computed the length of a short packet by neglecting to account for the ihl field of the IP header representing 32 bit words rather than bytes.  This caused a reversion of #33844.

Furthermore, the change in short packet detection depends on the incoming bpf_context structure having the "len" field set correctly, which the BPF tests for that condition did not set.

This corrects the comparison for the inner L4 packet length and updates the short ICMP error packet BPF tests to ensure the ctx->len field is set like the kernel does.

Fixes: https://github.com/cilium/cilium/commit/1a018d56d623 ("bpf: Refine inner packet L4 checksum detection")

```relase-note
Fix Layer 4 length computation for checksum detection in SNAT-ed ICMP DestinationUnreachable (FragmentationNeeded) packets.
```
