### PR TITLE
[CFP-39876]: Add namespace filtering conditions to ServiceImport controller

### DIFF
--- a/pkg/clustermesh/mcsapi/cell.go
+++ b/pkg/clustermesh/mcsapi/cell.go
@@ -18,6 +18,7 @@ import (
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	mcsapitypes "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
+	cmnamespace "github.com/cilium/cilium/pkg/clustermesh/namespace"
 	"github.com/cilium/cilium/pkg/clustermesh/operator"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s/apis"
@@ -60,6 +61,8 @@ type mcsAPIParams struct {
 	Logger          *slog.Logger
 	JobGroup        job.Group
 	MetricsRegistry *metrics.Registry
+
+	NamespaceConfig cmnamespace.Config
 }
 
 var requiredGVK = []schema.GroupVersionKind{
@@ -123,7 +126,7 @@ func registerMCSAPIController(params mcsAPIParams) error {
 		return err
 	}
 
-	if err := newMCSAPIServiceReconciler(params.CtrlRuntimeManager, params.Logger).SetupWithManager(params.CtrlRuntimeManager); err != nil {
+	if err := newMCSAPIServiceReconciler(params.CtrlRuntimeManager, params.Logger, params.NamespaceConfig).SetupWithManager(params.CtrlRuntimeManager); err != nil {
 		return fmt.Errorf("Failed to register MCSAPIServiceReconciler: %w", err)
 	}
 
@@ -142,6 +145,7 @@ func registerMCSAPIController(params mcsAPIParams) error {
 		params.CtrlRuntimeManager, params.Logger, params.ClusterInfo.Name,
 		params.ClusterMesh.GlobalServiceExports(), remoteClusterServiceSource,
 		params.AgentConfig.EnableIPv4, params.AgentConfig.EnableIPv6,
+		params.NamespaceConfig,
 	)
 
 	params.JobGroup.Add(job.OneShot("mcsapi-main", func(ctx context.Context, health cell.Health) error {

--- a/pkg/clustermesh/namespace/namespace.go
+++ b/pkg/clustermesh/namespace/namespace.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cilium/hive/cell"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -87,4 +88,17 @@ func (m *manager) IsGlobalNamespaceByName(ns string) (bool, error) {
 		return false, fmt.Errorf("namespace %s does not exist in store", ns)
 	}
 	return m.IsGlobalNamespaceByObject(obj), nil
+}
+
+// IsGlobalNamespace determines whether the given namespace should be treated as a global
+// namespace based on its annotations and the provided default value.
+func IsGlobalNamespace(ns *corev1.Namespace, globalByDefault bool) bool {
+	if ns == nil {
+		return false
+	}
+	annotations := ns.GetAnnotations()
+	if value, ok := annotations[annotation.GlobalNamespace]; ok {
+		return strings.ToLower(value) == "true"
+	}
+	return globalByDefault
 }


### PR DESCRIPTION
## Summary

Add namespace global status checking to the MCS-API ServiceImport controller. This implements the MCS-API portion of the ClusterMesh global namespace filtering feature as described in [CFP-39876](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-39876-clustermesh-filtered-export.md#mcs-support).


Follow-up of:
-  #42905
- #43385

### Changes

- Set `Invalid` condition on ServiceExport when namespace is not global
- Set `NamespaceNotGlobal` condition on ServiceImport when namespace is not global  
- Service controller directly checks namespace global status and skips/deletes derived Service for non-global namespaces"

And add pkg/clustermesh/mcsapi/service_controller.go and pkg/clustermesh/mcsapi/service_controller_test.go to the list of modified files.

### CFP Requirements Addressed

Per the CFP MCS Support section:

1. **ServiceExport**: Reports a Condition signaling the namespace is local and service is not exported
2. **ServiceImport**: Still created but reports a Condition signaling service cannot be imported
3. **Derived Service**: Not created (and existing ones deleted) for non-global namespaces

### Files Changed

- `pkg/clustermesh/mcsapi/cell.go` - Add namespace manager dependency
- `pkg/clustermesh/mcsapi/serviceimport_controller.go` - Add namespace filtering logic and conditions
- `pkg/clustermesh/mcsapi/serviceimport_controller_test.go` - Add tests for non-global namespace handling
- `pkg/clustermesh/mcsapi/service_controller.go` – namespace filtering in derived service controller
- `pkg/clustermesh/mcsapi/service_controller_test.go` – tests for non-global namespace handling

## Test plan

- [x] Unit tests pass for ServiceImport controller with non-global namespace
- [ ] Integration tests with actual cluster