### PR TITLE
deps, bgp: Bump GoBGP version to most recent v3.37 fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ replace sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16
 
 // Using private fork of gobgp. See commit msg for more context as to why we
 // are using a private fork.
-replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
+replace github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6
 
 tool (
 	github.com/cilium/deepequal-gen

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.7.0 h1:4EKBtTweQrJoD4q45qDGu8udulmYMo48Y0BhEbrB1jc=
 github.com/cilium/fake v0.7.0/go.mod h1:hA1YsEjgIs5Gdeq/DVrDWGuhLCoVok7THTvQaGDO5bc=
-github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674 h1:RPXlDz/YCj2qscehc5oVFwHgUTDQGYHIgTxlN65F8R8=
-github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
+github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6 h1:JiuFG0n56b113TIYlP5Hdj+F2egjK3kZsskF3RQ5hBE=
+github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6/go.mod h1:kVHVFy1/fyZHJ8P32+ctvPeJogn9qKwa1YCeMRXXrP0=
 github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c h1:mP/Z+oVplgbg3oV1lwsAC86NPLWioN/TqlmZ6+BI2I0=
 github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c/go.mod h1:4/8FBMcTjVdkrNNWaB7t3QqaU4kZDJLJ1leKVP9GjEI=
 github.com/cilium/linters v0.3.0 h1:XZzur3mcyM04YSnDeoKSb1l+9W7k3kvUoL0yF8ICCQA=

--- a/pkg/bgp/test/testdata/peering-multi-instance.txtar
+++ b/pkg/bgp/test/testdata/peering-multi-instance.txtar
@@ -238,9 +238,9 @@ Prefix            NextHop       Attrs
 10.96.50.104/32   10.99.0.110   [{Origin: i} {AsPath: 65002} {Nexthop: 10.99.0.110}]
 -- cilium-peers.expected --
 Instance    Peer           Session State   Uptime   Family         Received   Accepted   Advertised
-tor-65001   gobgp-peer-1   established     -        ipv4-unicast   0          0          3
-            gobgp-peer-2   established     -        ipv4-unicast   0          0          3
-tor-65002   gobgp-peer-3   established     -        ipv4-unicast   0          0          3
+tor-65001   gobgp-peer-1   established     -        ipv4-unicast   0          0          2
+            gobgp-peer-2   established     -        ipv4-unicast   0          0          2
+tor-65002   gobgp-peer-3   established     -        ipv4-unicast   0          0          2
 -- cilium-routes.expected --
 VRouter   Peer          Prefix            NextHop       Attrs
 65001     10.99.0.101   10.244.0.0/24     10.99.0.110   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.110}]

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1299,7 +1299,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
-# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
+# github.com/osrg/gobgp/v3 v3.37.0 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6
 ## explicit; go 1.23.0
 github.com/osrg/gobgp/v3/api
 github.com/osrg/gobgp/v3/internal/pkg/table
@@ -2914,4 +2914,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
 sigs.k8s.io/yaml/kyaml
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
-# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20251113221723-3540251c0674
+# github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6


### PR DESCRIPTION
GoBGP version bump resolving an issue with invalid advertised routes counters: 

When Graceful Restart was enabled, the advertised routes counters reported one extra route (internally accounted for the GR EOR marker).

```release-note
Bump GoBGP version to the most recent v3.37 cilium/gobgp fork, to pick up the fix for invalid advertised routes counters.
```
