### PR TITLE
cilium, bigtcp: Probe BIG TCP for tunnels

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -186,7 +186,6 @@ cilium-agent [flags]
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
-      --enable-tunnel-big-tcp                                     Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
       --enable-unreachable-routes                                 Add unreachable routes on pod deletion
       --enable-vtep                                               Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -98,7 +98,6 @@ cilium-agent hive [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
-      --enable-tunnel-big-tcp                                     Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                          Enable WireGuard
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -104,7 +104,6 @@ cilium-agent hive dot-graph [flags]
       --enable-route-mtu-for-cni-chaining                         Enable route MTU for pod netns when CNI chaining is used
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
-      --enable-tunnel-big-tcp                                     Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
       --enable-wireguard                                          Enable WireGuard
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1320,10 +1320,6 @@
      - Enable Non-Default-Deny policies
      - bool
      - ``true``
-   * - :spelling:ignore:`enableTunnelBIGTCP`
-     - Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
-     - bool
-     - ``false``
    * - :spelling:ignore:`enableXTSocketFallback`
      - Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -380,7 +380,6 @@ contributors across the globe, there is almost always someone available to help.
 | enableMasqueradeRouteSource | bool | `false` | Enables masquerading to the source of the route for traffic leaving the node from endpoints. |
 | enableNoServiceEndpointsRoutable | bool | `true` | Enable routing to a service that has zero endpoints |
 | enableNonDefaultDenyPolicies | bool | `true` | Enable Non-Default-Deny policies |
-| enableTunnelBIGTCP | bool | `false` | Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
 | encryption.ipsec.encryptedOverlay | bool | `false` | Enable IPsec encrypted overlay |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -706,7 +706,6 @@ data:
   enable-ipv4-big-tcp: {{ .Values.enableIPv4BIGTCP | quote }}
   enable-ipv6-big-tcp: {{ .Values.enableIPv6BIGTCP | quote }}
   enable-ipv6-masquerade: {{ .Values.enableIPv6Masquerade | quote }}
-  enable-tunnel-big-tcp: {{ .Values.enableTunnelBIGTCP | quote }}
 
 {{- if hasKey .Values.bpf "enableTCX" }}
   enable-tcx: {{ .Values.bpf.enableTCX | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1898,9 +1898,6 @@
     "enableNonDefaultDenyPolicies": {
       "type": "boolean"
     },
-    "enableTunnelBIGTCP": {
-      "type": "boolean"
-    },
     "enableXTSocketFallback": {
       "type": "boolean"
     },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2395,8 +2395,6 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
-# -- Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
-enableTunnelBIGTCP: false
 nat:
   # -- Number of the top-k SNAT map connections to track in Cilium statedb.
   mapStatsEntries: 32

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2417,8 +2417,6 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
-# -- Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels
-enableTunnelBIGTCP: false
 
 nat:
   # -- Number of the top-k SNAT map connections to track in Cilium statedb.

--- a/pkg/datapath/fake/types/bigtcp.go
+++ b/pkg/datapath/fake/types/bigtcp.go
@@ -10,9 +10,6 @@ type BigTCPUserConfig struct {
 
 	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
 	EnableIPv4BIGTCP bool
-
-	// EnableTunnelBIGTCP enables BIG TCP (larger GSO/GRO limits) in tunneling mode for VXLAN and GENEVE tunnels.
-	EnableTunnelBIGTCP bool
 }
 
 func (def BigTCPUserConfig) IsIPv4Enabled() bool {
@@ -21,8 +18,4 @@ func (def BigTCPUserConfig) IsIPv4Enabled() bool {
 
 func (def BigTCPUserConfig) IsIPv6Enabled() bool {
 	return def.EnableIPv6BIGTCP
-}
-
-func (def BigTCPUserConfig) IsTunnelEnabled() bool {
-	return def.EnableTunnelBIGTCP
 }

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -111,3 +111,13 @@ func TestPrivilegedHaveFibLookupSkipNeigh(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "6.6", "BPF_FIB_LOOKUP_SKIP_NEIGH")
 	assert.NoError(t, HaveFibLookupSkipNeigh())
 }
+
+func TestBIGTCPIPv4(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "6.3", "BIG TCP IPv4")
+	assert.NoError(t, HaveBIGTCPIPv4())
+}
+
+func TestBIGTCPIPv6(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "5.19", "BIG TCP IPv6")
+	assert.NoError(t, HaveBIGTCPIPv6())
+}

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -121,3 +121,9 @@ func TestBIGTCPIPv6(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.19", "BIG TCP IPv6")
 	assert.NoError(t, HaveBIGTCPIPv6())
 }
+
+func TestPrivilegedBIGTCPTunnel(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	testutils.SkipOnOldKernel(t, "6.20", "BIG TCP for UDP tunnels")
+	assert.NoError(t, HaveBIGTCPTunnel())
+}

--- a/pkg/datapath/types/bigtcp.go
+++ b/pkg/datapath/types/bigtcp.go
@@ -8,9 +8,12 @@ import (
 )
 
 const (
-	EnableIPv4BIGTCPFlag   = "enable-ipv4-big-tcp"
-	EnableIPv6BIGTCPFlag   = "enable-ipv6-big-tcp"
-	EnableTunnelBIGTCPFlag = "enable-tunnel-big-tcp"
+	EnableIPv4BIGTCPFlag = "enable-ipv4-big-tcp"
+	EnableIPv6BIGTCPFlag = "enable-ipv6-big-tcp"
+
+	// Corresponds to the value of GRO_LEGACY_MAX_SIZE and GSO_LEGACY_MAX_SIZE in
+	// the kernel. This is the maximum aggregation size of a packet pre BIG TCP.
+	GROGSOLegacyMaxSize = 65536
 )
 
 // BigTCPUserConfig are the configuration flags that the user can modify.
@@ -20,15 +23,11 @@ type BigTCPUserConfig struct {
 
 	// EnableIPv4BIGTCP enables IPv4 BIG TCP (larger GSO/GRO limits) for the node including pods.
 	EnableIPv4BIGTCP bool
-
-	// EnableTunnelBIGTCP enables BIG TCP (larger GSO/GRO limits) in tunneling mode for VXLAN and GENEVE tunnels.
-	EnableTunnelBIGTCP bool
 }
 
 func (def BigTCPUserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(EnableIPv4BIGTCPFlag, def.EnableIPv4BIGTCP, "Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4")
 	flags.Bool(EnableIPv6BIGTCPFlag, def.EnableIPv6BIGTCP, "Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6")
-	flags.Bool(EnableTunnelBIGTCPFlag, def.EnableTunnelBIGTCP, "Enable BIG TCP in tunneling mode and increase maximum GRO/GSO limits for VXLAN/GENEVE tunnels")
 }
 
 func (def BigTCPUserConfig) IsIPv4Enabled() bool {
@@ -39,14 +38,9 @@ func (def BigTCPUserConfig) IsIPv6Enabled() bool {
 	return def.EnableIPv6BIGTCP
 }
 
-func (def BigTCPUserConfig) IsTunnelEnabled() bool {
-	return def.EnableTunnelBIGTCP
-}
-
 type BigTCPConfig interface {
 	IsIPv4Enabled() bool
 	IsIPv6Enabled() bool
-	IsTunnelEnabled() bool
 }
 
 type BigTCPConfiguration interface {

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -72,9 +72,8 @@ func (m mockFeaturesParams) DatapathOperationalMode() string {
 }
 
 type bigTCPMock struct {
-	ipv4Enabled   bool
-	ipv6Enabled   bool
-	tunnelEnabled bool
+	ipv4Enabled bool
+	ipv6Enabled bool
 }
 
 func (b bigTCPMock) IsIPv4Enabled() bool {
@@ -83,10 +82,6 @@ func (b bigTCPMock) IsIPv4Enabled() bool {
 
 func (b bigTCPMock) IsIPv6Enabled() bool {
 	return b.ipv6Enabled
-}
-
-func (b bigTCPMock) IsTunnelEnabled() bool {
-	return b.tunnelEnabled
 }
 
 func TestUpdateNetworkMode(t *testing.T) {
@@ -1266,7 +1261,6 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 		name             string
 		enableIPv4       bool
 		enableIPv6       bool
-		enableTunnel     bool
 		expectedProtocol string
 	}{
 		{
@@ -1305,9 +1299,8 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 			params := mockFeaturesParams{
 				CNIChainingMode: defaultChainingModes[0],
 				bigTCPMock: bigTCPMock{
-					ipv4Enabled:   tt.enableIPv4,
-					ipv6Enabled:   tt.enableIPv6,
-					tunnelEnabled: tt.enableTunnel,
+					ipv4Enabled: tt.enableIPv4,
+					ipv6Enabled: tt.enableIPv6,
 				},
 			}
 


### PR DESCRIPTION
Obsolete the --enable-tunnel-big-tcp command line flag introduced when
adding support for BIG TCP in VXLAN and GENEVE. This flag was used to
let the admin tell Cilium whether it's running on a supported kernel.
Turns out it's possible to probe kernel support by checking tso_max_size
of a GENEVE netdev (doesn't work for VXLAN netdevs because they inherit
it from the lower device).

Fixes: https://github.com/cilium/cilium/commit/f8762a6bd9f17610af1098995a0b36d5e3a7dc3a ("cilium, bigtcp: BIG TCP for tunnels")

```release-note
Probe support for BIG TCP for tunnels instead of relying on the config option.
```
