### PR TITLE
fix: Make Cluster Mesh work with OwnerReferencesPermissionEnforcement

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -10,6 +10,12 @@ nodes:
         kind: InitConfiguration
         nodeRegistration:
           taints: []
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
+
   - role: worker
   - role: worker
 networking:

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -78,6 +78,17 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.clustermesh.enableEndpointSliceSynchronization }}
+- apiGroups:
+  - ""
+  resources:
+  # The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
+  # resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
+  # This is required when the admission plugin OwnerReferencesPermissionEnforcement is activated.
+  - services/finalizers
+  verbs:
+  - update
+{{- end }}
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Some clusters have the admission plugin [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) activated. This plugin protects access to metadata.ownerReferences[x].blockOwnerDeletion, only users with the update permission to the finalizers subresource of the referenced owner can change it.
This adds such permissions to the cilium-operator clusterRole, as the operator sets EnpointSlices owner references.

```release-note
Add permissions to the cilium-operator so that it can create EndpointSlices when the admission plugin OwnerReferencesPermissionEnforcement is activated
```
