### PR TITLE
gateway-api: Implement FrontendTLSValidation for downstream mTLS

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -67,6 +67,7 @@ var Cell = cell.Module(
 
 	cell.Invoke(initGatewayAPIController),
 	cell.Provide(registerSecretSync),
+	cell.Provide(registerFrontendTLSConfigMapSync),
 )
 
 // gatewayAPIPreconditions holds the result of Gateway API precondition checks.
@@ -343,6 +344,29 @@ func registerSecretSync(params secretSyncParams) secretsync.SecretSyncRegistrati
 			RefObject:            &gatewayv1.BackendTLSPolicy{},
 			RefObjectEnqueueFunc: handler.EnqueueBackendTLSPolicyConfigMaps(),
 			RefObjectCheckFunc:   handler.ConfigMapIsReferencedInGateway,
+			SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
+		},
+	}
+}
+
+// registerFrontendTLSConfigMapSync registers Gateway API for ConfigMap synchronization based on
+// CA certificates referenced in Gateway frontend TLS validation (mTLS).
+func registerFrontendTLSConfigMapSync(params secretSyncParams) secretsync.SecretSyncRegistrationOut {
+	if !params.Preconditions.Enabled {
+		return secretsync.SecretSyncRegistrationOut{}
+	}
+
+	if !params.GatewayApiConfig.EnableGatewayAPISecretsSync {
+		return secretsync.SecretSyncRegistrationOut{}
+	}
+
+	handler := NewSecretSyncHandler(params.CtrlRuntimeManager.GetClient(), params.Logger, defaultControllerName)
+
+	return secretsync.SecretSyncRegistrationOut{
+		ConfigMapSyncRegistration: &secretsync.ConfigMapSyncRegistration{
+			RefObject:            &gatewayv1.Gateway{},
+			RefObjectEnqueueFunc: handler.EnqueueFrontendTLSConfigMaps(),
+			RefObjectCheckFunc:   handler.FrontendTLSConfigMapIsReferenced,
 			SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
 		},
 	}

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -207,6 +207,8 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to BackendTLSPolicy
 		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger, r.controllerName)).
 		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger, r.controllerName)).
+		// Watch for changes to Frontend TLS ConfigMaps
+		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForFrontendTLSConfigMap(r.Client, r.logger, r.controllerName)).
 		// Watch for changes to node in order to populate gateway ip addresses if svc of type NodePort
 		Watches(&corev1.Node{}, watchhandlers.EnqueueRequestForNodes(r.Client, r.logger, owningGatewayLabel, r.controllerName)).
 		// Watch created and owned resources

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -103,6 +103,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// At this point, the GatewayClass is managed by Cilium, so Gateway-level validations are safe to run.
+	setGatewayInsecureFrontendValidationMode(gw)
 	if ref := gw.Spec.Infrastructure; ref != nil && ref.ParametersRef != nil {
 		setGatewayAccepted(gw, false, "Invalid Gateway parameters: spec.infrastructure.parametersRef is not supported", gatewayv1.GatewayReasonInvalidParameters)
 		setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
@@ -1288,9 +1289,10 @@ func (r *gatewayReconciler) setListenerStatus(
 		invalidMessages = append(invalidMessages, res.invalidMessages...)
 		conds = merge(conds, res.conds...)
 		supportedKinds := res.supportedKinds
+		rejectionReason := res.invalidReason
 
 		// Validate Frontend TLS (mTLS) ConfigMap references
-		if isValid {
+		if isValid && l.Protocol == gatewayv1.HTTPSProtocolType {
 			frontendValidation := getFrontendTLSValidation(gw, l.Port)
 			if frontendValidation != nil && len(frontendValidation.CACertificateRefs) > 1 {
 				conds = merge(conds, metav1.Condition{
@@ -1304,15 +1306,18 @@ func (r *gatewayReconciler) setListenerStatus(
 			}
 			if ref, ok := helpers.FirstFrontendTLSCACertificateRef(frontendValidation); ok {
 				if !helpers.IsObjectRefConfigMap(ref) {
+					message := fmt.Sprintf("Frontend TLS CACertificateRef %q has unsupported kind %q; must be a ConfigMap", ref.Name, ref.Kind)
 					conds = merge(conds, metav1.Condition{
 						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 						Status:             metav1.ConditionFalse,
 						Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateKind),
-						Message:            "Invalid Frontend TLS CACertificateRef, must be a ConfigMap",
+						Message:            message,
+						ObservedGeneration: gw.GetGeneration(),
 						LastTransitionTime: metav1.Now(),
 					})
-					invalidMessages = append(invalidMessages, "Invalid Frontend TLS CACertificateRef, must be a ConfigMap.")
+					invalidMessages = append(invalidMessages, message+".")
 					isValid = false
+					rejectionReason = gatewayv1.ListenerReasonNoValidCACertificate
 				}
 
 				if isValid {
@@ -1320,15 +1325,18 @@ func (r *gatewayReconciler) setListenerStatus(
 					if refNs != gw.Namespace && !helpers.IsObjectRefAllowed(gw.Namespace, ref,
 						gatewayv1.SchemeGroupVersion.WithKind("Gateway"),
 						corev1.SchemeGroupVersion.WithKind("ConfigMap"), grants.Items) {
+						message := fmt.Sprintf("Frontend TLS CACertificateRef %q in namespace %q is not permitted", ref.Name, refNs)
 						conds = merge(conds, metav1.Condition{
 							Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 							Status:             metav1.ConditionFalse,
 							Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
-							Message:            "Frontend TLS CACertificateRef is not permitted",
+							Message:            message,
+							ObservedGeneration: gw.GetGeneration(),
 							LastTransitionTime: metav1.Now(),
 						})
-						invalidMessages = append(invalidMessages, "Invalid Frontend TLS CACertificateRef, not permitted.")
+						invalidMessages = append(invalidMessages, message+".")
 						isValid = false
+						rejectionReason = gatewayv1.ListenerReasonNoValidCACertificate
 					}
 				}
 
@@ -1338,15 +1346,18 @@ func (r *gatewayReconciler) setListenerStatus(
 						r.logger.InfoContext(ctx, "Found an invalid Frontend TLS ConfigMap",
 							logfields.Error, err.Error(),
 							logfields.Resource, client.ObjectKeyFromObject(gw).String())
+						message := fmt.Sprintf("Frontend TLS CACertificateRef %q is invalid: %s", ref.Name, err)
 						conds = merge(conds, metav1.Condition{
 							Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 							Status:             metav1.ConditionFalse,
 							Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateRef),
-							Message:            "Invalid Frontend TLS CACertificateRef",
+							Message:            message,
+							ObservedGeneration: gw.GetGeneration(),
 							LastTransitionTime: metav1.Now(),
 						})
-						invalidMessages = append(invalidMessages, "Invalid Frontend TLS CACertificateRef, "+err.Error())
+						invalidMessages = append(invalidMessages, message+".")
 						isValid = false
+						rejectionReason = gatewayv1.ListenerReasonNoValidCACertificate
 					}
 				}
 			}
@@ -1355,7 +1366,7 @@ func (r *gatewayReconciler) setListenerStatus(
 		if !isValid {
 			invalidListeners++
 			conds = merge(conds,
-				listenerAcceptedCondition(gw.GetGeneration(), false, res.invalidReason, "Listener not valid. "+strings.Join(invalidMessages, " ")),
+				listenerAcceptedCondition(gw.GetGeneration(), false, rejectionReason, "Listener not valid. "+strings.Join(invalidMessages, " ")),
 				listenerProgrammedCondition(gw.GetGeneration(), false, gatewayv1.ListenerReasonPending, "Address not ready yet"))
 			// If the Listener is not valid, then no kinds are supported
 			// supportedKinds = []gatewayv1.RouteGroupKind{}

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1289,6 +1289,69 @@ func (r *gatewayReconciler) setListenerStatus(
 		conds = merge(conds, res.conds...)
 		supportedKinds := res.supportedKinds
 
+		// Validate Frontend TLS (mTLS) ConfigMap references
+		if isValid {
+			frontendValidation := getFrontendTLSValidation(gw, l.Port)
+			if frontendValidation != nil && len(frontendValidation.CACertificateRefs) > 1 {
+				conds = merge(conds, metav1.Condition{
+					Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+					Message:            "Having more than one Frontend TLS CA Certificate Ref is not supported; only the first reference is used.",
+					ObservedGeneration: gw.GetGeneration(),
+					LastTransitionTime: metav1.Now(),
+				})
+			}
+			if ref, ok := helpers.FirstFrontendTLSCACertificateRef(frontendValidation); ok {
+				if !helpers.IsObjectRefConfigMap(ref) {
+					conds = merge(conds, metav1.Condition{
+						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+						Status:             metav1.ConditionFalse,
+						Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateKind),
+						Message:            "Invalid Frontend TLS CACertificateRef, must be a ConfigMap",
+						LastTransitionTime: metav1.Now(),
+					})
+					invalidMessages = append(invalidMessages, "Invalid Frontend TLS CACertificateRef, must be a ConfigMap.")
+					isValid = false
+				}
+
+				if isValid {
+					refNs := helpers.NamespaceDerefOr(ref.Namespace, gw.Namespace)
+					if refNs != gw.Namespace && !helpers.IsObjectRefAllowed(gw.Namespace, ref,
+						gatewayv1.SchemeGroupVersion.WithKind("Gateway"),
+						corev1.SchemeGroupVersion.WithKind("ConfigMap"), grants.Items) {
+						conds = merge(conds, metav1.Condition{
+							Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
+							Message:            "Frontend TLS CACertificateRef is not permitted",
+							LastTransitionTime: metav1.Now(),
+						})
+						invalidMessages = append(invalidMessages, "Invalid Frontend TLS CACertificateRef, not permitted.")
+						isValid = false
+					}
+				}
+
+				if isValid {
+					refNs := helpers.NamespaceDerefOr(ref.Namespace, gw.Namespace)
+					if err := validateFrontendTLSConfigMap(ctx, r.Client, refNs, string(ref.Name)); err != nil {
+						r.logger.InfoContext(ctx, "Found an invalid Frontend TLS ConfigMap",
+							logfields.Error, err.Error(),
+							logfields.Resource, client.ObjectKeyFromObject(gw).String())
+						conds = merge(conds, metav1.Condition{
+							Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(gatewayv1.ListenerReasonInvalidCACertificateRef),
+							Message:            "Invalid Frontend TLS CACertificateRef",
+							LastTransitionTime: metav1.Now(),
+						})
+						invalidMessages = append(invalidMessages, "Invalid Frontend TLS CACertificateRef, "+err.Error())
+						isValid = false
+					}
+				}
+			}
+		}
+
 		if !isValid {
 			invalidListeners++
 			conds = merge(conds,
@@ -1544,6 +1607,47 @@ func validateTLSSecret(ctx context.Context, c client.Client, namespace, name str
 	return nil
 }
 
+// getFrontendTLSValidation returns the FrontendTLSValidation for a given listener port.
+// It checks per-port overrides first, then falls back to the default configuration.
+func getFrontendTLSValidation(gw *gatewayv1.Gateway, port gatewayv1.PortNumber) *gatewayv1.FrontendTLSValidation {
+	if gw.Spec.TLS == nil || gw.Spec.TLS.Frontend == nil {
+		return nil
+	}
+
+	frontend := gw.Spec.TLS.Frontend
+
+	// Check per-port override first
+	for _, perPort := range frontend.PerPort {
+		if perPort.Port == port && perPort.TLS.Validation != nil {
+			return perPort.TLS.Validation
+		}
+	}
+
+	// Fall back to default
+	return frontend.Default.Validation
+}
+
+// validateFrontendTLSConfigMap validates that a ConfigMap exists and has the required ca.crt key.
+func validateFrontendTLSConfigMap(ctx context.Context, c client.Client, namespace, name string) error {
+	cfgMap := &corev1.ConfigMap{}
+	if err := c.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, cfgMap); err != nil {
+		return err
+	}
+
+	caCert, ok := cfgMap.Data["ca.crt"]
+	if !ok {
+		return fmt.Errorf("ConfigMap %s/%s does not contain 'ca.crt' key", namespace, name)
+	}
+
+	if !helpers.IsValidPemFormat([]byte(caCert)) {
+		return fmt.Errorf("PEM format error in ca.crt")
+	}
+
+	return nil
+}
 func (r *gatewayReconciler) handleReconcileErrorWithStatus(ctx context.Context, reconcileErr error, original *gatewayv1.Gateway, modified *gatewayv1.Gateway) (ctrl.Result, error) {
 	if err := r.updateStatus(ctx, original, modified); err != nil {
 		return controllerruntime.Fail(fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err))

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1290,6 +1290,225 @@ func Test_sectionNameMatched(t *testing.T) {
 	}
 }
 
+func Test_setListenerStatus_FrontendTLSConfigMapValidation(t *testing.T) {
+	tests := []struct {
+		name                string
+		caRefs              []gatewayv1.ObjectReference
+		objects             []client.Object
+		wantListenersStatus ListenersStatus
+		wantResolvedStatus  metav1.ConditionStatus
+		wantResolvedReason  gatewayv1.ListenerConditionReason
+		wantResolvedMsg     string
+	}{
+		{
+			name: "invalid frontend CA ref kind",
+			caRefs: []gatewayv1.ObjectReference{
+				{
+					Group: "",
+					Kind:  "Secret",
+					Name:  "frontend-ca",
+				},
+			},
+			wantListenersStatus: ListenersStatusNoneValid,
+			wantResolvedStatus:  metav1.ConditionFalse,
+			wantResolvedReason:  gatewayv1.ListenerReasonInvalidCACertificateKind,
+		},
+		{
+			name: "frontend configmap does not exist",
+			caRefs: []gatewayv1.ObjectReference{
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  "frontend-ca",
+				},
+			},
+			wantListenersStatus: ListenersStatusNoneValid,
+			wantResolvedStatus:  metav1.ConditionFalse,
+			wantResolvedReason:  gatewayv1.ListenerReasonInvalidCACertificateRef,
+		},
+		{
+			name: "frontend configmap missing ca.crt key",
+			caRefs: []gatewayv1.ObjectReference{
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  "frontend-ca",
+				},
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "frontend-ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"other-key": "value",
+					},
+				},
+			},
+			wantListenersStatus: ListenersStatusNoneValid,
+			wantResolvedStatus:  metav1.ConditionFalse,
+			wantResolvedReason:  gatewayv1.ListenerReasonInvalidCACertificateRef,
+		},
+		{
+			name: "valid frontend configmap reference",
+			caRefs: []gatewayv1.ObjectReference{
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  "frontend-ca",
+				},
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "frontend-ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"ca.crt": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+					},
+				},
+			},
+			wantListenersStatus: ListenersStatusAllValid,
+			wantResolvedStatus:  metav1.ConditionTrue,
+			wantResolvedReason:  gatewayv1.ListenerReasonResolvedRefs,
+		},
+		{
+			name: "valid first frontend configmap reference ignores invalid second reference",
+			caRefs: []gatewayv1.ObjectReference{
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  "frontend-ca",
+				},
+				{
+					Group: "",
+					Kind:  "Secret",
+					Name:  "ignored-frontend-ca",
+				},
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "frontend-ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"ca.crt": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+					},
+				},
+			},
+			wantListenersStatus: ListenersStatusAllValid,
+			wantResolvedStatus:  metav1.ConditionFalse,
+			wantResolvedReason:  gatewayv1.ListenerReasonInvalidCACertificateRef,
+			wantResolvedMsg:     "Having more than one Frontend TLS CA Certificate Ref is not supported; only the first reference is used.",
+		},
+		{
+			name: "invalid first frontend configmap reference is not rescued by valid second reference",
+			caRefs: []gatewayv1.ObjectReference{
+				{
+					Group: "",
+					Kind:  "Secret",
+					Name:  "frontend-ca",
+				},
+				{
+					Group: "",
+					Kind:  "ConfigMap",
+					Name:  "ignored-frontend-ca",
+				},
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ignored-frontend-ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"ca.crt": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+					},
+				},
+			},
+			wantListenersStatus: ListenersStatusNoneValid,
+			wantResolvedStatus:  metav1.ConditionFalse,
+			wantResolvedReason:  gatewayv1.ListenerReasonInvalidCACertificateKind,
+			wantResolvedMsg:     "Invalid Frontend TLS CACertificateRef, must be a ConfigMap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+				WithObjects(tt.objects...).
+				Build()
+
+			r := &gatewayReconciler{
+				Client: c,
+				logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+			}
+
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cilium",
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "https",
+							Port:     443,
+							Protocol: gatewayv1.HTTPSProtocolType,
+						},
+					},
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: tt.caRefs,
+									Mode:              gatewayv1.AllowValidOnly,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			listenersStatus, err := r.setListenerStatus(
+				t.Context(),
+				gw,
+				&gatewayv1.HTTPRouteList{},
+				&gatewayv1.TLSRouteList{},
+				&gatewayv1.GRPCRouteList{},
+				&gatewayv1alpha2.TCPRouteList{},
+				&gatewayv1alpha2.UDPRouteList{},
+				helpers.NamespaceLabelIndex{},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantListenersStatus, listenersStatus)
+			require.Len(t, gw.Status.Listeners, 1)
+
+			resolvedRefs := findListenerCondition(gw.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+			require.NotNil(t, resolvedRefs, "missing ResolvedRefs condition")
+			assert.Equal(t, tt.wantResolvedStatus, resolvedRefs.Status)
+			assert.Equal(t, string(tt.wantResolvedReason), resolvedRefs.Reason)
+			if tt.wantResolvedMsg != "" {
+				assert.Equal(t, tt.wantResolvedMsg, resolvedRefs.Message)
+			}
+		})
+	}
+}
+
+func findListenerCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
 // fakeIndexHTTPRouteByBackendService is a client.IndexerFunc that takes a single HTTPRoute and
 // returns all referenced backend service full names (`namespace/name`) to add to the relevant index.
 //

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1432,7 +1432,7 @@ func Test_setListenerStatus_FrontendTLSConfigMapValidation(t *testing.T) {
 			wantListenersStatus: ListenersStatusNoneValid,
 			wantResolvedStatus:  metav1.ConditionFalse,
 			wantResolvedReason:  gatewayv1.ListenerReasonInvalidCACertificateKind,
-			wantResolvedMsg:     "Invalid Frontend TLS CACertificateRef, must be a ConfigMap",
+			wantResolvedMsg:     "Frontend TLS CACertificateRef \"frontend-ca\" has unsupported kind \"Secret\"; must be a ConfigMap",
 		},
 	}
 
