### PR TITLE
bpf: flowtracer

### DIFF
--- a/bpf/lib/flowtracer.h
+++ b/bpf/lib/flowtracer.h
@@ -297,9 +297,9 @@ struct ft_l4_ports {
 struct ft_ctx {
 	bool parsed;
 	bool tx_ready;
-	__u16 l4_off;      /* Total offset from data to L4 hdr (ports) */
-	__u16 l4_csum_off; /* Total offset from data to the L4 csum */
-	__u16 ft_hdr_off;  /* Total offset from data to FT hdr */
+	__u8 l4_off;       /* Total offset from data to L4 hdr (ports) */
+	__u8 l4_csum_off;  /* Total offset from data to the L4 csum */
+	__u8 ft_hdr_off;   /* Total offset from data to FT hdr */
 
 	__be32 sum;        /* Accumulated L4 csum delta */
 };
@@ -580,7 +580,7 @@ void __ft_intercept(struct __ctx_buff *ctx, const __u8 l4_proto,
 	void *data_end = ctx_data_end(ctx);
 	void *data = ctx_data(ctx);
 	__u16 sport;
-	__u16 l4_size;
+	__u8 l4_size;
 	struct ft_hdr *hdr;
 	struct ft_l4_ports *l4;
 
@@ -590,7 +590,7 @@ void __ft_intercept(struct __ctx_buff *ctx, const __u8 l4_proto,
 
 	ft->parsed = true;
 
-	ft->l4_off = (__u16)l4_off;
+	ft->l4_off = (__u8)l4_off;
 	l4 = (struct ft_l4_ports *)(data + l4_off);
 	if (((void *)(l4 + 1)) > data_end)
 		return;
@@ -604,7 +604,7 @@ void __ft_intercept(struct __ctx_buff *ctx, const __u8 l4_proto,
 	    sport < FT_SENTINEL_MIN_PORT)
 		return;
 
-	ft->l4_csum_off = (__u16)l4_off;
+	ft->l4_csum_off = (__u8)l4_off;
 
 	switch (l4_proto) {
 	case IPPROTO_TCP:
@@ -620,7 +620,7 @@ void __ft_intercept(struct __ctx_buff *ctx, const __u8 l4_proto,
 		return;
 	}
 
-	ft->ft_hdr_off = (__u16)l4_off + l4_size;
+	ft->ft_hdr_off = (__u8)l4_off + l4_size;
 	hdr = data + ft->ft_hdr_off;
 	if ((void *)(hdr + 1) > data_end)
 		goto ERR;

--- a/bpf/lib/flowtracer.h
+++ b/bpf/lib/flowtracer.h
@@ -1,0 +1,735 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include "lib/common.h"
+#include <linux/tcp.h>
+#include <linux/udp.h>
+#include <bpf/compiler.h>
+/* TODO: add SCTP */
+
+/**
+ * Flowtracer is a library that allows especially crafted (sentinel) packets
+ * to flow through the datapath _as if_ they were real flow traffic (same
+ * src/dst IP, protocol and src/dst L4 port), but executing commands while
+ * traversing it. Commands can be used to force the execution of particular
+ * code paths, collect debug information (traces) and metrics.
+ *
+ * Sentinel packets MUST be injected from a trusted source (e.g. from a worker
+ * node, see WARNING note) and MUST be dropped before being delivered outside of
+ * the system under test (e.g. before delivering the packet to a Pod).
+ *
+ * Injected sentinel packets have the following structure:
+ *
+ * +--------------------+
+ * |       IP hdr       |
+ * +--------------------+
+ * |       L4 hdr       |
+ * |   (TCP/UDP/SCTP)   |
+ * +--------------------+
+ * |   FlowTracer hdr   |
+ * |   (list of cmds)   |
+ * +--------------------+
+ * |    Padding 0x0     |
+ * //       ...        //  (Pre-alloced space for trace information)
+ * |        0x0         |
+ * +--------------------+
+ *
+ * L4 payload starts with the FlowTracer header and a padding region of up
+ * to MTU - IP - L4 - FT hdr bytes, all set to 0x0. This space is used to
+ * store trace information while traversing the datapath without the need to
+ * call to bpf_xdp_adjust_tail()/ bpf_skb_change_tail(), changing L3/L4 hdr
+ * (e.g. tot_len) and making sure L3/L4 csum is additive.
+ *
+ * Sentinel packets with trace data have the following structure:
+ *
+ * +--------------------+
+ * |       IP hdr       |
+ * +--------------------+
+ * |       L4 hdr       |
+ * |   (TCP/UDP/SCTP)   |
+ * +--------------------+
+ * |   FlowTracer hdr   |
+ * |   (list of cmds)   |
+ * +--------------------+
+ * |  TLV: trace data1  |
+ * +--------------------+
+ * |  TLV: trace data2  |
+ * +--------------------+
+ * //       ...        //
+ * +--------------------+
+ * |    Padding 0x0     |
+ * //       ...        //  (Pre-alloced space for trace information)
+ * |        0x0         |
+ * +--------------------+
+ *
+ * Sentinel packets MUST be dropped and logged (E.g. hubble, output to a debug
+ * net device etc.) before making it to the final (flow) destination (E.g. a
+ * Pod).
+ *
+ * Sentinel packets need to be clearly identified from real traffic. There are a
+ * limited set of fields that can be (ab)used for this and that work for
+ * TCP/UDP/SCTP:
+ *
+ * - DSCP/TOS: possible, but there is the risk that fabrics rewrite it if they
+ *             do any kind of special QoS treatment (e.g. between worked nodes)
+ *             Some public clouds (e.g. AWS may preserve them, but some like
+ *             Azure might not).
+ *
+ * - Use a well-know port as a L4 src_port. Well behaved OSs should never use
+ *   ports < 1024 as a src_port (sentinel). It is therefore easy to identify
+ *   these packets as early as they are received. Then the original (> 1024)
+ *   L4 src_port, part of the L4 payload, can be restored, but the packet can
+ *   be marked as a sentinel.
+ *
+ *  Note that this has its nuances too:
+ *     - NLBs and RSS will use the "sentinel" L4 src_port for flow hashing if
+ *       the L4 src_port option is used. Most public clouds do. This is
+ *       generally not an issue, as for real traffic src_port is random
+ *       (`ip_local_port_range`), but if a particular path (e.g. node->node)
+ *       wants to be replicating it might need some spraying.
+ *
+ *     - If packets traverse nodes (e.g. worker node to worker node) the
+ *       sentinel src_port needs to be restored prior to TX (e.g. node->node).
+ *
+ * WARNING: Sentinel packets are a potential DOS vector. Untrusted flows must
+ * be filter to avoid DoS attacks (e.g. with NACLs).
+ */
+
+#define FT_SENTINEL_MIN_PORT 0x0380 /* 896 */
+#define FT_SENTINEL_MAX_PORT 0x03FF /* 1023 */
+
+#define FT_MAX_TLV_LEN 9100 /* Verifier max val. clamping */
+
+/**
+ * TLV type
+ */
+enum ft_tlv_type {
+	FT_TLV_INVALID       = 0,
+	FT_TLV_PKT_INFO      = 1, /* SKB_BUFF info (queue_id, mark etc.)*/
+	FT_TLV_ING_IFINDEX   = 2, /* Ingress interface */
+	FT_TLV_EGR_IFINDEX   = 3, /* Egress interface */
+	FT_TLV_CPU           = 4, /* CPU processing the packet */
+	FT_TLV_ING_TS        = 5, /* Ingress timestamp */
+	FT_TLV_EGR_TS        = 6, /* Egress timestamp */
+	FT_TLV_PKT_SNAPSHOT  = 7, /* First N bytes packet snapshot */
+	FT_TLV_DBG           = 8, /* DBG TLV */
+
+	FT_TLV_NODE          = 9, /* Node wher tracing is happening */
+	FT_TLV_LB_NODE       = 10, /* Selected backend's node */
+	FT_TLV_LB_BACK       = 11  /* Selected backend */
+
+	/* Add more... */
+};
+
+/**
+ * Bitmap of FlowTracer commands
+ */
+enum ft_cmd {
+	FT_CMD_TRACE_PKT_INFO    = (1 << FT_TLV_PKT_INFO),
+	FT_CMD_TRACE_IIFINDEX    = (1 << FT_TLV_ING_IFINDEX),
+	FT_CMD_TRACE_EIFINDEX    = (1 << FT_TLV_EGR_IFINDEX),
+	FT_CMD_TRACE_CPU         = (1 << FT_TLV_CPU),
+	FT_CMD_TRACE_ING_TS      = (1 << FT_TLV_ING_TS),
+	FT_CMD_TRACE_EGR_TS      = (1 << FT_TLV_EGR_TS),
+	FT_CMD_PKT_CAPTURE       = (1 << FT_TLV_PKT_SNAPSHOT),
+	FT_CMD_DBG               = (1 << FT_TLV_DBG),
+
+	FT_CMD_TRACE_NODE        = (1 << FT_TLV_NODE),
+	FT_CMD_TRACE_LB_NODE     = (1 << FT_TLV_LB_NODE),
+	FT_CMD_TRACE_LB_BACK     = (1 << FT_TLV_LB_BACK)
+};
+
+/**
+ * Commands structure
+ */
+struct ft_cmds {
+	__be32 cmds;        /* Commands bitmap */
+	__be32 reserved[3]; /* TODO: reserved for cmd options */
+} __packed;
+
+/**
+ * Basic Type+Length definition (out of the TLV)
+ */
+struct ft_tl {
+	__be32 type;  /* enum ft_tlv_type */
+	__u16 len;    /* Length in bytes including ft_tl */
+	__u8 pad[2];  /* Align to 4 byte */
+} __packed;
+
+/**
+ * Pkt info
+ */
+struct ft_tlv_info {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__be32 queue_id;
+	__be32 pkt_type;
+	__be32 hash;
+	__be32 mark;
+	__be32 gso_segs;
+	__be32 gso_size;
+} __packed;
+
+/* Note: generics make BPF code easier. Use specifics for the client side */
+
+/**
+ * Generic 32 bit Value TLV
+ */
+struct ft_tlv_32 {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__be32 value;
+} __packed;
+
+/**
+ * Generic 64 bit Value TLV
+ */
+struct ft_tlv_64 {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__be64 value;
+} __packed;
+
+/**
+ * Ingress/egress ifindex TLV
+ */
+struct ft_tlv_iface {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__be32 ifindex;
+} __packed;
+
+/**
+ * Processing CPU
+ */
+struct ft_tlv_cpu {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__be32 cpu;
+} __packed;
+
+/**
+ * Timestamp trace
+ */
+struct ft_tlv_ts {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__be64 ts; /* Timestamp in ns from bpf_ktime_get_ns() */
+} __packed;
+
+/**
+ * Packet snapshot
+ *
+ * Note: snaplen is part of tl->len (snaplen = tl->len - sizeof(struct ft_tl))
+ */
+struct ft_tlv_pkt_snap {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__u8 data[0];
+} __packed;
+
+/**
+ * Debug TLV
+ *
+ * Debug TLV is an opaque TLV
+ *
+ * Note: debug info length is part of tl->len (dbg_len = tl->len -
+ *       sizeof(struct ft_tl))
+ *
+ * XXX: is this really neeed? If you need to add support for this you might
+ *      as well define your own TLV
+ */
+struct ft_tlv_dbg {
+	struct ft_tl tl;
+
+	__be32 trace_point;
+	__u8 data[0];
+} __packed;
+
+enum ft_flags {
+	FT_TRUNCATED = (1 << 0),
+	FT_ERROR     = (1 << 1)
+};
+
+/**
+ * Flowtracer header that is immediately after the L4 header (L4 payload)
+ *
+ * Note: l4_sport MUST be aligned to a power of 2.
+ * Note2: tlvs_len is strictly not necessary but helps with logic. Also it's
+ *        oversized to align to 4byte.
+ */
+struct ft_hdr {
+	struct ft_cmds cmds;
+
+	__be16 l4_sport;      /* (original) src port to be used for lookups */
+	__u8   flags;
+	__u8   pad;
+	__be32 tlvs_len;     /* Size of all TLVs (bytes), aligned 4 bytes */
+	struct ft_tl tlvs[0]; /* First TLV */
+} __packed;
+
+/**
+ * Helper struct just to make code slightly cleaner
+ * Note: TCP/UDP/SCTP all have the same src/dst port in the same place
+ */
+struct ft_l4_ports {
+	__be16 sport;
+	__be16 dport;
+} __packed;
+
+/**
+ * Flowtracer parsing context
+ *
+ * Note: this makes the implicit assumption that no tunneling will happen to
+ * this point.
+ *
+ * TODO tracing encapsulated packets
+ */
+struct ft_ctx {
+	bool parsed;
+	bool tx_ready;
+	__u16 l4_off;      /* Total offset from data to L4 hdr (ports) */
+	__u16 l4_csum_off; /* Total offset from data to the L4 csum */
+	__u16 ft_hdr_off;  /* Total offset from data to FT hdr */
+};
+
+/**
+ * Get the Flowtracer parsing context
+ *
+ * Static var which should end up in stack
+ */
+static __always_inline
+struct ft_ctx *__ft_get(void)
+{
+	static struct ft_ctx ctx = {0};
+
+	return &ctx;
+}
+
+static __always_inline
+void ft_set_cmd(struct ft_hdr *hdr, const enum ft_cmd cmd)
+{
+	hdr->cmds.cmds = bpf_htonl(bpf_ntohl(hdr->cmds.cmds) | cmd);
+}
+
+static __always_inline
+bool ft_has_cmd(struct ft_hdr *hdr, const enum ft_cmd cmd)
+{
+	return bpf_ntohl(hdr->cmds.cmds) & cmd;
+}
+
+static __always_inline
+void ft_add_dbg_trace(struct __ctx_buff *ctx /*TODO*/)
+{
+	(void)ctx;
+	/* TODO */
+}
+
+static __always_inline
+void __ft_add_trace_uint(struct __ctx_buff *ctx, struct ft_ctx *ft,
+			 struct ft_hdr *hdr, const enum ft_tlv_type type,
+			 __u32 trace_point, const __u32 *value32,
+			 const __u64 *value64)
+{
+	void *data_end = ctx_data_end(ctx);
+	struct ft_tlv_32 *tlv;
+	__be32 old_tlvs_len;
+	__u16 tlvs_len;
+	__be32 sum;
+
+	build_bug_on(sizeof(struct ft_tlv_32) != 16);
+	build_bug_on(sizeof(struct ft_tlv_64) != 20);
+
+	if (!value32 && !value64)
+		return;
+
+	old_tlvs_len = hdr->tlvs_len;
+	tlvs_len = (__u16)bpf_ntohl(old_tlvs_len);
+
+	/*
+	 * clang optimizes tlvs_len with old_tlvs_len (32bit), so we need to
+	 * clamp the max value so that the verifier doesn't complain.
+	 */
+	if (tlvs_len > FT_MAX_TLV_LEN)
+		return;
+
+	tlv = (struct ft_tlv_32 *)((void *)(hdr + 1) + tlvs_len);
+	if ((void *)(tlv + 1) > data_end) {
+		hdr->flags |= FT_TRUNCATED;
+		return;
+	}
+
+	tlv->tl.type = bpf_htonl(type);
+	tlv->trace_point = bpf_htonl(trace_point);
+
+	if (value32) {
+		tlv->value = bpf_htonl(*value32);
+		tlv->tl.len = bpf_htons(sizeof(*tlv));
+		tlvs_len += sizeof(*tlv);
+		sum = csum_diff(NULL, 0, tlv, sizeof(*tlv), 0);
+	} else {
+		struct ft_tlv_64 *tlv64 = (struct ft_tlv_64 *)tlv;
+
+		if ((void *)(tlv64 + 1) > data_end)
+			goto ERR;
+
+		tlv64->value = bpf_cpu_to_be64(*value64);
+		tlv64->tl.len = bpf_htons(sizeof(*tlv64));
+		tlvs_len += sizeof(*tlv64);
+		sum = csum_diff(NULL, 0, tlv64, sizeof(*tlv64), 0);
+	}
+
+	hdr->tlvs_len = bpf_htonl(tlvs_len);
+	sum = csum_diff((__be32 *)&old_tlvs_len, 4,
+			(__be32 *)&hdr->tlvs_len, 4,
+			sum);
+
+	/*
+	 * Note this should never fail. If we were to jump to ERR, we would
+	 * have to revalidate ptrs etc, which would be very annoying.
+	 */
+	l4_csum_replace(ctx, ft->l4_csum_off, 0, sum, BPF_F_PSEUDO_HDR);
+
+	return;
+ERR:
+	hdr->tlvs_len = old_tlvs_len;
+	tlv->tl.type = 0;
+	tlv->tl.len = 0;
+	hdr->flags |= FT_ERROR;
+}
+
+static __always_inline
+void ft_add_trace32(struct __ctx_buff *ctx, const enum ft_tlv_type type,
+		    __u32 trace_point, const __u32 value)
+{
+#ifndef ENABLE_FLOWTRACER
+	return;
+#endif /* ENABLE_FLOWTRACER */
+
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	struct ft_ctx *ft = __ft_get();
+	struct ft_hdr *hdr;
+
+	/* Optimize for the non-sentinel pkt */
+	if (likely(ft->ft_hdr_off == 0))
+		return;
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		return;
+
+	if (!ft_has_cmd(hdr, (enum ft_cmd)(1 << type)))
+		return;
+
+	switch (type) {
+	case FT_TLV_ING_IFINDEX:
+	case FT_TLV_EGR_IFINDEX:
+	case FT_TLV_CPU:
+		break;
+	default:
+		return;
+	}
+
+	__ft_add_trace_uint(ctx, ft, hdr, type, trace_point, &value, NULL);
+}
+
+static __always_inline
+void ft_add_trace64(struct __ctx_buff *ctx, const enum ft_tlv_type type,
+		    __u32 trace_point, const __u64 value)
+{
+#ifndef ENABLE_FLOWTRACER
+	return;
+#endif /* ENABLE_FLOWTRACER */
+
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	struct ft_ctx *ft = __ft_get();
+	struct ft_hdr *hdr;
+
+	/* Optimize for the non-sentinel pkt */
+	if (likely(ft->ft_hdr_off == 0))
+		return;
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		return;
+
+	if (!ft_has_cmd(hdr, (enum ft_cmd)(1 << type)))
+		return;
+
+	switch (type) {
+	case FT_TLV_ING_TS:
+	case FT_TLV_EGR_TS:
+
+	case FT_TLV_NODE:
+	case FT_TLV_LB_NODE:
+	case FT_TLV_LB_BACK:
+		break;
+	default:
+		return;
+	}
+
+	__ft_add_trace_uint(ctx, ft, hdr, type, trace_point, NULL, &value);
+}
+
+static __always_inline
+void ft_add_pkt_snap(struct __ctx_buff *ctx, __u32 trace_point, const __u16 len)
+{
+#ifndef ENABLE_FLOWTRACER
+	return;
+#endif /* ENABLE_FLOWTRACER */
+
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	struct ft_ctx *ft = __ft_get();
+	struct ft_hdr *hdr;
+	struct ft_tlv_pkt_snap *tlv;
+	__be32 old_tlvs_len;
+	void *snap;
+	__be32 sum;
+
+	/* Optimize for the non-sentinel pkt */
+	if (likely(ft->ft_hdr_off == 0))
+		return;
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		return;
+
+	if (!ft_has_cmd(hdr, FT_CMD_PKT_CAPTURE))
+		return;
+
+	old_tlvs_len = hdr->tlvs_len;
+
+	tlv = (struct ft_tlv_pkt_snap *)((void *)(hdr + 1) + bpf_ntohl(old_tlvs_len));
+	if ((void *)(tlv + 1) > data_end) {
+		hdr->flags |= FT_TRUNCATED;
+		return;
+	}
+
+	snap = (void *)(tlv + 1);
+	if ((snap + len) > data_end) {
+		hdr->flags |= FT_TRUNCATED;
+		return;
+	}
+
+	/* Append as TLV payload first len bytes of the pkt */
+	/* Do this BEFORE adding the TLV */
+	memcpy(snap, data, len);
+
+	tlv->tl.type = bpf_htonl(FT_TLV_PKT_SNAPSHOT);
+	tlv->tl.len = bpf_htons(sizeof(*tlv));
+	tlv->trace_point = bpf_htonl(trace_point);
+	old_tlvs_len = hdr->tlvs_len;
+
+	hdr->tlvs_len = bpf_htonl(bpf_ntohl(old_tlvs_len) +
+				     sizeof(*tlv) + len);
+	sum = csum_diff((__be32 *)&old_tlvs_len, 4,
+			(__be32 *)&hdr->tlvs_len, 4,
+			0);
+	sum = csum_diff(NULL, 0, tlv, sizeof(*tlv), sum);
+	sum = csum_diff(NULL, 0, data, len, sum);
+
+	if (l4_csum_replace(ctx, ft->l4_csum_off, 0, sum,
+			    BPF_F_PSEUDO_HDR) < 0) {
+		hdr->tlvs_len = old_tlvs_len;
+		hdr->flags |= FT_ERROR;
+	}
+}
+
+static __always_inline
+int __ft_flip_l4_src_port(struct __ctx_buff *ctx, struct ft_ctx *ft,
+			  struct ft_hdr *hdr)
+{
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	struct ft_l4_ports *l4;
+	__be16 tmp;
+
+	if (!ft || !hdr)
+		return -1;
+
+	if (hdr->l4_sport == 0)
+		return 0;
+
+	l4 = (struct ft_l4_ports *)(data + ft->l4_off);
+	if ((void *)(l4 + 1) > data_end)
+		return -1;
+
+	/**
+	 * NOTE: this doesn't affect the L4 csum as the two values are
+	 * flipped and both compute in the csum. For this to be true
+	 * l4_sport needs to be aligned to a multiple of 2 byte offset.
+	 */
+	tmp = l4->sport;
+	l4->sport = hdr->l4_sport;
+	hdr->l4_sport = tmp;
+
+	return 0;
+}
+
+static __always_inline
+void __ft_intercept(struct __ctx_buff *ctx, const __u8 l4_proto,
+		    const int l4_off)
+{
+	struct ft_ctx *ft = __ft_get();
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	__u16 sport;
+	__u16 l4_size;
+	struct ft_hdr *hdr;
+	struct ft_l4_ports *l4;
+
+	/* Optimize for the non-sentinel pkt */
+	if (ft->parsed && likely(ft->ft_hdr_off == 0))
+		return;
+
+	ft->parsed = true;
+
+	ft->l4_off = (__u16)l4_off;
+	l4 = (struct ft_l4_ports *)(data + l4_off);
+	if (((void *)(l4 + 1)) > data_end)
+		return;
+
+	sport = bpf_ntohs(l4->sport);
+
+	/* TODO: implement DSCP intercepting mode */
+
+	/* Skip FT packets as early as possible (hot) */
+	if (likely(sport > FT_SENTINEL_MAX_PORT) ||
+	    sport < FT_SENTINEL_MIN_PORT)
+		return;
+
+	ft->l4_csum_off = (__u16)l4_off;
+
+	switch (l4_proto) {
+	case IPPROTO_TCP:
+		l4_size = sizeof(struct tcphdr);
+		ft->l4_csum_off += offsetof(struct tcphdr, check);
+		break;
+	case IPPROTO_UDP:
+		l4_size = sizeof(struct udphdr);
+		ft->l4_csum_off += offsetof(struct udphdr, check);
+		break;
+	/* TODO case IPPROTO_SCTP: */
+	default:
+		return;
+	}
+
+	ft->ft_hdr_off = (__u16)l4_off + l4_size;
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		goto ERR;
+
+	if (__ft_flip_l4_src_port(ctx, ft, hdr) != 0)
+		goto ERR;
+
+	return;
+ERR:
+	ft->l4_off = 0;
+	ft->l4_csum_off = 0;
+	ft->ft_hdr_off = 0;
+}
+
+/**
+ * Parses and caches the Flowtracer header if it's sentinel packet, else is a
+ * no op.
+ */
+static __always_inline
+void ft_intercept(struct __ctx_buff *ctx, const __u8 l4_proto, const int l4_off)
+{
+#ifndef ENABLE_FLOWTRACER
+	return;
+#endif /* ENABLE_FLOWTRACER */
+
+	__ft_intercept(ctx, l4_proto, l4_off);
+}
+
+/**
+ * Trap packet to CPU
+ */
+static __always_inline
+void ft_trap(struct __ctx_buff *ctx)
+{
+#ifndef ENABLE_FLOWTRACER
+	return;
+#endif /* ENABLE_FLOWTRACER */
+
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	struct ft_ctx *ft = __ft_get();
+	struct ft_hdr *hdr;
+
+	/* Optimize for the non-sentinel pkt */
+	if (likely(ft->ft_hdr_off == 0))
+		return;
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		return;
+
+	/* Prepare the message */
+	/* XXX */
+}
+
+/**
+ * Drop sentinel pkt
+ */
+static __always_inline
+int ft_drop(struct __ctx_buff *ctx)
+{
+#ifndef ENABLE_FLOWTRACER
+	return 0;
+#endif /* ENABLE_FLOWTRACER */
+
+	struct ft_ctx *ft = __ft_get();
+	(void)ctx;
+
+	/* Optimize for the non-sentinel pkt */
+	if (likely(ft->ft_hdr_off == 0))
+		return 0;
+
+	return DROP_UNROUTABLE;
+}
+
+/**
+ * Prepares the packet to be transmitted to another host (flips back src port)
+ * if needed.
+ *
+ * This function is idempotent.
+ */
+static __always_inline
+void ft_prep_tx(struct __ctx_buff *ctx)
+{
+#ifndef ENABLE_FLOWTRACER
+	return;
+#endif /* ENABLE_FLOWTRACER */
+
+	void *data_end = ctx_data_end(ctx);
+	void *data = ctx_data(ctx);
+	struct ft_ctx *ft = __ft_get();
+	struct ft_hdr *hdr;
+
+	/* Optimize for the non-sentinel pkt */
+	if (likely(ft->ft_hdr_off == 0) || ft->tx_ready)
+		return;
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		return;
+
+	if (__ft_flip_l4_src_port(ctx, ft, hdr) != 0)
+		return;
+
+	ft->tx_ready = true;
+}

--- a/bpf/tests/scapy/flowtracer_hdr.py
+++ b/bpf/tests/scapy/flowtracer_hdr.py
@@ -1,0 +1,389 @@
+from scapy.all import *
+from scapy.packet import Packet, bind_layers
+from scapy.fields import *
+
+from enum import IntFlag
+
+# A field that is not serialized in the wire
+class HiddenLenField(Field):
+    def __init__(self, name, default):
+        super().__init__(name, default, fmt="!I")
+    def addfield(self, pkt, s, val):
+        # Don't add anything to the wire
+        return s
+    def getfield(self, pkt, s):
+        return s, getattr(pkt, self.name)
+    def i2repr(self, pkt, x):
+        return str(x)
+
+# Note: this needs match definitions on lib/flowtracer.h
+
+# TLV types
+FT_TLV_INVALID       = 0
+FT_TLV_PKT_INFO      = 1
+FT_TLV_ING_IFINDEX   = 2
+FT_TLV_EGR_IFINDEX   = 3
+FT_TLV_CPU           = 4
+FT_TLV_ING_TS        = 5
+FT_TLV_EGR_TS        = 6
+FT_TLV_PKT_SNAPSHOT  = 7
+FT_TLV_DBG           = 8
+FT_TLV_NODE          = 9
+FT_TLV_LB_NODE       = 10
+FT_TLV_LB_BACK       = 11
+
+# TLV map (scapy field)
+FT_TLV_MAP = {
+    FT_TLV_INVALID: "FT_TLV_INVALID",
+    FT_TLV_PKT_INFO: "FT_TLV_PKT_INFO",
+    FT_TLV_ING_IFINDEX: "FT_TLV_ING_IFINDEX",
+    FT_TLV_EGR_IFINDEX: "FT_TLV_EGR_IFINDEX",
+    FT_TLV_CPU: "FT_TLV_CPU",
+    FT_TLV_ING_TS: "FT_TLV_ING_TS",
+    FT_TLV_EGR_TS: "FT_TLV_EGR_TS",
+    FT_TLV_PKT_SNAPSHOT: "FT_TLV_PKT_SNAPSHOT",
+    FT_TLV_DBG: "FT_TLV_DBG",
+    FT_TLV_NODE: "FT_TLV_NODE",
+    FT_TLV_LB_NODE: "FT_TLV_LB_NODE",
+    FT_TLV_LB_BACK: "FT_TLV_LB_BACK"
+}
+
+class FlowTracerTLVBase(Packet):
+    name = "TLVBase"
+    tlv_type = FT_TLV_INVALID
+    tlv_len = 12
+
+    fields_desc = [
+        IntField("type", 0),
+        ShortField("len", 0),
+        StrFixedLenField("pad", b'\x00\x00', length=2),
+        IntField("tracepoint", 0)
+    ]
+
+    def __init__(self, *args, **kwargs):
+        kwargs["type"] = self.__class__.tlv_type
+        kwargs["len"] = self.__class__.tlv_len
+        super().__init__(*args, **kwargs)
+
+    def guess_payload_class(self, p):
+        cls = Raw
+        if len(p) < 4:
+            return Raw
+        next_type = int.from_bytes(p[:4], byteorder='big')
+        if next_type in FT_TLV_TYPE_MAP:
+            cls = FT_TLV_TYPE_MAP.get(next_type, Raw)
+        return cls
+
+class FlowTracerTLVInfo(FlowTracerTLVBase):
+    name = "TLVInfo"
+    tlv_type = FT_TLV_PKT_INFO
+    tlv_len = 36
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        IntField("queue_id", 0),
+        IntField("pkt_type", 0),
+        IntField("hash", 0),
+        IntField("mark", 0),
+        IntField("gso_segs", 0),
+        IntField("gso_size", 0)
+    ]
+
+class FlowTracerTLVIngIfindex(FlowTracerTLVBase):
+    name = "TLVIngIface"
+    tlv_type = FT_TLV_ING_IFINDEX
+    tlv_len = 16
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        IntField("ifindex", 0),
+    ]
+
+class FlowTracerTLVEgrIfindex(FlowTracerTLVBase):
+    name = "TLVEgrIface"
+    tlv_type = FT_TLV_EGR_IFINDEX
+    tlv_len = 16
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        IntField("ifindex", 0),
+    ]
+
+class FlowTracerTLVCpu(FlowTracerTLVBase):
+    name = "TLVCpu"
+    tlv_type = FT_TLV_CPU
+    tlv_len = 16
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        IntField("cpu", 0),
+    ]
+
+class FlowTracerTLVIngTs(FlowTracerTLVBase):
+    name = "TLVIngTs"
+    tlv_type = FT_TLV_ING_TS
+    tlv_len = 20
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        LongField("ts", 0),
+    ]
+
+class FlowTracerTLVEgrTs(FlowTracerTLVBase):
+    name = "TLVEgrTs"
+    tlv_type = FT_TLV_EGR_TS
+    tlv_len = 20
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        LongField("ts", 0),
+    ]
+
+class FlowTracerTLVDbg(FlowTracerTLVBase):
+    name = "TLVDbg"
+    tlv_type = FT_TLV_DBG
+    tlv_len = 12
+
+    fields_desc = FlowTracerTLVBase.fields_desc
+
+    #TODO: add variable length
+
+class FlowTracerTLVPacketSnap(FlowTracerTLVBase):
+    name = "TLVPacketSnap"
+    tlv_type = FT_TLV_PKT_SNAPSHOT
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        PacketField("data", None, Packet),
+    ]
+
+    def __init__(self, *args, **kwargs):
+        if "data" in kwargs:
+            self.tlv_len = 12 + len(kwargs["data"])
+        super().__init__(*args, **kwargs)
+
+class FlowTracerTLVNode(FlowTracerTLVBase):
+    name = "TLVNode"
+    tlv_type = FT_TLV_NODE
+    tlv_len = 20
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        LongField("node", 0),
+    ]
+
+class FlowTracerTLVLBNode(FlowTracerTLVBase):
+    name = "TLVLBNode"
+    tlv_type = FT_TLV_LB_NODE
+    tlv_len = 20
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        LongField("node", 0),
+    ]
+
+class FlowTracerTLVLBBackend(FlowTracerTLVBase):
+    name = "TLVLBBackend"
+    tlv_type = FT_TLV_LB_BACK
+    tlv_len = 20
+
+    fields_desc = FlowTracerTLVBase.fields_desc + [
+        LongField("backend", 0),
+    ]
+
+# For scapy parsing
+FT_TLV_TYPE_MAP = {
+    FT_TLV_PKT_INFO: FlowTracerTLVInfo,
+    FT_TLV_ING_IFINDEX: FlowTracerTLVIngIfindex,
+    FT_TLV_EGR_IFINDEX: FlowTracerTLVEgrIfindex,
+    FT_TLV_CPU: FlowTracerTLVCpu,
+    FT_TLV_ING_TS: FlowTracerTLVIngTs,
+    FT_TLV_EGR_TS: FlowTracerTLVEgrTs,
+    FT_TLV_PKT_SNAPSHOT: FlowTracerTLVPacketSnap,
+    FT_TLV_DBG: FlowTracerTLVDbg,
+    FT_TLV_NODE: FlowTracerTLVNode,
+    FT_TLV_LB_NODE: FlowTracerTLVLBNode,
+    FT_TLV_LB_BACK: FlowTracerTLVLBBackend
+}
+
+# Commands
+FT_CMD_TRACE_PKT_INFO = (1 << FT_TLV_PKT_INFO)
+FT_CMD_TRACE_IIFINDEX = (1 << FT_TLV_ING_IFINDEX)
+FT_CMD_TRACE_EIFINDEX = (1 << FT_TLV_EGR_IFINDEX)
+FT_CMD_TRACE_CPU      = (1 << FT_TLV_CPU)
+FT_CMD_TRACE_ING_TS   = (1 << FT_TLV_ING_TS)
+FT_CMD_TRACE_EGR_TS   = (1 << FT_TLV_EGR_TS)
+FT_CMD_PKT_CAPTURE    = (1 << FT_TLV_PKT_SNAPSHOT)
+FT_CMD_DBG            = (1 << FT_TLV_DBG)
+
+FT_CMD_TRACE_NODE    = (1 << FT_TLV_NODE)
+FT_CMD_TRACE_LB_NODE    = (1 << FT_TLV_LB_NODE)
+FT_CMD_TRACE_LB_BACK  = (1 << FT_TLV_LB_BACK)
+
+FT_CMDS_MAP = {
+    FT_CMD_TRACE_PKT_INFO : "FT_CMD_TRACE_PKT_INFO",
+    FT_CMD_TRACE_IIFINDEX : "FT_CMD_TRACE_IIFINDEX",
+    FT_CMD_TRACE_EIFINDEX : "FT_CMD_TRACE_EIFINDEX",
+    FT_CMD_TRACE_CPU : "FT_CMD_TRACE_CPU",
+    FT_CMD_TRACE_ING_TS : "FT_CMD_TRACE_ING_TS",
+    FT_CMD_TRACE_EGR_TS : "FT_CMD_TRACE_EGR_TS",
+    FT_CMD_PKT_CAPTURE : "FT_CMD_PKT_CAPTURE",
+    FT_CMD_DBG : "FT_CMD_DBG",
+
+    FT_CMD_TRACE_NODE : "FT_CMD_TRACE_NODE",
+    FT_CMD_TRACE_LB_NODE : "FT_CMD_TRACE_LB_NODE",
+    FT_CMD_TRACE_LB_BACK : "FT_CMD_TRACE_LB_BACK"
+}
+
+FT_CMDS_ALL = 0
+for k in FT_CMDS_MAP: FT_CMDS_ALL |= k
+
+# Flags
+FT_TRUNCATED = (1 << 0)
+FT_ERROR = (1 << 0)
+
+FT_FLAGS_MAP = {
+    FT_TRUNCATED: "FT_TRUNCATED",
+    FT_ERROR: "FT_ERROR"
+}
+
+def tlv_dispatcher(raw_bytes, **kwargs):
+    try:
+        cls = Raw
+        if len(raw_bytes) < 4:
+            return cls
+        next_type = int.from_bytes(raw_bytes[:4], byteorder='big')
+        if next_type in FT_TLV_TYPE_MAP:
+            cls = FT_TLV_TYPE_MAP.get(next_type, Raw)
+        return cls(raw_bytes, **kwargs)
+    except Exception as e:
+        print(f"Error parsing: {e}")
+
+
+class FlowTracer(Packet):
+    name = "FlowTracer"
+    fields_desc = [
+        # struct ft_cmds
+        FlagsField("cmds", 0, 32, FT_CMDS_MAP),
+        StrFixedLenField("cmd_pad3", b"\x00"*12, length=12),
+
+        # struct ft_hdr
+        ShortField("l4_sport", 0),
+        FlagsField("flags", 0, 8, FT_FLAGS_MAP),
+        StrFixedLenField("pad1", b"\x00", length=1),
+        FieldLenField("tlvs_len", None, length_of="tlvs", fmt="!I"),
+        PacketListField("tlvs", [], tlv_dispatcher, length_from=lambda pkt: pkt.tlvs_len),
+    ]
+
+# Bind default port
+default_port = 896
+bind_layers(TCP, FlowTracer, sport=default_port)
+bind_layers(UDP, FlowTracer, sport=default_port)
+bind_layers(SCTP, FlowTracer, sport=default_port)
+
+def autotest():
+    # Make sure structs are correctly aligned
+    assert len(FlowTracer()) == 24
+
+    assert len(FlowTracerTLVBase()) == 12
+
+    info_tlv = FlowTracerTLVInfo()
+    assert len(info_tlv) == 36
+    assert info_tlv.type == FT_TLV_PKT_INFO
+    assert info_tlv.len == 36
+    info2_tlv = FlowTracerTLVInfo(bytes(info_tlv))
+    assert info2_tlv.type == FT_TLV_PKT_INFO
+    assert info2_tlv.len == 36
+
+    ingif_tlv = FlowTracerTLVIngIfindex()
+    assert len(ingif_tlv) == 16
+    assert ingif_tlv.type == FT_TLV_ING_IFINDEX
+    assert ingif_tlv.len == 16
+
+    egrif_tlv = FlowTracerTLVEgrIfindex()
+    assert len(egrif_tlv) == 16
+    assert egrif_tlv.type == FT_TLV_EGR_IFINDEX
+    assert egrif_tlv.len == 16
+
+    cpu_tlv = FlowTracerTLVCpu()
+    assert len(cpu_tlv) == 16
+    assert cpu_tlv.type == FT_TLV_CPU
+    assert cpu_tlv.len == 16
+
+    ingts_tlv = FlowTracerTLVIngTs()
+    assert len(ingts_tlv) == 20
+    assert ingts_tlv.type == FT_TLV_ING_TS
+    assert ingts_tlv.len == 20
+
+    egrts_tlv = FlowTracerTLVEgrTs()
+    assert len(egrts_tlv) == 20
+    assert egrts_tlv.type == FT_TLV_EGR_TS
+    assert egrts_tlv.len == 20
+
+    dbg_tlv = FlowTracerTLVDbg()
+    assert len(dbg_tlv) == 12
+    assert dbg_tlv.type == FT_TLV_DBG
+    assert dbg_tlv.len == 12
+
+    pktsnap_tlv = FlowTracerTLVPacketSnap()
+    assert len(pktsnap_tlv) == 12
+    assert pktsnap_tlv.type == FT_TLV_PKT_SNAPSHOT
+    assert pktsnap_tlv.len == 12
+    """
+    #TODO fixme
+    pktsnap_a_tlv = FlowTracerTLVPacketSnap(data=IP())
+    pktsnap_b_tlv = FlowTracerTLVPacketSnap(bytes(pktsnap_a_tlv))
+    pktsnap_a_tlv.show()
+    pktsnap_b_tlv.show()
+    hexdump(pktsnap_a_tlv)
+    hexdump(pktsnap_b_tlv)
+
+    assert pktsnap_a_tlv.len == 12 + 20
+    assert len(bytes(pktsnap_a_tlv)) == 12 + 20
+    assert pktsnap_b_tlv.len ==  12 + 20
+    """
+
+    node_tlv = FlowTracerTLVNode()
+    assert len(node_tlv) == 20
+    assert node_tlv.type == FT_TLV_NODE
+    assert node_tlv.len == 20
+
+    lbnode_tlv = FlowTracerTLVLBNode()
+    assert len(lbnode_tlv) == 20
+    assert lbnode_tlv.type == FT_TLV_LB_NODE
+    assert lbnode_tlv.len == 20
+
+    lbback_tlv = FlowTracerTLVLBBackend()
+    assert len(lbback_tlv) == 20
+    assert lbback_tlv.type == FT_TLV_LB_BACK
+    assert lbback_tlv.len == 20
+
+    # Make sure tlvs_len is properly calculated when stacking
+    p = TCP() / FlowTracer(tlvs = [
+        FlowTracerTLVIngIfindex()
+    ])
+
+    p = TCP(bytes(p))
+    assert p["FlowTracer"].tlvs_len == 16
+
+    tlv = p['FlowTracer'].tlvs[0]
+
+    p = (
+        FlowTracer(tlvs = [
+            FlowTracerTLVIngTs(),
+            FlowTracerTLVEgrTs(),
+            FlowTracerTLVIngIfindex(),
+            #FlowTracerTLVPacketSnap(data=IP()/TCP()) / TODO fixme
+            FlowTracerTLVNode(),
+            FlowTracerTLVLBNode(),
+            FlowTracerTLVLBBackend()
+        ]) /
+        Raw(load=b'\x00' * 512)
+    )
+
+    p = FlowTracer(bytes(p))
+
+    p2 = FlowTracer(bytes(p))
+    assert len(p) == len(p2)
+
+    tlvs_len = 20 + 20 + 16 + 20 + 20 + 20 #+ TODO add pkt snap(12 + 40)
+    p["FlowTracer"].tlvs_len = tlvs_len #Note: scapy doesn't populate tlvs_len, not even after build()
+    assert p == p2
+
+    assert len(p) == (24 + tlvs_len + 512)
+    assert p["FlowTracer"].tlvs_len == tlvs_len
+
+    return True
+
+assert autotest()

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -13,3 +13,4 @@ from tc_l2_announce6_pkt_defs import *
 from wg_from_netdev_pkt_defs import *
 from tc_wireguard_from_overlay_pkt_defs import *
 from icmp_err_revnat_pkt_defs import *
