### PR TITLE
bgp: Make the BGP peer name retrievable from GoBGP

### DIFF
--- a/api/v1/models/bgp_peer.go
+++ b/api/v1/models/bgp_peer.go
@@ -66,6 +66,9 @@ type BgpPeer struct {
 	// Capabilities announced by the local peer
 	LocalCapabilities []*BgpCapabilities `json:"local-capabilities"`
 
+	// Name of peer
+	Name string `json:"name,omitempty"`
+
 	// IP Address of peer
 	PeerAddress string `json:"peer-address,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3621,6 +3621,9 @@ definitions:
 
       +k8s:deepcopy-gen=true
     properties:
+      name:
+        description: Name of peer
+        type: string
       local-asn:
         description: Local AS Number
         type: integer

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1786,6 +1786,10 @@ func init() {
             "$ref": "#/definitions/BgpCapabilities"
           }
         },
+        "name": {
+          "description": "Name of peer",
+          "type": "string"
+        },
         "peer-address": {
           "description": "IP Address of peer",
           "type": "string"
@@ -7115,6 +7119,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/BgpCapabilities"
           }
+        },
+        "name": {
+          "description": "Name of peer",
+          "type": "string"
         },
         "peer-address": {
           "description": "IP Address of peer",

--- a/pkg/bgp/gobgp/state.go
+++ b/pkg/bgp/gobgp/state.go
@@ -5,6 +5,7 @@ package gobgp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
@@ -61,6 +62,14 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateRespo
 			peerState.PeerAddress = peer.Conf.NeighborAddress
 			peerState.PeerAsn = int64(peer.Conf.PeerAsn)
 			peerState.TCPPasswordEnabled = peer.Conf.AuthPassword != ""
+			if peer.Conf.Description != "" {
+				pd := peerDescription{}
+				if err := json.Unmarshal([]byte(peer.Conf.Description), &pd); err == nil {
+					// If unmarshal is not successful, we
+					// ignore and do not set Name field.
+					peerState.Name = pd.Name
+				}
+			}
 		}
 
 		if peer.State != nil {

--- a/pkg/bgp/gobgp/state_test.go
+++ b/pkg/bgp/gobgp/state_test.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	neighbor64125 = &types.Neighbor{
+		Name:    "neighbor-64125",
 		ASN:     64125,
 		Address: netip.MustParseAddr("192.168.0.1"),
 		Transport: &types.NeighborTransport{
@@ -35,6 +36,7 @@ var (
 
 	// changed ConnectRetryTime
 	neighbor64125Update = &types.Neighbor{
+		Name:    "neighbor-64125",
 		ASN:     64125,
 		Address: netip.MustParseAddr("192.168.0.1"),
 		Transport: &types.NeighborTransport{
@@ -52,6 +54,7 @@ var (
 
 	// enabled graceful restart
 	neighbor64125UpdateGR = &types.Neighbor{
+		Name:    "neighbor-64125",
 		ASN:     64125,
 		Address: netip.MustParseAddr("192.168.0.1"),
 		Transport: &types.NeighborTransport{
@@ -73,6 +76,7 @@ var (
 
 	// enabled graceful restart - updated restart time
 	neighbor64125UpdateGRTimer = &types.Neighbor{
+		Name:    "neighbor-64125",
 		ASN:     64125,
 		Address: netip.MustParseAddr("192.168.0.1"),
 		Transport: &types.NeighborTransport{
@@ -93,6 +97,7 @@ var (
 	}
 
 	neighbor64126 = &types.Neighbor{
+		Name:    "neighbor-64126",
 		ASN:     64126,
 		Address: netip.MustParseAddr("192.168.66.1"),
 		Transport: &types.NeighborTransport{
@@ -110,6 +115,7 @@ var (
 
 	// changed HoldTime & KeepAliveTime
 	neighbor64126Update = &types.Neighbor{
+		Name:    "neighbor-64126",
 		ASN:     64126,
 		Address: netip.MustParseAddr("192.168.66.1"),
 		Transport: &types.NeighborTransport{
@@ -126,6 +132,7 @@ var (
 	}
 
 	neighbor64127 = &types.Neighbor{
+		Name:    "neighbor-64127",
 		ASN:     64127,
 		Address: netip.MustParseAddr("192.168.88.1"),
 		EbgpMultihop: &types.NeighborEbgpMultihop{
@@ -140,6 +147,7 @@ var (
 
 	// changed EBGPMultihopTTL
 	neighbor64127Update = &types.Neighbor{
+		Name:    "neighbor-64127",
 		ASN:     64127,
 		Address: netip.MustParseAddr("192.168.88.1"),
 		EbgpMultihop: &types.NeighborEbgpMultihop{
@@ -153,6 +161,7 @@ var (
 	}
 
 	neighbor64128 = &types.Neighbor{
+		Name:    "neighbor-64128",
 		ASN:     64128,
 		Address: netip.MustParseAddr("192.168.77.1"),
 		Transport: &types.NeighborTransport{
@@ -344,7 +353,7 @@ func TestGetPeerState(t *testing.T) {
 // validatePeers validates that peers returned from GoBGP GetPeerState match expected list of CiliumBGPNeighbors
 func validatePeers(t *testing.T, localASN uint32, neighbors []*types.Neighbor, peers []*models.BgpPeer) {
 	for _, n := range neighbors {
-		p := findMatchingPeer(t, peers, n)
+		p := findMatchingPeer(peers, n)
 		require.NotNilf(t, p, "no matching peer for PeerASN %d and PeerAddress %s", n.ASN, n.Address.String())
 
 		// validate basic data is returned correctly
@@ -374,13 +383,10 @@ func validatePeers(t *testing.T, localASN uint32, neighbors []*types.Neighbor, p
 	}
 }
 
-// findMatchingPeer finds models.BgpPeer matching to the provided types.Neighbor based on the peer ASN and IP
-func findMatchingPeer(t *testing.T, peers []*models.BgpPeer, n *types.Neighbor) *models.BgpPeer {
+// findMatchingPeer finds models.BgpPeer matching to the provided types.Neighbor based on the name
+func findMatchingPeer(peers []*models.BgpPeer, n *types.Neighbor) *models.BgpPeer {
 	for _, p := range peers {
-		pIP, err := netip.ParseAddr(p.PeerAddress)
-		require.NoError(t, err)
-
-		if p.PeerAsn == int64(n.ASN) && pIP == n.Address {
+		if p.Name == n.Name {
 			return p
 		}
 	}

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -66,6 +66,7 @@ type Path struct {
 // of GoBGP's Peer object, but only contains minimal fields required for Cilium
 // usecases.
 type Neighbor struct {
+	Name            string
 	Address         netip.Addr
 	ASN             uint32
 	AuthPassword    string

--- a/pkg/bgp/types/conversions.go
+++ b/pkg/bgp/types/conversions.go
@@ -289,6 +289,7 @@ func ToAgentFamily(fam v2.CiliumBGPFamily) Family {
 func ToNeighborV2(np *v2.CiliumBGPNodePeer, pc *v2.CiliumBGPPeerConfigSpec, password string) *Neighbor {
 	neighbor := &Neighbor{}
 
+	neighbor.Name = np.Name
 	neighbor.Address = toPeerAddressV2(*np.PeerAddress)
 	neighbor.ASN = uint32(*np.PeerASN)
 	neighbor.AuthPassword = password


### PR DESCRIPTION
This is a preparation for the upcoming new BGPv2-native CLI and metrics.

In BGPv2, the peer is identified by the explicit name instead of IP address. The reason for this spec is that makes it easier for users to identify dynamically discovered peers on CLI or metrics.

However, the CLI and metrics output are based on the information retrieved from the RouterManager which doesn't have a peer name => peer IP address correspondence. Having this mapping in the RouterManager is tricky because the peer discovery is done by the reconcilers.

The solution here is keeping the peer name in the GoBGP's Peer object. While GoBGP still identifies peer with IP address, we have a Description field that accepts arbitrary string. We can keep the peer name there.

For the sake of the future extensibility, the name is encoded as a JSON string. Whenever we want to encode additional metadata, we can introduce a new JSON field.

The agent API field is extended with name:

```
$ cilium-dbg bgp peer -o json
[
  {
    "configured-hold-time-seconds": 90,
    "configured-keep-alive-time-seconds": 30,
    "connect-retry-time-seconds": 120,
    "ebgp-multihop-ttl": 1,
    "families": [
      {
        "afi": "ipv6",
        "safi": "unicast"
      },
      {
        "afi": "ipv4",
        "safi": "unicast"
      }
    ],
    ...
    "name": "peer0",
    "peer-address": "10.0.0.1",
    "peer-port": 179,
    "remote-capabilities": [],
    "session-state": "active"
  }
]
```

Note that cilium-cli is not yet updated with this change because we will introduce a completely new CLI output shortly, so it doesn't make sense to augment the current output with name.

The TestGetPeerStatus test case used to identify peer with IP + ASN. Change it to leverage this API.

```release-note
bgp: Make the BGP instance name retrievable from GoBGP
```