@@ -1450,8 +1450,9 @@ func Test_setListenerStatus_FrontendTLSConfigMapValidation(t *testing.T) {
 
 			gw := &gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "gw",
-					Namespace: "default",
+					Name:       "gw",
+					Namespace:  "default",
+					Generation: 7,
 				},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: "cilium",
@@ -1481,8 +1482,8 @@ func Test_setListenerStatus_FrontendTLSConfigMapValidation(t *testing.T) {
 				&gatewayv1.HTTPRouteList{},
 				&gatewayv1.TLSRouteList{},
 				&gatewayv1.GRPCRouteList{},
-				&gatewayv1alpha2.TCPRouteList{},
-				&gatewayv1alpha2.UDPRouteList{},
+				&gatewayv1.TCPRouteList{},
+				&gatewayv1.UDPRouteList{},
 				helpers.NamespaceLabelIndex{},
 			)
 			require.NoError(t, err)
@@ -1496,14 +1497,105 @@ func Test_setListenerStatus_FrontendTLSConfigMapValidation(t *testing.T) {
 			if tt.wantResolvedMsg != "" {
 				assert.Equal(t, tt.wantResolvedMsg, resolvedRefs.Message)
 			}
+			assert.Equal(t, gw.Generation, resolvedRefs.ObservedGeneration)
+
+			accepted := findListenerCondition(gw.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionAccepted))
+			require.NotNil(t, accepted, "missing Accepted condition")
+			if tt.wantListenersStatus == ListenersStatusNoneValid {
+				assert.Equal(t, metav1.ConditionFalse, accepted.Status)
+				assert.Equal(t, string(gatewayv1.ListenerReasonNoValidCACertificate), accepted.Reason)
+			} else {
+				assert.Equal(t, metav1.ConditionTrue, accepted.Status)
+				assert.Equal(t, string(gatewayv1.ListenerReasonAccepted), accepted.Reason)
+			}
+			assert.Equal(t, gw.Generation, accepted.ObservedGeneration)
+
+			programmed := findListenerCondition(gw.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionProgrammed))
+			require.NotNil(t, programmed, "missing Programmed condition")
+			assert.Equal(t, metav1.ConditionFalse, programmed.Status)
+			assert.Equal(t, gw.Generation, programmed.ObservedGeneration)
 		})
 	}
