### PR TITLE
cilium-cli: Fix NodePort deployment check in dual-stack clusters

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -2732,6 +2732,13 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 					continue
 				}
 
+				// Skip IP addresses of families which are not enabled in Cilium
+				addrFamily := features.GetIPFamily(addr.Address)
+				if (addrFamily == features.IPFamilyV4 && !ct.Features[features.IPv4].Enabled) ||
+					(addrFamily == features.IPFamilyV6 && !ct.Features[features.IPv6].Enabled) {
+					continue
+				}
+
 				for _, s := range ct.echoServices {
 					if err := WaitForNodePorts(ctx, ct, *client, addr.Address, s); err != nil {
 						return err


### PR DESCRIPTION
If the K8s cluster is dual-stack enabled, but Cilium is not running in dual-stack mode, the Cilium CLI deployment check will fail because it is trying to access a NodePort IP for an IP family that it not enabled. This causes failures like these:

```
⌛ [kind-cluster] Waiting for NodePort 172.128.0.9:30182 (cilium-test-1/echo-other-node) to become ready...
⌛ [kind-cluster] Waiting for NodePort 172.128.0.9:30858 (cilium-test-1/echo-same-node) to become ready...
⌛ [kind-cluster] Waiting for NodePort fc00:128::9:30182 (cilium-test-1/echo-other-node) to become ready...
timeout reached waiting for NodePort fc00:128::9:30182 (cilium-test-1/echo-other-node) (last error: command failed (pod=cilium-test-1/client-7b7877766f-tspfx, container=): command terminated with exit code 1)
```

This commit fixes that issue by checking the node address family first.

Fixes: https://github.com/cilium/cilium/pull/40812