### PR TITLE
hubble-cli: prevent empty strings in colorer escape sequences to fix excessive cpu usage

### DIFF
--- a/hubble/pkg/printer/color.go
+++ b/hubble/pkg/printer/color.go
@@ -129,8 +129,12 @@ func (c *colorer) sequences() []string {
 			// should never happen
 			continue
 		}
-		unique[split[0]] = struct{}{}
-		unique[split[1]] = struct{}{}
+		if split[0] != "" {
+			unique[split[0]] = struct{}{}
+		}
+		if split[1] != "" {
+			unique[split[1]] = struct{}{}
+		}
 	}
 	return slices.Collect(maps.Keys(unique))
 }

--- a/hubble/pkg/printer/color_test.go
+++ b/hubble/pkg/printer/color_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package printer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColorersSequences(t *testing.T) {
+	tests := []struct {
+		colorerMode string
+		want        []string
+	}{
+		{
+			colorerMode: "never",
+			want:        []string{},
+		}, {
+			colorerMode: "auto",
+			want:        []string{},
+		}, {
+			colorerMode: "always",
+			want: []string{
+				"\x1b[31m", // red
+				"\x1b[32m", // green
+				"\x1b[34m", // blue
+				"\x1b[36m", // cyan
+				"\x1b[35m", // magenta
+				"\x1b[33m", // yellow
+				"\x1b[0m",  // reset
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s => %v", tt.colorerMode, tt.want), func(t *testing.T) {
+			colorer := newColorer(tt.colorerMode)
+			got := colorer.sequences()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)  
   // no, thank you :) 
- [x] Thanks for contributing!

This PR adds additional empty string checks to the colorer `sequences()` func responsible for generating color escape sequences. 
A bug in this func caused non-empty list of sequenced being generated for cases when coloring was expected to be disabled - there was an empty string returned in the array in such cases. Those empty strings were misinterpreted and caused a lot of unnecessary string replace calls in `terminalEscaperWriter`, increasing CPU usage of `hubble observe` command significantly under high load.

Fixes: #42564

```release-note
Fixes increased CPU usage in `hubble observe` caused by log coloring feature, even when coloring was disabled
```
