### PR TITLE
bgp: Introduce bgp/peers Hive Shell command

### DIFF
--- a/pkg/bgp/agent/routermgr.go
+++ b/pkg/bgp/agent/routermgr.go
@@ -20,12 +20,16 @@ type BGPRouterManager interface {
 	// and the implementation will configure itself to apply this configuration.
 	ReconcileInstances(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
 
-	// GetPeers fetches BGP peering state from underlying routing daemon.
+	// GetPeersLegacy fetches BGP peering state from underlying routing
+	// daemon.
 	//
-	// List of all peers will be returned and if there are multiple instances of
-	// BGP daemon running locally, then peers can be differentiated based on
-	// local AS number.
-	GetPeers(ctx context.Context) ([]*models.BgpPeer, error)
+	// List of all peers will be returned and if there are multiple
+	// instances of BGP daemon running locally, then peers can be
+	// differentiated based on local AS number.
+	//
+	// This is a legacy method used by the REST API and will be replaced in
+	// the future.
+	GetPeersLegacy(ctx context.Context) ([]*models.BgpPeer, error)
 
 	// GetRoutes fetches BGP routes from underlying routing daemon's RIBs.
 	GetRoutes(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)

--- a/pkg/bgp/agent/routermgr.go
+++ b/pkg/bgp/agent/routermgr.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	"github.com/cilium/cilium/pkg/bgp/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
@@ -19,6 +20,10 @@ type BGPRouterManager interface {
 	// ReconcileInstances evaluates the provided CiliumBGPNodeConfig
 	// and the implementation will configure itself to apply this configuration.
 	ReconcileInstances(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
+
+	// GetPeers fetches peer states for all BGP instances managed by this
+	// manager. It returns a mapping of instance name to its peer states.
+	GetPeers(ctx context.Context, req *GetPeersRequest) (*GetPeersResponse, error)
 
 	// GetPeersLegacy fetches BGP peering state from underlying routing
 	// daemon.
@@ -39,4 +44,18 @@ type BGPRouterManager interface {
 
 	// Stop will stop all BGP instances and clean up local state.
 	Stop(ctx cell.HookContext) error
+}
+
+// GetPeersRequest is a request for GetPeers method.
+type GetPeersRequest struct{}
+
+// GetPeersResponse is the response type for GetPeers method.
+type GetPeersResponse struct {
+	Instances []InstancePeerStates
+}
+
+// InstancePeerStates holds peer states for a specific BGP instance.
+type InstancePeerStates struct {
+	Name  string
+	Peers []types.PeerState
 }

--- a/pkg/bgp/api/get_peer.go
+++ b/pkg/bgp/api/get_peer.go
@@ -32,7 +32,7 @@ func (h *getPeerHandler) Handle(params restapi.GetBgpPeersParams) middleware.Res
 	if h.controller == nil {
 		return api.Error(http.StatusNotImplemented, agent.ErrBGPControlPlaneDisabled)
 	}
-	peers, err := h.controller.BGPMgr.GetPeers(params.HTTPRequest.Context())
+	peers, err := h.controller.BGPMgr.GetPeersLegacy(params.HTTPRequest.Context())
 	if err != nil {
 		return api.Error(http.StatusInternalServerError, fmt.Errorf("failed to get peers: %w", err))
 	}

--- a/pkg/bgp/cell.go
+++ b/pkg/bgp/cell.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/agent"
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgp/api"
+	"github.com/cilium/cilium/pkg/bgp/commands"
 	"github.com/cilium/cilium/pkg/bgp/gobgp"
 	"github.com/cilium/cilium/pkg/bgp/manager"
 	"github.com/cilium/cilium/pkg/bgp/manager/reconciler"
@@ -95,6 +96,9 @@ var Cell = cell.Module(
 
 	// BGP state reconcilers
 	reconciler.StateReconcilers,
+
+	// Script commands
+	commands.Cell,
 
 	cell.Invoke(
 		// Invoke bgp controller to trigger the constructor.

--- a/pkg/bgp/commands/cell.go
+++ b/pkg/bgp/commands/cell.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+
+	"github.com/cilium/cilium/pkg/bgp/agent"
+)
+
+var Cell = cell.Provide(BGPCommands)
+
+func BGPCommands(bgpMgr agent.BGPRouterManager) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"bgp/peers": BGPPPeersCmd(bgpMgr),
+	})
+}

--- a/pkg/bgp/commands/peer.go
+++ b/pkg/bgp/commands/peer.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/bgp/agent"
+	"github.com/cilium/cilium/pkg/bgp/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func BGPPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List BGP peers on Cilium",
+			Flags: func(fs *pflag.FlagSet) {
+				addOutFileFlag(fs)
+				fs.Bool("no-uptime", false, "Do not show Uptime for testing purpose")
+			},
+			Detail: []string{
+				"List current state of all BGP peers configured in Cilium BGP Control Plane",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(*script.State) (stdout, stderr string, err error) {
+				noUptime, err := s.Flags.GetBool("no-uptime")
+				if err != nil {
+					return "", "", err
+				}
+
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				res, err := bgpMgr.GetPeers(s.Context(), &agent.GetPeersRequest{})
+				if err != nil {
+					return "", "", err
+				}
+
+				PrintPeerStates(tw, res.Instances, noUptime)
+
+				tw.Flush()
+
+				return buf.String(), "", err
+			}, nil
+		},
+	)
+}
+
+func PrintPeerStates(tw *tabwriter.Writer, instances []agent.InstancePeerStates, noUptime bool) {
+	type row struct {
+		Instance     string
+		Peer         string
+		SessionState string
+		Uptime       string
+		Family       string
+		Received     string
+		Accepted     string
+		Advertised   string
+	}
+
+	var rows []row
+
+	rows = append(rows, row{
+		Instance:     "Instance",
+		Peer:         "Peer",
+		SessionState: "Session State",
+		Uptime:       "Uptime",
+		Family:       "Family",
+		Received:     "Received",
+		Accepted:     "Accepted",
+		Advertised:   "Advertised",
+	})
+
+	for _, instance := range instances {
+		for _, peer := range instance.Peers {
+			for _, family := range peer.Families {
+				rows = append(rows, row{
+					Instance:     instance.Name,
+					Peer:         peer.Name,
+					SessionState: peer.SessionState.String(),
+					Uptime:       peer.Uptime.Truncate(time.Second).String(),
+					Family:       family.String(),
+					Received:     strconv.FormatUint(family.ReceivedRoutes, 10),
+					Accepted:     strconv.FormatUint(family.AcceptedRoutes, 10),
+					Advertised:   strconv.FormatUint(family.AdvertisedRoutes, 10),
+				})
+			}
+		}
+	}
+
+	// Sort by Instance, Peer, Family for better deduplication
+	slices.SortFunc(rows, func(a, b row) int {
+		c := strings.Compare(a.Instance, b.Instance)
+		if c != 0 {
+			return c
+		}
+		c = strings.Compare(a.Peer, b.Peer)
+		if c != 0 {
+			return c
+		}
+		return strings.Compare(a.Family, b.Family)
+	})
+
+	prevInstance := ""
+	prevPeer := ""
+	for i, row := range rows {
+		// Always print header
+		if i != 0 {
+			established := row.SessionState == types.SessionEstablished.String()
+
+			// Deduplicate Instance name
+			if row.Instance == prevInstance {
+				row.Instance = ""
+			}
+
+			if row.Peer == prevPeer {
+				// Deduplicate Peer name. Also per-peer information like
+				// Session State and Uptime doesn't need to be repeated.
+				row.Peer = ""
+				row.SessionState = ""
+				row.Uptime = ""
+			} else if noUptime {
+				// Hide Uptime if requested
+				row.Uptime = "-"
+			} else if !established {
+				// Hide Uptime if session is not established
+				row.Uptime = "-"
+			}
+
+			// Hide route counts if session is not established
+			if !established {
+				row.Received = "-"
+				row.Accepted = "-"
+				row.Advertised = "-"
+			}
+
+			prevInstance = row.Instance
+			prevPeer = row.Peer
+		}
+
+		fmt.Fprintf(tw, "%s\n", strings.Join([]string{
+			row.Instance,
+			row.Peer,
+			row.SessionState,
+			row.Uptime,
+			row.Family,
+			row.Received,
+			row.Accepted,
+			row.Advertised,
+		}, "\t"))
+	}
+}

