### PR TITLE
policy: return ICMP "Destination unreachable" on ipv4 ingress policy denials

### DIFF
--- a/Documentation/security/policy/intro.rst
+++ b/Documentation/security/policy/intro.rst
@@ -121,8 +121,8 @@ This behavior can be configured with the ``--policy-deny-response`` option:
   This provides immediate feedback to applications that the connection was rejected.
 
 .. note::
-   This is an experimental feature and only applies to ipv4 egress pod traffic denied by network policy.
-   Ingress traffic denial behavior and ipv6 are not supported currently. Check :gh-issue:`41859` for updates
+   This is an experimental feature and only applies to ipv4 pod traffic denied by network policy.
+   IPv6 is not supported currently. Check :gh-issue:`41859` for updates
 
 .. warning::
    When using ``--policy-deny-response=icmp``, ensure that ICMP ingress traffic is allowed by your network policies. 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1406,7 +1406,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 			    (verdict == DROP_POLICY || verdict == DROP_POLICY_DENY)) {
 				ctx_store_meta(ctx, CB_VERDICT, verdict);
 				ctx_store_meta(ctx, CB_POLICY_DENY_DIR, METRIC_EGRESS);
-				ctx_store_meta(ctx, CB_POLICY_DENY_SRC_ID, SECLABEL_IPV4);
+				ctx_store_meta(ctx, CB_SRC_LABEL, SECLABEL_IPV4);
 #if defined(TUNNEL_MODE)
 				ctx_store_meta(ctx, CB_FROM_TUNNEL, 0);
 #endif
@@ -2147,7 +2147,7 @@ ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, __u32 src_label,
 			    (verdict == DROP_POLICY || verdict == DROP_POLICY_DENY)) {
 				ctx_store_meta(ctx, CB_VERDICT, verdict);
 				ctx_store_meta(ctx, CB_POLICY_DENY_DIR, METRIC_INGRESS);
-				ctx_store_meta(ctx, CB_POLICY_DENY_SRC_ID, src_label);
+				ctx_store_meta(ctx, CB_SRC_LABEL, src_label);
 #if defined(TUNNEL_MODE)
 				ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);
 #endif
@@ -2576,8 +2576,7 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	__u32 verdict = ctx_load_meta(ctx, CB_VERDICT);
 	__u8 metric_dir = (__u8)ctx_load_meta(ctx, CB_POLICY_DENY_DIR);
-	__u32 src_label = metric_dir == METRIC_EGRESS ?
-			  SECLABEL_IPV4 : ctx_load_meta(ctx, CB_POLICY_DENY_SRC_ID);
+	__u32 src_label = ctx_load_meta(ctx, CB_SRC_LABEL);
 	__u32 dst_sec_identity = WORLD_IPV4_ID;
 
 	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PKT_FILTERED);
@@ -2588,6 +2587,16 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 		}
 
 		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, ctx_get_ifindex(ctx));
+
+		if (metric_dir == METRIC_EGRESS) {
+			ret = redirect_self(ctx);
+			if (!IS_ERR(ret)) {
+				update_metrics(ctx_full_len(ctx), metric_dir,
+					       __DROP_REASON(verdict));
+				return ret;
+			}
+			goto drop_err;
+		}
 
 		info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 		if (info)
@@ -2605,26 +2614,24 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 			return ret;
 		}
 
-#if !defined(ENABLE_HOST_ROUTING) && !defined(ENABLE_ROUTING)
-		/* If the shared helper returned CTX_ACT_OK (pass to stack) but
-		 * routing is disabled, we need to redirect the ICMP response
-		 * back out the same interface it came from instead.
-		 */
 		if (ret == CTX_ACT_OK) {
+#if !defined(ENABLE_HOST_ROUTING) && !defined(ENABLE_ROUTING)
+			/* If the shared helper returned CTX_ACT_OK (pass to stack) but
+			 * routing is disabled, we need to redirect the ICMP response
+			 * back out the same interface it came from instead.
+			 */
 			ret = redirect_self(ctx);
 			if (!IS_ERR(ret)) {
 				update_metrics(ctx_full_len(ctx), metric_dir,
 					       __DROP_REASON(verdict));
 				return ret;
 			}
-		}
-#else
-		if (ret == CTX_ACT_OK) {
+			goto drop_err;
+#endif /* !ENABLE_HOST_ROUTING && !ENABLE_ROUTING */
 			update_metrics(ctx_full_len(ctx), metric_dir,
 				       __DROP_REASON(verdict));
 			return ret;
 		}
