### PR TITLE
feat(bpf,hubble): enhanced IP Option packet tracing support, hubble filtering, and documentation

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -104,6 +104,7 @@ get started and experiment with Cilium.
    observability/grafana
    observability/metrics
    observability/visibility
+   observability/packet-tracing
 
 .. toctree::
    :maxdepth: 2

--- a/Documentation/observability/hubble/ip-packet-tracing.rst
+++ b/Documentation/observability/hubble/ip-packet-tracing.rst
@@ -81,7 +81,7 @@ Manual Verification
 ===================
 
 To verify the feature, manually inject a known Trace ID into packets using ``nping``.
-The following examples uses a payload of 4 bytes to meet the strict length requirements.
+The following examples uses a payload of 4 bytes:
 
 #. Deploy Client and Server Pods
    Deploy an ``nginx`` server and a ``netshoot`` client (containing ``nping``):
@@ -112,13 +112,15 @@ The following examples uses a payload of 4 bytes to meet the strict length requi
        # 2. Run nping with Option 136 (0x88)
        # Format: \x88 (Type 136) \x04 (Data + header length) \x34\x21 (Data/ID)
        # The data 0x3421 corresponds to decimal 13345.
-       # Note: Length must be exactly 2, 4 or 8 bytes of payload. Length 4 for the message indicates 2 bytes of payload
+       # Note: Supports up to 8 bytes of payload. If the provided data exceeds 
+       # this limit, it is automatically truncated. In this example, we use 4 bytes of data.
        kubectl exec deployment/client -- nping --tcp -p 80 --ip-options '\x88\x04\x34\x21' -c 3 ${server_ip}
 
 Observing with Hubble
 =====================
 
-With traffic flowing, use the Hubble CLI to observe the extracted data.
+With traffic flowing, use the Hubble CLI to observe and filter the extracted data. 
+Hubble provides two flags to filter flows based on IP Options metadata.
 
 #. Build and Connect Hubble
 
@@ -128,12 +130,27 @@ With traffic flowing, use the Hubble CLI to observe the extracted data.
        make hubble
        cilium hubble port-forward &
 
-#. Filter by Trace ID
+#. Filter and Observe Data
 
-   Filter specifically for the injected ID ``13345`` (hex ``0x3421``):
+   You can filter your observation based on a specific ID value or by the IP Option type itself.
+
+   **Filter by Trace ID**
+   
+   Use the ``--ip-trace-id`` flag to look for a specific value. This is useful when you have a 
+   known ID from an application log and want to find the corresponding network flow.
 
    .. code-block:: shell-session
 
        ./hubble observe -f --ip-trace-id 13345
 
-   Verify that flows between the ``client`` and ``server`` pods appear with the matching ID.
+   **Filter by Option Type**
+   
+   Use the ``--ip-trace-option`` flag to observe any traffic that contains a specific IP Option type, 
+   regardless of the ID value. This is the preferred method for verifying that your sidecars or 
+   devices are correctly injecting metadata.
+
+   .. code-block:: shell-session
+
+       ./hubble observe -f --ip-trace-option 136
+
+   Verify that flows between the ``client`` and ``server`` pods appear with the expected metadata.

