### PR TITLE
Backport upgrade docs for v1.19

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -291,26 +291,33 @@ features. Read the notes carefully below to understand what to do during upgrade
 Network Policy
 ##############
 
-* DNS Policies match pattern now support a wildcard prefix(``**.``) to match multilevel subdomains as pattern prefix. For usage see :ref:`DNS based` policies.
-  This change introduces a difference in behavior for existing policies with ``**.`` wildcard prefix in match patterns.
-  This pattern now selects all cascaded subdomains in prefix as opposed to just a single level. For example: ``**.cilium.io`` now selects both ``app.cilium.io`` and ``test.app.cilium.io`` as
-  opposed to just ``app.cilium.io`` previously.
+* DNS patterns as used by :ref:`Layer-3 DNS-based policy <DNS based>` and
+  :ref:`Layer-7 DNS policy <dns_discovery>` now support extended subdomain
+  matching via the ``**`` wildcard. Previously, ``**`` was allowed as a
+  wildcard but treated the same as ``*``. If you have any existing patterns that
+  start with ``**.``, they will now match multiple subdomains. Check that your
+  DNS wildcards match the subdomains you intend to be allowed.
 * The `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy` CRDs now
   enforce that the ``FromRequires`` and ``ToRequires`` fields are empty.
-  These fields were previously deprecated and can no longer be used.
+  These fields were previously deprecated and can no longer be used. If you
+  are using this feature, remove these fields from your policies before upgrade.
 * Kafka Network Policy support is deprecated and will be removed in Cilium v1.20.
 
 Cluster Mesh
 ############
 
-* In a Cluster Mesh environment, network policy ingress and egress selectors currently select by default
-  endpoints from all clusters unless one or more clusters are explicitly specified in the policy itself.
-  The ``policy-default-local-cluster`` flag allows to change this behavior, and only select endpoints
-  from the local cluster, unless explicitly specified, to improve the default security posture.
-  This option is now enabled by default in Cilium v1.19. If you are using Cilium ClusterMesh and network policies,
-  you need to take action to update your network policies to avoid this change from breaking connectivity for applications
-  across different clusters. See :ref:`change_policy_default_local_cluster` for more details and migration recommendations
-  to update your network policies.
+* In a Cluster Mesh environment, network policy ingress and egress selectors
+  previously selected endpoints from all clusters unless one or more clusters
+  are explicitly specified in the policy itself. In Cilium v1.19 this behavior
+  has changed to only select endpoints from the local cluster by default. The
+  change is made to improve the default security posture. You can change this
+  behavior with the ``policy-default-local-cluster`` flag, for instance by
+  setting it to ``false`` to retain the previous behavior. This option is now
+  enabled by default in Cilium v1.19.
+  If you are using Cilium ClusterMesh and network policies, update your network
+  policies to avoid this change from breaking connectivity for applications
+  across different clusters. See :ref:`change_policy_default_local_cluster` for
+  more details and migration recommendations to update your network policies.
 * The ``clustermesh.apiserver.tls.authMode`` option is set by default to ``migration`` as
   a first step to transition to ``cluster`` in a future release. If you are using
   ``clustermesh.useAPIServer=true``  and ``clustermesh.config.enabled=false``

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -327,7 +327,9 @@ communicating via the proxy must reconnect to re-establish connections.
   when setting ``clustermesh.apiserver.tls.auto.enabled=false``.
 * Testing for RHEL8 compatibility now uses a RHEL8.10-compatible kernel
   (previously this was a RHEL8.6-compatible kernel).
-* The previously deprecated ``FromRequires`` and ``ToRequires`` fields of the `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy` CRDs have been removed.
+* The `CiliumNetworkPolicy` and `CiliumClusterwideNetworkPolicy` CRDs now
+  enforce that the ``FromRequires`` and ``ToRequires`` fields are empty.
+  These fields were previously deprecated and can no longer be used.
 * This release introduces enabling packet layer path MTU discovery by default on CNI Pod endpoints, this is controlled via the ``enable-endpoint-packet-layer-pmtud`` flag.
 * The ``clustermesh.apiserver.tls.authMode`` option is set by default to ``migration`` as
   a first step to transition to ``cluster`` in a future release. If you are using

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -397,9 +397,11 @@ The following options have been introduced in this version of Cilium:
   This flag currently masquerades traffic to node ``InternalIP`` addresses.
   This may change in future. See :gh-issue:`35823`
   and :gh-issue:`17177` for further discussion on this topic.
-* The new agent flag ``encryption-strict-mode-ingress`` allows dropping any pod-to-pod traffic that hasn't been encrypted. It
-  is only available when WireGuard and tunneling are enabled as well. It should be noted that enabling this feature directly
-  with the upgrade can lead to intermittent packet drops.
+* The new agent flag ``encryption-strict-mode-ingress`` allows dropping any
+  pod-to-pod traffic that hasn't been encrypted. This feature requires
+  WireGuard and tunneling to be enabled. When you enable this feature, there
+  may be temporary disruption to packet delivery between nodes until the nodes
+  are all running with the feature enabled.
 * The agent flag ``enable-endpoint-packet-layer-pmtud`` introduces packet layer
   path MTU discovery by default for all Cilium-managed endpoints.
 


### PR DESCRIPTION
Partial backport of #43913. I dropped the v1.20-specific changes.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43913
```
