### PR TITLE
pkg/nodediscovery: Fix global static IP tags with flags

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -388,6 +388,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 
 	nodeResource.Spec.BootID = ln.BootID
 
+	nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
 	if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
 		if len(c.IPAM.StaticIPTags) > 0 {
 			nodeResource.Spec.IPAM.StaticIPTags = c.IPAM.StaticIPTags
@@ -433,7 +434,6 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
 		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
 		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
-		nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
 
 		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
 			if c.IPAM.MinAllocate != 0 {
@@ -505,7 +505,6 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
 		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
 		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
-		nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
 		nodeResource.Spec.Azure.InterfaceName = n.config.AzureInterfaceName
 
 		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
@@ -557,7 +556,6 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
 		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
 		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
-		nodeResource.Spec.IPAM.StaticIPTags = n.config.IPAMStaticIPTags
 		nodeResource.Spec.AlibabaCloud.VSwitches = n.config.AlibabaCloudVSwitches
 		nodeResource.Spec.AlibabaCloud.VSwitchTags = n.config.AlibabaCloudVSwitchTags
 		nodeResource.Spec.AlibabaCloud.SecurityGroups = n.config.AlibabaCloudSecurityGroups


### PR DESCRIPTION
In a previous PR #43524 setting static IP tags was made global to all IPAM modes. This makes sure the behavior also applies when setting the tags through the IPAM flag.

For more details see #43524.

```release-note
Fix static IP tags from IPAM flags parsing to work on all IPAM modes
```
