### PR TITLE
Implement scope annotation for twoScopes balancers

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -156,6 +156,15 @@ const (
 	// the latter two, one can set the annotation with the value "LoadBalancer".
 	ServiceTypeExposure = ServicePrefix + "/type"
 
+	// ServiceScopeExposure restricts which frontend scopes are installed.
+	// Only matters if externalTrafficPolicy != internalTrafficPolicy (service is two-scoped)
+	// Allowed values are of type loadbalancer.SVCScope:
+	//  - none
+	//      default behaviour, install both external and internal scopes (if applicable)
+	//  - external-only
+	//      install only external-scope frontends
+	ServiceScopeExposure = ServicePrefix + "/scope"
+
 	// ServiceSourceRangesPolicy is the annotation name used to specify the policy
 	// of the user-provided loadBalancerSourceRanges, meaning whether this CIDR
 	// list should act as an allow- or deny-list. Both "allow" or "deny" are

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -95,6 +95,20 @@ func ToSVCForwardingMode(s string, proto ...uint8) SVCForwardingMode {
 	}
 }
 
+type SVCScope string
+
+const (
+	SVCScopeNone         = SVCScope("none")
+	SVCScopeExternalOnly = SVCScope("external-only")
+)
+
+func ToSVCScope(s string) SVCScope {
+	if SVCScope(s) == SVCScopeExternalOnly {
+		return SVCScopeExternalOnly
+	}
+	return SVCScopeNone
+}
+
 type SVCLoadBalancingAlgorithm uint8
 
 const (

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -58,6 +58,13 @@ func getAnnotationServiceForwardingMode(cfg loadbalancer.Config, svc *slim_corev
 	return loadbalancer.SVCForwardingModeUndef, nil
 }
 
+func getAnnotationServiceScope(svc *slim_corev1.Service) loadbalancer.SVCScope {
+	if value, ok := annotation.Get(svc, annotation.ServiceScopeExposure); ok {
+		return loadbalancer.ToSVCScope(strings.ToLower(value))
+	}
+	return loadbalancer.SVCScopeNone
+}
+
 func isHeadless(svc *slim_corev1.Service) bool {
 	_, headless := svc.Labels[corev1.IsHeadlessService]
 	if strings.ToLower(svc.Spec.ClusterIP) == "none" {
@@ -85,6 +92,7 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
 		ForwardingMode:      loadbalancer.SVCForwardingModeUndef,
 		LoadBalancerClass:   svc.Spec.LoadBalancerClass,
+		SVCScope:            getAnnotationServiceScope(svc),
 	}
 
 	if cfg.LBModeAnnotation {
@@ -227,6 +235,9 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 			expType.CanExpose(slim_corev1.ServiceTypeNodePort) {
 
 			for _, scope := range scopes {
+				if s.SVCScope == loadbalancer.SVCScopeExternalOnly && scope == loadbalancer.ScopeInternal {
+					continue
+				}
 				for _, family := range getIPFamilies(svc) {
 					if (!extCfg.EnableIPv6 && family == slim_corev1.IPv6Protocol) ||
 						(!extCfg.EnableIPv4 && family == slim_corev1.IPv4Protocol) {
@@ -299,6 +310,9 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 			}
 
 			for _, scope := range scopes {
+				if s.SVCScope == loadbalancer.SVCScopeExternalOnly && scope == loadbalancer.ScopeInternal {
+					continue
+				}
 				for _, port := range svc.Spec.Ports {
 					fe := loadbalancer.FrontendParams{
 						Type:        loadbalancer.SVCTypeLoadBalancer,

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -58,6 +58,9 @@ type Service struct {
 	// to the backend. If undefined the default mode is used (--bpf-lb-mode).
 	ForwardingMode SVCForwardingMode
 
+	// SVCScope controls which frontend scopes are programmed into LB BPF maps.
+	SVCScope SVCScope
+
 	// SessionAffinity if true will enable the client IP based session affinity.
 	SessionAffinity bool
 

--- a/pkg/loadbalancer/tests/testdata/svc-scope-annotation.txtar
+++ b/pkg/loadbalancer/tests/testdata/svc-scope-annotation.txtar
@@ -1,0 +1,128 @@
+#! --lb-test-fault-probability=0.0
+
+# Start the test application
+hive start
+
+# Add the endpoints and service
+k8s/add endpointslice.yaml
+k8s/add service.yaml
+db/cmp frontends frontends-all.table
+db/cmp services services.table
+
+# Set "service.cilium.io/scope=external-only"
+k8s/update service-external-only.yaml
+db/cmp frontends frontends-external.table
+db/cmp services services.table
+
+#####
+
+-- services.table --
+Name         Source   PortNames   TrafficPolicy           Flags
+test/echo    k8s      http=80     Ext=Local, Int=Cluster
+
+-- frontends-all.table --
+Address               Type         ServiceName   PortName   Status  Backends
+1.2.19.98:80/TCP      LoadBalancer test/echo     http       Done    10.244.1.1:80/TCP
+1.2.19.98:80/TCP/i    LoadBalancer test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.19.98:80/TCP    ClusterIP    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+
+-- frontends-external.table --
+Address               Type         ServiceName   PortName   Status  Backends
+1.2.19.98:80/TCP      LoadBalancer test/echo     http       Done    10.244.1.1:80/TCP
+10.96.19.98:80/TCP    ClusterIP    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  allocateLoadBalancerNodePorts: false
+  clusterIP: 10.96.19.98
+  clusterIPs:
+  - 10.96.19.98
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 1.2.19.98
+
+-- service-external-only.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "742"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+  annotations:
+    service.cilium.io/scope: external-only
+spec:
+  allocateLoadBalancerNodePorts: false
+  clusterIP: 10.96.19.98
+  clusterIPs:
+  - 10.96.19.98
+  externalTrafficPolicy: Local
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 1.2.19.98
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: testnode
+- addresses:
+  - 10.244.1.2
+  nodeName: othernode
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -369,6 +369,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		features.Annotations = append(features.Annotations, annotation.ServiceNodeExposure)
 		features.Annotations = append(features.Annotations, annotation.ServiceNodeSelectorExposure)
 		features.Annotations = append(features.Annotations, annotation.ServiceTypeExposure)
+		features.Annotations = append(features.Annotations, annotation.ServiceScopeExposure)
 		features.Annotations = append(features.Annotations, annotation.ServiceProxyDelegation)
 		features.Annotations = append(features.Annotations, annotation.ServiceSourceRangesPolicy)
 		sort.Strings(features.Annotations)


### PR DESCRIPTION
### Add service scope annotation to suppress internal-scope LB frontends

#### Summary
This PR introduces a new service annotation `service.cilium.io/scope=external-only` that prevents creation of internal-scope LB frontends when a Service has distinct internal/external traffic policies. This allows Cilium to NAT only external traffic (from standalone LBs) while leaving internal traffic to the standalone balancers.

#### Motivation
In our clusters, standalone load balancers proxy into Cilium. We need Cilium’s NAT for external traffic (LB IP/port → pod IP/port) but want internal traffic to bypass Cilium’s LB and be handled by the standalone balancers for balancing over non-k8s reals and unified access control and metrics.

#### Implementation
  - Add ServiceScopeExposure annotation.
  - Add SVCScope model and parser.
  - Plumb annotation through service conversion.
  - When service is two-scoped, skip internal-scope frontend generation if annotation is external-only.
  - Expose the annotation in KPR feature reporting.
  - Add a script-based test that validates internal /i frontend is present by default and removed with the annotation.

#### Testing:

`  - GOTOOLCHAIN=auto go test -v -count=1 ./pkg/loadbalancer/tests -run 'TestScript/svc-scope-annotation.txtar'
`



