### PR TITLE
cilium-cli: Fix container name in connectivity test logs

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -264,7 +264,7 @@ func (a *Action) WriteDataToPod(ctx context.Context, filePath string, data []byt
 	pod := a.src
 
 	output, err := pod.K8sClient.ExecInPod(ctx,
-		pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"],
+		pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Spec.Containers[0].Name,
 		[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d > %s", encodedData, filePath)})
 
 	if err != nil {
@@ -300,7 +300,7 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 	// output.
 	for i := 1; i <= testCommandRetries; i++ {
 		output, errOutput, err = pod.K8sClient.ExecInPodWithStderr(ctx,
-			pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Labels["name"], cmd)
+			pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Spec.Containers[0].Name, cmd)
 		a.cmdOutput = output.String()
 		// Check for inconclusive results.
 		if err == nil && strings.TrimSpace(pingHeaderPattern.ReplaceAllString(output.String(), "")) == "" {

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1593,7 +1593,7 @@ func (ct *ConnectivityTest) patchDeployment(ctx context.Context) error {
 		}
 
 		for _, pod := range clientPods.Items {
-			_, err := ct.client.ExecInPod(ctx, ct.params.TestNamespace, pod.Name, "",
+			_, err := ct.client.ExecInPod(ctx, ct.params.TestNamespace, pod.Name, pod.Spec.Containers[0].Name,
 				[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d >> /etc/ssl/certs/ca-certificates.crt", encodedCert)})
 			if err != nil {
 				return fmt.Errorf("unable to add CA to pod %s: %w", pod.Name, err)
@@ -2787,7 +2787,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			if iface := ct.params.SecondaryNetworkIface; iface != "" {
 				if ct.Features[features.IPv4].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
-					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, "", cmd)
+					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 					if err != nil {
 						return fmt.Errorf("failed to fetch secondary network ip addr: %w", err)
 					}
@@ -2795,7 +2795,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 				}
 				if ct.Features[features.IPv6].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet6 -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
-					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, "", cmd)
+					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 					if err != nil {
 						return fmt.Errorf("failed to fetch secondary network ip addr: %w", err)
 					}

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -94,7 +94,7 @@ func WaitForPodDNS(ctx context.Context, log Logger, src, dst Pod) error {
 		// See https://coredns.io/plugins/local/ for more info.
 		target := "localhost"
 		stdout, err := src.K8sClient.ExecInPod(ctx, src.Namespace(), src.NameWithoutNamespace(),
-			"", []string{"nslookup", target, dst.Address(features.IPFamilyAny)})
+			src.Pod.Spec.Containers[0].Name, []string{"nslookup", target, dst.Address(features.IPFamilyAny)})
 
 		if err == nil {
 			return nil
@@ -123,7 +123,7 @@ func WaitForCoreDNS(ctx context.Context, log Logger, client Pod) error {
 	for {
 		target := "kubernetes.default"
 		stdout, err := client.K8sClient.ExecInPod(ctx, client.Namespace(), client.NameWithoutNamespace(),
-			"", []string{"nslookup", target})
+			client.Pod.Spec.Containers[0].Name, []string{"nslookup", target})
 		if err == nil {
 			return nil
 		}
@@ -177,7 +177,7 @@ func WaitForService(ctx context.Context, log Logger, client Pod, service Service
 
 	for {
 		stdout, err := client.K8sClient.ExecInPod(ctx,
-			client.Namespace(), client.NameWithoutNamespace(), "",
+			client.Namespace(), client.NameWithoutNamespace(), client.Pod.Spec.Containers[0].Name,
 			[]string{"nslookup", service.Service.Name}) // BusyBox nslookup doesn't support any arguments.
 
 		// Lookup successful.
@@ -299,7 +299,7 @@ func WaitForNodePorts(ctx context.Context, log Logger, client Pod, nodeIP string
 			client.K8sClient.ClusterName(), nodeIP, nodePort, service.Name())
 		for {
 			stdout, err := client.K8sClient.ExecInPod(ctx,
-				client.Namespace(), client.NameWithoutNamespace(), "",
+				client.Namespace(), client.NameWithoutNamespace(), client.Pod.Spec.Containers[0].Name,
 				[]string{"nc", "-w", "3", "-z", nodeIP, strconv.Itoa(int(nodePort))})
 			if err == nil {
 				break

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -200,7 +200,7 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 
 	dbg.Debugf("Running sniffer in background on %s (%s), mode=%s: %s",
 		target.String(), target.NodeName(), mode, strings.Join(sniffer.cmd, " "))
-	if _, err := target.K8sClient.ExecInPod(ctx, target.Pod.Namespace, target.Pod.Name, "", sniffer.cmd); err != nil {
+	if _, err := target.K8sClient.ExecInPod(ctx, target.Pod.Namespace, target.Pod.Name, target.Pod.Spec.Containers[0].Name, sniffer.cmd); err != nil {
 		err = fmt.Errorf("Failed to execute tcpdump: %w", err)
 		if errors.Is(err, context.Canceled) {
 			// Child/Parent context has been canceled, we now stop the remote
@@ -270,7 +270,7 @@ func (sniffer *Sniffer) stop() (err error) {
 		defer cancel()
 
 		// Stop tcpdump and store output.
-		sniffer.out, err = sniffer.target.K8sClient.ExecInPod(ctx, sniffer.target.Pod.Namespace, sniffer.target.Pod.Name, "", sniffer.stopCmd)
+		sniffer.out, err = sniffer.target.K8sClient.ExecInPod(ctx, sniffer.target.Pod.Namespace, sniffer.target.Pod.Name, sniffer.target.Pod.Spec.Containers[0].Name, sniffer.stopCmd)
 		if err != nil {
 			err = fmt.Errorf("Failed to stop tcpdump on %s (%s): %w", sniffer.target.String(), sniffer.target.NodeName(), err)
 		}


### PR DESCRIPTION
When running connectivity checks with `cilium connectivity test`, I noticed some errors where missing the container name:

```
🐛 [my-cluster] Error looking up localhost from pod cilium-test-1/client3-86cb9b6846-xzqfs to server on pod cilium-test-1/echo-same-node-6c77c74696-pfdl6: command failed (pod=cilium-test-1/client3-86cb9b6846-xzqfs, container=): command terminated with exit code 1: ;; communications error to 100.64.16.9#53: timed out
;; communications error to 100.64.16.9#53: timed out
;; communications error to 100.64.16.9#53: timed out
;; no servers could be reached

🐛 [my-cluster] Error looking up localhost from pod cilium-test-1/client3-86cb9b6846-xzqfs to server on pod cilium-test-1/echo-same-node-6c77c74696-pfdl6: command failed (pod=cilium-test-1/client3-86cb9b6846-xzqfs, container=): context deadline exceeded:
timeout reached waiting for lookup for localhost from pod cilium-test-1/client3-86cb9b6846-xzqfs to server on pod cilium-test-1/echo-same-node-6c77c74696-pfdl6 to succeed (last error: command failed (pod=cilium-test-1/client3-86cb9b6846-xzqfs, container=): context deadline exceeded)
```

This is because the container name printed in those error messages comes directly from the argument passed to `ExecInPod`/`ExecInPodWithStderr`. But in most cases today, we pass an empty string for the container name argument for those functions, which leads to the command being executed in the first container of the pod.

This PR updates `ExecInPod` calls to explicitely set the container name argument to the first container of the pod, which leads to that container name being properly propagated down to the error log in case of failure:

```
🐛 [my-cluster] Error looking up localhost from pod cilium-test-1/client3-86cb9b6846-4w6n4 to server on pod cilium-test-1/echo-same-node-6c77c74696-pn2vf: command failed (pod=cilium-test-1/client3-86cb9b6846-4w6n4, container=client3): command terminated with exit code 1: ;; communications error to 100.64.16.6#53: timed out
;; communications error to 100.64.16.6#53: timed out
;; communications error to 100.64.16.6#53: timed out
;; no servers could be reached

🐛 [my-cluster] Error looking up localhost from pod cilium-test-1/client3-86cb9b6846-4w6n4 to server on pod cilium-test-1/echo-same-node-6c77c74696-pn2vf: command failed (pod=cilium-test-1/client3-86cb9b6846-4w6n4, container=client3): context deadline exceeded:
timeout reached waiting for lookup for localhost from pod cilium-test-1/client3-86cb9b6846-4w6n4 to server on pod cilium-test-1/echo-same-node-6c77c74696-pn2vf to succeed (last error: command failed (pod=cilium-test-1/client3-86cb9b6846-4w6n4, container=client3): context deadline exceeded)
```
