### PR TITLE
Replace `byteorder.Native` by Go stdlib `binary.NativeEndian`

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -6,6 +6,7 @@ package infraendpoints
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -21,7 +22,6 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/common"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
@@ -812,7 +812,7 @@ func getCiliumHostIPsFromFile(nodeConfig string) (ipv4GW, ipv6Router net.IP) {
 				}
 				if ipv4GWUint64 != 0 {
 					bs := make([]byte, net.IPv4len)
-					byteorder.Native.PutUint32(bs, uint32(ipv4GWUint64))
+					binary.NativeEndian.PutUint32(bs, uint32(ipv4GWUint64))
 					ipv4GW = net.IPv4(bs[0], bs[1], bs[2], bs[3])
 					hasIPv4 = true
 				}

--- a/pkg/byteorder/byteorder.go
+++ b/pkg/byteorder/byteorder.go
@@ -4,6 +4,7 @@
 package byteorder
 
 import (
+	"encoding/binary"
 	"net"
 	"net/netip"
 )
@@ -13,10 +14,10 @@ import (
 func NetIPv4ToHost32(ip net.IP) uint32 {
 	ipv4 := ip.To4()
 	_ = ipv4[3] // Assert length of ipv4.
-	return Native.Uint32(ipv4)
+	return binary.NativeEndian.Uint32(ipv4)
 }
 
 func NetIPAddrToHost32(ip netip.Addr) uint32 {
 	ipv4 := ip.As4()
-	return Native.Uint32(ipv4[:])
+	return binary.NativeEndian.Uint32(ipv4[:])
 }

--- a/pkg/byteorder/byteorder_bigendian.go
+++ b/pkg/byteorder/byteorder_bigendian.go
@@ -5,10 +5,6 @@
 
 package byteorder
 
-import "encoding/binary"
-
-var Native binary.ByteOrder = binary.BigEndian
-
 func HostToNetwork16(u uint16) uint16 { return u }
 func HostToNetwork32(u uint32) uint32 { return u }
 func HostToNetwork64(u uint64) uint64 { return u }

--- a/pkg/byteorder/byteorder_littleendian.go
+++ b/pkg/byteorder/byteorder_littleendian.go
@@ -5,12 +5,7 @@
 
 package byteorder
 
-import (
-	"encoding/binary"
-	"math/bits"
-)
-
-var Native binary.ByteOrder = binary.LittleEndian
+import "math/bits"
 
 func HostToNetwork16(u uint16) uint16 { return bits.ReverseBytes16(u) }
 func HostToNetwork32(u uint32) uint32 { return bits.ReverseBytes32(u) }

--- a/pkg/byteorder/byteorder_test.go
+++ b/pkg/byteorder/byteorder_test.go
@@ -5,6 +5,7 @@ package byteorder
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,5 +29,15 @@ func TestNetIPv4ToHost32(t *testing.T) {
 	} else {
 		require.Equal(t, uint32(0x5b810b0a), NetIPv4ToHost32(net.ParseIP("10.11.129.91")))
 		require.Equal(t, uint32(0xd68a0b0a), NetIPv4ToHost32(net.ParseIP("10.11.138.214")))
+	}
+}
+
+func TestNetiIPAddrToHost32(t *testing.T) {
+	if cpu.IsBigEndian {
+		require.Equal(t, uint32(0x0a0b815b), NetIPAddrToHost32(netip.MustParseAddr("10.11.129.91")))
+		require.Equal(t, uint32(0x0a0b8ad6), NetIPAddrToHost32(netip.MustParseAddr("10.11.138.214")))
+	} else {
+		require.Equal(t, uint32(0x5b810b0a), NetIPAddrToHost32(netip.MustParseAddr("10.11.129.91")))
+		require.Equal(t, uint32(0xd68a0b0a), NetIPAddrToHost32(netip.MustParseAddr("10.11.138.214")))
 	}
 }

--- a/pkg/byteorder/byteorder_test.go
+++ b/pkg/byteorder/byteorder_test.go
@@ -4,35 +4,29 @@
 package byteorder
 
 import (
-	"encoding/binary"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/cpu"
 )
 
