### PR TITLE
Use binary.NativeEndian instead of nl.NativeEndian

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/hivetest"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/tools/cover"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
@@ -485,7 +484,7 @@ func subTest(progSet programSet, resultMap *ebpf.Map, scapyAssertMap *ebpf.Map, 
 				}
 
 				status := make([]byte, 4)
-				nl.NativeEndian().PutUint32(status, statusCode)
+				binary.NativeEndian.PutUint32(status, statusCode)
 				data = append(status, data...)
 			}
 

--- a/pkg/cgroups/cgroups_linux.go
+++ b/pkg/cgroups/cgroups_linux.go
@@ -4,10 +4,10 @@
 package cgroups
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 
-	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/mountinfo"
@@ -61,8 +61,9 @@ func GetCgroupID(cgroupPath string) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("NameToHandleAt failed: %w", err)
 	}
-	b := handle.Bytes()[:8]
-	cgID := nl.NativeEndian().Uint64(b)
-
-	return cgID, nil
+	b := handle.Bytes()
+	if len(b) < 8 {
+		return 0, fmt.Errorf("handle returned by NameToHandleAt is too small (%v bytes)", len(b))
+	}
+	return binary.NativeEndian.Uint64(b[:8]), nil
 }


### PR DESCRIPTION
Use the `NativeEndian` native-endian var provided by the Go standard library `encoding/binary` package instead of the version from the `netlink/nl` package.

While at it, also check the length of the handle returned by `unix.NameToHandleAt` before accessing it.

Follow-up to commit 2c1b49cac70b ("byteorder: use binary.NativeEndian")