### PR TITLE
Fix backend slot index mismatch in LB reconciler

### DIFF
--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -877,7 +877,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 
 	// Update backends that are new or changed.
 	slotID := 1
-	for i, be := range orderedBackends {
+	for _, be := range orderedBackends {
 		var beID loadbalancer.BackendID
 		if s, ok := ops.backendStates[be.Address]; ok && s.id != 0 {
 			beID = s.id
@@ -925,7 +925,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 
 		svcVal.SetBackendID(beID)
 		svcVal.SetRevNat(int(feID))
-		svcKey.SetBackendSlot(i + 1)
+		svcKey.SetBackendSlot(slotID)
 		if err := ops.upsertService(svcKey, svcVal); err != nil {
 			return fmt.Errorf("upsert service: %w", err)
 		}


### PR DESCRIPTION
## Summary

Fix a bug in the load balancer BPF reconciler where backend slots were incorrectly assigned when maintenance backends exist. The code used the loop index (`i + 1`) instead of the sequential slot counter (`slotID`) when setting backend slots, causing gaps in slot assignments when maintenance backends are skipped.

**Bug:** When backends in maintenance state are skipped during reconciliation, subsequent backends are assigned to wrong slots (e.g., slots 1, 3 instead of 1, 2), causing traffic misrouting or drops.

**Fix:** Use `slotID` (which correctly tracks sequential slot numbers) instead of `i + 1` (loop index).

## Release Note

```release-note
Fixed a bug in service load balancing where backend slot assignments could have gaps when maintenance backends exist, potentially causing traffic misrouting.
```

## Test Plan

- Verified the fix aligns with existing code intent (debug log at line 944 already uses `slotID`)
- The comment at line 940-941 states "the slot ids here are sequential" confirming expected behavior