### PR TITLE
cyclonus: add higher timeout and retries to avoid flakes

### DIFF
--- a/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
+++ b/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
@@ -15,8 +15,8 @@ spec:
             - --fail-fast=true
             - --exclude=
             - --include=upstream-e2e
-            - --perturbation-wait-seconds=10
-            - --retries=5
+            - --perturbation-wait-seconds=20
+            - --retries=7
             - --noisy=true
             - --ignore-loopback=true
             - --cleanup-namespaces=false


### PR DESCRIPTION
This shorter timeout seems to be too short for the tests to be successful. We should increase them and see if the flakiness decreases.