### PR TITLE
Resync feature metrics documentation

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -179,7 +179,15 @@ jobs:
              --helm-set operator.prometheus.tls.server.mtls.enabled=true \
              --helm-set hubble.enabled=true \
              --helm-set=hubble.metrics.enabled=\"{dns,drop,tcp,flow,port-distribution,icmp,http}\" \
-             --helm-set ingressController.enabled=true"
+             --helm-set ingressController.enabled=true \
+             --set-string extraEnv[3].name=CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION \
+             --set-string extraEnv[3].value=true \
+             --set-string operator.extraEnv[3].name=CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION \
+             --set-string operator.extraEnv[3].value=true \
+             --set-string clustermesh.apiserver.extraEnv[3].name=CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION \
+             --set-string clustermesh.apiserver.extraEnv[3].value=true \
+             --set-string hubble.relay.extraEnv[3].name=CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION \
+             --set-string hubble.relay.extraEnv[3].value=true"
 
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
 
@@ -264,8 +272,8 @@ jobs:
              --metrics-prefix cilium_operator_feature \
              --metrics-separators adv_connect_and_lb \
              > Documentation/observability/feature-metrics-operator.txt
-          if ! git diff; then
-            echo "Feature documentation metrics out-of-sync"
+          if ! git diff --quiet; then
+            echo "Feature metrics documentation out-of-sync"
             exit 1
           fi
 

--- a/Documentation/observability/feature-metrics-agent.txt
+++ b/Documentation/observability/feature-metrics-agent.txt
@@ -175,6 +175,16 @@
     - ``"true"``
     -
     -
+  * - ``transparent_encryption``
+    - ``strict_mode_enabled``
+    - ``"false"``
+    -
+    -
+  * -
+    -
+    - ``"true"``
+    -
+    -
   * - ``vtep_enabled``
     - *None*
     - *None*
@@ -296,11 +306,21 @@
     - ``"none"``
     -
     -
+  * -
+    -
+    - ``"portmap"``
+    -
+    -
   * - ``config``
-    - ``mode``
-    - ``"netkit"``
+    - ``configured_mode``
+    - ``"auto"``
     - Datapath config mode enabled on the agent
     - gauge
+  * -
+    -
+    - ``"netkit"``
+    -
+    -
   * -
     -
     - ``"netkit-l2"``
@@ -311,6 +331,26 @@
     - ``"veth"``
     -
     -
+  * - ``config``
+    - ``operational_mode``
+    - ``"netkit"``
+    -
+    -
+  * -
+    -
+    - ``"netkit-l2"``
+    -
+    -
+  * -
+    -
+    - ``"veth"``
+    -
+    -
+  * - ``endpoint_routes_enabled``
+    - *None*
+    - *None*
+    - Endpoint Routes enabled in the datapath
+    - gauge
   * - ``internet_protocol``
     - ``address_family``
     - ``"ipv4-ipv6-dual-stack"``
@@ -356,14 +396,9 @@
     - Type
   * - ``cidr_policies``
     - ``mode``
-    - ``"remote-node"``
+    - ``"nodes"``
     - Mode to apply CIDR Policies to Nodes
     - gauge
-  * -
-    -
-    - ``"world"``
-    -
-    -
   * - ``cilium_clusterwide_envoy_config_total``
     - ``action``
     - ``"add"``

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -33,6 +33,10 @@ import (
 var (
 	// withDefaults will set enable all default metrics in the agent.
 	withDefaults = os.Getenv("CILIUM_FEATURE_METRICS_WITH_DEFAULTS")
+
+	// withoutEnvVersion can be used to disable any metric that expresses
+	// host-specific data, such as kernel version.
+	withoutEnvVersion = os.Getenv("CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION")
 )
 
 // Cell will retrieve information from all other cells /
@@ -67,10 +71,9 @@ var Cell = cell.Module(
 		},
 	),
 	metrics.Metric(func() Metrics {
-		if withDefaults != "" {
-			return NewMetrics(true)
-		}
-		return NewMetrics(false)
+		showDefaults := withDefaults != ""
+		showEnvVersion := withoutEnvVersion == ""
+		return NewMetrics(showDefaults, showEnvVersion)
 	}),
 )
 