-#endif
 	}
 
 drop_err:

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -336,7 +336,6 @@ enum {
 #define	CB_ENCRYPT_MAGIC	CB_SRC_LABEL	/* Alias, non-overlapping */
 #define	CB_DST_ENDPOINT_ID	CB_SRC_LABEL    /* Alias, non-overlapping */
 #define CB_SRV6_SID_1		CB_SRC_LABEL	/* Alias, non-overlapping */
-#define CB_VERDICT		CB_SRC_LABEL	/* Alias, non-overlapping */
 	CB_1,
 #define	CB_DELIVERY_REDIRECT	CB_1		/* Alias, non-overlapping */
 #define	CB_NAT_46X64		CB_1		/* Alias, non-overlapping */
@@ -353,7 +352,7 @@ enum {
 #define	CB_CLUSTER_ID_INGRESS	CB_2		/* Alias, non-overlapping */
 #define CB_NAT_FLAGS		CB_2		/* Alias, non-overlapping */
 	CB_3,
-#define CB_POLICY_DENY_SRC_ID	CB_3		/* Alias, non-overlapping */
+#define CB_VERDICT			CB_3		/* Alias, non-overlapping */
 #define	CB_ADDR_V6_3		CB_3		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_3		/* Alias, non-overlapping */
 #define CB_SRV6_SID_4		CB_3		/* Alias, non-overlapping */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -347,11 +347,13 @@ enum {
 #define	CB_CLUSTER_ID_EGRESS	CB_1		/* Alias, non-overlapping */
 #define	CB_TRACED		CB_1		/* Alias, non-overlapping */
 	CB_2,
+#define	CB_POLICY_DENY_DIR	CB_2		/* Alias, non-overlapping */
 #define	CB_ADDR_V6_2		CB_2		/* Alias, non-overlapping */
 #define CB_SRV6_SID_3		CB_2		/* Alias, non-overlapping */
 #define	CB_CLUSTER_ID_INGRESS	CB_2		/* Alias, non-overlapping */
 #define CB_NAT_FLAGS		CB_2		/* Alias, non-overlapping */
 	CB_3,
+#define CB_POLICY_DENY_SRC_ID	CB_3		/* Alias, non-overlapping */
 #define	CB_ADDR_V6_3		CB_3		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_3		/* Alias, non-overlapping */
 #define CB_SRV6_SID_4		CB_3		/* Alias, non-overlapping */

--- a/bpf/tests/tc_policy_reject_response_test.c
+++ b/bpf/tests/tc_policy_reject_response_test.c
@@ -113,3 +113,101 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 
 	test_finish();
 }
+
+#define INGRESS_SRC_IP v4_ext_one
+#define INGRESS_DST_IP v4_pod_one
+
+PKTGEN("tc", "policy_reject_response_ingress_v4")
+int policy_reject_response_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_two, (__u8 *)mac_one,
+					  INGRESS_SRC_IP, INGRESS_DST_IP,
+					  tcp_src_one, tcp_dst_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "policy_reject_response_ingress_v4")
+int policy_reject_response_ingress_setup(struct __ctx_buff *ctx)
+{
+	/* Add endpoint for destination */
+	endpoint_v4_add_entry(INGRESS_DST_IP, 0, 0, 0, 0, 0, NULL, NULL);
+
+	/* Add ipcache entries */
+	ipcache_v4_add_entry(INGRESS_SRC_IP, 0, 778899, 0, 0);
+	ipcache_v4_add_entry(INGRESS_DST_IP, 0, 112233, 0, 0);
+
+	/* Add policy that denies ingress from source */
+	policy_add_ingress_deny_all_entry();
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "policy_reject_response_ingress_v4")
+int policy_reject_response_ingress_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct icmphdr *icmp;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* Should redirect ICMP response back to interface */
+	assert(*status_code == TC_ACT_REDIRECT);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	/* Verify this is an ICMP response packet */
+	if (l3->protocol != IPPROTO_ICMP)
+		test_fatal("expected ICMP protocol, got %d", l3->protocol);
+
+	/* Source should be swapped to destination, destination should be source */
+	if (l3->saddr != INGRESS_DST_IP)
+		test_fatal("ICMP src should be destination IP");
+
+	if (l3->daddr != INGRESS_SRC_IP)
+		test_fatal("ICMP dst should be source IP");
+
+	icmp = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)icmp + sizeof(struct icmphdr) > data_end)
+		test_fatal("ICMP header out of bounds");
+
+	/* Verify ICMP error type and code for policy rejection */
+	if (icmp->type != ICMP_DEST_UNREACH)
+		test_fatal("expected ICMP_DEST_UNREACH, got type %d", icmp->type);
+
+	if (icmp->code != ICMP_PKT_FILTERED)
+		test_fatal("expected ICMP_PKT_FILTERED, got code %d", icmp->code);
+
+	test_finish();
+}

