### PR TITLE
ctmap: Allow creation of additional CT maps

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -925,9 +924,9 @@ func (e *Endpoint) deleteMaps() []error {
 // scrubIPsInConntrackTableLocked will run the CTMap garbagecollector with the endpoint IPs.
 func (e *Endpoint) scrubIPsInConntrackTableLocked() {
 	e.ctMapGC.Run(ctmap.GCFilter{
-		MatchIPs: map[netip.Addr]struct{}{
-			e.IPv4: {},
-			e.IPv6: {},
+		MatchIPs: map[ctmap.NetAddr]struct{}{
+			{Addr: e.IPv4}: {},
+			{Addr: e.IPv6}: {},
 		},
 	})
 }

--- a/pkg/maps/ctmap/cell.go
+++ b/pkg/maps/ctmap/cell.go
@@ -29,13 +29,13 @@ func newCTMaps(lifecycle cell.Lifecycle, daemonConfig *option.DaemonConfig, regi
 	ctMaps := &ctMaps{}
 
 	if daemonConfig.IPv4Enabled() {
-		ctMaps.v4AnyMap = newMap(MapNameAny4Global, mapTypeIPv4AnyGlobal, registry)
-		ctMaps.v4TCPMap = newMap(MapNameTCP4Global, mapTypeIPv4TCPGlobal, registry)
+		ctMaps.v4AnyMap = newMap(MapNameAny4Global, mapTypeIPv4AnyGlobal, WithRegistry(registry))
+		ctMaps.v4TCPMap = newMap(MapNameTCP4Global, mapTypeIPv4TCPGlobal, WithRegistry(registry))
 	}
 
 	if daemonConfig.IPv6Enabled() {
-		ctMaps.v6AnyMap = newMap(MapNameAny6Global, mapTypeIPv6AnyGlobal, registry)
-		ctMaps.v6TCPMap = newMap(MapNameTCP6Global, mapTypeIPv6TCPGlobal, registry)
+		ctMaps.v6AnyMap = newMap(MapNameAny6Global, mapTypeIPv6AnyGlobal, WithRegistry(registry))
+		ctMaps.v6TCPMap = newMap(MapNameTCP6Global, mapTypeIPv6TCPGlobal, WithRegistry(registry))
 	}
 
 	lifecycle.Append(cell.Hook{

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -331,6 +331,28 @@ func WithClusterID(clusterID uint32) MapOption {
 	}
 }
 
+type MapConfig struct {
+	IPv6 bool
+	TCP  bool
+}
+
+// NewGlobalMap allows the creation of additional global CT map.
+// This is intended to be used to register additional CT maps for GC with gc.AdditionalCTMapsFunc.
+func NewGlobalMap(name string, cfg MapConfig, opts ...MapOption) *Map {
+	var newMapType mapType
+	switch {
+	case cfg.IPv6 && cfg.TCP:
+		newMapType = mapTypeIPv6TCPGlobal
+	case cfg.IPv6 && !cfg.TCP:
+		newMapType = mapTypeIPv6AnyGlobal
+	case !cfg.IPv6 && cfg.TCP:
+		newMapType = mapTypeIPv4TCPGlobal
+	case !cfg.IPv6 && !cfg.TCP:
+		newMapType = mapTypeIPv4AnyGlobal
+	}
+	return newMap(name, newMapType, opts...)
+}
+
 // newMap creates a new CT map of the specified type with the specified name.
 func newMap(mapName string, m mapType, opts ...MapOption) *Map {
 	result := &Map{

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -196,6 +196,11 @@ type GCEvent struct {
 	NatMap *nat.Map
 }
 
+type MapPair struct {
+	TCP *Map
+	Any *Map
+}
+
 type natDeleteFunc func(natMap *nat.Map, key tuple.TupleKey) error
 
 func NatMapNext4(event GCEvent) {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -40,7 +40,7 @@ func setupCTMap(tb testing.TB) {
 }
 
 func BenchmarkMapBatchLookup(b *testing.B) {
-	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal, nil)
+	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal)
 	err := m.OpenOrCreate()
 	assert.NoError(b, m.Map.Unpin())
 	assert.NoError(b, err)
@@ -59,7 +59,7 @@ func BenchmarkMapBatchLookup(b *testing.B) {
 func BenchmarkPrivileged_MapUpdate(b *testing.B) {
 	setupCTMap(b)
 
-	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal, nil)
+	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal)
 	err := m.OpenOrCreate()
 	defer m.Map.Unpin()
 	require.NoError(b, err)
@@ -139,7 +139,7 @@ func TestPrivilegedCtGcIcmp(t *testing.T) {
 		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4AnyGlobal].natMapLock,
 	}
 
-	ctMap := newMap(ctMapName, mapTypeIPv4AnyGlobal, nil)
+	ctMap := newMap(ctMapName, mapTypeIPv4AnyGlobal)
 	err = ctMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMap.Map.Unpin()
@@ -253,7 +253,7 @@ func TestPrivilegedCtGcTcp(t *testing.T) {
 		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4TCPGlobal].natMapLock,
 	}
 
-	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal, nil)
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
 	err = ctMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMap.Map.Unpin()
@@ -368,7 +368,7 @@ func TestPrivilegedCtGcDsr(t *testing.T) {
 		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4TCPGlobal].natMapLock,
 	}
 
-	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal, nil)
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
 	err = ctMap.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMap.Map.Unpin()
@@ -460,7 +460,7 @@ func TestPrivilegedOrphanNatGC(t *testing.T) {
 	mapInfo[mapTypeIPv4AnyGlobal] = mapAttributes{
 		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4AnyGlobal].natMapLock,
 	}
-	ctMapAny := newMap(ctMapAnyName, mapTypeIPv4AnyGlobal, nil)
+	ctMapAny := newMap(ctMapAnyName, mapTypeIPv4AnyGlobal)
 	err = ctMapAny.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMapAny.Map.Unpin()
@@ -469,7 +469,7 @@ func TestPrivilegedOrphanNatGC(t *testing.T) {
 	mapInfo[mapTypeIPv4TCPGlobal] = mapAttributes{
 		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4TCPGlobal].natMapLock,
 	}
-	ctMapTCP := newMap(ctMapTCPName, mapTypeIPv4TCPGlobal, nil)
+	ctMapTCP := newMap(ctMapTCPName, mapTypeIPv4TCPGlobal)
 	err = ctMapTCP.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMapTCP.Map.Unpin()
@@ -701,7 +701,7 @@ func TestPrivilegedOrphanNatGC(t *testing.T) {
 	mapInfo[mapTypeIPv6AnyGlobal] = mapAttributes{
 		natMap: natMapV6, natMapLock: mapInfo[mapTypeIPv6AnyGlobal].natMapLock,
 	}
-	ctMapAnyV6 := newMap(ctMapAnyName, mapTypeIPv6AnyGlobal, nil)
+	ctMapAnyV6 := newMap(ctMapAnyName, mapTypeIPv6AnyGlobal)
 	err = ctMapAnyV6.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMapAnyV6.Map.Unpin()
@@ -710,7 +710,7 @@ func TestPrivilegedOrphanNatGC(t *testing.T) {
 	mapInfo[mapTypeIPv6TCPGlobal] = mapAttributes{
 		natMap: natMapV6, natMapLock: mapInfo[mapTypeIPv6TCPGlobal].natMapLock,
 	}
-	ctMapTCPV6 := newMap(ctMapTCPName, mapTypeIPv6TCPGlobal, nil)
+	ctMapTCPV6 := newMap(ctMapTCPName, mapTypeIPv6TCPGlobal)
 	err = ctMapTCP.OpenOrCreate()
 	require.NoError(t, err)
 	defer ctMapTCPV6.Map.Unpin()
@@ -758,7 +758,7 @@ func TestPrivilegedCount(t *testing.T) {
 	option.Config.CTMapEntriesGlobalTCP = 524288
 	size := 8192 // choose a reasonbly large map that does not make test time too long.
 
-	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal, nil)
+	m := newMap(MapNameTCP4Global+"_test", mapTypeIPv4TCPGlobal)
 	err := m.OpenOrCreate()
 	assert.NoError(t, err)
 	assert.NoError(t, m.Map.Unpin())
@@ -876,7 +876,7 @@ func benchmarkCtGc(t *testing.B, size int) {
 		defer func() {
 			option.Config.CTMapEntriesGlobalTCP = prev
 		}()
-		ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal, nil)
+		ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
 		err = ctMap.OpenOrCreate()
 		assert.NoError(t, err)
 		defer ctMap.Map.Unpin()

--- a/pkg/maps/ctmap/fake/per_cluster.go
+++ b/pkg/maps/ctmap/fake/per_cluster.go
@@ -25,7 +25,7 @@ func NewPerClusterMaps() *PerClusterMaps {
 func (maps *PerClusterMaps) OpenOrCreate() error { return nil }
 func (maps *PerClusterMaps) Close() error        { return nil }
 
-func (maps *PerClusterMaps) GetAllClusterCTMaps() []*ctmap.Map { return nil }
+func (maps *PerClusterMaps) GetAllClusterCTMaps() []ctmap.MapPair { return nil }
 
 func (maps *PerClusterMaps) CreateClusterCTMaps(clusterID uint32) error {
 	maps.Lock()

--- a/pkg/maps/ctmap/per_cluster_ctmap.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap.go
@@ -284,8 +284,7 @@ func newPerClusterCTMap(m mapType) *PerClusterCTMap {
 
 func (om *PerClusterCTMap) newInnerMap(clusterID uint32) *Map {
 	name := ClusterInnerMapName(om.m, clusterID)
-	im := newMap(name, om.m, nil)
-	im.clusterID = clusterID
+	im := newMap(name, om.m, WithClusterID(clusterID))
 	return im
 }
 

--- a/pkg/maps/ctmap/per_cluster_ctmap_test.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap_test.go
@@ -130,7 +130,7 @@ func TestPrivilegedPerClusterCTMaps(t *testing.T) {
 
 	// Basic get all
 	ims := maps.GetAllClusterCTMaps()
-	require.Len(t, ims, 8, "Retrieved an unexpected number of maps")
+	require.Len(t, ims, 4, "Retrieved an unexpected number of maps")
 
 	// Basic delete
 	require.NoError(t, maps.DeleteClusterCTMaps(1), "Failed to delete maps")


### PR DESCRIPTION
This PR allows additional connection tracking (CT) maps to be created by vendor-specific extensions, which can also be registered to be part of CT GC. To avoid unwanted interactions with existing CT GC notifications, we add a network identifier that ensures that GC filters and callbacks do not confuse the entries in those additional CT maps with the ones found in the global CT maps.

In addition, existing `PerClusterCTMapsRetriever` logic (that already allowed the injection of additional maps to CT GC) is generalized to not just per-cluster maps and is made a bit more robust.

See individual commit messages for details.