### PR TITLE
bgp: Clean up and test improvements

### DIFF
--- a/pkg/bgp/gobgp/conversions.go
+++ b/pkg/bgp/gobgp/conversions.go
@@ -562,7 +562,6 @@ func ToGoBGPPeer(n *types.Neighbor, oldPeer *gobgp.Peer, v4 bool) *gobgp.Peer {
 
 	newPeer.Conf = toGoBGPPeerConf(n, oldPeer)
 	newPeer.EbgpMultihop = toGoBGPEbgpMultihop(n.EbgpMultihop)
-	newPeer.RouteReflector = toGoBGPRouteReflector(n.RouteReflector)
 	newPeer.Timers = toGoBGPTimers(n.Timers)
 	newPeer.Transport = toGoBGPTransport(n.Transport, oldPeer, v4)
 	newPeer.GracefulRestart = toGoBGPGracefulRestart(n.GracefulRestart)
@@ -620,16 +619,6 @@ func toGoBGPEbgpMultihop(n *types.NeighborEbgpMultihop) *gobgp.EbgpMultihop {
 	return &gobgp.EbgpMultihop{
 		Enabled:     true,
 		MultihopTtl: n.TTL,
-	}
-}
-
-func toGoBGPRouteReflector(n *types.NeighborRouteReflector) *gobgp.RouteReflector {
-	if n == nil {
-		return nil
-	}
-	return &gobgp.RouteReflector{
-		RouteReflectorClient:    n.Client,
-		RouteReflectorClusterId: n.ClusterID,
 	}
 }
 

--- a/pkg/bgp/gobgp/conversions.go
+++ b/pkg/bgp/gobgp/conversions.go
@@ -698,7 +698,18 @@ func toGoBGPGracefulRestart(n *types.NeighborGracefulRestart) *gobgp.GracefulRes
 
 func toGoBGPAfiSafi(fams []*types.Family, gr *gobgp.GracefulRestart) []*gobgp.AfiSafi {
 	if len(fams) == 0 {
-		return defaultSafiAfi
+		res := make([]*gobgp.AfiSafi, len(defaultAfiSafi))
+		for i, v := range defaultAfiSafi {
+			res[i] = &gobgp.AfiSafi{
+				Config: &gobgp.AfiSafiConfig{
+					Family: &gobgp.Family{
+						Afi:  gobgp.Family_Afi(v.Config.Family.Afi),
+						Safi: gobgp.Family_Safi(v.Config.Family.Safi),
+					},
+				},
+			}
+		}
+		return res
 	}
 	afisafis := make([]*gobgp.AfiSafi, 0, len(fams))
 	for _, fam := range fams {

--- a/pkg/bgp/gobgp/conversions_test.go
+++ b/pkg/bgp/gobgp/conversions_test.go
@@ -82,7 +82,7 @@ func TestToGoBGPPeer(t *testing.T) {
 				Conf: &gobgp.PeerConf{
 					NeighborAddress: "10.0.0.1",
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -94,7 +94,7 @@ func TestToGoBGPPeer(t *testing.T) {
 				Conf: &gobgp.PeerConf{
 					NeighborAddress: "fd00::1",
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestToGoBGPPeer(t *testing.T) {
 					NeighborAddress: "10.0.0.1",
 					PeerAsn:         65000,
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -122,7 +122,7 @@ func TestToGoBGPPeer(t *testing.T) {
 					NeighborAddress: "10.0.0.1",
 					AuthPassword:    "password",
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -141,7 +141,7 @@ func TestToGoBGPPeer(t *testing.T) {
 					Enabled:     true,
 					MultihopTtl: 10,
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -161,7 +161,7 @@ func TestToGoBGPPeer(t *testing.T) {
 					RouteReflectorClient:    true,
 					RouteReflectorClusterId: "255.0.0.1",
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -186,7 +186,7 @@ func TestToGoBGPPeer(t *testing.T) {
 						IdleHoldTimeAfterReset: idleHoldTimeAfterResetSeconds,
 					},
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func TestToGoBGPPeer(t *testing.T) {
 					LocalPort:    1179,
 					RemotePort:   1179,
 				},
-				AfiSafis: defaultSafiAfi,
+				AfiSafis: defaultAfiSafi,
 			},
 		},
 		{

--- a/pkg/bgp/gobgp/conversions_test.go
+++ b/pkg/bgp/gobgp/conversions_test.go
@@ -145,26 +145,6 @@ func TestToGoBGPPeer(t *testing.T) {
 			},
 		},
 		{
-			name: "RouteReflector",
-			neighbor: &types.Neighbor{
-				Address: netip.MustParseAddr("10.0.0.1"),
-				RouteReflector: &types.NeighborRouteReflector{
-					Client:    true,
-					ClusterID: "255.0.0.1",
-				},
-			},
-			expected: &gobgp.Peer{
-				Conf: &gobgp.PeerConf{
-					NeighborAddress: "10.0.0.1",
-				},
-				RouteReflector: &gobgp.RouteReflector{
-					RouteReflectorClient:    true,
-					RouteReflectorClusterId: "255.0.0.1",
-				},
-				AfiSafis: defaultAfiSafi,
-			},
-		},
-		{
 			name: "Timers",
 			neighbor: &types.Neighbor{
 				Address: netip.MustParseAddr("10.0.0.1"),

--- a/pkg/bgp/gobgp/server.go
+++ b/pkg/bgp/gobgp/server.go
@@ -59,7 +59,7 @@ var (
 		},
 	}
 	// The default S/Afi pair to use if not provided by the user.
-	defaultSafiAfi = []*gobgp.AfiSafi{
+	defaultAfiSafi = []*gobgp.AfiSafi{
 		{
 			Config: &gobgp.AfiSafiConfig{
 				Family: GoBGPIPv4Family,

--- a/pkg/bgp/test/commands/gobgp.go
+++ b/pkg/bgp/test/commands/gobgp.go
@@ -255,6 +255,11 @@ func GoBGPAddPeerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 							Safi: gobgpapi.Family_Safi(types.ParseSafi(afiSafiArr[1])),
 						},
 					},
+					AddPaths: &gobgpapi.AddPaths{
+						Config: &gobgpapi.AddPathsConfig{
+							Receive: true,
+						},
+					},
 				})
 			}
 
@@ -496,6 +501,9 @@ func printPathHeader(w *tabwriter.Writer) {
 
 func printPath(w *tabwriter.Writer, dst *gobgpapi.Destination) {
 	aPaths, _ := gobgp.ToAgentPaths(dst.Paths)
+	sort.Slice(aPaths, func(i, j int) bool {
+		return fmt.Sprint(aPaths[i].PathAttributes) < fmt.Sprint(aPaths[j].PathAttributes)
+	})
 	for _, path := range aPaths {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", dst.Prefix, api.NextHopFromPathAttributes(path.PathAttributes), path.PathAttributes)
 	}

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -71,7 +71,6 @@ type Neighbor struct {
 	ASN             uint32
 	AuthPassword    string
 	EbgpMultihop    *NeighborEbgpMultihop
-	RouteReflector  *NeighborRouteReflector
 	Timers          *NeighborTimers
 	Transport       *NeighborTransport
 	GracefulRestart *NeighborGracefulRestart
@@ -97,11 +96,6 @@ type NeighborTimers struct {
 type NeighborGracefulRestart struct {
 	Enabled     bool
 	RestartTime uint32
-}
-
-type NeighborRouteReflector struct {
-	Client    bool
-	ClusterID string
 }
 
 // SoftResetDirection defines the direction in which a BGP soft reset should be performed


### PR DESCRIPTION
- Remove unused RouteReflector
- Enhance GoBGP test commands
- Fix variable name typo and copy defaultAfiSafi to avoid the in place mutation


```release-note
bgp: Clean up unused RouteReflector and improve GoBGP test commands
```
