### PR TITLE
[network-driver] Add support for multi-pool Resource IPAM

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -411,6 +411,7 @@ cilium-agent [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default default=8) (default [])
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --route-metric int                                          Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
       --routing-mode string                                       Routing mode ("native" or "tunnel") (default "tunnel")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -259,6 +259,7 @@ cilium-agent hive [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default default=8) (default [])
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -264,6 +264,7 @@ cilium-agent hive dot-graph [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default default=8) (default [])
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -50,7 +50,7 @@ type MultiPoolAllocatorParams struct {
 }
 
 type multiPoolAllocator struct {
-	manager *multiPoolManager
+	manager *MultiPoolManager
 	family  Family
 }
 
@@ -60,7 +60,7 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 		logging.Fatal(p.Logger, fmt.Sprintf("Invalid %s flag value", option.IPAMMultiPoolPreAllocation), logfields.Error, err)
 	}
 
-	mgr := newMultiPoolManager(MultiPoolManagerParams{
+	mgr := NewMultiPoolManager(MultiPoolManagerParams{
 		Logger:                p.Logger,
 		IPv4Enabled:           p.IPv4Enabled,
 		IPv6Enabled:           p.IPv6Enabled,
@@ -92,23 +92,23 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 }
 
 func (c *multiPoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	return c.manager.allocateIP(ip, owner, pool, c.family, true)
+	return c.manager.AllocateIP(ip, owner, pool, c.family, true)
 }
 
 func (c *multiPoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	return c.manager.allocateIP(ip, owner, pool, c.family, false)
+	return c.manager.AllocateIP(ip, owner, pool, c.family, false)
 }
 
 func (c *multiPoolAllocator) Release(ip net.IP, pool Pool) error {
-	return c.manager.releaseIP(ip, pool, c.family, true)
+	return c.manager.ReleaseIP(ip, pool, c.family, true)
 }
 
 func (c *multiPoolAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
-	return c.manager.allocateNext(owner, pool, c.family, true)
+	return c.manager.AllocateNext(owner, pool, c.family, true)
 }
 
 func (c *multiPoolAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
-	return c.manager.allocateNext(owner, pool, c.family, false)
+	return c.manager.AllocateNext(owner, pool, c.family, false)
 }
 
 func (c *multiPoolAllocator) Dump() (map[Pool]map[string]string, string) {
@@ -134,7 +134,7 @@ func (c *multiPoolAllocator) Capacity() uint64 {
 }
 
 func (c *multiPoolAllocator) RestoreFinished() {
-	c.manager.restoreFinished(c.family)
+	c.manager.RestoreFinished(c.family)
 }
 
 func shouldSkipMasqForPool(db *statedb.DB, podIPPools statedb.Table[podippool.LocalPodIPPool], onlyMasqueradeDefaultPool bool) SkipMasqueradeForPoolFn {
@@ -189,10 +189,10 @@ func waitForPool(logger *slog.Logger, db *statedb.DB, podIPPools statedb.Table[p
 	}
 }
 
-func waitForLocalNodeUpdate(logger *slog.Logger, mgr *multiPoolManager) {
+func waitForLocalNodeUpdate(logger *slog.Logger, mgr *MultiPoolManager) {
 	for {
 		select {
-		case <-mgr.localNodeUpdated():
+		case <-mgr.LocalNodeUpdated():
 			return
 		case <-time.After(5 * time.Second):
 			logger.Info("Waiting for local CiliumNode resource to synchronize local node store")

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -97,6 +97,28 @@ func (driver *Driver) UnprepareResourceClaims(ctx context.Context, claims []kube
 	return result, err
 }
 
+func (driver *Driver) deviceClaimConfigs(ctx context.Context, claim *resourceapi.ResourceClaim) (map[string]types.DeviceConfig, error) {
+	devicesCfg := map[string]types.DeviceConfig{}
+	for _, cfg := range claim.Status.Allocation.Devices.Config {
+		if cfg.Opaque.Parameters.Raw != nil {
+			c := types.DeviceConfig{}
+			if err := json.Unmarshal(cfg.Opaque.Parameters.Raw, &c); err != nil {
+				driver.logger.ErrorContext(
+					ctx, "failed to parse config",
+					logfields.Request, cfg.Requests,
+					logfields.Params, cfg.Opaque.Parameters,
+					logfields.Error, err,
+				)
+				return nil, fmt.Errorf("failed to unmarshal config for %s: %w", path.Join(claim.Namespace, claim.Name), err)
+			}
+			for _, request := range cfg.Requests {
+				devicesCfg[request] = c
+			}
+		}
+	}
+	return devicesCfg, nil
+}
+
 func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourceapi.ResourceClaim) kubeletplugin.PrepareResult {
 	if len(claim.Status.ReservedFor) != 1 {
 		return kubeletplugin.PrepareResult{
@@ -112,6 +134,11 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 		}
 	}
 
+	deviceClaimConfigs, err := driver.deviceClaimConfigs(ctx, claim)
+	if err != nil {
+		return kubeletplugin.PrepareResult{Err: err}
+	}
+
 	var (
 		alloc         []allocation
 		devicesStatus []resourceapi.AllocatedDeviceStatus
@@ -120,36 +147,9 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 	for _, result := range claim.Status.Allocation.Devices.Results {
 		var thisAlloc allocation
 
-		for _, cfg := range claim.Status.Allocation.Devices.Config {
-			for _, reqName := range cfg.Requests {
-				var foundConfig bool
-
-				if reqName == result.Request && cfg.Opaque.Parameters.Raw != nil {
-					c := types.DeviceConfig{}
-					err := json.Unmarshal(cfg.Opaque.Parameters.Raw, &c)
-					if err != nil {
-						driver.logger.ErrorContext(
-							ctx, "failed to parse config",
-							logfields.Request, reqName,
-							logfields.Params, cfg.Opaque.Parameters,
-							logfields.Error, err,
-						)
-
-						return kubeletplugin.PrepareResult{
-							Err: fmt.Errorf("failed to unmarshal config for %s: %w", path.Join(claim.Namespace, claim.Name), err),
-						}
-					}
-
-					thisAlloc.Config = c
-					foundConfig = true
-					break
-				}
-
-				if foundConfig {
-					// we found a config for this, no need to look further
-					break
-				}
-			}
+		cfg, ok := deviceClaimConfigs[result.Request]
+		if ok {
+			thisAlloc.Config = cfg
 		}
 
 		var found bool

--- a/pkg/networkdriver/dra_test.go
+++ b/pkg/networkdriver/dra_test.go
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package networkdriver
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	resourceapi "k8s.io/api/resource/v1"
+	v1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+
+	"github.com/cilium/cilium/daemon/k8s"
+	operatoripam "github.com/cilium/cilium/operator/pkg/networkdriver/ipam"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamtypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/networkdriver/dummy"
+	"github.com/cilium/cilium/pkg/networkdriver/types"
+	nodetypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestNetworkDriverIPAM(t *testing.T) {
+	t.Cleanup(func() {
+		testutils.GoleakVerifyNone(t)
+	})
+
+	var (
+		daemonCfg = &option.DaemonConfig{
+			EnableCiliumNetworkDriver: true,
+			EnableIPv4:                true,
+			EnableIPv6:                true,
+			IPAMCiliumNodeUpdateRate:  time.Nanosecond,
+		}
+
+		driverName = "test.cilium.k8s.io"
+		devicePool = "test-device-pool"
+		request    = "test-request"
+		device     = "test-device"
+
+		claimName      = "test-pod-test-4d5bl"
+		claimNamespace = "default"
+		claimUID       = kubetypes.UID("ba3c7922-9a56-44eb-a96f-84ee8b74dd23")
+
+		claimConsumerResource = "pods"
+		ClaimConsumerName     = "test-pod"
+		ClaimConsumerUID      = kubetypes.UID("bec9dd67-13f9-4d4b-a3c1-76fc3e485e68")
+	)
+
+	var (
+		ipv4 = "10.30.0.1/32"
+		ipv6 = "fd00:300:1::1/128"
+	)
+
+	rawParam, err := json.Marshal(map[string]string{
+		"ipv4Addr": ipv4,
+		"ipv6Addr": ipv6,
+	})
+	assert.NoError(t, err)
+
+	claims := []*resourceapi.ResourceClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      claimName,
+				Namespace: claimNamespace,
+				UID:       claimUID,
+			},
+			Status: v1.ResourceClaimStatus{
+				Allocation: &v1.AllocationResult{
+					Devices: v1.DeviceAllocationResult{
+						Config: []v1.DeviceAllocationConfiguration{
+							{
+								Source:   v1.AllocationConfigSourceClaim,
+								Requests: []string{request},
+								DeviceConfiguration: v1.DeviceConfiguration{
+									Opaque: &v1.OpaqueDeviceConfiguration{
+										Driver: driverName,
+										Parameters: runtime.RawExtension{
+											Raw: rawParam,
+										},
+									},
+								},
+							},
+						},
+						Results: []v1.DeviceRequestAllocationResult{
+							{
+								Device:  device,
+								Driver:  driverName,
+								Pool:    devicePool,
+								Request: request,
+							},
+						},
+					},
+				},
+				ReservedFor: []v1.ResourceClaimConsumerReference{
+					{
+						Resource: claimConsumerResource,
+						Name:     ClaimConsumerName,
+						UID:      ClaimConsumerUID,
+					},
+				},
+			},
+		},
+	}
+
+	var (
+		mgr *ipam.MultiPoolManager
+		cs  *k8sClient.FakeClientset
+	)
+
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.LocalNodeCell,
+		cell.Provide(func() *option.DaemonConfig {
+			return daemonCfg
+		}),
+		resourceIPAM,
+
+		cell.Invoke(func(c *k8sClient.FakeClientset) {
+			for _, claim := range claims {
+				_, err := c.KubernetesFakeClientset.ResourceV1().ResourceClaims(claim.Namespace).Create(t.Context(), claim, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+		}),
+		cell.Invoke(func(m *ipam.MultiPoolManager, c *k8sClient.FakeClientset) {
+			mgr = m
+			cs = c
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	assert.NoError(t, hive.Start(tlog, t.Context()))
+
+	driver := &Driver{
+		logger:     tlog,
+		kubeClient: cs,
+		config: &v2alpha1.CiliumNetworkDriverNodeConfigSpec{
+			DriverName: driverName,
+		},
+		devices: map[types.DeviceManagerType][]types.Device{
+			types.DeviceManagerTypeDummy: {
+				&dummy.DummyDevice{
+					Name: device,
+				},
+			},
+		},
+		allocations:  make(map[kubetypes.UID]map[kubetypes.UID][]allocation),
+		multiPoolMgr: mgr,
+		ipv4Enabled:  daemonCfg.IPv4Enabled(),
+		ipv6Enabled:  daemonCfg.IPv6Enabled(),
+	}
+
+	results, err := driver.PrepareResourceClaims(t.Context(), claims)
+	assert.NoError(t, err)
+	assert.Contains(t, results, claimUID)
+	assert.NoError(t, results[claimUID].Err)
+
+	claim, err := cs.Clientset.ResourceV1().ResourceClaims(claimNamespace).Get(t.Context(), claimName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	assert.Len(t, claim.Status.Devices, 1)
+	assert.Equal(t, driverName, claim.Status.Devices[0].Driver)
+	assert.Equal(t, devicePool, claim.Status.Devices[0].Pool)
+	assert.Equal(t, device, claim.Status.Devices[0].Device)
+	assert.Len(t, claim.Status.Devices[0].Conditions, 1)
+	assert.Equal(t, "Ready", claim.Status.Devices[0].Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, claim.Status.Devices[0].Conditions[0].Status)
+
+	var alloc allocation
+	assert.NoError(t, json.Unmarshal(claim.Status.Devices[0].Data.Raw, &alloc))
+	assert.Empty(t, alloc.Config.IPPool)
+	assert.Equal(t, netip.MustParsePrefix(ipv4), alloc.Config.IPv4Addr)
+	assert.Equal(t, netip.MustParsePrefix(ipv6), alloc.Config.IPv6Addr)
+
+	assert.Equal(t, device, claim.Status.Devices[0].NetworkData.InterfaceName)
+	addrs := []string{alloc.Config.IPv4Addr.String(), alloc.Config.IPv6Addr.String()}
+	assert.ElementsMatch(t, addrs, claim.Status.Devices[0].NetworkData.IPs)
+
+	claimsToRelease := []kubeletplugin.NamespacedObject{
+		{
+			NamespacedName: kubetypes.NamespacedName{
+				Namespace: claimNamespace,
+				Name:      claimName,
+			},
+			UID: claimUID,
+		},
+	}
+
+	releaseResults, err := driver.UnprepareResourceClaims(t.Context(), claimsToRelease)
+	assert.NoError(t, err)
+	assert.Contains(t, releaseResults, claimUID)
+	assert.NoError(t, releaseResults[claimUID])
+
+	assert.NoError(t, hive.Stop(tlog, t.Context()))
+}
+
+func TestNetworkDriverIPAMPool(t *testing.T) {
+	t.Cleanup(func() {
+		testutils.GoleakVerifyNone(t)
+	})
+
+	var (
+		daemonCfg = &option.DaemonConfig{
+			EnableCiliumNetworkDriver: true,
+			EnableIPv4:                true,
+			EnableIPv6:                true,
+			IPAMCiliumNodeUpdateRate:  time.Nanosecond,
+		}
+
+		localNodeName = "test-local-node"
+
+		driverName = "test.cilium.k8s.io"
+		devicePool = "test-device-pool"
+		request    = "test-request"
+		device     = "test-device"
+
+		claimName      = "test-pod-test-4d5bl"
+		claimNamespace = "default"
+		claimUID       = kubetypes.UID("ba3c7922-9a56-44eb-a96f-84ee8b74dd23")
+
+		claimConsumerResource = "pods"
+		ClaimConsumerName     = "test-pod"
+		ClaimConsumerUID      = kubetypes.UID("bec9dd67-13f9-4d4b-a3c1-76fc3e485e68")
+	)
+
+	var (
+		ipPoolName   = "test-ip-pool"
+		ipv4CIDR     = "10.10.0.0/16"
+		ipv4MaskSize = 24
+		ipv6CIDR     = "fd00:200:1::/48"
+		ipv6MaskSize = 64
+	)
+
+	rawParam, err := json.Marshal(map[string]string{"ip-pool": ipPoolName})
+	assert.NoError(t, err)
+
+	claims := []*resourceapi.ResourceClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      claimName,
+				Namespace: claimNamespace,
+				UID:       claimUID,
+			},
+			Status: v1.ResourceClaimStatus{
+				Allocation: &v1.AllocationResult{
+					Devices: v1.DeviceAllocationResult{
+						Config: []v1.DeviceAllocationConfiguration{
+							{
+								Source:   v1.AllocationConfigSourceClaim,
+								Requests: []string{request},
+								DeviceConfiguration: v1.DeviceConfiguration{
+									Opaque: &v1.OpaqueDeviceConfiguration{
+										Driver: driverName,
+										Parameters: runtime.RawExtension{
+											Raw: rawParam,
+										},
+									},
+								},
+							},
+						},
+						Results: []v1.DeviceRequestAllocationResult{
+							{
+								Device:  device,
+								Driver:  driverName,
+								Pool:    devicePool,
+								Request: request,
+							},
+						},
+					},
+				},
+				ReservedFor: []v1.ResourceClaimConsumerReference{
+					{
+						Resource: claimConsumerResource,
+						Name:     ClaimConsumerName,
+						UID:      ClaimConsumerUID,
+					},
+				},
+			},
+		},
+	}
+
+	resourceIPPool := v2alpha1.CiliumResourceIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ipPoolName,
+		},
+		Spec: v2alpha1.ResourceIPPoolSpec{
+			IPv4: &v2alpha1.IPv4PoolSpec{
+				CIDRs: []v2alpha1.PoolCIDR{
+					v2alpha1.PoolCIDR(ipv4CIDR),
+				},
+				MaskSize: uint8(ipv4MaskSize),
+			},
+			IPv6: &v2alpha1.IPv6PoolSpec{
+				CIDRs: []v2alpha1.PoolCIDR{
+					v2alpha1.PoolCIDR(ipv6CIDR),
+				},
+				MaskSize: uint8(ipv6MaskSize),
+			},
+		},
+	}
+
+	var (
+		mgr *ipam.MultiPoolManager
+		cs  *k8sClient.FakeClientset
+	)
+
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		k8s.ResourcesCell,
+		cell.Provide(func() *option.DaemonConfig {
+			return daemonCfg
+		}),
+		operatoripam.Cell,
+		resourceIPAM,
+
+		cell.Invoke(func(c *k8sClient.FakeClientset) {
+			for _, claim := range claims {
+				_, err := c.KubernetesFakeClientset.ResourceV1().ResourceClaims(claim.Namespace).Create(t.Context(), claim, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			_, err := c.CiliumFakeClientset.CiliumV2alpha1().CiliumResourceIPPools().Create(t.Context(), &resourceIPPool, metav1.CreateOptions{})
+			assert.NoError(t, err)
+
+			nodetypes.SetName(localNodeName)
+			localNode := v2.CiliumNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: localNodeName,
+				},
+			}
+			_, err = c.CiliumFakeClientset.CiliumV2().CiliumNodes().Create(t.Context(), &localNode, metav1.CreateOptions{})
+			assert.NoError(t, err)
+		}),
+		cell.Invoke(func(m *ipam.MultiPoolManager, c *k8sClient.FakeClientset) {
+			mgr = m
+			cs = c
+		}),
+	)
+
+	tlog := hivetest.Logger(t)
+	assert.NoError(t, hive.Start(tlog, t.Context()))
+
+	driver := &Driver{
+		logger:     tlog,
+		kubeClient: cs,
+		config: &v2alpha1.CiliumNetworkDriverNodeConfigSpec{
+			DriverName: driverName,
+		},
+		devices: map[types.DeviceManagerType][]types.Device{
+			types.DeviceManagerTypeDummy: {
+				&dummy.DummyDevice{
+					Name: device,
+				},
+			},
+		},
+		allocations:  make(map[kubetypes.UID]map[kubetypes.UID][]allocation),
+		multiPoolMgr: mgr,
+		ipv4Enabled:  daemonCfg.IPv4Enabled(),
+		ipv6Enabled:  daemonCfg.IPv6Enabled(),
+	}
+
+	if driver.ipv4Enabled {
+		driver.multiPoolMgr.RestoreFinished(ipam.IPv4)
+	}
+	if driver.ipv6Enabled {
+		driver.multiPoolMgr.RestoreFinished(ipam.IPv6)
+	}
+
+	results, err := driver.PrepareResourceClaims(t.Context(), claims)
+	assert.NoError(t, err)
+	assert.Contains(t, results, claimUID)
+	assert.NoError(t, results[claimUID].Err)
+
+	claim, err := cs.Clientset.ResourceV1().ResourceClaims(claimNamespace).Get(t.Context(), claimName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	assert.Len(t, claim.Status.Devices, 1)
+	assert.Equal(t, driverName, claim.Status.Devices[0].Driver)
+	assert.Equal(t, devicePool, claim.Status.Devices[0].Pool)
+	assert.Equal(t, device, claim.Status.Devices[0].Device)
+	assert.Len(t, claim.Status.Devices[0].Conditions, 1)
+	assert.Equal(t, "Ready", claim.Status.Devices[0].Conditions[0].Type)
+	assert.Equal(t, metav1.ConditionTrue, claim.Status.Devices[0].Conditions[0].Status)
+
+	curLocalNode, err := cs.CiliumFakeClientset.CiliumV2().CiliumNodes().Get(t.Context(), localNodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, []ipamtypes.IPAMPoolRequest{
+		{
+			Pool: ipPoolName,
+			Needed: ipamtypes.IPAMPoolDemand{
+				IPv4Addrs: 1,
+				IPv6Addrs: 1,
+			},
+		},
+	}, curLocalNode.Spec.IPAM.ResourcePools.Requested)
+	assert.Len(t, curLocalNode.Spec.IPAM.ResourcePools.Allocated, 1)
+	assert.Equal(t, ipPoolName, curLocalNode.Spec.IPAM.ResourcePools.Allocated[0].Pool)
+
+	v4PoolCIDR, v6PoolCIDR := netip.MustParsePrefix(ipv4CIDR), netip.MustParsePrefix(ipv6CIDR)
+
+	var v4NodeCIDR, v6NodeCIDR netip.Prefix
+	nodeCIDRs := curLocalNode.Spec.IPAM.ResourcePools.Allocated[0].CIDRs
+	for _, cidr := range nodeCIDRs {
+		prefix, err := cidr.ToPrefix()
+		assert.NoError(t, err)
+		if prefix.Addr().Is6() {
+			v6NodeCIDR = *prefix
+		} else {
+			v4NodeCIDR = *prefix
+		}
+	}
+
+	// allocated IP addresses must be contained in both the pool CIDR and the
+	// sub-CIDR assigned to the node.
+	var alloc allocation
+	assert.NoError(t, json.Unmarshal(claim.Status.Devices[0].Data.Raw, &alloc))
+	assert.Equal(t, ipPoolName, alloc.Config.IPPool)
+	assert.Equal(t, 32, alloc.Config.IPv4Addr.Bits())
+	assert.True(t, v4PoolCIDR.Contains(alloc.Config.IPv4Addr.Masked().Addr()))
+	assert.True(t, v4NodeCIDR.Contains(alloc.Config.IPv4Addr.Masked().Addr()))
+	assert.Equal(t, 128, alloc.Config.IPv6Addr.Bits())
+	assert.True(t, v6PoolCIDR.Contains(alloc.Config.IPv6Addr.Masked().Addr()))
+	assert.True(t, v6NodeCIDR.Contains(alloc.Config.IPv6Addr.Masked().Addr()))
+
+	assert.Equal(t, device, claim.Status.Devices[0].NetworkData.InterfaceName)
+	addrs := []string{alloc.Config.IPv4Addr.String(), alloc.Config.IPv6Addr.String()}
+	assert.ElementsMatch(t, addrs, claim.Status.Devices[0].NetworkData.IPs)
+
+	claimsToRelease := []kubeletplugin.NamespacedObject{
+		{
+			NamespacedName: kubetypes.NamespacedName{
+				Namespace: claimNamespace,
+				Name:      claimName,
+			},
+			UID: claimUID,
+		},
+	}
+
+	releaseResults, err := driver.UnprepareResourceClaims(t.Context(), claimsToRelease)
+	assert.NoError(t, err)
+	assert.Contains(t, releaseResults, claimUID)
+	assert.NoError(t, releaseResults[claimUID])
+
+	// CIDR assigned to node must be returned to the operator
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		localNode, err := cs.CiliumFakeClientset.CiliumV2().CiliumNodes().Get(t.Context(), localNodeName, metav1.GetOptions{})
+		assert.NoError(c, err)
+		assert.Empty(c, localNode.Spec.IPAM.ResourcePools.Requested)
+		assert.Empty(c, localNode.Spec.IPAM.ResourcePools.Allocated)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	assert.NoError(t, hive.Stop(tlog, t.Context()))
+}

--- a/pkg/networkdriver/ipam.go
+++ b/pkg/networkdriver/ipam.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package networkdriver
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamtypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const (
+	// AddrAddRetryInterval is the initial interval for the exponential backoff between
+	// subsequent "address add request" retries to the IPAM manager.
+	// This is needed when requesting an IP address from a not yet ready pool, in order
+	// to let the operator handle the new request and reserve a CIDR for the node.
+	AddrAddRetryInterval = time.Second
+
+	// AddrAddMaxRetries is the maximum number of "address add request" retries before
+	// failing the operation.
+	AddrAddMaxRetries = 25
+
+	// ResourceIPAMMultiPoolPreAllocation defines the pre-allocation value for each resource
+	// IPAM pool.
+	ResourceIPAMMultiPoolPreAllocation = "resource-ipam-multi-pool-pre-allocation"
+)
+
+type ipamAction string
+
+const (
+	addrAdd ipamAction = "add"
+	addrDel ipamAction = "del"
+)
+
+var resourceIPAM = cell.Group(
+	cell.Config(defaultIPAMConfig),
+
+	cell.ProvidePrivate(newMultiPoolManager),
+)
+
+type IPAMConfig struct {
+	ResourceIPAMMultiPoolPreAllocation map[string]string
+}
+
+var defaultIPAMConfig = IPAMConfig{}
+
+func (cfg IPAMConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringToString(ResourceIPAMMultiPoolPreAllocation, cfg.ResourceIPAMMultiPoolPreAllocation,
+		fmt.Sprintf("Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default %s=8)", defaults.IPAMDefaultIPPool))
+}
+
+func newMultiPoolManager(
+	Logger *slog.Logger,
+	DaemonCfg *option.DaemonConfig,
+	LocalNode k8s.LocalCiliumNodeResource,
+	ClientSet k8sClient.Clientset,
+	JobGroup job.Group,
+	Cfg IPAMConfig,
+) *ipam.MultiPoolManager {
+	if !ClientSet.IsEnabled() || !DaemonCfg.EnableCiliumNetworkDriver {
+		return nil
+	}
+
+	preallocMap, err := ipam.ParseMultiPoolPreAllocMap(Cfg.ResourceIPAMMultiPoolPreAllocation)
+	if err != nil {
+		Logger.Error("Invalid flag value",
+			logfields.Flag, ResourceIPAMMultiPoolPreAllocation,
+			logfields.Error, err)
+		return nil
+	}
+
+	return ipam.NewMultiPoolManager(ipam.MultiPoolManagerParams{
+		Logger:               Logger,
+		IPv4Enabled:          DaemonCfg.IPv4Enabled(),
+		IPv6Enabled:          DaemonCfg.IPv6Enabled(),
+		CiliumNodeUpdateRate: DaemonCfg.IPAMCiliumNodeUpdateRate,
+		PreallocMap:          preallocMap,
+		Node:                 LocalNode,
+		CNClient:             ClientSet.CiliumV2().CiliumNodes(),
+		JobGroup:             JobGroup,
+		PoolsFromResource: func(cn *v2.CiliumNode) *ipamtypes.IPAMPoolSpec {
+			return &cn.Spec.IPAM.ResourcePools
+		},
+	})
+}

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -141,13 +141,17 @@ type RouteSet map[netip.Prefix]AddrSet
 type AddrSet map[netip.Prefix]struct{}
 
 type DeviceConfig struct {
-	Ipv4Addr netip.Prefix `json:"ipv4Addr"`
+	IPv4Addr netip.Prefix `json:"ipv4Addr"`
+	IPv6Addr netip.Prefix `json:"ipv6Addr"`
+	IPPool   string       `json:"ip-pool"`
 	Routes   RouteSet
 	Vlan     uint16
 }
 
 func (d *DeviceConfig) Empty() bool {
-	return d.Ipv4Addr == (netip.Prefix{}) &&
+	return d.IPv4Addr == (netip.Prefix{}) &&
+		d.IPv6Addr == (netip.Prefix{}) &&
+		d.IPPool == "" &&
 		d.Routes == nil &&
 		d.Vlan == 0
 }


### PR DESCRIPTION
Multi-Pool Resource IPAM replicates the way [Multi-Pool IPAM](https://docs.cilium.io/en/latest/network/concepts/ipam/multi-pool/) mode allocates IP addresses to pods, but specializes for DRA resources. When a pod with a ResourceClaim is scheduled on a node, the Cilium Network Driver is responsible for setting up the needed DRA resources to fulfill the claim. With Multi Pool Resource IPAM the claim may specify a pool (namely, a `CiliumResourceIPPool` object) from which the IP address should be taken and assigned to the resource.

This PR adds the agent part of Multi-Pool Resource IPAM (for more details refer to the Cilium Network Driver [CfP](https://github.com/cilium/design-cfps/pull/85/changes#diff-d7847da6e71b01e3ca0e845e7f46483c7b7ffc376792e06867214d9d5e433cc9R345-R357)). The needed IP addresses are taken from the pool specified in the ResourceClaim device request and assigned to the DRA resource in the `PrepareResourceClaims` hook.

---

### How to test the PR manually

Enable the Cilium Network Driver in the Helm chart:

```diff
diff --git a/contrib/testing/kind-fast.yaml b/contrib/testing/kind-fast.yaml
index 02167d50b2..4940b66b95 100644
--- a/contrib/testing/kind-fast.yaml
+++ b/contrib/testing/kind-fast.yaml
@@ -75,3 +75,6 @@ cni:
   # binary we directly copied to the node. But we still want the configuration
   # to be created, which is also controlled by `cni.install`.
   binPath: /opt/dummy/
+
+networkDriver:
+  enabled: true
\ No newline at end of file
```

Create a two nodes kind cluster and install Cilium:

```bash
make kind && make kind-image-fast && make kind-install-cilium-fast
```

Enable Cilium Network Driver for dummy devices on each node, `kind-worker` and `kind-control-plane`:

```bash
cat <<EOF | kubectl apply -f -
apiVersion: cilium.io/v2alpha1
kind: CiliumNetworkDriverNodeConfig
metadata:
  name: kind-worker
spec:
  draRegistrationRetryInterval: 1
  draRegistrationTimeout: 600
  publishInterval: 10
  driverName: "dummy.cilium.k8s.io"
  pools:
    - name: "dummy-pool"
      filter:
        deviceManagers:
          - "dummy"
  deviceManagerConfigs:
    dummy:
      enabled: true
---
apiVersion: cilium.io/v2alpha1
kind: CiliumNetworkDriverNodeConfig
metadata:
  name: kind-control-plane
spec:
  draRegistrationRetryInterval: 1
  draRegistrationTimeout: 600
  publishInterval: 10
  driverName: "dummy.cilium.k8s.io"
  pools:
    - name: "dummy-pool"
      filter:
        deviceManagers:
          - "dummy"
  deviceManagerConfigs:
    dummy:
      enabled: true
EOF
```

Add two dummy devices on `kind-worker`:

```bash
$ docker exec -ti kind-worker bash
# ip link add dummy0 type dummy && ip link set dummy0 up && ip link add dummy1 type dummy && ip link set dummy1 up
```

Define the DeviceClass for dummy devices:

```bash
cat <<EOF | kubectl apply -f -
apiVersion: resource.k8s.io/v1
kind: DeviceClass
metadata:
  name: dummy.cilium.k8s.io
  namespace: kube-system
spec:
  selectors:
  - cel:
      expression: device.driver == "dummy.cilium.k8s.io"
EOF
```

Add two CiliumResourceIPPool, `a-ip-pool` and `b-ip-pool`:

```bash
cat <<EOF | kubectl apply -f -
apiVersion: cilium.io/v2alpha1
kind: CiliumResourceIPPool
metadata:
  name: a-ip-pool
spec:
  ipv4:
    cidrs:
    - 10.10.0.0/16
    maskSize: 24
  ipv6:
    cidrs:
    - fd00:100:1::/48
    maskSize: 64
---
apiVersion: cilium.io/v2alpha1
kind: CiliumResourceIPPool
metadata:
  name: b-ip-pool
spec:
  ipv4:
    cidrs:
    - 10.20.0.0/16
    maskSize: 24
  ipv6:
    cidrs:
    - fd00:200:1::/48
    maskSize: 64
EOF
```

Create a ResourceClaimTemplate that requests two dummy devices, one with addresses from `a-ip-pool` and the other with addresses from `b-ip-pool`:

```bash
cat <<EOF | kubectl apply -f -
apiVersion: resource.k8s.io/v1
kind: ResourceClaimTemplate
metadata:
  name: dummy
spec:
  spec:
    devices:
      requests:
      - name: dummy-a
        exactly:
          deviceClassName: dummy.cilium.k8s.io
      - name: dummy-b
        exactly:
          deviceClassName: dummy.cilium.k8s.io
      config:
        - requests:
          - dummy-a
          opaque:
            driver: dummy.cilium.k8s.io
            parameters:
              ip-pool: a-ip-pool
        - requests:
          - dummy-b
          opaque:
            driver: dummy.cilium.k8s.io
            parameters:
              ip-pool: b-ip-pool
EOF
```

Add a pod using the ResourceClaim `dummy` to request two dummy devices:

```bash
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: dummy-pod
spec:
  securityContext:
    runAsUser: 0
  containers:
  - name: app
    image: busybox
    command: ["sleep", "inf"]
  resourceClaims:
  - name: dummy
    resourceClaimTemplateName: dummy
EOF
```

The pod is scheduled on `kind-worker` node, with `dummy0` and `dummy1` devices having addresses from the `a-ip-pool` and `b-ip-pool` respectively:

```bash
$ kubectl exec -ti dummy-pod -- ip addr
8: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue qlen 1000
    link/ether 7a:1c:9c:df:da:97 brd ff:ff:ff:ff:ff:ff
    inet 10.10.0.158/32 scope global dummy0
       valid_lft forever preferred_lft forever
    inet6 fd00:100:1::918e/128 scope global 
       valid_lft forever preferred_lft forever
9: dummy1: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue qlen 1000
    link/ether 42:59:f4:ef:e6:c5 brd ff:ff:ff:ff:ff:ff
    inet 10.20.0.141/32 scope global dummy1
       valid_lft forever preferred_lft forever
    inet6 fd00:200:1::4fb1/128 scope global 
       valid_lft forever preferred_lft forever
```

The `kind-worker` CiliumNode reports the CIDRs requested from and allocated to the node:

```bash
$ ks get ciliumnode kind-worker -o yaml | yq .spec.ipam.resourcepools
allocated:
  - cidrs:
      - 10.10.0.0/24
      - fd00:100:1::/64
    pool: a-ip-pool
  - cidrs:
      - 10.20.0.0/24
      - fd00:200:1::/64
    pool: b-ip-pool
requested:
  - needed:
      ipv4-addrs: 1
      ipv6-addrs: 1
    pool: a-ip-pool
  - needed:
      ipv4-addrs: 1
      ipv6-addrs: 1
    pool: b-ip-pool
```

Related: https://github.com/cilium/cilium/pull/44081
~Depends on https://github.com/cilium/cilium/pull/44081~