### PR TITLE
bpf: simplify local delivery metrics check

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1974,9 +1974,7 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 
 	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL_IPV6);
 
-#ifdef LOCAL_DELIVERY_METRICS
 	update_metrics(ctx_full_len(ctx), METRIC_INGRESS, REASON_FORWARDED);
-#endif
 
 	ret = ipv6_policy(ctx, ip6, src_sec_identity, NULL, &ext_err,
 			  &proxy_port, false);
@@ -2291,9 +2289,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 
 	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL_IPV4);
 
-#ifdef LOCAL_DELIVERY_METRICS
 	update_metrics(ctx_full_len(ctx), METRIC_INGRESS, REASON_FORWARDED);
-#endif
 
 	ret = ipv4_policy(ctx, ip4, src_sec_identity, NULL, &ext_err,
 			  &proxy_port, false);

--- a/bpf/ep_config.h
+++ b/bpf/ep_config.h
@@ -14,5 +14,3 @@
 #endif
 #define DROP_NOTIFY
 #define TRACE_NOTIFY
-
-#define LOCAL_DELIVERY_METRICS

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -121,7 +121,7 @@ local_delivery(struct __ctx_buff *ctx, __u32 seclabel, __u32 magic,
 {
 	bool use_fast_redirect;
 
-#ifdef LOCAL_DELIVERY_METRICS
+#if defined(IS_BPF_LXC) || defined(IS_BPF_HOST)
 	/*
 	 * Special LXC case for updating egress forwarding metrics.
 	 * Note that the packet could still be dropped but it would show up

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -723,9 +723,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, cfg *datapath.L
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	// Local delivery metrics should always be set for endpoint programs.
-	fmt.Fprint(fw, "#define LOCAL_DELIVERY_METRICS 1\n")
-
 	h.writeNetdevConfig(fw, e.GetOptions())
 
 	return fw.Flush()

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -723,11 +723,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, cfg *datapath.L
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	if e.IsHost() {
-		// Only used to differentiate between host endpoint template and other templates.
-		fmt.Fprintf(fw, "#define HOST_ENDPOINT 1\n")
-	}
-
 	// Local delivery metrics should always be set for endpoint programs.
 	fmt.Fprint(fw, "#define LOCAL_DELIVERY_METRICS 1\n")
 


### PR DESCRIPTION
`LOCAL_DELIVERY_METRICS` is only defined for `bpf_lxc`, so the update_metrics calls in `bpf_lxc` can be made unconditional. Use the `IS_BPF_LXC` macro in `local_delivery.h` instead, even more so as the comment already mentions LXC specifically. Also remove the unused `HOST_ENDPOINT` define.

See commits for details.