--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -425,6 +425,7 @@ multiple fields are set, then all fields must match for the filter to match.
 | trace_id | [string](#string) | repeated | trace_id filters flows by trace ID |
 | ip_trace_id | [uint64](#uint64) | repeated | ip_trace_id filters flows by IPTraceID |
 | encrypted | [bool](#bool) | repeated | encrypted filters flows based on encryption status (WireGuard/IPsec). When set to true, only encrypted flows are returned. When set to false, only unencrypted flows are returned. |
+| ip_trace_option | [uint32](#uint32) | repeated | ip_trace_option filters flows by IP option type |
 | experimental | [FlowFilter.Experimental](#flow-FlowFilter-Experimental) |  | experimental contains filters that are not stable yet. Support for experimental features is always optional and subject to change. |
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -3606,6 +3606,8 @@ type FlowFilter struct {
 	// When set to true, only encrypted flows are returned.
 	// When set to false, only unencrypted flows are returned.
 	Encrypted []bool `protobuf:"varint,40,rep,packed,name=encrypted,proto3" json:"encrypted,omitempty"`
+	// ip_trace_option filters flows by IP option type
+	IpTraceOption []uint32 `protobuf:"varint,41,rep,packed,name=ip_trace_option,json=ipTraceOption,proto3" json:"ip_trace_option,omitempty"`
 	// experimental contains filters that are not stable yet. Support for
 	// experimental features is always optional and subject to change.
 	Experimental  *FlowFilter_Experimental `protobuf:"bytes,999,opt,name=experimental,proto3" json:"experimental,omitempty"`
@@ -3919,6 +3921,13 @@ func (x *FlowFilter) GetIpTraceId() []uint64 {
 func (x *FlowFilter) GetEncrypted() []bool {
 	if x != nil {
 		return x.Encrypted
+	}
+	return nil
+}
+
+func (x *FlowFilter) GetIpTraceOption() []uint32 {
+	if x != nil {
+		return x.IpTraceOption
 	}
 	return nil
 }
@@ -5679,7 +5688,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\bsub_type\x18\x03 \x01(\x05R\asubType\"@\n" +
 	"\x0fCiliumEventType\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\x05R\x04type\x12\x19\n" +
-	"\bsub_type\x18\x02 \x01(\x05R\asubType\"\xe2\r\n" +
+	"\bsub_type\x18\x02 \x01(\x05R\asubType\"\x8a\x0e\n" +
 	"\n" +
 	"FlowFilter\x12\x12\n" +
 	"\x04uuid\x18\x1d \x03(\tR\x04uuid\x12\x1b\n" +
@@ -5730,7 +5739,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"ip_version\x18\x19 \x03(\x0e2\x0f.flow.IPVersionR\tipVersion\x12\x19\n" +
 	"\btrace_id\x18\x1c \x03(\tR\atraceId\x12\x1e\n" +
 	"\vip_trace_id\x18' \x03(\x04R\tipTraceId\x12\x1c\n" +
-	"\tencrypted\x18( \x03(\bR\tencrypted\x12B\n" +
+	"\tencrypted\x18( \x03(\bR\tencrypted\x12&\n" +
+	"\x0fip_trace_option\x18) \x03(\rR\ripTraceOption\x12B\n" +
 	"\fexperimental\x18\xe7\a \x01(\v2\x1d.flow.FlowFilter.ExperimentalR\fexperimental\x1a5\n" +
 	"\fExperimental\x12%\n" +
 	"\x0ecel_expression\x18\x01 \x03(\tR\rcelExpression\"\xce\x01\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -696,6 +696,9 @@ message FlowFilter {
     // When set to false, only unencrypted flows are returned.
     repeated bool encrypted = 40;
 
+    // ip_trace_option filters flows by IP option type
+    repeated uint32 ip_trace_option = 41;
+
     // Experimental contains filters that are not stable yet. Support for
     // experimental features is always optional and subject to change.
     message Experimental {

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -426,6 +426,10 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 		"Show only flows which match this IP trace ID"))
 
 	filterFlags.Var(filterVar(
+		"ip-trace-option", ofilter,
+		"Show only flows which match this IP trace option type"))
+
+	filterFlags.Var(filterVar(
 		"from-fqdn", ofilter,
 		`Show all flows originating at the given fully qualified domain name (e.g. "*.cilium.io").`))
 	filterFlags.Var(filterVar(

--- a/hubble/cmd/observe/flows_filter.go
+++ b/hubble/cmd/observe/flows_filter.go
@@ -527,6 +527,15 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 			f.IpTraceId = append(f.GetIpTraceId(), traceID)
 		})
 
+	case "ip-trace-option":
+		opt, err := strconv.ParseUint(val, 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid --ip-trace-option value: %w", err)
+		}
+		f.apply(func(f *flowpb.FlowFilter) {
+			f.IpTraceOption = append(f.GetIpTraceOption(), uint32(opt))
+		})
+
 	case "verdict":
 		if wipe {
 			f.apply(func(f *flowpb.FlowFilter) {

--- a/pkg/hubble/filters/ip_tracing.go
+++ b/pkg/hubble/filters/ip_tracing.go
@@ -18,6 +18,17 @@ func filterByIPTraceID(tids []uint64) FilterFunc {
 	}
 }
 
+func filterByIPTraceOption(options []uint32) FilterFunc {
+	return func(ev *v1.Event) bool {
+		tid := ev.GetFlow().GetIpTraceId()
+		if tid == nil || tid.GetTraceId() == 0 {
+			return false
+		}
+		opt := tid.GetIpOptionType()
+		return slices.Contains(options, opt)
+	}
+}
+
 // TraceIDFilter implements filtering based on IP trace IDs.
 type IPTraceIDFilter struct{}
 
@@ -26,6 +37,9 @@ func (t *IPTraceIDFilter) OnBuildFilter(_ context.Context, ff *flowpb.FlowFilter
 	var fs []FilterFunc
 	if ids := ff.GetIpTraceId(); len(ids) > 0 {
 		fs = append(fs, filterByIPTraceID(ids))
+	}
+	if opts := ff.GetIpTraceOption(); len(opts) > 0 {
+		fs = append(fs, filterByIPTraceOption(opts))
 	}
 	return fs, nil
 }

--- a/pkg/hubble/filters/ip_tracing_test.go
+++ b/pkg/hubble/filters/ip_tracing_test.go
@@ -85,6 +85,83 @@ func TestIPTraceIDFilter(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "option_match",
+			f: []*flowpb.FlowFilter{
+				{IpTraceOption: []uint32{100}},
+			},
+			ev: &v1.Event{
+				Event: &flowpb.Flow{
+					IpTraceId: &flowpb.IPTraceID{
+						TraceId:      123,
+						IpOptionType: 100,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "option_mismatch",
+			f: []*flowpb.FlowFilter{
+				{IpTraceOption: []uint32{100}},
+			},
+			ev: &v1.Event{
+				Event: &flowpb.Flow{
+					IpTraceId: &flowpb.IPTraceID{
+						TraceId:      123,
+						IpOptionType: 200,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "option_match_but_no_trace_id",
+			f: []*flowpb.FlowFilter{
+				{IpTraceOption: []uint32{100}},
+			},
+			ev: &v1.Event{
+				Event: &flowpb.Flow{
+					IpTraceId: &flowpb.IPTraceID{
+						IpOptionType: 100,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "option_match_trace_id_zero",
+			f: []*flowpb.FlowFilter{
+				{IpTraceOption: []uint32{100}},
+			},
+			ev: &v1.Event{
+				Event: &flowpb.Flow{
+					IpTraceId: &flowpb.IPTraceID{
+						TraceId:      0,
+						IpOptionType: 100,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "option_and_id_match",
+			f: []*flowpb.FlowFilter{
+				{
+					IpTraceId:     []uint64{123},
+					IpTraceOption: []uint32{100},
+				},
+			},
+			ev: &v1.Event{
+				Event: &flowpb.Flow{
+					IpTraceId: &flowpb.IPTraceID{
+						TraceId:      123,
+						IpOptionType: 100,
+					},
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Summary 

This PR enhances Cilium's packet tracing feature <https://github.com/cilium/cilium/pull/41306> by improving BPF-level IP option parsing, adding new Hubble filtering options, and creating documentation for the feature. These changes allow for better interoperability with external tracing tools like Grafana Beyla and simplify the observation of traced flows.

# Key Changes

   * BPF: Variable Length IP Option Support
       * Updated the IP option parsing logic (trace_id_from_ip4) to support arbitrary payload lengths.
       * Implemented truncation for payloads exceeding 8 bytes (MAX_TRACE_ID_SIZE), ensuring compatibility with external tools (e.g., W3C Trace Context used by Beyla) while maintaining
         existing storage constraints.
   * Hubble: IP Trace Option Filtering
       * Introduced the --ip-trace-option flag to the Hubble CLI.
       * Added observer-side filtering logic to match flows based on specific IP option types and non-zero Trace IDs.
       * Updated the FlowFilter API to include ip_trace_option.
   * Documentation
       * Updated packet-tracing documentation to relfect new changes.