### PR TITLE
operator/spire: make SPIRE client configurable for ztunnel

### DIFF
--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -19,10 +19,12 @@ import (
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/auth/identity"
+	ztunnel "github.com/cilium/cilium/operator/pkg/ztunnel/config"
 	"github.com/cilium/cilium/pkg/backoff"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/lock"
@@ -42,12 +44,40 @@ var defaultSelectors = []*types.Selector{
 	},
 }
 
+// DefaultSpireEntryConfig returns the default SpireEntryConfig for mutual-auth mode.
+func DefaultSpireEntryConfig() SpireEntryConfig {
+	return SpireEntryConfig{
+		ParentID:      defaultParentID,
+		PathFunc:      toPath,
+		SelectorsFunc: func(id string) []*types.Selector { return defaultSelectors },
+	}
+}
+
+// ZtunnelSpireEntryConfig returns the SpireEntryConfig for ztunnel mode.
+// In ztunnel mode:
+// - ParentID is "/ztunnel"
+// - Path format is "/ns/{namespace}/sa/{serviceaccount}"
+// - Selectors are k8s namespace and service account selectors
+func ZtunnelSpireEntryConfig() SpireEntryConfig {
+	return SpireEntryConfig{
+		ParentID:      "/ztunnel",
+		PathFunc:      ztunnel.SpiffeIDPathFunc,
+		SelectorsFunc: ztunnel.SpiffeIDSelectorsFunc,
+	}
+}
+
 // Cell is the cell for the SPIRE client.
 var Cell = cell.Module(
 	"spire-client",
 	"Spire Server API Client",
 	cell.Config(defaultMutualAuthConfig),
 	cell.Config(defaultClientConfig),
+	cell.Provide(func(zfg ztunnel.Config) SpireEntryConfig {
+		if zfg.EnableZTunnel {
+			return ZtunnelSpireEntryConfig()
+		}
+		return DefaultSpireEntryConfig()
+	}),
 	cell.Provide(NewClient),
 )
 
@@ -56,6 +86,7 @@ var FakeCellClient = cell.Module(
 	"Fake Spire Server API Client",
 	cell.Config(defaultMutualAuthConfig),
 	cell.Config(defaultClientConfig),
+	cell.Provide(DefaultSpireEntryConfig),
 	cell.Provide(NewFakeClient),
 )
 
