### PR TITLE
install/Makefile: add ability to override Makefile.values variables

### DIFF
--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -1,7 +1,9 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-DIGESTS_PATH:=Makefile.digests
+-include Makefile.values.override
+
+DIGESTS_PATH ?= Makefile.digests
 include $(DIGESTS_PATH)
 export USE_DIGESTS ?= $(shell if grep -q '""' $(DIGESTS_PATH); then echo "false"; else echo "true"; fi)
 export RELEASE_REGISTRY ?= quay.io


### PR DESCRIPTION
Add an optional Makefile.values.override, to allow overriding variable definitions. Additionally, change the DIGESTS_PATH definition to use a conditional assignment, so that it can be overridden externally.
