### PR TITLE
feat(helm): operator enable read-only root filesystem for security hardening

### DIFF
--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -871,10 +871,10 @@ contributors across the globe, there is almost always someone available to help.
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
 | operator.endpointGCInterval | string | `"5m0s"` | Interval for endpoint garbage collection. |
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
-| operator.extraEnv | list | `[]` | Additional cilium-operator environment variables. |
+| operator.extraEnv | list | `[{"name":"GOPS_CONFIG_DIR","value":"/tmp"}]` | Additional cilium-operator environment variables. |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
-| operator.extraVolumeMounts | list | `[]` | Additional cilium-operator volumeMounts. |
-| operator.extraVolumes | list | `[]` | Additional cilium-operator volumes. |
+| operator.extraVolumeMounts | list | `[{"mountPath":"/tmp","name":"tmp"}]` | Additional cilium-operator volumeMounts. |
+| operator.extraVolumes | list | `[{"emptyDir":{},"name":"tmp"}]` | Additional cilium-operator volumes. |
 | operator.hostNetwork | bool | `true` | HostNetwork setting |
 | operator.hostUsers | bool | `true` | HostUsers setting (must be true if hostNetwork is true) |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
@@ -910,7 +910,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
-| operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Security context to be added to cilium-operator pods |
+| operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |
 | operator.setNodeTaints | string | same as removeNodeTaints | Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5031,7 +5031,20 @@
           "type": "array"
         },
         "extraEnv": {
-          "items": {},
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
           "type": "array"
         },
         "extraHostPathMounts": {
@@ -5039,11 +5052,37 @@
           "type": "array"
         },
         "extraVolumeMounts": {
-          "items": {},
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
           "type": "array"
         },
         "extraVolumes": {
-          "items": {},
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "emptyDir": {
+                    "type": "object"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          },
           "type": "array"
         },
         "hostNetwork": {
@@ -5284,6 +5323,9 @@
                 }
               },
               "type": "object"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
             }
           },
           "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3159,7 +3159,9 @@ operator:
   # -- Additional cilium-operator container arguments.
   extraArgs: []
   # -- Additional cilium-operator environment variables.
-  extraEnv: []
+  extraEnv:
+    - name: GOPS_CONFIG_DIR
+      value: /tmp
   # -- Additional cilium-operator hostPath mounts.
   extraHostPathMounts: []
   # - name: host-mnt-data
@@ -3170,9 +3172,13 @@ operator:
   #   mountPropagation: HostToContainer
 
   # -- Additional cilium-operator volumes.
-  extraVolumes: []
+  extraVolumes:
+    - name: tmp
+      emptyDir: {}
   # -- Additional cilium-operator volumeMounts.
-  extraVolumeMounts: []
+  extraVolumeMounts:
+    - name: tmp
+      mountPath: /tmp
   # -- Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator)
   annotations: {}
   # -- HostNetwork setting
@@ -3224,6 +3230,7 @@ operator:
       drop:
         - ALL
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
   # runAsUser: 0
 
   # -- Interval for endpoint garbage collection.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3187,7 +3187,9 @@ operator:
   # -- Additional cilium-operator container arguments.
   extraArgs: []
   # -- Additional cilium-operator environment variables.
-  extraEnv: []
+  extraEnv:
+  - name: GOPS_CONFIG_DIR
+    value: /tmp
   # -- Additional cilium-operator hostPath mounts.
   extraHostPathMounts: []
   # - name: host-mnt-data
@@ -3198,9 +3200,13 @@ operator:
   #   mountPropagation: HostToContainer
 
   # -- Additional cilium-operator volumes.
-  extraVolumes: []
+  extraVolumes:
+  - name: tmp
+    emptyDir: {}
   # -- Additional cilium-operator volumeMounts.
-  extraVolumeMounts: []
+  extraVolumeMounts:
+  - name: tmp
+    mountPath: /tmp
   # -- Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator)
   annotations: {}
   # -- HostNetwork setting
@@ -3252,6 +3258,7 @@ operator:
       drop:
       - ALL
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
   # runAsUser: 0
 
   # -- Interval for endpoint garbage collection.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Add support for running cilium-operator with a read-only root filesystem to improve security posture and align with Pod Security Standards.

This change configures the operator to:
- Set readOnlyRootFilesystem: true in securityContext
- Configure GOPS_CONFIG_DIR to use /tmp for profiling tool writes
- Mount an emptyDir volume at /tmp for necessary write operations
