### PR TITLE
policy: Fix CCG matching for duplicate label keys

### DIFF
--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -42,7 +42,12 @@ func (p *policyWatcher) cidrsAndLabelsForCIDRGroup(name string) (sets.Set[netip.
 
 	// If CIDRGroup isn't deleted; populate newCIDRs
 	if cidrGroup, ok := p.cidrGroupCache[name]; ok {
-		lbls = labels.Map2Labels(utils.RemoveCiliumLabels(cidrGroup.Labels), labels.LabelSourceCIDRGroup)
+		filtered := utils.RemoveCiliumLabels(cidrGroup.Labels)
+		lbls = make(labels.Labels, len(filtered))
+		for k, v := range filtered {
+			l := labels.NewLabel(k, v, labels.LabelSourceCIDRGroup)
+			lbls[name+"/"+l.Key+"="+l.Value] = l
+		}
 		lbl := api.LabelForCIDRGroupRef(name)
 		lbls[lbl.Key] = lbl
 


### PR DESCRIPTION
When two CCGs share a label key with different values on the same CIDR
prefix, ipcache merges their labels into one map. LookupLabel returns
the first match by key, so Equals matching for the other value silently
fails.

Fix this by emitting an extra encoded label (key+value as the label key)
for each CCG label, and teaching CIDRGroupSelector to check for encoded
key existence instead of value comparison.