+
+	t.Run("invalid default frontend validation does not affect HTTP listeners", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			Build()
+		r := &gatewayReconciler{
+			Client: c,
+			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default", Generation: 7},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "cilium",
+				Listeners: []gatewayv1.Listener{
+					{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+					{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+				},
+				TLS: &gatewayv1.GatewayTLSConfig{
+					Frontend: &gatewayv1.FrontendTLSConfig{
+						Default: gatewayv1.TLSConfig{
+							Validation: &gatewayv1.FrontendTLSValidation{
+								CACertificateRefs: []gatewayv1.ObjectReference{{
+									Group: "", Kind: "ConfigMap", Name: "does-not-exist",
+								}},
+								Mode: gatewayv1.AllowValidOnly,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		listenersStatus, err := r.setListenerStatus(
+			t.Context(), gw,
+			&gatewayv1.HTTPRouteList{}, &gatewayv1.TLSRouteList{}, &gatewayv1.GRPCRouteList{},
+			&gatewayv1.TCPRouteList{}, &gatewayv1.UDPRouteList{}, helpers.NamespaceLabelIndex{},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, ListenersStatusSomeInvalid, listenersStatus)
+
+		https := findListenerStatus(gw.Status.Listeners, "https")
+		require.NotNil(t, https)
+		httpsResolved := findListenerCondition(https.Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+		require.NotNil(t, httpsResolved)
+		assert.Equal(t, metav1.ConditionFalse, httpsResolved.Status)
+		httpsAccepted := findListenerCondition(https.Conditions, string(gatewayv1.ListenerConditionAccepted))
+		require.NotNil(t, httpsAccepted)
+		assert.Equal(t, metav1.ConditionFalse, httpsAccepted.Status)
+		assert.Equal(t, string(gatewayv1.ListenerReasonNoValidCACertificate), httpsAccepted.Reason)
+		httpsProgrammed := findListenerCondition(https.Conditions, string(gatewayv1.ListenerConditionProgrammed))
+		require.NotNil(t, httpsProgrammed)
+		assert.Equal(t, metav1.ConditionFalse, httpsProgrammed.Status)
+
+		http := findListenerStatus(gw.Status.Listeners, "http")
+		require.NotNil(t, http)
+		httpResolved := findListenerCondition(http.Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+		require.NotNil(t, httpResolved)
+		assert.Equal(t, metav1.ConditionTrue, httpResolved.Status)
+		httpAccepted := findListenerCondition(http.Conditions, string(gatewayv1.ListenerConditionAccepted))
+		require.NotNil(t, httpAccepted)
+		assert.Equal(t, metav1.ConditionTrue, httpAccepted.Status)
+		httpProgrammed := findListenerCondition(http.Conditions, string(gatewayv1.ListenerConditionProgrammed))
+		require.NotNil(t, httpProgrammed)
+		assert.Equal(t, metav1.ConditionFalse, httpProgrammed.Status)
+	})
 }
 
 func findListenerCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
 	for i := range conditions {
 		if conditions[i].Type == condType {
 			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func findListenerStatus(statuses []gatewayv1.ListenerStatus, name gatewayv1.SectionName) *gatewayv1.ListenerStatus {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return &statuses[i]
 		}
 	}
 	return nil

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -6,6 +6,7 @@ package gateway_api
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -20,6 +21,44 @@ func setGatewayAccepted(gw *gatewayv1.Gateway, accepted bool, msg string, reason
 func setGatewayProgrammed(gw *gatewayv1.Gateway, status metav1.ConditionStatus, msg string, reason gatewayv1.GatewayConditionReason) *gatewayv1.Gateway {
 	gw.Status.Conditions = merge(gw.Status.Conditions, gatewayStatusProgrammedCondition(gw, status, msg, reason))
 	return gw
+}
+
+// setGatewayInsecureFrontendValidationMode adds the warning condition required
+// for AllowInsecureFallback and removes it as soon as the mode is no longer in
+// use by either the default or a per-port frontend TLS configuration.
+func setGatewayInsecureFrontendValidationMode(gw *gatewayv1.Gateway) *gatewayv1.Gateway {
+	conditionType := string(gatewayv1.GatewayConditionInsecureFrontendValidationMode)
+	if !hasInsecureFrontendValidationMode(gw) {
+		meta.RemoveStatusCondition(&gw.Status.Conditions, conditionType)
+		return gw
+	}
+
+	gw.Status.Conditions = merge(gw.Status.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gatewayv1.GatewayReasonConfigurationChanged),
+		Message:            "Gateway is configured to allow insecure frontend certificate validation",
+		ObservedGeneration: gw.GetGeneration(),
+		LastTransitionTime: metav1.Now(),
+	})
+	return gw
+}
+
+func hasInsecureFrontendValidationMode(gw *gatewayv1.Gateway) bool {
+	if gw.Spec.TLS == nil || gw.Spec.TLS.Frontend == nil {
+		return false
+	}
+
+	frontend := gw.Spec.TLS.Frontend
+	if frontend.Default.Validation != nil && frontend.Default.Validation.Mode == gatewayv1.AllowInsecureFallback {
+		return true
+	}
+	for _, perPort := range frontend.PerPort {
+		if perPort.TLS.Validation != nil && perPort.TLS.Validation.Mode == gatewayv1.AllowInsecureFallback {
+			return true
+		}
+	}
+	return false
 }
 
 func gatewayStatusAcceptedCondition(gw *gatewayv1.Gateway, accepted bool, msg string, reason gatewayv1.GatewayConditionReason) metav1.Condition {

--- a/operator/pkg/gateway-api/gateway_status_test.go
+++ b/operator/pkg/gateway-api/gateway_status_test.go
@@ -9,9 +9,47 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+func Test_setGatewayInsecureFrontendValidationMode(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Generation: 7},
+		Spec: gatewayv1.GatewaySpec{
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{Mode: gatewayv1.AllowInsecureFallback},
+					},
+				},
+			},
+		},
+	}
+
+	setGatewayInsecureFrontendValidationMode(gw)
+	condition := findListenerCondition(gw.Status.Conditions, string(gatewayv1.GatewayConditionInsecureFrontendValidationMode))
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionTrue, condition.Status)
+	assert.Equal(t, string(gatewayv1.GatewayReasonConfigurationChanged), condition.Reason)
+	assert.Equal(t, gw.Generation, condition.ObservedGeneration)
+
+	gw.Spec.TLS.Frontend.Default.Validation.Mode = gatewayv1.AllowValidOnly
+	gw.Spec.TLS.Frontend.PerPort = []gatewayv1.TLSPortConfig{{
+		Port: 8443,
+		TLS: gatewayv1.TLSConfig{
+			Validation: &gatewayv1.FrontendTLSValidation{Mode: gatewayv1.AllowInsecureFallback},
+		},
+	}}
+	setGatewayInsecureFrontendValidationMode(gw)
+	condition = findListenerCondition(gw.Status.Conditions, string(gatewayv1.GatewayConditionInsecureFrontendValidationMode))
+	require.NotNil(t, condition, "per-port fallback must retain the condition")
+
+	gw.Spec.TLS.Frontend.PerPort[0].TLS.Validation.Mode = gatewayv1.AllowValidOnly
+	setGatewayInsecureFrontendValidationMode(gw)
+	assert.Nil(t, findListenerCondition(gw.Status.Conditions, string(gatewayv1.GatewayConditionInsecureFrontendValidationMode)))
+}
 
 func Test_gatewayStatusScheduledCondition(t *testing.T) {
 	type args struct {

--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -30,7 +30,6 @@ var exemptFeatures = []features.Feature{
 	features.BackendTLSPolicySanValidationFeature,
 	features.TLSRouteModeTerminateFeature,
 	features.GatewayBackendClientCertificateFeature,
-	features.GatewayFrontendClientCertificateValidationFeature,
 	features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,
 }
 

--- a/operator/pkg/gateway-api/gatewayclass_status_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_status_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/pkg/features"
 )
 
 func Test_gatewayClassAcceptedCondition(t *testing.T) {
@@ -66,4 +67,10 @@ func Test_gatewayClassAcceptedCondition(t *testing.T) {
 			assert.True(t, cmp.Equal(got, tt.want, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")), "httpRouteAcceptedCondition() = %v, want %v", got, tt.want)
 		})
 	}
+}
+
+func Test_gatewayClassAdvertisesFrontendClientCertificateValidation(t *testing.T) {
+	assert.Contains(t, gatewayClassSupportedFeatures, gatewayv1.SupportedFeature{
+		Name: gatewayv1.FeatureName(features.SupportGatewayFrontendClientCertificateValidation),
+	})
 }

--- a/operator/pkg/gateway-api/helpers/referencegrants.go
+++ b/operator/pkg/gateway-api/helpers/referencegrants.go
@@ -51,3 +51,8 @@ func isReferenceAllowed(originatingNamespace, name string, namespace *gatewayv1.
 	}
 	return false
 }
+
+// IsObjectRefAllowed returns true if the object reference is allowed by the reference grant.
+func IsObjectRefAllowed(originatingNamespace string, ref gatewayv1.ObjectReference, fromGVK, toGVK schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
+	return isReferenceAllowed(originatingNamespace, string(ref.Name), ref.Namespace, fromGVK, toGVK, grants)
+}

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -97,6 +97,20 @@ func IsConfigMap(certRef gatewayv1.LocalObjectReference) bool {
 	return certRef.Kind == kindConfigMap && certRef.Group == corev1.GroupName
 }
 
+// IsObjectRefConfigMap checks if an ObjectReference refers to a ConfigMap.
+func IsObjectRefConfigMap(ref gatewayv1.ObjectReference) bool {
+	return ref.Kind == kindConfigMap && (ref.Group == "" || ref.Group == corev1.GroupName)
+}
+
+// FirstFrontendTLSCACertificateRef returns the only frontend TLS CA reference
+// supported by Gateway API Core conformance.
+func FirstFrontendTLSCACertificateRef(validation *gatewayv1.FrontendTLSValidation) (gatewayv1.ObjectReference, bool) {
+	if validation == nil || len(validation.CACertificateRefs) == 0 {
+		return gatewayv1.ObjectReference{}, false
+	}
+	return validation.CACertificateRefs[0], true
+}
+
 func IsServiceTargetRef(tr gatewayv1.LocalPolicyTargetReferenceWithSectionName) bool {
 	return tr.Kind == kindService && tr.Group == corev1.GroupName
 }

--- a/operator/pkg/gateway-api/secretsync.go
+++ b/operator/pkg/gateway-api/secretsync.go
@@ -179,3 +179,119 @@ func (h *SecretSyncHandler) ConfigMapIsReferencedInGateway(ctx context.Context, 
 	}
 	return false
 }
+
+// EnqueueFrontendTLSConfigMaps produces a handler.EventHandler that, when it is passed a
+// Gateway as the object.Object, returns any ConfigMaps referenced in the Frontend TLS validation.
+func (h *SecretSyncHandler) EnqueueFrontendTLSConfigMaps() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		scopedLog := h.logger.With(
+			logfields.Resource, obj.GetName(),
+		)
+
+		gw, ok := obj.(*gatewayv1.Gateway)
+		if !ok {
+			return nil
+		}
+
+		// Check whether Gateway is managed by Cilium
+		if !helpers.GatewayHasMatchingControllerFn(ctx, h.client, h.controllerName, h.logger)(gw) {
+			return nil
+		}
+
+		var reqs []reconcile.Request
+
+		if gw.Spec.TLS == nil || gw.Spec.TLS.Frontend == nil {
+			return nil
+		}
+
+		frontend := gw.Spec.TLS.Frontend
+
+		if frontend.Default.Validation != nil {
+			if certRef, ok := helpers.FirstFrontendTLSCACertificateRef(frontend.Default.Validation); ok &&
+				helpers.IsObjectRefConfigMap(certRef) {
+				cm := types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(certRef.Namespace, gw.Namespace),
+					Name:      string(certRef.Name),
+				}
+				reqs = append(reqs, reconcile.Request{NamespacedName: cm})
+				scopedLog.DebugContext(ctx, "Enqueued configmap for gateway frontend TLS", logfields.ConfigMapName, cm)
+			}
+		}
+
+		for _, perPort := range frontend.PerPort {
+			if perPort.TLS.Validation == nil {
+				continue
+			}
+			if certRef, ok := helpers.FirstFrontendTLSCACertificateRef(perPort.TLS.Validation); ok &&
+				helpers.IsObjectRefConfigMap(certRef) {
+				cm := types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(certRef.Namespace, gw.Namespace),
+					Name:      string(certRef.Name),
+				}
+				reqs = append(reqs, reconcile.Request{NamespacedName: cm})
+				scopedLog.DebugContext(ctx, "Enqueued configmap for gateway frontend TLS per-port", logfields.ConfigMapName, cm)
+			}
+		}
+
+		return reqs
+	})
+}
+
+// FrontendTLSConfigMapIsReferenced checks if a ConfigMap is referenced by any Cilium Gateway's
+// frontend TLS validation configuration.
+func (h *SecretSyncHandler) FrontendTLSConfigMapIsReferenced(ctx context.Context, _ client.Client, _ *slog.Logger, cfgMap *corev1.ConfigMap) bool {
+	gateways := getGatewaysForFrontendTLSConfigMap(ctx, h.client, cfgMap, h.logger)
+	for _, gw := range gateways {
+		if helpers.GatewayHasMatchingControllerFn(ctx, h.client, h.controllerName, h.logger)(gw) {
+			return true
+		}
+	}
+	return false
+}
+
+// getGatewaysForFrontendTLSConfigMap returns all Gateways that reference the given ConfigMap
+// in their frontend TLS validation configuration.
+func getGatewaysForFrontendTLSConfigMap(ctx context.Context, c client.Client, cfgMap *corev1.ConfigMap, logger *slog.Logger) []*gatewayv1.Gateway {
+	scopedLog := logger.With(
+		logfields.Resource, cfgMap.GetName(),
+	)
+
+	gwList := &gatewayv1.GatewayList{}
+	if err := c.List(ctx, gwList); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to list Gateways", logfields.Error, err)
+		return nil
+	}
+
+	var gateways []*gatewayv1.Gateway
+	for i := range gwList.Items {
+		gw := &gwList.Items[i]
+		if gw.Spec.TLS == nil || gw.Spec.TLS.Frontend == nil {
+			continue
+		}
+
+		frontend := gw.Spec.TLS.Frontend
+
+		if frontend.Default.Validation != nil {
+			if certRef, ok := helpers.FirstFrontendTLSCACertificateRef(frontend.Default.Validation); ok {
+				refNs := helpers.NamespaceDerefOr(certRef.Namespace, gw.Namespace)
+				if refNs == cfgMap.Namespace && string(certRef.Name) == cfgMap.Name {
+					gateways = append(gateways, gw)
+				}
+			}
+		}
+
+		for _, perPort := range frontend.PerPort {
+			if perPort.TLS.Validation == nil {
+				continue
+			}
+			if certRef, ok := helpers.FirstFrontendTLSCACertificateRef(perPort.TLS.Validation); ok {
+				refNs := helpers.NamespaceDerefOr(certRef.Namespace, gw.Namespace)
+				if refNs == cfgMap.Namespace && string(certRef.Name) == cfgMap.Name {
+					gateways = append(gateways, gw)
+				}
+			}
+		}
+	}
+
+	return gateways
+}

