### PR TITLE
fix(field-mask): Allow FieldMasking on oneof variants

### DIFF
--- a/pkg/hubble/exporter/aggregator.go
+++ b/pkg/hubble/exporter/aggregator.go
@@ -64,6 +64,10 @@ func (a *Aggregator) Add(ev *v1.Event) {
 
 	k := generateAggregationKey(processedFlow)
 
+	// Enrich the processed flow with timestamp after key generation.
+	// This ensures timestamp doesn't affect aggregation, but preserves temporal context.
+	processedFlow.Time = f.GetTime()
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/pkg/hubble/parser/fieldmask/fieldmask_test.go
+++ b/pkg/hubble/parser/fieldmask/fieldmask_test.go
@@ -100,3 +100,82 @@ func TestFieldMask_copy_without_alloc(t *testing.T) {
 		Destination: &flowpb.Endpoint{ID: 5678, PodName: "podB", Namespace: "nsB", Identity: 9123},
 	}, flow), "expected exported flow fields to be equal")
 }
+
+func TestFieldMask_oneof_multiple_variants(t *testing.T) {
+	// Test that specifying multiple oneof variants only copies the active one.
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{
+		"source.namespace",
+		"l4.TCP.destination_port",
+		"l4.UDP.destination_port",
+		"l7.http.code",
+		"l7.dns.rcode",
+	}})
+	assert.NoError(t, err)
+	assert.True(t, fm.Active())
+
+	// Source flow has TCP and HTTP (not UDP or DNS).
+	srcFlow := &flowpb.Flow{
+		Source: &flowpb.Endpoint{Namespace: "default"},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					SourcePort:      33001,
+					DestinationPort: 443,
+				},
+			},
+		},
+		L7: &flowpb.Layer7{
+			Type: flowpb.L7FlowType_RESPONSE,
+			Record: &flowpb.Layer7_Http{
+				Http: &flowpb.HTTP{
+					Code: 200,
+				},
+			},
+		},
+	}
+
+	dstFlow := &flowpb.Flow{}
+	fm.Copy(dstFlow.ProtoReflect(), srcFlow.ProtoReflect())
+
+	// Should only copy TCP (not UDP) and HTTP (not DNS).
+	assert.NotNil(t, dstFlow.L4, "L4 should be set")
+	assert.IsType(t, &flowpb.Layer4_TCP{}, dstFlow.L4.Protocol, "Should have TCP protocol, not UDP")
+	assert.Equal(t, uint32(443), dstFlow.L4.GetTCP().GetDestinationPort(), "TCP destination port should be 443")
+	assert.Equal(t, uint32(0), dstFlow.L4.GetTCP().GetSourcePort(), "TCP source port should be 0 (not in mask)")
+
+	assert.NotNil(t, dstFlow.L7, "L7 should be set")
+	assert.IsType(t, &flowpb.Layer7_Http{}, dstFlow.L7.Record, "Should have HTTP record, not DNS")
+	assert.Equal(t, uint32(200), dstFlow.L7.GetHttp().GetCode(), "HTTP code should be 200")
+
+	// Verify no spurious UDP or DNS created.
+	assert.Nil(t, dstFlow.L4.GetUDP(), "Should not have UDP structure")
+	assert.Nil(t, dstFlow.L7.GetDns(), "Should not have DNS structure")
+}
+
+func TestFieldMask_nested_vs_parent_only(t *testing.T) {
+	// Test the difference between specifying nested properties vs parent-only fields:
+	// - Nested property (e.g., "source.namespace") creates empty object when not present
+	// - Parent-only (e.g., "l4") results in nil when not present
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{
+		"source.namespace",
+		"l4",
+	}})
+	assert.NoError(t, err)
+
+	srcFlow := &flowpb.Flow{
+		// No Source, No L4
+		Destination: &flowpb.Endpoint{
+			PodName: "test",
+		},
+	}
+
+	dstFlow := &flowpb.Flow{}
+	fm.Copy(dstFlow.ProtoReflect(), srcFlow.ProtoReflect())
+
+	// Source is not nil because "source.namespace" (nested property) was specified.
+	assert.NotNil(t, dstFlow.Source, "Source should be allocated when nested property specified")
+	assert.Empty(t, dstFlow.Source.Namespace, "Source namespace should be empty")
+
+	// L4 is nil because "l4" was specified without nested properties.
+	assert.Nil(t, dstFlow.L4, "L4 should be nil when parent specified without nested properties")
+}


### PR DESCRIPTION
### Problem

