### PR TITLE
.github/renovate: skip cilium/ebpf

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -303,7 +303,9 @@
         "/github.com/onsi/ginkgo/",
         "/github.com/onsi/gomega/*/",
         // We can't update to helm v4 until https://github.com/helm/helm/issues/31525 is fixed
-        "helm.sh/helm/*"
+        "helm.sh/helm/*",
+        // We can't update it, see https://github.com/cilium/cilium/issues/44063 for more info
+        "github.com/cilium/ebpf"
       ]
     },
     {


### PR DESCRIPTION
This dependency has a regression in one of its commits that is preventing the renovate PRs from being merged automatically. As such, it will be skipped from being automatically updated.

