### PR TITLE
docs: Add upgrade note about wildcard service entries.

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -455,6 +455,9 @@ General Notes
   ``-use-default-field-mask`` (now ``true`` by default).
 * Testing for RHEL8 compatibility now uses a RHEL8.10-compatible kernel
   (previously this was a RHEL8.6-compatible kernel).
+* The Cilium datapath will now drop TCP/UDP traffic towards a LoadBalancer or
+  ClusterIP allocated by LB-IPAM in the north-south direction if the destination
+  port does not match a provisioned service.
 
 Cluster Mesh
 ############


### PR DESCRIPTION
Adds entry to the upgrade notes for Cilium 1.19 relating to the introduction of wildcard service entries and the underlying behaviour change this brings to the datapath.

Relates to: https://github.com/cilium/cilium/pull/40684
Relates to: https://github.com/cilium/cilium/pull/43565
Relates to: https://github.com/cilium/cilium/pull/43721