### PR TITLE
bpf: unconditionally define `ipv6_local_delivery`

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-#if !defined(__LIB_ICMP6__) && defined(ENABLE_IPV6)
-#define __LIB_ICMP6__
+#pragma once
 
 #include <linux/icmpv6.h>
 #include <linux/in.h>
@@ -573,5 +572,3 @@ bool icmp6_ndisc_validate(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
 
 	return true;
 }
-
-#endif

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -9,7 +9,6 @@
 #include "eth.h"
 #include "icmp6.h"
 
-#ifdef ENABLE_IPV6
 static __always_inline int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 				   const __u8 *smac, const __u8 *dmac,
 				   __u8 __maybe_unused direction)
@@ -32,7 +31,6 @@ static __always_inline int ipv6_l3(struct __ctx_buff *ctx, int l3_off,
 
 	return CTX_ACT_OK;
 }
-#endif /* ENABLE_IPV6 */
 
 static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 				   const __u8 *smac, const __u8 *dmac,

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -177,7 +177,6 @@ local_delivery(struct __ctx_buff *ctx, __u32 seclabel, __u32 magic,
 	return tail_call_policy(ctx, ep->lxc_id);
 }
 
-#ifdef ENABLE_IPV6
 /* Performs IPv6 L2/L3 handling and delivers the packet to the destination pod
  * on the same node, either via the stack or via a redirect call.
  * Depending on the configuration, it may also enforce ingress policies for the
@@ -202,7 +201,6 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	return local_delivery(ctx, seclabel, magic, ep, direction, from_host,
 			      from_tunnel, 0);
 }
-#endif /* ENABLE_IPV6 */
 
 /* Performs IPv4 L2/L3 handling and delivers the packet to the destination pod
  * on the same node, either via the stack or via a redirect call.

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -9,6 +9,7 @@
 #define ENABLE_SCTP
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT
+#include <bpf/config/global.h>
 #include <bpf/config/node.h>
 
 #define DEBUG

--- a/bpf/tests/icmp_error_revnat.c
+++ b/bpf/tests/icmp_error_revnat.c
@@ -8,6 +8,7 @@
 
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT
+#include <bpf/config/global.h>
 #include <bpf/config/node.h>
 
 #define DEBUG

--- a/bpf/tests/remote_node_masquerade_skip_test.c
+++ b/bpf/tests/remote_node_masquerade_skip_test.c
@@ -9,6 +9,7 @@
 #define ENABLE_SCTP
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT
+#include <bpf/config/global.h>
 #include <bpf/config/node.h>
 
 #define DEBUG

--- a/bpf/tests/remote_node_masquerade_test.c
+++ b/bpf/tests/remote_node_masquerade_test.c
@@ -9,6 +9,7 @@
 #define ENABLE_SCTP
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT
+#include <bpf/config/global.h>
 #include <bpf/config/node.h>
 
 #define DEBUG


### PR DESCRIPTION
Currently, `ipv6_local_delivery` is only defined if `ENABLE_IPV6` is defined. However, its `ipv4_local_delivery` counterpart is defined unconditionally, i.e. not dependent on `ENABLE_IPV4`. Do this for `ipv6_local_delivery` and its dependencies as well which allows callers to be defined unconditionally as well.