### PR TITLE
Revert "chore: Add OwnerReferencesPermissionEnforcement to kind in CI"

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -10,12 +10,6 @@ nodes:
         kind: InitConfiguration
         nodeRegistration:
           taints: []
-      - |
-        kind: ClusterConfiguration
-        apiServer:
-          extraArgs:
-            enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
-
   - role: worker
   - role: worker
 networking:


### PR DESCRIPTION
This reverts commit f682f0874051726aa014dcf073dca1a4e96d7819.

It looks like this change broke our CI. Let's revert for the moment to unbreak it; we can introduce it again once fixed.