--- a/operator/pkg/gateway-api/secretsync_frontendtls_test.go
+++ b/operator/pkg/gateway-api/secretsync_frontendtls_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+func TestFrontendTLSConfigMapSyncUsesOnlyFirstRef(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	gw := gatewayWithFrontendTLSConfigMapRefs("gateway", []gatewayv1.ObjectReference{
+		{Group: "", Kind: "ConfigMap", Name: "first-ca"},
+		{Group: "", Kind: "ConfigMap", Name: "ignored-ca"},
+	})
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(
+			&gatewayv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "cilium"},
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: defaultControllerName,
+				},
+			},
+			gw,
+		).
+		Build()
+	handler := NewSecretSyncHandler(c, logger, defaultControllerName)
+
+	firstCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "first-ca"},
+	}
+	ignoredCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ignored-ca"},
+	}
+
+	require.True(t, handler.FrontendTLSConfigMapIsReferenced(t.Context(), c, logger, firstCA))
+	require.False(t, handler.FrontendTLSConfigMapIsReferenced(t.Context(), c, logger, ignoredCA))
+
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	t.Cleanup(queue.ShutDown)
+
+	handler.EnqueueFrontendTLSConfigMaps().Create(t.Context(), event.CreateEvent{Object: gw}, queue)
+
+	require.Equal(t, 1, queue.Len())
+	item, shutdown := queue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, reconcile.Request{NamespacedName: clientObjectKey("default", "first-ca")}, item)
+	queue.Done(item)
+}
+
+func gatewayWithFrontendTLSConfigMapRefs(name string, refs []gatewayv1.ObjectReference) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: refs,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func clientObjectKey(namespace, name string) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+}

--- a/operator/pkg/gateway-api/watch-handlers/frontendtls.go
+++ b/operator/pkg/gateway-api/watch-handlers/frontendtls.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForFrontendTLSConfigMap returns reconcile requests for Cilium
+// Gateways that reference the changed ConfigMap in frontend TLS validation.
+func EnqueueRequestForFrontendTLSConfigMap(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		cfgMap, ok := o.(*corev1.ConfigMap)
+		if !ok {
+			return nil
+		}
+
+		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-frontend-tls-configmap")
+
+		gwList := &gatewayv1.GatewayList{}
+		if err := c.List(ctx, gwList); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to list Gateways", logfields.Error, err)
+			return nil
+		}
+
+		reconcileRequests := make(map[reconcile.Request]struct{})
+		for i := range gwList.Items {
+			gw := &gwList.Items[i]
+			if !hasMatchingController(ctx, c, controllerName, logger)(gw) {
+				continue
+			}
+			if !frontendTLSConfigMapMatches(gw, cfgMap) {
+				continue
+			}
+			reconcileRequests[reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: gw.GetNamespace(),
+					Name:      gw.GetName(),
+				},
+			}] = struct{}{}
+		}
+
+		recs := slices.Collect(maps.Keys(reconcileRequests))
+		if len(recs) > 0 {
+			scopedLog.DebugContext(ctx, "Frontend TLS ConfigMap relevant to Gateways",
+				logfields.Resource, client.ObjectKeyFromObject(o).String(),
+				logfields.Gateway, recs)
+		}
+		return recs
+	})
+}
+
+func frontendTLSConfigMapMatches(gw *gatewayv1.Gateway, cfgMap *corev1.ConfigMap) bool {
+	if gw.Spec.TLS == nil || gw.Spec.TLS.Frontend == nil {
+		return false
+	}
+
+	frontend := gw.Spec.TLS.Frontend
+	if frontend.Default.Validation != nil {
+		if ref, ok := helpers.FirstFrontendTLSCACertificateRef(frontend.Default.Validation); ok &&
+			configMapRefMatchesGateway(ref, gw.Namespace, cfgMap) {
+			return true
+		}
+	}
+
+	for _, perPort := range frontend.PerPort {
+		if perPort.TLS.Validation == nil {
+			continue
+		}
+		if ref, ok := helpers.FirstFrontendTLSCACertificateRef(perPort.TLS.Validation); ok &&
+			configMapRefMatchesGateway(ref, gw.Namespace, cfgMap) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func configMapRefMatchesGateway(ref gatewayv1.ObjectReference, defaultNamespace string, cfgMap *corev1.ConfigMap) bool {
+	if !helpers.IsObjectRefConfigMap(ref) {
+		return false
+	}
+	refNs := helpers.NamespaceDerefOr(ref.Namespace, defaultNamespace)
+	return refNs == cfgMap.Namespace && string(ref.Name) == cfgMap.Name
+}

--- a/operator/pkg/gateway-api/watch-handlers/frontendtls_test.go
+++ b/operator/pkg/gateway-api/watch-handlers/frontendtls_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func Test_frontendTLSConfigMapMatchesUsesOnlyFirstRef(t *testing.T) {
+	cfgMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "first-ca",
+		},
+	}
+	ignoredCfgMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "ignored-ca",
+		},
+	}
+
+	tests := map[string]struct {
+		gateway *gatewayv1.Gateway
+	}{
+		"default validation": {
+			gateway: gatewayWithFrontendTLSRefs([]gatewayv1.ObjectReference{
+				{Group: "", Kind: "ConfigMap", Name: "first-ca"},
+				{Group: "", Kind: "ConfigMap", Name: "ignored-ca"},
+			}, nil),
+		},
+		"per-port validation": {
+			gateway: gatewayWithFrontendTLSRefs(nil, []gatewayv1.ObjectReference{
+				{Group: "", Kind: "ConfigMap", Name: "first-ca"},
+				{Group: "", Kind: "ConfigMap", Name: "ignored-ca"},
+			}),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.True(t, frontendTLSConfigMapMatches(tt.gateway, cfgMap))
+			require.False(t, frontendTLSConfigMapMatches(tt.gateway, ignoredCfgMap))
+		})
+	}
+}
+
+func gatewayWithFrontendTLSRefs(defaultRefs, perPortRefs []gatewayv1.ObjectReference) *gatewayv1.Gateway {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "gateway",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{},
+			},
+		},
+	}
+
+	if defaultRefs != nil {
+		gw.Spec.TLS.Frontend.Default.Validation = &gatewayv1.FrontendTLSValidation{
+			CACertificateRefs: defaultRefs,
+		}
+	}
+	if perPortRefs != nil {
+		gw.Spec.TLS.Frontend.PerPort = []gatewayv1.TLSPortConfig{
+			{
+				Port: 443,
+				TLS: gatewayv1.TLSConfig{
+					Validation: &gatewayv1.FrontendTLSValidation{
+						CACertificateRefs: perPortRefs,
+					},
+				},
+			},
+		}
+	}
+
+	return gw
+}

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -236,6 +236,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				Port:                       uint32(l.Port),
 				Hostname:                   toHostname(l.Hostname),
 				TLS:                        toTLS(l.TLS, input.ReferenceGrants, l.Source.Namespace, schema.GroupVersionKind{Group: l.Source.Group, Version: l.Source.Version, Kind: l.Source.Kind}),
+				FrontendTLSValidation:      toFrontendTLSValidation(&input.Gateway, l.Port, input.ReferenceGrants),
 				Routes:                     httpRoutes,
 				Infrastructure:             infra,
 				Service:                    toServiceModel(input.GatewayClassConfig),
@@ -1492,6 +1493,61 @@ func toTLS(tls *gatewayv1.ListenerTLSConfig, grants []gatewayv1.ReferenceGrant, 
 		})
 	}
 	return res
