### PR TITLE
cilium-cli: Skip external IP NodePort validation on GKE

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -2739,6 +2739,15 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 					continue
 				}
 
+				// On GKE, ExternalIP is not reachable from inside a cluster.
+				// Skip validation for external IPs in GKE to match the actual test behavior.
+				if addr.Type == slimcorev1.NodeExternalIP {
+					if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
+						ct.Debugf("Skipping NodePort validation for external IP %s on GKE", addr.Address)
+						continue
+					}
+				}
+
 				for _, s := range ct.echoServices {
 					if err := WaitForNodePorts(ctx, ct, *client, addr.Address, s); err != nil {
 						return err


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Summary

Fixes #43749 by skipping external IP NodePort validation on GKE, where external IPs are not reachable from inside the cluster.

## Details

PR #40812 enhanced NodePort validation to check all node IP addresses (including external IPs) to fix dual-stack clusters. However, on GKE, external IPs are not reachable from within the cluster due to firewall restrictions.

The actual connectivity tests already handle this correctly by skipping external IPs on GKE (`service.go:252-257`), but the upfront validation code did not have this check, causing test failures.

## Changes

- Added GKE-aware external IP skip logic to NodePort validation in `deployment.go` (lines 2742-2749)
- Rebased on main to incorporate the new IPv4/IPv6 family filtering check
- Works alongside the existing IP family validation (lines 2735-2740)
- Uses the same pattern already present elsewhere in the codebase (`service.go:252-257`, `deployment.go:1781-1786`)
- Only affects GKE environments (no change for other platforms)
- Preserves the dual-stack fix from PR #40812

## Root Cause Analysis

### Current Code Structure (After Rebase)

The NodePort validation now has **three sequential checks** to filter addresses:

```go
for _, node := range ct.Nodes() {
    for _, addr := range node.Status.Addresses {
        // 1. Only check IP addresses (skip DNS names, hostnames)
        if addr.Type != slimcorev1.NodeInternalIP && addr.Type != slimcorev1.NodeExternalIP {
            continue
        }

        // 2. Skip IP addresses of families which are not enabled in Cilium
        //    (Added by upstream after PR #40812)
        addrFamily := features.GetIPFamily(addr.Address)
        if (addrFamily == features.IPFamilyV4 && !ct.Features[features.IPv4].Enabled) ||
            (addrFamily == features.IPFamilyV6 && !ct.Features[features.IPv6].Enabled) {
            continue
        }

        // 3. [THIS PR] On GKE, ExternalIP is not reachable from inside a cluster
        //    Skip validation for external IPs in GKE to match the actual test behavior
        if addr.Type == slimcorev1.NodeExternalIP {
            if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
                ct.Debugf("Skipping NodePort validation for external IP %s on GKE", addr.Address)
                continue
            }
        }

        // Validate NodePort readiness
        for _, s := range ct.echoServices {
            if err := WaitForNodePorts(ctx, ct, *client, addr.Address, s); err != nil {
                return err
            }
        }
    }
}
```

### What Broke

In PR #40812, the upfront NodePort validation was enhanced from:
```go
// Old: Only validated HostIP (one IP per node, typically IPv4)
for _, ciliumPod := range ct.ciliumPods {
    hostIP := ciliumPod.Pod.Status.HostIP
    WaitForNodePorts(ctx, ct, *client, hostIP, s)
}
```

To:
```go
// New: Validates ALL node addresses (internal + external)
for _, node := range ct.Nodes() {
    for _, addr := range node.Status.Addresses {
        if addr.Type != slimcorev1.NodeInternalIP && addr.Type != slimcorev1.NodeExternalIP {
            continue
        }
        WaitForNodePorts(ctx, ct, *client, addr.Address, s)  // Validates external IPs too
    }
}
```

This correctly fixed dual-stack IPv6 validation but inadvertently started validating external IPs that are unreachable on GKE due to firewall restrictions.

### The Fix

The actual connectivity tests already skip external IPs on GKE:
```go
// From service.go:252-257
if addr.Type == slimcorev1.NodeExternalIP {
    if f, ok := t.Context().Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
        continue  // ← Tests skip external IPs on GKE
    }
}
```

This same pattern exists in another part of `deployment.go`:
```go
// From deployment.go:1781-1786
// On GKE ExternalIP is not reachable from inside a cluster
if addr.Type == slimcorev1.NodeExternalIP {
    if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
        continue
    }
}
```

This PR adds the same check to the NodePort validation phase for consistency:
```go
// In deployment.go:2742-2749 (this PR)
// On GKE, ExternalIP is not reachable from inside a cluster.
// Skip validation for external IPs in GKE to match the actual test behavior.
if addr.Type == slimcorev1.NodeExternalIP {
    if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode == "gke" {
        ct.Debugf("Skipping NodePort validation for external IP %s on GKE", addr.Address)
        continue
    }
}
```

### Why External IPs Are Unreachable on GKE

On GKE:
- **Internal IPs** (e.g., `10.128.0.2`): ✅ Reachable from inside the cluster
- **External IPs** (e.g., `34.106.17.216`): ❌ Blocked by GKE firewall, not reachable from inside the cluster

The error logs from issue #43749 show timeouts on external IPs:
```
⌛ Waiting for NodePort 34.106.17.216:31639...
timeout reached waiting for NodePort 34.106.17.216:31639
```

## Testing

This fix should resolve failures in:
- GKE `no-tunnel` config
- GKE `tunnel` config

Without affecting:
- GKE `tunnel-ingress-controller` config (KPR)
- Dual-stack IPv6 functionality (still validates IPv6 internal addresses)
- Other cloud providers (EKS, AKS, bare metal, etc.)
- IPv4/IPv6 family filtering

## References

Fixes: #43749  
See-also: #39793 (original dual-stack issue fixed by #40812)  
See-also: #40812 (PR that introduced the validation enhancement)

```release-note
Fix GKE conformance test NodePort timeouts by skipping unreachable external IP validation on GKE
```