### PR TITLE
.github/workflows: k8s-kind-network-e2e: add shorter timeout

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -255,6 +255,7 @@ jobs:
 
       # Sequentially kill kube-apiserver pods to verify cilium agent pods fail over to an active instance.
       - name: Test kube-apiserver high availability
+        timeout-minutes: 10
         run: |
           PORT=6443
           NAMESPACE="kube-system"


### PR DESCRIPTION
This time should have a shorter timeout so it doesn't take 1h30m of CI in case the step fails as seen in [1]. Since this step takes around 4 minutes on a successful run [2], 10 minutes of timeout seems to be a good limit.

[1] https://github.com/cilium/cilium/actions/runs/21205723313/job/61001679788
[2] https://github.com/cilium/cilium/actions/runs/21216876084/job/61040455144