### PR TITLE
ci: fix scheduled workflows for 1.19 branch

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -2,6 +2,7 @@ allowed-teams:
   - organization-members
 
 triggers:
+  # This trigger needs to be kept in sync with ariane-scheduled.yaml workflow
   /test\s*:
     workflows:
     - conformance-aws-cni.yaml
@@ -111,6 +112,7 @@ triggers:
     workflows:
     - l7-perf.yaml
 
+# This trigger needs to be kept in sync with ariane-scheduled.yaml workflow
 schedule:
   nightly:
     workflows:

--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -53,8 +53,11 @@ jobs:
 
           REF="${{ matrix.branch }}"
           SHA=$(git rev-parse ${REF})
+          # /test for 1.18 branch and lower
+          # /test\s* for 1.19 branch and higher
           readarray workflows < <((
             yq '.triggers["/test"].workflows[]' .github/ariane-config.yaml
+            yq '.triggers["/test\s*"].workflows[]' .github/ariane-config.yaml
             yq '.schedule.nightly.workflows[]' .github/ariane-config.yaml
           ) | sort -u)
 


### PR DESCRIPTION
Scheduled runs on stable branches are triggered based on the list of
workflows under specific trigger. PR https://github.com/cilium/cilium/pull/41309 changed the trigger and once
we branched off, scheduled runs for 1.19 were not running.
Additionally, add comment to make sure that this is kept in sync in the
future.

Fixes https://github.com/cilium/cilium/pull/41309

Example run: https://github.com/cilium/cilium/actions/runs/21217016258/job/61040887633
(` tests-datapath-verifier.yaml` failure to trigger seems to be a separate issue)
