### PR TITLE
iptables: Don't fail on missing ip6tables when InstallIptRules=false

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -497,7 +497,7 @@ func (m *Manager) Start(ctx cell.HookContext) error {
 		}
 	}
 	if !m.haveIp6tables {
-		if m.sharedCfg.EnableIPv6 {
+		if m.sharedCfg.EnableIPv6 && m.sharedCfg.InstallIptRules {
 			return fmt.Errorf("IPv6 is enabled, but the needed ip6tables tables are unavailable (try disabling IPv6 in Cilium or installing ip6tables and kernel modules: ip6_tables, ip6table_mangle, ip6table_raw, ip6table_filter)")
 		}
 	} else {


### PR DESCRIPTION
InstallIptRules sets whether Cilium should install any iptables in general.  When disabled, Cilium should not require ip6tables kernel modules to be present. The current code fails startup if IPv6 is enabled but ip6tables is unavailable, even when iptables rules are not being installed.

This fix allows Cilium to start in environments where ip6tables is not available but iptables rule installation is disabled via configuration.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
  -SKIPPED: Testing this would require setting up proper mocks for logger and both iptables interfaces. Many similar conditions in this codebase are not unit-tested directly but are covered by integration tests.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
iptables:  Allow Cilium to start in environments where `ip6tables` is not available but iptables rule installation is disabled via configuration.
```