--- a/pkg/bgp/commands/utils.go
+++ b/pkg/bgp/commands/utils.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+)
+
+const (
+	outFileFlag      = "out"
+	outFileFlagShort = "o"
+
+	tabPadding     = 3
+	tabMinWidth    = 5
+	tabPaddingChar = ' '
+)
+
+func addOutFileFlag(fs *pflag.FlagSet) {
+	fs.StringP(outFileFlag, outFileFlagShort, "", "File to write to instead of stdout")
+}
+
+func getCmdTabWriter(s *script.State) (tw *tabwriter.Writer, buf *strings.Builder, f *os.File, err error) {
+	fileName := ""
+	fileName, err = s.Flags.GetString(outFileFlag)
+	if err != nil {
+		return
+	}
+
+	buf = &strings.Builder{}
+	var writer io.Writer
+	if fileName == "" {
+		// will write to string buffer
+		writer = buf
+	} else {
+		// will write to file
+		f, err = os.OpenFile(s.Path(fileName), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		if err != nil {
+			err = fmt.Errorf("error opening file %s: %w", fileName, err)
+			return
+		}
+		writer = f
+	}
+
+	tw = tabwriter.NewWriter(writer, tabMinWidth, 0, tabPadding, tabPaddingChar, 0)
+	return
+}

--- a/pkg/bgp/gobgp/state.go
+++ b/pkg/bgp/gobgp/state.go
@@ -43,8 +43,8 @@ func (g *GoBGPServer) GetBGP(ctx context.Context) (types.GetBGPResponse, error) 
 	}, nil
 }
 
