### PR TITLE
tests: remove allowlist entry for deleting no longer present service

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -195,7 +195,6 @@ const (
 	failedToReleaseLock        = "Failed to release lock:"
 	errorCreatingInitialLeader = "error initially creating leader election record:"
 	cantEnableJIT              = "bpf_jit_enable: no such file or directory"                             // Because we run tests in Kind.
-	delMissingService          = "Deleting no longer present service"                                    // cf. https://github.com/cilium/cilium/issues/29679
 	podCIDRUnavailable         = " PodCIDR not available"                                                // cf. https://github.com/cilium/cilium/issues/29680
 	unableGetNode              = "Unable to get node resource"                                           // cf. https://github.com/cilium/cilium/issues/29710
 	objectHasBeenModified      = "the object has been modified; please apply your changes"               // cf. https://github.com/cilium/cilium/issues/29712
@@ -255,8 +254,8 @@ var badLogMessages = map[string][]string{
 	logutils.ErrorLogs: {opCantBeFulfilled, initLeaderElection, globalDataSupport,
 		failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock,
 		failedToReleaseLock, errorCreatingInitialLeader},
-	logutils.WarningLogs: {cantEnableJIT, delMissingService, podCIDRUnavailable,
-		unableGetNode, objectHasBeenModified, etcdTimeout, endpointRestoreFailed,
+	logutils.WarningLogs: {cantEnableJIT, podCIDRUnavailable, unableGetNode,
+		objectHasBeenModified, etcdTimeout, endpointRestoreFailed,
 		cantFindIdentityInCache, keyAllocFailedFoundMaster, cantRecreateMasterKey,
 		cantUpdateCRDIdentity, cantDeleteFromPolicyMap, failedToListCRDs, mutationDetector},
 }


### PR DESCRIPTION
The warning log "Deleting no longer present service" was emitted because cilium-agent in versions <= 1.13 waited on the wrong Kubernetes API group during startup.

Specifically, it waited for K8sAPIGroupEndpointSliceV1Beta1Discovery instead of K8sAPIGroupEndpointSliceV1Discovery, causing SyncWithK8sFinished to run before all services were fully synced. This resulted in services restored from the datapath being temporarily deleted and later re-added, even though they were still present and active.

This behavior was unintentionally fixed in v1.14 by refactoring the Kubernetes watcher initialization and resource synchronization logic. As a result, this warning is no longer expected. Remove the corresponding allowlist entry. More details of analysis in #29679.

Fixes: #29679