### PR TITLE
operator/multi-pool: Minor improvements to the node handler

### DIFF
--- a/operator/pkg/ipam/multipool.go
+++ b/operator/pkg/ipam/multipool.go
@@ -77,7 +77,7 @@ func startMultiPoolAllocator(p multiPoolParams) {
 
 	logger := p.Logger.With([]any{logfields.LogSubsys, "ipam-allocator-multi-pool"}...)
 
-	allocator := multipool.NewPoolAllocator(logger)
+	allocator := multipool.NewPoolAllocator(logger, p.DaemonCfg.EnableIPv4, p.DaemonCfg.EnableIPv6)
 
 	p.Lifecycle.Append(
 		cell.Hook{

--- a/operator/pkg/multipool/node_handler.go
+++ b/operator/pkg/multipool/node_handler.go
@@ -98,6 +98,10 @@ func (n *NodeHandler) Resync(context.Context, time.Time) {
 	n.nodesPendingAllocation = nil
 }
 
+func (n *NodeHandler) Stop() {
+	n.controllerManager.RemoveAllAndWait()
+}
+
 func (n *NodeHandler) upsertLocked(resource *v2.CiliumNode) {
 	if !n.restoreFinished {
 		n.nodesPendingAllocation[resource.Name] = resource

--- a/operator/pkg/multipool/node_handler_test.go
+++ b/operator/pkg/multipool/node_handler_test.go
@@ -92,7 +92,7 @@ func GetIPAMPools(cn *v2.CiliumNode) *ipamTypes.IPAMPoolSpec {
 }
 
 func TestNodeHandler(t *testing.T) {
-	backend := NewPoolAllocator(hivetest.Logger(t))
+	backend := NewPoolAllocator(hivetest.Logger(t), true, true)
 	err := backend.UpsertPool("default", []string{"10.0.0.0/8"}, 24, nil, 0)
 	assert.NoError(t, err)
 
@@ -245,7 +245,7 @@ func TestNodeHandler(t *testing.T) {
 }
 
 func TestOrphanCIDRsAfterRestart(t *testing.T) {
-	backend := NewPoolAllocator(hivetest.Logger(t))
+	backend := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	onUpdateArgs := make(chan mockArgs)
 
@@ -372,7 +372,7 @@ func TestOrphanCIDRsAfterRestart(t *testing.T) {
 }
 
 func TestOrphanCIDRsReleased(t *testing.T) {
-	backend := NewPoolAllocator(hivetest.Logger(t))
+	backend := NewPoolAllocator(hivetest.Logger(t), true, true)
 	err := backend.UpsertPool("test-pool",
 		[]string{"10.0.0.0/28", "10.0.0.16/28", "10.0.0.32/28", "10.0.0.48/28"}, 28,
 		nil, 0)

--- a/operator/pkg/multipool/node_handler_test.go
+++ b/operator/pkg/multipool/node_handler_test.go
@@ -21,6 +21,7 @@ import (
 
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 type k8sNodeMock struct {
@@ -92,6 +93,8 @@ func GetIPAMPools(cn *v2.CiliumNode) *ipamTypes.IPAMPoolSpec {
 }
 
 func TestNodeHandler(t *testing.T) {
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
+
 	backend := NewPoolAllocator(hivetest.Logger(t), true, true)
 	err := backend.UpsertPool("default", []string{"10.0.0.0/8"}, 24, nil, 0)
 	assert.NoError(t, err)
@@ -242,9 +245,13 @@ func TestNodeHandler(t *testing.T) {
 
 	nh.Delete(node1Update.node)
 	nh.Delete(node2Update.node)
+
+	nh.Stop()
 }
 
 func TestOrphanCIDRsAfterRestart(t *testing.T) {
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
+
 	backend := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	onUpdateArgs := make(chan mockArgs)
@@ -369,9 +376,13 @@ func TestOrphanCIDRsAfterRestart(t *testing.T) {
 			},
 		},
 	}, backend.nodes)
+
+	nh.Stop()
 }
 
 func TestOrphanCIDRsReleased(t *testing.T) {
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
+
 	backend := NewPoolAllocator(hivetest.Logger(t), true, true)
 	err := backend.UpsertPool("test-pool",
 		[]string{"10.0.0.0/28", "10.0.0.16/28", "10.0.0.32/28", "10.0.0.48/28"}, 28,
@@ -473,4 +484,6 @@ func TestOrphanCIDRsReleased(t *testing.T) {
 		t.Fatal("Update should not have been called after releasing orphan CIDRs")
 	default:
 	}
+
+	nh.Stop()
 }

--- a/operator/pkg/multipool/pool_allocator_test.go
+++ b/operator/pkg/multipool/pool_allocator_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPoolAllocator(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 	err := p.UpsertPool("default",
 		[]string{"10.100.0.0/16", "10.200.0.0/16"}, 24,
 		[]string{"fd00:100::/80", "fc00:100::/80"}, 96,
@@ -233,7 +233,7 @@ func TestPoolAllocator(t *testing.T) {
 }
 
 func TestPoolAllocator_PoolErrors(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 	p.RestoreFinished()
 
 	node := &v2.CiliumNode{
@@ -351,7 +351,7 @@ func TestPoolAllocator_PoolErrors(t *testing.T) {
 }
 
 func TestPoolAllocator_AddUpsertDelete(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	_, exists := p.pools["jupiter"]
 	assert.False(t, exists)
@@ -504,7 +504,7 @@ func Test_addrsInPrefix(t *testing.T) {
 // TestUpdateCIDRSets_ShrinkPool ensures that shrinking a pool does not
 // trigger a nil dereference in updateCIDRSets.
 func TestUpdateCIDRSets_ShrinkPool(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	// Initial pool with two IPv4 CIDRs
 	err := p.UpsertPool("shrink-test",
@@ -527,7 +527,7 @@ func TestUpdateCIDRSets_ShrinkPool(t *testing.T) {
 }
 
 func TestPoolUpdateWithCIDRInUse(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	// no pools available
 	assert.Empty(t, p.pools)
@@ -600,7 +600,7 @@ func TestPoolUpdateWithCIDRInUse(t *testing.T) {
 }
 
 func TestOrphanCIDRs(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	// no pools available
 	assert.Empty(t, p.pools)
@@ -932,7 +932,7 @@ func TestOrphanCIDRs(t *testing.T) {
 }
 
 func TestOrphanCIDRsNotStolenFromAnotherPool(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	// no pools available
 	assert.Empty(t, p.pools)
@@ -1029,7 +1029,7 @@ func TestOrphanCIDRsNotStolenFromAnotherPool(t *testing.T) {
 }
 
 func TestUpdatePoolKeepOldCIDRs(t *testing.T) {
-	p := NewPoolAllocator(hivetest.Logger(t))
+	p := NewPoolAllocator(hivetest.Logger(t), true, true)
 
 	err := p.UpsertPool("test-pool",
 		[]string{"10.0.0.0/28", "10.0.0.16/28", "10.0.0.32/28", "10.0.0.48/28"}, 28,


### PR DESCRIPTION
A couple of minor improvements to the multi-pool node handler:

1) remove direct dependency from daemon config and prefer boolean flags passed at initialization
2) add a method to remove all controllers and test that no goroutines are leaked when the node handler is properly stopped

Related: https://github.com/cilium/cilium/pull/43937