--- a/bpf/tests/tc_policy_reject_response_test.c
+++ b/bpf/tests/tc_policy_reject_response_test.c
@@ -19,8 +19,8 @@ ASSIGN_CONFIG(bool, policy_deny_response_enabled, true)
 #define CLIENT_IP v4_pod_one
 #define TARGET_IP v4_ext_one
 
-PKTGEN("tc", "policy_reject_response_v4")
-int policy_reject_response_pktgen(struct __ctx_buff *ctx)
+static __always_inline int build_packet(struct __ctx_buff *ctx,
+					__be32 saddr, __be32 daddr)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -31,7 +31,7 @@ int policy_reject_response_pktgen(struct __ctx_buff *ctx)
 
 	l4 = pktgen__push_ipv4_tcp_packet(&builder,
 					  (__u8 *)mac_one, (__u8 *)mac_two,
-					  CLIENT_IP, TARGET_IP,
+					  saddr, daddr,
 					  tcp_src_one, tcp_dst_one);
 	if (!l4)
 		return TEST_ERROR;
@@ -46,24 +46,22 @@ int policy_reject_response_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "policy_reject_response_v4")
-int policy_reject_response_setup(struct __ctx_buff *ctx)
+static __always_inline void init_policy_reject_response_setup(__be32 saddr,
+							      __be32 daddr,
+							      __u32 saddr_sec_identity,
+							      __u32 daddr_sec_identity
+)
 {
-	/* Add endpoint for source */
-	endpoint_v4_add_entry(CLIENT_IP, 0, 0, 0, 0, 0, NULL, NULL);
-
 	/* Add ipcache entries */
-	ipcache_v4_add_entry(CLIENT_IP, 0, 112233, 0, 0);
-	ipcache_v4_add_entry(TARGET_IP, 0, 445566, 0, 0);
+	ipcache_v4_add_entry(saddr, 0, saddr_sec_identity, 0, 0);
+	ipcache_v4_add_entry(daddr, 0, daddr_sec_identity, 0, 0);
 
 	/* Add policy that denies egress to target */
 	policy_add_egress_deny_all_entry();
-
-	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "policy_reject_response_v4")
-int policy_reject_response_check(const struct __ctx_buff *ctx)
+static __always_inline int check_policy_reject_response(const struct __ctx_buff *ctx,
+							__be32 saddr, __be32 daddr)
 {
 	void *data, *data_end;
 	__u32 *status_code;
@@ -71,7 +69,6 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 	struct icmphdr *icmp;
 
 	test_init();
-
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 
@@ -92,109 +89,11 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 	if (l3->protocol != IPPROTO_ICMP)
 		test_fatal("expected ICMP protocol, got %d", l3->protocol);
 
-	/* Source should be swapped to target, destination should be client */
-	if (l3->saddr != TARGET_IP)
-		test_fatal("ICMP src should be target IP");
-
-	if (l3->daddr != CLIENT_IP)
-		test_fatal("ICMP dst should be client IP");
-
-	icmp = (void *)l3 + sizeof(struct iphdr);
-
-	if ((void *)icmp + sizeof(struct icmphdr) > data_end)
-		test_fatal("ICMP header out of bounds");
-
-	/* Verify ICMP error type and code for policy rejection */
-	if (icmp->type != ICMP_DEST_UNREACH)
-		test_fatal("expected ICMP_DEST_UNREACH, got type %d", icmp->type);
-
-	if (icmp->code != ICMP_PKT_FILTERED)
-		test_fatal("expected ICMP_PKT_FILTERED, got code %d", icmp->code);
-
-	test_finish();
-}
-
-#define INGRESS_SRC_IP v4_ext_one
-#define INGRESS_DST_IP v4_pod_one
-
-PKTGEN("tc", "policy_reject_response_ingress_v4")
-int policy_reject_response_ingress_pktgen(struct __ctx_buff *ctx)
-{
-	struct pktgen builder;
-	struct tcphdr *l4;
-	void *data;
-
-	/* Init packet builder */
-	pktgen__init(&builder, ctx);
-
-	l4 = pktgen__push_ipv4_tcp_packet(&builder,
-					  (__u8 *)mac_two, (__u8 *)mac_one,
-					  INGRESS_SRC_IP, INGRESS_DST_IP,
-					  tcp_src_one, tcp_dst_one);
-	if (!l4)
-		return TEST_ERROR;
-
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
-	pktgen__finish(&builder);
-
-	return 0;
-}
-
-SETUP("tc", "policy_reject_response_ingress_v4")
-int policy_reject_response_ingress_setup(struct __ctx_buff *ctx)
-{
-	/* Add endpoint for destination */
-	endpoint_v4_add_entry(INGRESS_DST_IP, 0, 0, 0, 0, 0, NULL, NULL);
-
-	/* Add ipcache entries */
-	ipcache_v4_add_entry(INGRESS_SRC_IP, 0, 778899, 0, 0);
-	ipcache_v4_add_entry(INGRESS_DST_IP, 0, 112233, 0, 0);
-
-	/* Add policy that denies ingress from source */
-	policy_add_ingress_deny_all_entry();
-
-	return pod_receive_packet(ctx);
-}
-
-CHECK("tc", "policy_reject_response_ingress_v4")
-int policy_reject_response_ingress_check(const struct __ctx_buff *ctx)
-{
-	void *data, *data_end;
-	__u32 *status_code;
-	struct iphdr *l3;
-	struct icmphdr *icmp;
-
-	test_init();
-
-	data = (void *)(long)ctx->data;
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-
-	/* Should redirect ICMP response back to interface */
-	assert(*status_code == TC_ACT_REDIRECT);
-
-	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
-
-	if ((void *)l3 + sizeof(struct iphdr) > data_end)
-		test_fatal("l3 out of bounds");
-
-	/* Verify this is an ICMP response packet */
-	if (l3->protocol != IPPROTO_ICMP)
-		test_fatal("expected ICMP protocol, got %d", l3->protocol);
-
-	/* Source should be swapped to destination, destination should be source */
-	if (l3->saddr != INGRESS_DST_IP)
+	/* Source should be swapped to target, destination should be source */
+	if (l3->saddr != daddr)
 		test_fatal("ICMP src should be destination IP");
 
-	if (l3->daddr != INGRESS_SRC_IP)
+	if (l3->daddr != saddr)
 		test_fatal("ICMP dst should be source IP");
 
 	icmp = (void *)l3 + sizeof(struct iphdr);
@@ -210,4 +109,139 @@ int policy_reject_response_ingress_check(const struct __ctx_buff *ctx)
 		test_fatal("expected ICMP_PKT_FILTERED, got code %d", icmp->code);
 
 	test_finish();
+}
+
+PKTGEN("tc", "policy_reject_response_egress_v4")
+int policy_reject_response_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx, CLIENT_IP, TARGET_IP);
+}
+
+SETUP("tc", "policy_reject_response_egress_v4")
+int policy_reject_response_setup(struct __ctx_buff *ctx)
+{
+	init_policy_reject_response_setup(CLIENT_IP, TARGET_IP, 112233, 445566);
+
+	/* Add endpoint for source */
+	endpoint_v4_add_entry(CLIENT_IP, 0, 0, 0, 0, 0, NULL, NULL);
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "policy_reject_response_egress_v4")
+int policy_reject_response_check(const struct __ctx_buff *ctx)
+{
+	return check_policy_reject_response(ctx, CLIENT_IP, TARGET_IP);
+}
+
+#define INGRESS_WORLD_SRC v4_ext_one
+#define INGRESS_REMOTE_NODE_SRC v4_node_two
+#define INGRESS_LOCAL_NODE_SRC v4_node_one
+#define INGRESS_POD_SRC v4_pod_two
+#define INGRESS_DST_IP v4_pod_one
+
+/* Test policy deny response on ingress WORLD -> POD
+ * The return should be an ICMP packet filtered from POD -> WORLD
+ */
+PKTGEN("tc", "policy_reject_response_ingress_from_world_v4")
+int policy_reject_response_ingress_from_world_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx, INGRESS_WORLD_SRC, INGRESS_DST_IP);
+}
+
+SETUP("tc", "policy_reject_response_ingress_from_world_v4")
+int policy_reject_response_ingress_from_world_setup(struct __ctx_buff *ctx)
+{
+	init_policy_reject_response_setup(INGRESS_WORLD_SRC, INGRESS_DST_IP, WORLD_ID, 112233);
+
+	/* Add endpoint for destination */
+	endpoint_v4_add_entry(INGRESS_DST_IP, 0, 0, 0, 0, 0, NULL, NULL);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "policy_reject_response_ingress_from_world_v4")
+int policy_reject_response_ingress_from_world_check(const struct __ctx_buff *ctx)
+{
+	return check_policy_reject_response(ctx, INGRESS_WORLD_SRC, INGRESS_DST_IP);
+}
+
+/* Test policy deny response on ingress REMOTE_NODE -> POD
+ * The return should be an ICMP packet filtered from POD -> REMOTE_NODE
+ */
+PKTGEN("tc", "policy_reject_response_ingress_from_remote_node_v4")
+int policy_reject_response_ingress_from_remote_node_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx, INGRESS_REMOTE_NODE_SRC, INGRESS_DST_IP);
+}
+
+SETUP("tc", "policy_reject_response_ingress_from_remote_node_v4")
+int policy_reject_response_ingress_from_remote_node_setup(struct __ctx_buff *ctx)
+{
+	init_policy_reject_response_setup(INGRESS_REMOTE_NODE_SRC, INGRESS_DST_IP,
+					  REMOTE_NODE_ID, 112233);
+
+	/* Add endpoint for destination */
+	endpoint_v4_add_entry(INGRESS_DST_IP, 0, 0, 0, 0, 0, NULL, NULL);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "policy_reject_response_ingress_from_remote_node_v4")
+int policy_reject_response_ingress_from_remote_node_check(const struct __ctx_buff *ctx)
+{
+	return check_policy_reject_response(ctx, INGRESS_REMOTE_NODE_SRC, INGRESS_DST_IP);
+}
+
+/* Test policy deny response on ingress LOCAL_NODE -> POD
+ * The return should be an ICMP packet filtered from POD -> LOCAL_NODE
+ */
+PKTGEN("tc", "policy_reject_response_ingress_from_local_node_v4")
+int policy_reject_response_ingress_from_local_node_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx, INGRESS_LOCAL_NODE_SRC, INGRESS_DST_IP);
+}
+
+SETUP("tc", "policy_reject_response_ingress_from_local_node_v4")
+int policy_reject_response_ingress_from_local_node_setup(struct __ctx_buff *ctx)
+{
+	init_policy_reject_response_setup(INGRESS_LOCAL_NODE_SRC, INGRESS_DST_IP, HOST_ID, 112233);
+
+	/* Add endpoint for destination */
+	endpoint_v4_add_entry(INGRESS_DST_IP, 0, 0, 0, 0, 0, NULL, NULL);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "policy_reject_response_ingress_from_local_node_v4")
+int policy_reject_response_ingress_from_local_node_check(const struct __ctx_buff *ctx)
+{
+	return check_policy_reject_response(ctx, INGRESS_LOCAL_NODE_SRC, INGRESS_DST_IP);
+}
+
+/* Test policy deny response on ingress POD_OTHER -> POD
+ * The return should be an ICMP packet filtered from POD -> POD_OTHER
+ */
+PKTGEN("tc", "policy_reject_response_ingress_from_pod_v4")
+int policy_reject_response_ingress_from_pod_pktgen(struct __ctx_buff *ctx)
+{
+	return build_packet(ctx, INGRESS_POD_SRC, INGRESS_DST_IP);
+}
+
+SETUP("tc", "policy_reject_response_ingress_from_pod_v4")
+int policy_reject_response_ingress_from_pod_setup(struct __ctx_buff *ctx)
+{
+	init_policy_reject_response_setup(INGRESS_POD_SRC, INGRESS_DST_IP, 112233, 445566);
+
+	/* Add endpoint for destination */
+	endpoint_v4_add_entry(INGRESS_DST_IP, 0, 0, 0, 0, 0, NULL, NULL);
+	endpoint_v4_add_entry(INGRESS_POD_SRC, 0, 0, 0, 0, 0, NULL, NULL);
+
+	return pod_receive_packet(ctx);
+}
+
+CHECK("tc", "policy_reject_response_ingress_from_pod_v4")
+int policy_reject_response_ingress_from_pod_check(const struct __ctx_buff *ctx)
+{
+	return check_policy_reject_response(ctx, INGRESS_POD_SRC, INGRESS_DST_IP);
 }


