### PR TITLE
cilium-dbg: add --kubeproxy-replacement

### DIFF
--- a/Documentation/cmdref/cilium-dbg_status.md
+++ b/Documentation/cmdref/cilium-dbg_status.md
@@ -19,6 +19,7 @@ cilium-dbg status [flags]
       --all-redirects              Show all redirects
       --brief                      Only print a one-line status message
   -h, --help                       help for status
+      --kubeproxy-replacement      Show KubeProxy Replacement Details
   -o, --output string              json| yaml| jsonpath='{}'
       --require-k8s-connectivity   If true, when the cilium-agent cannot access the Kubernetes control plane, this status command returns a non-zero exit status. (default true)
       --timeout duration           Sets the timeout to use when querying for health (default 30s)

--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -49,6 +49,7 @@ func init() {
 	statusCmd.Flags().BoolVar(&statusDetails.AllNodes, "all-nodes", false, "Show all nodes, not just localhost")
 	statusCmd.Flags().BoolVar(&statusDetails.AllRedirects, "all-redirects", false, "Show all redirects")
 	statusCmd.Flags().BoolVar(&statusDetails.AllClusters, "all-clusters", false, "Show all clusters")
+	statusCmd.Flags().BoolVar(&statusDetails.KubeProxyReplacementDetails, "kubeproxy-replacement", false, "Show KubeProxy Replacement Details")
 	statusCmd.Flags().BoolVar(&allHealth, "all-health", false, "Show all health status, not just failing")
 	statusCmd.Flags().BoolVar(&brief, "brief", false, "Only print a one-line status message")
 	statusCmd.Flags().BoolVar(&requireK8sConnectivity, "require-k8s-connectivity", true, "If true, when the cilium-agent cannot access the Kubernetes control plane, this status command returns a non-zero exit status.")


### PR DESCRIPTION
Add --kubeproxy-replacement to get KubeProxy Replacement Details Actually, you need to use --verbose but lot of output when you only need to check KubeProxy info

