### PR TITLE
test: increase verifier load coverage for EnablePolicyAccounting

### DIFF
--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -11,7 +11,7 @@ import (
 
 func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
 	return func(yield func(*config.BPFLXC) bool) {
-		for permutation := range permute(5) {
+		for permutation := range permute(6) {
 			cfg := config.NewBPFLXC(*config.NewNode())
 			cfg.Node.TracingIPOptionType = 1
 			cfg.Node.PolicyDenyResponseEnabled = permutation[0]
@@ -19,6 +19,7 @@ func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
 			cfg.EnableICMPRule = permutation[2]
 			cfg.EnableLRP = permutation[3]
 			cfg.HybridRoutingEnabled = permutation[4]
+			cfg.EnablePolicyAccounting = permutation[5]
 
 			if !yield(cfg) {
 				return
@@ -29,7 +30,7 @@ func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
 
 func hostLoadPermutations() iter.Seq[*config.BPFHost] {
 	return func(yield func(*config.BPFHost) bool) {
-		for permutation := range permute(6) {
+		for permutation := range permute(7) {
 			cfg := config.NewBPFHost(*config.NewNode())
 			cfg.Node.TracingIPOptionType = 1
 			cfg.EnableRemoteNodeMasquerade = permutation[0]
@@ -42,6 +43,7 @@ func hostLoadPermutations() iter.Seq[*config.BPFHost] {
 			cfg.AllowICMPFragNeeded = permutation[3]
 			cfg.EnableICMPRule = permutation[4]
 			cfg.HybridRoutingEnabled = permutation[5]
+			cfg.EnablePolicyAccounting = permutation[6]
 
 			if !yield(cfg) {
 				return


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

EnablePolicyAccounting is used in both the LXC and host datapaths, so it is included in the permutations for
`lxcLoadPermutations` and `hostLoadPermutations`.

related: https://github.com/cilium/cilium/pull/43042#discussion_r2707236457