### PR TITLE
[v1.18] bpf: Fix marker to skip nodeport when punting to proxy

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1151,7 +1151,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 
 	if (lb6_svc_is_l7_punt_proxy(svc) &&
 	    __lookup_ip6_endpoint(&backend->address)) {
-		ctx_skip_nodeport_set(ctx);
+		ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 		return LB_PUNT_TO_STACK;
 	}
 	if (skip_xlate)
@@ -1955,7 +1955,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 
 	if (lb4_svc_is_l7_punt_proxy(svc) &&
 	    __lookup_ip4_endpoint(backend->address)) {
-		ctx_skip_nodeport_set(ctx);
+		ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 		return LB_PUNT_TO_STACK;
 	}
 	if (skip_xlate)

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -470,7 +470,7 @@ int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *
 /* Test that a L7 delegate SVC request
  * - gets passed up from XDP to TC without DNAT,
  * - does have XFER_PKT_NO_SVC flag set so that TC does not process it again
- * if the backend is a local backend
+ * if the backend is a /local/ backend
  */
 PKTGEN("xdp", "xdp_nodeport_l7delegate_local")
 int nodeport_l7delegate_local_pktgen(struct __ctx_buff *ctx)
@@ -573,6 +573,114 @@ int nodeport_l7delegate_local_check(const struct __ctx_buff *ctx)
 
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("dst port has changed");
+
+	test_finish();
+}
+
+/* Test that a L7 delegate SVC request
+ * - performs DNAT to the remote destination,
+ * - does not have XFER_PKT_NO_SVC flag set
+ * if the backend is a /remote/ backend. Similar test as the
+ * xdp_nodeport_l7delegate_local just that the backend is not
+ * part of the endpoint map.
+ */
+PKTGEN("xdp", "xdp_nodeport_l7delegate_remote")
+int nodeport_l7delegate_remote_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP_REMOTE,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("xdp", "xdp_nodeport_l7delegate_remote")
+int nodeport_l7delegate_remote_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	lb_v4_add_service_with_flags(FRONTEND_IP_REMOTE, FRONTEND_PORT,
+				     IPPROTO_TCP, 1, revnat_id,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_LOADBALANCER,
+				     SVC_FLAG_L7_DELEGATE);
+
+	lb_v4_add_backend(FRONTEND_IP_REMOTE, FRONTEND_PORT, 1, 124,
+			  BACKEND_IP_REMOTE, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(BACKEND_IP_REMOTE, 0, 112233, 0, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("xdp", "xdp_nodeport_l7delegate_remote")
+int nodeport_l7delegate_remote_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(fib_ok(*status_code));
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)remote_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend MAC")
+
+	if (l3->saddr != LB_IP)
+		test_fatal("src IP hasn't been NATed to LB IP");
+
+	if (l3->daddr != BACKEND_IP_REMOTE)
+		test_fatal("dst IP hasn't been NATed to remote backend IP");
+
+	if (l3->check != bpf_htons(0xa711))
+		test_fatal("L3 checksum is invalid: %x", bpf_htons(l3->check));
+
+	if (l4->source == CLIENT_PORT)
+		test_fatal("src port hasn't been NATed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
 
 	test_finish();
 }


### PR DESCRIPTION
Manual backport of:

 * #43069

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43069
```