+}
+
+// toFrontendTLSValidation converts Gateway API FrontendTLSValidation to model.FrontendTLSValidation
+// for client certificate validation (mTLS).
+func toFrontendTLSValidation(
+	gw *gatewayv1.Gateway,
+	listenerPort gatewayv1.PortNumber,
+	grants []gatewayv1.ReferenceGrant,
+) *model.FrontendTLSValidation {
+	if gw.Spec.TLS == nil || gw.Spec.TLS.Frontend == nil {
+		return nil
+	}
+
+	frontend := gw.Spec.TLS.Frontend
+
+	// Check per-port override first
+	var validation *gatewayv1.FrontendTLSValidation
+	for _, perPort := range frontend.PerPort {
+		if perPort.Port == listenerPort && perPort.TLS.Validation != nil {
+			validation = perPort.TLS.Validation
+			break
+		}
+	}
+
+	// Fall back to default
+	if validation == nil && frontend.Default.Validation != nil {
+		validation = frontend.Default.Validation
+	}
+
+	ref, ok := helpers.FirstFrontendTLSCACertificateRef(validation)
+	if !ok {
+		return nil
+	}
+	if !helpers.IsObjectRefConfigMap(ref) {
+		return nil
+	}
+
+	refNs := helpers.NamespaceDerefOr(ref.Namespace, gw.Namespace)
+	if refNs != gw.Namespace && !helpers.IsObjectRefAllowed(gw.Namespace, ref,
+		gatewayv1.SchemeGroupVersion.WithKind("Gateway"),
+		corev1.SchemeGroupVersion.WithKind("ConfigMap"), grants) {
+		return nil
+	}
+
+	caCertRef := model.FullyQualifiedResource{
+		Group:     string(ref.Group),
+		Kind:      string(ref.Kind),
+		Name:      string(ref.Name),
+		Namespace: refNs,
+	}
+
+	return &model.FrontendTLSValidation{
+		CACertRefs:               []model.FullyQualifiedResource{caCertRef},
+		RequireClientCertificate: validation.Mode != gatewayv1.AllowInsecureFallback,
+	}
 }
 
 func toHTTPHeaders(headers []gatewayv1.HTTPHeader) []model.Header {

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -212,6 +212,11 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 	}
 
 	for _, l := range listeners {
+		var frontendTLSValidation *model.FrontendTLSValidation
+		if l.Protocol == gatewayv1.HTTPSProtocolType {
+			frontendTLSValidation = toFrontendTLSValidation(&input.Gateway, l.Port, input.ReferenceGrants)
+		}
+
 		switch l.Protocol {
 		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType, gatewayv1.TLSProtocolType:
 			filteredHTTPRoutes := l.FilterHTTPRoutes(input.HTTPRoutes)
@@ -236,7 +241,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				Port:                       uint32(l.Port),
 				Hostname:                   toHostname(l.Hostname),
 				TLS:                        toTLS(l.TLS, input.ReferenceGrants, l.Source.Namespace, schema.GroupVersionKind{Group: l.Source.Group, Version: l.Source.Version, Kind: l.Source.Kind}),
-				FrontendTLSValidation:      toFrontendTLSValidation(&input.Gateway, l.Port, input.ReferenceGrants),
+				FrontendTLSValidation:      frontendTLSValidation,
 				Routes:                     httpRoutes,
 				Infrastructure:             infra,
 				Service:                    toServiceModel(input.GatewayClassConfig),

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -1960,3 +1960,41 @@ func TestToFrontendTLSValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayAPIFrontendTLSValidationOnlyAppliesToHTTPS(t *testing.T) {
+	gw := gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "default"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+				{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType},
+			},
+			TLS: &gatewayv1.GatewayTLSConfig{
+				Frontend: &gatewayv1.FrontendTLSConfig{
+					Default: gatewayv1.TLSConfig{
+						Validation: &gatewayv1.FrontendTLSValidation{
+							CACertificateRefs: []gatewayv1.ObjectReference{{
+								Group: "", Kind: "ConfigMap", Name: "client-ca",
+							}},
+							Mode: gatewayv1.AllowValidOnly,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := GatewayAPI(hivetest.Logger(t), Input{Gateway: gw})
+	require.Len(t, m.HTTP, 2)
+	for _, listener := range m.HTTP {
+		switch listener.Name {
+		case "http":
+			assert.Nil(t, listener.FrontendTLSValidation)
+		case "https":
+			require.NotNil(t, listener.FrontendTLSValidation)
+			assert.Equal(t, "client-ca", listener.FrontendTLSValidation.CACertRefs[0].Name)
+		default:
+			t.Fatalf("unexpected listener %q", listener.Name)
+		}
+	}
+}

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -1708,3 +1708,255 @@ func readGatewayInput(t *testing.T, testName string) Input {
 
 	return input
 }
+
+func TestToFrontendTLSValidation(t *testing.T) {
+	tests := map[string]struct {
+		gateway      gatewayv1.Gateway
+		listenerPort gatewayv1.PortNumber
+		want         *model.FrontendTLSValidation
+	}{
+		"no tls config": {
+			gateway: gatewayv1.Gateway{},
+			want:    nil,
+		},
+		"no frontend config": {
+			gateway: gatewayv1.Gateway{
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{},
+				},
+			},
+			want: nil,
+		},
+		"default validation with AllowValidOnly mode": {
+			gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Group: "",
+											Kind:  "ConfigMap",
+											Name:  "ca-cert",
+										},
+									},
+									Mode: gatewayv1.AllowValidOnly,
+								},
+							},
+						},
+					},
+				},
+			},
+			listenerPort: 443,
+			want: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "ca-cert",
+						Namespace: "default",
+					},
+				},
+				RequireClientCertificate: true,
+			},
+		},
+		"default validation with AllowInsecureFallback mode": {
+			gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Group: "",
+											Kind:  "ConfigMap",
+											Name:  "ca-cert",
+										},
+									},
+									Mode: gatewayv1.AllowInsecureFallback,
+								},
+							},
+						},
+					},
+				},
+			},
+			listenerPort: 443,
+			want: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "ca-cert",
+						Namespace: "default",
+					},
+				},
+				RequireClientCertificate: false,
+			},
+		},
+		"per-port override": {
+			gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Group: "",
+											Kind:  "ConfigMap",
+											Name:  "default-ca",
+										},
+									},
+									Mode: gatewayv1.AllowValidOnly,
+								},
+							},
+							PerPort: []gatewayv1.TLSPortConfig{
+								{
+									Port: 8443,
+									TLS: gatewayv1.TLSConfig{
+										Validation: &gatewayv1.FrontendTLSValidation{
+											CACertificateRefs: []gatewayv1.ObjectReference{
+												{
+													Group: "",
+													Kind:  "ConfigMap",
+													Name:  "port-specific-ca",
+												},
+											},
+											Mode: gatewayv1.AllowInsecureFallback,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			listenerPort: 8443,
+			want: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "port-specific-ca",
+						Namespace: "default",
+					},
+				},
+				RequireClientCertificate: false,
+			},
+		},
+		"per-port override not matched falls back to default": {
+			gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Group: "",
+											Kind:  "ConfigMap",
+											Name:  "default-ca",
+										},
+									},
+									Mode: gatewayv1.AllowValidOnly,
+								},
+							},
+							PerPort: []gatewayv1.TLSPortConfig{
+								{
+									Port: 8443,
+									TLS: gatewayv1.TLSConfig{
+										Validation: &gatewayv1.FrontendTLSValidation{
+											CACertificateRefs: []gatewayv1.ObjectReference{
+												{
+													Group: "",
+													Kind:  "ConfigMap",
+													Name:  "port-specific-ca",
+												},
+											},
+											Mode: gatewayv1.AllowInsecureFallback,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			listenerPort: 443,
+			want: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "default-ca",
+						Namespace: "default",
+					},
+				},
+				RequireClientCertificate: true,
+			},
+		},
+		"multiple refs uses only first": {
+			gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					TLS: &gatewayv1.GatewayTLSConfig{
+						Frontend: &gatewayv1.FrontendTLSConfig{
+							Default: gatewayv1.TLSConfig{
+								Validation: &gatewayv1.FrontendTLSValidation{
+									CACertificateRefs: []gatewayv1.ObjectReference{
+										{
+											Group: "",
+											Kind:  "ConfigMap",
+											Name:  "first-ca",
+										},
+										{
+											Group: "",
+											Kind:  "ConfigMap",
+											Name:  "ignored-ca",
+										},
+									},
+									Mode: gatewayv1.AllowValidOnly,
+								},
+							},
+						},
+					},
+				},
+			},
+			listenerPort: 443,
+			want: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Name:      "first-ca",
+						Namespace: "default",
+					},
+				},
+				RequireClientCertificate: true,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := toFrontendTLSValidation(&tc.gateway, tc.listenerPort, nil)
+			assert.Equal(t, tc.want, result)
+		})
+	}
+}

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -91,6 +91,8 @@ type HTTPListener struct {
 	Hostname string `json:"hostname,omitempty"`
 	// TLS Certificate information. If omitted, then the listener is a cleartext HTTP listener.
 	TLS []TLSSecret `json:"tls,omitempty"`
+	// FrontendTLSValidation holds mTLS configuration for client certificate validation.
+	FrontendTLSValidation *FrontendTLSValidation `json:"frontend_tls_validation,omitempty"`
 	// Routes associated with HTTP traffic to the service.
 	// An empty list means that traffic will not be routed.
 	Routes []HTTPRoute `json:"routes,omitempty"`
@@ -366,6 +368,15 @@ func (r HTTPRouteRule) key() string {
 type TLSSecret struct {
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
+}
+
+// FrontendTLSValidation holds configuration for client certificate validation (mTLS).
+type FrontendTLSValidation struct {
+	// CACertRefs references ConfigMaps containing CA certificates for client validation.
+	CACertRefs []FullyQualifiedResource `json:"ca_cert_refs,omitempty"`
+	// RequireClientCertificate when true requires valid client cert (AllowValidOnly mode).
+	// When false, allows connections without valid cert (AllowInsecureFallback mode).
+	RequireClientCertificate bool `json:"require_client_certificate,omitempty"`
 }
 
 // DirectResponse holds configuration for a direct response.
@@ -1005,32 +1016,98 @@ func (m *Model) AllPorts() []uint32 {
 	return slices.SortedUnique(ports)
 }
 
-// TLSSecretsToHostnames returns a map of TLS secrets to hostnames.
+// TLSSecretListenerData holds TLS secret data along with the listener's frontend validation.
+type TLSSecretListenerData struct {
+	TLSSecret             TLSSecret
+	Hostnames             []string
+	FrontendTLSValidation *FrontendTLSValidation
+}
+
+// TLSSecretsToHostnamesWithValidation returns grouped TLS secret data with hostnames and frontend validation.
 // This is only for HTTP listeners.
-func (m *Model) TLSSecretsToHostnames() map[TLSSecret][]string {
-	res := make(map[TLSSecret][]string)
+func (m *Model) TLSSecretsToHostnamesWithValidation() []TLSSecretListenerData {
+	return m.tlsSecretListenerData(0, false)
+}
+
+// TLSSecretsToListenerDataForPort returns grouped TLS secret data for HTTPS listeners on a port.
+func (m *Model) TLSSecretsToListenerDataForPort(port uint32) []TLSSecretListenerData {
+	return m.tlsSecretListenerData(port, true)
+}
+
+func (m *Model) tlsSecretListenerData(port uint32, filterByPort bool) []TLSSecretListenerData {
+	type listenerBucket struct {
+		secret              TLSSecret
+		validation          *FrontendTLSValidation
+		validationKey       string
+		aggregatedHostnames []string
+	}
+
+	res := make(map[string]*listenerBucket)
 	for _, h := range m.HTTP {
+		if filterByPort && h.Port != port {
+			continue
+		}
 		for _, s := range h.TLS {
-			res[s] = append(res[s], h.Hostname)
+			validationKey := frontendTLSValidationKey(h.FrontendTLSValidation)
+			key := tlsSecretListenerDataKey(s, validationKey)
+
+			bucket, exists := res[key]
+			if !exists {
+				bucket = &listenerBucket{
+					secret:        s,
+					validation:    h.FrontendTLSValidation,
+					validationKey: validationKey,
+				}
+				res[key] = bucket
+			}
+			bucket.aggregatedHostnames = append(bucket.aggregatedHostnames, h.Hostname)
 		}
 	}
-	return res
-}
 
-// TLSListenerRef records a (hostname, port) pair for an HTTPS listener.
-type TLSListenerRef struct {
-	Hostname string
-	Port     uint32
-}
-
-// TLSSecretsToListeners returns, for each TLS secret, the set of
-// (hostname, port) pairs of all HTTPS listeners that reference it.
-func (m *Model) TLSSecretsToListeners() map[TLSSecret][]TLSListenerRef {
-	res := make(map[TLSSecret][]TLSListenerRef)
-	for _, l := range m.HTTP {
-		for _, s := range l.TLS {
-			res[s] = append(res[s], TLSListenerRef{Hostname: l.Hostname, Port: l.Port})
-		}
+	keys := make([]string, 0, len(res))
+	for k := range res {
+		keys = append(keys, k)
 	}
-	return res
+
+	sort.Slice(keys, func(i, j int) bool {
+		left := res[keys[i]]
+		right := res[keys[j]]
+		if left.secret.Namespace != right.secret.Namespace {
+			return left.secret.Namespace < right.secret.Namespace
+		}
+		if left.secret.Name != right.secret.Name {
+			return left.secret.Name < right.secret.Name
+		}
+		return left.validationKey < right.validationKey
+	})
+
+	output := make([]TLSSecretListenerData, 0, len(keys))
+	for _, key := range keys {
+		bucket := res[key]
+		output = append(output, TLSSecretListenerData{
+			TLSSecret:             bucket.secret,
+			Hostnames:             slices.SortedUnique(bucket.aggregatedHostnames),
+			FrontendTLSValidation: bucket.validation,
+		})
+	}
+
+	return output
+}
+
+func tlsSecretListenerDataKey(secret TLSSecret, validationKey string) string {
+	return strings.Join([]string{secret.Namespace, secret.Name, validationKey}, "|")
+}
+
+func frontendTLSValidationKey(validation *FrontendTLSValidation) string {
+	if validation == nil {
+		return "none"
+	}
+
+	refs := make([]string, 0, len(validation.CACertRefs))
+	for _, ref := range validation.CACertRefs {
+		refs = append(refs, strings.Join([]string{ref.Group, ref.Version, ref.Kind, ref.Namespace, ref.Name}, "/"))
+	}
+	sort.Strings(refs)
+
+	return "require_client_cert=" + strconv.FormatBool(validation.RequireClientCertificate) + ";ca_refs=" + strings.Join(refs, ",")
 }

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -713,32 +713,6 @@ func TestIsHTTPSPortConfigured(t *testing.T) {
 	assert.False(t, m.IsHTTPSPortConfigured(9999))
 }
 
-func TestTLSSecretsToListeners(t *testing.T) {
-	certA := TLSSecret{Name: "cert-a", Namespace: "ns"}
-	certB := TLSSecret{Name: "cert-b", Namespace: "ns"}
-
-	m := Model{
-		HTTP: []HTTPListener{
-			{Port: 443, Hostname: "a.com", TLS: []TLSSecret{certA}},
-			{Port: 50051, Hostname: "a.com", TLS: []TLSSecret{certA}},
-			{Port: 8443, Hostname: "b.com", TLS: []TLSSecret{certB}},
-		},
-	}
-
-	got := m.TLSSecretsToListeners()
-
-	assert.ElementsMatch(t, []TLSListenerRef{
-		{Hostname: "a.com", Port: 443},
-		{Hostname: "a.com", Port: 50051},
-	}, got[certA])
-
-	assert.ElementsMatch(t, []TLSListenerRef{
-		{Hostname: "b.com", Port: 8443},
-	}, got[certB])
-
-	assert.Len(t, got, 2)
-}
-
 func TestModel_IsAccessLogsConfigured(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -987,5 +961,147 @@ func TestModel_IsTCPAccessLogsConfigured(t *testing.T) {
 				t.Errorf("Model.IsTCPAccessLogsConfigured() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestModel_TLSSecretsToHostnamesWithValidation_SharedSecretDifferentValidation(t *testing.T) {
+	secret := TLSSecret{Name: "server-cert", Namespace: "default"}
+	validOnly := &FrontendTLSValidation{
+		CACertRefs: []FullyQualifiedResource{
+			{Kind: "ConfigMap", Namespace: "default", Name: "ca-valid-only"},
+		},
+		RequireClientCertificate: true,
+	}
+	insecureFallback := &FrontendTLSValidation{
+		CACertRefs: []FullyQualifiedResource{
+			{Kind: "ConfigMap", Namespace: "default", Name: "ca-fallback"},
+		},
+		RequireClientCertificate: false,
+	}
+
+	m := &Model{
+		HTTP: []HTTPListener{
+			{
+				Hostname:              "a.example.com",
+				TLS:                   []TLSSecret{secret},
+				FrontendTLSValidation: validOnly,
+			},
+			{
+				Hostname:              "b.example.com",
+				TLS:                   []TLSSecret{secret},
+				FrontendTLSValidation: insecureFallback,
+			},
+		},
+	}
+
+	got := m.TLSSecretsToHostnamesWithValidation()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 grouped entries, got %d", len(got))
+	}
+
+	gotByValidation := make(map[string]TLSSecretListenerData, len(got))
+	for _, entry := range got {
+		if entry.TLSSecret != secret {
+			t.Fatalf("unexpected TLS secret: %+v", entry.TLSSecret)
+		}
+		gotByValidation[frontendTLSValidationKey(entry.FrontendTLSValidation)] = entry
+	}
+
+	validOnlyEntry, ok := gotByValidation[frontendTLSValidationKey(validOnly)]
+	if !ok {
+		t.Fatalf("missing valid-only group: %+v", gotByValidation)
+	}
+	if !reflect.DeepEqual(validOnlyEntry.Hostnames, []string{"a.example.com"}) {
+		t.Fatalf("unexpected hostnames for valid-only group: %+v", validOnlyEntry.Hostnames)
+	}
+
+	insecureEntry, ok := gotByValidation[frontendTLSValidationKey(insecureFallback)]
+	if !ok {
+		t.Fatalf("missing insecure-fallback group: %+v", gotByValidation)
+	}
+	if !reflect.DeepEqual(insecureEntry.Hostnames, []string{"b.example.com"}) {
+		t.Fatalf("unexpected hostnames for insecure-fallback group: %+v", insecureEntry.Hostnames)
+	}
+}
+
+func TestModel_TLSSecretsToHostnamesWithValidation_SharedSecretSameValidation(t *testing.T) {
+	secret := TLSSecret{Name: "server-cert", Namespace: "default"}
+	validation := &FrontendTLSValidation{
+		CACertRefs: []FullyQualifiedResource{
+			{Kind: "ConfigMap", Namespace: "default", Name: "client-ca"},
+		},
+		RequireClientCertificate: true,
+	}
+
+	m := &Model{
+		HTTP: []HTTPListener{
+			{
+				Hostname:              "b.example.com",
+				TLS:                   []TLSSecret{secret},
+				FrontendTLSValidation: validation,
+			},
+			{
+				Hostname:              "a.example.com",
+				TLS:                   []TLSSecret{secret},
+				FrontendTLSValidation: validation,
+			},
+		},
+	}
+
+	got := m.TLSSecretsToHostnamesWithValidation()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grouped entry, got %d", len(got))
+	}
+
+	if got[0].TLSSecret != secret {
+		t.Fatalf("unexpected TLS secret: %+v", got[0].TLSSecret)
+	}
+	if !reflect.DeepEqual(got[0].Hostnames, []string{"a.example.com", "b.example.com"}) {
+		t.Fatalf("unexpected hostnames: %+v", got[0].Hostnames)
+	}
+	if !reflect.DeepEqual(got[0].FrontendTLSValidation, validation) {
+		t.Fatalf("unexpected frontend validation: %+v", got[0].FrontendTLSValidation)
+	}
+}
+
+func TestModel_TLSSecretsToHostnamesWithValidation_DeterministicOrder(t *testing.T) {
+	listeners := []HTTPListener{
+		{
+			Hostname: "b.example.com",
+			TLS:      []TLSSecret{{Name: "shared-cert", Namespace: "default"}},
+			FrontendTLSValidation: &FrontendTLSValidation{
+				CACertRefs: []FullyQualifiedResource{
+					{Kind: "ConfigMap", Namespace: "default", Name: "ca-fallback"},
+				},
+				RequireClientCertificate: false,
+			},
+		},
+		{
+			Hostname: "a.example.com",
+			TLS:      []TLSSecret{{Name: "shared-cert", Namespace: "default"}},
+			FrontendTLSValidation: &FrontendTLSValidation{
+				CACertRefs: []FullyQualifiedResource{
+					{Kind: "ConfigMap", Namespace: "default", Name: "ca-valid-only"},
+				},
+				RequireClientCertificate: true,
+			},
+		},
+		{
+			Hostname: "z.example.com",
+			TLS:      []TLSSecret{{Name: "other-cert", Namespace: "default"}},
+			FrontendTLSValidation: &FrontendTLSValidation{
+				CACertRefs: []FullyQualifiedResource{
+					{Kind: "ConfigMap", Namespace: "default", Name: "ca-other"},
+				},
+				RequireClientCertificate: true,
+			},
+		},
+	}
+
+	got1 := (&Model{HTTP: listeners}).TLSSecretsToHostnamesWithValidation()
+	got2 := (&Model{HTTP: []HTTPListener{listeners[2], listeners[0], listeners[1]}}).TLSSecretsToHostnamesWithValidation()
+
+	if !reflect.DeepEqual(got1, got2) {
+		t.Fatalf("expected deterministic output for reordered listeners.\nfirst:  %#v\nsecond: %#v", got1, got2)
 	}
 }

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -888,13 +888,31 @@ func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret, fron
 		downStreamContext.RequireClientCertificate = &wrapperspb.BoolValue{
 			Value: frontendValidation.RequireClientCertificate,
 		}
-		downStreamContext.CommonTlsContext.ValidationContextType =
-			&envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
-				ValidationContextSdsSecretConfig: &envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig{
-					Name: fmt.Sprintf("%s/%s-cfgmap-%s",
-						ciliumSecretNamespace, caCertRef.Namespace, caCertRef.Name),
-				},
-			}
+		validationContextSDS := &envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig{
+			Name: syncnames.SyncedConfigMapSDSSecretName(
+				ciliumSecretNamespace,
+				types.NamespacedName{Namespace: caCertRef.Namespace, Name: caCertRef.Name},
+			),
+		}
+		if frontendValidation.RequireClientCertificate {
+			downStreamContext.CommonTlsContext.ValidationContextType =
+				&envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
+					ValidationContextSdsSecretConfig: validationContextSDS,
+				}
+		} else {
+			// AllowInsecureFallback permits both absent and untrusted client
+			// certificates. Keep the CA bundle available through SDS while
+			// overriding verification behavior for this filter chain only.
+			downStreamContext.CommonTlsContext.ValidationContextType =
+				&envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_CombinedCertificateValidationContext{
+						DefaultValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
+							TrustChainVerification: envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_ACCEPT_UNTRUSTED,
+						},
+						ValidationContextSdsSecretConfig: validationContextSDS,
+					},
+				}
+		}
 	}
 
 	downstreamBytes, _ := proto.Marshal(&downStreamContext)

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -6,7 +6,6 @@ package translation
 import (
 	"cmp"
 	"fmt"
-	"maps"
 	goslices "slices"
 	"strings"
 	"syscall"
@@ -360,27 +359,21 @@ func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_conf
 
 // httpsFilterChains returns the HTTPS filter chains for the given model.
 func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
-	tlsToHostnames := m.TLSSecretsToHostnames()
-	if len(tlsToHostnames) == 0 {
+	tlsData := m.TLSSecretsToHostnamesWithValidation()
+	if len(tlsData) == 0 {
 		return nil, nil
 	}
 
 	var filterChains []*envoy_config_listener.FilterChain
 
-	orderedSecrets := goslices.SortedStableFunc(maps.Keys(tlsToHostnames), func(a, b model.TLSSecret) int {
-		return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
-	})
-
-	for _, secret := range orderedSecrets {
-		hostNames := tlsToHostnames[secret]
-
+	for _, data := range tlsData {
 		secureHCMName := fmt.Sprintf("%s-%s", name, secureHost)
 		secureHCM, err := i.desiredHTTPConnectionManager(secureHCMName, secureHCMName, m)
 		if err != nil {
 			return nil, err
 		}
 		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
-			FilterChainMatch: toFilterChainMatch(hostNames),
+			FilterChainMatch: toFilterChainMatch(data.Hostnames),
 			Filters: []*envoy_config_listener.Filter{
 				{
 					Name: httpConnectionManagerType,
@@ -389,7 +382,7 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy
 					},
 				},
 			},
-			TransportSocket: toTransportSocket(i.Config.SecretsNamespace, []model.TLSSecret{secret}),
+			TransportSocket: toTransportSocket(i.Config.SecretsNamespace, []model.TLSSecret{data.TLSSecret}, data.FrontendTLSValidation),
 		})
 	}
 
