### PR TITLE
[CI - e2e-upgrade]: Continue on failures for agent restart L7 traffic disruption test

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -610,6 +610,7 @@ jobs:
 
       - name: Test Cilium ${{ steps.vars.outputs.skip_upgrade != 'true' && 'after agent restart' }}
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' }}
+        continue-on-error: true
         uses: ./.github/actions/conn-disrupt-test-check
         with:
           job-name: cilium-restart-${{ matrix.name }}-precheck


### PR DESCRIPTION
Temporarily ignore failures in L7 traffic disruption tests on cilium-agent restart, while we work on root causing the underlying reason for test flakiness.
Fixes https://github.com/cilium/cilium/issues/43770