### PR TITLE
test: Remove references to removed tests

### DIFF
--- a/test/ginkgo-ext/junit_reporter.go
+++ b/test/ginkgo-ext/junit_reporter.go
@@ -309,8 +309,6 @@ func (reporter *JUnitReporter) mapTestToCODEOWNER(prefix string) string {
 		return "test/k8s/chaos.go"
 	case "K8sAgentFQDNTest":
 		return "test/k8s/fqdn.go"
-	case "RuntimeAgentFQDNPolicies":
-		return "test/runtime/fqdn.go"
 	case "K8sAgentHubbleTest":
 		return "test/k8s/hubble.go"
 	case "K8sAgentPolicyTest":
@@ -319,8 +317,6 @@ func (reporter *JUnitReporter) mapTestToCODEOWNER(prefix string) string {
 		return "test/k8s/config.go"
 	case "K8sPolicyTestExtended":
 		return "test/k8s/net_policies.go"
-	case "RuntimeAgentPolicies":
-		return "test/runtime/net_policies.go"
 	case "K8sDatapathBandwidthTest":
 		return "test/k8s/bandwidth.go"
 	case "K8sDatapathConfig":


### PR DESCRIPTION
These two case statements referred to tests that have previously been
removed, so there's no need to handle the match any more.

Fixes: a6e937760cdc ("test/runtime: remove remaining policy tests:")
Related: https://github.com/cilium/cilium/issues/37859
Related: https://github.com/cilium/cilium/issues/37838