@@ -605,42 +598,19 @@ func (i *cecTranslator) httpFilterChain(name string, m *model.Model) (*envoy_con
 
 // httpsFilterChainsForPort returns the HTTPS filter chains for the given port.
 func (i *cecTranslator) httpsFilterChainsForPort(name string, port uint32, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
-	tlsToListeners := m.TLSSecretsToListeners()
-	if len(tlsToListeners) == 0 {
+	tlsData := m.TLSSecretsToListenerDataForPort(port)
+	if len(tlsData) == 0 {
 		return nil, nil
 	}
-
-	hostsBySecret := map[model.TLSSecret][]string{}
-	for secret, refs := range tlsToListeners {
-		for _, ref := range refs {
-			if ref.Port == port {
-				hostsBySecret[secret] = append(hostsBySecret[secret], ref.Hostname)
-			}
-		}
-	}
-
-	if len(hostsBySecret) == 0 {
-		return nil, nil
-	}
-
-	orderedSecrets := make([]model.TLSSecret, 0, len(hostsBySecret))
-	for secret := range hostsBySecret {
-		orderedSecrets = append(orderedSecrets, secret)
-	}
-	goslices.SortStableFunc(orderedSecrets, func(a, b model.TLSSecret) int {
-		return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
-	})
 
 	var filterChains []*envoy_config_listener.FilterChain
-	for _, secret := range orderedSecrets {
-		hostNames := hostsBySecret[secret]
-
+	for _, data := range tlsData {
 		hcm, err := i.desiredHTTPConnectionManager(name, name, m)
 		if err != nil {
 			return nil, err
 		}
 		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
-			FilterChainMatch: toFilterChainMatch(hostNames),
+			FilterChainMatch: toFilterChainMatch(data.Hostnames),
 			Filters: []*envoy_config_listener.Filter{
 				{
 					Name: httpConnectionManagerType,
@@ -649,7 +619,7 @@ func (i *cecTranslator) httpsFilterChainsForPort(name string, port uint32, m *mo
 					},
 				},
 			},
-			TransportSocket: toTransportSocket(i.Config.SecretsNamespace, []model.TLSSecret{secret}),
+			TransportSocket: toTransportSocket(i.Config.SecretsNamespace, []model.TLSSecret{data.TLSSecret}, data.FrontendTLSValidation),
 		})
 	}
 
@@ -893,7 +863,7 @@ func tlsPassthroughBackendWeight(backend model.Backend) uint32 {
 	return uint32(*backend.Weight)
 }
 
-func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) *envoy_config_core_v3.TransportSocket {
+func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret, frontendValidation *model.FrontendTLSValidation) *envoy_config_core_v3.TransportSocket {
 	var tlsSdsConfig []*envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig
 	tlsMap := map[string]struct{}{}
 	for _, t := range tls {
@@ -911,6 +881,22 @@ func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) *env
 			TlsCertificateSdsSecretConfigs: tlsSdsConfig,
 		},
 	}
