### PR TITLE
cilium-cli: add --cleanup flag for connectivity test artifacts

### DIFF
--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -17,6 +17,7 @@ cilium connectivity test [flags]
       --assume-cilium-version string                          Assume Cilium version for connectivity tests
       --chart-directory string                                Helm chart directory
       --cilium-pod-selector string                            Label selector matching all cilium-related pods (default "app.kubernetes.io/part-of=cilium")
+      --cleanup                                               Cleanup all connectivity test artifacts (namespaces, deployments, services) without running tests
       --collect-sysdump-on-failure                            Collect sysdump after a test fails
       --conn-disrupt-dispatch-interval duration               TCP packet dispatch interval
       --conn-disrupt-test-restarts-path string                Conn disrupt test temporary result file (used internally) (default "/tmp/cilium-conn-disrupt-restarts")

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -137,6 +137,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.PrintFlows, "print-flows", false, "Print flow logs for each test")
 	cmd.Flags().DurationVar(&params.PostTestSleepDuration, "post-test-sleep", 0, "Wait time after each test before next test starts")
 	cmd.Flags().BoolVar(&params.ForceDeploy, "force-deploy", false, "Force re-deploying test artifacts")
+	cmd.Flags().BoolVar(&params.CleanupOnly, "cleanup", false, "Cleanup all connectivity test artifacts (namespaces, deployments, services) without running tests")
 	cmd.Flags().BoolVar(&params.Hubble, "hubble", true, "Automatically use Hubble for flow validation & troubleshooting")
 	cmd.Flags().StringVar(&params.HubbleServer, "hubble-server", "localhost:4245", "Address of the Hubble endpoint for flow validation")
 	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -57,6 +57,7 @@ type Parameters struct {
 	SingleNode                bool
 	PrintFlows                bool
 	ForceDeploy               bool
+	CleanupOnly               bool
 	Hubble                    bool
 	HubbleServer              string
 	K8sLocalHostTest          bool

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -20,6 +20,18 @@ type Hooks interface {
 }
 
 func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) error {
+	// If cleanup-only mode is enabled, perform cleanup and return
+	if len(connTests) > 0 && connTests[0].Params().CleanupOnly {
+		connTests[0].Infof("🧹 Cleanup mode enabled - removing all connectivity test artifacts")
+		for i := range connTests {
+			if err := connTests[i].CleanupConnectivityTest(ctx); err != nil {
+				connTests[i].Warnf("Cleanup encountered errors: %v", err)
+			}
+		}
+		connTests[0].Infof("✅ Cleanup complete")
+		return nil
+	}
+
 	if err := setupConnectivityTests(ctx, connTests, extra); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds `--cleanup` to `cilium connectivity test` to remove connectivity test artifacts without running any tests.

The cleanup reuses existing helpers to delete:
- test namespaces/resources (cilium-test-*)
- conn-disrupt test artifacts
- CCNP test environments

Clients are initialized when cleanup is invoked standalone.

Fixes: cilium/cilium-cli#3161

Tests: go test ./cilium-cli/...