### PR TITLE
endpoint: Log labels as structured JSON objects

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2079,8 +2079,8 @@ func (e *Endpoint) UpdateLabels(ctx context.Context, sourceFilter string, identi
 	e.getLogger().Debug(
 		"Refreshing labels of endpoint",
 		logfields.SourceFilter, sourceFilter,
-		logfields.IdentityLabels, identityLabels,
-		logfields.InfoLabels, infoLabels,
+		logfields.IdentityLabels, map[string]labels.Label(identityLabels),
+		logfields.InfoLabels, map[string]labels.Label(infoLabels),
 	)
 
 	if err := e.lockAlive(); err != nil {
@@ -2139,7 +2139,7 @@ func (e *Endpoint) UpdateLabelsFrom(oldLbls, newLbls map[string]string, source s
 
 	e.getLogger().Debug(
 		"Updated endpoint with new labels",
-		logfields.Labels, newIdtyLabels,
+		logfields.Labels, map[string]labels.Label(newIdtyLabels),
 	)
 	return nil
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1155,7 +1155,7 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) (identityToReleas
 			"Identity of endpoint changed",
 			logfields.IdentityNew, identity.StringID(),
 			logfields.IdentityOld, oldIdentity,
-			logfields.IdentityLabels, identity.Labels,
+			logfields.IdentityLabels, map[string]labels.Label(identity.Labels),
 		)
 	}
 	e.UpdateLogger(map[string]any{


### PR DESCRIPTION
<!-- Description of change -->
Standardize logging in pkg/endpoint so that identityLabels and related fields are logged as structured JSON objects instead of comma-separated strings by explicitly casting labels.Labels to map[string]labels.Label.

```release-note
Fix logging identity labels in endpoint as structured JSON objects instead of strings to enable parsing logs in a structured way.
```
