### PR TITLE
datapath: block use of tproxy with netkit due to incompatibility

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -361,7 +361,7 @@
      - int
      - ``524288``
    * - :spelling:ignore:`bpf.datapathMode`
-     - Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2)
+     - Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2). Note netkit is incompatible with TPROXY (\ ``bpf.tproxy``\ ).
      - string
      - ``veth``
    * - :spelling:ignore:`bpf.disableExternalIPMitigation`
@@ -489,7 +489,7 @@
      - string
      - ``"/sys/fs/bpf"``
    * - :spelling:ignore:`bpf.tproxy`
-     - Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy.
+     - Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy. Note this is incompatible with netkit (\ ``bpf.datapathMode=netkit``\ , ``bpf.datapathMode=netkit-l2``\ ).
      - bool
      - ``false``
    * - :spelling:ignore:`bpf.vlanBypass`

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -309,6 +309,9 @@ The following options have been introduced in this version of Cilium:
   side effect of splitting the datapath-mode into "configured mode" and "operational mode"
   in status outputs, where they differ. The default remains ``bpf.datapathMode=veth``
   but may change in future releases.
+* ``bpf.tproxy=true`` is incompatible with netkit datapath mode. If netkit is also enabled,
+  Cilium will fail to start. If auto-detect datapath mode is used, Cilium will revert to
+  veth mode, even if netkit support is present.
 
 Changed Options
 ###############

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -140,7 +140,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.ctAccounting | bool | `false` | Enable CT accounting for packets and bytes |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |
 | bpf.ctTcpMax | int | `524288` | Configure the maximum number of entries in the TCP connection tracking table. |
-| bpf.datapathMode | string | `veth` | Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2) |
+| bpf.datapathMode | string | `veth` | Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2). Note netkit is incompatible with TPROXY (`bpf.tproxy`). |
 | bpf.disableExternalIPMitigation | bool | `false` | Disable ExternalIP mitigation (CVE-2020-8554) |
 | bpf.distributedLRU | object | `{"enabled":false}` | Control to use a distributed per-CPU backend memory for the core BPF LRU maps which Cilium uses. This improves performance significantly, but it is also recommended to increase BPF map sizing along with that. |
 | bpf.distributedLRU.enabled | bool | `false` | Enable distributed LRU backend memory. For compatibility with existing installations it is off by default. |
@@ -172,7 +172,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.policyStatsMapMax | int | `65536` | Configure the maximum number of entries in global policy stats map. @schema type: [null, integer] @schema |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
-| bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy. |
+| bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy. Note this is incompatible with netkit (`bpf.datapathMode=netkit`, `bpf.datapathMode=netkit-l2`). |
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
 | bpfClockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
 | certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":3},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:19921f48ee7e2295ea4dca955878a6cd8d70e6d4219d08f688e866ece9d95d4d","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/certgen","tag":"v0.3.2","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":null}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -231,3 +231,11 @@
   {{- end }}
 {{- end }}
 
