### PR TITLE
kpr: Remove redundant host routing fallback logic

### DIFF
--- a/pkg/kpr/initializer/kube_proxy_replacement.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement.go
@@ -43,10 +43,6 @@ type kprInitializer struct {
 }
 
 func (r *kprInitializer) InitKubeProxyReplacementOptions() error {
-	if !r.kprCfg.KubeProxyReplacement {
-		option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting = true
-	}
-
 	if !option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting {
 		msg := ""
 		switch {


### PR DESCRIPTION
when `enable-host-legacy-routing` is set to `false` through the flag and kpr is disabled. we quietly set the host networking as legacy and make the troubleshooting diffcult. This pr will have extra log showing users `enable-host-legacy-routing` has been enabled when kpr is disabled.

Here is the my output when I set `enable-host-legacy-routing` to `false` and found that `Routing Host: Legacy`. I use the legacy as keyword and can't find any logs.

```
(⎈|kind-kind:N/A)~/work/test/gke_lrp cilium_agent_log | grep legacy
time=2026-01-27T20:31:03.28708293Z level=info msg="  --enable-bgp-legacy-origin-attribute='false'"
time=2026-01-27T20:31:03.28718631Z level=info msg="  --enable-host-legacy-routing='false'"
time=2026-01-27T20:30:24.269021211Z level=info msg="  --enable-bgp-legacy-origin-attribute='false'"
time=2026-01-27T20:30:24.269214154Z level=info msg="  --enable-host-legacy-routing='false'"
time=2026-01-27T20:30:44.966076873Z level=info msg="  --enable-bgp-legacy-origin-attribute='false'"
time=2026-01-27T20:30:44.966333319Z level=info msg="  --enable-host-legacy-routing='false'"
(⎈|kind-kind:N/A)~/work/test/gke_lrp k exec -it ds/cilium -n kube-system -- bash


root@kind-worker2:/home/cilium#
root@kind-worker2:/home/cilium# cilium status
KVStore:                     Disabled
Kubernetes:                  Ok         1.34 (v1.34.0) [linux/amd64]
Kubernetes APIs:             ["cilium/v2::CiliumCIDRGroup", "cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumEndpoint", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "core/v1::Pods", "networking.k8s.io/v1::NetworkPolicy"]
KubeProxyReplacement:        False
Host firewall:               Disabled
SRv6:                        Disabled
CNI Chaining:                none
CNI Config file:             successfully wrote CNI configuration file to /host/etc/cni/net.d/05-cilium.conflist
Cilium:                      Ok   1.20.0-dev (v1.20.0-dev-0c915b38)
NodeMonitor:                 Listening for events on 12 CPUs with 64x4096 of shared memory
Cilium health daemon:        Ok
IPAM:                        IPv4: 2/254 allocated from 10.244.2.0/24,
IPv4 BIG TCP:                Disabled
IPv6 BIG TCP:                Disabled
BandwidthManager:            Disabled
Routing:                     Network: Tunnel [vxlan]   Host: Legacy
Attach Mode:                 TCX
Device Mode:                 veth
Masquerading:                IPTables [IPv4: Enabled, IPv6: Disabled]
Controller Status:           14/14 healthy
Proxy Status:                OK, ip 10.244.2.204, 0 redirects active on ports 10000-20000, Envoy: external
Global Identity Range:       min 256, max 65535
Hubble:                      Ok              Current/Max Flows: 81/4095 (1.98%), Flows/s: 0.49   Metrics: Disabled
Encryption:                  Disabled
Cluster health:              2/3 reachable   (2026-01-27T20:30:26Z)   (Probe interval: 1m56.754608943s)
Name                         IP              Node                     Endpoints
  kind-worker2 (localhost)   172.18.0.4      1/1                      0/1
Modules Health:              Stopped(24) Degraded(0) OK(70)

root@kind-worker2:/home/cilium# exit

```



```release-note
extra info log to show `enable-host-legacy-routing` is enabled when kpr is disabled
```
