### PR TITLE
Add a note to Pools section of documentation

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -48,6 +48,12 @@ A basic IP Pools with both an IPv4 and IPv6 range looks like this:
       - start: "20.0.20.100"
         stop: "20.0.20.200"
 
+.. caution::
+
+    Pay attention to the dashes in the YAML file: the ``start`` and ``stop``
+    fields together define a single, independent block and must be specified as
+    one item in the ``blocks`` sequence.
+
 After adding the pool to the cluster, it appears like so.
 
 .. code-block:: shell-session


### PR DESCRIPTION
This a note clarifies the meaning of the start/stop element in blocks.

Fixes: #43168

```release-note
docs: Add a note to avoid mistakes in the YAML description of IP ranges for LB IPAM pool blocks
```