### PR TITLE
bpf: Move clustermesh NODE_CONFIG declarations to node.h

### DIFF
--- a/bpf/include/bpf/config/node.h
+++ b/bpf/include/bpf/config/node.h
@@ -33,3 +33,14 @@ NODE_CONFIG(bool, supports_fib_lookup_skip_neigh,
 NODE_CONFIG(__u8, tracing_ip_option_type, "The IP option type to use for packet tracing")
 
 NODE_CONFIG(bool, policy_deny_response_enabled, "Enable ICMP responses for policy-denied traffic")
+
+NODE_CONFIG(__u32, cluster_id, "Cluster ID")
+
+NODE_CONFIG(__u32, cluster_id_bits, "Number of bits of the identity reserved for the Cluster ID")
+
+/* Allow to override the assigned value in tests */
+#ifndef DEFAULT_CLUSTER_ID_BITS
+#define DEFAULT_CLUSTER_ID_BITS 8
+#endif
+
+ASSIGN_CONFIG(__u32, cluster_id_bits, DEFAULT_CLUSTER_ID_BITS)

--- a/bpf/lib/clustermesh.h
+++ b/bpf/lib/clustermesh.h
@@ -2,17 +2,9 @@
 
 #pragma once
 
+#include <bpf/config/node.h>
+
 #include "lib/utils.h"
-
-NODE_CONFIG(__u32, cluster_id, "Cluster ID")
-
-/* Allow to override the assigned value in tests */
-#ifndef DEFAULT_CLUSTER_ID_BITS
-#define DEFAULT_CLUSTER_ID_BITS 8
-#endif
-
-NODE_CONFIG(__u32, cluster_id_bits, "Number of bits of the identity reserved for the Cluster ID")
-ASSIGN_CONFIG(__u32, cluster_id_bits, DEFAULT_CLUSTER_ID_BITS)
 
 /*
  * Non node-local identity is 24 bits total. cluster_id_bits selects how many


### PR DESCRIPTION
As of bc492b6a49b4ec5e1f7d9800a32df86cba3b5b5d and e76dbfc516a36ff24004dc07e0632e489ad0e789 we use `NODE_CONFIG` for clustermesh's `cluster_id` and `cluster_id_max` (now `cluster_id_bits`) configuration. (CC @viktor-kurchenko )

To avoid the need for including clustermesh header file (explicitly or transitively) whenever node config is loaded in a bpf program, move the clustermesh `NODE_CONFIG` declarations to the common node config header file.

Missing clustermesh `NODE_CONFIG` declarations may cause an error by loading, such as: `can't set non-existent Variable cluster_id`.