### PR TITLE
[v1.18] Backport: k8s: include namespace in EndpointSliceName

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -230,7 +230,7 @@ func ParseEndpointsID(ep *slim_corev1.Endpoints) EndpointSliceID {
 			ep.ObjectMeta.Namespace,
 			ep.ObjectMeta.Name,
 		),
-		EndpointSliceName: ep.ObjectMeta.Name,
+		EndpointSliceName: ep.ObjectMeta.Namespace + "/" + ep.ObjectMeta.Name,
 	}
 }
 
@@ -287,7 +287,7 @@ func ParseEndpointSliceID(es endpointSlice) EndpointSliceID {
 			es.GetNamespace(),
 			es.GetLabels()[slim_discovery_v1.LabelServiceName],
 		),
-		EndpointSliceName: es.GetName(),
+		EndpointSliceName: es.GetNamespace() + "/" + es.GetName(),
 	}
 }
 

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -262,7 +262,7 @@ func Test_parseK8sEPv1(t *testing.T) {
 	}
 	sliceID := EndpointSliceID{
 		ServiceName:       loadbalancer.NewServiceName("bar", "foo"),
-		EndpointSliceName: "foo",
+		EndpointSliceName: "bar/foo",
 	}
 	newEmptyEndpoints := func() *Endpoints {
 		eps := newEndpoints(1)
@@ -577,7 +577,7 @@ func Test_parseK8sEPSlicev1Beta1(t *testing.T) {
 	}
 	sliceID := EndpointSliceID{
 		ServiceName:       loadbalancer.NewServiceName("bar", "quux"),
-		EndpointSliceName: "foo",
+		EndpointSliceName: "bar/foo",
 	}
 
 	newEmptyEndpoints := func() *Endpoints {
@@ -1161,7 +1161,7 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 	}
 	sliceID := EndpointSliceID{
 		ServiceName:       loadbalancer.NewServiceName("bar", "quux"),
-		EndpointSliceName: "foo",
+		EndpointSliceName: "bar/foo",
 	}
 
 	newEmptyEndpoints := func() *Endpoints {

--- a/pkg/loadbalancer/tests/testdata/name-collisions.txtar
+++ b/pkg/loadbalancer/tests/testdata/name-collisions.txtar
@@ -1,0 +1,106 @@
+#
+# Regression test case for checking that the EndpointSlice names are allowed to overlap across
+# namespaces. https://github.com/cilium/cilium/pull/43999.
+#
+
+# Start the test application
+hive/start
+
+# Make the test-b variants of the Service and EndpointSlice
+cp service-a.yaml service-b.yaml
+sed 'namespace: test-a' 'namespace: test-b' service-b.yaml
+sed '10.96.50.104' '10.96.50.105' service-b.yaml
+cp endpointslice-a.yaml endpointslice-b.yaml
+sed 'namespace: test-a' 'namespace: test-b' endpointslice-b.yaml
+sed '10.244.1.' '10.245.1.' endpointslice-b.yaml
+
+# 1. Add the test-a Service and EndpointSlice.
+k8s/add service-a.yaml endpointslice-a.yaml
+db/cmp frontends frontends-1.table
+db/cmp backends backends-1.table
+
+# 2. Add the test-b Service and EndpointSlice. Both EndpointSlices have
+# the same name, but exist in different namespaces, so should not collide.
+k8s/add service-b.yaml endpointslice-b.yaml
+db/cmp frontends frontends-2.table
+db/cmp backends backends-2.table
+
+# 3. Update test-a EndpointSlice - remove an address.
+sed '.*- 10.244.1.2' '' endpointslice-a.yaml
+k8s/update endpointslice-a.yaml
+db/cmp frontends frontends-3.table
+db/cmp backends backends-3.table
+
+-- frontends-1.table --
+Address               Type        ServiceName      PortName   Backends                             Status   Error
+10.96.50.104:80/TCP   ClusterIP   test-a/service   http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP Done
+
+-- backends-1.table --
+Address             Instances               Shadows   NodeName
+10.244.1.1:80/TCP   test-a/service (http)             nodeport-worker
+10.244.1.2:80/TCP   test-a/service (http)             nodeport-worker
+
+-- frontends-2.table --
+Address               Type        ServiceName      PortName   Backends                             Status   Error
+10.96.50.104:80/TCP   ClusterIP   test-a/service   http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP Done
+10.96.50.105:80/TCP   ClusterIP   test-b/service   http       10.245.1.1:80/TCP, 10.245.1.2:80/TCP Done
+
+-- backends-2.table --
+Address             Instances               Shadows   NodeName
+10.244.1.1:80/TCP   test-a/service (http)             nodeport-worker
+10.244.1.2:80/TCP   test-a/service (http)             nodeport-worker
+10.245.1.1:80/TCP   test-b/service (http)             nodeport-worker
+10.245.1.2:80/TCP   test-b/service (http)             nodeport-worker
+
+-- frontends-3.table --
+Address               Type        ServiceName      PortName   Backends                             Status   Error
+10.96.50.104:80/TCP   ClusterIP   test-a/service   http       10.244.1.1:80/TCP                    Done
+10.96.50.105:80/TCP   ClusterIP   test-b/service   http       10.245.1.1:80/TCP, 10.245.1.2:80/TCP Done
+
+-- backends-3.table --
+Address             Instances               Shadows   NodeName
+10.244.1.1:80/TCP   test-a/service (http)             nodeport-worker
+10.245.1.1:80/TCP   test-b/service (http)             nodeport-worker
+10.245.1.2:80/TCP   test-b/service (http)             nodeport-worker
+
+-- service-a.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+  namespace: test-a
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ClusterIP
+  sessionAffinity: ClientIP
+
+-- endpointslice-a.yaml --
+# Initial EndpointSlice has two addresses
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: service
+  name: service
+  namespace: test-a
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  - 10.244.1.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP


### PR DESCRIPTION
Backport of #43999:

5c146c3f9f08f8aa41a26ae3889458933d52e690
74c1bdead526895e5dc6a2b32a6d1a27e840ab97

I have provided an explicit backport PR because v1.18 does not include d0036787c2cc7a2b40ad1a7f3ae8aa17cae4d359, which removed the older `EndpointSlicesV1Beta` and `Endpoints` APIs. As v1.18 still includes these APIs, simply copy-pasting the patchset from #43999 would cause the tests that covered those APIs to fail.

cc @joamaki & @borkmann as you reviewed the original PR.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
43999
```
