### PR TITLE
renovate: Enable major azure SDK upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,7 @@
     ".github/ISSUE_TEMPLATE/bug_report.yaml",
     "Documentation/requirements-min/requirements.txt",
     "cilium-cli/**",
+    "pkg/azure/**",
     "images/**",
     "examples/hubble/*",
     "go.mod",


### PR DESCRIPTION
Renovate is currently configured to do major upgrades but fails to do so for the Azure SDK because it needs to update import paths in source files and those files are not included in its `includePaths` config.

See https://github.com/cilium/cilium/pull/43832#issuecomment-3767632786:

> Looking at the failure here, I wonder if the problem is coming from the github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v7 major upgrade from v7 to v8. For major upgrades, renovate needs to update all import paths in go files, and is configured to do so with the gomodUpdateImportPaths option [here](https://github.com/cilium/cilium/blob/de8ffdaaeb36dfc590094b75421f387884c4a1d3/.github/renovate.json5#L231).
> 
> Renovate has successfully done major upgrades for github.com/google/go-github/vXX in the past but never for that azure package. I think it may be because the github package is used in files under cilium-cli/ whereas the azure package is used under pkg/ and renovate can update files under cilium-cli (configured [here](https://github.com/cilium/cilium/blob/de8ffdaaeb36dfc590094b75421f387884c4a1d3/.github/renovate.json5#L50)) but ignores all files under pkg.
> So I think that adding pkg (or a more specific path like pkg/azure/api) to renovate's [includePaths](https://github.com/cilium/cilium/blob/de8ffdaaeb36dfc590094b75421f387884c4a1d3/.github/renovate.json5#L35) may solve these kind of problems in the future.
> What do you think?