+
+	// Configure client validation (mTLS) if frontend validation is specified
+	if frontendValidation != nil && len(frontendValidation.CACertRefs) > 0 {
+		caCertRef := frontendValidation.CACertRefs[0]
+		downStreamContext.RequireClientCertificate = &wrapperspb.BoolValue{
+			Value: frontendValidation.RequireClientCertificate,
+		}
+		downStreamContext.CommonTlsContext.ValidationContextType =
+			&envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
+				ValidationContextSdsSecretConfig: &envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig{
+					Name: fmt.Sprintf("%s/%s-cfgmap-%s",
+						ciliumSecretNamespace, caCertRef.Namespace, caCertRef.Name),
+				},
+			}
+	}
+
 	downstreamBytes, _ := proto.Marshal(&downStreamContext)
 
 	return &envoy_config_core_v3.TransportSocket{

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	syncnames "github.com/cilium/cilium/pkg/secretsync/names"
 )
 
 func Test_getHostNetworkListenerAddresses(t *testing.T) {
@@ -947,6 +949,7 @@ func Test_toTransportSocket(t *testing.T) {
 		frontendValidation       *model.FrontendTLSValidation
 		wantRequireClientCert    bool
 		wantValidationContextSDS string
+		wantAcceptUntrusted      bool
 	}{
 		{
 			name:                  "server TLS only - no client validation",
@@ -970,8 +973,11 @@ func Test_toTransportSocket(t *testing.T) {
 				},
 				RequireClientCertificate: true,
 			},
-			wantRequireClientCert:    true,
-			wantValidationContextSDS: "cilium-secrets/default-cfgmap-client-ca",
+			wantRequireClientCert: true,
+			wantValidationContextSDS: syncnames.SyncedConfigMapSDSSecretName(
+				"cilium-secrets",
+				types.NamespacedName{Namespace: "default", Name: "client-ca"},
+			),
 		},
 		{
 			name:                  "with frontend validation - AllowInsecureFallback mode",
@@ -985,8 +991,12 @@ func Test_toTransportSocket(t *testing.T) {
 				},
 				RequireClientCertificate: false,
 			},
-			wantRequireClientCert:    false,
-			wantValidationContextSDS: "cilium-secrets/gateway-ns-cfgmap-ca-bundle",
+			wantRequireClientCert: false,
+			wantValidationContextSDS: syncnames.SyncedConfigMapSDSSecretName(
+				"cilium-secrets",
+				types.NamespacedName{Namespace: "gateway-ns", Name: "ca-bundle"},
+			),
+			wantAcceptUntrusted: true,
 		},
 		{
 			name:                  "empty CACertRefs - no validation context",
@@ -1030,11 +1040,21 @@ func Test_toTransportSocket(t *testing.T) {
 
 			// Check ValidationContext SDS config
 			if tt.wantValidationContextSDS != "" {
-				sdsConfig := downstreamCtx.CommonTlsContext.GetValidationContextSdsSecretConfig()
+				sdsConfig := downstreamValidationContextSDS(&downstreamCtx)
 				assert.NotNil(t, sdsConfig, "expected ValidationContextSdsSecretConfig to be set")
 				assert.Equal(t, tt.wantValidationContextSDS, sdsConfig.Name)
 			} else {
-				assert.Nil(t, downstreamCtx.CommonTlsContext.GetValidationContextSdsSecretConfig())
+				assert.Nil(t, downstreamValidationContextSDS(&downstreamCtx))
+			}
+
+			combined := downstreamCtx.CommonTlsContext.GetCombinedValidationContext()
+			if tt.wantAcceptUntrusted {
+				require.NotNil(t, combined)
+				assert.Equal(t,
+					envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_ACCEPT_UNTRUSTED,
+					combined.DefaultValidationContext.TrustChainVerification)
+			} else {
+				assert.Nil(t, combined)
 			}
 
 			// Verify server TLS certificates are present
@@ -1093,7 +1113,7 @@ func Test_httpsFilterChains_SharedSecretDifferentValidation(t *testing.T) {
 		downstreamCtx := downstreamTLSContextFromTransportSocket(t, chain.TransportSocket)
 		requireClientCert := downstreamCtx.RequireClientCertificate != nil && downstreamCtx.RequireClientCertificate.GetValue()
 		validationSDS := ""
-		if sds := downstreamCtx.CommonTlsContext.GetValidationContextSdsSecretConfig(); sds != nil {
+		if sds := downstreamValidationContextSDS(downstreamCtx); sds != nil {
 			validationSDS = sds.Name
 		}
 
@@ -1112,13 +1132,26 @@ func Test_httpsFilterChains_SharedSecretDifferentValidation(t *testing.T) {
 	}{
 		"a.example.com": {
 			requireClientCert: true,
-			validationSDS:     "cilium-secrets/gateway-ns-cfgmap-client-ca-a",
+			validationSDS: syncnames.SyncedConfigMapSDSSecretName(
+				"cilium-secrets",
+				types.NamespacedName{Namespace: "gateway-ns", Name: "client-ca-a"},
+			),
 		},
 		"b.example.com": {
 			requireClientCert: false,
-			validationSDS:     "cilium-secrets/gateway-ns-cfgmap-client-ca-b",
+			validationSDS: syncnames.SyncedConfigMapSDSSecretName(
+				"cilium-secrets",
+				types.NamespacedName{Namespace: "gateway-ns", Name: "client-ca-b"},
+			),
 		},
 	}, gotByHostname)
+}
+
+func downstreamValidationContextSDS(ctx *envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext) *envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig {
+	if sds := ctx.CommonTlsContext.GetValidationContextSdsSecretConfig(); sds != nil {
+		return sds
+	}
+	return ctx.CommonTlsContext.GetCombinedValidationContext().GetValidationContextSdsSecretConfig()
 }
 
 func Test_httpsFilterChains_DeterministicAcrossListenerOrder(t *testing.T) {

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -10,6 +10,7 @@ import (
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_extensions_filters_network_hcm_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_filters_network_tcp_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -936,4 +937,240 @@ func TestDesiredEnvoyListenerSingleHTTPS(t *testing.T) {
 
 	hcm1 := decodeHCM(l.FilterChains[1])
 	require.Equal(t, "listener-secure", hcm1.GetRds().GetRouteConfigName())
+}
+
+func Test_toTransportSocket(t *testing.T) {
+	tests := []struct {
+		name                     string
+		ciliumSecretNamespace    string
+		tls                      []model.TLSSecret
+		frontendValidation       *model.FrontendTLSValidation
+		wantRequireClientCert    bool
+		wantValidationContextSDS string
+	}{
+		{
+			name:                  "server TLS only - no client validation",
+			ciliumSecretNamespace: "cilium-secrets",
+			tls: []model.TLSSecret{
+				{Namespace: "default", Name: "server-cert"},
+			},
+			frontendValidation:       nil,
+			wantRequireClientCert:    false,
+			wantValidationContextSDS: "",
+		},
+		{
+			name:                  "with frontend validation - AllowValidOnly mode",
+			ciliumSecretNamespace: "cilium-secrets",
+			tls: []model.TLSSecret{
+				{Namespace: "default", Name: "server-cert"},
+			},
+			frontendValidation: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{Namespace: "default", Name: "client-ca"},
+				},
+				RequireClientCertificate: true,
+			},
+			wantRequireClientCert:    true,
+			wantValidationContextSDS: "cilium-secrets/default-cfgmap-client-ca",
+		},
+		{
+			name:                  "with frontend validation - AllowInsecureFallback mode",
+			ciliumSecretNamespace: "cilium-secrets",
+			tls: []model.TLSSecret{
+				{Namespace: "default", Name: "server-cert"},
+			},
+			frontendValidation: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{Namespace: "gateway-ns", Name: "ca-bundle"},
+				},
+				RequireClientCertificate: false,
+			},
+			wantRequireClientCert:    false,
+			wantValidationContextSDS: "cilium-secrets/gateway-ns-cfgmap-ca-bundle",
+		},
+		{
+			name:                  "empty CACertRefs - no validation context",
+			ciliumSecretNamespace: "cilium-secrets",
+			tls: []model.TLSSecret{
+				{Namespace: "default", Name: "server-cert"},
+			},
+			frontendValidation: &model.FrontendTLSValidation{
+				CACertRefs:               []model.FullyQualifiedResource{},
+				RequireClientCertificate: true,
+			},
+			wantRequireClientCert:    false,
+			wantValidationContextSDS: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := toTransportSocket(tt.ciliumSecretNamespace, tt.tls, tt.frontendValidation)
+			assert.NotNil(t, ts)
+			assert.Equal(t, tlsTransportSocketType, ts.Name)
+
+			// Unmarshal the DownstreamTlsContext
+			typedConfig := ts.GetTypedConfig()
+			assert.NotNil(t, typedConfig)
+
+			var downstreamCtx envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext
+			err := proto.Unmarshal(typedConfig.GetValue(), &downstreamCtx)
+			assert.NoError(t, err)
+
+			// Check RequireClientCertificate
+			if tt.wantRequireClientCert {
+				assert.NotNil(t, downstreamCtx.RequireClientCertificate)
+				assert.True(t, downstreamCtx.RequireClientCertificate.GetValue())
+			} else {
+				// Either nil or false
+				if downstreamCtx.RequireClientCertificate != nil {
+					assert.False(t, downstreamCtx.RequireClientCertificate.GetValue())
+				}
+			}
+
+			// Check ValidationContext SDS config
+			if tt.wantValidationContextSDS != "" {
+				sdsConfig := downstreamCtx.CommonTlsContext.GetValidationContextSdsSecretConfig()
+				assert.NotNil(t, sdsConfig, "expected ValidationContextSdsSecretConfig to be set")
+				assert.Equal(t, tt.wantValidationContextSDS, sdsConfig.Name)
+			} else {
+				assert.Nil(t, downstreamCtx.CommonTlsContext.GetValidationContextSdsSecretConfig())
+			}
+
+			// Verify server TLS certificates are present
+			assert.NotEmpty(t, downstreamCtx.CommonTlsContext.TlsCertificateSdsSecretConfigs)
+		})
+	}
+}
+
+func Test_httpsFilterChains_SharedSecretDifferentValidation(t *testing.T) {
+	translator := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+		},
+	}
+
+	sharedSecret := model.TLSSecret{Name: "server-cert", Namespace: "gateway-ns"}
+	m := &model.Model{
+		HTTP: []model.HTTPListener{
+			{
+				Hostname: "a.example.com",
+				TLS:      []model.TLSSecret{sharedSecret},
+				FrontendTLSValidation: &model.FrontendTLSValidation{
+					CACertRefs: []model.FullyQualifiedResource{
+						{Namespace: "gateway-ns", Name: "client-ca-a"},
+					},
+					RequireClientCertificate: true,
+				},
+			},
+			{
+				Hostname: "b.example.com",
+				TLS:      []model.TLSSecret{sharedSecret},
+				FrontendTLSValidation: &model.FrontendTLSValidation{
+					CACertRefs: []model.FullyQualifiedResource{
+						{Namespace: "gateway-ns", Name: "client-ca-b"},
+					},
+					RequireClientCertificate: false,
+				},
+			},
+		},
+	}
+
+	chains, err := translator.httpsFilterChains("listener", m)
+	assert.NoError(t, err)
+	assert.Len(t, chains, 2)
+
+	gotByHostname := map[string]struct {
+		requireClientCert bool
+		validationSDS     string
+	}{}
+
+	for _, chain := range chains {
+		assert.NotNil(t, chain.FilterChainMatch)
+		assert.Len(t, chain.FilterChainMatch.ServerNames, 1)
+		hostname := chain.FilterChainMatch.ServerNames[0]
+
+		downstreamCtx := downstreamTLSContextFromTransportSocket(t, chain.TransportSocket)
+		requireClientCert := downstreamCtx.RequireClientCertificate != nil && downstreamCtx.RequireClientCertificate.GetValue()
+		validationSDS := ""
+		if sds := downstreamCtx.CommonTlsContext.GetValidationContextSdsSecretConfig(); sds != nil {
+			validationSDS = sds.Name
+		}
+
+		gotByHostname[hostname] = struct {
+			requireClientCert bool
+			validationSDS     string
+		}{
+			requireClientCert: requireClientCert,
+			validationSDS:     validationSDS,
+		}
+	}
+
+	assert.Equal(t, map[string]struct {
+		requireClientCert bool
+		validationSDS     string
+	}{
+		"a.example.com": {
+			requireClientCert: true,
+			validationSDS:     "cilium-secrets/gateway-ns-cfgmap-client-ca-a",
+		},
+		"b.example.com": {
+			requireClientCert: false,
+			validationSDS:     "cilium-secrets/gateway-ns-cfgmap-client-ca-b",
+		},
+	}, gotByHostname)
+}
+
+func Test_httpsFilterChains_DeterministicAcrossListenerOrder(t *testing.T) {
+	translator := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+		},
+	}
+
+	listeners := []model.HTTPListener{
+		{
+			Hostname: "b.example.com",
+			TLS:      []model.TLSSecret{{Name: "shared-cert", Namespace: "gateway-ns"}},
+			FrontendTLSValidation: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{Namespace: "gateway-ns", Name: "ca-fallback"},
+				},
+				RequireClientCertificate: false,
+			},
+		},
+		{
+			Hostname: "a.example.com",
+			TLS:      []model.TLSSecret{{Name: "shared-cert", Namespace: "gateway-ns"}},
+			FrontendTLSValidation: &model.FrontendTLSValidation{
+				CACertRefs: []model.FullyQualifiedResource{
+					{Namespace: "gateway-ns", Name: "ca-valid-only"},
+				},
+				RequireClientCertificate: true,
+			},
+		},
+	}
+
+	got1, err := translator.httpsFilterChains("listener", &model.Model{HTTP: listeners})
+	assert.NoError(t, err)
+
+	got2, err := translator.httpsFilterChains("listener", &model.Model{HTTP: []model.HTTPListener{listeners[1], listeners[0]}})
+	assert.NoError(t, err)
+
+	diffOutput := cmp.Diff(got1, got2, protocmp.Transform())
+	assert.Emptyf(t, diffOutput, "HTTPS filter chains differ for reordered listeners:\n%s", diffOutput)
+}
+
+func downstreamTLSContextFromTransportSocket(t *testing.T, ts *envoy_config_core_v3.TransportSocket) *envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext {
+	t.Helper()
+
+	assert.NotNil(t, ts)
+	typedConfig := ts.GetTypedConfig()
+	assert.NotNil(t, typedConfig)
+
+	downstreamCtx := &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{}
+	err := proto.Unmarshal(typedConfig.GetValue(), downstreamCtx)
+	assert.NoError(t, err)
+
+	return downstreamCtx
 }


