### PR TITLE
linux-desired-device: introducing Cilium managed devices reconciler 

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	dpcfg "github.com/cilium/cilium/pkg/datapath/linux/config"
+	deviceReconciler "github.com/cilium/cilium/pkg/datapath/linux/device"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
@@ -160,6 +161,9 @@ var Cell = cell.Module(
 	// Provides the desired route table, and a reconciler that installs these desired routes
 	// into the Linux kernel routing table.
 	routeReconciler.Cell,
+
+	// Provides the desired device table, and a reconciler that install these links into the Linux kernel.
+	deviceReconciler.Cell,
 )
 
 func initDatapath(rootLogger *slog.Logger, lifecycle cell.Lifecycle) {

--- a/pkg/datapath/linux/device/cell.go
+++ b/pkg/datapath/linux/device/cell.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+)
+
+var Cell = cell.Module(
+	"device-reconciler",
+	"Reconciles desired devices to the Linux kernel links",
+	TableCell,
+	cell.Provide(newDeviceManager),
+	cell.Invoke(registerReconciler),
+)
+
+var TableCell = cell.Group(
+	cell.ProvidePrivate(newDesiredDeviceTable),
+	cell.Provide(statedb.RWTable[*DesiredDevice].ToTable),
+)

--- a/pkg/datapath/linux/device/manager.go
+++ b/pkg/datapath/linux/device/manager.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var (
+	ErrOwnerDoesNotExist = errors.New("owner does not exist")
+)
+
+// ManagerOperations is the interface for the desired device reconciler manager
+type ManagerOperations interface {
+	// UpsertDevice upserts a desired device into the desired device table.
+	UpsertDevice(device DesiredDevice) error
+	// UpsertDeviceWait upserts a desired device into the desired device table
+	// and waits for the device to be reconciled.
+	UpsertDeviceWait(device DesiredDevice, timeout time.Duration) error
+	// DeleteDevice deletes a desired device from the desired device table.
+	DeleteDevice(device DesiredDevice) error
+	// GetOrRegisterOwner gets or registers an owner with the given name.
+	GetOrRegisterOwner(name string) DeviceOwner
+	// RemoveOwner removes an owner and associated devices with the given owner.
+	RemoveOwner(owner DeviceOwner) error
+	// RegisterInitializer registers an initializer with the given name and returns
+	// the initializer to the caller.
+	RegisterInitializer(name string) Initializer
+	// FinalizeInitializer should be called by the caller with registered initializer
+	// once callers initial sync is completed. Once all initializers are finalized,
+	// the reconciler will start initial pruning.
+	FinalizeInitializer(initializer Initializer)
+}
+
+type manager struct {
+	db  *statedb.DB
+	tbl statedb.RWTable[*DesiredDevice]
+
+	owners lock.Map[string, DeviceOwner]
+}
+
+func newDeviceManager(db *statedb.DB, tbl statedb.RWTable[*DesiredDevice]) ManagerOperations {
+	return &manager{
+		db:  db,
+		tbl: tbl,
+	}
+}
+
+type Initializer struct {
+	initialized func(statedb.WriteTxn)
+}
+
+func (m *manager) RegisterInitializer(name string) Initializer {
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Commit()
+
+	return Initializer{
+		initialized: m.tbl.RegisterInitializer(txn, name),
+	}
+}
+
+func (m *manager) FinalizeInitializer(initializer Initializer) {
+	if initializer.initialized != nil {
+		txn := m.db.WriteTxn(m.tbl)
+		defer txn.Commit()
+		initializer.initialized(txn)
+	}
+}
+
+func (m *manager) GetOrRegisterOwner(name string) DeviceOwner {
+	owner, _ := m.owners.LoadOrStore(name, DeviceOwner{
+		Name: name,
+	})
+	return owner
+}
+
+func (m *manager) RemoveOwner(owner DeviceOwner) error {
+	if _, exists := m.owners.Load(owner.Name); !exists {
+		return ErrOwnerDoesNotExist
+	}
+
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Abort()
+
+	for device := range m.tbl.Prefix(txn, DesiredDeviceIndex.Query(DesiredDeviceKey{
+		Owner: owner,
+	})) {
+		if _, _, err := m.tbl.Delete(txn, device); err != nil {
+			return err
+		}
+	}
+
+	m.owners.Delete(owner.Name)
+	txn.Commit()
+	return nil
+}
+
+func (m *manager) UpsertDevice(device DesiredDevice) error {
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Abort()
+
+	if err := device.Validate(); err != nil {
+		return err
+	}
+
+	if _, ok := m.owners.Load(device.Owner.Name); !ok {
+		return ErrOwnerDoesNotExist
+	}
+
+	if oldObj, _, found := m.tbl.Get(txn, DesiredDeviceNameIndex.Query(device.Name)); found && oldObj.Owner != device.Owner {
+		return fmt.Errorf("device %s exists with different owner %s", device.Name, oldObj.Owner.Name)
+	}
+
+	if _, _, err := m.tbl.Insert(txn, device.SetStatus(reconciler.StatusPending())); err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func (m *manager) UpsertDeviceWait(device DesiredDevice, timeout time.Duration) error {
+	err := m.UpsertDevice(device)
+	if err != nil {
+		return err
+	}
+
+	return m.waitForReconciliation(device.GetKey(), timeout)
+}
+
+func (m *manager) DeleteDevice(device DesiredDevice) error {
+	txn := m.db.WriteTxn(m.tbl)
+	defer txn.Abort()
+
+	if err := device.Validate(); err != nil {
+		return err
+	}
+
+	if _, ok := m.owners.Load(device.Owner.Name); !ok {
+		return ErrOwnerDoesNotExist
+	}
+
+	if oldObj, _, found := m.tbl.Get(txn, DesiredDeviceNameIndex.Query(device.Name)); found && oldObj.Owner != device.Owner {
+		return fmt.Errorf("device %s exists with different owner %s", device.Name, oldObj.Owner.Name)
+	}
+
+	if _, _, err := m.tbl.Delete(txn, &device); err != nil {
+		return err
+	}
+
+	txn.Commit()
+	return nil
+}
+
+func (m *manager) waitForReconciliation(deviceKey DesiredDeviceKey, timeout time.Duration) error {
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+
+	var err error
+	for {
+		obj, _, watch, found := m.tbl.GetWatch(m.db.ReadTxn(), DesiredDeviceIndex.Query(deviceKey))
+		if !found {
+			return fmt.Errorf("device %s not found", deviceKey)
+		}
+
+		switch obj.status.Kind {
+		case reconciler.StatusKindDone:
+			return nil
+		case reconciler.StatusKindError:
+			err = errors.New(obj.status.GetError())
+		}
+
+		select {
+		case <-t.C:
+			return fmt.Errorf("timeout waiting for %s reconciliation: %w", deviceKey, err)
+		case <-watch:
+		}
+	}
+}

--- a/pkg/datapath/linux/device/reconciler.go
+++ b/pkg/datapath/linux/device/reconciler.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/wal"
+)
+
+func registerReconciler(
+	params reconciler.Params,
+	lc cell.Lifecycle,
+	tbl statedb.RWTable[*DesiredDevice],
+	linuxDevices statedb.Table[*tables.Device],
+	log *slog.Logger,
+	config *option.DaemonConfig,
+) (reconciler.Reconciler[*DesiredDevice], error) {
+	ops := newOps(lc, params.DB, tbl, linuxDevices, log, config)
+	rec, err := reconciler.Register(
+		params,
+		tbl,
+		(*DesiredDevice).Clone,
+		(*DesiredDevice).SetStatus,
+		(*DesiredDevice).GetStatus,
+		ops,
+		nil,
+		reconciler.WithPruning(30*time.Minute),
+	)
+	return rec, err
+}
+
+type ops struct {
+	db           *statedb.DB
+	tbl          statedb.Table[*DesiredDevice]
+	linuxDevices statedb.Table[*tables.Device]
+	log          *slog.Logger
+	conf         *option.DaemonConfig
+
+	handle        *netlink.Handle
+	wal           *wal.Writer[*reconcilerEvent]
+	persistedKeys set.Set[DesiredDeviceKey]
+}
+
+func newOps(
+	lifecycle cell.Lifecycle,
+	db *statedb.DB,
+	tbl statedb.Table[*DesiredDevice],
+	linuxDevices statedb.Table[*tables.Device],
+	log *slog.Logger,
+	conf *option.DaemonConfig,
+) *ops {
+	ops := &ops{
+		db:           db,
+		tbl:          tbl,
+		linuxDevices: linuxDevices,
+		log:          log,
+		conf:         conf,
+
+		persistedKeys: set.NewSet[DesiredDeviceKey](),
+	}
+
+	lifecycle.Append(ops)
+
+	return ops
+}
+
+func (ops *ops) Start(_ cell.HookContext) error {
+	var err error
+	ops.handle, err = netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+
+	walPath := filepath.Join(ops.conf.StateDir, "device-reconciler.wal")
+
+	// Read all old device keys from the WAL.
+	events, err := wal.Read(walPath, func(data []byte) (*reconcilerEvent, error) {
+		var key reconcilerEvent
+		if err := key.UnmarshalBinary(data); err != nil {
+			return &reconcilerEvent{}, err
+		}
+		return &key, nil
+	})
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	} else {
+		for oldDeviceKey, err := range events {
+			if err != nil {
+				ops.log.Error("Failed to read old device key from WAL", logfields.Error, err)
+				continue
+			}
+
+			if oldDeviceKey.Deleted {
+				ops.persistedKeys.Remove(oldDeviceKey.Key)
+			} else {
+				ops.persistedKeys.Insert(oldDeviceKey.Key)
+			}
+		}
+	}
+
+	ops.wal, err = wal.NewWriter[*reconcilerEvent](walPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ops *ops) Stop(_ cell.HookContext) error {
+	if ops.handle != nil {
+		_ = ops.handle.Close()
+		ops.handle = nil
+	}
+	if ops.wal != nil {
+		_ = ops.wal.Close()
+	}
+	return nil
+}
+
+func (ops *ops) Update(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision, obj *DesiredDevice) error {
+	nl, linkExist, err := ops.checkAndGetLink(obj)
+	if err != nil {
+		return err
+	}
+
+	// write to WAL first
+	err = ops.wal.Write(&reconcilerEvent{
+		Deleted: false,
+		Key:     obj.GetKey(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write update event to WAL: %w", err)
+	}
+
+	if linkExist {
+		err = ops.handle.LinkModify(nl)
+	} else {
+		err = ops.handle.LinkAdd(nl)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to add or modify link: %w", err)
+	}
+
+	ops.persistedKeys.Insert(obj.GetKey())
+
+	return ops.handle.LinkSetUp(nl)
+}
+
+func (ops *ops) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision, obj *DesiredDevice) error {
+	nl, linkExist, err := ops.checkAndGetLink(obj)
+	if err != nil {
+		return err
+	}
+
+	if !linkExist {
+		return nil
+	}
+
+	delErr := ops.handle.LinkDel(nl)
+	if delErr == nil {
+		ops.persistedKeys.Remove(obj.GetKey())
+	}
+
+	err = ops.wal.Write(&reconcilerEvent{
+		Deleted: true,
+		Key:     obj.GetKey(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write delete event to WAL: %w", err)
+	}
+
+	return delErr
+}
+
+func (ops *ops) Prune(_ context.Context, txn statedb.ReadTxn, objects iter.Seq2[*DesiredDevice, statedb.Revision]) error {
+	for key := range ops.persistedKeys.Members() {
+		_, _, found := ops.tbl.Get(txn, DesiredDeviceNameIndex.Query(key.Name))
+		if !found {
+			link, err := safenetlink.WithRetryResult(func() (netlink.Link, error) {
+				//nolint:forbidigo
+				return ops.handle.LinkByName(key.Name)
+			})
+			// best effort cleanup of link which is present in WAL but missing in desired devices table.
+			if err == nil {
+				_ = ops.handle.LinkDel(link)
+			}
+
+			ops.persistedKeys.Remove(key)
+		}
+	}
+
+	return ops.wal.Compact(func(yield func(*reconcilerEvent) bool) {
+		for obj := range objects {
+			if obj.GetStatus().Kind == reconciler.StatusKindError {
+				continue
+			}
+
+			if !yield(&reconcilerEvent{
+				Deleted: false,
+				Key:     obj.GetKey(),
+			}) {
+				return
+			}
+		}
+	})
+}
+
+// checkAndGetLink checks that the caller passing DesiredObject is not taking ownership of a device that is not owned by it.
+// Few cases to consider
+//  1. Device created by owner1. Owner2 tries to create device with same name. ( Not allowed )
+//  2. Device already exist in kernel but not managed by Cilium ( persisted key does not exist ). Cilium owner tries
+//     to create/delete a device with same name. ( Not allowed )
+//  3. Device created by owner1. Cilium restart - Owner1 recreates the device ( allowed ). This case works as we
+//     repopulate the persisted keys from the WAL.
+func (ops *ops) checkAndGetLink(obj *DesiredDevice) (netlink.Link, bool, error) {
+	nl, err := obj.DeviceSpec.ToNetlink()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to translate to netlink link: %w", err)
+	}
+
+	var linkExist bool
+	_, err = safenetlink.WithRetryResult(func() (netlink.Link, error) {
+		//nolint:forbidigo
+		return ops.handle.LinkByName(nl.Attrs().Name)
+	})
+	if err == nil || !errors.As(err, &netlink.LinkNotFoundError{}) {
+		linkExist = true
+	}
+
+	if linkExist && !ops.persistedKeys.Has(obj.GetKey()) {
+		return nil, false, fmt.Errorf("device %s exist in kernel but not with desired device owner %s", obj.Name, obj.Owner)
+	}
+
+	return nl, linkExist, nil
+}
+
+type reconcilerEvent struct {
+	Deleted bool
+	Key     DesiredDeviceKey
+}
+
+func (e *reconcilerEvent) MarshalBinary() ([]byte, error) {
+	var buf []byte
+	if e.Deleted {
+		buf = append(buf, byte(1))
+	} else {
+		buf = append(buf, byte(0))
+	}
+
+	keyBuf, err := e.Key.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	buf = append(buf, keyBuf...)
+
+	return buf, nil
+}
+
+func (e *reconcilerEvent) UnmarshalBinary(data []byte) error {
+	if len(data) < 1 {
+		return fmt.Errorf("invalid event data: %v", data)
+	}
+
+	e.Deleted = data[0] == 1
+
+	if err := e.Key.UnmarshalBinary(data[1:]); err != nil {
+		return fmt.Errorf("invalid event data: %v", data)
+	}
+
+	return nil
+}

--- a/pkg/datapath/linux/device/scripttest/device_test.go
+++ b/pkg/datapath/linux/device/scripttest/device_test.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package scripttest
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/afero"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/linux"
+	linuxdevice "github.com/cilium/cilium/pkg/datapath/linux/device"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	ciliumhive "github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/scriptnet"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+type desiredVlanDevice struct {
+	Name         string `yaml:"name"`
+	ParentDevice string `yaml:"parentDevice"`
+	VlanID       int    `yaml:"vlanID"`
+	MTU          int    `yaml:"mtu"`
+
+	parentIdx int
+}
+
+func (d desiredVlanDevice) ToNetlink() (netlink.Link, error) {
+	return &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        d.Name,
+			MTU:         d.MTU,
+			ParentIndex: d.parentIdx,
+		},
+		VlanId: d.VlanID,
+	}, nil
+}
+
+func (d desiredVlanDevice) Properties() string {
+	return fmt.Sprintf("Type=vlan, ParentDevice=%s, VlanID=%d", d.ParentDevice, d.VlanID)
+}
+
+func (d desiredVlanDevice) MarshalYAML() (any, error) {
+	return map[string]any{
+		"name":         d.Name,
+		"parentDevice": d.ParentDevice,
+		"vlanID":       d.VlanID,
+		"mtu":          d.MTU,
+	}, nil
+}
+
+func (d desiredVlanDevice) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"name":         d.Name,
+		"parentDevice": d.ParentDevice,
+		"vlanID":       d.VlanID,
+		"mtu":          d.MTU,
+	})
+}
+
+func TestPrivilegedScript(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	// When certain kernel modules are loaded, the kernel will by default try
+	// to create fallback devices in newly created network namespaces.
+	// For eg, in CI runs, sit0 interface gets created in all namespaces, which
+	// is not in the expected devices table.
+	// Setting net.core.fb_tunnels_only_for_init=2 will prevent the kernel from
+	// creating fallback devices so we have a more predictable test environment.
+	sc := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+	val, _ := sc.ReadInt([]string{"net", "core", "fb_tunnels_only_for_init_net"})
+	t.Log("sysctl net.core.fb_tunnels_only_for_init_net was set to ", val)
+	if val != 2 {
+		t.Log("Setting sysctl net.core.fb_tunnels_only_for_init_net to 2")
+		sc.WriteInt([]string{"net", "core", "fb_tunnels_only_for_init_net"}, 2)
+
+		// Lets be a good citizen and clean up after ourselves.
+		t.Cleanup(func() {
+			t.Log("Resetting sysctl net.core.fb_tunnels_only_for_init_net to previous value", val)
+			sc.WriteInt([]string{"net", "core", "fb_tunnels_only_for_init_net"}, val)
+		})
+	}
+
+	scripttest.Test(
+		t,
+		ctx,
+		scriptEngine,
+		[]string{},
+		"testdata/*.txtar",
+	)
+}
+
+func scriptEngine(t testing.TB, args []string) *script.Engine {
+	var (
+		opts   []hivetest.LogOption
+		db     *statedb.DB
+		dm     linuxdevice.ManagerOperations
+		devTbl statedb.Table[*tables.Device]
+	)
+
+	stateDir := t.TempDir()
+	nsManager, err := scriptnet.NewNSManager(t)
+	require.NoError(t, err, "NewNSManager")
+	require.NoError(t, nsManager.LockThreadAndInitialize(t, true), "LockThreadAndInitialize")
+
+	cells := []cell.Cell{
+		linuxdevice.Cell,
+		linux.DevicesControllerCell,
+		cell.Provide(func() *option.DaemonConfig {
+			return &option.DaemonConfig{
+				StateDir: stateDir,
+			}
+		}),
+		cell.Invoke(func(d *statedb.DB, m linuxdevice.ManagerOperations, devices statedb.Table[*tables.Device]) {
+			db = d
+			dm = m
+			devTbl = devices
+		}),
+	}
+	h := ciliumhive.New(
+		cells...,
+	)
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		logging.SetLogLevelToDebug()
+	}
+	log := hivetest.Logger(t, opts...)
+	t.Cleanup(func() {
+		assert.NoError(t, h.Stop(log, context.Background()))
+	})
+
+	cmds, err := h.ScriptCommands(log)
+	require.NoError(t, err, "ScriptCommands")
+
+	maps.Insert(cmds, maps.All(script.DefaultCmds()))
+	maps.Insert(cmds, maps.All(nsManager.Commands()))
+	maps.Insert(cmds, maps.All(testDesiredDevicesCmds(db, dm, devTbl)))
+
+	cmds["hive/recreate"] = script.Command(
+		script.CmdUsage{
+			Summary: "Restart the hive",
+		},
+		func(s1 *script.State, s2 ...string) (script.WaitFunc, error) {
+			newHive := ciliumhive.New(cells...)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			newHive.RegisterFlags(flags)
+			require.NoError(t, flags.Parse(args), "flags.Parse")
+
+			newHiveCmds, err := newHive.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+
+			maps.Insert(cmds, maps.All(newHiveCmds))
+			maps.Insert(cmds, maps.All(testDesiredDevicesCmds(db, dm, devTbl)))
+			return nil, nil
+		},
+	)
+	return &script.Engine{
+		Cmds:          cmds,
+		RetryInterval: 10 * time.Millisecond,
+	}
+}
+
+func testDesiredDevicesCmds(db *statedb.DB, dm linuxdevice.ManagerOperations, devTbl statedb.Table[*tables.Device]) map[string]script.Cmd {
+	initializers := make(map[string]linuxdevice.Initializer)
+	addDeviceCmd := script.Command(
+		script.CmdUsage{
+			Summary: "Add a device",
+			Args:    "owner device-file",
+		},
+		func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 2 {
+				return nil, script.ErrUsage
+			}
+
+			owner := dm.GetOrRegisterOwner(args[0])
+
+			deviceFile, err := os.ReadFile(state.Path(args[1]))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read device file %q: %w", args[1], err)
+			}
+
+			var device desiredVlanDevice
+			if err := yaml.Unmarshal(deviceFile, &device); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal device file %q: %w", args[1], err)
+			}
+
+			dev, _, found := devTbl.Get(db.ReadTxn(), tables.DeviceNameIndex.Query(device.ParentDevice))
+			if !found {
+				return nil, fmt.Errorf("parent device %q not found for VLAN device %q", device.ParentDevice, device.Name)
+			}
+			device.parentIdx = dev.Index
+
+			if err := dm.UpsertDevice(linuxdevice.DesiredDevice{
+				Owner:      owner,
+				Name:       device.Name,
+				DeviceSpec: device,
+			}); err != nil {
+				return nil, fmt.Errorf("failed to upsert device %q: %w", device.Name, err)
+			}
+
+			return nil, nil
+		},
+	)
+
+	removeOwnerCmd := script.Command(
+		script.CmdUsage{
+			Summary: "Remove an owner",
+			Args:    "owner",
+		},
+		func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			owner := dm.GetOrRegisterOwner(args[0])
+
+			if err := dm.RemoveOwner(owner); err != nil {
+				return nil, fmt.Errorf("failed to remove owner %q: %w", args[0], err)
+			}
+
+			return nil, nil
+		},
+	)
+	addInitializer := script.Command(
+		script.CmdUsage{
+			Summary: "Add device initializer",
+			Args:    "name",
+		},
+		func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			initializers[args[0]] = dm.RegisterInitializer(args[0])
+			return nil, nil
+		},
+	)
+	finishInitializer := script.Command(
+		script.CmdUsage{
+			Summary: "Finish device initializer",
+			Args:    "name",
+		},
+		func(state *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, script.ErrUsage
+			}
+
+			initializer, ok := initializers[args[0]]
+			if !ok {
+				return nil, fmt.Errorf("initializer %q not found", args[0])
+			}
+			dm.FinalizeInitializer(initializer)
+			return nil, nil
+		},
+	)
+
+	return map[string]script.Cmd{
+		"add-device":         addDeviceCmd,
+		"remove-owner":       removeOwnerCmd,
+		"add-initializer":    addInitializer,
+		"finish-initializer": finishInitializer,
+	}
+}

