### PR TITLE
CODEOWNERS: let Cilium committers own MAINTAINERS.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,6 +33,8 @@
 #   These owners are a stand-in for the user community to bring a user
 #   perspective to the review process. Consider how information is presented,
 #   consistency of flags and options.
+# - @cilium/committers:
+#   Cilium contributors with commit access.
 # - @cilium/ci-structure:
 #   Provide guidance around the best use of Cilium project continuous
 #   integration and testing infrastructure, including GitHub actions, VM
@@ -500,7 +502,7 @@ Makefile* @cilium/build
 /install/kubernetes/cilium/templates/hubble* @cilium/helm @cilium/sig-hubble
 /install/kubernetes/cilium/templates/standalone-dns-proxy* @cilium/helm @cilium/fqdn
 /LICENSE @cilium/contributing
-/MAINTAINERS.md @cilium/contributing
+/MAINTAINERS.md @cilium/committers
 /netlify.toml @cilium/ci-structure
 /operator/ @cilium/operator
 /operator/doublewrite @cilium/metrics

--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -36,6 +36,8 @@ repository in the Cilium project:
   These owners are a stand-in for the user community to bring a user
   perspective to the review process. Consider how information is presented,
   consistency of flags and options.
+- `@cilium/committers <https://github.com/orgs/cilium/teams/committers>`__:
+  Cilium contributors with commit access.
 - `@cilium/ci-structure <https://github.com/orgs/cilium/teams/ci-structure>`__:
   Provide guidance around the best use of Cilium project continuous
   integration and testing infrastructure, including GitHub actions, VM


### PR DESCRIPTION
Developers in @cilium/contributing aren't necessarily all committers, so it feels weird letting them gate addition and removal of Cilium committers. Let's let Cilium maintainers have the final say instead.

Suggested-by: @bimmlerd 