### PR TITLE
docs: Document BPF_EVENTS requirement

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -155,6 +155,7 @@ linked, either choice is valid.
 ::
 
         CONFIG_BPF=y
+        CONFIG_BPF_EVENTS=y
         CONFIG_BPF_SYSCALL=y
         CONFIG_NET_CLS_BPF=y
         CONFIG_BPF_JIT=y


### PR DESCRIPTION
When running cilium on kernels that were not compiled with `CONFIG_BPF_EVENTS=y`, no events are passed from BPF back to userspace, making hubble show no L3/L4 events, without error.

Some discussion of this can be found on #37480.

`BPF_EVENTS` was enabled and tested in a slim distro here: https://github.com/EmilyShepherd/kiOS/commit/9de663bfcfcf1ad4fa18fb1b15bb75007963bd8d.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

```release-note
docs: Document hubble requirement on kernels with BPF_EVENTS compiled in
```
