### PR TITLE
gha: let CiliumEndpointSlice migration be run nightly on stable branches

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -120,6 +120,7 @@ schedule:
     - conformance-gateway-api.yaml
     - conformance-gke.yaml
     - conformance-ipsec.yaml
+    - tests-ces-migrate.yaml
     - tests-e2e-upgrade.yaml
 
 workflows:


### PR DESCRIPTION
The CiliumEndpointSlice migration workflow is currently run on schedule on the main branch. However, it is not being triggered for stable branches, because it is not part of the test suite triggered via /test. Let's get this divergence fixed adding it to the list of nightly workflows, so that it gets periodically run on stable branches as well.
