### PR TITLE
k8s: include namespace in EndpointSliceName

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -225,7 +225,7 @@ func ParseEndpointSliceID(es endpointSlice) EndpointSliceID {
 			es.GetNamespace(),
 			es.GetLabels()[slim_discovery_v1.LabelServiceName],
 		),
-		EndpointSliceName: es.GetName(),
+		EndpointSliceName: es.GetNamespace() + "/" + es.GetName(),
 	}
 }
 

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -262,7 +262,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 	}
 	sliceID := EndpointSliceID{
 		ServiceName:       loadbalancer.NewServiceName("bar", "quux"),
-		EndpointSliceName: "foo",
+		EndpointSliceName: "bar/foo",
 	}
 
 	newEmptyEndpoints := func() *Endpoints {

--- a/pkg/loadbalancer/tests/testdata/name-collisions.txtar
+++ b/pkg/loadbalancer/tests/testdata/name-collisions.txtar
@@ -1,0 +1,106 @@
+#
+# Regression test case for checking that the EndpointSlice names are allowed to overlap across
+# namespaces. https://github.com/cilium/cilium/pull/43999.
+#
+
+# Start the test application
+hive/start
+
+# Make the test-b variants of the Service and EndpointSlice
+cp service-a.yaml service-b.yaml
+sed 'namespace: test-a' 'namespace: test-b' service-b.yaml
+sed '10.96.50.104' '10.96.50.105' service-b.yaml
+cp endpointslice-a.yaml endpointslice-b.yaml
+sed 'namespace: test-a' 'namespace: test-b' endpointslice-b.yaml
+sed '10.244.1.' '10.245.1.' endpointslice-b.yaml
+
+# 1. Add the test-a Service and EndpointSlice.
+k8s/add service-a.yaml endpointslice-a.yaml
+db/cmp frontends frontends-1.table
+db/cmp backends backends-1.table
+
+# 2. Add the test-b Service and EndpointSlice. Both EndpointSlices have
+# the same name, but exist in different namespaces, so should not collide.
+k8s/add service-b.yaml endpointslice-b.yaml
+db/cmp frontends frontends-2.table
+db/cmp backends backends-2.table
+
+# 3. Update test-a EndpointSlice - remove an address.
+sed '.*- 10.244.1.2' '' endpointslice-a.yaml
+k8s/update endpointslice-a.yaml
+db/cmp frontends frontends-3.table
+db/cmp backends backends-3.table
+
+-- frontends-1.table --
+Address               Type        ServiceName      PortName   Backends                             Status   Error
+10.96.50.104:80/TCP   ClusterIP   test-a/service   http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP Done
+
+-- backends-1.table --
+Address             Instances               Shadows   NodeName
+10.244.1.1:80/TCP   test-a/service (http)             nodeport-worker
+10.244.1.2:80/TCP   test-a/service (http)             nodeport-worker
+
+-- frontends-2.table --
+Address               Type        ServiceName      PortName   Backends                             Status   Error
+10.96.50.104:80/TCP   ClusterIP   test-a/service   http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP Done
+10.96.50.105:80/TCP   ClusterIP   test-b/service   http       10.245.1.1:80/TCP, 10.245.1.2:80/TCP Done
+
+-- backends-2.table --
+Address             Instances               Shadows   NodeName
+10.244.1.1:80/TCP   test-a/service (http)             nodeport-worker
+10.244.1.2:80/TCP   test-a/service (http)             nodeport-worker
+10.245.1.1:80/TCP   test-b/service (http)             nodeport-worker
+10.245.1.2:80/TCP   test-b/service (http)             nodeport-worker
+
+-- frontends-3.table --
+Address               Type        ServiceName      PortName   Backends                             Status   Error
+10.96.50.104:80/TCP   ClusterIP   test-a/service   http       10.244.1.1:80/TCP                    Done
+10.96.50.105:80/TCP   ClusterIP   test-b/service   http       10.245.1.1:80/TCP, 10.245.1.2:80/TCP Done
+
+-- backends-3.table --
+Address             Instances               Shadows   NodeName
+10.244.1.1:80/TCP   test-a/service (http)             nodeport-worker
+10.245.1.1:80/TCP   test-b/service (http)             nodeport-worker
+10.245.1.2:80/TCP   test-b/service (http)             nodeport-worker
+
+-- service-a.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: test-a
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ClusterIP
+  sessionAffinity: ClientIP
+
+-- endpointslice-a.yaml --
+# Initial EndpointSlice has two addresses
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: service
+  name: service
+  namespace: test-a
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  - 10.244.1.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP


### PR DESCRIPTION
We previously did not include the Namespace in EndpointSliceNames, relying on the fact that EndpointSlices that use generateName- are unlikely to have name collisions, even across namespaces. While this is usually the case, there is no requirement for EndpointSlice managers to use generateName, and there are examples of controllers that do not (for example the master kubernetes service's EndpointSlice is always called "kubernetes").

Including the namespace in EndpointSliceNames guarantees collisions cannot occur.

Warning: If this bugfix is to be merged into a branch that does not yet contain d0036787c2cc7a2b40ad1a7f3ae8aa17cae4d359, the old code that that commit cleaned up suffers from the same bug. Happy to provide a separate PR for that, if required, although it looks very out of date.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


```release-note
Fix a bug where removed addresses from EndpointSlices might be missed if multiple EndpointSlices share the same name
```
