### PR TITLE
.github/ariane-config: schedule runs on conformance-ipsec.yaml

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -117,6 +117,7 @@ schedule:
     - conformance-aks.yaml
     - conformance-gateway-api.yaml
     - conformance-gke.yaml
+    - conformance-ipsec.yaml
     - tests-e2e-upgrade.yaml
 
 workflows:


### PR DESCRIPTION
conformance-ipsec.yaml needs to be tested on a scheduled basis on stable branches, therefore it should be added to this list since GitHub doesn't trigger schedule events for non-default branches.