-// GetPeerState invokes goBGP ListPeer API to get current peering state.
-func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateResponse, error) {
+// GetPeerStateLegacy invokes goBGP ListPeer API to get current peering state.
+func (g *GoBGPServer) GetPeerStateLegacy(ctx context.Context) (types.GetPeerStateLegacyResponse, error) {
 	var data []*models.BgpPeer
 	fn := func(peer *gobgp.Peer) {
 		if peer == nil {
@@ -132,10 +132,10 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateRespo
 	// advertised routes.
 	err := g.server.ListPeer(ctx, &gobgp.ListPeerRequest{EnableAdvertised: true}, fn)
 	if err != nil {
-		return types.GetPeerStateResponse{}, err
+		return types.GetPeerStateLegacyResponse{}, err
 	}
 
-	return types.GetPeerStateResponse{
+	return types.GetPeerStateLegacyResponse{
 		Peers: data,
 	}, nil
 }

--- a/pkg/bgp/gobgp/state_test.go
+++ b/pkg/bgp/gobgp/state_test.go
@@ -321,7 +321,7 @@ func TestGetPeerState(t *testing.T) {
 				}
 			}
 
-			res, err := testSC.GetPeerState(context.Background())
+			res, err := testSC.GetPeerStateLegacy(context.Background())
 			require.NoError(t, err)
 
 			// validate neighbors count
@@ -341,7 +341,7 @@ func TestGetPeerState(t *testing.T) {
 				}
 			}
 
-			res, err = testSC.GetPeerState(context.Background())
+			res, err = testSC.GetPeerStateLegacy(context.Background())
 			require.NoError(t, err)
 
 			// validate peers

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -214,8 +214,8 @@ func (m *BGPRouterManager) reconcileStateWithRetry(ctx context.Context) error {
 	return wait.ExponentialBackoffWithContext(ctx, bo, retryFn)
 }
 
-// GetPeers gets peering state from previously initialized bgp instances.
-func (m *BGPRouterManager) GetPeers(ctx context.Context) ([]*models.BgpPeer, error) {
+// GetPeersLegacy gets peering state from previously initialized bgp instances.
+func (m *BGPRouterManager) GetPeersLegacy(ctx context.Context) ([]*models.BgpPeer, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -225,7 +225,7 @@ func (m *BGPRouterManager) GetPeers(ctx context.Context) ([]*models.BgpPeer, err
 
 	var res []*models.BgpPeer
 	for _, i := range m.BGPInstances {
-		getPeerResp, err := i.Router.GetPeerState(ctx)
+		getPeerResp, err := i.Router.GetPeerStateLegacy(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -266,7 +266,7 @@ func (m *BGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpR
 		}
 		if allPeers {
 			// get routes for each peer of the server
-			getPeerResp, err := i.Router.GetPeerState(ctx)
+			getPeerResp, err := i.Router.GetPeerStateLegacy(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/bgp/manager/reconciler/crd_status.go
+++ b/pkg/bgp/manager/reconciler/crd_status.go
@@ -355,7 +355,7 @@ func (r *StatusReconciler) getInstanceStatus(ctx context.Context, instance *inst
 	}
 
 	// get peer status
-	peers, err := instance.Router.GetPeerState(ctx)
+	peers, err := instance.Router.GetPeerStateLegacy(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bgp/manager/reconciler/neighbor_test.go
+++ b/pkg/bgp/manager/reconciler/neighbor_test.go
@@ -534,7 +534,7 @@ func setupNeighbors(t *testing.T, peers []PeerData) (NeighborReconcilerIn, *v2.C
 }
 
 func getRunningPeers(req *require.Assertions, instance *instance.BGPInstance) []PeerData {
-	getPeerResp, err := instance.Router.GetPeerState(context.Background())
+	getPeerResp, err := instance.Router.GetPeerStateLegacy(context.Background())
 	req.NoError(err)
 
 	var runningPeers []PeerData

--- a/pkg/bgp/metrics/metrics.go
+++ b/pkg/bgp/metrics/metrics.go
@@ -83,7 +83,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	// revisit this timeout when the metrics collection starts to involve a
 	// network communication.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	peers, err := c.in.RouterManager.GetPeers(ctx)
+	peers, err := c.in.RouterManager.GetPeersLegacy(ctx)
 	cancel()
 	if err != nil {
 		c.in.Logger.Error("Failed to retrieve BGP peer information. Metrics is not collected.", logfields.Error, err)

--- a/pkg/bgp/mock/mocks.go
+++ b/pkg/bgp/mock/mocks.go
@@ -37,6 +37,7 @@ var _ agent.BGPRouterManager = (*MockBGPRouterManager)(nil)
 
 type MockBGPRouterManager struct {
 	ReconcileInstances_ func(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
+	GetPeers_           func(ctx context.Context, req *agent.GetPeersRequest) (*agent.GetPeersResponse, error)
 	GetPeersLegacy_     func(ctx context.Context) ([]*models.BgpPeer, error)
 	GetRoutes_          func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	GetRoutePolicies_   func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
@@ -45,6 +46,10 @@ type MockBGPRouterManager struct {
 
 func (m *MockBGPRouterManager) ReconcileInstances(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error {
 	return m.ReconcileInstances_(ctx, bgpnc, ciliumNode)
+}
+
+func (m *MockBGPRouterManager) GetPeers(ctx context.Context, req *agent.GetPeersRequest) (*agent.GetPeersResponse, error) {
+	return m.GetPeers_(ctx, req)
 }
 
 func (m *MockBGPRouterManager) GetPeersLegacy(ctx context.Context) ([]*models.BgpPeer, error) {

--- a/pkg/bgp/mock/mocks.go
+++ b/pkg/bgp/mock/mocks.go
@@ -37,7 +37,7 @@ var _ agent.BGPRouterManager = (*MockBGPRouterManager)(nil)
 
 type MockBGPRouterManager struct {
 	ReconcileInstances_ func(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
-	GetPeers_           func(ctx context.Context) ([]*models.BgpPeer, error)
+	GetPeersLegacy_     func(ctx context.Context) ([]*models.BgpPeer, error)
 	GetRoutes_          func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	GetRoutePolicies_   func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
 	Stop_               func(cell.HookContext) error
@@ -47,8 +47,8 @@ func (m *MockBGPRouterManager) ReconcileInstances(ctx context.Context, bgpnc *v2
 	return m.ReconcileInstances_(ctx, bgpnc, ciliumNode)
 }
 
-func (m *MockBGPRouterManager) GetPeers(ctx context.Context) ([]*models.BgpPeer, error) {
-	return m.GetPeers_(ctx)
+func (m *MockBGPRouterManager) GetPeersLegacy(ctx context.Context) ([]*models.BgpPeer, error) {
+	return m.GetPeersLegacy_(ctx)
 }
 
 func (m *MockBGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {

--- a/pkg/bgp/test/commands/bgp.go
+++ b/pkg/bgp/test/commands/bgp.go
@@ -49,7 +49,7 @@ func BGPPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					defer f.Close()
 				}
 
-				peers, err := bgpMgr.GetPeers(s.Context())
+				peers, err := bgpMgr.GetPeersLegacy(s.Context())
 				if err != nil {
 					return "", "", err
 				}

--- a/pkg/bgp/test/commands/bgp.go
+++ b/pkg/bgp/test/commands/bgp.go
@@ -22,43 +22,9 @@ const (
 
 func BGPScriptCmds(bgpMgr agent.BGPRouterManager) map[string]script.Cmd {
 	return map[string]script.Cmd{
-		"bgp/peers":          BGPPPeersCmd(bgpMgr),
 		"bgp/routes":         BGPPRoutesCmd(bgpMgr),
 		"bgp/route-policies": BGPPRoutePolicies(bgpMgr),
 	}
-}
-
-func BGPPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
-	return script.Command(
-		script.CmdUsage{
-			Summary: "List BGP peers on Cilium",
-			Flags: func(fs *pflag.FlagSet) {
-				addOutFileFlag(fs)
-			},
-			Detail: []string{
-				"List current state of all BGP peers configured in Cilium BGP Control Plane.",
-			},
-		},
-		func(s *script.State, args ...string) (script.WaitFunc, error) {
-			return func(*script.State) (stdout, stderr string, err error) {
-				tw, buf, f, err := getCmdTabWriter(s)
-				if err != nil {
-					return "", "", err
-				}
-				if f != nil {
-					defer f.Close()
-				}
-
-				peers, err := bgpMgr.GetPeersLegacy(s.Context())
-				if err != nil {
-					return "", "", err
-				}
-				api.PrintBGPPeersTable(tw, peers, false)
-
-				return buf.String(), "", err
-			}, nil
-		},
-	)
 }
 
 func BGPPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {

--- a/pkg/bgp/test/testdata/peering-default-gateway.txtar
+++ b/pkg/bgp/test/testdata/peering-default-gateway.txtar
@@ -21,7 +21,7 @@ k8s/add bgp-node-config.yaml bgp-peer-config.yaml
 k8s/add service-lb.yaml
 
 # Validate that there are no BGP peers configured yet
-bgp/peers -o peers.actual
+bgp/peers -o peers.actual --no-uptime
 * cmp bgp-peers-empty.expected peers.actual
 
 # Add device and routes entries into statedb
@@ -35,7 +35,7 @@ gobgp/wait-state -s v4 10.99.0.136 ESTABLISHED
 gobgp/wait-state -s v6 fd00::aa:bb:cc:136 ESTABLISHED
 
 # Validate discovered BGP peers
-bgp/peers -o peers.actual
+bgp/peers -o peers.actual --no-uptime
 * cmp bgp-peers-discovered.expected peers.actual
 
 # Validate routes on v4 server
@@ -180,11 +180,11 @@ status:
     - ip: 172.16.1.1
 
 -- bgp-peers-empty.expected --
-Local AS   Peer AS   Peer Address   Session   Family   Received   Advertised
+Instance   Peer   Session State   Uptime   Family   Received   Accepted   Advertised
 -- bgp-peers-discovered.expected --
-Local AS   Peer AS   Peer Address              Session       Family         Received   Advertised
-65001      65010     10.99.0.135:1790          established   ipv4/unicast   0          2
-65001      65011     fd00::aa:bb:cc:135:1790   established   ipv4/unicast   0          2
+Instance   Peer         Session State   Uptime   Family         Received   Accepted   Advertised
+tor        gw-peer-v4   established     -        ipv4-unicast   0          0          2
+           gw-peer-v6   established     -        ipv4-unicast   0          0          2
 -- gobgp-routes-v4.expected --
 Prefix          NextHop       Attrs
 10.244.0.0/24   10.99.0.136   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.136}]

--- a/pkg/bgp/test/testdata/peering-multi-instance.txtar
+++ b/pkg/bgp/test/testdata/peering-multi-instance.txtar
@@ -71,7 +71,7 @@ gobgp/routes -s test2 -o routes.actual
 * cmp gobgp-routes-all-65002.expected routes.actual
 
 # Validate peers on Cilium
-bgp/peers -o peers.actual
+bgp/peers -o peers.actual --no-uptime
 * cmp cilium-peers.expected peers.actual
 
 # Validate advertised routes on Cilium
@@ -237,10 +237,10 @@ Prefix            NextHop       Attrs
 10.244.0.0/24     10.99.0.110   [{Origin: i} {AsPath: 65002} {Nexthop: 10.99.0.110}]
 10.96.50.104/32   10.99.0.110   [{Origin: i} {AsPath: 65002} {Nexthop: 10.99.0.110}]
 -- cilium-peers.expected --
-Local AS   Peer AS   Peer Address       Session       Family         Received   Advertised
-65001      65010     10.99.0.101:1790   established   ipv4/unicast   0          3
-65001      65011     10.99.0.102:1790   established   ipv4/unicast   0          3
-65002      65012     10.99.0.103:1790   established   ipv4/unicast   0          3
+Instance    Peer           Session State   Uptime   Family         Received   Accepted   Advertised
+tor-65001   gobgp-peer-1   established     -        ipv4-unicast   0          0          3
+            gobgp-peer-2   established     -        ipv4-unicast   0          0          3
+tor-65002   gobgp-peer-3   established     -        ipv4-unicast   0          0          3
 -- cilium-routes.expected --
 VRouter   Peer          Prefix            NextHop       Attrs
 65001     10.99.0.101   10.244.0.0/24     10.99.0.110   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.110}]

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -422,8 +422,8 @@ type RoutePolicyRequest struct {
 	Policy              *RoutePolicy
 }
 
-// GetPeerStateResponse contains state of peers configured in given instance
-type GetPeerStateResponse struct {
+// GetPeerStateLegacyResponse contains state of peers configured in given instance
+type GetPeerStateLegacyResponse struct {
 	Peers []*models.BgpPeer
 }
 
@@ -549,8 +549,8 @@ type Router interface {
 	// RemoveRoutePolicy removes a routing policy from the underlying router.
 	RemoveRoutePolicy(ctx context.Context, p RoutePolicyRequest) error
 
-	// GetPeerState returns status of BGP peers
-	GetPeerState(ctx context.Context) (GetPeerStateResponse, error)
+	// GetPeerStateLegacy returns status of BGP peers
+	GetPeerStateLegacy(ctx context.Context) (GetPeerStateLegacyResponse, error)
 
 	// GetRoutes retrieves routes from the RIB of underlying router
 	GetRoutes(ctx context.Context, r *GetRoutesRequest) (*GetRoutesResponse, error)

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/netip"
 	"strings"
+	"time"
 
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 
@@ -142,6 +143,34 @@ type ResetAllNeighborsRequest struct {
 	Soft               bool
 	SoftResetDirection SoftResetDirection
 	AdminCommunication string
+}
+
+// PeerState contains status information for a BGP peer
+type PeerState struct {
+	// Name of the peer
+	Name string
+
+	// BGP peer operational state as described here
+	// https://www.rfc-editor.org/rfc/rfc4271#section-8.2.2
+	SessionState SessionState
+
+	// BGP peer connection uptime. The precision depends on the underlying
+	// router implementation.
+	Uptime time.Duration
+
+	// BGP peer address family states
+	Families []PeerFamilyState
+}
+
+// PeerFamilyState contains status information for a specific address family.
+// The Family field identifies the address family enabled for the peer. When
+// the address family is not enabled on the peer side, all other fields are
+// zeroed.
+type PeerFamilyState struct {
+	Family
+	ReceivedRoutes   uint64
+	AcceptedRoutes   uint64
+	AdvertisedRoutes uint64
 }
 
 // PathRequest contains parameters for advertising or withdrawing a Path

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -150,22 +150,19 @@ type PeerState struct {
 	// Name of the peer
 	Name string
 
-	// BGP peer operational state as described here
-	// https://www.rfc-editor.org/rfc/rfc4271#section-8.2.2
+	// BGP peer state
 	SessionState SessionState
 
-	// BGP peer connection uptime. The precision depends on the underlying
-	// router implementation.
+	// The rest of the fields are only valid if SessionState is Established
+
+	// Time since the BGP session was established
 	Uptime time.Duration
 
-	// BGP peer address family states
+	// BGP peer address family states. All configured address families are present here.
 	Families []PeerFamilyState
 }
 
 // PeerFamilyState contains status information for a specific address family.
-// The Family field identifies the address family enabled for the peer. When
-// the address family is not enabled on the peer side, all other fields are
-// zeroed.
 type PeerFamilyState struct {
 	Family
 	ReceivedRoutes   uint64
@@ -451,6 +448,14 @@ type RoutePolicyRequest struct {
 	Policy              *RoutePolicy
 }
 
+// GetPeerStateRequest contains parameters for retrieving BGP peer states
+type GetPeerStateRequest struct{}
+
+// GetPeerStateResponse contains state of peers configured in given instances
+type GetPeerStateResponse struct {
+	Peers []PeerState
+}
+
 // GetPeerStateLegacyResponse contains state of peers configured in given instance
 type GetPeerStateLegacyResponse struct {
 	Peers []*models.BgpPeer
@@ -577,6 +582,9 @@ type Router interface {
 
 	// RemoveRoutePolicy removes a routing policy from the underlying router.
 	RemoveRoutePolicy(ctx context.Context, p RoutePolicyRequest) error
+
+	// GetPeerState returns status of BGP peers
+	GetPeerState(ctx context.Context, r *GetPeerStateRequest) (*GetPeerStateResponse, error)
 
 	// GetPeerStateLegacy returns status of BGP peers
 	GetPeerStateLegacy(ctx context.Context) (GetPeerStateLegacyResponse, error)

--- a/pkg/bgp/types/fake_router.go
+++ b/pkg/bgp/types/fake_router.go
@@ -61,8 +61,8 @@ func (f *FakeRouter) RemoveRoutePolicy(ctx context.Context, p RoutePolicyRequest
 	return nil
 }
 
-func (f *FakeRouter) GetPeerState(ctx context.Context) (GetPeerStateResponse, error) {
-	return GetPeerStateResponse{}, nil
+func (f *FakeRouter) GetPeerStateLegacy(ctx context.Context) (GetPeerStateLegacyResponse, error) {
+	return GetPeerStateLegacyResponse{}, nil
 }
 
 func (f *FakeRouter) GetRoutes(ctx context.Context, r *GetRoutesRequest) (*GetRoutesResponse, error) {

--- a/pkg/bgp/types/fake_router.go
+++ b/pkg/bgp/types/fake_router.go
@@ -61,6 +61,10 @@ func (f *FakeRouter) RemoveRoutePolicy(ctx context.Context, p RoutePolicyRequest
 	return nil
 }
 
+func (f *FakeRouter) GetPeerState(ctx context.Context, r *GetPeerStateRequest) (*GetPeerStateResponse, error) {
+	return &GetPeerStateResponse{}, nil
+}
+
 func (f *FakeRouter) GetPeerStateLegacy(ctx context.Context) (GetPeerStateLegacyResponse, error) {
 	return GetPeerStateLegacyResponse{}, nil
 }


### PR DESCRIPTION
This is a preparation work to renew the current `cilium-dbg bgp peers` command output to reflect BGPv2 structure better. Introducing bgp/peers Hive Shell command which eventually become a backend of the `cilium-dbg bgp peers` command. Note that this PR doesn't replace `cilium-dbg bpf peers`. It will be covered in the separate PR. Please review commit-by-commit.

```release-note
bgp: Introduce bgp/peers Hive Shell command
```