--- a/pkg/metrics/features/cell.go
+++ b/pkg/metrics/features/cell.go
@@ -27,6 +27,7 @@ import (
 	k8s2 "github.com/cilium/cilium/pkg/policy/k8s"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/version"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
@@ -137,6 +138,14 @@ func (fp *featuresParams) DatapathOperationalMode() string {
 	return fp.ConnectorConfig.GetOperationalMode().String()
 }
 
+func (fp *featuresParams) KernelVersion() string {
+	kernelVersion, err := version.GetKernelVersion()
+	if err != nil {
+		return kernelVersionUnknown
+	}
+	return kernelVersion.String()
+}
+
 type enabledFeatures interface {
 	TunnelProtocol() tunnel.EncapProtocol
 	GetChainingMode() string
@@ -147,4 +156,5 @@ type enabledFeatures interface {
 	IsDynamicConfigSourceKindNodeConfig() bool
 	DatapathConfiguredMode() string
 	DatapathOperationalMode() string
+	KernelVersion() string
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -238,8 +238,9 @@ var (
 )
 
 // NewMetrics returns all feature metrics. If 'withDefaults' is set, then
-// all metrics will have defined all of their possible values.
-func NewMetrics(withDefaults bool) Metrics {
+// all metrics will have defined all of their possible values. If 'withEnvVersion'
+// is set, then we include things like version information from the host.
+func NewMetrics(withDefaults bool, withEnvVersion bool) Metrics {
 	return Metrics{
 		CPIPAM: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
 			Help:      "IPAM mode enabled on the agent",
@@ -1034,7 +1035,6 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 		m.DPEndpointRoutes.Set(1)
 	}
 
-	// Get kernel version - this would need to be implemented to detect actual kernel version
 	kernelVersion, err := version.GetKernelVersion()
 	if err != nil || kernelVersion.String() == "" {
 		m.DPKernelVersion.WithLabelValues(kernelVersionUnknown).Set(1)

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -112,7 +112,7 @@ func TestUpdateNetworkMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -166,7 +166,7 @@ func TestUpdateIPAMMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				EnableIPv4:             true,
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
@@ -218,7 +218,7 @@ func TestUpdateCNIChainingMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -280,7 +280,7 @@ func TestUpdateInternetProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
@@ -332,7 +332,7 @@ func TestUpdateIdentityAllocationMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -386,7 +386,7 @@ func TestUpdateCiliumEndpointSlices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                      defaultIPAMModes[0],
 				EnableIPv4:                true,
@@ -460,7 +460,7 @@ func TestUpdateDeviceMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -518,7 +518,7 @@ func TestUpdateHostFirewall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -563,7 +563,7 @@ func TestUpdateLocalRedirectPolicies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                      defaultIPAMModes[0],
 				EnableIPv4:                true,
@@ -608,7 +608,7 @@ func TestUpdateMutualAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -654,7 +654,7 @@ func TestUpdateNonDefaultDeny(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                         defaultIPAMModes[0],
 				EnableIPv4:                   true,
@@ -697,7 +697,7 @@ func TestUpdateCIDRPolicyModeToNode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -820,7 +820,7 @@ func TestUpdateEncryptionMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                             defaultIPAMModes[0],
 				EnableIPv4:                       true,
@@ -883,7 +883,7 @@ func TestUpdateKubeProxyReplacement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -939,7 +939,7 @@ func TestUpdateNodePortConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -999,7 +999,7 @@ func TestUpdateBGP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -1045,7 +1045,7 @@ func TestUpdateIPv4EgressGateway(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -1092,7 +1092,7 @@ func TestUpdateBandwidthManager(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -1138,7 +1138,7 @@ func TestUpdateSCTP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				EnableSCTP:             tt.enableSCTP,
 				IPAM:                   defaultIPAMModes[0],
@@ -1184,7 +1184,7 @@ func TestUpdateVTEP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				EnableVTEP:             tt.enableVTEP,
 				IPAM:                   defaultIPAMModes[0],
@@ -1230,7 +1230,7 @@ func TestUpdateEnvoyConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				EnableEnvoyConfig:      tt.enableEnvoyConfig,
 				IPAM:                   defaultIPAMModes[0],
@@ -1283,7 +1283,7 @@ func TestUpdateBigTCPProtocol(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				IdentityAllocationMode: defaultIdentityAllocationModes[0],
@@ -1342,7 +1342,7 @@ func TestUpdateL2Announcements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				EnableL2Announcements:  tt.enableL2Announcements,
 				IPAM:                   defaultIPAMModes[0],
@@ -1388,7 +1388,7 @@ func TestUpdateL2PodAnnouncements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,
@@ -1434,7 +1434,7 @@ func TestUpdateExtEnvoyProxyMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				ExternalEnvoyProxy:     tt.externalEnvoyProxy,
 				IPAM:                   defaultIPAMModes[0],
@@ -1490,7 +1490,7 @@ func TestUpdateDynamicNodeConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.DaemonConfig{
 				IPAM:                   defaultIPAMModes[0],
 				EnableIPv4:             true,

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -1520,3 +1520,55 @@ func TestUpdateDynamicNodeConfig(t *testing.T) {
 		})
 	}
 }
+func TestUpdateKernelVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		withEnvVersion bool
+		enabled        bool
+		expected       float64
+	}{
+		{
+			name:           "Kernel version metric withEnvVersion=true",
+			withEnvVersion: true,
+			enabled:        true,
+			expected:       1,
+		},
+		{
+			name:           "Kernel version metric withEnvVersion=false",
+			withEnvVersion: false,
+			enabled:        false,
+			expected:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := NewMetrics(true, tt.withEnvVersion)
+
+			config := &option.DaemonConfig{
+				IPAM:                   defaultIPAMModes[0],
+				IdentityAllocationMode: defaultIdentityAllocationModes[0],
+				DatapathMode:           defaultConfiguredDatapathMode,
+				NodePortAcceleration:   defaultNodePortModeAccelerations[0],
+				EnableIPv4:             true,
+			}
+
+			lbConfig := loadbalancer.DefaultConfig
+			lbConfig.LBAlgorithm = defaultNodePortModeAlgorithms[0]
+			lbConfig.LBMode = defaultNodePortModes[0]
+
+			params := mockFeaturesParams{
+				KernelVersionString: "3.2.1",
+			}
+
+			metrics.update(params, config, lbConfig, kpr.KPRConfig{}, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{})
+
+			counter, err := metrics.DPKernelVersion.GetMetricWithLabelValues(params.KernelVersion())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.enabled, counter.IsEnabled())
+
+			counterValue := counter.Get()
+			assert.Equal(t, tt.expected, counterValue, "Expected version %s to be %f", params.KernelVersion(), tt.expected)
+		})
+	}
+}

--- a/pkg/metrics/features/metrics_test.go
+++ b/pkg/metrics/features/metrics_test.go
@@ -27,6 +27,7 @@ type mockFeaturesParams struct {
 	L2PodAnnouncement                   bool
 	isDynamicConfigSourceKindNodeConfig bool
 	ConnectorConfig                     types.ConnectorConfig
+	KernelVersionString                 string
 }
 
 func (m mockFeaturesParams) TunnelProtocol() tunnel.EncapProtocol {
@@ -69,6 +70,10 @@ func (m mockFeaturesParams) DatapathOperationalMode() string {
 		return m.ConnectorConfig.GetOperationalMode().String()
 	}
 	return "mocked"
+}
+
+func (m mockFeaturesParams) KernelVersion() string {
+	return m.KernelVersionString
 }
 
 type bigTCPMock struct {

--- a/pkg/metrics/features/misc_test.go
+++ b/pkg/metrics/features/misc_test.go
@@ -44,7 +44,7 @@ func TestLRPConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddLRPConfig(tt.args.lrpID)
 
 			assert.Equalf(t, tt.want.wantMetrics.npLRPConfigIngested, metrics.NPLRPIngested.WithLabelValues(actionAdd).Get(), "NPLRPIngested different")
@@ -91,7 +91,7 @@ func TestInternalTrafficPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddService(&tt.args.svc)
 
 			assert.Equalf(t, tt.want.wantMetrics.aclbInternalTrafficPolicyIngested, metrics.ACLBInternalTrafficPolicyIngested.WithLabelValues(actionAdd).Get(), "ACLBInternalTrafficPolicyIngested different")
@@ -136,7 +136,7 @@ func TestCiliumEnvoyConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddCEC()
 
 			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumEnvoyConfigIngested, metrics.ACLBCiliumEnvoyConfigIngested.WithLabelValues(actionAdd).Get(), "ACLBCiliumEnvoyConfigIngested different")
@@ -181,7 +181,7 @@ func TestCiliumClusterwideEnvoyConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddCCEC()
 
 			assert.Equalf(t, tt.want.wantMetrics.aclbCiliumClusterwideEnvoyConfigIngested, metrics.ACLBCiliumClusterwideEnvoyConfigIngested.WithLabelValues(actionAdd).Get(), "ACLBCiliumClusterwideEnvoyConfigIngested different")
@@ -226,7 +226,7 @@ func TestCNP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddCNP(&tt.args.cnp)
 
 			assert.Equalf(t, tt.want.wantMetrics.npCNPIngested, metrics.NPCNPIngested.WithLabelValues(actionAdd).Get(), "NPCNPIngested different")
@@ -271,7 +271,7 @@ func TestCCNP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddCCNP(&tt.args.cnp)
 
 			assert.Equalf(t, tt.want.wantMetrics.npCCNPIngested, metrics.NPCCNPIngested.WithLabelValues(actionAdd).Get(), "NPCCNPIngested different")
@@ -310,7 +310,7 @@ func TestClusterMesh(t *testing.T) {
 			for _, mode := range defaultClusterMeshMode {
 				for _, maxClusters := range defaultClusterMeshMaxConnectedClusters {
 
-					metrics := NewMetrics(true)
+					metrics := NewMetrics(true, false)
 					metrics.AddClusterMeshConfig(tt.mode, tt.maxClusters)
 
 					counter, err := metrics.ACLBClusterMeshEnabled.GetMetricWithLabelValues(mode, maxClusters)

--- a/pkg/metrics/features/operator/cell.go
+++ b/pkg/metrics/features/operator/cell.go
@@ -22,6 +22,10 @@ import (
 var (
 	// withDefaults will set enable all default metrics in the operator.
 	withDefaults = os.Getenv("CILIUM_FEATURE_METRICS_WITH_DEFAULTS")
+
+	// withoutEnvVersion can be used to disable metrics that express environment
+	// version info from the host, such as Kubernetes version.
+	withoutEnvVersion = os.Getenv("CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION")
 )
 
 // Cell will retrieve information from all other cells /
@@ -38,10 +42,9 @@ var Cell = cell.Module(
 		},
 	),
 	metrics.Metric(func() Metrics {
-		if withDefaults != "" {
-			return NewMetrics(true)
-		}
-		return NewMetrics(false)
+		showDefaults := withDefaults != ""
+		showEnvVersion := withoutEnvVersion == ""
+		return NewMetrics(showDefaults, showEnvVersion)
 	}),
 )
 

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -25,8 +25,9 @@ const (
 )
 
 // NewMetrics returns all feature metrics. If 'withDefaults' is set, then
-// all metrics will have defined all of their possible values.
-func NewMetrics(withDefaults bool) Metrics {
+// all metrics will have defined all of their possible values.  If 'withEnvVersion'
+// is set, then we include things like version information from the host.
+func NewMetrics(withDefaults bool, withEnvVersion bool) Metrics {
 	return Metrics{
 		ACLBGatewayAPIEnabled: metric.NewGauge(metric.GaugeOpts{
 			Namespace: metrics.Namespace,

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -69,6 +69,7 @@ func NewMetrics(withDefaults bool, withEnvVersion bool) Metrics {
 			Subsystem: subsystemCP,
 			Help:      "Kubernetes version detected by the operator",
 			Name:      "kubernetes_version",
+			Disabled:  !withEnvVersion,
 		}, metric.Labels{
 			{
 				Name: "version",
@@ -97,7 +98,9 @@ func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 	if params.IsNodeIPAMEnabled() {
 		m.ACLBNodeIPAMEnabled.Set(1)
 	}
-	if k8sVersionStr := params.K8sVersion(); k8sVersionStr != "" {
-		m.CPKubernetesVersion.WithLabelValues(k8sVersionStr).Set(1)
+	if m.CPKubernetesVersion.IsEnabled() {
+		if k8sVersionStr := params.K8sVersion(); k8sVersionStr != "" {
+			m.CPKubernetesVersion.WithLabelValues(k8sVersionStr).Set(1)
+		}
 	}
 }

--- a/pkg/metrics/features/operator/metrics_test.go
+++ b/pkg/metrics/features/operator/metrics_test.go
@@ -59,7 +59,7 @@ func TestUpdateGatewayAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.OperatorConfig{
 				EnableGatewayAPI: tt.enableGatewayAPI,
 			}
@@ -94,7 +94,7 @@ func TestUpdateIngressControllerEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.OperatorConfig{}
 
 			params := mockFeaturesParams{
@@ -129,7 +129,7 @@ func TestUpdateLBIPAMEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.OperatorConfig{}
 
 			params := mockFeaturesParams{
@@ -164,7 +164,7 @@ func TestUpdateLoadBalancerL7(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.OperatorConfig{}
 
 			params := mockFeaturesParams{
@@ -199,7 +199,7 @@ func TestUpdateNodeIPAMEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			config := &option.OperatorConfig{}
 
 			params := mockFeaturesParams{
@@ -227,7 +227,7 @@ func TestUpdateKubernetesVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, true)
 			config := &option.OperatorConfig{}
 
 			params := mockFeaturesParams{

--- a/pkg/metrics/features/policy_test.go
+++ b/pkg/metrics/features/policy_test.go
@@ -502,7 +502,7 @@ func Test_ruleType(t *testing.T) {
 			rt := ruleType(tt.args.r)
 			assert.Equalf(t, tt.want.wantRF, rt, "ruleType(%v)", tt.args.r)
 
-			metrics := NewMetrics(true)
+			metrics := NewMetrics(true, false)
 			metrics.AddRule(tt.args.r)
 
 			assert.Equalf(t, tt.want.wantMetrics.npL3Ingested, metrics.NPL3Ingested.WithLabelValues(actionAdd).Get(), "NPL3Ingested different")


### PR DESCRIPTION
In order to facilitate automatic datapath mode selection, the configured datapath became separate to the operational datapath mode. This was reflected in metrics but a documentation update was missed.

This led to the discovery that the CI workflow to detect out-of-sync docs was broken.

This led to the discovery that version information was leaking into the auto-generated documentation.

This PR:
1. Expands `pkg/metrics` with a new environment variable that removes host-info from metrics when set (specifically k8s and kernel version)

3. Updates the CI smoke test workflow to set the new environment variable, and to properly fail if docs are out of sync

4. Resynchronises feature metrics docs.

```release-note
Updates to feature metrics documentation.
```
