### PR TITLE
ci: e2e: improve GitHub action readability

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -187,9 +187,9 @@ jobs:
   setup-and-test:
     needs: [wait-for-images, generate-matrix]
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    name: 'Setup & Test'
+    name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }})'
     env:
-      job_name: 'Setup & Test'
+      job_name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }})'
     strategy:
       fail-fast: false
       max-parallel: 100
@@ -614,7 +614,7 @@ jobs:
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested before cilium-agent restart"
-          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before agent restart"
+          json-filename: "${{ env.job_name }} - before agent restart"
 
       - name: Setup conn-disrupt-test before restarting
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' }}
@@ -649,7 +649,7 @@ jobs:
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested before downgrade"
-          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - before downgrade"
+          json-filename: "${{ env.job_name }} - before downgrade"
 
       - name: Setup conn-disrupt-test before downgrading
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' }}
@@ -731,7 +731,7 @@ jobs:
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested after downgrade"
-          json-filename: "${{ env.job_name }} (${{ matrix.name }}) - after downgrade"
+          json-filename: "${{ env.job_name }} - after downgrade"
 
       - name: Fetch artifacts
         if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -198,6 +198,11 @@ jobs:
 
     timeout-minutes: 55
     steps:
+      - name: Log Matrix Configuration
+        run: |
+          echo "Current matrix configuration:"
+          echo '${{ toJSON(matrix) }}'
+
       - name: Set commit status to pending
         uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:


### PR DESCRIPTION
* 1st commit: simplify the name, by printing only `matrix.name` and `matrix.mode` in the job title, rather than the whole matrix entry (that will be too long, therefore truncated in GitHub). This result in having jobs like `Setup & Tests (ipsec-1, minor)`, etc. Simple and clean
* 2nd commit: add a step in each job to dump the current matrix configuration under test. It is true that one can always open the file and look it up, but having it complete on the UI would make it simpler.