### PR TITLE
ipam: Fix concurrent map access to multipool map

### DIFF
--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -116,21 +116,7 @@ func (c *multiPoolAllocator) Dump() (map[Pool]map[string]string, string) {
 }
 
 func (c *multiPoolAllocator) Capacity() uint64 {
-	var capacity uint64
-	for _, pool := range c.manager.pools {
-		var p *cidrPool
-		switch c.family {
-		case IPv4:
-			p = pool.v4
-		case IPv6:
-			p = pool.v6
-		}
-		if p == nil {
-			continue
-		}
-		capacity += uint64(p.capacity())
-	}
-	return uint64(capacity)
+	return c.manager.capacity(c.family)
 }
 
 func (c *multiPoolAllocator) RestoreFinished() {

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -761,6 +761,27 @@ func (m *multiPoolManager) releaseIP(ip net.IP, poolName Pool, family Family, up
 	return nil
 }
 
+func (m *multiPoolManager) capacity(family Family) uint64 {
+	m.poolsMutex.Lock()
+	defer m.poolsMutex.Unlock()
+
+	var cap uint64
+	for _, pool := range m.pools {
+		var p *cidrPool
+		switch family {
+		case IPv4:
+			p = pool.v4
+		case IPv6:
+			p = pool.v6
+		}
+		if p == nil {
+			continue
+		}
+		cap += uint64(p.capacity())
+	}
+	return uint64(cap)
+}
+
 func (m *multiPoolManager) getNode() *ciliumv2.CiliumNode {
 	m.nodeMutex.Lock()
 	defer m.nodeMutex.Unlock()


### PR DESCRIPTION
For some reason, I forgot to acquire the mutex when accessing the
multipool map in 788d1aa82b2d ("ipam, metrics: Add new capacity
metric"). Fix it now to prevent the concurrent map access panic as seen
in https://github.com/cilium/cilium/issues/44107.

Fixes: 788d1aa82b2d ("ipam, metrics: Add new capacity
metric")
Fixes: https://github.com/cilium/cilium/issues/44107

Signed-off-by: Chris Tarazi <chris@isovalent.com>