+from tc_flowtracer_pkt_defs import *

--- a/bpf/tests/scapy/tc_flowtracer_pkt_defs.py
+++ b/bpf/tests/scapy/tc_flowtracer_pkt_defs.py
@@ -50,3 +50,17 @@ ee_tc_ft_traces3264 = (
 )
 ee_tc_ft_traces3264_csum = ee_tc_ft_traces3264.copy()
 ee_tc_ft_traces3264_csum["TCP"].chksum = None
+
+ee_tc_ft_nospace = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(dport=80) /
+    FlowTracer(cmds = FT_CMDS_ALL, l4_sport=64000)
+)
+
+ee_tc_ft_nospace_err = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(dport=80) /
+    FlowTracer(cmds = FT_CMDS_ALL, l4_sport=64000, flags=FT_TRUNCATED)
+)

--- a/bpf/tests/scapy/tc_flowtracer_pkt_defs.py
+++ b/bpf/tests/scapy/tc_flowtracer_pkt_defs.py
@@ -1,0 +1,46 @@
+from pkt_defs import *
+from flowtracer_hdr import *
+
+ee_tc_ft_sentinel = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(dport=80) /
+    FlowTracer(cmds = FT_CMDS_ALL, l4_sport=64000) /
+    Raw(b'\00'*512)
+)
+
+ee_tc_ft_sentinel_intercepted = ee_tc_ft_sentinel.copy()
+ee_tc_ft_sentinel_intercepted["TCP"].sport = 64000
+ee_tc_ft_sentinel_intercepted["FlowTracer"].l4_sport = 896
+
+assert(ee_tc_ft_sentinel["TCP"].sport == 896)
+assert(ee_tc_ft_sentinel_intercepted["TCP"].sport == 64000)
+
+ee_tc_ft_traces32 = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(dport=80, sport=64000) /
+    FlowTracer(cmds = FT_CMDS_ALL, l4_sport=896, tlvs= [
+        FlowTracerTLVIngIfindex(tracepoint=0x16E55, ifindex=1),
+        FlowTracerTLVEgrIfindex(tracepoint=0xE6E55, ifindex=2),
+        FlowTracerTLVCpu(tracepoint=0xC06E, cpu=2)
+    ]) /
+    Raw(b'\00'*464)
+)
+
+ee_tc_ft_traces3264 = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(dport=80, sport=64000) /
+    FlowTracer(cmds = FT_CMDS_ALL, l4_sport=896, tlvs= [
+        FlowTracerTLVIngIfindex(tracepoint=0x16E55, ifindex=1),
+        FlowTracerTLVEgrIfindex(tracepoint=0xE6E55, ifindex=2),
+        FlowTracerTLVCpu(tracepoint=0xC06E, cpu=2),
+        FlowTracerTLVIngTs(tracepoint=0x16E55, ts=0x1234),
+        FlowTracerTLVEgrTs(tracepoint=0xE6E55, ts=0x4321),
+        FlowTracerTLVNode(tracepoint=0xE6E55, node=0x1B00F1),
+        FlowTracerTLVLBNode(tracepoint=0xE6E55, node=0x1B00F2),
+        FlowTracerTLVLBBackend(tracepoint=0xE6E55, backend=0x1B00BE)
+    ]) /
+    Raw(b'\00'*364)
+)

