### PR TITLE
ztunnel: fix test env not deploying + address comments

### DIFF
--- a/cilium-cli/connectivity/builder/ztunnel_pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/ztunnel_pod_to_pod_encryption.go
@@ -21,7 +21,7 @@ func (t ztunnelPodToPodEncryption) build(ct *check.ConnectivityTest, _ map[strin
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
 		WithFeatureRequirements(features.RequireEnabled(features.Ztunnel)).
 		WithSetupFunc(func(ctx context.Context, t *check.Test, testCtx *check.ConnectivityTest) error {
-			return nil
+			return check.DeployZtunnelTestEnv(ctx, t, testCtx)
 		}).
 		WithScenarios(
 			tests.ZTunnelEnrolledToEnrolledSameNode(),


### PR DESCRIPTION
Add deployZtunnelTestEnv function to create test infrastructure for
ztunnel e2e tests. The function creates 3 namespaces and deploys
client and echo pods in each for testing mTLS encryption scenarios.

Changes include:
- Add DeployZtunnelTestEnv function called via WithSetupFunc
- Use correct namespace enrollment label (io.cilium/mtls-enabled)
- Make internal constants unexported (sameNode, differentNode, etc.)
- Remove verbose banner comments
- Refactor filterPodsByLocation to use slice instead of pointer
- Use patch instead of get+update for namespace enrollment
- Extract startSniffer helper to reduce code duplication
- Change Pod struct fields from pointers to values where nil check not needed
- Validate server ztunnel state for DifferentNode scenarios

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
