### PR TITLE
Policy: Fix rule origin for ordered policies

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1232,16 +1232,6 @@ func (resMap *L4PolicyMap) addL4Filter(policyCtx PolicyContext,
 		return err
 	}
 
-	// To keep the rule origin tracking correct, merge the rule label arrays for each
-	// CachedSelector we know about. New CachedSelectors are added.
-	for cs, newLabels := range filterToMerge.RuleOrigin {
-		if existingLabels, ok := existingFilter.RuleOrigin[cs]; ok {
-			existingFilter.RuleOrigin[cs] = existingLabels.Merge(newLabels)
-		} else {
-			existingFilter.RuleOrigin[cs] = newLabels
-		}
-	}
-
 	resMap.Upsert(p.Port, uint16(p.EndPort), string(p.Protocol), existingFilter)
 	return nil
 }

--- a/pkg/policy/origin_test.go
+++ b/pkg/policy/origin_test.go
@@ -104,7 +104,7 @@ func TestOriginMerge(t *testing.T) {
 			td.cachedSelectorB: nil,
 		},
 		RuleOrigin: OriginLogsForTest(map[CachedSelector]string{
-			td.cachedSelectorB: "rule1\x1frule2",
+			td.cachedSelectorB: "rule2",
 		}),
 	}})
 

--- a/pkg/policy/origin_test.go
+++ b/pkg/policy/origin_test.go
@@ -6,15 +6,26 @@ package policy
 import (
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/utils"
 )
 
 func OriginForTest(m map[CachedSelector]labels.LabelArrayList) map[CachedSelector]ruleOrigin {
 	res := make(map[CachedSelector]ruleOrigin, len(m))
 	for cs, lbls := range m {
 		res[cs] = makeRuleOrigin(lbls, nil)
+	}
+	return res
+}
+
+func OriginLogsForTest(m map[CachedSelector]string) map[CachedSelector]ruleOrigin {
+	res := make(map[CachedSelector]ruleOrigin, len(m))
+	for cs, log := range m {
+		res[cs] = makeSingleRuleOrigin(nil, log)
 	}
 	return res
 }
