### PR TITLE
[v1.19] ztunnel: document unsupported traffic limitation

### DIFF
--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -173,6 +173,10 @@ Validate the Setup
 Limitations
 ===========
 
+* Traffic between workloads is only supported when both the source and
+  destination endpoints are enrolled in ztunnel. Communication between an
+  enrolled workload and a non-enrolled workload is not supported.
+
 * The ztunnel integration currently only supports enrollment via namespace
   labels. Pod-level enrollment is not supported.
 


### PR DESCRIPTION
v1.19 backports 2026-02-02

 - [ ] #44133 -- ztunnel: document unsupported traffic limitation (@rgo3)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
44133
```
