### PR TITLE
proxy/accesslog: use new context to retrieve local node

### DIFF
--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -232,7 +232,7 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 	// requests because an identity isn't in the local cache yet.
 	logContext, lcncl := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer lcncl()
-	record, err := h.proxyAccessLogger.NewLogRecord(logContext, flowType, false,
+	record, err := h.proxyAccessLogger.NewLogRecord(context.Background(), flowType, false,
 		func(lr *accesslog.LogRecord, _ accesslog.EndpointInfoRegistry) {
 			lr.TransportProtocol = accesslog.TransportProtocol(protoID)
 		},


### PR DESCRIPTION
The refactorings of #43600 (using the log context to retrieve the local node from the store) can lead to errors.

```
Failed to process DNS response" during connectivity check, with error="failed create log record: failed to get local node: context deadline exceeded
```

Before #43600, the local node store was retrieved via global function that is using a new context without expiration (`context.TODO()`) (https://github.com/cilium/cilium/blob/main/pkg/node/address.go#L34-L46).

Reusing the [logcontext with its 10ms](https://github.com/cilium/cilium/blob/main/pkg/fqdn/messagehandler/message_handler.go#L233-L234) seems to be too optimistic. Therefore, this commit reverts parts of the refactoring and uses a new `context.Background` without expiration for retrieving the node again. Even though it would be better 
to eventually have a context that spans the full request that could be used for this.

Fixes: #43600
Fixes: #44077