### PR TITLE
examples: Fix example for host firewall policy

### DIFF
--- a/examples/policies/host/allow-extended-protocols.yaml
+++ b/examples/policies/host/allow-extended-protocols.yaml
@@ -20,4 +20,5 @@ spec:
         protocol: TCP
       - port: "8472"
         protocol: UDP
-      - protocol: VRRP
+      - port: "0"
+        protocol: VRRP

--- a/examples/policies/host/allow-extended-protocols.yaml
+++ b/examples/policies/host/allow-extended-protocols.yaml
@@ -6,7 +6,7 @@ spec:
   description: "Allow specific traffic on egress of worker nodes"
   nodeSelector:
     matchLabels:
-      type: ingress-worker
+      type: egress-worker
   egress:
   - toPorts:
     - ports:


### PR DESCRIPTION
Fixes egress host fw example policy that was introduced as part of PR  #39872 which introduces new protocol support. 

changed label name to match example info given for feature, changed port/protocol layout. Need to specify port as 0 in 1.19-rc.1 otherwise CCNP won't apply due to a valid=false status. 

needs backporting to 1.19 branches