### PR TITLE
bpf: subnet: make subnet map read-only

### DIFF
--- a/bpf/lib/subnet.h
+++ b/bpf/lib/subnet.h
@@ -39,7 +39,7 @@ struct {
 	__type(value, struct subnet_value);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, SUBNET_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_subnet_map __section_maps_btf;
 
 /* SUBNET_STATIC_PREFIX gets sizeof non-IP, non-prefix part of subnet_key */


### PR DESCRIPTION
The datapath doesn't need write access for this map.