### PR TITLE
helm: align `cilium-tlsinterception-secrets` Role/RoleBinding conditionals

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -120,7 +120,7 @@ rules:
   - watch
 {{- end}}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create $readSecretsOnlyFromSecretsNamespace .Values.tls.secretsNamespace.name }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create $readSecretsOnlyFromSecretsNamespace .Values.tls.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -126,7 +126,7 @@ subjects:
   namespace: {{ include "cilium.namespace" . }}
 {{- end}}
 
-{{- if and (not .Values.preflight.enabled) $readSecretsOnlyFromSecretsNamespace .Values.tls.secretsNamespace.name }}
+{{- if and .Values.agent (not .Values.preflight.enabled) .Values.serviceAccounts.cilium.create $readSecretsOnlyFromSecretsNamespace .Values.tls.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Fixed conditional mismatch between `cilium-tlsinterception-secrets` Role and RoleBinding in Helm templates. 
The Role incorrectly depended on `operator.enabled` while the RoleBinding did not, causing RBAC errors when `operator.enabled=false`.
Both now use consistent agent-based conditionals matching other Role/RoleBinding pairs in the same files.

Fixes: #44053




```release-note
helm: Fixed RBAC errors with `operator.enabled=false` by aligning cilium-tlsinterception-secrets Role/RoleBinding conditionals
```