+{{/* validate we don't run tproxy with netkit - see GH issue 39892 */}}
+{{- if hasKey .Values "bpf" }}
+  {{- if and (hasKey .Values.bpf "tproxy") (hasKey .Values.bpf "datapathMode") }}
+    {{- if and (.Values.bpf.tproxy) (list "netkit" "netkit-l2" | has .Values.bpf.datapathMode) }}
+      {{ fail ".Values.bpf.tproxy cannot be enabled with .Values.bpf.datapathMode=netkit or .Values.bpf.datapathMode=netkit-l2" }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -700,7 +700,8 @@ bpf:
   # type: [null, boolean]
   # @schema
   # -- (bool) Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules
-  # for implementing Layer 7 policy.
+  # for implementing Layer 7 policy. Note this is incompatible with netkit (`bpf.datapathMode=netkit`,
+  # `bpf.datapathMode=netkit-l2`).
   # @default -- `false`
   tproxy: ~
   # @schema
@@ -726,7 +727,8 @@ bpf:
   # supported kernels.
   # @default -- `true`
   enableTCX: true
-  # -- (string) Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2)
+  # -- (string) Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2).
+  # Note netkit is incompatible with TPROXY (`bpf.tproxy`).
   # @default -- `veth`
   datapathMode: veth
 # -- Enable BPF clock source probing for more efficient tick retrieval.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -703,7 +703,8 @@ bpf:
   # type: [null, boolean]
   # @schema
   # -- (bool) Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules
-  # for implementing Layer 7 policy.
+  # for implementing Layer 7 policy. Note this is incompatible with netkit (`bpf.datapathMode=netkit`,
+  # `bpf.datapathMode=netkit-l2`).
   # @default -- `false`
   tproxy: ~
   # @schema
@@ -729,7 +730,8 @@ bpf:
   # supported kernels.
   # @default -- `true`
   enableTCX: true
-  # -- (string) Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2)
+  # -- (string) Mode for Pod devices for the core datapath (auto, veth, netkit, netkit-l2).
+  # Note netkit is incompatible with TPROXY (`bpf.tproxy`).
   # @default -- `veth`
   datapathMode: veth
 # -- Enable BPF clock source probing for more efficient tick retrieval.

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -47,19 +47,40 @@ var (
 
 	// DaemonConfigs
 	daemonConfigVeth = option.DaemonConfig{
-		DatapathMode: datapathOption.DatapathModeVeth,
-		EnableIPv4:   true,
-		EnableIPv6:   true,
+		DatapathMode:    datapathOption.DatapathModeVeth,
+		EnableIPv4:      true,
+		EnableIPv6:      true,
+		EnableBPFTProxy: false,
+	}
+	daemonConfigVethTproxy = option.DaemonConfig{
+		DatapathMode:    datapathOption.DatapathModeVeth,
+		EnableIPv4:      true,
+		EnableIPv6:      true,
+		EnableBPFTProxy: true,
 	}
 	daemonConfigNetkit = option.DaemonConfig{
-		DatapathMode: datapathOption.DatapathModeNetkit,
-		EnableIPv4:   true,
-		EnableIPv6:   true,
+		DatapathMode:    datapathOption.DatapathModeNetkit,
+		EnableIPv4:      true,
+		EnableIPv6:      true,
+		EnableBPFTProxy: false,
+	}
+	daemonConfigNetkitTproxy = option.DaemonConfig{
+		DatapathMode:    datapathOption.DatapathModeNetkit,
+		EnableIPv4:      true,
+		EnableIPv6:      true,
+		EnableBPFTProxy: true,
 	}
 	daemonConfigNetkitL2 = option.DaemonConfig{
-		DatapathMode: datapathOption.DatapathModeNetkitL2,
-		EnableIPv4:   true,
-		EnableIPv6:   true,
+		DatapathMode:    datapathOption.DatapathModeNetkitL2,
+		EnableIPv4:      true,
+		EnableIPv6:      true,
+		EnableBPFTProxy: false,
+	}
+	daemonConfigNetkitL2Tproxy = option.DaemonConfig{
+		DatapathMode:    datapathOption.DatapathModeNetkitL2,
+		EnableIPv4:      true,
+		EnableIPv6:      true,
+		EnableBPFTProxy: true,
 	}
 
 	// WireguardConfigs
@@ -159,6 +180,14 @@ func TestNewConfig(t *testing.T) {
 			shouldError:    false,
 		},
 		{
+			name:           "datapath-veth+tproxy",
+			daemonConfig:   &daemonConfigVethTproxy,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigVeth,
+			shouldError:    false,
+		},
+		{
 			name:           "datapath-netkit",
 			daemonConfig:   &daemonConfigNetkit,
 			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
@@ -167,12 +196,28 @@ func TestNewConfig(t *testing.T) {
 			shouldError:    !hostSupportsNetkit(),
 		},
 		{
+			name:           "datapath-netkit+tproxy",
+			daemonConfig:   &daemonConfigNetkitTproxy,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkit,
+			shouldError:    true,
+		},
+		{
 			name:           "datapath-netkit-l2",
 			daemonConfig:   &daemonConfigNetkitL2,
 			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
 			tunnelConfig:   tunnelConfigNative,
 			expectedConfig: &connectorConfigNetkitL2,
 			shouldError:    !hostSupportsNetkit(),
+		},
+		{
+			name:           "datapath-netkit-l2+tproxy",
+			daemonConfig:   &daemonConfigNetkitL2Tproxy,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkitL2,
+			shouldError:    true,
 		},
 	}
 


### PR DESCRIPTION
This PR adds logic to detect use of `bpf.tproxy` with netkit datapath mode, because the `bpf_sk_assign()` helper is broken under netkit. The underlying cause needs upstream kernel work and it will take some time.

Related issue: https://github.com/cilium/cilium/issues/39892.

* With `bpf.datapathMode={netkit,netkit-l2}` Cilium will fail to start.

* With `bpf.datapathMode=auto` Cilium will fall back to veth and log a warning.

This PR also introduces more unit testing for `bpf.datapathMode=auto` as well as tests to cover the tproxy combinations.

```release-note
Detect and block use of TPROXY under netkit datapath mode (or fallback to veth in automatic datapath mode) due to incompatibility.
```
