### PR TITLE
Fix ingress reconciliation when OwnerReferencesPermissionEnforcement is active

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -10,6 +10,12 @@ nodes:
         kind: InitConfiguration
         nodeRegistration:
           taints: []
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
+
   - role: worker
   - role: worker
 networking:

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -323,6 +323,10 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses/status # To update ingress status with load balancer IP.
+  # The controller needs to be able to set ingress finalizers to be able to create a CiliumEnvoyConfig
+  # resource that is owned by the ingress, and set blockOwnerDeletion=true in its ownerRef.
+  # This is required when the admission plugin OwnerReferencesPermissionEnforcement is activated.
+  - ingresses/finalizers
   verbs:
   - update
 {{- end }}


### PR DESCRIPTION
The CI changes from https://github.com/cilium/cilium/pull/43912 highlighted an issue in ingresses reconciliation when the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission plugin is active, and got subsequently [reverted](https://github.com/cilium/cilium/pull/43935) to unbreak the main branch. This PR fixes the issue by adding the appropriate permissions to the cilium operator, and reapplies the test change to catch possible regressions in the future.

/cc @fgiloux FYI

<!-- Description of change -->

```release-note
Grant permissions to the cilium-operator so that it can reconcile ingresses when the when the admission plugin OwnerReferencesPermissionEnforcement is activated
```
