### PR TITLE
v1.19 Backports 2026-02-03

### DIFF
--- a/bpf/include/bpf/helpers.h
+++ b/bpf/include/bpf/helpers.h
@@ -97,6 +97,9 @@ static struct bpf_sock *BPF_FUNC(sk_lookup_udp, void *ctx,
 static int BPF_FUNC_REMAP(get_socket_opt, void *ctx, int level, int optname,
 			  void *optval, int optlen) =
 	(void *)BPF_FUNC_getsockopt;
+static int BPF_FUNC_REMAP(set_socket_opt, void *ctx, int level, int optname,
+			  void *optval, int optlen) =
+	(void *)BPF_FUNC_setsockopt;
 
 static __u64 BPF_FUNC(get_current_cgroup_id);
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -290,16 +290,10 @@ enum metric_dir {
 
 #define MARK_MAGIC_KEY_MASK		0xFF00
 
-/* MARK_MAGIC_HEALTH_IPIP_DONE can overlap with MARK_MAGIC_SNAT_DONE with both
- * being mutual exclusive given former is only under DSR. Used to push health
- * probe packets to ipip tunnel device & to avoid looping back.
+/* Note, MARK_MAGIC_HEALTH is user-facing UAPI for LB! The tcx datapath will
+ * not see the MARK_MAGIC_HEALTH value given sock_lb is going to reset it.
  */
-#define MARK_MAGIC_HEALTH_IPIP_DONE	MARK_MAGIC_SNAT_DONE
-
-/* MARK_MAGIC_HEALTH can overlap with MARK_MAGIC_DECRYPT with both being
- * mutual exclusive. Note, MARK_MAGIC_HEALTH is user-facing UAPI for LB!
- */
-#define MARK_MAGIC_HEALTH		MARK_MAGIC_DECRYPT
+#define MARK_MAGIC_HEALTH		0x0D00
 
 /* MARK_MAGIC_CLUSTER_ID shouldn't interfere with MARK_MAGIC_TO_PROXY. Lower
  * 8bits carries cluster_id, and when extended via the 'max-connected-clusters'
@@ -317,7 +311,7 @@ enum metric_dir {
 #define TC_INDEX_F_FROM_INGRESS_PROXY	1
 #define TC_INDEX_F_FROM_EGRESS_PROXY	2
 #define TC_INDEX_F_SKIP_NODEPORT	4
-#define TC_INDEX_F_UNUSED		8
+#define TC_INDEX_F_SKIP_HEALTH_CHECK	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
 #define CB_NAT_FLAGS_REVDNAT_ONLY	(1 << 0)

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -590,8 +590,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 	__sock_cookie key __maybe_unused;
 	int ret __maybe_unused;
 
-	if ((ctx->mark & MARK_MAGIC_HEALTH_IPIP_DONE) ==
-	    MARK_MAGIC_HEALTH_IPIP_DONE)
+	if (ctx->tc_index & TC_INDEX_F_SKIP_HEALTH_CHECK)
 		return CTX_ACT_OK;
 
 	switch (proto) {
@@ -615,7 +614,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 			ret = dsr_set_ipip4_dev(ctx, val->peer.address, 0);
 			if (ret != 0)
 				return ret;
-			ctx->mark |= MARK_MAGIC_HEALTH_IPIP_DONE;
+			ctx->tc_index |= TC_INDEX_F_SKIP_HEALTH_CHECK;
 		}
 
 		return ctx_redirect(ctx, ENCAP4_IFINDEX, flags);
@@ -641,7 +640,7 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 			ret = dsr_set_ipip6_dev(ctx, &val->peer.address, 0);
 			if (ret != 0)
 				return ret;
-			ctx->mark |= MARK_MAGIC_HEALTH_IPIP_DONE;
+			ctx->tc_index |= TC_INDEX_F_SKIP_HEALTH_CHECK;
 		}
 
 		return ctx_redirect(ctx, ENCAP6_IFINDEX, flags);

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -232,7 +232,7 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 	// requests because an identity isn't in the local cache yet.
 	logContext, lcncl := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer lcncl()
-	record, err := h.proxyAccessLogger.NewLogRecord(logContext, flowType, false,
+	record, err := h.proxyAccessLogger.NewLogRecord(context.Background(), flowType, false,
 		func(lr *accesslog.LogRecord, _ accesslog.EndpointInfoRegistry) {
 			lr.TransportProtocol = accesslog.TransportProtocol(protoID)
 		},

--- a/pkg/kpr/initializer/kube_proxy_replacement.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement.go
@@ -195,7 +195,8 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
 		}
 
 		if option.Config.EnableHealthDatapath {
-			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetsockopt) != nil {
+			if probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnGetsockopt) != nil ||
+				probes.HaveProgramHelper(logger, ebpf.CGroupSockAddr, asm.FnSetsockopt) != nil {
 				option.Config.EnableHealthDatapath = false
 				if !option.Config.EnableIPIPTermination &&
 					option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {


### PR DESCRIPTION
 * [x] #44037 (@borkmann) :warning: resolved conflicts
   - resolved conflict in `kube_proxy_replacement.go` caused by moving the `EnableHealthDatapath` config knob under `UnsafeDaemonConfigOption` in main
 * [x] #44110 (@mhofstetter)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 44037 44110
```