@@ -109,34 +140,90 @@ func (cfg ClientConfig) Flags(flags *pflag.FlagSet) {
 type params struct {
 	cell.In
 
-	K8sClient k8sClient.Clientset
+	Logger           *slog.Logger
+	K8sClient        k8sClient.Clientset
+	Lifecycle        cell.Lifecycle
+	MutualAuthConfig MutualAuthConfig
+	ClientConfig     ClientConfig
+	EntryConfig      SpireEntryConfig
+	ZtunnelConfig    ztunnel.Config
+}
+
+// SpireEntryConfig contains the configuration for SPIRE entry generation.
+// This allows the SPIRE client to be configured for different use cases
+// such as mutual-auth or ztunnel.
+type SpireEntryConfig struct {
+	ParentID      string
+	PathFunc      func(string) string
+	SelectorsFunc func(string) []*types.Selector
+}
+
+type out struct {
+	cell.Out
+
+	Provider identity.Provider
+	Client   *Client
 }
 
 type Client struct {
-	cfg        ClientConfig
-	log        *slog.Logger
-	entry      entryv1.EntryClient
-	entryMutex lock.RWMutex
-	k8sClient  k8sClient.Clientset
+	cfg         ClientConfig
+	log         *slog.Logger
+	entry       entryv1.EntryClient
+	entryCfg    SpireEntryConfig
+	entryMutex  lock.RWMutex
+	k8sClient   k8sClient.Clientset
+	initialized chan struct{}
 }
 
 // NewClient creates a new SPIRE client.
 // If the mutual authentication is not enabled, it returns a noop client.
-func NewClient(params params, lc cell.Lifecycle, authCfg MutualAuthConfig, cfg ClientConfig, log *slog.Logger) identity.Provider {
-	if !authCfg.Enabled {
-		return &noopClient{}
-	}
-	client := &Client{
-		k8sClient: params.K8sClient,
-		cfg:       cfg,
-		log:       log.With(logfields.LogSubsys, "spire-client"),
+// When ztunnel is enabled, the client is still created but the identity.Provider
+// returned is a noop since ztunnel handles identity differently.
+func NewClient(params params) out {
+	if !params.MutualAuthConfig.Enabled {
+		return out{
+			Provider: &noopClient{},
+			Client:   nil,
+		}
 	}
 
-	lc.Append(cell.Hook{
+	client := &Client{
+		k8sClient:   params.K8sClient,
+		cfg:         params.ClientConfig,
+		entryCfg:    params.EntryConfig,
+		log:         params.Logger.With(logfields.LogSubsys, "spire-client"),
+		initialized: make(chan struct{}),
+	}
+
+	var provider identity.Provider = client
+	if params.ZtunnelConfig.EnableZTunnel {
+		params.Logger.Debug("Ztunnel-Spire integration enabled, returning noop identity provider")
+		provider = &noopClient{}
+	}
+
+	params.Lifecycle.Append(cell.Hook{
 		OnStart: client.onStart,
 		OnStop:  func(_ cell.HookContext) error { return nil },
 	})
-	return client
+	return out{
+		Provider: provider,
+		Client:   client,
+	}
+}
+
+// GetSpireEntryConfig returns the SPIRE entry configuration.
+func (c *Client) GetSpireEntryConfig() SpireEntryConfig {
+	return c.entryCfg
+}
+
+// GetSpireTrustDomain returns the SPIFFE trust domain.
+func (c *Client) GetSpireTrustDomain() string {
+	return c.cfg.SpiffeTrustDomain
+}
+
+// Initialized returns a channel that is closed when the client is initialized.
+func (c *Client) Initialized() <-chan struct{} {
+	return c.initialized
 }
 
 func (c *Client) onStart(ctx cell.HookContext) error {
@@ -151,6 +238,7 @@ func (c *Client) onStart(ctx cell.HookContext) error {
 				c.entryMutex.Lock()
 				c.entry = entryv1.NewEntryClient(conn)
 				c.entryMutex.Unlock()
+				close(c.initialized)
 				break
 			}
 			c.log.WarnContext(ctx,
@@ -212,7 +300,7 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 }
 
 // Upsert creates or updates the SPIFFE ID for the given ID.
-// The SPIFFE ID is in the form of spiffe://<trust-domain>/identity/<id>.
+// The SPIFFE ID path and selectors are determined by the SpireEntryConfig.
 func (c *Client) Upsert(ctx context.Context, id string) error {
 	c.entryMutex.RLock()
 	defer c.entryMutex.RUnlock()
@@ -229,13 +317,13 @@ func (c *Client) Upsert(ctx context.Context, id string) error {
 		{
 			SpiffeId: &types.SPIFFEID{
 				TrustDomain: c.cfg.SpiffeTrustDomain,
-				Path:        toPath(id),
+				Path:        c.entryCfg.PathFunc(id),
 			},
 			ParentId: &types.SPIFFEID{
 				TrustDomain: c.cfg.SpiffeTrustDomain,
-				Path:        defaultParentID,
+				Path:        c.entryCfg.ParentID,
 			},
-			Selectors: defaultSelectors,
+			Selectors: c.entryCfg.SelectorsFunc(id),
 		},
 	}
 
@@ -250,8 +338,78 @@ func (c *Client) Upsert(ctx context.Context, id string) error {
 	return err
 }
 
+// UpsertBatch creates or updates multiple SPIFFE entries at once.
+// For each ID, it checks if an entry exists and updates it, otherwise creates it.
+func (c *Client) UpsertBatch(ctx context.Context, ids []string) error {
+	c.entryMutex.RLock()
+	defer c.entryMutex.RUnlock()
+
+	if c.entry == nil {
+		return fmt.Errorf("unable to connect to SPIRE server %s", c.cfg.SpireServerAddress)
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// Build entries for all IDs
+	entries := make([]*types.Entry, 0, len(ids))
+	for _, id := range ids {
+		entries = append(entries, &types.Entry{
+			SpiffeId: &types.SPIFFEID{
+				TrustDomain: c.cfg.SpiffeTrustDomain,
+				Path:        c.entryCfg.PathFunc(id),
+			},
+			ParentId: &types.SPIFFEID{
+				TrustDomain: c.cfg.SpiffeTrustDomain,
+				Path:        c.entryCfg.ParentID,
+			},
+			Selectors: c.entryCfg.SelectorsFunc(id),
+		})
+	}
+
+	resp, err := c.entry.BatchCreateEntry(ctx,
+		&entryv1.BatchCreateEntryRequest{Entries: entries},
+	)
+	if err != nil {
+		return fmt.Errorf("batch create failed: %w", err)
+	}
+
+	// For AlreadyExists entries, we need to update them
+	var errs []error
+	var toUpdate []*types.Entry
+	for j, r := range resp.Results {
+		if r.Status.Code == int32(codes.AlreadyExists) {
+			toUpdate = append(toUpdate, entries[j])
+		} else if r.Status.Code != int32(codes.OK) {
+			errs = append(errs, fmt.Errorf("entry create failed: %v: %s",
+				r.Status.Code, r.Status.Message))
+		}
+	}
+
+	// Update existing entries
+	if len(toUpdate) > 0 {
+		_, err := c.entry.BatchUpdateEntry(ctx,
+			&entryv1.BatchUpdateEntryRequest{Entries: toUpdate},
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("batch update failed: %w", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		c.log.Warn("UpsertBatch completed with errors",
+			logfields.Total, len(ids),
+			logfields.ErrorCount, len(errs))
+		return fmt.Errorf("batch upsert had %d errors: %w", len(errs), errs[0])
+	}
+
+	c.log.Debug("UpsertBatch completed successfully", logfields.Count, len(ids))
+	return nil
+}
+
 // Delete deletes the SPIFFE ID for the given ID.
-// The SPIFFE ID is in the form of spiffe://<trust-domain>/identity/<id>.
+// The SPIFFE ID path is determined by the SpireEntryConfig.
 func (c *Client) Delete(ctx context.Context, id string) error {
 	c.entryMutex.RLock()
 	defer c.entryMutex.RUnlock()
@@ -273,7 +431,7 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 	if len(entries.Entries) == 0 {
 		return nil
 	}
-	var ids = make([]string, 0, len(entries.Entries))
+	ids := make([]string, 0, len(entries.Entries))
 	for _, e := range entries.Entries {
 		ids = append(ids, e.Id)
 	}
@@ -285,20 +443,123 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 	return err
 }
 
+// DeleteBatch deletes multiple SPIFFE entries at once.
+// It lists all entries by parent ID, filters to the requested IDs, and deletes in batches.
+// This is more efficient than looking up each entry individually.
+func (c *Client) DeleteBatch(ctx context.Context, ids []string) error {
+	c.entryMutex.RLock()
+	defer c.entryMutex.RUnlock()
+	if c.entry == nil {
+		return fmt.Errorf("unable to connect to SPIRE server %s", c.cfg.SpireServerAddress)
+	}
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	// Build a set of SPIFFE ID paths we want to delete
+	pathsToDelete := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		path := c.entryCfg.PathFunc(id)
+		if path != "" {
+			pathsToDelete[path] = struct{}{}
+		}
+	}
+
+	if len(pathsToDelete) == 0 {
+		return nil
+	}
+
+	// List all entries by parent ID and filter to ones we want to delete
+	var entryIDs []string
+	var pageToken string
+	for {
+		resp, err := c.entry.ListEntries(ctx, &entryv1.ListEntriesRequest{
+			Filter: &entryv1.ListEntriesRequest_Filter{
+				ByParentId: &types.SPIFFEID{
+					TrustDomain: c.cfg.SpiffeTrustDomain,
+					Path:        c.entryCfg.ParentID,
+				},
+			},
+			PageToken: pageToken,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to list entries: %w", err)
+		}
+
+		for _, e := range resp.Entries {
+			if e.SpiffeId != nil {
+				if _, ok := pathsToDelete[e.SpiffeId.Path]; ok {
+					entryIDs = append(entryIDs, e.Id)
+				}
+			}
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	if len(entryIDs) == 0 {
+		c.log.Debug("DeleteBatch: no entries found to delete", logfields.Requested, len(ids))
+		return nil
+	}
+
+	resp, err := c.entry.BatchDeleteEntry(ctx, &entryv1.BatchDeleteEntryRequest{
+		Ids: entryIDs,
+	})
+	if err != nil {
+		return fmt.Errorf("batch delete failed: %w", err)
+	}
+
+	// Check individual results, ignore NotFound errors
+	var errs []error
+	for _, r := range resp.Results {
+		if r.Status.Code != int32(codes.OK) &&
+			r.Status.Code != int32(codes.NotFound) {
+			errs = append(errs, fmt.Errorf("entry delete failed: %v: %s",
+				r.Status.Code, r.Status.Message))
+		}
+	}
+
+	if len(errs) > 0 {
+		c.log.Warn("DeleteBatch completed with errors",
+			logfields.Requested, len(ids),
+			logfields.Found, len(entryIDs),
+			logfields.ErrorCount, len(errs))
+		return fmt.Errorf("batch delete had %d errors: %w", len(errs), errs[0])
+	}
+
+	c.log.Debug("DeleteBatch completed successfully",
+		logfields.Requested, len(ids),
+		logfields.Deleted, len(entryIDs))
+	return nil
+}
+
 func (c *Client) List(ctx context.Context) ([]string, error) {
 	c.entryMutex.RLock()
 	defer c.entryMutex.RUnlock()
-	entries, err := c.entry.ListEntries(ctx, &entryv1.ListEntriesRequest{
-		Filter: &entryv1.ListEntriesRequest_Filter{
-			ByParentId: &types.SPIFFEID{
-				TrustDomain: c.cfg.SpiffeTrustDomain,
-				Path:        defaultParentID,
-			},
-			BySelectors: &types.SelectorMatch{
-				Selectors: defaultSelectors,
-				Match:     types.SelectorMatch_MATCH_EXACT,
-			},
+
+	filter := &entryv1.ListEntriesRequest_Filter{
+		ByParentId: &types.SPIFFEID{
+			TrustDomain: c.cfg.SpiffeTrustDomain,
+			Path:        c.entryCfg.ParentID,
 		},
+	}
+
+	// Only add selector filter if selectors are provided.
+	// For ztunnel mode, SelectorsFunc("") returns nil since each entry
+	// has unique selectors, so we only filter by ParentID.
+	if selectors := c.entryCfg.SelectorsFunc(""); selectors != nil {
+		filter.BySelectors = &types.SelectorMatch{
+			Selectors: selectors,
+			Match:     types.SelectorMatch_MATCH_EXACT,
+		}
+	}
+
+	entries, err := c.entry.ListEntries(ctx, &entryv1.ListEntriesRequest{
+		Filter: filter,
 	})
 	if err != nil {
 		return nil, err
@@ -306,7 +567,7 @@ func (c *Client) List(ctx context.Context) ([]string, error) {
 	if len(entries.Entries) == 0 {
 		return nil, nil
 	}
-	var ids = make([]string, 0, len(entries.Entries))
+	ids := make([]string, 0, len(entries.Entries))
 	for _, e := range entries.Entries {
 		ids = append(ids, e.Id)
 	}
@@ -320,14 +581,14 @@ func (c *Client) listEntries(ctx context.Context, id string) (*entryv1.ListEntri
 		Filter: &entryv1.ListEntriesRequest_Filter{
 			BySpiffeId: &types.SPIFFEID{
 				TrustDomain: c.cfg.SpiffeTrustDomain,
-				Path:        toPath(id),
+				Path:        c.entryCfg.PathFunc(id),
 			},
 			ByParentId: &types.SPIFFEID{
 				TrustDomain: c.cfg.SpiffeTrustDomain,
-				Path:        defaultParentID,
+				Path:        c.entryCfg.ParentID,
 			},
 			BySelectors: &types.SelectorMatch{
-				Selectors: defaultSelectors,
+				Selectors: c.entryCfg.SelectorsFunc(id),
 				Match:     types.SelectorMatch_MATCH_EXACT,
 			},
 		},

--- a/operator/pkg/ztunnel/cell.go
+++ b/operator/pkg/ztunnel/cell.go
@@ -5,25 +5,14 @@ package ztunnel
 
 import (
 	"github.com/cilium/hive/cell"
-	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/operator/pkg/ztunnel/config"
 )
-
-var DefaultConfig = Config{
-	EnableZTunnel: false,
-}
-
-type Config struct {
-	EnableZTunnel bool
-}
-
-func (c Config) Flags(flags *pflag.FlagSet) {
-	flags.Bool("enable-ztunnel", false, "Use zTunnel as Cilium's encryption infrastructure")
-}
 
 // Cell provides ztunnel configuration.
 var Cell = cell.Module(
 	"ztunnel",
 	"ZTunnel Configuration",
 
-	cell.Config(DefaultConfig),
+	cell.Config(config.DefaultConfig),
 )

--- a/operator/pkg/ztunnel/config/config.go
+++ b/operator/pkg/ztunnel/config/config.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+)
+
+var DefaultConfig = Config{
+	EnableZTunnel: false,
+}
+
+type Config struct {
+	EnableZTunnel bool
+}
+
+func (c Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-ztunnel", false, "Use zTunnel as Cilium's encryption infrastructure")
+}
+
+// SpiffeIDPathFunc returns the SPIFFE ID path in the form of /ns/{namespace}/sa/{serviceaccount}
+func SpiffeIDPathFunc(namespacedname string) string {
+	parts := strings.Split(namespacedname, "/")
+	if len(parts) != 2 {
+		return ""
+	}
+	return fmt.Sprintf("/ns/%s/sa/%s", parts[0], parts[1])
+}
+
+// SpiffeIDSelectorsFunc returns the SPIFFE ID selectors for a given service account's namespaced name.
+// The selectors are in the form of:
+//
+//	{Type: "k8s", Value: "ns:<namespace>"}
+//	{Type: "k8s", Value: "sa:<serviceaccount>"}
+func SpiffeIDSelectorsFunc(namespacedname string) []*types.Selector {
+	parts := strings.Split(namespacedname, "/")
+	if len(parts) != 2 {
+		return nil
+	}
+	return []*types.Selector{
+		{
+			Type:  "k8s",
+			Value: "ns:" + parts[0],
+		},
+		{
+			Type:  "k8s",
+			Value: "sa:" + parts[1],
+		},
+	}
+}

--- a/operator/pkg/ztunnel/config/config_test.go
+++ b/operator/pkg/ztunnel/config/config_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpiffeIDPathFunc(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespacedname string
+		expected       string
+	}{
+		{
+			name:           "valid namespace/serviceaccount",
+			namespacedname: "default/my-service",
+			expected:       "/ns/default/sa/my-service",
+		},
+		{
+			name:           "kube-system namespace",
+			namespacedname: "kube-system/coredns",
+			expected:       "/ns/kube-system/sa/coredns",
+		},
+		{
+			name:           "invalid format - no slash",
+			namespacedname: "invalid",
+			expected:       "",
+		},
+		{
+			name:           "invalid format - too many parts",
+			namespacedname: "a/b/c",
+			expected:       "",
+		},
+		{
+			name:           "empty string",
+			namespacedname: "",
+			expected:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SpiffeIDPathFunc(tt.namespacedname)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSpiffeIDSelectorsFunc(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespacedname string
+		expectedLen    int
+		expectedNs     string
+		expectedSa     string
+	}{
+		{
+			name:           "valid namespace/serviceaccount",
+			namespacedname: "default/my-service",
+			expectedLen:    2,
+			expectedNs:     "ns:default",
+			expectedSa:     "sa:my-service",
+		},
+		{
+			name:           "kube-system namespace",
+			namespacedname: "kube-system/coredns",
+			expectedLen:    2,
+			expectedNs:     "ns:kube-system",
+			expectedSa:     "sa:coredns",
+		},
+		{
+			name:           "invalid format - no slash",
+			namespacedname: "invalid",
+			expectedLen:    0,
+		},
+		{
+			name:           "invalid format - too many parts",
+			namespacedname: "a/b/c",
+			expectedLen:    0,
+		},
+		{
+			name:           "empty string",
+			namespacedname: "",
+			expectedLen:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SpiffeIDSelectorsFunc(tt.namespacedname)
+			require.Len(t, result, tt.expectedLen)
+
+			if tt.expectedLen == 2 {
+				require.Equal(t, "k8s", result[0].Type)
+				require.Equal(t, tt.expectedNs, result[0].Value)
+				require.Equal(t, "k8s", result[1].Type)
+				require.Equal(t, tt.expectedSa, result[1].Value)
+			}
+		})
+	}
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -722,6 +722,15 @@ const (
 
 	Total = "total"
 
+	// ErrorCount is the number of errors encountered
+	ErrorCount = "errorCount"
+
+	// Requested is the number of resources requested
+	Requested = "requested"
+
+	// Found is the number of resources found
+	Found = "found"
+
 	// Debug is a boolean value for whether debug is set or not.
 	Debug = "debug"
 


### PR DESCRIPTION
Refactor the SPIRE client to support both mutual-auth and ztunnel modes through a configurable SpireEntryConfig. When ztunnel is enabled, the client uses different SPIFFE ID paths and selectors suitable for Kubernetes service account-based identities.

Key changes:
- Add `SpireEntryConfig` struct with configurable `ParentID`, `PathFunc`, and `SelectorsFunc` to support different entry generation strategies
- Add ztunnel config package with SPIFFE ID path/selector functions that use `/ns/{namespace}/sa/{serviceaccount}` format
- Update `NewClient` to return both `identity.Provider` and `*Client`, allowing ztunnel reconcilers to use the client directly while returning a noop provider for the identity watcher
- Add `Initialized()` channel to signal when client is connected
- Add `UpsertBatch` and `DeleteBatch` for efficient bulk operations with chunking and error aggregation
- Add accessor methods `GetSpireEntryConfig()` and `GetSpireTrustDomain()`
- Fix `List()` to handle nil selectors in ztunnel mode

When `--enable-ztunnel` is set:
- ParentID: `/ztunnel` (instead of `/cilium-operator`)
- Path: `/ns/{ns}/sa/{sa}` (instead of `/identity/{id}`)
- Selectors: `k8s:ns:{ns}, k8s:sa:{sa}` (instead of `cilium:mutual-auth`)

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!