### PR TITLE
daemon/multipool: Streamline implementation and improve reusability

### DIFF
--- a/operator/pkg/multipool/node_handler.go
+++ b/operator/pkg/multipool/node_handler.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
-	"github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -22,15 +21,13 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-type PoolsFromResourceFunc func(*v2.CiliumNode) *types.IPAMPoolSpec
-
 type NodeHandler struct {
 	logger *slog.Logger
 	mutex  lock.Mutex
 
 	poolManager       *PoolAllocator
 	cnClient          cilium_v2.CiliumNodeInterface
-	poolsFromResource PoolsFromResourceFunc
+	poolsFromResource v2.PoolsFromResourceFunc
 
 	name string
 
@@ -49,7 +46,7 @@ func NewNodeHandler(
 	logger *slog.Logger,
 	manager *PoolAllocator,
 	cnClient cilium_v2.CiliumNodeInterface,
-	poolsFromResource PoolsFromResourceFunc,
+	poolsFromResource v2.PoolsFromResourceFunc,
 ) *NodeHandler {
 	return &NodeHandler{
 		logger:                 logger,

--- a/pkg/ipam/cell/cell.go
+++ b/pkg/ipam/cell/cell.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
 
@@ -83,6 +84,7 @@ type ipamParams struct {
 	EndpointManager     endpointmanager.EndpointManager
 	IPMasqAgent         *ipmasq.IPMasqAgent
 
+	JobGroup   job.Group
 	DB         *statedb.DB
 	PodIPPools statedb.Table[podippool.LocalPodIPPool]
 }
@@ -105,6 +107,7 @@ func newIPAddressManager(params ipamParams, c ipamConfig) (*ipam.IPAM, error) {
 		Sysctl:                    params.Sysctl,
 		IPMasqAgent:               params.IPMasqAgent,
 		DB:                        params.DB,
+		JobGroup:                  params.JobGroup,
 		PodIPPools:                params.PodIPPools,
 		OnlyMasqueradeDefaultPool: c.OnlyMasqueradeDefaultPool,
 	})

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -145,7 +145,7 @@ func (ipam *IPAM) ConfigureAllocator() {
 			Node:                      ipam.nodeResource,
 			Owner:                     ipam.nodeDiscovery,
 			LocalNodeStore:            ipam.localNodeStore,
-			Clientset:                 ipam.clientset.CiliumV2().CiliumNodes(),
+			CNClient:                  ipam.clientset.CiliumV2().CiliumNodes(),
 			JobGroup:                  ipam.jg,
 			DB:                        ipam.db,
 			PodIPPools:                ipam.podIPPools,

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
@@ -84,6 +85,8 @@ type NewIPAMParams struct {
 	Sysctl         sysctl.Sysctl
 	IPMasqAgent    *ipmasq.IPMasqAgent
 
+	JobGroup job.Group
+
 	DB                        *statedb.DB
 	PodIPPools                statedb.Table[podippool.LocalPodIPPool]
 	OnlyMasqueradeDefaultPool bool
@@ -107,6 +110,7 @@ func NewIPAM(params NewIPAMParams) *IPAM {
 		metadata:                  params.Metadata,
 		sysctl:                    params.Sysctl,
 		ipMasqAgent:               params.IPMasqAgent,
+		jg:                        params.JobGroup,
 		db:                        params.DB,
 		podIPPools:                params.PodIPPools,
 		onlyMasqueradeDefaultPool: params.OnlyMasqueradeDefaultPool,
@@ -142,6 +146,7 @@ func (ipam *IPAM) ConfigureAllocator() {
 			Owner:                     ipam.nodeDiscovery,
 			LocalNodeStore:            ipam.localNodeStore,
 			Clientset:                 ipam.clientset.CiliumV2().CiliumNodes(),
+			JobGroup:                  ipam.jg,
 			DB:                        ipam.db,
 			PodIPPools:                ipam.podIPPools,
 			OnlyMasqueradeDefaultPool: ipam.onlyMasqueradeDefaultPool,

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -141,7 +141,10 @@ func (ipam *IPAM) ConfigureAllocator() {
 		ipam.logger.Info("Initializing MultiPool IPAM")
 		manager := newMultiPoolManager(MultiPoolManagerParams{
 			Logger:                    ipam.logger,
-			Conf:                      ipam.config,
+			IPv4Enabled:               ipam.config.IPv4Enabled(),
+			IPv6Enabled:               ipam.config.IPv6Enabled(),
+			CiliumNodeUpdateRate:      ipam.config.IPAMCiliumNodeUpdateRate,
+			PreAllocPools:             ipam.config.IPAMMultiPoolPreAllocation,
 			Node:                      ipam.nodeResource,
 			Owner:                     ipam.nodeDiscovery,
 			LocalNodeStore:            ipam.localNodeStore,

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -147,13 +147,14 @@ func (ipam *IPAM) ConfigureAllocator() {
 			CiliumNodeUpdateRate:      ipam.config.IPAMCiliumNodeUpdateRate,
 			PreAllocPools:             ipam.config.IPAMMultiPoolPreAllocation,
 			Node:                      ipam.nodeResource,
-			LocalNodeStore:            ipam.localNodeStore,
 			CNClient:                  ipam.clientset.CiliumV2().CiliumNodes(),
 			JobGroup:                  ipam.jg,
 			DB:                        ipam.db,
 			PodIPPools:                ipam.podIPPools,
 			OnlyMasqueradeDefaultPool: ipam.onlyMasqueradeDefaultPool,
 		})
+
+		startLocalNodeAllocCIDRsSync(ipam.config.EnableIPv4, ipam.config.EnableIPv6, ipam.jg, ipam.nodeResource, ipam.localNodeStore)
 
 		// wait for local node to be updated to avoid propagating spurious updates.
 		waitForLocalNodeUpdate(ipam.logger, manager)

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -146,7 +146,6 @@ func (ipam *IPAM) ConfigureAllocator() {
 			CiliumNodeUpdateRate:      ipam.config.IPAMCiliumNodeUpdateRate,
 			PreAllocPools:             ipam.config.IPAMMultiPoolPreAllocation,
 			Node:                      ipam.nodeResource,
-			Owner:                     ipam.nodeDiscovery,
 			LocalNodeStore:            ipam.localNodeStore,
 			CNClient:                  ipam.clientset.CiliumV2().CiliumNodes(),
 			JobGroup:                  ipam.jg,

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -5,224 +5,25 @@ package ipam
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"maps"
 	"net"
-	"slices"
-	"sort"
-	"strconv"
-	"sync"
 
-	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
-	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam/podippool"
-	"github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
-const (
-	waitForPoolTimeout = 3 * time.Minute
+var _ Allocator = (*multiPoolAllocator)(nil)
 
-	// pendingAllocationTTL is how long we wait for pending allocation to
-	// be fulfilled
-	pendingAllocationTTL = 5 * time.Minute
-
-	// refreshPoolsInterval defines the run interval of the ipam-sync-multi-pool controller
-	refreshPoolInterval = 1 * time.Minute
-)
-
-type ErrPoolNotReadyYet struct {
-	poolName Pool
-	family   Family
-	ip       net.IP
-}
-
-func (e *ErrPoolNotReadyYet) Error() string {
-	if e.ip == nil {
-		return fmt.Sprintf("unable to allocate from pool %q (family %s): pool not (yet) available", e.poolName, e.family)
-	} else {
-		return fmt.Sprintf("unable to reserve IP %s from pool %q (family %s): pool not (yet) available", e.ip, e.poolName, e.family)
-	}
-}
-
-func (e *ErrPoolNotReadyYet) Is(err error) bool {
-	_, ok := err.(*ErrPoolNotReadyYet)
-	return ok
-}
-
-type poolPair struct {
-	v4 *podCIDRPool
-	v6 *podCIDRPool
-}
-
-type preAllocatePerPool map[Pool]int
-
-func parseMultiPoolPreAllocMap(conf map[string]string) (preAllocatePerPool, error) {
-	m := make(map[Pool]int, len(conf))
-	for pool, s := range conf {
-		value, err := strconv.ParseInt(s, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("invalid value for pool %q: %w", pool, err)
-		}
-		m[Pool(pool)] = int(value)
-	}
-
-	return m, nil
-}
-
-// pendingAllocationsPerPool tracks the number of pending allocations per pool.
-// A pending allocation is an allocation that has been requested, but not yet
-// fulfilled (i.e. typically because the pool is currently empty).
-// If an allocation is pending, we will request one additional IP from the
-// operator for every outstanding pending request. We will do this until the
-// allocation is fulfilled (e.g. because the operator has replenished our pool),
-// or if pending allocation expires (i.e. the owner has not performed any retry
-// attempt within pendingAllocationTTL)
-type pendingAllocationsPerPool struct {
-	logger *slog.Logger
-	pools  map[Pool]pendingAllocationsPerOwner
-	clock  func() time.Time // support custom clock for testing
-}
-
-// newPendingAllocationsPerPool returns a new pendingAllocationsPerPool with the
-// default monotonic expiration clock
-func newPendingAllocationsPerPool(logger *slog.Logger) *pendingAllocationsPerPool {
-	return &pendingAllocationsPerPool{
-		logger: logger,
-		pools:  map[Pool]pendingAllocationsPerOwner{},
-		clock: func() time.Time {
-			return time.Now()
-		},
-	}
-}
-
-// upsertPendingAllocation adds (or refreshes) a pending allocation to a particular pool.
-// The pending allocation is associated with a particular owner for bookkeeping purposes.
-func (p pendingAllocationsPerPool) upsertPendingAllocation(poolName Pool, owner string, family Family) {
-	pool, ok := p.pools[poolName]
-	if !ok {
-		pool = pendingAllocationsPerOwner{}
-	}
-
-	p.logger.Debug(
-		"IP allocation failed, upserting pending allocation",
-		logfields.Owner, owner,
-		logfields.Family, family,
-		logfields.PoolName, poolName,
-	)
-
-	now := p.clock()
-	pool.startExpirationAt(now, owner, family)
-	p.pools[poolName] = pool
-}
-
-// markAsAllocated marks a pending allocation as fulfilled. This means that the owner
-// has now been assigned an IP from the given IP family
-func (p pendingAllocationsPerPool) markAsAllocated(poolName Pool, owner string, family Family) {
-	p.logger.Debug(
-		"Marking pending allocation as allocated",
-		logfields.Owner, owner,
-		logfields.Family, family,
-		logfields.PoolName, poolName,
-	)
-
-	pool, ok := p.pools[poolName]
-	if !ok {
-		return
-	}
-	pool.removeExpiration(owner, family)
-	if len(pool) == 0 {
-		delete(p.pools, poolName)
-	}
-}
-
-// removeExpiredEntries removes all expired pending allocations from all pools.
-// Pending allocations expire if they are not fulfilled after the time interval
-// specified in pendingAllocationTTL has elapsed.
-// This typically means that we are no longer trying to reserve an additional IP for
-// the expired allocation. The owner of the expired pending allocation may still
-// reissue the allocation and be successful next time if the IP pool has now
-// enough capacity.
-func (p pendingAllocationsPerPool) removeExpiredEntries() {
-	now := p.clock()
-	for poolName, pool := range p.pools {
-		pool.removeExpiredEntries(p.logger, now, poolName)
-		if len(pool) == 0 {
-			delete(p.pools, poolName)
-		}
-	}
-}
-
-// pendingForPool returns how many IP allocations are pending for the given
-// pool and IP family
-func (p pendingAllocationsPerPool) pendingForPool(pool Pool, family Family) int {
-	return p.pools[pool].pendingForFamily(family)
-}
-
-// pendingAllocationsPerOwner tracks if an IP owner has a pending allocation
-// request for a particular IP family.
-// The IP family as the first key allows one to quickly determine how many
-// IP allocations are pending for a given IP family.
-type pendingAllocationsPerOwner map[Family]map[string]time.Time
-
-// startExpiration starts the expiration timer for a pending allocation
-func (p pendingAllocationsPerOwner) startExpirationAt(now time.Time, owner string, family Family) {
-	expires, ok := p[family]
-	if !ok {
-		expires = map[string]time.Time{}
-	}
-
-	expires[owner] = now.Add(pendingAllocationTTL)
-	p[family] = expires
-}
-
-// removeExpiration removes the expiration timer for a pending allocation, this
-// happens either because the timer expired, or the allocation was fulfilled
-func (p pendingAllocationsPerOwner) removeExpiration(owner string, family Family) {
-	delete(p[family], owner)
-	if len(p[family]) == 0 {
-		delete(p, family)
-	}
-}
-
-// removeExpiredEntries removes all pending allocation requests which have expired
-func (p pendingAllocationsPerOwner) removeExpiredEntries(logger *slog.Logger, now time.Time, pool Pool) {
-	for family, owners := range p {
-		for owner, expires := range owners {
-			if now.After(expires) {
-				p.removeExpiration(owner, family)
-				logger.Debug(
-					"Pending IP allocation has expired without being fulfilled",
-					logfields.Owner, owner,
-					logfields.Family, family,
-					logfields.PoolName, pool,
-				)
-			}
-		}
-	}
-}
-
-// pendingForPool returns how many IP allocations are pending for the given family
-func (p pendingAllocationsPerOwner) pendingForFamily(family Family) int {
-	return len(p[family])
-}
-
-type MultiPoolManagerParams struct {
+type MultiPoolAllocatorParams struct {
 	Logger *slog.Logger
 
 	IPv4Enabled          bool
@@ -230,564 +31,48 @@ type MultiPoolManagerParams struct {
 	CiliumNodeUpdateRate time.Duration
 	PreAllocPools        map[string]string
 
-	Node     agentK8s.LocalCiliumNodeResource
-	CNClient cilium_v2.CiliumNodeInterface
-	JobGroup job.Group
+	Node           agentK8s.LocalCiliumNodeResource
+	LocalNodeStore *node.LocalNodeStore
+	CNClient       cilium_v2.CiliumNodeInterface
+	JobGroup       job.Group
 
 	DB                        *statedb.DB
 	PodIPPools                statedb.Table[podippool.LocalPodIPPool]
 	OnlyMasqueradeDefaultPool bool
 }
 
-type multiPoolManager struct {
-	mutex *lock.Mutex
-
-	ipv4Enabled bool
-	ipv6Enabled bool
-
-	preallocatedIPsPerPool preAllocatePerPool
-	pendingIPsPerPool      *pendingAllocationsPerPool
-
-	pools        map[Pool]*poolPair
-	poolsUpdated chan struct{}
-
-	node *ciliumv2.CiliumNode
-
-	jobGroup   job.Group
-	k8sUpdater job.Trigger
-	cnClient   cilium_v2.CiliumNodeInterface
-
-	localNodeUpdate   chan struct{}
-	localNodeUpdateFn func()
-
-	finishedRestore map[Family]bool
-	logger          *slog.Logger
-
-	db                        *statedb.DB
-	podIPPools                statedb.Table[podippool.LocalPodIPPool]
-	onlyMasqueradeDefaultPool bool
-}
-
-var _ Allocator = (*multiPoolAllocator)(nil)
-
-func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
-	preallocMap, err := parseMultiPoolPreAllocMap(p.PreAllocPools)
-	if err != nil {
-		logging.Fatal(p.Logger, fmt.Sprintf("Invalid %s flag value", option.IPAMMultiPoolPreAllocation), logfields.Error, err)
-	}
-
-	localNodeUpdated := make(chan struct{})
-	mgr := &multiPoolManager{
-		logger:                 p.Logger,
-		mutex:                  &lock.Mutex{},
-		ipv4Enabled:            p.IPv4Enabled,
-		ipv6Enabled:            p.IPv6Enabled,
-		preallocatedIPsPerPool: preallocMap,
-		pendingIPsPerPool:      newPendingAllocationsPerPool(p.Logger),
-		pools:                  map[Pool]*poolPair{},
-		poolsUpdated:           make(chan struct{}, 1),
-		node:                   nil,
-		jobGroup:               p.JobGroup,
-		k8sUpdater:             job.NewTrigger(job.WithDebounce(p.CiliumNodeUpdateRate)),
-		cnClient:               p.CNClient,
-		finishedRestore:        map[Family]bool{},
-		localNodeUpdate:        localNodeUpdated,
-		localNodeUpdateFn: sync.OnceFunc(func() {
-			close(localNodeUpdated)
-		}),
-		db:                        p.DB,
-		podIPPools:                p.PodIPPools,
-		onlyMasqueradeDefaultPool: p.OnlyMasqueradeDefaultPool,
-	}
-
-	mgr.jobGroup.Add(
-		job.OneShot(
-			"multi-pool-cilium-node-events-handler",
-			func(ctx context.Context, health cell.Health) error {
-				for ev := range p.Node.Events(ctx) {
-					switch ev.Kind {
-					case resource.Upsert:
-						mgr.ciliumNodeUpdated(ev.Object)
-					case resource.Delete:
-						mgr.logger.Debug(
-							"Local CiliumNode deleted. IPAM will continue on last seen version",
-							logfields.Node, ev.Object,
-						)
-					}
-					ev.Done(nil)
-				}
-				return nil
-			},
-		),
-		job.Timer(
-			"multi-pool-cilium-node-updater",
-			mgr.updateLocalNode,
-			refreshPoolInterval,
-			job.WithTrigger(mgr.k8sUpdater),
-		),
-	)
-
-	mgr.waitForAllPools()
-
-	return mgr
-}
-
-// waitForAllPools waits for all pools in preallocatedIPsPerPool to have IPs available.
-// This function blocks the IPAM constructor forever and periodically logs
-// that it is waiting for IPs to be assigned. This blocking behavior is
-// consistent with other IPAM modes.
-func (m *multiPoolManager) waitForAllPools() {
-	allPoolsReady := false
-	for !allPoolsReady {
-		allPoolsReady = true
-		for pool := range m.preallocatedIPsPerPool {
-			ctx, cancel := context.WithTimeout(context.Background(), waitForPoolTimeout)
-			if m.ipv4Enabled {
-				allPoolsReady = m.waitForPool(ctx, IPv4, pool) && allPoolsReady
-			}
-			if m.ipv6Enabled {
-				allPoolsReady = m.waitForPool(ctx, IPv6, pool) && allPoolsReady
-			}
-			cancel()
-		}
-	}
-}
-
-// waitForPool waits for the pool poolName to have at least one allocatable IP
-// available for the given IP family. This function is supposed to only be called
-// before any IPs are handed out, so hasAvailableIPs returns true so as long as
-// the local node has IPs assigned to it in the given pool.
-func (m *multiPoolManager) waitForPool(ctx context.Context, family Family, poolName Pool) (ready bool) {
-	for {
-		m.mutex.Lock()
-		poolReady := false
-		switch family {
-		case IPv4:
-			if p, ok := m.pools[poolName]; ok && p.v4 != nil && p.v4.hasAvailableIPs() {
-				poolReady = true
-			}
-		case IPv6:
-			if p, ok := m.pools[poolName]; ok && p.v6 != nil && p.v6.hasAvailableIPs() {
-				poolReady = true
-			}
-		}
-		m.mutex.Unlock()
-
-		// ensure the pool is present in stateDB for checking annotations at allocation time
-		txn := m.db.ReadTxn()
-		_, _, dbWatch, found := m.podIPPools.GetWatch(txn, podippool.ByName(string(poolName)))
-		if poolReady && found {
-			return true
-		}
-
-		select {
-		case <-ctx.Done():
-			return false
-		case <-m.poolsUpdated:
-			continue
-		case <-dbWatch:
-			continue
-		case <-time.After(5 * time.Second):
-			m.logger.Info(
-				"Waiting for podCIDR pool to become available",
-				logfields.PoolName, poolName,
-				logfields.Family, family,
-				logfields.HelpMessage, "Check if cilium-operator pod is running and does not have any warnings or error messages.",
-			)
-		}
-	}
-}
-
-func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	for _, pool := range newNode.Spec.IPAM.Pools.Allocated {
-		m.upsertPoolLocked(Pool(pool.Pool), pool.CIDRs)
-	}
-
-	// m.node will only be nil the first time this callback is invoked
-	// Note: The job will only run after m.mutex is unlocked
-	if m.node == nil {
-		m.k8sUpdater.Trigger()
-	}
-
-	m.node = newNode
-}
-
-func (m *multiPoolManager) localNodeUpdated() <-chan struct{} {
-	return m.localNodeUpdate
-}
-
-// neededIPCeil rounds up numIPs to the next but one multiple of preAlloc.
-// Example for preAlloc=16:
-//
-//	numIP  0 -> 16
-//	numIP  1 -> 32
-//	numIP 15 -> 32
-//	numIP 16 -> 32
-//	numIP 17 -> 48
-//
-// This always ensures that there we always have a buffer of at least preAlloc
-// IPs.
-func neededIPCeil(numIP int, preAlloc int) int {
-	if preAlloc == 0 {
-		return numIP
-	}
-
-	quotient := numIP / preAlloc
-	rem := numIP % preAlloc
-	if rem > 0 {
-		return (quotient + 2) * preAlloc
-	}
-	return (quotient + 1) * preAlloc
-}
-
-// computeNeededIPsPerPoolLocked computes how many IPs we want to request from
-// the operator for each pool. The formula we use for each pool is basically
-//
-//	neededIPs = roundUp(inUseIPs + pendingIPs + preAllocIPs, preAllocIPs)
-//
-//	      inUseIPs      Number of IPs that are currently actively in use
-//	      pendingIPs    Number of IPs that have been requested, but not yet assigned
-//	      preAllocIPs   Minimum number of IPs that we want to pre-allocate as a buffer
-//
-// Rounded up to the next multiple of preAllocIPs.
-func (m *multiPoolManager) computeNeededIPsPerPoolLocked() map[Pool]types.IPAMPoolDemand {
-	demand := make(map[Pool]types.IPAMPoolDemand, len(m.pools))
-
-	// inUseIPs
-	for poolName, pool := range m.pools {
-		ipv4Addrs := 0
-		if p := pool.v4; p != nil {
-			ipv4Addrs = p.inUseIPCount()
-		}
-		ipv6Addrs := 0
-		if p := pool.v6; p != nil {
-			ipv6Addrs = p.inUseIPCount()
-		}
-
-		demand[poolName] = types.IPAMPoolDemand{
-			IPv4Addrs: ipv4Addrs,
-			IPv6Addrs: ipv6Addrs,
-		}
-	}
-
-	// + pendingIPs
-	for poolName, pending := range m.pendingIPsPerPool.pools {
-		ipv4Addrs := demand[poolName].IPv4Addrs + pending.pendingForFamily(IPv4)
-		ipv6Addrs := demand[poolName].IPv6Addrs + pending.pendingForFamily(IPv6)
-
-		demand[poolName] = types.IPAMPoolDemand{
-			IPv4Addrs: ipv4Addrs,
-			IPv6Addrs: ipv6Addrs,
-		}
-	}
-
-	// + preAllocIPs
-	for poolName, preAlloc := range m.preallocatedIPsPerPool {
-		ipv4Addrs := demand[poolName].IPv4Addrs
-		if m.ipv4Enabled {
-			ipv4Addrs = neededIPCeil(ipv4Addrs, preAlloc)
-		}
-		ipv6Addrs := demand[poolName].IPv6Addrs
-		if m.ipv6Enabled {
-			ipv6Addrs = neededIPCeil(ipv6Addrs, preAlloc)
-		}
-
-		demand[poolName] = types.IPAMPoolDemand{
-			IPv4Addrs: ipv4Addrs,
-			IPv6Addrs: ipv6Addrs,
-		}
-	}
-
-	return demand
-}
-
-func (m *multiPoolManager) restoreFinished(family Family) {
-	m.mutex.Lock()
-	m.finishedRestore[family] = true
-	m.mutex.Unlock()
-}
-
-func (m *multiPoolManager) isRestoreFinishedLocked(family Family) bool {
-	return m.finishedRestore[family]
-}
-
-func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
-	m.mutex.Lock()
-
-	if m.node == nil {
-		m.mutex.Unlock()
-		return nil
-	}
-
-	newNode := m.node.DeepCopy()
-	requested := []types.IPAMPoolRequest{}
-	allocated := []types.IPAMPoolAllocation{}
-
-	m.pendingIPsPerPool.removeExpiredEntries()
-	neededIPsPerPool := m.computeNeededIPsPerPoolLocked()
-	for poolName, needed := range neededIPsPerPool {
-		if needed.IPv4Addrs == 0 && needed.IPv6Addrs == 0 {
-			continue // no need to request "0" IPs
-		}
-
-		requested = append(requested, types.IPAMPoolRequest{
-			Pool:   poolName.String(),
-			Needed: needed,
-		})
-	}
-
-	// Write in-use pools to podCIDR. This removes any released pod CIDRs
-	for poolName, pool := range m.pools {
-		neededIPs := neededIPsPerPool[poolName]
-
-		cidrs := []types.IPAMCIDR{}
-		if v4Pool := pool.v4; v4Pool != nil {
-			if m.isRestoreFinishedLocked(IPv4) {
-				// releaseExcessCIDRsMultiPool interprets neededIPs as how many
-				// free addresses must remain after a CIDR is dropped.
-				// Therefore we subtract the number of in-use addresses from neededIPs.
-				freeNeeded4 := max(neededIPs.IPv4Addrs-v4Pool.inUseIPCount(), 0)
-				v4Pool.releaseExcessCIDRsMultiPool(freeNeeded4)
-			}
-			v4CIDRs := v4Pool.inUsePodCIDRs()
-
-			slices.Sort(v4CIDRs)
-			cidrs = append(cidrs, v4CIDRs...)
-		}
-		if v6Pool := pool.v6; v6Pool != nil {
-			if m.isRestoreFinishedLocked(IPv6) {
-				freeNeeded6 := max(neededIPs.IPv6Addrs-v6Pool.inUseIPCount(), 0)
-				v6Pool.releaseExcessCIDRsMultiPool(freeNeeded6)
-			}
-			v6CIDRs := v6Pool.inUsePodCIDRs()
-
-			slices.Sort(v6CIDRs)
-			cidrs = append(cidrs, v6CIDRs...)
-		}
-
-		// remove pool if we've released all CIDRs
-		if len(cidrs) == 0 {
-			delete(m.pools, poolName)
-			continue
-		}
-
-		allocated = append(allocated, types.IPAMPoolAllocation{
-			Pool:  poolName.String(),
-			CIDRs: cidrs,
-		})
-	}
-
-	sort.Slice(requested, func(i, j int) bool {
-		return requested[i].Pool < requested[j].Pool
-	})
-	sort.Slice(allocated, func(i, j int) bool {
-		return allocated[i].Pool < allocated[j].Pool
-	})
-	newNode.Spec.IPAM.Pools.Requested = requested
-	newNode.Spec.IPAM.Pools.Allocated = allocated
-
-	m.mutex.Unlock()
-
-	if !newNode.Spec.IPAM.DeepEqual(&m.node.Spec.IPAM) {
-		_, err := m.cnClient.Update(ctx, newNode, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to update node spec: %w", err)
-		}
-	}
-
-	m.localNodeUpdateFn()
-
-	return nil
-}
-
-func (m *multiPoolManager) upsertPoolLocked(poolName Pool, podCIDRs []types.IPAMCIDR) {
-	pool, ok := m.pools[poolName]
-	if !ok {
-		pool = &poolPair{}
-		if m.ipv4Enabled {
-			pool.v4 = newPodCIDRPool(m.logger)
-		}
-		if m.ipv6Enabled {
-			pool.v6 = newPodCIDRPool(m.logger)
-		}
-	}
-
-	var ipv4PodCIDRs, ipv6PodCIDRs []string
-	for _, ipamPodCIDR := range podCIDRs {
-		podCIDR := string(ipamPodCIDR)
-		switch podCIDRFamily(podCIDR) {
-		case IPv4:
-			ipv4PodCIDRs = append(ipv4PodCIDRs, podCIDR)
-		case IPv6:
-			ipv6PodCIDRs = append(ipv6PodCIDRs, podCIDR)
-		}
-	}
-
-	if pool.v4 != nil {
-		pool.v4.updatePool(ipv4PodCIDRs)
-	}
-	if pool.v6 != nil {
-		pool.v6.updatePool(ipv6PodCIDRs)
-	}
-
-	m.pools[poolName] = pool
-
-	select {
-	case m.poolsUpdated <- struct{}{}:
-	default:
-	}
-}
-
-func (m *multiPoolManager) dump(family Family) (allocated map[Pool]map[string]string, status string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	allocated = map[Pool]map[string]string{}
-	for poolName, pool := range m.pools {
-		var p *podCIDRPool
-		switch family {
-		case IPv4:
-			p = pool.v4
-		case IPv6:
-			p = pool.v6
-		}
-		if p == nil {
-			return nil, fmt.Sprintf("family %q not supported", family)
-		}
-
-		ipToOwner, _, _, _, err := p.dump()
-		if err != nil {
-			return nil, fmt.Sprintf("error: %s", err)
-		}
-
-		if poolName == "" {
-			poolName = PoolDefault()
-		}
-
-		if _, ok := allocated[poolName]; !ok {
-			allocated[poolName] = map[string]string{}
-		}
-
-		maps.Copy(allocated[poolName], ipToOwner)
-	}
-
-	return allocated, fmt.Sprintf("%d IPAM pool(s) available", len(m.pools))
-}
-
-func (m *multiPoolManager) poolByFamilyLocked(poolName Pool, family Family) *podCIDRPool {
-	switch family {
-	case IPv4:
-		pair, ok := m.pools[poolName]
-		if ok {
-			return pair.v4
-		}
-	case IPv6:
-		pair, ok := m.pools[poolName]
-		if ok {
-			return pair.v6
-		}
-	}
-
-	return nil
-}
-
-func (m *multiPoolManager) allocateNext(owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	defer func() {
-		if syncUpstream {
-			m.k8sUpdater.Trigger()
-		}
-	}()
-
-	pool := m.poolByFamilyLocked(poolName, family)
-	if pool == nil {
-		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
-		return nil, &ErrPoolNotReadyYet{poolName: poolName, family: family}
-	}
-	skipMasq := false
-	// If the flag is set, skip masquerade for all non-default pools
-	if m.onlyMasqueradeDefaultPool && poolName != PoolDefault() {
-		skipMasq = true
-	} else {
-		// Lookup the IP pool from stateDB and check if it has the explicit annotations
-		txn := m.db.ReadTxn()
-		podIPPool, _, found := m.podIPPools.Get(txn, podippool.ByName(string(poolName)))
-		if !found {
-			m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
-			return nil, fmt.Errorf("IP pool '%s' not found in stateDB table", string(poolName))
-		}
-		if v, ok := podIPPool.Annotations[annotation.IPAMSkipMasquerade]; ok && v == "true" {
-			skipMasq = true
-		}
-	}
-
-	ip, err := pool.allocateNext()
-	if err != nil {
-		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
-		return nil, err
-	}
-
-	m.pendingIPsPerPool.markAsAllocated(poolName, owner, family)
-	return &AllocationResult{IP: ip, IPPoolName: poolName, SkipMasquerade: skipMasq}, nil
-}
-
-func (m *multiPoolManager) allocateIP(ip net.IP, owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	defer func() {
-		if syncUpstream {
-			m.k8sUpdater.Trigger()
-		}
-	}()
-
-	pool := m.poolByFamilyLocked(poolName, family)
-	if pool == nil {
-		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
-		return nil, &ErrPoolNotReadyYet{poolName: poolName, family: family, ip: ip}
-	}
-
-	err := pool.allocate(ip)
-	if err != nil {
-		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
-		return nil, err
-	}
-
-	m.pendingIPsPerPool.markAsAllocated(poolName, owner, family)
-	return &AllocationResult{IP: ip, IPPoolName: poolName}, nil
-}
-
-func (m *multiPoolManager) releaseIP(ip net.IP, poolName Pool, family Family, upstreamSync bool) error {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	pool := m.poolByFamilyLocked(poolName, family)
-	if pool == nil {
-		return fmt.Errorf("unable to release IP %s of unknown pool %q (family %s)", ip, poolName, family)
-	}
-
-	pool.release(ip)
-	if upstreamSync {
-		m.k8sUpdater.Trigger()
-	}
-	return nil
-}
-
-func (m *multiPoolManager) Allocator(family Family) Allocator {
-	return &multiPoolAllocator{
-		manager: m,
-		family:  family,
-	}
-}
-
 type multiPoolAllocator struct {
 	manager *multiPoolManager
 	family  Family
+}
+
+func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
+	mgr := newMultiPoolManager(MultiPoolManagerParams{
+		Logger:                    p.Logger,
+		IPv4Enabled:               p.IPv4Enabled,
+		IPv6Enabled:               p.IPv6Enabled,
+		CiliumNodeUpdateRate:      p.CiliumNodeUpdateRate,
+		PreAllocPools:             p.PreAllocPools,
+		Node:                      p.Node,
+		CNClient:                  p.CNClient,
+		JobGroup:                  p.JobGroup,
+		DB:                        p.DB,
+		PodIPPools:                p.PodIPPools,
+		OnlyMasqueradeDefaultPool: p.OnlyMasqueradeDefaultPool,
+	})
+
+	startLocalNodeAllocCIDRsSync(p.IPv4Enabled, p.IPv6Enabled, p.JobGroup, p.Node, p.LocalNodeStore)
+
+	// wait for local node to be updated to avoid propagating spurious updates.
+	waitForLocalNodeUpdate(p.Logger, mgr)
+
+	return &multiPoolAllocator{
+			manager: mgr,
+			family:  IPv4,
+		}, &multiPoolAllocator{
+			manager: mgr,
+			family:  IPv6,
+		}
 }
 
 func (c *multiPoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
@@ -834,6 +119,17 @@ func (c *multiPoolAllocator) Capacity() uint64 {
 
 func (c *multiPoolAllocator) RestoreFinished() {
 	c.manager.restoreFinished(c.family)
+}
+
+func waitForLocalNodeUpdate(logger *slog.Logger, mgr *multiPoolManager) {
+	for {
+		select {
+		case <-mgr.localNodeUpdated():
+			return
+		case <-time.After(5 * time.Second):
+			logger.Info("Waiting for local CiliumNode resource to synchronize local node store")
+		}
+	}
 }
 
 func startLocalNodeAllocCIDRsSync(

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -102,7 +102,7 @@ func (c *multiPoolAllocator) Dump() (map[Pool]map[string]string, string) {
 func (c *multiPoolAllocator) Capacity() uint64 {
 	var capacity uint64
 	for _, pool := range c.manager.pools {
-		var p *podCIDRPool
+		var p *cidrPool
 		switch c.family {
 		case IPv4:
 			p = pool.v4

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -231,7 +231,6 @@ type MultiPoolManagerParams struct {
 	PreAllocPools        map[string]string
 
 	Node           agentK8s.LocalCiliumNodeResource
-	Owner          Owner
 	LocalNodeStore *node.LocalNodeStore
 	CNClient       cilium_v2.CiliumNodeInterface
 	JobGroup       job.Group
@@ -243,7 +242,6 @@ type MultiPoolManagerParams struct {
 
 type multiPoolManager struct {
 	mutex *lock.Mutex
-	owner Owner
 
 	ipv4Enabled bool
 	ipv6Enabled bool
@@ -284,7 +282,6 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 	c := &multiPoolManager{
 		logger:                 p.Logger,
 		mutex:                  &lock.Mutex{},
-		owner:                  p.Owner,
 		ipv4Enabled:            p.IPv4Enabled,
 		ipv6Enabled:            p.IPv6Enabled,
 		preallocatedIPsPerPool: preallocMap,
@@ -332,8 +329,6 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 			job.WithTrigger(c.k8sUpdater),
 		),
 	)
-
-	p.Owner.UpdateCiliumNodeResource()
 
 	c.waitForAllPools()
 

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -15,6 +15,7 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam/podippool"
+	"github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -69,6 +70,9 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 		CNClient:              p.CNClient,
 		JobGroup:              p.JobGroup,
 		SkipMasqueradeForPool: shouldSkipMasqForPool(p.DB, p.PodIPPools, p.OnlyMasqueradeDefaultPool),
+		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
+			return &cn.Spec.IPAM.Pools
+		},
 	})
 
 	waitForAllPools(p.Logger, p.DB, p.PodIPPools, preallocMap)

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -1,0 +1,775 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net"
+	"slices"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/ipam/podippool"
+	"github.com/cilium/cilium/pkg/ipam/types"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	waitForPoolTimeout = 3 * time.Minute
+
+	// pendingAllocationTTL is how long we wait for pending allocation to
+	// be fulfilled
+	pendingAllocationTTL = 5 * time.Minute
+
+	// refreshPoolsInterval defines the run interval of the ipam-sync-multi-pool controller
+	refreshPoolInterval = 1 * time.Minute
+)
+
+type ErrPoolNotReadyYet struct {
+	poolName Pool
+	family   Family
+	ip       net.IP
+}
+
+func (e *ErrPoolNotReadyYet) Error() string {
+	if e.ip == nil {
+		return fmt.Sprintf("unable to allocate from pool %q (family %s): pool not (yet) available", e.poolName, e.family)
+	} else {
+		return fmt.Sprintf("unable to reserve IP %s from pool %q (family %s): pool not (yet) available", e.ip, e.poolName, e.family)
+	}
+}
+
+func (e *ErrPoolNotReadyYet) Is(err error) bool {
+	_, ok := err.(*ErrPoolNotReadyYet)
+	return ok
+}
+
+type poolPair struct {
+	v4 *podCIDRPool
+	v6 *podCIDRPool
+}
+
+type preAllocatePerPool map[Pool]int
+
+func parseMultiPoolPreAllocMap(conf map[string]string) (preAllocatePerPool, error) {
+	m := make(map[Pool]int, len(conf))
+	for pool, s := range conf {
+		value, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for pool %q: %w", pool, err)
+		}
+		m[Pool(pool)] = int(value)
+	}
+
+	return m, nil
+}
+
+// pendingAllocationsPerPool tracks the number of pending allocations per pool.
+// A pending allocation is an allocation that has been requested, but not yet
+// fulfilled (i.e. typically because the pool is currently empty).
+// If an allocation is pending, we will request one additional IP from the
+// operator for every outstanding pending request. We will do this until the
+// allocation is fulfilled (e.g. because the operator has replenished our pool),
+// or if pending allocation expires (i.e. the owner has not performed any retry
+// attempt within pendingAllocationTTL)
+type pendingAllocationsPerPool struct {
+	logger *slog.Logger
+	pools  map[Pool]pendingAllocationsPerOwner
+	clock  func() time.Time // support custom clock for testing
+}
+
+// newPendingAllocationsPerPool returns a new pendingAllocationsPerPool with the
+// default monotonic expiration clock
+func newPendingAllocationsPerPool(logger *slog.Logger) *pendingAllocationsPerPool {
+	return &pendingAllocationsPerPool{
+		logger: logger,
+		pools:  map[Pool]pendingAllocationsPerOwner{},
+		clock: func() time.Time {
+			return time.Now()
+		},
+	}
+}
+
+// upsertPendingAllocation adds (or refreshes) a pending allocation to a particular pool.
+// The pending allocation is associated with a particular owner for bookkeeping purposes.
+func (p pendingAllocationsPerPool) upsertPendingAllocation(poolName Pool, owner string, family Family) {
+	pool, ok := p.pools[poolName]
+	if !ok {
+		pool = pendingAllocationsPerOwner{}
+	}
+
+	p.logger.Debug(
+		"IP allocation failed, upserting pending allocation",
+		logfields.Owner, owner,
+		logfields.Family, family,
+		logfields.PoolName, poolName,
+	)
+
+	now := p.clock()
+	pool.startExpirationAt(now, owner, family)
+	p.pools[poolName] = pool
+}
+
+// markAsAllocated marks a pending allocation as fulfilled. This means that the owner
+// has now been assigned an IP from the given IP family
+func (p pendingAllocationsPerPool) markAsAllocated(poolName Pool, owner string, family Family) {
+	p.logger.Debug(
+		"Marking pending allocation as allocated",
+		logfields.Owner, owner,
+		logfields.Family, family,
+		logfields.PoolName, poolName,
+	)
+
+	pool, ok := p.pools[poolName]
+	if !ok {
+		return
+	}
+	pool.removeExpiration(owner, family)
+	if len(pool) == 0 {
+		delete(p.pools, poolName)
+	}
+}
+
+// removeExpiredEntries removes all expired pending allocations from all pools.
+// Pending allocations expire if they are not fulfilled after the time interval
+// specified in pendingAllocationTTL has elapsed.
+// This typically means that we are no longer trying to reserve an additional IP for
+// the expired allocation. The owner of the expired pending allocation may still
+// reissue the allocation and be successful next time if the IP pool has now
+// enough capacity.
+func (p pendingAllocationsPerPool) removeExpiredEntries() {
+	now := p.clock()
+	for poolName, pool := range p.pools {
+		pool.removeExpiredEntries(p.logger, now, poolName)
+		if len(pool) == 0 {
+			delete(p.pools, poolName)
+		}
+	}
+}
+
+// pendingForPool returns how many IP allocations are pending for the given
+// pool and IP family
+func (p pendingAllocationsPerPool) pendingForPool(pool Pool, family Family) int {
+	return p.pools[pool].pendingForFamily(family)
+}
+
+// pendingAllocationsPerOwner tracks if an IP owner has a pending allocation
+// request for a particular IP family.
+// The IP family as the first key allows one to quickly determine how many
+// IP allocations are pending for a given IP family.
+type pendingAllocationsPerOwner map[Family]map[string]time.Time
+
+// startExpiration starts the expiration timer for a pending allocation
+func (p pendingAllocationsPerOwner) startExpirationAt(now time.Time, owner string, family Family) {
+	expires, ok := p[family]
+	if !ok {
+		expires = map[string]time.Time{}
+	}
+
+	expires[owner] = now.Add(pendingAllocationTTL)
+	p[family] = expires
+}
+
+// removeExpiration removes the expiration timer for a pending allocation, this
+// happens either because the timer expired, or the allocation was fulfilled
+func (p pendingAllocationsPerOwner) removeExpiration(owner string, family Family) {
+	delete(p[family], owner)
+	if len(p[family]) == 0 {
+		delete(p, family)
+	}
+}
+
+// removeExpiredEntries removes all pending allocation requests which have expired
+func (p pendingAllocationsPerOwner) removeExpiredEntries(logger *slog.Logger, now time.Time, pool Pool) {
+	for family, owners := range p {
+		for owner, expires := range owners {
+			if now.After(expires) {
+				p.removeExpiration(owner, family)
+				logger.Debug(
+					"Pending IP allocation has expired without being fulfilled",
+					logfields.Owner, owner,
+					logfields.Family, family,
+					logfields.PoolName, pool,
+				)
+			}
+		}
+	}
+}
+
+// pendingForPool returns how many IP allocations are pending for the given family
+func (p pendingAllocationsPerOwner) pendingForFamily(family Family) int {
+	return len(p[family])
+}
+
+type MultiPoolManagerParams struct {
+	Logger *slog.Logger
+
+	IPv4Enabled          bool
+	IPv6Enabled          bool
+	CiliumNodeUpdateRate time.Duration
+	PreAllocPools        map[string]string
+
+	Node     agentK8s.LocalCiliumNodeResource
+	CNClient cilium_v2.CiliumNodeInterface
+	JobGroup job.Group
+
+	DB                        *statedb.DB
+	PodIPPools                statedb.Table[podippool.LocalPodIPPool]
+	OnlyMasqueradeDefaultPool bool
+}
+
+type multiPoolManager struct {
+	mutex *lock.Mutex
+
+	ipv4Enabled bool
+	ipv6Enabled bool
+
+	preallocatedIPsPerPool preAllocatePerPool
+	pendingIPsPerPool      *pendingAllocationsPerPool
+
+	pools        map[Pool]*poolPair
+	poolsUpdated chan struct{}
+
+	node *ciliumv2.CiliumNode
+
+	jobGroup   job.Group
+	k8sUpdater job.Trigger
+	cnClient   cilium_v2.CiliumNodeInterface
+
+	localNodeUpdate   chan struct{}
+	localNodeUpdateFn func()
+
+	finishedRestore map[Family]bool
+	logger          *slog.Logger
+
+	db                        *statedb.DB
+	podIPPools                statedb.Table[podippool.LocalPodIPPool]
+	onlyMasqueradeDefaultPool bool
+}
+
+func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
+	preallocMap, err := parseMultiPoolPreAllocMap(p.PreAllocPools)
+	if err != nil {
+		logging.Fatal(p.Logger, fmt.Sprintf("Invalid %s flag value", option.IPAMMultiPoolPreAllocation), logfields.Error, err)
+	}
+
+	localNodeUpdated := make(chan struct{})
+	mgr := &multiPoolManager{
+		logger:                 p.Logger,
+		mutex:                  &lock.Mutex{},
+		ipv4Enabled:            p.IPv4Enabled,
+		ipv6Enabled:            p.IPv6Enabled,
+		preallocatedIPsPerPool: preallocMap,
+		pendingIPsPerPool:      newPendingAllocationsPerPool(p.Logger),
+		pools:                  map[Pool]*poolPair{},
+		poolsUpdated:           make(chan struct{}, 1),
+		node:                   nil,
+		jobGroup:               p.JobGroup,
+		k8sUpdater:             job.NewTrigger(job.WithDebounce(p.CiliumNodeUpdateRate)),
+		cnClient:               p.CNClient,
+		finishedRestore:        map[Family]bool{},
+		localNodeUpdate:        localNodeUpdated,
+		localNodeUpdateFn: sync.OnceFunc(func() {
+			close(localNodeUpdated)
+		}),
+		db:                        p.DB,
+		podIPPools:                p.PodIPPools,
+		onlyMasqueradeDefaultPool: p.OnlyMasqueradeDefaultPool,
+	}
+
+	mgr.jobGroup.Add(
+		job.OneShot(
+			"multi-pool-cilium-node-events-handler",
+			func(ctx context.Context, health cell.Health) error {
+				for ev := range p.Node.Events(ctx) {
+					switch ev.Kind {
+					case resource.Upsert:
+						mgr.ciliumNodeUpdated(ev.Object)
+					case resource.Delete:
+						mgr.logger.Debug(
+							"Local CiliumNode deleted. IPAM will continue on last seen version",
+							logfields.Node, ev.Object,
+						)
+					}
+					ev.Done(nil)
+				}
+				return nil
+			},
+		),
+		job.Timer(
+			"multi-pool-cilium-node-updater",
+			mgr.updateLocalNode,
+			refreshPoolInterval,
+			job.WithTrigger(mgr.k8sUpdater),
+		),
+	)
+
+	mgr.waitForAllPools()
+
+	return mgr
+}
+
+// waitForAllPools waits for all pools in preallocatedIPsPerPool to have IPs available.
+// This function blocks the IPAM constructor forever and periodically logs
+// that it is waiting for IPs to be assigned. This blocking behavior is
+// consistent with other IPAM modes.
+func (m *multiPoolManager) waitForAllPools() {
+	allPoolsReady := false
+	for !allPoolsReady {
+		allPoolsReady = true
+		for pool := range m.preallocatedIPsPerPool {
+			ctx, cancel := context.WithTimeout(context.Background(), waitForPoolTimeout)
+			if m.ipv4Enabled {
+				allPoolsReady = m.waitForPool(ctx, IPv4, pool) && allPoolsReady
+			}
+			if m.ipv6Enabled {
+				allPoolsReady = m.waitForPool(ctx, IPv6, pool) && allPoolsReady
+			}
+			cancel()
+		}
+	}
+}
+
+// waitForPool waits for the pool poolName to have at least one allocatable IP
+// available for the given IP family. This function is supposed to only be called
+// before any IPs are handed out, so hasAvailableIPs returns true so as long as
+// the local node has IPs assigned to it in the given pool.
+func (m *multiPoolManager) waitForPool(ctx context.Context, family Family, poolName Pool) (ready bool) {
+	for {
+		m.mutex.Lock()
+		poolReady := false
+		switch family {
+		case IPv4:
+			if p, ok := m.pools[poolName]; ok && p.v4 != nil && p.v4.hasAvailableIPs() {
+				poolReady = true
+			}
+		case IPv6:
+			if p, ok := m.pools[poolName]; ok && p.v6 != nil && p.v6.hasAvailableIPs() {
+				poolReady = true
+			}
+		}
+		m.mutex.Unlock()
+
+		// ensure the pool is present in stateDB for checking annotations at allocation time
+		txn := m.db.ReadTxn()
+		_, _, dbWatch, found := m.podIPPools.GetWatch(txn, podippool.ByName(string(poolName)))
+		if poolReady && found {
+			return true
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-m.poolsUpdated:
+			continue
+		case <-dbWatch:
+			continue
+		case <-time.After(5 * time.Second):
+			m.logger.Info(
+				"Waiting for podCIDR pool to become available",
+				logfields.PoolName, poolName,
+				logfields.Family, family,
+				logfields.HelpMessage, "Check if cilium-operator pod is running and does not have any warnings or error messages.",
+			)
+		}
+	}
+}
+
+func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for _, pool := range newNode.Spec.IPAM.Pools.Allocated {
+		m.upsertPoolLocked(Pool(pool.Pool), pool.CIDRs)
+	}
+
+	// m.node will only be nil the first time this callback is invoked
+	// Note: The job will only run after m.mutex is unlocked
+	if m.node == nil {
+		m.k8sUpdater.Trigger()
+	}
+
+	m.node = newNode
+}
+
+func (m *multiPoolManager) localNodeUpdated() <-chan struct{} {
+	return m.localNodeUpdate
+}
+
+// neededIPCeil rounds up numIPs to the next but one multiple of preAlloc.
+// Example for preAlloc=16:
+//
+//	numIP  0 -> 16
+//	numIP  1 -> 32
+//	numIP 15 -> 32
+//	numIP 16 -> 32
+//	numIP 17 -> 48
+//
+// This always ensures that there we always have a buffer of at least preAlloc
+// IPs.
+func neededIPCeil(numIP int, preAlloc int) int {
+	if preAlloc == 0 {
+		return numIP
+	}
+
+	quotient := numIP / preAlloc
+	rem := numIP % preAlloc
+	if rem > 0 {
+		return (quotient + 2) * preAlloc
+	}
+	return (quotient + 1) * preAlloc
+}
+
+// computeNeededIPsPerPoolLocked computes how many IPs we want to request from
+// the operator for each pool. The formula we use for each pool is basically
+//
+//	neededIPs = roundUp(inUseIPs + pendingIPs + preAllocIPs, preAllocIPs)
+//
+//	      inUseIPs      Number of IPs that are currently actively in use
+//	      pendingIPs    Number of IPs that have been requested, but not yet assigned
+//	      preAllocIPs   Minimum number of IPs that we want to pre-allocate as a buffer
+//
+// Rounded up to the next multiple of preAllocIPs.
+func (m *multiPoolManager) computeNeededIPsPerPoolLocked() map[Pool]types.IPAMPoolDemand {
+	demand := make(map[Pool]types.IPAMPoolDemand, len(m.pools))
+
+	// inUseIPs
+	for poolName, pool := range m.pools {
+		ipv4Addrs := 0
+		if p := pool.v4; p != nil {
+			ipv4Addrs = p.inUseIPCount()
+		}
+		ipv6Addrs := 0
+		if p := pool.v6; p != nil {
+			ipv6Addrs = p.inUseIPCount()
+		}
+
+		demand[poolName] = types.IPAMPoolDemand{
+			IPv4Addrs: ipv4Addrs,
+			IPv6Addrs: ipv6Addrs,
+		}
+	}
+
+	// + pendingIPs
+	for poolName, pending := range m.pendingIPsPerPool.pools {
+		ipv4Addrs := demand[poolName].IPv4Addrs + pending.pendingForFamily(IPv4)
+		ipv6Addrs := demand[poolName].IPv6Addrs + pending.pendingForFamily(IPv6)
+
+		demand[poolName] = types.IPAMPoolDemand{
+			IPv4Addrs: ipv4Addrs,
+			IPv6Addrs: ipv6Addrs,
+		}
+	}
+
+	// + preAllocIPs
+	for poolName, preAlloc := range m.preallocatedIPsPerPool {
+		ipv4Addrs := demand[poolName].IPv4Addrs
+		if m.ipv4Enabled {
+			ipv4Addrs = neededIPCeil(ipv4Addrs, preAlloc)
+		}
+		ipv6Addrs := demand[poolName].IPv6Addrs
+		if m.ipv6Enabled {
+			ipv6Addrs = neededIPCeil(ipv6Addrs, preAlloc)
+		}
+
+		demand[poolName] = types.IPAMPoolDemand{
+			IPv4Addrs: ipv4Addrs,
+			IPv6Addrs: ipv6Addrs,
+		}
+	}
+
+	return demand
+}
+
+func (m *multiPoolManager) restoreFinished(family Family) {
+	m.mutex.Lock()
+	m.finishedRestore[family] = true
+	m.mutex.Unlock()
+}
+
+func (m *multiPoolManager) isRestoreFinishedLocked(family Family) bool {
+	return m.finishedRestore[family]
+}
+
+func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
+	m.mutex.Lock()
+
+	if m.node == nil {
+		m.mutex.Unlock()
+		return nil
+	}
+
+	newNode := m.node.DeepCopy()
+	requested := []types.IPAMPoolRequest{}
+	allocated := []types.IPAMPoolAllocation{}
+
+	m.pendingIPsPerPool.removeExpiredEntries()
+	neededIPsPerPool := m.computeNeededIPsPerPoolLocked()
+	for poolName, needed := range neededIPsPerPool {
+		if needed.IPv4Addrs == 0 && needed.IPv6Addrs == 0 {
+			continue // no need to request "0" IPs
+		}
+
+		requested = append(requested, types.IPAMPoolRequest{
+			Pool:   poolName.String(),
+			Needed: needed,
+		})
+	}
+
+	// Write in-use pools to podCIDR. This removes any released pod CIDRs
+	for poolName, pool := range m.pools {
+		neededIPs := neededIPsPerPool[poolName]
+
+		cidrs := []types.IPAMCIDR{}
+		if v4Pool := pool.v4; v4Pool != nil {
+			if m.isRestoreFinishedLocked(IPv4) {
+				// releaseExcessCIDRsMultiPool interprets neededIPs as how many
+				// free addresses must remain after a CIDR is dropped.
+				// Therefore we subtract the number of in-use addresses from neededIPs.
+				freeNeeded4 := max(neededIPs.IPv4Addrs-v4Pool.inUseIPCount(), 0)
+				v4Pool.releaseExcessCIDRsMultiPool(freeNeeded4)
+			}
+			v4CIDRs := v4Pool.inUsePodCIDRs()
+
+			slices.Sort(v4CIDRs)
+			cidrs = append(cidrs, v4CIDRs...)
+		}
+		if v6Pool := pool.v6; v6Pool != nil {
+			if m.isRestoreFinishedLocked(IPv6) {
+				freeNeeded6 := max(neededIPs.IPv6Addrs-v6Pool.inUseIPCount(), 0)
+				v6Pool.releaseExcessCIDRsMultiPool(freeNeeded6)
+			}
+			v6CIDRs := v6Pool.inUsePodCIDRs()
+
+			slices.Sort(v6CIDRs)
+			cidrs = append(cidrs, v6CIDRs...)
+		}
+
+		// remove pool if we've released all CIDRs
+		if len(cidrs) == 0 {
+			delete(m.pools, poolName)
+			continue
+		}
+
+		allocated = append(allocated, types.IPAMPoolAllocation{
+			Pool:  poolName.String(),
+			CIDRs: cidrs,
+		})
+	}
+
+	sort.Slice(requested, func(i, j int) bool {
+		return requested[i].Pool < requested[j].Pool
+	})
+	sort.Slice(allocated, func(i, j int) bool {
+		return allocated[i].Pool < allocated[j].Pool
+	})
+	newNode.Spec.IPAM.Pools.Requested = requested
+	newNode.Spec.IPAM.Pools.Allocated = allocated
+
+	m.mutex.Unlock()
+
+	if !newNode.Spec.IPAM.DeepEqual(&m.node.Spec.IPAM) {
+		_, err := m.cnClient.Update(ctx, newNode, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update node spec: %w", err)
+		}
+	}
+
+	m.localNodeUpdateFn()
+
+	return nil
+}
+
+func (m *multiPoolManager) upsertPoolLocked(poolName Pool, podCIDRs []types.IPAMCIDR) {
+	pool, ok := m.pools[poolName]
+	if !ok {
+		pool = &poolPair{}
+		if m.ipv4Enabled {
+			pool.v4 = newPodCIDRPool(m.logger)
+		}
+		if m.ipv6Enabled {
+			pool.v6 = newPodCIDRPool(m.logger)
+		}
+	}
+
+	var ipv4PodCIDRs, ipv6PodCIDRs []string
+	for _, ipamPodCIDR := range podCIDRs {
+		podCIDR := string(ipamPodCIDR)
+		switch podCIDRFamily(podCIDR) {
+		case IPv4:
+			ipv4PodCIDRs = append(ipv4PodCIDRs, podCIDR)
+		case IPv6:
+			ipv6PodCIDRs = append(ipv6PodCIDRs, podCIDR)
+		}
+	}
+
+	if pool.v4 != nil {
+		pool.v4.updatePool(ipv4PodCIDRs)
+	}
+	if pool.v6 != nil {
+		pool.v6.updatePool(ipv6PodCIDRs)
+	}
+
+	m.pools[poolName] = pool
+
+	select {
+	case m.poolsUpdated <- struct{}{}:
+	default:
+	}
+}
+
+func (m *multiPoolManager) dump(family Family) (allocated map[Pool]map[string]string, status string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	allocated = map[Pool]map[string]string{}
+	for poolName, pool := range m.pools {
+		var p *podCIDRPool
+		switch family {
+		case IPv4:
+			p = pool.v4
+		case IPv6:
+			p = pool.v6
+		}
+		if p == nil {
+			return nil, fmt.Sprintf("family %q not supported", family)
+		}
+
+		ipToOwner, _, _, _, err := p.dump()
+		if err != nil {
+			return nil, fmt.Sprintf("error: %s", err)
+		}
+
+		if poolName == "" {
+			poolName = PoolDefault()
+		}
+
+		if _, ok := allocated[poolName]; !ok {
+			allocated[poolName] = map[string]string{}
+		}
+
+		maps.Copy(allocated[poolName], ipToOwner)
+	}
+
+	return allocated, fmt.Sprintf("%d IPAM pool(s) available", len(m.pools))
+}
+
+func (m *multiPoolManager) poolByFamilyLocked(poolName Pool, family Family) *podCIDRPool {
+	switch family {
+	case IPv4:
+		pair, ok := m.pools[poolName]
+		if ok {
+			return pair.v4
+		}
+	case IPv6:
+		pair, ok := m.pools[poolName]
+		if ok {
+			return pair.v6
+		}
+	}
+
+	return nil
+}
+
+func (m *multiPoolManager) allocateNext(owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	defer func() {
+		if syncUpstream {
+			m.k8sUpdater.Trigger()
+		}
+	}()
+
+	pool := m.poolByFamilyLocked(poolName, family)
+	if pool == nil {
+		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
+		return nil, &ErrPoolNotReadyYet{poolName: poolName, family: family}
+	}
+	skipMasq := false
+	// If the flag is set, skip masquerade for all non-default pools
+	if m.onlyMasqueradeDefaultPool && poolName != PoolDefault() {
+		skipMasq = true
+	} else {
+		// Lookup the IP pool from stateDB and check if it has the explicit annotations
+		txn := m.db.ReadTxn()
+		podIPPool, _, found := m.podIPPools.Get(txn, podippool.ByName(string(poolName)))
+		if !found {
+			m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
+			return nil, fmt.Errorf("IP pool '%s' not found in stateDB table", string(poolName))
+		}
+		if v, ok := podIPPool.Annotations[annotation.IPAMSkipMasquerade]; ok && v == "true" {
+			skipMasq = true
+		}
+	}
+
+	ip, err := pool.allocateNext()
+	if err != nil {
+		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
+		return nil, err
+	}
+
+	m.pendingIPsPerPool.markAsAllocated(poolName, owner, family)
+	return &AllocationResult{IP: ip, IPPoolName: poolName, SkipMasquerade: skipMasq}, nil
+}
+
+func (m *multiPoolManager) allocateIP(ip net.IP, owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	defer func() {
+		if syncUpstream {
+			m.k8sUpdater.Trigger()
+		}
+	}()
+
+	pool := m.poolByFamilyLocked(poolName, family)
+	if pool == nil {
+		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
+		return nil, &ErrPoolNotReadyYet{poolName: poolName, family: family, ip: ip}
+	}
+
+	err := pool.allocate(ip)
+	if err != nil {
+		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
+		return nil, err
+	}
+
+	m.pendingIPsPerPool.markAsAllocated(poolName, owner, family)
+	return &AllocationResult{IP: ip, IPPoolName: poolName}, nil
+}
+
+func (m *multiPoolManager) releaseIP(ip net.IP, poolName Pool, family Family, upstreamSync bool) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	pool := m.poolByFamilyLocked(poolName, family)
+	if pool == nil {
+		return fmt.Errorf("unable to release IP %s of unknown pool %q (family %s)", ip, poolName, family)
+	}
+
+	pool.release(ip)
+	if upstreamSync {
+		m.k8sUpdater.Trigger()
+	}
+	return nil
+}

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -359,7 +359,7 @@ func Test_MultiPoolManager(t *testing.T) {
 		allocatedMarsIPs = append(allocatedMarsIPs, ar.IP)
 	}
 	_, err = c.allocateNext("mars-pod-overflow", "mars", IPv4, false)
-	assert.ErrorContains(t, err, "all pod CIDR ranges are exhausted")
+	assert.ErrorContains(t, err, "all CIDR ranges are exhausted")
 
 	ipv4Dump, _ := c.dump(IPv4)
 	assert.Len(t, ipv4Dump, 2) // 2 pools: default + mars

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -126,7 +129,7 @@ func Test_MultiPoolManager(t *testing.T) {
 		Node:           fakeK8sCiliumNodeAPI,
 		Owner:          fakeOwner,
 		LocalNodeStore: fakeLocalNodeStore,
-		Clientset:      fakeK8sCiliumNodeAPI,
+		CNClient:       fakeK8sCiliumNodeAPI,
 		JobGroup:       jg,
 		DB:             db,
 		PodIPPools:     poolsTbl,
@@ -601,7 +604,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 		Node:           fakeK8sAPI,
 		Owner:          fakeOwner,
 		LocalNodeStore: fakeLocalNodeStore,
-		Clientset:      fakeK8sAPI,
+		CNClient:       fakeK8sAPI,
 		JobGroup:       jg,
 		DB:             db,
 		PodIPPools:     poolsTbl,
@@ -724,7 +727,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 		Node:           fakeK8sAPI,
 		Owner:          fakeOwner,
 		LocalNodeStore: fakeLocalNodeStore,
-		Clientset:      fakeK8sAPI,
+		CNClient:       fakeK8sAPI,
 		JobGroup:       jg,
 		DB:             db,
 		PodIPPools:     poolsTbl,
@@ -856,9 +859,37 @@ type fakeK8sCiliumNodeAPIResource struct {
 	onDeleteEvent func(err error)
 }
 
+func (k *fakeK8sCiliumNodeAPIResource) Create(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, opts v1.CreateOptions) (*ciliumv2.CiliumNode, error) {
+	panic("unimplemented")
+}
+
 func (f *fakeK8sCiliumNodeAPIResource) Update(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, _ metav1.UpdateOptions) (*ciliumv2.CiliumNode, error) {
 	err := f.updateNode(ciliumNode)
 	return ciliumNode, err
+}
+
+func (k *fakeK8sCiliumNodeAPIResource) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+	panic("unimplemented")
+}
+
+func (k *fakeK8sCiliumNodeAPIResource) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	panic("unimplemented")
+}
+
+func (k *fakeK8sCiliumNodeAPIResource) Get(ctx context.Context, name string, opts v1.GetOptions) (*ciliumv2.CiliumNode, error) {
+	panic("unimplemented")
+}
+
+func (k *fakeK8sCiliumNodeAPIResource) List(ctx context.Context, opts v1.ListOptions) (*ciliumv2.CiliumNodeList, error) {
+	panic("unimplemented")
+}
+
+func (k *fakeK8sCiliumNodeAPIResource) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+	panic("unimplemented")
+}
+
+func (k *fakeK8sCiliumNodeAPIResource) Patch(ctx context.Context, name string, pt k8sTypes.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *ciliumv2.CiliumNode, err error) {
+	panic("unimplemented")
 }
 
 func (f *fakeK8sCiliumNodeAPIResource) UpdateStatus(ctx context.Context, ciliumNode *ciliumv2.CiliumNode, _ metav1.UpdateOptions) (*ciliumv2.CiliumNode, error) {
@@ -1033,7 +1064,7 @@ func createSkipMasqTestManager(t *testing.T, db *statedb.DB, pools statedb.Table
 		Node:                      fakeK8sAPI,
 		Owner:                     fakeOwner,
 		LocalNodeStore:            fakeLocalNodeStore,
-		Clientset:                 fakeK8sAPI,
+		CNClient:                  fakeK8sAPI,
 		JobGroup:                  jg,
 		DB:                        db,
 		PodIPPools:                pools,

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -124,15 +124,18 @@ func Test_MultiPoolManager(t *testing.T) {
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
 	c := newMultiPoolManager(MultiPoolManagerParams{
-		Logger:         hivetest.Logger(t),
-		Conf:           fakeConfig,
-		Node:           fakeK8sCiliumNodeAPI,
-		Owner:          fakeOwner,
-		LocalNodeStore: fakeLocalNodeStore,
-		CNClient:       fakeK8sCiliumNodeAPI,
-		JobGroup:       jg,
-		DB:             db,
-		PodIPPools:     poolsTbl,
+		Logger:               hivetest.Logger(t),
+		IPv4Enabled:          fakeConfig.EnableIPv4,
+		IPv6Enabled:          fakeConfig.EnableIPv6,
+		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
+		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
+		Node:                 fakeK8sCiliumNodeAPI,
+		Owner:                fakeOwner,
+		LocalNodeStore:       fakeLocalNodeStore,
+		CNClient:             fakeK8sCiliumNodeAPI,
+		JobGroup:             jg,
+		DB:                   db,
+		PodIPPools:           poolsTbl,
 	})
 
 	// assert initial CiliumNode upsert has been sent to the events chan
@@ -599,15 +602,18 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
 	mgr := newMultiPoolManager(MultiPoolManagerParams{
-		Logger:         logger,
-		Conf:           fakeConfig,
-		Node:           fakeK8sAPI,
-		Owner:          fakeOwner,
-		LocalNodeStore: fakeLocalNodeStore,
-		CNClient:       fakeK8sAPI,
-		JobGroup:       jg,
-		DB:             db,
-		PodIPPools:     poolsTbl,
+		Logger:               logger,
+		IPv4Enabled:          fakeConfig.EnableIPv4,
+		IPv6Enabled:          fakeConfig.EnableIPv6,
+		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
+		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
+		Node:                 fakeK8sAPI,
+		Owner:                fakeOwner,
+		LocalNodeStore:       fakeLocalNodeStore,
+		CNClient:             fakeK8sAPI,
+		JobGroup:             jg,
+		DB:                   db,
+		PodIPPools:           poolsTbl,
 	})
 
 	// Trigger controller immediately when requested by the IPAM trigger
@@ -722,15 +728,18 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
 	mgr := newMultiPoolManager(MultiPoolManagerParams{
-		Logger:         logger,
-		Conf:           fakeConfig,
-		Node:           fakeK8sAPI,
-		Owner:          fakeOwner,
-		LocalNodeStore: fakeLocalNodeStore,
-		CNClient:       fakeK8sAPI,
-		JobGroup:       jg,
-		DB:             db,
-		PodIPPools:     poolsTbl,
+		Logger:               logger,
+		IPv4Enabled:          fakeConfig.EnableIPv4,
+		IPv6Enabled:          fakeConfig.EnableIPv6,
+		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
+		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
+		Node:                 fakeK8sAPI,
+		Owner:                fakeOwner,
+		LocalNodeStore:       fakeLocalNodeStore,
+		CNClient:             fakeK8sAPI,
+		JobGroup:             jg,
+		DB:                   db,
+		PodIPPools:           poolsTbl,
 	})
 
 	// Trigger controller immediately when requested
@@ -1060,7 +1069,10 @@ func createSkipMasqTestManager(t *testing.T, db *statedb.DB, pools statedb.Table
 
 	mgr := newMultiPoolManager(MultiPoolManagerParams{
 		Logger:                    hivetest.Logger(t),
-		Conf:                      fakeConfig,
+		IPv4Enabled:               fakeConfig.EnableIPv4,
+		IPv6Enabled:               fakeConfig.EnableIPv6,
+		CiliumNodeUpdateRate:      fakeConfig.IPAMCiliumNodeUpdateRate,
+		PreAllocPools:             fakeConfig.IPAMMultiPoolPreAllocation,
 		Node:                      fakeK8sAPI,
 		Owner:                     fakeOwner,
 		LocalNodeStore:            fakeLocalNodeStore,

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -118,12 +118,15 @@ func Test_MultiPoolManager(t *testing.T) {
 	assert.NoError(t, h.Start(tlog, t.Context()))
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
+	preallocMap, err := ParseMultiPoolPreAllocMap(fakeConfig.IPAMMultiPoolPreAllocation)
+	assert.NoError(t, err)
+
 	c := newMultiPoolManager(MultiPoolManagerParams{
 		Logger:               hivetest.Logger(t),
 		IPv4Enabled:          fakeConfig.EnableIPv4,
 		IPv6Enabled:          fakeConfig.EnableIPv6,
 		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
-		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
+		PreallocMap:          preallocMap,
 		Node:                 fakeK8sCiliumNodeAPI,
 		CNClient:             fakeK8sCiliumNodeAPI,
 		JobGroup:             jg,
@@ -528,12 +531,15 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 	assert.NoError(t, h.Start(tlog, t.Context()))
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
+	preallocMap, err := ParseMultiPoolPreAllocMap(fakeConfig.IPAMMultiPoolPreAllocation)
+	assert.NoError(t, err)
+
 	mgr := newMultiPoolManager(MultiPoolManagerParams{
 		Logger:               logger,
 		IPv4Enabled:          fakeConfig.EnableIPv4,
 		IPv6Enabled:          fakeConfig.EnableIPv6,
 		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
-		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
+		PreallocMap:          preallocMap,
 		Node:                 fakeK8sAPI,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
@@ -650,12 +656,15 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 	assert.NoError(t, h.Start(tlog, t.Context()))
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
+	preallocMap, err := ParseMultiPoolPreAllocMap(fakeConfig.IPAMMultiPoolPreAllocation)
+	assert.NoError(t, err)
+
 	mgr := newMultiPoolManager(MultiPoolManagerParams{
 		Logger:               logger,
 		IPv4Enabled:          fakeConfig.EnableIPv4,
 		IPv6Enabled:          fakeConfig.EnableIPv6,
 		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
-		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
+		PreallocMap:          preallocMap,
 		Node:                 fakeK8sAPI,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
@@ -1160,12 +1169,15 @@ func createSkipMasqTestManager(t *testing.T, db *statedb.DB, pools statedb.Table
 	assert.NoError(t, h.Start(tlog, t.Context()))
 	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
+	preallocMap, err := ParseMultiPoolPreAllocMap(fakeConfig.IPAMMultiPoolPreAllocation)
+	assert.NoError(t, err)
+
 	mgr := newMultiPoolManager(MultiPoolManagerParams{
 		Logger:                    hivetest.Logger(t),
 		IPv4Enabled:               fakeConfig.EnableIPv4,
 		IPv6Enabled:               fakeConfig.EnableIPv6,
 		CiliumNodeUpdateRate:      fakeConfig.IPAMCiliumNodeUpdateRate,
-		PreAllocPools:             fakeConfig.IPAMMultiPoolPreAllocation,
+		PreallocMap:               preallocMap,
 		Node:                      fakeK8sAPI,
 		CNClient:                  fakeK8sAPI,
 		JobGroup:                  jg,

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -1075,5 +1075,7 @@ func createSkipMasqTestManager(t *testing.T, db *statedb.DB, pools statedb.Table
 		OnlyMasqueradeDefaultPool: onlyMasqDefault,
 	})
 
+	waitForLocalNodeUpdate(tlog, mgr)
+
 	return mgr
 }

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -123,6 +123,9 @@ func Test_MultiPoolManager(t *testing.T) {
 		Node:                 fakeK8sCiliumNodeAPI,
 		CNClient:             fakeK8sCiliumNodeAPI,
 		JobGroup:             jg,
+		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
+			return &cn.Spec.IPAM.Pools
+		},
 	})
 
 	// assert initial CiliumNode upsert has been sent to the events chan
@@ -529,6 +532,9 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 		Node:                 fakeK8sAPI,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
+		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
+			return &cn.Spec.IPAM.Pools
+		},
 	})
 
 	// Trigger controller immediately when requested by the IPAM trigger
@@ -647,6 +653,9 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 		Node:                 fakeK8sAPI,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
+		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
+			return &cn.Spec.IPAM.Pools
+		},
 	})
 
 	// Trigger controller immediately when requested

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -58,7 +58,6 @@ func Test_MultiPoolManager(t *testing.T) {
 		"default": "16",
 		"mars":    "8",
 	}
-	fakeOwner := &ownerMock{}
 	fakeLocalNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	events := make(chan string, 1)
 	cnEvents := make(chan resource.Event[*ciliumv2.CiliumNode])
@@ -130,7 +129,6 @@ func Test_MultiPoolManager(t *testing.T) {
 		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
 		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
 		Node:                 fakeK8sCiliumNodeAPI,
-		Owner:                fakeOwner,
 		LocalNodeStore:       fakeLocalNodeStore,
 		CNClient:             fakeK8sCiliumNodeAPI,
 		JobGroup:             jg,
@@ -552,7 +550,6 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 	fakeConfig := testConfiguration
 	// disable pre-allocation
 	fakeConfig.IPAMMultiPoolPreAllocation = map[string]string{}
-	fakeOwner := &ownerMock{}
 	fakeLocalNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	events := make(chan string, 2)
 	cnEvents := make(chan resource.Event[*ciliumv2.CiliumNode])
@@ -608,7 +605,6 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
 		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
 		Node:                 fakeK8sAPI,
-		Owner:                fakeOwner,
 		LocalNodeStore:       fakeLocalNodeStore,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
@@ -674,7 +670,6 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 		"default": "1",
 	}
 
-	fakeOwner := &ownerMock{}
 	fakeLocalNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	events := make(chan string, 2)
 	cnEvents := make(chan resource.Event[*ciliumv2.CiliumNode])
@@ -734,7 +729,6 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
 		PreAllocPools:        fakeConfig.IPAMMultiPoolPreAllocation,
 		Node:                 fakeK8sAPI,
-		Owner:                fakeOwner,
 		LocalNodeStore:       fakeLocalNodeStore,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
@@ -1030,7 +1024,6 @@ func createSkipMasqTestManager(t *testing.T, db *statedb.DB, pools statedb.Table
 
 	fakeConfig := testConfiguration
 	fakeConfig.IPAMMultiPoolPreAllocation = map[string]string{}
-	fakeOwner := &ownerMock{}
 	fakeLocalNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	cnEvents := make(chan resource.Event[*ciliumv2.CiliumNode])
 	fakeK8sAPI := &fakeK8sCiliumNodeAPIResource{
@@ -1074,7 +1067,6 @@ func createSkipMasqTestManager(t *testing.T, db *statedb.DB, pools statedb.Table
 		CiliumNodeUpdateRate:      fakeConfig.IPAMCiliumNodeUpdateRate,
 		PreAllocPools:             fakeConfig.IPAMMultiPoolPreAllocation,
 		Node:                      fakeK8sAPI,
-		Owner:                     fakeOwner,
 		LocalNodeStore:            fakeLocalNodeStore,
 		CNClient:                  fakeK8sAPI,
 		JobGroup:                  jg,

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -21,19 +21,19 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// A podCIDRPool manages the allocation of IPs in multiple pod CIDRs.
-// It maintains one IP allocator for each pod CIDR in the pool.
-// Unused pod CIDRs which have been marked as released, but not yet deleted
+// A cidrPool manages the allocation of IPs in multiple CIDRs.
+// It maintains one IP allocator for each CIDR in the pool.
+// Unused CIDRs which have been marked as released, but not yet deleted
 // from the local CiliumNode CRD by the operator are put into the released set.
-// Once the operator removes a released pod CIDR from the CiliumNode CRD spec,
+// Once the operator removes a released CIDR from the CiliumNode CRD spec,
 // it is also deleted from the release set.
-// Pod CIDRs which have been erroneously deleted from the CiliumNode CRD spec
+// CIDRs which have been erroneously deleted from the CiliumNode CRD spec
 // (either by a buggy operator or by manual/human changes CRD) are marked in
-// the removed map. If IP addresses have been allocated from such a pod CIDR,
+// the removed map. If IP addresses have been allocated from such a CIDR,
 // its allocator is kept around. But no new IPs will be allocated from this
-// pod CIDR. By keeping removed CIDRs in the CiliumNode CRD status, we indicate
-// to the operator that we would like to re-gain ownership over that pod CIDR.
-type podCIDRPool struct {
+// CIDR. By keeping removed CIDRs in the CiliumNode CRD status, we indicate
+// to the operator that we would like to re-gain ownership over that CIDR.
+type cidrPool struct {
 	logger       *slog.Logger
 	mutex        lock.Mutex
 	ipAllocators []*ipallocator.Range
@@ -41,16 +41,16 @@ type podCIDRPool struct {
 	removed      map[string]struct{} // key is a CIDR string, e.g. 10.20.30.0/24
 }
 
-// newPodCIDRPool creates a new pod CIDR pool.
-func newPodCIDRPool(logger *slog.Logger) *podCIDRPool {
-	return &podCIDRPool{
+// newCIDRPool creates a new CIDR pool.
+func newCIDRPool(logger *slog.Logger) *cidrPool {
+	return &cidrPool{
 		logger:   logger,
 		released: map[string]struct{}{},
 		removed:  map[string]struct{}{},
 	}
 }
 
-func (p *podCIDRPool) allocate(ip net.IP) error {
+func (p *cidrPool) allocate(ip net.IP) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -61,14 +61,14 @@ func (p *podCIDRPool) allocate(ip net.IP) error {
 		}
 	}
 
-	return fmt.Errorf("IP %s not in range of any pod CIDR", ip)
+	return fmt.Errorf("IP %s not in range of any CIDR", ip)
 }
 
-func (p *podCIDRPool) allocateNext() (net.IP, error) {
+func (p *cidrPool) allocateNext() (net.IP, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	// When allocating a random IP, we try the pod CIDRs in the order they are
+	// When allocating a random IP, we try the CIDRs in the order they are
 	// listed in the CRD. This avoids internal fragmentation.
 	for _, ipAllocator := range p.ipAllocators {
 		cidrNet := ipAllocator.CIDR()
@@ -82,10 +82,10 @@ func (p *podCIDRPool) allocateNext() (net.IP, error) {
 		return ipAllocator.AllocateNext()
 	}
 
-	return nil, errors.New("all pod CIDR ranges are exhausted")
+	return nil, errors.New("all CIDR ranges are exhausted")
 }
 
-func (p *podCIDRPool) release(ip net.IP) {
+func (p *cidrPool) release(ip net.IP) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -98,7 +98,7 @@ func (p *podCIDRPool) release(ip net.IP) {
 	}
 }
 
-func (p *podCIDRPool) hasAvailableIPs() bool {
+func (p *cidrPool) hasAvailableIPs() bool {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -116,7 +116,7 @@ func (p *podCIDRPool) hasAvailableIPs() bool {
 	return false
 }
 
-func (p *podCIDRPool) inUseIPCount() (count int) {
+func (p *cidrPool) inUseIPCount() (count int) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -126,22 +126,22 @@ func (p *podCIDRPool) inUseIPCount() (count int) {
 	return count
 }
 
-func (p *podCIDRPool) inUsePodCIDRs() []types.IPAMCIDR {
+func (p *cidrPool) inUseCIDRs() []types.IPAMCIDR {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	return p.inUsePodCIDRsLocked()
+	return p.inUseCIDRsLocked()
 }
 
-func (p *podCIDRPool) inUsePodCIDRsLocked() []types.IPAMCIDR {
-	podCIDRs := make([]types.IPAMCIDR, 0, len(p.ipAllocators))
+func (p *cidrPool) inUseCIDRsLocked() []types.IPAMCIDR {
+	CIDRs := make([]types.IPAMCIDR, 0, len(p.ipAllocators))
 	for _, ipAllocator := range p.ipAllocators {
 		ipnet := ipAllocator.CIDR()
-		podCIDRs = append(podCIDRs, types.IPAMCIDR(ipnet.String()))
+		CIDRs = append(CIDRs, types.IPAMCIDR(ipnet.String()))
 	}
-	return podCIDRs
+	return CIDRs
 }
 
-func (p *podCIDRPool) dump() (ipToOwner map[string]string, usedIPs, freeIPs, numPodCIDRs int, err error) {
+func (p *cidrPool) dump() (ipToOwner map[string]string, usedIPs, freeIPs, numCIDRs int, err error) {
 	// TODO(gandro): Use the Snapshot interface to avoid locking during dump
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -158,12 +158,12 @@ func (p *podCIDRPool) dump() (ipToOwner map[string]string, usedIPs, freeIPs, num
 			ipToOwner[ip.String()] = ""
 		})
 	}
-	numPodCIDRs = len(p.ipAllocators)
+	numCIDRs = len(p.ipAllocators)
 
 	return
 }
 
-func (p *podCIDRPool) capacity() (freeIPs int) {
+func (p *cidrPool) capacity() (freeIPs int) {
 	// TODO(gandro): Use the Snapshot interface to avoid locking during dump
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -180,7 +180,7 @@ func (p *podCIDRPool) capacity() (freeIPs int) {
 }
 
 // releaseExcessCIDRsMultiPool implements the logic for multi-pool IPAM
-func (p *podCIDRPool) releaseExcessCIDRsMultiPool(neededIPs int) {
+func (p *cidrPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -189,21 +189,21 @@ func (p *podCIDRPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 		totalFree += ipAllocator.Free()
 	}
 
-	// Iterate over pod CIDRs in reverse order, so we prioritize releasing
-	// later pod CIDRs.
+	// Iterate over CIDRs in reverse order, so we prioritize releasing
+	// later CIDRs.
 	retainedAllocators := []*ipallocator.Range{}
 	for i := len(p.ipAllocators) - 1; i >= 0; i-- {
 		ipAllocator := p.ipAllocators[i]
 		cidrNet := ipAllocator.CIDR()
 		cidrStr := cidrNet.String()
 
-		// If the pod CIDR is not used and releasing it would
+		// If the CIDR is not used and releasing it would
 		// not take us below the release threshold, then release it immediately
 		free := ipAllocator.Free()
 		if ipAllocator.Used() == 0 && totalFree-free >= neededIPs {
 			p.released[cidrStr] = struct{}{}
 			totalFree -= free
-			p.logger.Debug("releasing pod CIDR", logfields.CIDR, cidrStr)
+			p.logger.Debug("releasing CIDR", logfields.CIDR, cidrStr)
 		} else {
 			retainedAllocators = append(retainedAllocators, ipAllocator)
 		}
@@ -212,35 +212,35 @@ func (p *podCIDRPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 	p.ipAllocators = retainedAllocators
 }
 
-func (p *podCIDRPool) updatePool(podCIDRs []string) {
+func (p *cidrPool) updatePool(CIDRs []string) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	if option.Config.Debug {
 		p.logger.Debug(
 			"Updating IPAM pool",
-			logfields.NewCIDR, podCIDRs,
-			logfields.OldCIDR, p.inUsePodCIDRsLocked(),
+			logfields.NewCIDR, CIDRs,
+			logfields.OldCIDR, p.inUseCIDRsLocked(),
 		)
 	}
 
-	// Parse the pod CIDRs, ignoring invalid CIDRs, and de-duplicating them.
-	cidrNets := make([]*net.IPNet, 0, len(podCIDRs))
-	cidrStrSet := make(map[string]struct{}, len(podCIDRs))
-	for _, podCIDR := range podCIDRs {
-		_, cidr, err := net.ParseCIDR(podCIDR)
+	// Parse the CIDRs, ignoring invalid CIDRs, and de-duplicating them.
+	cidrNets := make([]*net.IPNet, 0, len(CIDRs))
+	cidrStrSet := make(map[string]struct{}, len(CIDRs))
+	for _, cidr := range CIDRs {
+		_, cidr, err := net.ParseCIDR(cidr)
 		if err != nil {
 			p.logger.Error(
-				"ignoring invalid pod CIDR",
+				"ignoring invalid CIDR",
 				logfields.Error, err,
-				logfields.CIDR, podCIDRs,
+				logfields.CIDR, CIDRs,
 			)
 			continue
 		}
 		if _, ok := cidrStrSet[cidr.String()]; ok {
 			p.logger.Error(
-				"ignoring duplicate pod CIDR",
-				logfields.CIDR, podCIDRs,
+				"ignoring duplicate CIDR",
+				logfields.CIDR, CIDRs,
 			)
 			continue
 		}
@@ -248,11 +248,11 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 		cidrStrSet[cidr.String()] = struct{}{}
 	}
 
-	// Forget any released pod CIDRs no longer present in the CRD.
+	// Forget any released CIDRs no longer present in the CRD.
 	for cidrStr := range p.released {
 		if _, ok := cidrStrSet[cidrStr]; !ok {
 			p.logger.Debug(
-				"removing released pod CIDR",
+				"removing released CIDR",
 				logfields.CIDR, cidrStr,
 			)
 			delete(p.released, cidrStr)
@@ -261,7 +261,7 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 		if option.Config.EnableUnreachableRoutes {
 			if err := cleanupUnreachableRoutes(cidrStr); err != nil {
 				p.logger.Warn(
-					"failed to remove unreachable routes for pod cidr",
+					"failed to remove unreachable routes for cidr",
 					logfields.Error, err,
 					logfields.CIDR, cidrStr,
 				)
@@ -270,9 +270,9 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 	}
 
 	// newIPAllocators is the new slice of IP allocators.
-	newIPAllocators := make([]*ipallocator.Range, 0, len(podCIDRs))
+	newIPAllocators := make([]*ipallocator.Range, 0, len(CIDRs))
 
-	// addedCIDRs is the set of pod CIDRs that have a corresponding allocator
+	// addedCIDRs is the set of CIDRs that have a corresponding allocator
 	existingAllocators := make(map[string]struct{}, len(p.ipAllocators))
 
 	// Add existing IP allocators to newIPAllocators in order.
@@ -284,7 +284,7 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 				continue
 			}
 			p.logger.Error(
-				"in-use pod CIDR was removed from spec",
+				"in-use CIDR was removed from spec",
 				logfields.CIDR, cidrStr,
 			)
 			p.removed[cidrStr] = struct{}{}
@@ -302,14 +302,14 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 		ipAllocator := ipallocator.NewCIDRRange(cidrNet)
 		if ipAllocator.Free() == 0 {
 			p.logger.Error(
-				"skipping too-small pod CIDR",
+				"skipping too-small CIDR",
 				logfields.CIDR, cidrNet,
 			)
 			p.released[cidrNet.String()] = struct{}{}
 			continue
 		}
 		p.logger.Debug(
-			"created new pod CIDR allocator",
+			"created new CIDR allocator",
 			logfields.CIDR, cidrStr,
 		)
 		newIPAllocators = append(newIPAllocators, ipAllocator)
@@ -317,14 +317,14 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 	}
 
 	if len(p.ipAllocators) > 0 && len(newIPAllocators) == 0 {
-		p.logger.Warn("Removed last pod CIDR allocator")
+		p.logger.Warn("Removed last CIDR allocator")
 	}
 
 	p.ipAllocators = newIPAllocators
 }
 
-func podCIDRFamily(podCIDR string) Family {
-	if strings.Contains(podCIDR, ":") {
+func cidrFamily(cidr string) Family {
+	if strings.Contains(cidr, ":") {
 		return IPv6
 	}
 	return IPv4
@@ -337,22 +337,22 @@ func containsCIDR(outer, inner *net.IPNet) bool {
 	return outerMask <= innerMask && outer.Contains(inner.IP)
 }
 
-// cleanupUnreachableRoutes remove all unreachable routes for the given pod CIDR.
+// cleanupUnreachableRoutes remove all unreachable routes for the given CIDR.
 // This is only needed if EnableUnreachableRoutes has been set.
-func cleanupUnreachableRoutes(podCIDR string) error {
-	_, removedCIDR, err := net.ParseCIDR(podCIDR)
+func cleanupUnreachableRoutes(cidr string) error {
+	_, removedCIDR, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return err
 	}
 
 	var family int
-	switch podCIDRFamily(podCIDR) {
+	switch cidrFamily(cidr) {
 	case IPv4:
 		family = netlink.FAMILY_V4
 	case IPv6:
 		family = netlink.FAMILY_V6
 	default:
-		return errors.New("unknown pod cidr family")
+		return errors.New("unknown cidr family")
 	}
 
 	routes, err := safenetlink.RouteListFiltered(family, &netlink.Route{

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
@@ -130,6 +131,8 @@ type IPAM struct {
 	nodeDiscovery  Owner
 	sysctl         sysctl.Sysctl
 	ipMasqAgent    *ipmasq.IPMasqAgent
+
+	jg job.Group
 
 	db         *statedb.DB
 	podIPPools statedb.Table[podippool.LocalPodIPPool]

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -535,6 +535,13 @@ func (n *CiliumNode) InstanceID() (instanceID string) {
 	return
 }
 
+// PoolsFromResourceFunc is the type of a function that returns the pool
+// specification in the CiliumNode that should be used by the multi pool
+// manager instance.
+// For multi pool pod IPAM this means referencing the .Spec.IPAM.Pools field
+// in the CiliumNode.
+type PoolsFromResourceFunc func(*CiliumNode) *ipamTypes.IPAMPoolSpec
+
 func (n NodeAddress) ToString() string {
 	return n.IP
 }


### PR DESCRIPTION
[Multi-pool IPAM](https://docs.cilium.io/en/latest/network/concepts/ipam/multi-pool/) has been proposed as the default IPAM mode to allocate IP addresses to [DRA resources](https://github.com/cilium/design-cfps/pull/85/changes#diff-d7847da6e71b01e3ca0e845e7f46483c7b7ffc376792e06867214d9d5e433cc9R344-R356) in the upcoming [Cilium Network Driver](https://github.com/cilium/design-cfps/pull/85).
In the context of the Network Driver, the core logic of the multi-pool mode (i.e: the ability to assign and release addresses from specific pools on demand) will be kept unchanged and reused through an additional instance of the multi-pool manager in the Driver. From the point of view of the codebase, this allows to have a single package that will be included in both pod IPAM and DRA resources IPAM. An example can be seen in this [branch](https://github.com/pippolo84/cilium/tree/feature/dra-driver-ipam-with-restore), where parts of the multi-pool IPAM code is duplicated and adapted to support DRA resources IPAM.

To achieve this goal, this PR aims to improve the multi-pool reusability on the agent side, moving all the parts specific to pod IPAM in the `Allocator` type and leaving the manager implementation as generic as possible. Specifically:

- remove direct dependency from the daemon configuration
- extract the parts related to the local CiliumNode update specifically tied to pod IPAM

Since we are at it, the manager is also modernized using hive-provided jobs instead of controllers.

The PR does not intend to change anything regarding the current behavior of multi pool IPAM.

**Note to reviewers**: please review each commit individually

Related: https://github.com/cilium/cilium/pull/43937