### PR DESCRIPTION
# Description

This is mostly a copy of PR #42068 following the changes introduced in PR #43226. See https://github.com/cilium/cilium/issues/41859 for the full list of TODOs.

This PR adds the ICMP response functionality to ingress policy denials.
The functionality works for local and remote endpoints with/without tunneling and with/without eBPF Host Routing.

# Testing
- Created a new unit test
- Performed integration tests: backported the PR to Cilium 1.18.6, then created a pod with an ingress policy denying all traffic. Then tried to reach this pod from multiple different places and confirmed ping was returning "Packet filtered":
``` 
# ping 10.130.112.4
 PING 10.130.112.4 (10.130.112.4) 56(84) bytes of data.
 From 10.130.112.4 icmp_seq=1 Packet filtered
 From 10.130.112.4 icmp_seq=2 Packet filtered
 [...]
```
- [x]  Local pod from same node [legacy routing]
- [x]  Pod from a different node in the same cluster [legacy routing]
- [x]  Pod in a different cluster [legacy routing]
- [x]  Local pod from same node [eBPF host routing]
- [x]  Pod from a different node in the same cluster [eBPF host routing]
- [x]  Pod in a different cluster [eBPF host routing]

```release-note
policy: add option to return ICMP "Destination unreachable" on ipv4 ingress policy denials
```
