### PR TITLE
v1.19 Backports 2026-02-02

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -10,6 +10,12 @@ nodes:
         kind: InitConfiguration
         nodeRegistration:
           taints: []
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
+
   - role: worker
   - role: worker
 networking:

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -78,6 +78,17 @@ rules:
   - get
   - list
   - watch
+{{- if .Values.clustermesh.enableEndpointSliceSynchronization }}
+- apiGroups:
+  - ""
+  resources:
+  # The controller needs to be able to set a service's finalizers to be able to create an EndpointSlice
+  # resource that is owned by the service and sets blockOwnerDeletion=true in its ownerRef.
+  # This is required when the admission plugin OwnerReferencesPermissionEnforcement is activated.
+  - services/finalizers
+  verbs:
+  - update
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -324,6 +324,10 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses/status # To update ingress status with load balancer IP.
+  # The controller needs to be able to set ingress finalizers to be able to create a CiliumEnvoyConfig
+  # resource that is owned by the ingress, and set blockOwnerDeletion=true in its ownerRef.
+  # This is required when the admission plugin OwnerReferencesPermissionEnforcement is activated.
+  - ingresses/finalizers
   verbs:
   - update
 {{- end }}


### PR DESCRIPTION
 * [x] #43912 (@fgiloux)
 * [x] #43949 (@giorio94)

ℹ️ I've dropped the second commit from https://github.com/cilium/cilium/pull/43949, as it reapplied the second one from https://github.com/cilium/cilium/pull/43912, that had been previously reverted on main. I've also reordered the commits so that the one enabling the check in CI comes after the fixes.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 43912 43949
```
