### PR TITLE
fix(socketlb): only detach cilium-owned cgroup programs

### DIFF
--- a/pkg/socketlb/cgroup.go
+++ b/pkg/socketlb/cgroup.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -228,14 +229,23 @@ func detachAll(logger *slog.Logger, attach ebpf.AttachType, cgroupRoot string) e
 		return nil
 	}
 
-	// cilium owns the cgroup and assumes only one program is attached.
-	// This allows to remove all ids returned in the query phase.
+	// Detach only Cilium-owned programs from the cgroup.
 	for _, id := range ids.Programs {
 		prog, err := ebpf.NewProgramFromID(id.ID)
 		if err != nil {
-			return fmt.Errorf("could not open program id %d: %w", id, err)
+			return fmt.Errorf("could not open program id %d: %w", id.ID, err)
 		}
 		defer prog.Close()
+
+		// Only detach programs that belong to Cilium (name starts with "cil_").
+		// This prevents accidentally detaching programs from other applications.
+		info, err := prog.Info()
+		if err != nil {
+			return fmt.Errorf("could not get info for program id %d: %w", id.ID, err)
+		}
+		if !strings.HasPrefix(info.Name, "cil_") {
+			continue
+		}
 
 		if err := link.RawDetachProgram(link.RawDetachProgramOptions{
 			Target:  int(cg.Fd()),

--- a/pkg/socketlb/cgroup_test.go
+++ b/pkg/socketlb/cgroup_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -190,4 +191,49 @@ func TestPrivilegedDetachCGroupWithExistingLink(t *testing.T) {
 	if err := detachCgroup(logger, "test", cgroupPath, linkPath); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// Verify that non-Cilium programs (programs without "cil_" prefix) are preserved
+// during cgroup detachment. This is a regression test for issue #43877.
+func TestPrivilegedDetachCGroupPreservesNonCiliumPrograms(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	logger := hivetest.Logger(t)
+
+	// mustCgroupProgram creates programs with empty names, which don't start
+	// with "cil_" and therefore simulate non-Cilium programs.
+	nonCiliumProg := mustCgroupProgram(t)
+
+	linkPath := testutils.TempBPFFS(t)
+	cgroupPath := testutils.TempCgroup(t)
+	f, err := os.Open(cgroupPath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	// Attach the non-Cilium program using PROG_ATTACH.
+	err = link.RawAttachProgram(link.RawAttachProgramOptions{
+		Target:  int(f.Fd()),
+		Program: nonCiliumProg,
+		Attach:  ebpf.AttachCGroupInetIngress,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = link.RawDetachProgram(link.RawDetachProgramOptions{
+			Target:  int(f.Fd()),
+			Program: nonCiliumProg,
+			Attach:  ebpf.AttachCGroupInetIngress,
+		})
+	})
+
+	// detachCgroup should NOT detach the non-Cilium program.
+	err = detachCgroup(logger, "test", cgroupPath, linkPath)
+	require.NoError(t, err)
+
+	// Verify the non-Cilium program is still attached.
+	ids, err := link.QueryPrograms(link.QueryOptions{
+		Target: int(f.Fd()),
+		Attach: ebpf.AttachCGroupInetIngress,
+	})
+	require.NoError(t, err)
+	require.Len(t, ids.Programs, 1, "non-Cilium program was incorrectly detached")
 }


### PR DESCRIPTION
When detaching BPF cgroup programs, check if the program name starts with `'cil_'` before detaching. This prevents cilium from accidentally detaching programs belonging to other applications on the node.

Previously, cilium would detach all programs of a given attach type from the cgroup, causing errors when other applications had their own BPF programs attached.



<!-- Description of change -->

Fixes: #43877

```release-note
fix(socketlb): only detach Cilium-owned cgroup programs
```
