### PR TITLE
loadbalancer/maps: use netip types

### DIFF
--- a/pkg/loadbalancer/maps/test_utils.go
+++ b/pkg/loadbalancer/maps/test_utils.go
@@ -66,7 +66,7 @@ func DumpLBMaps(lbmaps LBMaps, sanitizeIDs bool, customizeAddr func(types.AddrCl
 	svcCB := func(svcKey ServiceKey, svcValue ServiceValue) {
 		svcKey = svcKey.ToHost()
 		svcValue = svcValue.ToHost()
-		addr := types.MustAddrClusterFromIP(svcKey.GetAddress())
+		addr := types.AddrClusterFrom(svcKey.GetAddress(), 0)
 		addrS := customizeAddr(addr, svcKey.GetPort())
 		addrS += "/" + loadbalancer.NewL4TypeFromNumber(svcKey.GetProtocol())
 		if svcKey.GetScope() == loadbalancer.ScopeInternal {
@@ -112,10 +112,10 @@ func DumpLBMaps(lbmaps LBMaps, sanitizeIDs bool, customizeAddr func(types.AddrCl
 
 		switch v := revValue.(type) {
 		case *RevNat4Value:
-			addr = customizeAddr(types.MustAddrClusterFromIP(v.Address.IP()), v.Port)
+			addr = customizeAddr(types.AddrClusterFrom(v.Address.Addr(), 0), v.Port)
 
 		case *RevNat6Value:
-			addr = customizeAddr(types.MustAddrClusterFromIP(v.Address.IP()), v.Port)
+			addr = customizeAddr(types.AddrClusterFrom(v.Address.Addr(), 0), v.Port)
 		}
 
 		out = append(out, fmt.Sprintf("REV: ID=%s ADDR=%s",

--- a/pkg/loadbalancer/maps/test_utils.go
+++ b/pkg/loadbalancer/maps/test_utils.go
@@ -143,7 +143,7 @@ func DumpLBMaps(lbmaps LBMaps, sanitizeIDs bool, customizeAddr func(types.AddrCl
 		key = key.ToHost()
 		out = append(out, fmt.Sprintf("SRCRANGE: ID=%s CIDR=%s",
 			sanitizeID(key.GetRevNATID(), sanitizeIDs),
-			key.GetCIDR(),
+			key.GetPrefix(),
 		))
 	}
 	if err := lbmaps.DumpSourceRange(srcRangeCB); err != nil {

--- a/pkg/loadbalancer/maps/types.go
+++ b/pkg/loadbalancer/maps/types.go
@@ -54,7 +54,7 @@ type ServiceKey interface {
 	GetScope() uint8
 
 	// Get frontend IP address
-	GetAddress() net.IP
+	GetAddress() netip.Addr
 
 	// Get frontend port
 	GetPort() uint16
@@ -178,7 +178,7 @@ func (k *Service4Key) SetBackendSlot(slot int) { k.BackendSlot = uint16(slot) }
 func (k *Service4Key) GetBackendSlot() int     { return int(k.BackendSlot) }
 func (k *Service4Key) SetScope(scope uint8)    { k.Scope = scope }
 func (k *Service4Key) GetScope() uint8         { return k.Scope }
-func (k *Service4Key) GetAddress() net.IP      { return k.Address.IP() }
+func (k *Service4Key) GetAddress() netip.Addr  { return k.Address.Addr() }
 func (k *Service4Key) GetPort() uint16         { return k.Port }
 func (k *Service4Key) GetProtocol() uint8      { return k.Proto }
 
@@ -336,7 +336,7 @@ func (k *Service6Key) SetBackendSlot(slot int) { k.BackendSlot = uint16(slot) }
 func (k *Service6Key) GetBackendSlot() int     { return int(k.BackendSlot) }
 func (k *Service6Key) SetScope(scope uint8)    { k.Scope = scope }
 func (k *Service6Key) GetScope() uint8         { return k.Scope }
-func (k *Service6Key) GetAddress() net.IP      { return k.Address.IP() }
+func (k *Service6Key) GetAddress() netip.Addr  { return k.Address.Addr() }
 func (k *Service6Key) GetPort() uint16         { return k.Port }
 func (k *Service6Key) GetProtocol() uint8      { return k.Proto }
 

--- a/pkg/loadbalancer/maps/types.go
+++ b/pkg/loadbalancer/maps/types.go
@@ -6,12 +6,12 @@ package maps
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/byteorder"
-	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
@@ -1152,7 +1152,8 @@ const (
 type SourceRangeKey interface {
 	bpf.MapKey
 
-	GetCIDR() *cidr.CIDR
+	GetPrefix() netip.Prefix
+
 	GetRevNATID() loadbalancer.ServiceID
 
 	// Convert fields to network byte order.
@@ -1175,7 +1176,7 @@ type SourceRangeKey4 struct {
 
 func (k *SourceRangeKey4) String() string {
 	kHost := k.ToHost().(*SourceRangeKey4)
-	return fmt.Sprintf("%s (%d)", kHost.GetCIDR().String(), kHost.GetRevNATID())
+	return fmt.Sprintf("%s (%d)", kHost.GetPrefix(), kHost.GetRevNATID())
 }
 
 func (k *SourceRangeKey4) New() bpf.MapKey { return &SourceRangeKey4{} }
@@ -1195,16 +1196,12 @@ func (k *SourceRangeKey4) ToHost() SourceRangeKey {
 	return &h
 }
 
-func (k *SourceRangeKey4) GetCIDR() *cidr.CIDR {
-	var (
-		c  net.IPNet
-		ip types.IPv4
-	)
-	c.Mask = net.CIDRMask(int(k.PrefixLen)-lpmPrefixLen4, 32)
+func (k *SourceRangeKey4) GetPrefix() netip.Prefix {
+	var ip types.IPv4
 	k.Address.DeepCopyInto(&ip)
-	c.IP = ip.IP()
-	return cidr.NewCIDR(&c)
+	return netip.PrefixFrom(ip.Addr(), int(k.PrefixLen)-lpmPrefixLen4)
 }
+
 func (k *SourceRangeKey4) GetRevNATID() loadbalancer.ServiceID {
 	return loadbalancer.ServiceID(k.RevNATID)
 }
@@ -1218,7 +1215,7 @@ type SourceRangeKey6 struct {
 
 func (k *SourceRangeKey6) String() string {
 	kHost := k.ToHost().(*SourceRangeKey6)
-	return fmt.Sprintf("%s (%d)", kHost.GetCIDR().String(), kHost.GetRevNATID())
+	return fmt.Sprintf("%s (%d)", kHost.GetPrefix(), kHost.GetRevNATID())
 }
 
 func (k *SourceRangeKey6) New() bpf.MapKey { return &SourceRangeKey6{} }
@@ -1238,16 +1235,12 @@ func (k *SourceRangeKey6) ToHost() SourceRangeKey {
 	return &h
 }
 
-func (k *SourceRangeKey6) GetCIDR() *cidr.CIDR {
-	var (
-		c  net.IPNet
-		ip types.IPv6
-	)
-	c.Mask = net.CIDRMask(int(k.PrefixLen)-lpmPrefixLen6, 128)
+func (k *SourceRangeKey6) GetPrefix() netip.Prefix {
+	var ip types.IPv6
 	k.Address.DeepCopyInto(&ip)
-	c.IP = ip.IP()
-	return cidr.NewCIDR(&c)
+	return netip.PrefixFrom(ip.Addr(), int(k.PrefixLen)-lpmPrefixLen6)
 }
+
 func (k *SourceRangeKey6) GetRevNATID() loadbalancer.ServiceID {
 	return loadbalancer.ServiceID(k.RevNATID)
 }

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -640,10 +640,7 @@ func (ops *BPFOps) pruneSourceRanges() error {
 		// CIDR is part of the current set.
 		addr, ok := ops.serviceIDAlloc.idToAddr[key.GetRevNATID()]
 		if ok {
-			cidr := key.GetCIDR()
-			cidrAddr, _ := netip.AddrFromSlice(cidr.IP)
-			ones, _ := cidr.Mask.Size()
-			prefix := netip.PrefixFrom(cidrAddr, ones)
+			prefix := key.GetPrefix()
 			var cidrs sets.Set[netip.Prefix]
 			cidrs, ok = ops.prevSourceRanges[addr]
 			ok = ok && cidrs.Has(prefix)
@@ -651,7 +648,7 @@ func (ops *BPFOps) pruneSourceRanges() error {
 		if !ok {
 			ops.log.Debug("pruneSourceRanges: enqueing for deletion",
 				logfields.ID, key.GetRevNATID(),
-				logfields.CIDR, key.GetCIDR())
+				logfields.CIDR, key.GetPrefix())
 			toDelete = append(toDelete, key)
 		}
 	}

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -11,7 +11,7 @@ import (
 	"iter"
 	"log/slog"
 	"maps"
-	"net"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
@@ -719,28 +719,28 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 				svc.bes = append(svc.bes, bep)
 			}
 
-			feIP := net.ParseIP(p.HostIP)
-			if feIP != nil && feIP.IsLoopback() && !netnsCookie() {
+			feIP, err := netip.ParseAddr(p.HostIP)
+			if err == nil && feIP.IsLoopback() && !netnsCookie() {
 				log.Warn("The requested loopback address for hostIP is not supported for kernels which don't provide netns cookies. Ignoring.",
 					logfields.HostIP, feIP)
 				continue
 			}
 
-			feIPs := []net.IP{}
+			feIPs := []netip.Addr{}
 
 			// When HostIP is explicitly set, then we need to expose *only*
 			// on this address but not via other addresses. When it's not set,
 			// then expose via all local addresses. Same when the user provides
 			// an unspecified address (0.0.0.0 / [::]).
-			if feIP != nil && !feIP.IsUnspecified() {
+			if feIP.IsValid() && !feIP.IsUnspecified() {
 				// Migrate the loopback address into a 0.0.0.0 / [::]
 				// surrogate, thus internal datapath handling can be
 				// streamlined. It's not exposed for traffic from outside.
 				if feIP.IsLoopback() {
-					if feIP.To4() != nil {
-						feIP = net.IPv4zero
+					if feIP.Is4() {
+						feIP = netip.IPv4Unspecified()
 					} else {
-						feIP = net.IPv6zero
+						feIP = netip.IPv6Unspecified()
 					}
 					svc.service.LoopbackHostPort = true
 				} else if svc.service.LoopbackHostPort {
@@ -750,17 +750,17 @@ func upsertHostPort(netnsCookie HaveNetNSCookieSupport, config loadbalancer.Conf
 					continue
 				}
 				feIPs = append(feIPs, feIP)
-			} else if feIP == nil {
+			} else if !feIP.IsValid() {
 				if ipv4 {
-					feIPs = append(feIPs, net.IPv4zero)
+					feIPs = append(feIPs, netip.IPv4Unspecified())
 				}
 				if ipv6 {
-					feIPs = append(feIPs, net.IPv6zero)
+					feIPs = append(feIPs, netip.IPv6Unspecified())
 				}
 			}
 
 			for _, feIP := range feIPs {
-				addr := cmtypes.MustAddrClusterFromIP(feIP)
+				addr := cmtypes.AddrClusterFrom(feIP, 0)
 				fe := loadbalancer.FrontendParams{
 					Type:        loadbalancer.SVCTypeHostPort,
 					ServiceName: serviceName,


### PR DESCRIPTION
Use the `netip` types for IP addresses/prefixes. This allows simplifying the code a bit and avoid some unnecessary conversions for callers already expecting `netip` types.

See commit messages for details.

Accumulated `pkg/loadbalancer/benchmark` benchmark results:

    Before:
    Memory statistics from N=10 iterations:
    Min: Allocated 490378kB in total, 2471963 objects / 140742kB still reachable (per service:  49 objs, 10042B alloc,  2882B in-use)
    Avg: Allocated 501584kB in total, 2957195 objects / 177049kB still reachable (per service:  59 objs, 10272B alloc,  3625B in-use)
    Max: Allocated 543366kB in total, 3722287 objects / 227653kB still reachable (per service:  74 objs, 11128B alloc,  4662B in-use)

    After:
    Memory statistics from N=10 iterations:
    Min: Allocated 487023kB in total, 1944085 objects /  99675kB still reachable (per service:  38 objs,  9974B alloc,  2041B in-use)
    Avg: Allocated 498657kB in total, 2813561 objects / 166829kB still reachable (per service:  56 objs, 10212B alloc,  3416B in-use)
    Max: Allocated 542794kB in total, 3722246 objects / 227646kB still reachable (per service:  74 objs, 11116B alloc,  4662B in-use)

For #24246