### PR TITLE
bpf: sock: fine-tune the byte-swap in the wildcard lookup

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -191,11 +191,10 @@ sock4_wildcard_lookup(struct lb4_key *key, const bool include_remote_hosts,
 		      const bool inv_match, const bool in_hostns)
 {
 	const struct remote_endpoint_info *info;
-	__u16 service_port;
+	__be16 service_port = key->dport;
 
-	service_port = bpf_ntohs(key->dport);
-	if ((service_port < NODEPORT_PORT_MIN ||
-	     service_port > NODEPORT_PORT_MAX) ^ inv_match)
+	if ((service_port < bpf_htons(NODEPORT_PORT_MIN) ||
+	     service_port > bpf_htons(NODEPORT_PORT_MAX)) ^ inv_match)
 		return NULL;
 
 	/* When connecting to node port services in our cluster that
@@ -733,11 +732,10 @@ sock6_wildcard_lookup(struct lb6_key *key, const bool include_remote_hosts,
 		      const bool inv_match, const bool in_hostns)
 {
 	const struct remote_endpoint_info *info;
-	__u16 service_port;
+	__be16 service_port = key->dport;
 
-	service_port = bpf_ntohs(key->dport);
-	if ((service_port < NODEPORT_PORT_MIN ||
-	     service_port > NODEPORT_PORT_MAX) ^ inv_match)
+	if ((service_port < bpf_htons(NODEPORT_PORT_MIN) ||
+	     service_port > bpf_htons(NODEPORT_PORT_MAX)) ^ inv_match)
 		return NULL;
 
 	/* When connecting to node port services in our cluster that


### PR DESCRIPTION
The wildcard lookup code first determines whether the accessed port is within the nodeport range. Instead of dynamically byte-swapping the port info from the packet header, do it just *once* on the inserted range macros.