### PR TITLE
completion: fix memory leak in waitGroup

### DIFF
--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -27,7 +27,9 @@ type WaitGroup struct {
 	pendingCompletions []*Completion
 }
 
-// NewWaitGroup returns a new WaitGroup using the given context.
+// NewWaitGroup returns a new WaitGroup using the given context. It also returns a cancel function
+// to cancel the new context created for this waitGroup. It's important to always close it to avoid
+// leaking resources
 func NewWaitGroup(ctx context.Context) (*WaitGroup, context.CancelFunc) {
 	ctx2, cancel := context.WithCancel(ctx)
 	return &WaitGroup{ctx: ctx2, cancel: cancel}, cancel
@@ -78,7 +80,7 @@ func updateError(old, new error) error {
 }
 
 // Wait blocks until all completions added by calling AddCompletion are
-// completed, or the context is canceled, whichever happens first.
+// completed, or the context or waitGroup is canceled, whichever happens first.
 // Returns the context's error if it is cancelled, nil otherwise.
 // No callbacks of the completions in this wait group will be called after
 // this returns.

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -28,9 +28,9 @@ type WaitGroup struct {
 }
 
 // NewWaitGroup returns a new WaitGroup using the given context.
-func NewWaitGroup(ctx context.Context) *WaitGroup {
+func NewWaitGroup(ctx context.Context) (*WaitGroup, context.CancelFunc) {
 	ctx2, cancel := context.WithCancel(ctx)
-	return &WaitGroup{ctx: ctx2, cancel: cancel}
+	return &WaitGroup{ctx: ctx2, cancel: cancel}, cancel
 }
 
 // Context returns the context of all the Completions in the wait group.

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -24,7 +24,7 @@ func TestNoCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	// Wait should return immediately, since there are no completions.
 	err = wg.Wait()
@@ -37,7 +37,7 @@ func TestCompletionBeforeWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	comp := wg.AddCompletion()
 
@@ -54,7 +54,7 @@ func TestCompletionAfterWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	comp := wg.AddCompletion()
 
@@ -74,7 +74,7 @@ func TestCompletionBeforeAndAfterWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	comp1 := wg.AddCompletion()
 
@@ -101,7 +101,7 @@ func TestCompletionTimeout(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wgCtx, cancel := context.WithTimeout(ctx, WaitGroupTimeout)
 	defer cancel()
-	wg := NewWaitGroup(wgCtx)
+	wg, _ := NewWaitGroup(wgCtx)
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		// Callback gets called with context.DeadlineExceeded if the WaitGroup times out
@@ -127,7 +127,7 @@ func TestCompletionMultipleCompleteCalls(t *testing.T) {
 	defer cancel()
 
 	// Set a shorter timeout to shorten the test duration.
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	comp := wg.AddCompletion()
 
@@ -149,7 +149,7 @@ func TestCompletionWithCallback(t *testing.T) {
 	defer cancel()
 
 	// Set a shorter timeout to shorten the test duration.
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		if err == nil {
@@ -181,7 +181,7 @@ func TestCompletionWithCallbackError(t *testing.T) {
 	err2 := errors.New("Error2")
 
 	// Set a shorter timeout to shorten the test duration.
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		callbackCount++
@@ -221,7 +221,7 @@ func TestCompletionWithCallbackOtherError(t *testing.T) {
 	err2 := errors.New("Error2")
 
 	// Set a shorter timeout to shorten the test duration.
-	wg := NewWaitGroup(ctx)
+	wg, _ := NewWaitGroup(ctx)
 
 	wg.AddCompletionWithCallback(func(err error) {
 		callbackCount++
@@ -257,7 +257,7 @@ func TestCompletionWithCallbackTimeout(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wgCtx, cancel := context.WithTimeout(ctx, WaitGroupTimeout)
 	defer cancel()
-	wg := NewWaitGroup(wgCtx)
+	wg, _ := NewWaitGroup(wgCtx)
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		if err == nil {

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -24,9 +24,14 @@ func TestNoCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	// Wait should return immediately, since there are no completions.
+	err = wg.Wait()
+	require.NoError(t, err)
+
+	// A consecutive wait should also return nil
 	err = wg.Wait()
 	require.NoError(t, err)
 }
@@ -37,7 +42,8 @@ func TestCompletionBeforeWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	comp := wg.AddCompletion()
 
@@ -54,7 +60,8 @@ func TestCompletionAfterWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	comp := wg.AddCompletion()
 
@@ -74,7 +81,8 @@ func TestCompletionBeforeAndAfterWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
 
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	comp1 := wg.AddCompletion()
 
@@ -101,7 +109,8 @@ func TestCompletionTimeout(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wgCtx, cancel := context.WithTimeout(ctx, WaitGroupTimeout)
 	defer cancel()
-	wg, _ := NewWaitGroup(wgCtx)
+	wg, cancel := NewWaitGroup(wgCtx)
+	defer cancel()
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		// Callback gets called with context.DeadlineExceeded if the WaitGroup times out
@@ -127,7 +136,8 @@ func TestCompletionMultipleCompleteCalls(t *testing.T) {
 	defer cancel()
 
 	// Set a shorter timeout to shorten the test duration.
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	comp := wg.AddCompletion()
 
@@ -149,7 +159,8 @@ func TestCompletionWithCallback(t *testing.T) {
 	defer cancel()
 
 	// Set a shorter timeout to shorten the test duration.
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		if err == nil {
@@ -181,7 +192,8 @@ func TestCompletionWithCallbackError(t *testing.T) {
 	err2 := errors.New("Error2")
 
 	// Set a shorter timeout to shorten the test duration.
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
+	defer cancel()
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		callbackCount++
@@ -221,7 +233,7 @@ func TestCompletionWithCallbackOtherError(t *testing.T) {
 	err2 := errors.New("Error2")
 
 	// Set a shorter timeout to shorten the test duration.
-	wg, _ := NewWaitGroup(ctx)
+	wg, cancel := NewWaitGroup(ctx)
 
 	wg.AddCompletionWithCallback(func(err error) {
 		callbackCount++
@@ -245,6 +257,24 @@ func TestCompletionWithCallbackOtherError(t *testing.T) {
 	// The callbacks are called exactly once.
 	require.Equal(t, 1, callbackCount)
 	require.Equal(t, 1, callbackCount2)
+
+	// Cancel wg
+	cancel()
+	err = wg.Wait()
+	require.NoError(t, err)
+
+	// Add and complete a complete it, and ensure Wait still returns true
+	err = wg.AddCompletionWithCallback(func(err error) {}).Complete(nil)
+	require.NoError(t, err)
+	err = wg.Wait()
+	require.NoError(t, err)
+
+	// Add a complete that is running even tough waitGroup is closed and check that wait returns an error
+	_ = wg.AddCompletionWithCallback(func(err error) {})
+	require.NoError(t, err)
+	err = wg.Wait()
+	require.Equal(t, wg.Context().Err(), err)
+
 }
 
 func TestCompletionWithCallbackTimeout(t *testing.T) {
@@ -257,7 +287,9 @@ func TestCompletionWithCallbackTimeout(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wgCtx, cancel := context.WithTimeout(ctx, WaitGroupTimeout)
 	defer cancel()
-	wg, _ := NewWaitGroup(wgCtx)
+
+	wg, cancel := NewWaitGroup(wgCtx)
+	defer cancel()
 
 	comp := wg.AddCompletionWithCallback(func(err error) {
 		if err == nil {
@@ -272,6 +304,10 @@ func TestCompletionWithCallbackTimeout(t *testing.T) {
 	err = wg.Wait()
 	require.Error(t, err)
 	require.Equal(t, wgCtx.Err(), err)
+
+	// Consecutive waits should always return nil as long as no other
+	err = wg.Wait()
+	require.NoError(t, err)
 
 	// Complete is idempotent and harmless, and can be called after the
 	// context is canceled.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -399,6 +399,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 
 	datapathRegenCtxt.prepareForProxyUpdates(regenContext.parentContext)
 	defer datapathRegenCtxt.completionCancel()
+	defer datapathRegenCtxt.proxyWaitGroupCancel()
 
 	err = e.runPreCompilationSteps(regenContext)
 	// Keep track of the side-effects of the regeneration that need to be

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -344,7 +344,8 @@ func TestRedirectWithDeny(t *testing.T) {
 		ruleL4L7Allow.WithEndpointSelector(selectBar_),
 	})
 
-	cmp := completion.NewWaitGroup(t.Context())
+	cmp, cancel := completion.NewWaitGroup(t.Context())
+	defer cancel()
 	s.computePolicyForTest(t, ep, cmp)
 
 	// Redirect is still created, even if all MapState entries may have been overridden by a
@@ -474,7 +475,8 @@ func TestRedirectWithPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	cmp := completion.NewWaitGroup(t.Context())
+	cmp, cancel := completion.NewWaitGroup(t.Context())
+	defer cancel()
 	s.computePolicyForTest(t, ep, cmp)
 
 	// Check that all redirects have been created.
@@ -527,7 +529,8 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
 	})
 
-	cmp := completion.NewWaitGroup(t.Context())
+	cmp, cancel := completion.NewWaitGroup(t.Context())
+	defer cancel()
 	s.computePolicyForTest(t, ep, cmp)
 
 	// Check that all redirects have been created.

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -56,16 +56,17 @@ func ParseExternalRegenerationMetadata(ctx context.Context, logger *slog.Logger,
 // datapathRegenerationContext contains information related to regenerating the
 // datapath (BPF, proxy, etc.).
 type datapathRegenerationContext struct {
-	policyResult       *policyGenerateResult
-	bpfHeaderfilesHash string
-	epInfoCache        *epInfoCache
-	proxyWaitGroup     *completion.WaitGroup
-	ctCleaned          chan struct{}
-	completionCtx      context.Context
-	completionCancel   context.CancelFunc
-	currentDir         string
-	nextDir            string
-	regenerationLevel  regeneration.DatapathRegenerationLevel
+	policyResult         *policyGenerateResult
+	bpfHeaderfilesHash   string
+	epInfoCache          *epInfoCache
+	proxyWaitGroup       *completion.WaitGroup
+	proxyWaitGroupCancel context.CancelFunc
+	ctCleaned            chan struct{}
+	completionCtx        context.Context
+	completionCancel     context.CancelFunc
+	currentDir           string
+	nextDir              string
+	regenerationLevel    regeneration.DatapathRegenerationLevel
 
 	policyMapSyncDone bool
 	policyMapDump     policy.MapStateMap
@@ -76,7 +77,7 @@ type datapathRegenerationContext struct {
 
 func (ctx *datapathRegenerationContext) prepareForProxyUpdates(parentCtx context.Context) {
 	completionCtx, completionCancel := context.WithTimeout(parentCtx, EndpointGenerationTimeout)
-	ctx.proxyWaitGroup = completion.NewWaitGroup(completionCtx)
+	ctx.proxyWaitGroup, ctx.proxyWaitGroupCancel = completion.NewWaitGroup(completionCtx)
 	ctx.completionCtx = completionCtx
 	ctx.completionCancel = completionCancel
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -200,7 +200,7 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 	var epWG sync.WaitGroup
 	var wg sync.WaitGroup
 
-	proxyWaitGroup := completion.NewWaitGroup(ctx)
+	proxyWaitGroup, cancel := completion.NewWaitGroup(ctx)
 
 	eps := mgr.GetEndpoints()
 	epWG.Add(len(eps))
@@ -214,6 +214,7 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 		if err := mgr.waitForProxyCompletions(proxyWaitGroup); err != nil {
 			mgr.logger.Warn("Failed to apply L7 proxy policy changes. These will be re-applied in future updates.", logfields.Error, err)
 		}
+		cancel()
 
 		// Perform policy update call if required.
 		// This should not block the main flow for Endpoint.

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -55,7 +55,8 @@ func TestEnvoy(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	if os.Getenv("CILIUM_ENABLE_ENVOY_UNIT_TEST") == "" {
 		t.Skip("skipping envoy unit test; CILIUM_ENABLE_ENVOY_UNIT_TEST not set")
@@ -112,7 +113,8 @@ func TestEnvoy(t *testing.T) {
 	err = s.waitForProxyCompletion()
 	require.NoError(t, err)
 	t.Log("completed adding metrics listener")
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	t.Log("adding listener1")
 	xdsServer.AddListener("listener1", policy.ParserTypeHTTP, 8081, true, false, s.waitGroup, nil)
@@ -126,7 +128,8 @@ func TestEnvoy(t *testing.T) {
 	err = s.waitForProxyCompletion()
 	require.NoError(t, err)
 	t.Log("completed adding listener1, listener2, listener3")
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	// Remove listener3
 	t.Log("removing listener 3")
@@ -135,7 +138,8 @@ func TestEnvoy(t *testing.T) {
 	err = s.waitForProxyCompletion()
 	require.NoError(t, err)
 	t.Log("completed removing listener 3")
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	// Add listener3 again
 	t.Log("adding listener 3")
@@ -152,7 +156,8 @@ func TestEnvoy(t *testing.T) {
 	require.True(t, cbCalled)
 	require.NoError(t, cbErr)
 	t.Log("completed adding listener 3")
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	t.Log("stopping Envoy")
 	err = envoyProxy.Stop()
@@ -174,7 +179,8 @@ func TestEnvoyNACK(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
 	defer cancel()
 
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	cancel()
 
 	if os.Getenv("CILIUM_ENABLE_ENVOY_UNIT_TEST") == "" {
 		t.Skip("skipping envoy unit test; CILIUM_ENABLE_ENVOY_UNIT_TEST not set")
@@ -240,7 +246,8 @@ func TestEnvoyNACK(t *testing.T) {
 	require.Equal(t, err, cbErr)
 	require.EqualValues(t, &xds.ProxyError{Err: xds.ErrNackReceived, Detail: "Error adding/updating listener(s) listener:22: cannot bind '127.0.0.1:22': Address already in use\n"}, err)
 
-	s.waitGroup = completion.NewWaitGroup(ctx)
+	s.waitGroup, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 	// Remove listener1
 	t.Log("removing ", rName)
 	xdsServer.RemoveListener(rName, s.waitGroup)

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -85,7 +85,8 @@ func TestUpsertSingleNode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -139,7 +140,8 @@ func TestUseCurrent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -201,7 +203,8 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -254,7 +257,8 @@ func TestUpsertMoreRecentVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -284,7 +288,8 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -317,7 +322,8 @@ func TestDeleteSingleNode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -359,7 +365,8 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	// Empty cache is the version 1
@@ -401,7 +408,8 @@ func TestRevertInsert(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	cache := NewCache(logger)
@@ -443,7 +451,8 @@ func TestRevertUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	cache := NewCache(logger)
@@ -492,7 +501,8 @@ func TestRevertDelete(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 	metrics := newMockMetrics()
 
 	cache := NewCache(logger)

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -226,7 +226,8 @@ func TestAck(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	cache := NewCache(logger)
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
@@ -773,7 +774,8 @@ func TestNAck(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	cache := NewCache(logger)
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
@@ -851,7 +853,8 @@ func TestNAck(t *testing.T) {
 
 	// Create version 3 with resources 0 and 1.
 	// NACK cancelled the wg, create a new one
-	wg = completion.NewWaitGroup(ctx)
+	wg, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 	callback2, comp2 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
 	require.Condition(t, isNotCompletedComparison(comp2))
@@ -909,7 +912,8 @@ func TestNAckFromTheStart(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	cache := NewCache(logger)
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
@@ -991,7 +995,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.EqualValues(t, &ProxyError{Err: ErrNackReceived}, comp1.Err())
 
 	// NACK canceled the WaitGroup, create new one
-	wg = completion.NewWaitGroup(ctx)
+	wg, cancel = completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	// Create version 3 with resources 0 and 1.
 	callback2, comp2 := newCompCallback(logger)
@@ -1046,7 +1051,8 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	cache := NewCache(logger)
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
@@ -1118,7 +1124,8 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	cache := NewCache(logger)
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
@@ -1207,7 +1214,8 @@ func TestNotAckedAfterRestart(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	cache := NewCache(logger)
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
@@ -1311,7 +1319,8 @@ func TestWaitForAck(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	ldsCache := NewCache(logger)
 	ldsMutator := NewAckingResourceMutatorWrapper(logger, ldsCache, metrics)
@@ -1514,7 +1523,8 @@ func TestWaitForAckNoClusters(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancel()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	ldsCache := NewCache(logger)
 	ldsMutator := NewAckingResourceMutatorWrapper(logger, ldsCache, metrics)

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1946,7 +1946,9 @@ func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resource
 	// config does not fail for this reason.
 	// Enable wait before new Listeners are added if clusters are also added.
 	if len(resources.Listeners) > 0 && len(resources.Clusters) > 0 {
-		wg = completion.NewWaitGroup(ctx)
+		var cancel func()
+		wg, cancel = completion.NewWaitGroup(ctx)
+		defer cancel()
 	}
 	var revertFuncs xds.AckingResourceMutatorRevertFuncList
 	// Do not wait for the addition of routes, clusters, endpoints, routes,
@@ -2005,7 +2007,9 @@ func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resource
 	// Wait only if new Listeners are added, as they will always be acked.
 	// (unreferenced routes or endpoints (and maybe clusters) are not ACKed or NACKed).
 	if len(resources.Listeners) > 0 {
-		wg = completion.NewWaitGroup(ctx)
+		var cancel func()
+		wg, cancel = completion.NewWaitGroup(ctx)
+		defer cancel()
 	}
 	for _, r := range resources.Listeners {
 		s.logger.Debug("Envoy upsertListener",
@@ -2051,7 +2055,9 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	// Wait only if new Listeners are added, as they will always be acked.
 	// (unreferenced routes or endpoints (and maybe clusters) are not ACKed or NACKed).
 	if len(new.Listeners) > 0 {
-		wg = completion.NewWaitGroup(ctx)
+		var cancel func()
+		wg, cancel = completion.NewWaitGroup(ctx)
+		defer cancel()
 	}
 	// Delete old listeners not added in 'new' or if old and new listener have different ports
 	var deleteListeners []*envoy_config_listener.Listener
@@ -2205,7 +2211,9 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 			logfields.Duration, time.Since(start),
 		)
 		// new wait group for adds
-		wg = completion.NewWaitGroup(ctx)
+		var cancel func()
+		wg, cancel = completion.NewWaitGroup(ctx)
+		defer cancel()
 	}
 
 	// Add new Secrets
@@ -2237,7 +2245,10 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 			logfields.Duration, time.Since(start),
 		)
 		// new wait group for adds
-		wg = completion.NewWaitGroup(ctx)
+		var cancel func()
+		wg, cancel = completion.NewWaitGroup(ctx)
+		defer cancel()
+
 	}
 	// Add new Listeners
 	for _, r := range new.Listeners {
@@ -2287,7 +2298,9 @@ func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 	// Wait only if new Listeners are added, as they will always be acked.
 	// (unreferenced routes or endpoints (and maybe clusters) are not ACKed or NACKed).
 	if len(resources.Listeners) > 0 {
-		wg = completion.NewWaitGroup(ctx)
+		var cancel func()
+		wg, cancel = completion.NewWaitGroup(ctx)
+		defer cancel()
 	}
 	for _, r := range resources.Listeners {
 		listenerName := r.Name

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -93,7 +93,8 @@ func TestCreateOrUpdateRedirectMissingListener(t *testing.T) {
 	l4 := &fakeProxyPolicy{policy.ParserTypeCRD}
 
 	ctx := t.Context()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	proxyPort, err, revertFunc := p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", 1000, wg)
 	require.Equal(t, uint16(0), proxyPort)
@@ -122,7 +123,8 @@ func TestCreateOrUpdateRedirectMissingListenerWithUseOriginalSourceAddrFlagEnabl
 	l4 := &fakeProxyPolicy{policy.ParserTypeHTTP}
 
 	ctx := t.Context()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", 1000, wg)
 	require.True(t, envoyIntegration.proxyUseOriginalSourceAddress)
@@ -149,7 +151,8 @@ func TestCreateOrUpdateRedirectMissingListenerWithUseOriginalSourceAddrFlagDisab
 	l4 := &fakeProxyPolicy{policy.ParserTypeHTTP}
 
 	ctx := t.Context()
-	wg := completion.NewWaitGroup(ctx)
+	wg, cancel := completion.NewWaitGroup(ctx)
+	defer cancel()
 
 	p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", 1000, wg)
 	require.False(t, envoyIntegration.proxyUseOriginalSourceAddress)


### PR DESCRIPTION
See commit message for more info. This fixes a gnarly memory leak. Not sure if this is the best way to fix, and we need to look into the guarantees and write better docs - but its a start. I also want to run the tests to see if anything depend on this in a different way.

I also _partially_ bisected this down to where the WithCancel was introduced, and didn't spend more time digging into that. This most likely affect all versions of cilium, although in practice its mostly affecting environments with a lot of churn.

I've also updated tests to "document" the existing behavior and how the new cancel works together with it.

```release-note
Fix a slow memory leak triggered by incremental policy updates
```