--- a/bpf/tests/tc_flowtracer.c
+++ b/bpf/tests/tc_flowtracer.c
@@ -84,7 +84,6 @@ int test_intercept_check(struct __ctx_buff *ctx)
 	 * Intercept
 	 */
 	ft_intercept(ctx, IPPROTO_TCP, TCP_OFFSET);
-
 	ft = __ft_get();
 
 	/* Verify parsing state is congruent */

--- a/bpf/tests/tc_flowtracer.c
+++ b/bpf/tests/tc_flowtracer.c
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "bpf/ctx/skb.h"
+#include "common.h"
+#include "pktgen.h"
+
+#include "scapy.h"
+
+#include "node_config.h"
+#include "lib/common.h"
+
+#define ENABLE_FLOWTRACER 1
+#include "lib/flowtracer.h"
+
+#define TCP_OFFSET (sizeof(struct ethhdr) + sizeof(struct iphdr))
+
+CHECK("tc", "tc_ft_test_align")
+int check_struct_alignments(struct __ctx_buff *ctx)
+{
+	(void)ctx;
+
+	test_init();
+
+	assert(sizeof(struct ft_cmds) == 16);
+	assert(sizeof(struct ft_tl) == 8);
+	assert(sizeof(struct ft_tlv_info) == 36);
+
+	/* 32 bit TLVs */
+	assert(sizeof(struct ft_tlv_32) == 16);
+	assert(sizeof(struct ft_tlv_iface) == 16);
+	assert(sizeof(struct ft_tlv_cpu) == 16);
+
+	/* 64 bit TLVs */
+	assert(sizeof(struct ft_tlv_64) == 20);
+	assert(sizeof(struct ft_tlv_ts) == 20);
+
+	/* Var. length tlvs */
+	assert(sizeof(struct ft_tlv_pkt_snap) == 12);
+
+	/* Main Flowtracer header */
+	assert(sizeof(struct ft_hdr) == 24);
+
+	/* Other */
+	assert(sizeof(struct ft_l4_ports) == 4);
+
+	/* Make sure l4_sport is in aligned to multiple of 2 */
+	assert(offsetof(struct ft_hdr, l4_sport) % 2 == 0);
+
+	/* TODO add TLV DBG once properly defined */
+
+	test_finish();
+}
+
+PKTGEN("tc", "test_intercept")
+int test_intercept_build_pkt(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(FT_TC_SENTINEL_PKT1, ee_tc_ft_sentinel);
+	BUILDER_PUSH_BUF(builder, FT_TC_SENTINEL_PKT1);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "test_intercept")
+int test_intercept_check(struct __ctx_buff *ctx)
+{
+	void *data = ctx_data(ctx);
+	void *data_end = ctx_data_end(ctx);
+	struct ft_ctx *ft = NULL;
+	struct ft_hdr *hdr;
+	struct ft_l4_ports *l4;
+	__u32 tlvs_len;
+	__u16 off;
+
+	test_init();
+
+	/**
+	 * Intercept
+	 */
+	ft_intercept(ctx, IPPROTO_TCP, TCP_OFFSET);
+
+	ft = __ft_get();
+
+	/* Verify parsing state is congruent */
+	assert(ft);
+	assert(ft->parsed);
+	assert(ft->l4_off == TCP_OFFSET);
+	off = (TCP_OFFSET + offsetof(struct tcphdr, check));
+	assert(ft->l4_csum_off == off);
+	off = (TCP_OFFSET + sizeof(struct tcphdr));
+	assert(ft->ft_hdr_off == off);
+
+	/** FT hdr sport MUST be aligned to a power of 2 so flipping ports is
+	 * csum neutral
+	 */
+	off = ft->ft_hdr_off + offsetof(struct ft_hdr, l4_sport);
+	assert(off % 2 == 0);
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		test_fatal("hdr out of bounds");
+
+	l4 = (struct ft_l4_ports *)(data + ft->l4_off);
+	if (((void *)(l4 + 1)) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Now check ports have been flipped */
+	assert(hdr->l4_sport == bpf_htons(896));
+	assert(l4->sport == bpf_htons(64000));
+
+	/* Eth ... TCP should not have changed except for TCP.sport */
+	BUF_DECL(EXP_FT_TC_SENTINEL_INTER, ee_tc_ft_sentinel_intercepted);
+	ASSERT_CTX_BUF_OFF("ft_tc_intercept_ok", "Ether", ctx, 0,
+			   EXP_FT_TC_SENTINEL_INTER,
+			   sizeof(BUF(EXP_FT_TC_SENTINEL_INTER)));
+
+	/**
+	 * 32 bit traces
+	 */
+	ft_add_trace32(ctx, FT_TLV_ING_IFINDEX, 0x16E55, 1);
+	ft_add_trace32(ctx, FT_TLV_EGR_IFINDEX, 0xE6E55, 2);
+	ft_add_trace32(ctx, FT_TLV_CPU, 0xC06E, 2);
+
+	/* Parsing state should not have been modified */
+	assert(ft->parsed);
+	assert(ft->l4_off == TCP_OFFSET);
+	off = (TCP_OFFSET + offsetof(struct tcphdr, check));
+	assert(ft->l4_csum_off == off);
+	off = (TCP_OFFSET + sizeof(struct tcphdr));
+	assert(ft->ft_hdr_off == off);
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		test_fatal("hdr out of bounds");
+	tlvs_len = 3 * sizeof(struct ft_tlv_32);
+	assert(hdr->tlvs_len == bpf_htonl(tlvs_len));
+
+	BUF_DECL(EXP_FT_TC_TRACES32, ee_tc_ft_traces32);
+	ASSERT_CTX_BUF_OFF("ft_tc_traces32_ok", "Ether", ctx, 0,
+			   EXP_FT_TC_TRACES32, sizeof(BUF(EXP_FT_TC_TRACES32)));
+
+	/**
+	 * 64 bit traces
+	 */
+	ft_add_trace64(ctx, FT_TLV_ING_TS, 0x16E55, 0x1234ULL);
+	ft_add_trace64(ctx, FT_TLV_EGR_TS, 0xE6E55, 0x4321ULL);
+	ft_add_trace64(ctx, FT_TLV_NODE, 0xE6E55, 0x1B00F1ULL);
+	ft_add_trace64(ctx, FT_TLV_LB_NODE, 0xE6E55, 0x1B00F2ULL);
+	ft_add_trace64(ctx, FT_TLV_LB_BACK, 0xE6E55, 0x1B00BEULL);
+
+	/* Parsing state should not have been modified */
+	assert(ft->parsed);
+	assert(ft->l4_off == TCP_OFFSET);
+	off = (TCP_OFFSET + offsetof(struct tcphdr, check));
+	assert(ft->l4_csum_off == off);
+	off = (TCP_OFFSET + sizeof(struct tcphdr));
+	assert(ft->ft_hdr_off == off);
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		test_fatal("hdr out of bounds");
+	tlvs_len += 5 * sizeof(struct ft_tlv_64);
+
+	assert(hdr->tlvs_len == bpf_htonl(tlvs_len));
+
+	BUF_DECL(EXP_FT_TC_TRACES3264, ee_tc_ft_traces3264);
+	ASSERT_CTX_BUF_OFF("ft_tc_traces3264_ok", "Ether", ctx, 0,
+			   EXP_FT_TC_TRACES3264,
+			   sizeof(BUF(EXP_FT_TC_TRACES3264)));
+
+	/**
+	 * Test ft_trap
+	 */
+	/* TODO */
+
+	/**
+	 * Test ft_drop
+	 */
+
+	/* Mimic a non-intercepted pkt, which must NOT be dropped */
+	off = ft->ft_hdr_off;
+	ft->ft_hdr_off = 0;
+	assert(ft_drop(ctx) == 0);
+
+	/* Now an intercepted one */
+	ft->ft_hdr_off = (__u8)off;
+	assert(ft_drop(ctx) == DROP_UNROUTABLE);
+
+	/**
+	 * Test ft_prep_tx
+	 */
+	assert(!ft->tx_ready);
+	ft_prep_tx(ctx);
+	assert(ft->tx_ready);
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		test_fatal("hdr out of bounds");
+
+	l4 = (struct ft_l4_ports *)(data + ft->l4_off);
+	if (((void *)(l4 + 1)) > data_end)
+		test_fatal("l4 out of bounds");
+
+	/* Ports must be flipped back */
+	assert(hdr->l4_sport == bpf_htons(64000));
+	assert(l4->sport == bpf_htons(896));
+
+	/* Testing idempotency */
+	ft_prep_tx(ctx);
+	assert(ft->tx_ready);
+	assert(hdr->l4_sport == bpf_htons(64000));
+	assert(l4->sport == bpf_htons(896));
+
+	/* A packet that is intercepted can't be re-intercepted */
+	ft_intercept(ctx, IPPROTO_TCP, TCP_OFFSET);
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		test_fatal("hdr out of bounds");
+
+	l4 = (struct ft_l4_ports *)(data + ft->l4_off);
+	if (((void *)(l4 + 1)) > data_end)
+		test_fatal("l4 out of bounds");
+
+	assert(hdr->l4_sport == bpf_htons(896));
+	assert(l4->sport == bpf_htons(64000));
+	assert(ft->tx_ready);
+
+	test_finish();
+
+	return 0;
+}
+
+/* Necessary for test functions calling indirectly printk() */
+BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/tc_flowtracer2.c
+++ b/bpf/tests/tc_flowtracer2.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "bpf/ctx/skb.h"
+#include "common.h"
+#include "pktgen.h"
+
+#include "scapy.h"
+
+#include "node_config.h"
+#include "lib/common.h"
+
+#define ENABLE_FLOWTRACER 1
+#include "tc_flowtracer.h"
+
+#define TCP_OFFSET (sizeof(struct ethhdr) + sizeof(struct iphdr))
+
+PKTGEN("tc", "test_err_nospace")
+int test_err_nospace_build_pkt(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(FT_TC_NOSPACE, ee_tc_ft_nospace);
+	BUILDER_PUSH_BUF(builder, FT_TC_NOSPACE);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "test_err_nospace")
+int test_err_nospace(struct __ctx_buff *ctx)
+{
+	void *data = ctx_data(ctx);
+	void *data_end = ctx_data_end(ctx);
+	struct ft_ctx *ft = NULL;
+	struct ft_hdr *hdr;
+	__u16 off;
+
+	test_init();
+
+	/**
+	 * Intercept
+	 */
+	ft_intercept(ctx, IPPROTO_TCP, TCP_OFFSET);
+
+	/* Verify parsing state is congruent */
+	ft = __ft_get();
+	assert(ft);
+	assert(ft->parsed);
+	assert(ft->l4_off == TCP_OFFSET);
+	off = (TCP_OFFSET + offsetof(struct tcphdr, check));
+	assert(ft->l4_csum_off == off);
+	off = (TCP_OFFSET + sizeof(struct tcphdr));
+	assert(ft->ft_hdr_off == off);
+
+	/* Add a trace without space */
+	ft_add_trace32(ctx, FT_TLV_ING_IFINDEX, 0x16E55, 1);
+
+	hdr = data + ft->ft_hdr_off;
+	if ((void *)(hdr + 1) > data_end)
+		test_fatal("hdr out of bounds");
+	assert(hdr->tlvs_len == 0);
+	assert(hdr->flags & FT_TRUNCATED);
+
+	ft_prep_tx(ctx);
+
+	BUF_DECL(EXP_FT_TC_ERR_NOSPACE, ee_tc_ft_nospace_err);
+	ASSERT_CTX_BUF_OFF("ft_tc_err_nospace", "Ether", ctx, 0,
+			   EXP_FT_TC_ERR_NOSPACE,
+			   sizeof(BUF(EXP_FT_TC_ERR_NOSPACE)));
+
+	test_finish();
+
+	return 0;
+}
+
+/* Necessary for test functions calling indirectly printk() */
+BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/tc_flowtracer2.c
+++ b/bpf/tests/tc_flowtracer2.c
@@ -11,7 +11,7 @@
 #include "lib/common.h"
 
 #define ENABLE_FLOWTRACER 1
-#include "tc_flowtracer.h"
+#include "lib/flowtracer.h"
 
 #define TCP_OFFSET (sizeof(struct ethhdr) + sizeof(struct iphdr))
 


### PR DESCRIPTION
`Flowtracer` is a BPF library that allows especially crafted (sentinel) packets to flow through the datapath as if they were real flow traffic (same src/dst IP, protocol and src/dst L4 port), but executing commands while traversing it. Commands can be used to force the execution of particular code paths, collect debug information (traces) and metrics.

These packets with all the tracing information can later - before being delivered to the termination point - be trapped (captured) by hubble.

#### More details

Extracted from `flowtracer.h` (see first commit for the latest version):

```
/**
 * Flowtracer is a library that allows especially crafted (sentinel) packets
 * to flow through the datapath _as if_ they were real flow traffic (same
 * src/dst IP, protocol and src/dst L4 port), but executing commands while
 * traversing it. Commands can be used to force the execution of particular
 * code paths, collect debug information (traces) and metrics.
 *
 * Sentinel packets MUST be injected from a trusted source (e.g. from a worker
 * node, see WARNING note) and MUST be dropped before being delivered outside of
 * the system under test (e.g. before delivering the packet to a Pod).
 *
 * Injected sentinel packets have the following structure:
 *
 * +--------------------+
 * |       IP hdr       |
 * +--------------------+
 * |       L4 hdr       |
 * |   (TCP/UDP/SCTP)   |
 * +--------------------+
 * |   FlowTracer hdr   |
 * |   (list of cmds)   |
 * +--------------------+
 * |    Padding 0x0     |
 * //       ...        //  (Pre-alloced space for trace information)
 * |        0x0         |
 * +--------------------+
 *
 * L4 payload starts with the FlowTracer header and a padding region of up
 * to MTU - IP - L4 - FT hdr bytes, all set to 0x0. This space is used to
 * store trace information while traversing the datapath without the need to
 * call to bpf_xdp_adjust_tail()/ bpf_skb_change_tail(), changing L3/L4 hdr
 * (e.g. tot_len) and making sure L3/L4 csum is additive.
 *
 * Sentinel packets with trace data have the following structure:
 *
 * +--------------------+
 * |       IP hdr       |
 * +--------------------+
 * |       L4 hdr       |
 * |   (TCP/UDP/SCTP)   |
 * +--------------------+
 * |   FlowTracer hdr   |
 * |   (list of cmds)   |
 * +--------------------+
 * |  TLV: trace data1  |
 * +--------------------+
 * |  TLV: trace data2  |
 * +--------------------+
 * //       ...        //
 * +--------------------+
 * |    Padding 0x0     |
 * //       ...        //  (Pre-alloced space for trace information)
 * |        0x0         |
 * +--------------------+
 *
 * Sentinel packets MUST be dropped and logged (E.g. hubble, output to a debug
 * net device etc.) before making it to the final (flow) destination (E.g. a
 * Pod).
 *
 * Sentinel packets need to be clearly identified from real traffic. There are a
 * limited set of fields that can be (ab)used for this and that work for
 * TCP/UDP/SCTP:
 *
 * - DSCP/TOS: possible, but there is the risk that fabrics rewrite it if they
 *             do any kind of special QoS treatment (e.g. between worked nodes)
 *             Some public clouds (e.g. AWS may preserve them, but some like
 *             Azure might not).
 *
 * - Use a well-know port as a L4 src_port. Well behaved OSs should never use
 *   ports < 1024 as a src_port (sentinel). It is therefore easy to identify
 *   these packets as early as they are received. Then the original (> 1024)
 *   L4 src_port, part of the L4 payload, can be restored, but the packet can
 *   be marked as a sentinel.
 *
 *  Note that this has its nuances too:
 *     - NLBs and RSS will use the "sentinel" L4 src_port for flow hashing if
 *       the L4 src_port option is used. Most public clouds do. This is
 *       generally not an issue, as for real traffic src_port is random
 *       (`ip_local_port_range`), but if a particular path (e.g. node->node)
 *       wants to be replicating it might need some spraying.
 *
 *     - If packets traverse nodes (e.g. worker node to worker node) the
 *       sentinel src_port needs to be restored prior to TX (e.g. node->node).
 *
 * WARNING: Sentinel packets are a potential DOS vector. Untrusted flows must
 * be filter to avoid DoS attacks (e.g. with NACLs).
 */
```

#### TODO list:

* Implement DSCP mode and add it to the unit test coverage (see below).
* Add the security features to prevent DoS (see below).
* Add tracing code in the different Cilium paths we would like to trace (likely in a different PR).
* Hubble / trap support [here](https://github.com/cilium/cilium/blob/9eb765eb9c1724d9d91e2e6a8efd4a5127a7a316/bpf/lib/flowtracer.h#L682) (likely in a different PR).

Related:

* https://github.com/cilium/cilium/discussions/43941

```release-note
TBD
```
