### PR TITLE
datapath/neighbor: Add ratelimit to desired neighbor calculation

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -149,7 +149,7 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 		fakeDatapath.Cell,
 		neighbor.ForwardableIPCell,
 		reconciler.TableCell,
-		cell.Provide(neighbor.NewCommonTestConfig(true, false)),
+		cell.Provide(neighbor.NewCommonTestConfig(true, false, 100)),
 		prefilter.Cell,
 		monitorAgent.Cell,
 		dial.ServiceResolverCell,

--- a/pkg/datapath/linux/backend_neighbors_test.go
+++ b/pkg/datapath/linux/backend_neighbors_test.go
@@ -32,7 +32,7 @@ func TestBackendNeighborSync(t *testing.T) {
 			statedb.RWTable[*loadbalancer.Backend].ToTable,
 		),
 		neighbor.ForwardableIPCell,
-		cell.Provide(neighbor.NewCommonTestConfig(true, false)),
+		cell.Provide(neighbor.NewCommonTestConfig(true, false, 100)),
 		linux.BackendNeighborSyncCell,
 		cell.Invoke(func(db_ *statedb.DB, backends_ statedb.RWTable[*loadbalancer.Backend], forwardableIPs_ statedb.Table[*neighbor.ForwardableIP]) {
 			db = db_

--- a/pkg/datapath/neighbor/config.go
+++ b/pkg/datapath/neighbor/config.go
@@ -22,6 +22,8 @@ func (c neighborConfig) Flags(fs *pflag.FlagSet) {
 type CommonConfig struct {
 	Enabled              bool
 	ARPPingKernelManaged func() error
+
+	NeighborCalculatorRatelimit int64
 }
 
 func newCommonConfig(
@@ -30,8 +32,9 @@ func newCommonConfig(
 	lifecycle cell.Lifecycle,
 ) *CommonConfig {
 	return &CommonConfig{
-		Enabled:              config.EnableL2NeighDiscovery || !xdpConfig.Disabled(),
-		ARPPingKernelManaged: probes.HaveManagedNeighbors,
+		Enabled:                     config.EnableL2NeighDiscovery || !xdpConfig.Disabled(),
+		ARPPingKernelManaged:        probes.HaveManagedNeighbors,
+		NeighborCalculatorRatelimit: 1,
 	}
 }
 
@@ -39,6 +42,7 @@ func newCommonConfig(
 func NewCommonTestConfig(
 	enableL2NeighDiscovery bool,
 	arpPingKernelManaged bool,
+	neighborCalcRatelimit int64,
 ) func() *CommonConfig {
 	return func() *CommonConfig {
 		return &CommonConfig{
@@ -50,6 +54,7 @@ func NewCommonTestConfig(
 
 				return probes.ErrNotSupported
 			},
+			NeighborCalculatorRatelimit: neighborCalcRatelimit,
 		}
 	}
 }

--- a/pkg/datapath/neighbor/desired_neighbor_calculator.go
+++ b/pkg/datapath/neighbor/desired_neighbor_calculator.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -79,7 +80,22 @@ func (c *desiredNeighborCalculator) Run(ctx context.Context, health cell.Health)
 	const resyncInterval = 5 * time.Minute
 	resyncTimer := time.NewTimer(resyncInterval)
 
+	// Limit the rate of reconciliation. Interval was fairly arbitrarily chosen,
+	// it seems a good balance between frequent updates and resource usage.
+	limit := rate.NewLimiter(15*time.Second, c.Config.NeighborCalculatorRatelimit)
+
 	for {
+		// Block until the rate limiter allows us to proceed
+		err := limit.Wait(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				// If the context was canceled, we are shutting down, so stop the loop
+				return nil
+			}
+
+			return err
+		}
+
 		rx := c.DB.ReadTxn()
 
 		// Get inserted or updated forwardable IPs since the last revision processed

--- a/pkg/datapath/neighbor/forwardable_ip_test.go
+++ b/pkg/datapath/neighbor/forwardable_ip_test.go
@@ -24,7 +24,7 @@ func TestForwardableIPManager(t *testing.T) {
 
 	h := hive.New(
 		ForwardableIPCell,
-		cell.Provide(NewCommonTestConfig(true, false)),
+		cell.Provide(NewCommonTestConfig(true, false, 100)),
 		cell.Invoke(func(
 			fim_ *ForwardableIPManager,
 			fip_ statedb.Table[*ForwardableIP],

--- a/pkg/datapath/neighbor/test/script_test.go
+++ b/pkg/datapath/neighbor/test/script_test.go
@@ -90,7 +90,7 @@ func TestPrivilegedScript(t *testing.T) {
 				cell.Provide(func() *option.DaemonConfig { return &option.DaemonConfig{} }),
 				cell.Config(UseKernelManagedARPPing{}),
 				cell.DecorateAll(func(testConfig UseKernelManagedARPPing) *neighbor.CommonConfig {
-					return neighbor.NewCommonTestConfig(true, testConfig.ARPPingKernelManaged)()
+					return neighbor.NewCommonTestConfig(true, testConfig.ARPPingKernelManaged, 100)()
 				}),
 				cell.Provide(forwardableIPInitializers),
 			}

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -89,7 +89,7 @@ func (h *agentHandle) setupCiliumAgentHive(clientset k8sClient.Clientset, extraC
 		fakeDatapath.Cell,
 		neighbor.ForwardableIPCell,
 		reconciler.TableCell,
-		cell.Provide(neighbor.NewCommonTestConfig(true, false)),
+		cell.Provide(neighbor.NewCommonTestConfig(true, false, 100)),
 		prefilter.Cell,
 		monitorAgent.Cell,
 		metrics.Cell,


### PR DESCRIPTION
During investigation of a memory leak in v1.18, one of the pprof profiles showed a high amount of memory usage in
`netlink/nl.(*NetlinkSocket).Receive`.

https://github.com/cilium/cilium/issues/41623#issuecomment-3517334806

This is most likely due to a lack of rate limiting in the desired neighbor calculation which does a lot of netlink requests to get next hops.

So this PR limits desired neighbor calculation to once every 15 seconds. In the worst case scenario where the default gateway changes, XDP might not be able to forward traffic for up to 15 seconds. Such a scenario should only happen when configuration changes are made or when the network topology changes, and thus this seems an acceptable tradeoff.

```release-note
Add rate limiting to neighbor reconciler to reduce CPU usage and memory churn
```