--- a/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
@@ -1,0 +1,29 @@
+netns/create otherns
+link/add eth0 veth --peername veth0 --peerns otherns
+link/set veth0 --netns otherns up
+link/set eth0 up
+
+# device previously present in the system
+link/add eth0.10 dummy
+
+hive/start
+db/cmp devices devices.table
+
+# owner tries to take over same device
+add-device owner1 eth0.10.yaml
+remove-owner owner1
+
+# make sure reconciler does not cleanup incorrectly
+sleep 1s
+db/cmp devices devices.table
+
+-- devices.table --
+Name      Type     OperStatus
+lo        device   down
+eth0      veth     up
+eth0.10   dummy    down
+
+-- eth0.10.yaml --
+name: eth0.10
+parentDevice: eth0
+vlanID: 10

--- a/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
@@ -1,0 +1,64 @@
+netns/create otherns
+link/add eth0 veth --peername veth0 --peerns otherns
+link/set veth0 --netns otherns up
+link/set eth0 up
+
+hive/start
+
+add-device owner1 eth0.10.yaml
+add-device owner1 eth0.20.yaml
+
+# validate tables are populated correctly
+db/cmp desired-devices desired-device.1.table
+db/cmp devices devices.1.table
+
+# Stop and re-create the hive to simulate a restart
+hive/stop
+hive/recreate
+
+# Add initializer for the owner before starting the hive
+add-initializer owner1
+
+# Start the hive so the device table is populated
+hive/start
+
+# Add device again after restart, but only eth0.10 device
+add-device owner1 eth0.10.yaml
+
+# Mark initializer as finished so pruning can proceed
+finish-initializer owner1
+
+db/cmp desired-devices desired-device.2.table
+db/cmp devices devices.2.table
+
+-- eth0.10.yaml --
+name: eth0.10
+parentDevice: eth0
+vlanID: 10
+
+-- eth0.20.yaml --
+name: eth0.20
+parentDevice: eth0
+vlanID: 20
+
+-- desired-device.1.table --
+Owner  Name      Properties
+owner1 eth0.10   Type=vlan, ParentDevice=eth0, VlanID=10
+owner1 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+
+-- devices.1.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.10   vlan     1500    up
+eth0.20   vlan     1500    up
+
+-- desired-device.2.table --
+Owner  Name      Properties
+owner1 eth0.10   Type=vlan, ParentDevice=eth0, VlanID=10
+
+-- devices.2.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.10   vlan     1500    up

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
@@ -1,0 +1,75 @@
+netns/create otherns
+link/add eth0 veth --peername veth0 --peerns otherns
+link/set veth0 --netns otherns up
+link/set eth0 up
+
+hive/start
+
+add-device owner1 eth0.10.yaml
+add-device owner2 eth0.20.yaml
+
+# validate tables are populated correctly
+db/cmp desired-devices desired-device.1.table
+db/cmp devices devices.1.table
+
+# Remove owner1
+remove-owner owner1
+
+# revalidate data
+db/cmp desired-devices desired-device.2.table
+db/cmp devices devices.2.table
+
+# update MTU
+add-device owner2 eth0.20-updated.yaml
+
+# revalidate data
+db/cmp desired-devices desired-device.3.table
+db/cmp devices devices.3.table
+
+-- eth0.10.yaml --
+name: eth0.10
+parentDevice: eth0
+vlanID: 10
+
+-- eth0.20.yaml --
+name: eth0.20
+parentDevice: eth0
+vlanID: 20
+
+-- eth0.20-updated.yaml --
+name: eth0.20
+parentDevice: eth0
+vlanID: 20
+mtu: 1400
+
+-- desired-device.1.table --
+Owner  Name      Properties
+owner1 eth0.10   Type=vlan, ParentDevice=eth0, VlanID=10
+owner2 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+
+-- devices.1.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.10   vlan     1500    up
+eth0.20   vlan     1500    up
+
+-- desired-device.2.table --
+Owner  Name      Properties
+owner2 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+
+-- devices.2.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.20   vlan     1500    up
+
+-- desired-device.3.table --
+Owner  Name      Properties
+owner2 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+
+-- devices.3.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.20   vlan     1400    up

