### PR TITLE
gitattributes: make install/kubernetes driver match more specific.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,12 +27,13 @@ pkg/datapath/config/*_config.go linguist-generated
 go.mod merge=go-mod-tidy
 go.sum merge=go-mod-tidy
 vendor/** merge=go-mod-tidy
-install/kubernetes/** merge=kubernetes-update
+install/kubernetes/cilium/values.yaml merge=kubernetes-update
+install/kubernetes/cilium/README.md merge=kubernetes-update
+install/kubernetes/cilium/values.schema.json merge=schema-permissions
 Documentation/helm-values.rst merge=helm-values-update
 images/cilium/Dockerfile merge=images-update
 images/operator/Dockerfile merge=images-update
 images/hubble-relay/Dockerfile merge=images-update
 .devcontainer/devcontainer.json merge=images-update
 Documentation/cmdref/** merge=cmdref-update
-install/kubernetes/cilium/values.schema.json merge=schema-permissions
 api/** merge=generate-apis

--- a/.gitattributes
+++ b/.gitattributes
@@ -35,4 +35,36 @@ images/operator/Dockerfile merge=images-update
 images/hubble-relay/Dockerfile merge=images-update
 .devcontainer/devcontainer.json merge=images-update
 Documentation/cmdref/** merge=cmdref-update
-api/** merge=generate-apis
+
+# OpenAPI generated files
+api/v1/client/** merge=generate-api
+api/v1/server/** merge=generate-api
+api/v1/models/** merge=generate-api
+
+# Health API generate files
+api/v1/health/client/** merge=generate-health-api
+api/v1/health/models/** merge=generate-health-api
+api/v1/health/server/** merge=generate-health-api
+
+# KVStoreMesh API generate files
+api/v1/kvstoremesh/client/** merge=generate-kvstoremesh-api
+api/v1/kvstoremesh/models/** merge=generate-kvstoremesh-api
+api/v1/kvstoremesh/server/** merge=generate-kvstoremesh-api
+
+# Hubble API generate files
+api/v1/flow/**.go merge=generate-hubble-api
+api/v1/flow/README.md merge=generate-hubble-api
+api/v1/observer/**.go merge=generate-hubble-api
+api/v1/observer/README.md merge=generate-hubble-api
+api/v1/peer/**.go merge=generate-hubble-api
+api/v1/peer/README.md merge=generate-hubble-api
+api/v1/relay/**.go merge=generate-hubble-api
+api/v1/relay/README.md merge=generate-hubble-api
+
+# Operator API generate files
+api/v1/operator/client/** merge=generate-operator-api
+api/v1/operator/models/** merge=generate-operator-api
+api/v1/operator/server/** merge=generate-operator-api
+
+# Standalone DNS Proxy generate files
+api/v1/sdp/** merge=generate-sdp-api

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,7 +24,6 @@ pkg/datapath/config/*_config.go linguist-generated
 #
 # This will configure Git to use the appropriate merge drivers for each file pattern.
 #
-go.mod merge=go-mod-tidy
 go.sum merge=go-mod-tidy
 vendor/** merge=go-mod-tidy
 install/kubernetes/cilium/values.yaml merge=kubernetes-update

--- a/contrib/git/setup-merge-drivers.sh
+++ b/contrib/git/setup-merge-drivers.sh
@@ -7,7 +7,10 @@ git config merge.go-mod-tidy.driver "go mod tidy && go mod vendor"
 
 # Configure Kubernetes update driver
 git config merge.kubernetes-update.name "Kubernetes Update Merge Driver"
-git config merge.kubernetes-update.driver "make -C install/kubernetes && make -C Documentation update-helm-values"
+# Intead of running the default target in install/k8s, we just run targets that
+# completely regenerate files in the helm charts, and we avoid linting the template
+# files as this will not solve merge conflicts there.
+git config merge.kubernetes-update.driver "make -C install/kubernetes update-versions cilium/values.yaml docs && make -C Documentation update-helm-values"
 
 # Configure Helm values update driver
 git config merge.helm-values-update.name "Helm Values Update Merge Driver"

--- a/contrib/git/setup-merge-drivers.sh
+++ b/contrib/git/setup-merge-drivers.sh
@@ -28,8 +28,23 @@ git config merge.cmdref-update.driver "make -C Documentation update-cmdref"
 git config merge.schema-permissions.name "Schema Permissions Merge Driver"
 git config merge.schema-permissions.driver "chmod 644 install/kubernetes/cilium/values.schema.json"
 
-# Configure API generation driver
-git config merge.generate-apis.name "API Generation Merge Driver"
-git config merge.generate-apis.driver "make generate-apis"
+# Configure API generation drivers
+git config merge.generate-api.name "OpenAPI REST API Generation Merge Driver"
+git config merge.generate-api.driver "make generate-api"
+
+git config merge.generate-health-api.name "Health API Generation Merge Driver"
+git config merge.generate-health-api.driver "make generate-health-api"
+
+git config merge.generate-kvstoremesh-api.name "KVStoreMesh API Generation Merge Driver"
+git config merge.generate-kvstoremesh-api.driver "make generate-kvstoremesh-api"
+
+git config merge.generate-hubble-api.name "Hubble API Generation Merge Driver"
+git config merge.generate-hubble-api.driver "make generate-hubble-api"
+
+git config merge.generate-operator-api.name "Operator API Generation Merge Driver"
+git config merge.generate-operator-api.driver "make generate-hubble-api"
+
+git config merge.generate-sdp-api.name "Operator API Generation Merge Driver"
+git config merge.generate-sdp-api.driver "make generate-sdp-api"
 
 echo "Git merge drivers configured successfully!"


### PR DESCRIPTION
Our current drivers are matched on everything inside install/kubernetes. When you do `git merge ...`, git will check the return value of any matching drivers.
In the case of the install/k8s dir we have the kubernetes-update driver. However, because this presumably completes and returns 0, this also papers over any legitimate conflicts.

For example, if there is a conflict in cilium/values.yaml that requires regenerating, but also a legitimate conflict in another (non-generated) file then this will silently run the kubernetes-update driver commands and silently skip incoming changes for other files.

This commit tries to make that matching more specific, by matching only on files we know get overwritten by code generation we avoid wrongly auto-merging other changes.