@@ -34,4 +45,68 @@ func TestRuleOrigin(t *testing.T) {
 	ro = ro.Merge(makeSingleRuleOrigin(lbls2, "log2"))
 	require.ElementsMatch(t, labels.LabelArrayList{lbls1, lbls2}, ro.Value().LabelArray())
 	require.ElementsMatch(t, []string{"log1", "log2"}, ro.Value().log.List())
+}
+
+func TestOriginMerge(t *testing.T) {
+	td := newTestData(t, hivetest.Logger(t))
+
+	// A can access B with TCP on port 80 with HTTP GET on path "/"
+	rule1 := api.Rule{
+		Log: api.LogConfig{
+			Value: "rule1",
+		},
+		Egress: []api.EgressRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{endpointSelectorB},
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+					Rules: &api.L7Rules{
+						HTTP: []api.PortRuleHTTP{
+							{Method: "GET", Path: "/"},
+						},
+					},
+				}},
+			},
+		},
+	}
+	// A can access B with TCP on port 80 without HTTP requirements
+	rule2 := api.Rule{
+		Log: api.LogConfig{
+			Value: "rule2",
+		},
+		Egress: []api.EgressRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{endpointSelectorB},
+				},
+				ToPorts: []api.PortRule{{
+					Ports: []api.PortProtocol{
+						{Port: "80", Protocol: api.ProtoTCP},
+					},
+				}},
+			},
+		},
+	}
+
+	entries := utils.RulesToPolicyEntries(api.Rules{&rule1, &rule2})
+	// set priorities so that rule2 overrides rule1
+	entries[0].Priority = 1
+
+	// Expected incorrectly has rule origin from both rules!
+	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		Ingress: false,
+		PerSelectorPolicies: L7DataMap{
+			td.cachedSelectorB: nil,
+		},
+		RuleOrigin: OriginLogsForTest(map[CachedSelector]string{
+			td.cachedSelectorB: "rule1\x1frule2",
+		}),
+	}})
+
+	td.policyMapEqualsPolicyEntries(t, nil, expected, entries...)
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -155,23 +155,27 @@ func (l7Rules *PerSelectorPolicy) mergeRedirect(newL7Rules *PerSelectorPolicy) e
 func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterToMerge *L4Filter) (err error) {
 	selectorCache := policyCtx.GetSelectorCache()
 
-	for cs, newL7Rules := range filterToMerge.PerSelectorPolicies {
-		newPriority := newL7Rules.GetPriority()
+	// Iterate through each PerSelectorPolicy for each existing CachedSelector.
+	// Note that 'newPolicy' can be 'nil' for a zero-valued PerSelectorPolicy
+	// (== allow of highest precedence without any L7 rules nor TLS contexts).
+	for cs, newPolicy := range filterToMerge.PerSelectorPolicies {
 		newRuleOrigin := filterToMerge.RuleOrigin[cs]
+		newPriority := newPolicy.GetPriority()
 
 		// 'cs' will be merged or moved (see below), either way it needs
 		// to be removed from the maps it is in now.
 		delete(filterToMerge.PerSelectorPolicies, cs)
 		delete(filterToMerge.RuleOrigin, cs)
 
-		if l7Rules, ok := existingFilter.PerSelectorPolicies[cs]; !ok {
+		// Get the existing PerSelectorPolicies for this CachedSelector, if it exists
+		if existingPolicy, ok := existingFilter.PerSelectorPolicies[cs]; !ok {
 			// 'cs' is not in the existing filter yet
 
 			// Update selector owner to the existing filter
 			selectorCache.ChangeUser(cs, filterToMerge, existingFilter)
 
 			// Move L7 rules over.
-			existingFilter.PerSelectorPolicies[cs] = newL7Rules
+			existingFilter.PerSelectorPolicies[cs] = newPolicy
 
 			// add rule origin for 'cs' to the existing filter
 			existingFilter.RuleOrigin[cs] = newRuleOrigin
@@ -195,24 +199,24 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 
 			existingRuleOrigin := existingFilter.RuleOrigin[cs]
 
-			if l7Rules.Equal(newL7Rules) {
+			if existingPolicy.Equal(newPolicy) {
 				// identical rules for the same selector need no merging, but could
 				// still have different rule origin so merge them
 				existingFilter.RuleOrigin[cs] = existingRuleOrigin.Merge(newRuleOrigin)
 				continue
 			}
 
-			priority := l7Rules.GetPriority()
+			priority := existingPolicy.GetPriority()
 			// Check if either rule takes precedence due to precedence level or deny.
-			if priority < newPriority || (priority == newPriority && l7Rules.IsDeny()) {
+			if priority < newPriority || (priority == newPriority && existingPolicy.IsDeny()) {
 				// Lower precedence newL7Rules has no effect.
 				// Same level deny takes takes precedence over any other rule.
 				// Rule origins are not merged, existingRuleOrigin is retained.
 				continue
-			} else if priority > newPriority || (priority == newPriority && newL7Rules.IsDeny()) {
+			} else if priority > newPriority || (priority == newPriority && newPolicy.IsDeny()) {
 				// Earlier level (or same level deny) newL7Rules takes precedence.
 				// Overwrite existing filter.
-				existingFilter.PerSelectorPolicies[cs] = newL7Rules
+				existingFilter.PerSelectorPolicies[cs] = newPolicy
 				existingFilter.RuleOrigin[cs] = newRuleOrigin
 				continue
 			}
@@ -223,43 +227,43 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 			existingFilter.RuleOrigin[cs] = existingRuleOrigin.Merge(newRuleOrigin)
 
 			// One of the rules may be a nil rule, expand it to an empty non-nil rule
-			if l7Rules == nil {
-				l7Rules = &PerSelectorPolicy{Verdict: types.Allow}
+			if existingPolicy == nil {
+				existingPolicy = &PerSelectorPolicy{Verdict: types.Allow}
 			}
-			if newL7Rules == nil {
-				newL7Rules = &PerSelectorPolicy{Verdict: types.Allow}
+			if newPolicy == nil {
+				newPolicy = &PerSelectorPolicy{Verdict: types.Allow}
 			}
 
 			// Merge Redirect
-			if err := l7Rules.mergeRedirect(newL7Rules); err != nil {
+			if err := existingPolicy.mergeRedirect(newPolicy); err != nil {
 				policyCtx.PolicyTrace("   Merge conflict: %s\n", err.Error())
 				return err
 			}
 
-			if l7Rules.Authentication == nil || newL7Rules.Authentication == nil {
-				if newL7Rules.Authentication != nil {
-					l7Rules.Authentication = newL7Rules.Authentication
+			if existingPolicy.Authentication == nil || newPolicy.Authentication == nil {
+				if newPolicy.Authentication != nil {
+					existingPolicy.Authentication = newPolicy.Authentication
 				}
-			} else if !newL7Rules.Authentication.DeepEqual(l7Rules.Authentication) {
-				policyCtx.PolicyTrace("   Merge conflict: mismatching auth types %s/%s\n", newL7Rules.Authentication.Mode, l7Rules.Authentication.Mode)
-				return fmt.Errorf("cannot merge conflicting authentication types (%s/%s)", newL7Rules.Authentication.Mode, l7Rules.Authentication.Mode)
+			} else if !newPolicy.Authentication.DeepEqual(existingPolicy.Authentication) {
+				policyCtx.PolicyTrace("   Merge conflict: mismatching auth types %s/%s\n", newPolicy.Authentication.Mode, existingPolicy.Authentication.Mode)
+				return fmt.Errorf("cannot merge conflicting authentication types (%s/%s)", newPolicy.Authentication.Mode, existingPolicy.Authentication.Mode)
 			}
 
-			if l7Rules.TerminatingTLS == nil || newL7Rules.TerminatingTLS == nil {
-				if newL7Rules.TerminatingTLS != nil {
-					l7Rules.TerminatingTLS = newL7Rules.TerminatingTLS
+			if existingPolicy.TerminatingTLS == nil || newPolicy.TerminatingTLS == nil {
+				if newPolicy.TerminatingTLS != nil {
+					existingPolicy.TerminatingTLS = newPolicy.TerminatingTLS
 				}
-			} else if !newL7Rules.TerminatingTLS.Equal(l7Rules.TerminatingTLS) {
-				policyCtx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %s/%s\n", newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
-				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newL7Rules.TerminatingTLS, l7Rules.TerminatingTLS)
+			} else if !newPolicy.TerminatingTLS.Equal(existingPolicy.TerminatingTLS) {
+				policyCtx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %s/%s\n", newPolicy.TerminatingTLS, existingPolicy.TerminatingTLS)
+				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newPolicy.TerminatingTLS, existingPolicy.TerminatingTLS)
 			}
-			if l7Rules.OriginatingTLS == nil || newL7Rules.OriginatingTLS == nil {
-				if newL7Rules.OriginatingTLS != nil {
-					l7Rules.OriginatingTLS = newL7Rules.OriginatingTLS
+			if existingPolicy.OriginatingTLS == nil || newPolicy.OriginatingTLS == nil {
+				if newPolicy.OriginatingTLS != nil {
+					existingPolicy.OriginatingTLS = newPolicy.OriginatingTLS
 				}
-			} else if !newL7Rules.OriginatingTLS.Equal(l7Rules.OriginatingTLS) {
-				policyCtx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %s/%s\n", newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
-				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newL7Rules.OriginatingTLS, l7Rules.OriginatingTLS)
+			} else if !newPolicy.OriginatingTLS.Equal(existingPolicy.OriginatingTLS) {
+				policyCtx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %s/%s\n", newPolicy.OriginatingTLS, existingPolicy.OriginatingTLS)
+				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newPolicy.OriginatingTLS, existingPolicy.OriginatingTLS)
 			}
 
 			// For now we simply merge the set of allowed SNIs from different rules
@@ -284,57 +288,57 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 			// Note however that SNI rules are typically used with `toFQDNs`, each of
 			// which defines a separate destination, so that SNIs for different
 			// `toFQDNs` will not be merged together.
-			l7Rules.ServerNames = l7Rules.ServerNames.Merge(newL7Rules.ServerNames)
+			existingPolicy.ServerNames = existingPolicy.ServerNames.Merge(newPolicy.ServerNames)
 
 			// L7 rules can be applied with SNI filtering only if the TLS is also
 			// terminated
-			if len(l7Rules.ServerNames) > 0 && !l7Rules.L7Rules.IsEmpty() && l7Rules.TerminatingTLS == nil {
-				policyCtx.PolicyTrace("   Merge conflict: cannot use SNI filtering with L7 rules without TLS termination: %v\n", l7Rules.ServerNames)
-				return fmt.Errorf("cannot merge L7 rules for cached selector %s with SNI filtering without TLS termination: %v", cs.String(), l7Rules.ServerNames)
+			if len(existingPolicy.ServerNames) > 0 && !existingPolicy.L7Rules.IsEmpty() && existingPolicy.TerminatingTLS == nil {
+				policyCtx.PolicyTrace("   Merge conflict: cannot use SNI filtering with L7 rules without TLS termination: %v\n", existingPolicy.ServerNames)
+				return fmt.Errorf("cannot merge L7 rules for cached selector %s with SNI filtering without TLS termination: %v", cs.String(), existingPolicy.ServerNames)
 			}
 
 			// empty L7 rules effectively wildcard L7. When merging with a non-empty
 			// rule, the empty must be expanded to an actual wildcard rule for the
 			// specific L7
-			if !l7Rules.HasL7Rules() && newL7Rules.HasL7Rules() {
-				l7Rules.L7Rules = newL7Rules.appendL7WildcardRule(policyCtx)
-				existingFilter.PerSelectorPolicies[cs] = l7Rules
+			if !existingPolicy.HasL7Rules() && newPolicy.HasL7Rules() {
+				existingPolicy.L7Rules = newPolicy.appendL7WildcardRule(policyCtx)
+				existingFilter.PerSelectorPolicies[cs] = existingPolicy
 				continue
 			}
-			if l7Rules.HasL7Rules() && !newL7Rules.HasL7Rules() {
-				l7Rules.appendL7WildcardRule(policyCtx)
-				existingFilter.PerSelectorPolicies[cs] = l7Rules
+			if existingPolicy.HasL7Rules() && !newPolicy.HasL7Rules() {
+				existingPolicy.appendL7WildcardRule(policyCtx)
+				existingFilter.PerSelectorPolicies[cs] = existingPolicy
 				continue
 			}
 
 			// We already know from the L7Parser.Merge() above that there are no
 			// conflicting parser types, and rule validation only allows one type of L7
 			// rules in a rule, so we can just merge the rules here.
-			for _, newRule := range newL7Rules.HTTP {
-				if !newRule.Exists(l7Rules.L7Rules) {
-					l7Rules.HTTP = append(l7Rules.HTTP, newRule)
+			for _, newRule := range newPolicy.HTTP {
+				if !newRule.Exists(existingPolicy.L7Rules) {
+					existingPolicy.HTTP = append(existingPolicy.HTTP, newRule)
 				}
 			}
-			for _, newRule := range newL7Rules.Kafka {
-				if !newRule.Exists(l7Rules.L7Rules.Kafka) {
-					l7Rules.Kafka = append(l7Rules.Kafka, newRule)
+			for _, newRule := range newPolicy.Kafka {
+				if !newRule.Exists(existingPolicy.L7Rules.Kafka) {
+					existingPolicy.Kafka = append(existingPolicy.Kafka, newRule)
 				}
 			}
-			if l7Rules.L7Proto == "" && newL7Rules.L7Proto != "" {
-				l7Rules.L7Proto = newL7Rules.L7Proto
+			if existingPolicy.L7Proto == "" && newPolicy.L7Proto != "" {
+				existingPolicy.L7Proto = newPolicy.L7Proto
 			}
-			for _, newRule := range newL7Rules.L7 {
-				if !newRule.Exists(l7Rules.L7Rules) {
-					l7Rules.L7 = append(l7Rules.L7, newRule)
+			for _, newRule := range newPolicy.L7 {
+				if !newRule.Exists(existingPolicy.L7Rules) {
+					existingPolicy.L7 = append(existingPolicy.L7, newRule)
 				}
 			}
-			for _, newRule := range newL7Rules.DNS {
-				if !newRule.Exists(l7Rules.L7Rules) {
-					l7Rules.DNS = append(l7Rules.DNS, newRule)
+			for _, newRule := range newPolicy.DNS {
+				if !newRule.Exists(existingPolicy.L7Rules) {
+					existingPolicy.DNS = append(existingPolicy.DNS, newRule)
 				}
 			}
 			// Update the pointer in the map in case it was newly allocated
-			existingFilter.PerSelectorPolicies[cs] = l7Rules
+			existingFilter.PerSelectorPolicies[cs] = existingPolicy
 		}
 	}
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1076,6 +1076,9 @@ func TestIPProtocolsWithNoTransportPorts(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: nil,
 			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
 		},
 		"0/igmp": {
 			Port:     0,
@@ -1086,6 +1089,9 @@ func TestIPProtocolsWithNoTransportPorts(t *testing.T) {
 			PerSelectorPolicies: L7DataMap{
 				td.wildcardCachedSelector: nil,
 			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
 		},
 	})
 
@@ -1098,6 +1104,9 @@ func TestIPProtocolsWithNoTransportPorts(t *testing.T) {
 		PerSelectorPolicies: L7DataMap{
 			td.wildcardCachedSelector: nil,
 		},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+			td.wildcardCachedSelector: {nil},
+		}),
 	}})
 
 	td.policyMapEquals(t, expectedIn, expectedOut, &rule1)


### PR DESCRIPTION
Fix RuleOrigin merging for L4Filter's skipped due to priority override.

Add RuleOrigin verification to policy unit tests, rename local variables for clarity.
