### PR TITLE
loader: Detect duplicate map renames

### DIFF
--- a/pkg/datapath/loader/encryption.go
+++ b/pkg/datapath/loader/encryption.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
@@ -42,10 +41,9 @@ func encryptionConfiguration(lnc *datapath.LocalNodeConfiguration) (configs []an
 }
 
 // encryptionMapRenames returns the merged map of encryption map renames yielded by all registered rename providers.
-func encryptionMapRenames(lnc *datapath.LocalNodeConfiguration) (renames map[string]string) {
-	renames = make(map[string]string)
+func encryptionMapRenames(lnc *datapath.LocalNodeConfiguration) (renames []map[string]string) {
 	for f := range encryptionRenames.all() {
-		maps.Copy(renames, f(lnc))
+		renames = append(renames, f(lnc))
 	}
 	return renames
 }

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"net/netip"
 	"path/filepath"
 
@@ -60,10 +59,9 @@ func endpointConfiguration(ep datapath.EndpointConfiguration, lnc *datapath.Loca
 }
 
 // endpointMapRenames returns the merged map of endpoint map renames yielded by all registered rename providers.
-func endpointMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration) (renames map[string]string) {
-	renames = make(map[string]string)
+func endpointMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration) (renames []map[string]string) {
 	for f := range epRenames.all() {
-		maps.Copy(renames, f(ep, lnc))
+		renames = append(renames, f(ep, lnc))
 	}
 	return renames
 }

--- a/pkg/datapath/loader/host.go
+++ b/pkg/datapath/loader/host.go
@@ -6,7 +6,6 @@ package loader
 import (
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/netip"
 	"path/filepath"
 
@@ -77,10 +76,9 @@ func ciliumHostConfiguration(ep datapath.EndpointConfiguration, lnc *datapath.Lo
 }
 
 // ciliumHostMapRenames returns the merged map of host map renames yielded by all registered rename providers.
-func ciliumHostMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration) (renames map[string]string) {
-	renames = make(map[string]string)
+func ciliumHostMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration) (renames []map[string]string) {
 	for f := range ciliumHostRenames.all() {
-		maps.Copy(renames, f(ep, lnc))
+		renames = append(renames, f(ep, lnc))
 	}
 	return renames
 }
@@ -155,10 +153,9 @@ func ciliumNetConfiguration(ep datapath.EndpointConfiguration, lnc *datapath.Loc
 }
 
 // ciliumHostMapRenames returns the merged map of cilium_net map renames yielded by all registered rename providers.
-func ciliumNetMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames map[string]string) {
-	renames = make(map[string]string)
+func ciliumNetMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames []map[string]string) {
 	for f := range ciliumNetRenames.all() {
-		maps.Copy(renames, f(ep, lnc, link))
+		renames = append(renames, f(ep, lnc, link))
 	}
 	return renames
 }
@@ -224,10 +221,9 @@ func netdevConfiguration(ep datapath.EndpointConfiguration, lnc *datapath.LocalN
 }
 
 // netdevMapRenames returns the merged map of netdev map renames yielded by all registered rename providers.
-func netdevMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames map[string]string) {
-	renames = make(map[string]string)
+func netdevMapRenames(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames []map[string]string) {
 	for f := range netdevRenames.all() {
-		maps.Copy(renames, f(ep, lnc, link))
+		renames = append(renames, f(ep, lnc, link))
 	}
 	return renames
 }

--- a/pkg/datapath/loader/overlay.go
+++ b/pkg/datapath/loader/overlay.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"path/filepath"
 
 	"github.com/cilium/ebpf"
@@ -47,10 +46,9 @@ func overlayConfiguration(lnc *datapath.LocalNodeConfiguration, link netlink.Lin
 }
 
 // overlayMapRenames returns the merged map of overlay map renames yielded by all registered rename providers.
-func overlayMapRenames(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames map[string]string) {
-	renames = make(map[string]string)
+func overlayMapRenames(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames []map[string]string) {
 	for f := range overlayRenames.all() {
-		maps.Copy(renames, f(lnc, link))
+		renames = append(renames, f(lnc, link))
 	}
 	return renames
 }

--- a/pkg/datapath/loader/wireguard.go
+++ b/pkg/datapath/loader/wireguard.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"path/filepath"
 
 	"github.com/cilium/ebpf"
@@ -48,10 +47,9 @@ func wireguardConfiguration(lnc *datapath.LocalNodeConfiguration, link netlink.L
 }
 
 // wireguardMapRenames returns the merged map of wireguard map renames yielded by all registered rename providers.
-func wireguardMapRenames(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames map[string]string) {
-	renames = make(map[string]string)
+func wireguardMapRenames(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames []map[string]string) {
 	for f := range wireguardRenames.all() {
-		maps.Copy(renames, f(lnc, link))
+		renames = append(renames, f(lnc, link))
 	}
 	return renames
 }

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,10 +53,9 @@ func xdpConfiguration(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (
 }
 
 // xdpMapRenames returns the merged map of XDP map renames yielded by all registered rename providers.
-func xdpMapRenames(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames map[string]string) {
-	renames = make(map[string]string)
+func xdpMapRenames(lnc *datapath.LocalNodeConfiguration, link netlink.Link) (renames []map[string]string) {
 	for f := range xdpRenames.all() {
-		maps.Copy(renames, f(lnc, link))
+		renames = append(renames, f(lnc, link))
 	}
 	return renames
 }


### PR DESCRIPTION
This is a follow-up to cilium/cilium#44050 to add some additional checks in the map renaming logic to detect duplicate map renames. This ensures that an error is reported if two registered funcs are trying to rename the same map, instead of silently accepting the last write as we did previously.

Suggested-by: Timo Beckers <timo@isovalent.com>

