### PR TITLE
ztunnel: document unsupported traffic limitation

### DIFF
--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -173,6 +173,10 @@ Validate the Setup
 Limitations
 ===========
 
+* Traffic between workloads is only supported when both the source and
+  destination endpoints are enrolled in ztunnel. Communication between an
+  enrolled workload and a non-enrolled workload is not supported.
+
 * The ztunnel integration currently only supports enrollment via namespace
   labels. Pod-level enrollment is not supported.
 


### PR DESCRIPTION
When a pod is enrolled in ztunnel, its traffic is redirected via ztunnel proxy, which encrypts it using mTLS and sends it over HBONE (port 15008). The receiving ztunnel instance then decrypts the traffic before delivering it to the destination pod. This architecture requires both endpoints to be enrolled: if the destination is not enrolled, there is no ztunnel to decrypt the incoming traffic, and if the source is not enrolled, the reply traffic from the enrolled destination would be encrypted but the unenrolled source has no ztunnel to decrypt it.

cc @joestringer 
