### PR TITLE
ci: fix tests-datapath-verifier on 1.19

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -15,7 +15,7 @@ on:
         required: true
       base-SHA:
         description: "SHA of the base branch (target branch of the PR)."
-        required: true
+        required: false
       extra-args:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false


### PR DESCRIPTION
Since introduction of base-SHA as required dispatch argument, triggering that workflow started failing on branch 1.19 as we were not providing it.
