### PR TITLE
hubble: Fix typos in config/set.go

### DIFF
--- a/hubble/cmd/config/set.go
+++ b/hubble/cmd/config/set.go
@@ -76,7 +76,7 @@ func runSet(cmd *cobra.Command, vp *viper.Viper, key, value string) error {
 			newVal, err = csv.NewReader(strings.NewReader(val)).Read()
 		}
 	default:
-		return fmt.Errorf("unhandeld type %s, please open an issue", typ)
+		return fmt.Errorf("unhandled type %s, please open an issue", typ)
 	}
 	if err != nil {
 		return fmt.Errorf("cannot assign value=%s for key=%s, expected type=%s: %w", value, key, typ, err)
@@ -117,7 +117,7 @@ func newFileOnlyViper(configPath string) (*viper.Viper, error) {
 	vp.AddConfigPath(dir)
 
 	// Ensure that the configuration directory exists as viper does not create
-	// the directory fo the configuration file if it doesn't already exist.
+	// the directory for the configuration file if it doesn't already exist.
 	// (note: MkdirAll does nothing if it exists already)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("configuration directory does not exist and cannot be created: %w", err)


### PR DESCRIPTION
## Summary

Fixes two typos in `hubble/cmd/config/set.go`:
- Line 79: `unhandeld` → `unhandled`
- Line 120: `fo` → `for`

## Checklist

- [x] Tests not applicable (comments/strings only)
- [x] Commits signed off