While testing field aggregation with `source.namespace`, `destination.namespace`, and L4/L7 protocol fields, I discovered that flows were not aggregating correctly. When a field mask included multiple oneof variants (e.g., `l4.TCP.destination_port` and `l4.UDP.destination_port`), the field mask Copy() method would create spurious empty structures for ALL specified variants, not just the active one.

This caused TCP flows to incorrectly include empty UDP structures in their aggregation keys, preventing proper aggregation even when the actual flow data was identical.

### Solution
1st commit:
Modified `FieldMask.Copy()` to detect oneof fields using protobuf reflection (`fd.ContainingOneof()`) and only copy the active variant by checking `WhichOneof()`. This ensures that only the actual protocol present in the source flow is copied to the destination, preventing spurious structures.
This enables users to specify fine-grained oneof variant fields (e.g., `l4.TCP.destination_port`, `l4.UDP.destination_port`) in field masks for flow aggregation and export without creating incorrect aggregation keys.

Addition in 2nd commit:
Enrich Aggregated hubble flow logs with timestamp to have temporal context.
Aggregation only keeps and aggregates on the fields specified in the `fieldAggregate`.
There is no way to preserve a timestamp, and specifying time in `fieldAggretate` defeats aggregation.

The solution is to preserve the 1st occurring timestamp in the `processedFlow` after the aggregation key is generated.
The aggregation logic is not affected and temporal context is preserved.
### Testing

- Added unit tests in `fieldmask_test.go` demonstrating the fix works for L4 (TCP/UDP/SCTP/ICMP) and L7 (HTTP/DNS) oneof variants
- Added integration test in `aggregator_test.go` showing TCP+HTTP flows now correctly aggregate when the field mask includes both TCP/UDP and HTTP/DNS paths
- All existing tests continue to pass

### Manual Testing Steps:
Manual Verrification:
BYO CNI Cilium Cluster
- `helm upgrade cilium cilium/cilium --version 1.19-dev`
- Build local images and update cluster
- Deploy a workload that produces alot of pings to itself
-  Test aggreagtion via various combinations or below.
```
   --set "hubble.export.dynamic.config.content[1].aggregationInterval=25s" \
   --set "hubble.export.dynamic.config.content[1].fieldMask={time,source.namespace,source.pod_name,destination.namespace,destination.pod_name,l4,IP,node_name,is_reply,verdict,drop_reason_desc}" \
   --set "hubble.export.dynamic.config.content[1].fieldAggregate={l4.TCP.destination_port,l4.UDP.destination_port,l7.http.code,l7.dns.rcode,source.workloads,destination.workloads}" \
   --set "hubble.export.dynamic.config.content[1].name=fmfix" \
   --set "hubble.export.dynamic.config.content[1].filePath=/var/run/cilium/hubble/events-fmfix.log" \
   --set "hubble.export.dynamic.config.content[1].includeFilters[0].source_pod[0]=default/" \
   --set "hubble.export.dynamic.config.content[1].includeFilters[1].destination_pod[0]=default/"
```

- Verification of `cilium-flowlog-config` ConfigMap
- Verification of logs in multiple files via node-shell
   - `var/run/cilium/hubble`
   - check that file names match CM
   - check for aggregation counts
   - check for config reloads
   - check setting to 0s disables aggregation

Both UDP and TCP are logged:
<img width="1147" height="130" alt="image" src="https://github.com/user-attachments/assets/d888fdc9-c6e8-491c-ad7a-c09d3cf91db9" />

```
{"flow":{"time":"2026-01-22T16:47:11.987497620Z","l4":{"TCP":{"destination_port":40876}},"source":{"workloads":[{"name":"kapinger-bad","kind":"Deployment"}]},"destination":{"workloads":[{"name":"kapinger-good","kind":"Deployment"}]},"l7":{},"aggregate":{"egress_flow_count":3}},"time":"2026-01-22T16:47:11.987497620Z"}
{"flow":{"time":"2026-01-22T16:47:14.677500407Z","l4":{"UDP":{"destination_port":42749}},"source":{"workloads":[{"name":"coredns","kind":"Deployment"}]},"destination":{"workloads":[{"name":"kapinger-good","kind":"Deployment"}]},"l7":{},"aggregate":{"egress_flow_count":1}},"time":"2026-01-22T16:47:14.677500407Z"}
```

### FieldMask Changes:
New ability to mask nested oneof fields.
No other changes in FM functionality.

```release-note
Hubble Export FieldMask - Introduce functionality to specify multiple 'oneof' variants like l4.TCP/l4.UDP
Hubble Export Aggregation - Enrich aggregated flow logs with timestamp to preserve temporal context
```