### PR DESCRIPTION
## Summary

Implements GEP-91 FrontendTLSValidation support in Cilium's Gateway API to enable downstream mTLS, where the gateway validates client certificates before allowing connections.

### Key Changes

- **Model Layer**: Added `FrontendTLSValidation` struct to hold mTLS configuration with `CACertRefs` and `RequireClientCertificate` fields
- **Ingestion Layer**: Added `toFrontendTLSValidation()` to parse Gateway API FrontendTLSValidation from `Gateway.Spec.TLS.Frontend`
- **Translation Layer**: Modified `toTransportSocket()` to configure Envoy's `DownstreamTlsContext` with `RequireClientCertificate` and `ValidationContextSdsSecretConfig`
- **ConfigMap Sync**: Added functions to sync Frontend TLS CA certificate ConfigMaps to the secrets namespace
- **Gateway Reconciler**: Added validation for Frontend TLS ConfigMap references (existence, `ca.crt` key, ReferenceGrant permissions)
- **Gateway Watcher**: Added ConfigMap watcher to trigger reconciliation on CA certificate changes

### Target Envoy Config

```yaml
transportSocket:
  name: envoy.transport_sockets.tls
  typedConfig:
    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
    requireClientCertificate: true  # Based on Mode (AllowValidOnly vs AllowInsecureFallback)
    commonTlsContext:
      tlsCertificateSdsSecretConfigs: [...]  # Server certs (existing)
      validationContextSdsSecretConfig:       # NEW: Client CA certs
        name: cilium-secrets/namespace-cfgmap-ca-name
```

### Supported Configuration

- `Gateway.Spec.TLS.Frontend.Default.Validation` - Default mTLS config for all HTTPS listeners
- `Gateway.Spec.TLS.Frontend.PerPort[].TLS.Validation` - Per-port overrides
- `AllowValidOnly` mode - Requires valid client certificate
- `AllowInsecureFallback` mode - Allows connections without valid cert

## Test plan

- [x] Unit tests for `toFrontendTLSValidation()` covering all validation modes
- [x] All existing tests pass
- [x] Manual testing with Gateway configured with mTLS
- [x] Verify client with valid cert can connect
- [x] Verify client without cert is rejected (AllowValidOnly) or allowed (AllowInsecureFallback)

## Related Issues

Implements GEP-91 (Gateway API FrontendTLSValidation)