### PR TITLE
Fix cilium version parsing when using `GOEXPERIMENTS`

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,17 +47,21 @@ func init() {
 // FromString converts a version string into struct
 func FromString(versionString string) CiliumVersion {
 	// string to parse: "0.13.90 a722bdb 2018-01-09T22:32:37+01:00 go version go1.9 linux/amd64"
+	// With GOEXPERIMENTs: "1.18.6 9589669 2026-01-13T11:40:01+01:00 go version go1.24.11 X:jsonv2 linux/amd64"
 	fields := strings.Split(versionString, " ")
-	if len(fields) != 7 {
+	if len(fields) < 7 {
 		return CiliumVersion{}
 	}
 
 	cver := CiliumVersion{
-		Version:          fields[0],
-		Revision:         fields[1],
-		AuthorDate:       fields[2],
-		GoRuntimeVersion: fields[5],
-		Arch:             fields[6],
+		Version:    fields[0],
+		Revision:   fields[1],
+		AuthorDate: fields[2],
+		// Last field is always GOOS/GOARCH
+		Arch: fields[len(fields)-1],
+		// Everything between "version" keyword and ARCH is the Go version
+		// This handles cases like "go1.24.11 X:jsonv2" where runtime.Version() contains spaces
+		GoRuntimeVersion: strings.Join(fields[5:len(fields)-1], " "),
 	}
 	return cver
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -55,6 +55,28 @@ func TestStructIsSet(t *testing.T) {
 				AuthorDate:       "2018-01-09T22:32:37+01:00",
 			},
 		},
+		// With a GOEXPERIMENT
+		{
+			"1.18.6 9589669 2026-01-13T11:40:01+01:00 go version go1.25.6 X:jsonv2 darwin/arm64",
+			CiliumVersion{
+				Version:          "1.18.6",
+				Revision:         "9589669",
+				GoRuntimeVersion: "go1.25.6 X:jsonv2",
+				Arch:             "darwin/arm64",
+				AuthorDate:       "2026-01-13T11:40:01+01:00",
+			},
+		},
+		// With multiple GOEXPERIMENTs
+		{
+			"1.18.6 9589669 2026-01-13T11:40:01+01:00 go version go1.25.6 X:jsonv2,randautoseed linux/amd64",
+			CiliumVersion{
+				Version:          "1.18.6",
+				Revision:         "9589669",
+				GoRuntimeVersion: "go1.25.6 X:jsonv2,randautoseed",
+				Arch:             "linux/amd64",
+				AuthorDate:       "2026-01-13T11:40:01+01:00",
+			},
+		},
 		// Unformatted string should return empty struct
 		{
 			"0.13.90 7330b8d linux/arm",


### PR DESCRIPTION
I noticed something weird on my build of cilium, the version was failing to show on `cilium status`:

```sh
$ cilium version
Client: 1.18.6 f6e85ab276 2026-01-13T11:40:01+01:00 go version go1.24.11 X:jsonv2 linux/amd64
Daemon: 1.18.6 f6e85ab276 2026-01-13T11:40:01+01:00 go version go1.24.11 X:jsonv2 linux/amd64

$ cilium status
[...]
Cilium:                  Ok    (v-)
[...]
```

This is caused by the string parsing logic in [`version.FromString()`](https://github.com/cilium/cilium/blob/683f3ffa98e2a22bd5805726078e4052e76b20bc/pkg/version/version.go#L48) which expects a version string to be exactly a seven segment space separated string. But one of those segments is the go version obtained with [`runtime.Version()`](https://pkg.go.dev/runtime#Version), and as indicated in that function's [implementation](https://cs.opensource.google/go/go/+/refs/tags/go1.25.6:src/runtime/extern.go;l=366-381), it can contain space characters if there are active `GOEXPERIMENTS`:

```go
// buildVersion is the Go tree's version string at build time.
//
// If any GOEXPERIMENTs are set to non-default values, it will include
// "X:<GOEXPERIMENT>".
//
// This is set by the linker.
//
// This is accessed by "go version <binary>".
var buildVersion string

// Version returns the Go tree's version string.
// It is either the commit hash and date at the time of the build or,
// when possible, a release tag like "go1.3".
func Version() string {
	return buildVersion
}
```

So for example, if cilium is built with `GOEXPERIMENT=jsonv2`, `runtime.Version()` will return `go1.24.11 X:jsonv2`.

This PR updates the version string parsing logic to handle the case where `runtime.Version()` includes space characters.
