### PR TITLE
fix(test): solve non-constant initializer in tc_nodeport_l3_dev.h

### DIFF
--- a/bpf/tests/tc_nodeport_l3_dev.h
+++ b/bpf/tests/tc_nodeport_l3_dev.h
@@ -64,9 +64,10 @@ mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 # include "bpf_wireguard.c"
 # include "lib/endpoint.h"
 
-const union macaddr router_mac = { .addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00} };
+#define TEST_ROUTER_MAC_ADDR { .addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00} }
+const union macaddr router_mac = TEST_ROUTER_MAC_ADDR;
 
-ASSIGN_CONFIG(union macaddr, interface_mac, router_mac)
+ASSIGN_CONFIG(union macaddr, interface_mac, TEST_ROUTER_MAC_ADDR)
 #endif
 
 #if defined(IS_BPF_HOST)


### PR DESCRIPTION
While looking into another thing i faced the following compilation error running:

```bash
cd bpf/test
make all
```

```txt
clang -I.../cilium/bpf -I.../cilium/bpf/include -g -O2 --target=bpf -std=gnu99 -nostdinc -ftrap-function=__undefined_trap -Wall -Wextra -Werror -Wshadow -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end -Wimplicit-int-conversion -Wenum-conversion -Wimplicit-fallthrough -MD -mcpu=v3 -c tc_nodeport_l3_wireguard.c -o tc_nodeport_l3_wireguard.o
In file included from tc_nodeport_l3_wireguard.c:6:
./tc_nodeport_l3_dev.h:69:45: error: initializer element is not a compile-time constant
ASSIGN_CONFIG(union macaddr, interface_mac, router_mac)
                                            ^~~~~~~~~~
.../cilium/bpf/lib/static_data.h:59:40: note: expanded from macro 'ASSIGN_CONFIG'
        volatile const type __config_##name = value;
```

This PR should fix it.