--- a/pkg/datapath/linux/device/table.go
+++ b/pkg/datapath/linux/device/table.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"cmp"
+	"fmt"
+	"strings"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/vishvananda/netlink"
+)
+
+type DeviceOwner struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+type DesiredDeviceKey struct {
+	Owner DeviceOwner
+	Name  string
+}
+
+func (k DesiredDeviceKey) Key() index.Key {
+	return index.String(k.Owner.Name + "/" + k.Name)
+}
+
+func (k DesiredDeviceKey) String() string {
+	if k.Owner.Name == "" {
+		return k.Name
+	}
+	return fmt.Sprintf("%s/%s", k.Owner.Name, k.Name)
+}
+
+var desiredDeviceKeyBinaryVersion = 1
+
+func (k *DesiredDeviceKey) MarshalBinary() ([]byte, error) {
+	var buf []byte
+	buf = append(buf, byte(desiredDeviceKeyBinaryVersion))
+	buf = append(buf, k.Key()...)
+	return buf, nil
+}
+
+func (k *DesiredDeviceKey) UnmarshalBinary(data []byte) error {
+	if len(data) < 1 {
+		return fmt.Errorf("invalid data length: %d", len(data))
+	}
+
+	if data[0] != byte(desiredDeviceKeyBinaryVersion) {
+		return fmt.Errorf("unsupported DesiredDeviceKey version: %d", data[0])
+	}
+	parsedDeviceData := strings.Split(string(data[1:]), "/")
+	if len(parsedDeviceData) != 2 {
+		return fmt.Errorf("unsupported DesiredDeviceKey format")
+	}
+
+	k.Owner = DeviceOwner{
+		Name: parsedDeviceData[0],
+	}
+	k.Name = parsedDeviceData[1] // potentially check length, device size should not be > 16 bytes.
+	return nil
+}
+
+func (dd *DesiredDevice) GetKey() DesiredDeviceKey {
+	return DesiredDeviceKey{
+		Owner: dd.Owner,
+		Name:  dd.Name,
+	}
+}
+
+type DesiredDeviceSpec interface {
+	ToNetlink() (netlink.Link, error)
+	Properties() string
+	MarshalJSON() ([]byte, error)
+	MarshalYAML() (any, error)
+}
+
+type DesiredDevice struct {
+	Owner      DeviceOwner       `json:"owner" yaml:"owner"`
+	Name       string            `json:"name" yaml:"name"`
+	DeviceSpec DesiredDeviceSpec `json:"spec" yaml:"spec"`
+
+	status reconciler.Status
+}
+
+func (dd *DesiredDevice) TableHeader() []string {
+	return []string{
+		"Owner",
+		"Name",
+		"Properties",
+		"Status",
+	}
+}
+
+func (dd *DesiredDevice) TableRow() []string {
+	return []string{
+		// owner name
+		cmp.Or(dd.Owner.Name, "N/A"),
+		// device name
+		dd.Name,
+		// device properties
+		cmp.Or(dd.DeviceSpec.Properties(), "N/A"),
+		// reconciler status
+		dd.status.String(),
+	}
+}
+
+func (dd *DesiredDevice) Validate() error {
+	if dd.Owner.Name == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+
+	if dd.Name == "" {
+		return fmt.Errorf("device name cannot be empty")
+	}
+
+	if len(dd.Name) > 15 {
+		return fmt.Errorf("device name %q exceeds maximum length of 15 characters", dd.Name)
+	}
+
+	if dd.DeviceSpec == nil {
+		return fmt.Errorf("device spec cannot be nil")
+	}
+
+	nl, err := dd.DeviceSpec.ToNetlink()
+	if err != nil {
+		return fmt.Errorf("failed to translate to netlink link: %w", err)
+	}
+
+	if nl.Attrs().Name != dd.Name {
+		return fmt.Errorf("device name %s does not match with netlink link name %s", dd.Name, nl.Attrs().Name)
+	}
+
+	return nil
+}
+
+func (dd *DesiredDevice) SetStatus(s reconciler.Status) *DesiredDevice {
+	ndd := *dd
+	ndd.status = s
+	return &ndd
+}
+
+func (dd *DesiredDevice) GetStatus() reconciler.Status {
+	return dd.status
+}
+
+func (dd *DesiredDevice) Clone() *DesiredDevice {
+	dd2 := *dd
+	return &dd2
+}
+
+var (
+	DesiredDeviceIndex = statedb.Index[*DesiredDevice, DesiredDeviceKey]{
+		Name: "id",
+		FromObject: func(obj *DesiredDevice) index.KeySet {
+			return index.NewKeySet(obj.GetKey().Key())
+		},
+		FromKey:    DesiredDeviceKey.Key,
+		FromString: index.FromString,
+		Unique:     true,
+	}
+	DesiredDeviceNameIndex = statedb.Index[*DesiredDevice, string]{
+		Name: "name",
+		FromObject: func(obj *DesiredDevice) index.KeySet {
+			return index.NewKeySet(index.String(obj.Name))
+		},
+		FromKey:    index.String,
+		FromString: index.FromString,
+		Unique:     true,
+	}
+)
+
+func newDesiredDeviceTable(db *statedb.DB) (statedb.RWTable[*DesiredDevice], error) {
+	return statedb.NewTable(
+		db,
+		"desired-devices",
+		DesiredDeviceIndex,
+		DesiredDeviceNameIndex,
+	)
+}


### PR DESCRIPTION
Adding new reconciler in Cilium datapath/linux which can manage lifecycle of linux links created by Cilium.

Created devices are persisted on disk using write-ahead-log, upon restart the owners of the devices are expected to redo the configuration before calling finializer. Stale devices will be pruned.

Implementation is inspired by datapath/linux/route/reconciler.

It allows Cilium to manage the lifecycle of devices created by it. Currently this PR does not implement usage of this package from other subsystems. 

Code is exercised via scripttests which creates vlan device types. 

cc @dylandreimerink 