-func TestNativeIsInitialized(t *testing.T) {
-	require.NotNil(t, Native)
-}
-
 func TestHostToNetwork(t *testing.T) {
-	switch Native {
-	case binary.LittleEndian:
-		require.Equal(t, uint16(0xBBAA), HostToNetwork16(0xAABB))
-		require.Equal(t, uint32(0xDDCCBBAA), HostToNetwork32(0xAABBCCDD))
-	case binary.BigEndian:
+	if cpu.IsBigEndian {
 		require.Equal(t, uint16(0xAABB), HostToNetwork16(0xAABB))
 		require.Equal(t, uint32(0xAABBCCDD), HostToNetwork32(0xAABBCCDD))
+	} else {
+		require.Equal(t, uint16(0xBBAA), HostToNetwork16(0xAABB))
+		require.Equal(t, uint32(0xDDCCBBAA), HostToNetwork32(0xAABBCCDD))
 	}
 }
 
 func TestNetIPv4ToHost32(t *testing.T) {
-	switch Native {
-	case binary.LittleEndian:
-		require.Equal(t, uint32(0x5b810b0a), NetIPv4ToHost32(net.ParseIP("10.11.129.91")))
-		require.Equal(t, uint32(0xd68a0b0a), NetIPv4ToHost32(net.ParseIP("10.11.138.214")))
-	case binary.BigEndian:
+	if cpu.IsBigEndian {
 		require.Equal(t, uint32(0x0a0b815b), NetIPv4ToHost32(net.ParseIP("10.11.129.91")))
 		require.Equal(t, uint32(0x0a0b8ad6), NetIPv4ToHost32(net.ParseIP("10.11.138.214")))
+	} else {
+		require.Equal(t, uint32(0x5b810b0a), NetIPv4ToHost32(net.ParseIP("10.11.129.91")))
+		require.Equal(t, uint32(0xd68a0b0a), NetIPv4ToHost32(net.ParseIP("10.11.138.214")))
 	}
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -437,7 +437,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 			var ipv4 uint32
 			for _, addr := range drd.Addrs {
 				if addr.Addr.Is4() {
-					ipv4 = byteorder.NetIPv4ToHost32(addr.AsIP())
+					ipv4 = byteorder.NetIPAddrToHost32(addr.Addr)
 					break
 				}
 			}

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -158,10 +158,6 @@ type DeviceAddress struct {
 	Scope     RouteScope // Address scope, e.g. RT_SCOPE_LINK, RT_SCOPE_HOST etc.
 }
 
-func (d *DeviceAddress) AsIP() net.IP {
-	return d.Addr.AsSlice()
-}
-
 func (d *DeviceAddress) String() string {
 	return fmt.Sprintf("%s (secondary=%v, scope=%d)", d.Addr, d.Secondary, d.Scope)
 }

--- a/pkg/hubble/parser/debug/parser_test.go
+++ b/pkg/hubble/parser/debug/parser_test.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
@@ -24,7 +23,7 @@ import (
 
 func encodeDebugEvent(msg *monitor.DebugMsg) []byte {
 	buf := &bytes.Buffer{}
-	if err := binary.Write(buf, byteorder.Native, msg); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, msg); err != nil {
 		panic(fmt.Sprintf("failed to encode debug event: %s", err))
 	}
 	return buf.Bytes()

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/pkg/byteorder"
 	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -451,7 +450,7 @@ func TestDecodeSockEvent(t *testing.T) {
 			data := tc.rawMsg
 			if data == nil {
 				buf := &bytes.Buffer{}
-				err := binary.Write(buf, byteorder.Native, &tc.msg)
+				err := binary.Write(buf, binary.NativeEndian, &tc.msg)
 				assert.NoError(t, err)
 				data = buf.Bytes()
 			}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -552,7 +552,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 			}
 
 			buf := &bytes.Buffer{}
-			err := binary.Write(buf, byteorder.Native, &tn)
+			err := binary.Write(buf, binary.NativeEndian, &tn)
 			require.NoError(t, err)
 			buffer := gopacket.NewSerializeBuffer()
 			err = gopacket.SerializeLayers(buffer, gopacket.SerializeOptions{}, lay...)
@@ -712,7 +712,7 @@ func TestDecodeDropNotify(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			n := tc.dn
 			buf := &bytes.Buffer{}
-			if err := binary.Write(buf, byteorder.Native, n); err != nil {
+			if err := binary.Write(buf, binary.NativeEndian, n); err != nil {
 				t.Fatalf("Write(...) %T to buffer: %v", n, err)
 			}
 

--- a/pkg/hubble/testutils/payload.go
+++ b/pkg/hubble/testutils/payload.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gopacket/gopacket"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -25,7 +24,7 @@ func CreateL3L4Payload(message any, layers ...gopacket.SerializableLayer) ([]byt
 		monitor.DropNotify,
 		monitor.PolicyVerdictNotify,
 		monitor.TraceNotify:
-		if err := binary.Write(buf, byteorder.Native, message); err != nil {
+		if err := binary.Write(buf, binary.NativeEndian, message); err != nil {
 			return nil, err
 		}
 	case monitorAPI.AgentNotify:

--- a/pkg/monitor/api/monitor_event_interface_linux.go
+++ b/pkg/monitor/api/monitor_event_interface_linux.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 )
 
@@ -67,7 +66,7 @@ type DefaultDecoder struct{}
 
 // Decode decodes the message in 'data' into the struct.
 func (d *DefaultDecoder) Decode(data []byte) error {
-	return binary.Read(bytes.NewReader(data), byteorder.Native, d)
+	return binary.Read(bytes.NewReader(data), binary.NativeEndian, d)
 }
 
 // DefaultSrcDstGetter is a default implementation of the GetSrc and GetDst methods

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -5,6 +5,7 @@ package monitor
 
 import (
 	"bufio"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -217,7 +218,7 @@ func l4CreateInfo(n *DebugMsg) string {
 
 func ip4Str(arg1 uint32) string {
 	ip := make(net.IP, 4)
-	byteorder.Native.PutUint32(ip, arg1)
+	binary.NativeEndian.PutUint32(ip, arg1)
 	return ip.String()
 }
 
@@ -269,11 +270,11 @@ func (n *DebugMsg) Decode(data []byte) error {
 
 	n.Type = data[0]
 	n.SubType = data[1]
-	n.Source = byteorder.Native.Uint16(data[2:4])
-	n.Hash = byteorder.Native.Uint32(data[4:8])
-	n.Arg1 = byteorder.Native.Uint32(data[8:12])
-	n.Arg2 = byteorder.Native.Uint32(data[12:16])
-	n.Arg3 = byteorder.Native.Uint32(data[16:20])
+	n.Source = binary.NativeEndian.Uint16(data[2:4])
+	n.Hash = binary.NativeEndian.Uint32(data[4:8])
+	n.Arg1 = binary.NativeEndian.Uint32(data[8:12])
+	n.Arg2 = binary.NativeEndian.Uint32(data[12:16])
+	n.Arg3 = binary.NativeEndian.Uint32(data[16:20])
 
 	return nil
 }
@@ -488,14 +489,14 @@ func (n *DebugCapture) Decode(data []byte) error {
 
 	n.Type = data[0]
 	n.SubType = data[1]
-	n.Source = byteorder.Native.Uint16(data[2:4])
-	n.Hash = byteorder.Native.Uint32(data[4:8])
-	n.OrigLen = byteorder.Native.Uint32(data[8:12])
-	n.Len = byteorder.Native.Uint16(data[12:14])
+	n.Source = binary.NativeEndian.Uint16(data[2:4])
+	n.Hash = binary.NativeEndian.Uint32(data[4:8])
+	n.OrigLen = binary.NativeEndian.Uint32(data[8:12])
+	n.Len = binary.NativeEndian.Uint16(data[12:14])
 	n.Version = data[14]
 	n.ExtVersion = data[15]
-	n.Arg1 = byteorder.Native.Uint32(data[16:20])
-	n.Arg2 = byteorder.Native.Uint32(data[20:24])
+	n.Arg1 = binary.NativeEndian.Uint32(data[16:20])
+	n.Arg2 = binary.NativeEndian.Uint32(data[20:24])
 
 	return nil
 }

--- a/pkg/monitor/datapath_debug_test.go
+++ b/pkg/monitor/datapath_debug_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/cilium/pkg/byteorder"
 )
 
 func TestDecodeDebugCapture(t *testing.T) {
@@ -29,7 +27,7 @@ func TestDecodeDebugCapture(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	err := binary.Write(buf, byteorder.Native, input)
+	err := binary.Write(buf, binary.NativeEndian, input)
 	require.NoError(t, err)
 
 	output := &DebugCapture{}
@@ -110,18 +108,18 @@ func TestDecodeDebugCaptureExt(t *testing.T) {
 
 	for _, tc := range tcs {
 		buf := bytes.NewBuffer(nil)
-		err := binary.Write(buf, byteorder.Native, tc.dc)
+		err := binary.Write(buf, binary.NativeEndian, tc.dc)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, tc.extension)
+		err = binary.Write(buf, binary.NativeEndian, tc.extension)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, uint32(0xDEADBEEF))
+		err = binary.Write(buf, binary.NativeEndian, uint32(0xDEADBEEF))
 		require.NoError(t, err)
 
 		output := &DebugCapture{}
 		err = output.Decode(buf.Bytes())
 		require.NoError(t, err)
 
-		require.Equal(t, uint32(0xDEADBEEF), byteorder.Native.Uint32(buf.Bytes()[output.DataOffset():]))
+		require.Equal(t, uint32(0xDEADBEEF), binary.NativeEndian.Uint32(buf.Bytes()[output.DataOffset():]))
 	}
 }
 
@@ -129,7 +127,7 @@ func BenchmarkNewDecodeDebugCapture(b *testing.B) {
 	input := &DebugCapture{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -147,7 +145,7 @@ func BenchmarkOldDecodeDebugCapture(b *testing.B) {
 	input := &DebugCapture{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -155,7 +153,7 @@ func BenchmarkOldDecodeDebugCapture(b *testing.B) {
 
 	for b.Loop() {
 		dbg := &DebugCapture{}
-		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, dbg); err != nil {
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), binary.NativeEndian, dbg); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -177,7 +175,7 @@ func TestDecodeDebugMsg(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	err := binary.Write(buf, byteorder.Native, input)
+	err := binary.Write(buf, binary.NativeEndian, input)
 	require.NoError(t, err)
 
 	output := &DebugMsg{}
@@ -197,7 +195,7 @@ func BenchmarkNewDecodeDebugMsg(b *testing.B) {
 	input := &DebugMsg{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -215,7 +213,7 @@ func BenchmarkOldDecodeDebugMsg(b *testing.B) {
 	input := &DebugMsg{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -223,7 +221,7 @@ func BenchmarkOldDecodeDebugMsg(b *testing.B) {
 
 	for b.Loop() {
 		dbg := &DebugMsg{}
-		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, dbg); err != nil {
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), binary.NativeEndian, dbg); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -5,10 +5,10 @@ package monitor
 
 import (
 	"bufio"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -143,25 +143,25 @@ func (n *DropNotify) Decode(data []byte) error {
 		if l := len(data); l < dropNotifyV3Len {
 			return fmt.Errorf("unexpected DropNotify data length (version %d), expected at least %d but got %d", version, dropNotifyV3Len, l)
 		}
-		n.IPTraceID = byteorder.Native.Uint64(data[40:48])
+		n.IPTraceID = binary.NativeEndian.Uint64(data[40:48])
 	}
 
 	// Decode logic for version >= v0/v1.
 	n.Type = data[0]
 	n.SubType = data[1]
-	n.Source = byteorder.Native.Uint16(data[2:4])
-	n.Hash = byteorder.Native.Uint32(data[4:8])
-	n.OrigLen = byteorder.Native.Uint32(data[8:12])
-	n.CapLen = byteorder.Native.Uint16(data[12:14])
+	n.Source = binary.NativeEndian.Uint16(data[2:4])
+	n.Hash = binary.NativeEndian.Uint32(data[4:8])
+	n.OrigLen = binary.NativeEndian.Uint32(data[8:12])
+	n.CapLen = binary.NativeEndian.Uint16(data[12:14])
 	n.Version = version
 	n.ExtVersion = data[15]
-	n.SrcLabel = identity.NumericIdentity(byteorder.Native.Uint32(data[16:20]))
-	n.DstLabel = identity.NumericIdentity(byteorder.Native.Uint32(data[20:24]))
-	n.DstID = byteorder.Native.Uint32(data[24:28])
-	n.Line = byteorder.Native.Uint16(data[28:30])
+	n.SrcLabel = identity.NumericIdentity(binary.NativeEndian.Uint32(data[16:20]))
+	n.DstLabel = identity.NumericIdentity(binary.NativeEndian.Uint32(data[20:24]))
+	n.DstID = binary.NativeEndian.Uint32(data[24:28])
+	n.Line = binary.NativeEndian.Uint16(data[28:30])
 	n.File = data[30]
 	n.ExtError = int8(data[31])
-	n.Ifindex = byteorder.Native.Uint32(data[32:36])
+	n.Ifindex = binary.NativeEndian.Uint32(data[32:36])
 
 	return nil
 }

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/cilium/pkg/byteorder"
 )
 
 func TestDropNotifyV1_Decode(t *testing.T) {
@@ -49,7 +47,7 @@ func TestDropNotifyV1_Decode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
-			if err := binary.Write(buf, byteorder.Native, tc.input); err != nil {
+			if err := binary.Write(buf, binary.NativeEndian, tc.input); err != nil {
 				t.Fatalf("Unexpected error from Write(...); got: %v", err)
 			}
 
@@ -103,7 +101,7 @@ func TestDropNotify_Decode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
-			if err := binary.Write(buf, byteorder.Native, tc.input); err != nil {
+			if err := binary.Write(buf, binary.NativeEndian, tc.input); err != nil {
 				t.Fatalf("Unexpected error from Write(...); got: %v", err)
 			}
 
@@ -190,7 +188,7 @@ func TestDecodeDropNotify(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
-			if err := binary.Write(buf, byteorder.Native, tc.input); err != nil {
+			if err := binary.Write(buf, binary.NativeEndian, tc.input); err != nil {
 				t.Fatalf("Unexpected error from Write(...); got: %v", err)
 			}
 
@@ -271,18 +269,18 @@ func TestDecodeDropNotifyExtension(t *testing.T) {
 
 	for _, tc := range tcs {
 		buf := bytes.NewBuffer(nil)
-		err := binary.Write(buf, byteorder.Native, tc.dn)
+		err := binary.Write(buf, binary.NativeEndian, tc.dn)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, tc.extension)
+		err = binary.Write(buf, binary.NativeEndian, tc.extension)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, uint32(0xDEADBEEF))
+		err = binary.Write(buf, binary.NativeEndian, uint32(0xDEADBEEF))
 		require.NoError(t, err)
 
 		output := &DropNotify{}
 		err = output.Decode(buf.Bytes())
 		require.NoError(t, err)
 
-		require.Equal(t, uint32(0xDEADBEEF), byteorder.Native.Uint32(buf.Bytes()[output.DataOffset():]))
+		require.Equal(t, uint32(0xDEADBEEF), binary.NativeEndian.Uint32(buf.Bytes()[output.DataOffset():]))
 	}
 }
 
@@ -290,7 +288,7 @@ func BenchmarkNewDropNotifyV1_Decode(b *testing.B) {
 	input := DropNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -308,7 +306,7 @@ func BenchmarkOldDropNotifyV1_Decode(b *testing.B) {
 	input := DropNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -316,7 +314,7 @@ func BenchmarkOldDropNotifyV1_Decode(b *testing.B) {
 
 	for b.Loop() {
 		dn := &DropNotify{}
-		if err := binary.Read(bytes.NewReader(buf.Bytes()), byteorder.Native, dn); err != nil {
+		if err := binary.Read(bytes.NewReader(buf.Bytes()), binary.NativeEndian, dn); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_policy.go
+++ b/pkg/monitor/datapath_policy.go
@@ -5,9 +5,9 @@ package monitor
 
 import (
 	"bufio"
+	"encoding/binary"
 	"fmt"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
@@ -106,19 +106,19 @@ func (n *PolicyVerdictNotify) Decode(data []byte) error {
 
 	n.Type = data[0]
 	n.SubType = data[1]
-	n.Source = byteorder.Native.Uint16(data[2:4])
-	n.Hash = byteorder.Native.Uint32(data[4:8])
-	n.OrigLen = byteorder.Native.Uint32(data[8:12])
-	n.CapLen = byteorder.Native.Uint16(data[12:14])
+	n.Source = binary.NativeEndian.Uint16(data[2:4])
+	n.Hash = binary.NativeEndian.Uint32(data[4:8])
+	n.OrigLen = binary.NativeEndian.Uint32(data[8:12])
+	n.CapLen = binary.NativeEndian.Uint16(data[12:14])
 	n.Version = data[14]
 	n.ExtVersion = data[15]
-	n.RemoteLabel = identity.NumericIdentity(byteorder.Native.Uint32(data[16:20]))
-	n.Verdict = int32(byteorder.Native.Uint32(data[20:24]))
-	n.DstPort = byteorder.Native.Uint16(data[24:26])
+	n.RemoteLabel = identity.NumericIdentity(binary.NativeEndian.Uint32(data[16:20]))
+	n.Verdict = int32(binary.NativeEndian.Uint32(data[20:24]))
+	n.DstPort = binary.NativeEndian.Uint16(data[24:26])
 	n.Proto = data[26]
 	n.Flags = data[27]
 	n.AuthType = data[28]
-	n.Cookie = byteorder.Native.Uint32(data[32:36])
+	n.Cookie = binary.NativeEndian.Uint32(data[32:36])
 
 	return nil
 }

--- a/pkg/monitor/datapath_policy_test.go
+++ b/pkg/monitor/datapath_policy_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/cilium/pkg/byteorder"
 )
 
 func TestDecodePolicyVerdicyNotify(t *testing.T) {
@@ -35,7 +33,7 @@ func TestDecodePolicyVerdicyNotify(t *testing.T) {
 		Cookie:      0x1e_1f_20_21,
 	}
 	buf := bytes.NewBuffer(nil)
-	err := binary.Write(buf, byteorder.Native, input)
+	err := binary.Write(buf, binary.NativeEndian, input)
 	require.NoError(t, err)
 
 	output := &PolicyVerdictNotify{}
@@ -123,18 +121,18 @@ func TestDecodePolicyVerdictNotifyExtension(t *testing.T) {
 
 	for _, tc := range tcs {
 		buf := bytes.NewBuffer(nil)
-		err := binary.Write(buf, byteorder.Native, tc.pvn)
+		err := binary.Write(buf, binary.NativeEndian, tc.pvn)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, tc.extension)
+		err = binary.Write(buf, binary.NativeEndian, tc.extension)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, uint32(0xDEADBEEF))
+		err = binary.Write(buf, binary.NativeEndian, uint32(0xDEADBEEF))
 		require.NoError(t, err)
 
 		output := &PolicyVerdictNotify{}
 		err = output.Decode(buf.Bytes())
 		require.NoError(t, err)
 
-		require.Equal(t, uint32(0xDEADBEEF), byteorder.Native.Uint32(buf.Bytes()[output.DataOffset():]))
+		require.Equal(t, uint32(0xDEADBEEF), binary.NativeEndian.Uint32(buf.Bytes()[output.DataOffset():]))
 	}
 }
 
@@ -142,7 +140,7 @@ func BenchmarkNewDecodePolicyVerdictNotify(b *testing.B) {
 	input := &PolicyVerdictNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -160,7 +158,7 @@ func BenchmarkOldDecodePolicyVerdictNotify(b *testing.B) {
 	input := &PolicyVerdictNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -168,7 +166,7 @@ func BenchmarkOldDecodePolicyVerdictNotify(b *testing.B) {
 
 	for b.Loop() {
 		pvn := &PolicyVerdictNotify{}
-		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, pvn); err != nil {
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), binary.NativeEndian, pvn); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -4,10 +4,10 @@
 package monitor
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -71,9 +71,9 @@ func (t *TraceSockNotify) Decode(data []byte) error {
 	t.XlatePoint = data[1]
 	t.L4Proto = data[2]
 	t.Flags = data[3]
-	t.DstPort = byteorder.Native.Uint16(data[4:6])
-	t.SockCookie = byteorder.Native.Uint64(data[8:16])
-	t.CgroupId = byteorder.Native.Uint64(data[16:24])
+	t.DstPort = binary.NativeEndian.Uint16(data[4:6])
+	t.SockCookie = binary.NativeEndian.Uint64(data[8:16])
+	t.CgroupId = binary.NativeEndian.Uint64(data[16:24])
 	copy(t.DstIP[:], data[24:40])
 
 	return nil

--- a/pkg/monitor/datapath_sock_trace_test.go
+++ b/pkg/monitor/datapath_sock_trace_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/types"
 )
 
@@ -39,7 +38,7 @@ func TestDecodeTraceSockNotify(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	err := binary.Write(buf, byteorder.Native, input)
+	err := binary.Write(buf, binary.NativeEndian, input)
 	require.NoError(t, err)
 
 	output := &TraceSockNotify{}
@@ -59,7 +58,7 @@ func BenchmarkNewDecodeTraceSockNotify(b *testing.B) {
 	input := &TraceSockNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -77,7 +76,7 @@ func BenchmarkOldDecodeTraceSockNotify(b *testing.B) {
 	input := &TraceSockNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -85,7 +84,7 @@ func BenchmarkOldDecodeTraceSockNotify(b *testing.B) {
 
 	for b.Loop() {
 		tsn := &TraceSockNotify{}
-		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, tsn); err != nil {
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), binary.NativeEndian, tsn); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -5,11 +5,11 @@ package monitor
 
 import (
 	"bufio"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/monitor/api"
@@ -109,7 +109,7 @@ func (tn *TraceNotify) Decode(data []byte) error {
 		if l := len(data); l < traceNotifyV2Len {
 			return fmt.Errorf("unexpected TraceNotify data length (version %d), expected at least %d but got %d", version, traceNotifyV2Len, l)
 		}
-		tn.IPTraceID = byteorder.Native.Uint64(data[48:56])
+		tn.IPTraceID = binary.NativeEndian.Uint64(data[48:56])
 		fallthrough
 	case TraceNotifyVersion1:
 		if l := len(data); l < traceNotifyV1Len {
@@ -121,18 +121,18 @@ func (tn *TraceNotify) Decode(data []byte) error {
 	// Decode logic for version >= v0.
 	tn.Type = data[0]
 	tn.ObsPoint = data[1]
-	tn.Source = byteorder.Native.Uint16(data[2:4])
-	tn.Hash = byteorder.Native.Uint32(data[4:8])
-	tn.OrigLen = byteorder.Native.Uint32(data[8:12])
-	tn.CapLen = byteorder.Native.Uint16(data[12:14])
+	tn.Source = binary.NativeEndian.Uint16(data[2:4])
+	tn.Hash = binary.NativeEndian.Uint32(data[4:8])
+	tn.OrigLen = binary.NativeEndian.Uint32(data[8:12])
+	tn.CapLen = binary.NativeEndian.Uint16(data[12:14])
 	tn.Version = version
 	tn.ExtVersion = data[15]
-	tn.SrcLabel = identity.NumericIdentity(byteorder.Native.Uint32(data[16:20]))
-	tn.DstLabel = identity.NumericIdentity(byteorder.Native.Uint32(data[20:24]))
-	tn.DstID = byteorder.Native.Uint16(data[24:26])
+	tn.SrcLabel = identity.NumericIdentity(binary.NativeEndian.Uint32(data[16:20]))
+	tn.DstLabel = identity.NumericIdentity(binary.NativeEndian.Uint32(data[20:24]))
+	tn.DstID = binary.NativeEndian.Uint16(data[24:26])
 	tn.Reason = data[26]
 	tn.Flags = data[27]
-	tn.Ifindex = byteorder.Native.Uint32(data[28:32])
+	tn.Ifindex = binary.NativeEndian.Uint32(data[28:32])
 
 	return nil
 }

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -43,7 +42,7 @@ func TestDecodeTraceNotify(t *testing.T) {
 		IPTraceID: 0x2b_2c_2d_2e_2f_30_31_32,
 	}
 	buf := bytes.NewBuffer(nil)
-	err := binary.Write(buf, byteorder.Native, in)
+	err := binary.Write(buf, binary.NativeEndian, in)
 	require.NoError(t, err)
 
 	out := TraceNotify{}
@@ -131,18 +130,18 @@ func TestDecodeTraceNotifyExtension(t *testing.T) {
 
 	for _, tc := range tcs {
 		buf := bytes.NewBuffer(nil)
-		err := binary.Write(buf, byteorder.Native, tc.tn)
+		err := binary.Write(buf, binary.NativeEndian, tc.tn)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, tc.extension)
+		err = binary.Write(buf, binary.NativeEndian, tc.extension)
 		require.NoError(t, err)
-		err = binary.Write(buf, byteorder.Native, uint32(0xDEADBEEF))
+		err = binary.Write(buf, binary.NativeEndian, uint32(0xDEADBEEF))
 		require.NoError(t, err)
 
 		output := &TraceNotify{}
 		err = output.Decode(buf.Bytes())
 		require.NoError(t, err)
 
-		require.Equal(t, uint32(0xDEADBEEF), byteorder.Native.Uint32(buf.Bytes()[output.DataOffset():]))
+		require.Equal(t, uint32(0xDEADBEEF), binary.NativeEndian.Uint32(buf.Bytes()[output.DataOffset():]))
 	}
 }
 
@@ -396,7 +395,7 @@ func BenchmarkDecodeTraceNotifyVersion0(b *testing.B) {
 	input := TraceNotify{}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 
@@ -416,7 +415,7 @@ func BenchmarkDecodeTraceNotifyVersion1(b *testing.B) {
 	}
 	buf := bytes.NewBuffer(nil)
 
-	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+	if err := binary.Write(buf, binary.NativeEndian, input); err != nil {
 		b.Fatal(err)
 	}
 

--- a/pkg/monitor/payload/monitor_payload.go
+++ b/pkg/monitor/payload/monitor_payload.go
@@ -8,8 +8,6 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"io"
-
-	"github.com/cilium/cilium/pkg/byteorder"
 )
 
 // Below constants are based on the ones from <linux/perf_event.h>.
@@ -42,12 +40,12 @@ func (meta *Meta) MarshalBinary() ([]byte, error) {
 
 // ReadBinary reads the metadata from its binary representation.
 func (meta *Meta) ReadBinary(r io.Reader) error {
-	return binary.Read(r, byteorder.Native, meta)
+	return binary.Read(r, binary.NativeEndian, meta)
 }
 
 // WriteBinary writes the metadata into its binary representation.
 func (meta *Meta) WriteBinary(w io.Writer) error {
-	return binary.Write(w, byteorder.Native, meta)
+	return binary.Write(w, binary.NativeEndian, meta)
 }
 
 // Payload is the structure used when copying events from the main monitor.

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cilium/ebpf/perf"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
@@ -134,7 +133,7 @@ func signalCollectMetrics(signalType, signalData, signalStatus string) {
 func (sm *signalManager) signalReceive(msg *perf.Record) {
 	var which SignalType
 	reader := bytes.NewReader(msg.RawSample)
-	if err := binary.Read(reader, byteorder.Native, &which); err != nil {
+	if err := binary.Read(reader, binary.NativeEndian, &which); err != nil {
 		sm.logger.Warn("cannot parse signal type from BPF datapath", logfields.Error, err)
 		return
 	}
@@ -217,7 +216,7 @@ func ChannelHandler[T fmt.Stringer](ch chan<- T) SignalHandler {
 			return "", io.EOF
 		}
 		var data T
-		if err := binary.Read(reader, byteorder.Native, &data); err != nil {
+		if err := binary.Read(reader, binary.NativeEndian, &data); err != nil {
 			return "", err
 		}
 		select {

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/logging"
 	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
 )
@@ -54,7 +53,7 @@ func (r *testReader) Close() error {
 
 func TestSignalSet(t *testing.T) {
 	buf := new(bytes.Buffer)
-	binary.Write(buf, byteorder.Native, SignalNatFillUp)
+	binary.Write(buf, binary.NativeEndian, SignalNatFillUp)
 
 	events := &testReader{cpu: 1, data: buf.Bytes()}
 	sm := &signalManager{events: events}
@@ -164,12 +163,12 @@ func TestLifeCycle(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	buf1 := new(bytes.Buffer)
-	binary.Write(buf1, byteorder.Native, SignalNatFillUp)
-	binary.Write(buf1, byteorder.Native, SignalProtoV4)
+	binary.Write(buf1, binary.NativeEndian, SignalNatFillUp)
+	binary.Write(buf1, binary.NativeEndian, SignalProtoV4)
 
 	buf2 := new(bytes.Buffer)
-	binary.Write(buf2, byteorder.Native, SignalCTFillUp)
-	binary.Write(buf2, byteorder.Native, SignalProtoV4)
+	binary.Write(buf2, binary.NativeEndian, SignalCTFillUp)
+	binary.Write(buf2, binary.NativeEndian, SignalProtoV4)
 
 	messages := [][]byte{buf1.Bytes(), buf2.Bytes()}
 


### PR DESCRIPTION
Use the `NativeEndian` native-endian var provided by the Go standard library `encoding/binary` package instead of re-implementing it in `pkg/byteorder`.

Also add some missing test coverage.

See commits for details.