### PR TITLE
Check maps via ebpf package as well when handling GetMapName

### DIFF
--- a/pkg/ebpf/map_register.go
+++ b/pkg/ebpf/map_register.go
@@ -4,7 +4,11 @@
 package ebpf
 
 import (
+	"log/slog"
+	"path"
+
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -20,6 +24,18 @@ func registerMap(m *Map) {
 	mutex.Unlock()
 
 	m.logger.Debug("Registered BPF map", logfields.Path, m.path)
+}
+
+// GetMap returns the registered map with the given name or absolute path
+func GetMap(logger *slog.Logger, name string) *Map {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	if !path.IsAbs(name) {
+		name = bpf.MapPath(logger, name)
+	}
+
+	return mapRegister[name]
 }
 
 // GetOpenMaps returns a slice of all open BPF maps. This is identical to

--- a/pkg/maps/api.go
+++ b/pkg/maps/api.go
@@ -137,11 +137,16 @@ type getMapNameHandler struct {
 
 func (h *getMapNameHandler) Handle(params restapi.GetMapNameParams) middleware.Responder {
 	m := bpf.GetMap(h.logger, params.Name)
-	if m == nil {
-		return restapi.NewGetMapNameNotFound()
+	if m != nil {
+		return restapi.NewGetMapNameOK().WithPayload(m.GetModel())
 	}
 
-	return restapi.NewGetMapNameOK().WithPayload(m.GetModel())
+	em := ebpf.GetMap(h.logger, params.Name)
+	if em != nil {
+		return restapi.NewGetMapNameOK().WithPayload(em.GetModel())
+	}
+
+	return restapi.NewGetMapNameNotFound()
 }
 
 type getMapHandler struct{}


### PR DESCRIPTION
I observed that when executing `cilium-dbg map get cilium_metrics` the daemon replies with:
```bash
[root@master-01 ~]# oc exec -it -n cilium cilium-dzvg4 -- cilium-dbg map get cilium_metrics
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), install-cni-binaries (init)
Error: [GET /map/{name}][404] getMapNameNotFound
command terminated with exit code 1
```

Looking at the code the [handler](https://github.com/cilium/cilium/blob/main/pkg/maps/api.go#L138-L145) just looks if the map is present via the `bpf` package. Looking at the code at large seems that there are 2 ways of creating bpf maps and some of them are done via the `ebpf` package (e.g., the `cilium_metrics` one).

```release-note
Check maps via ebpf package as well when handling GetMapName
```
