### PR TITLE
ipcache: remove compatibility support for V1 ipcache

### DIFF
--- a/pkg/ipcache/restore/local_identity_restorer.go
+++ b/pkg/ipcache/restore/local_identity_restorer.go
@@ -136,37 +136,6 @@ func (d *LocalIdentityRestorer) dumpOldIPCache() (map[netip.Prefix]identity.Nume
 	if err != nil {
 		// ignore non-existent cache
 		if errors.Is(err, fs.ErrNotExist) {
-			// We might be in the upgrade case, with the ipcache v1 from v1.18
-			// still around.
-			return d.dumpOldIPCacheV1()
-		}
-	}
-	d.params.Logger.Debug("dumping ipache with local identities", logfields.Count, len(localPrefixes))
-	return localPrefixes, err
-}
-
-// dumpOldIPCacheV1 does the same as dumpOldIPCache but for the v1 of the ipcache map.
-func (d *LocalIdentityRestorer) dumpOldIPCacheV1() (map[netip.Prefix]identity.NumericIdentity, error) {
-	localPrefixes := map[netip.Prefix]identity.NumericIdentity{}
-
-	// Dump the bpf ipcache, recording any prefixes with local or ingress
-	// numeric identities.
-	err := ipcachemap.IPCacheMapV1().DumpWithCallback(func(key bpf.MapKey, value bpf.MapValue) {
-		k := key.(*ipcachemap.Key)
-		v := value.(*ipcachemap.RemoteEndpointInfoV1)
-		nid := identity.NumericIdentity(v.SecurityIdentity)
-
-		if nid.Scope() == identity.IdentityScopeLocal || (nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero()) {
-			localPrefixes[k.Prefix()] = nid
-		}
-	})
-	// dumpwithcallback() leaves the ipcache map open, must close before opened for
-	// parallel mode in daemon.initmaps()
-	ipcachemap.IPCacheMapV1().Close()
-
-	if err != nil {
-		// ignore non-existent cache
-		if errors.Is(err, fs.ErrNotExist) {
 			err = nil
 		}
 	}


### PR DESCRIPTION
fe6928d7f13b ("ipcache, daemon: Handle CIDR restoration from ipcache v1") kept support for the old ipcache version around, for upgrading from v1.18 to v1.19.

We no longer need this in v1.20, remove it.