### PR TITLE
localnodestore: provide WaitForNodeInformation

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
@@ -153,8 +152,8 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 			params.NodeDiscovery.UpdateCiliumNodeResource()
 		}
 
-		if err := agentK8s.WaitForNodeInformation(ctx, params.Logger, params.LocalNodeRes, params.LocalCiliumNodeRes); err != nil {
-			return fmt.Errorf("unable to connect to get node spec from apiserver: %w", err)
+		if err := params.LocalNodeStore.WaitForNodeInformation(ctx); err != nil {
+			return fmt.Errorf("failed to wait for node information: %w", err)
 		}
 
 		bootstrapStats.k8sInit.End(true)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cilium/cilium/daemon/cmd/legacy"
 	"github.com/cilium/cilium/daemon/infraendpoints"
-	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/common"
@@ -59,6 +58,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
@@ -1215,8 +1215,7 @@ type daemonParams struct {
 	Clientset           k8sClient.Clientset
 	KVStoreClient       kvstore.Client
 	WGAgent             wgTypes.WireguardAgent
-	LocalNodeRes        k8s.LocalNodeResource
-	LocalCiliumNodeRes  k8s.LocalCiliumNodeResource
+	LocalNodeStore      *node.LocalNodeStore
 	K8sWatcher          *watchers.K8sWatcher
 	NodeHandler         datapath.NodeHandler
 	EndpointManager     endpointmanager.EndpointManager

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -821,7 +821,7 @@ func (t testLocalNodeSync) SyncLocalNode(context.Context, *node.LocalNodeStore) 
 }
 
 // WaitForNodeInformation implements [node.LocalNodeSynchronizer].
-func (t testLocalNodeSync) WaitForNodeInformation(context.Context) error {
+func (t testLocalNodeSync) WaitForNodeInformation(context.Context, *node.LocalNodeStore) error {
 	return nil
 }
 

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -315,7 +315,6 @@ func TestNodeAddress(t *testing.T) {
 
 	for _, tt := range nodeAddressTests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			txn := db.WriteTxn(devices)
 			_, watch := nodeAddrs.AllWatch(txn)
 
@@ -353,7 +352,6 @@ func TestNodeAddress(t *testing.T) {
 			assert.ElementsMatch(t, nodePort, tt.wantNodePort, "NodePort addresses do not match")
 			assert.ElementsMatch(t, primary, tt.wantPrimary, "Primary addresses do not match")
 			assertOnePrimaryPerDevice(t, addrs)
-
 		})
 	}
 
@@ -809,8 +807,7 @@ func fixture(t *testing.T, addressScopeMax int, beforeStart func(*hive.Hive)) (*
 	return db, devices, nodeAddrs, localNodeStore
 }
 
-type testLocalNodeSync struct {
-}
+type testLocalNodeSync struct{}
 
 // InitLocalNode implements node.LocalNodeSynchronizer.
 func (t testLocalNodeSync) InitLocalNode(_ context.Context, n *node.LocalNode) error {
@@ -821,6 +818,11 @@ func (t testLocalNodeSync) InitLocalNode(_ context.Context, n *node.LocalNode) e
 
 // SyncLocalNode implements node.LocalNodeSynchronizer.
 func (t testLocalNodeSync) SyncLocalNode(context.Context, *node.LocalNodeStore) {
+}
+
+// WaitForNodeInformation implements [node.LocalNodeSynchronizer].
+func (t testLocalNodeSync) WaitForNodeInformation(context.Context) error {
+	return nil
 }
 
 var _ node.LocalNodeSynchronizer = testLocalNodeSync{}
@@ -917,7 +919,6 @@ func TestSortedAddresses(t *testing.T) {
 		actual = SortedAddresses(shuffleSlice(slices.Clone(expected)))
 		assert.Equal(t, expected, actual)
 	}
-
 }
 
 func TestFallbackAddresses(t *testing.T) {

--- a/pkg/node/local_node_store.go
+++ b/pkg/node/local_node_store.go
@@ -23,7 +23,7 @@ import (
 type LocalNodeSynchronizer interface {
 	InitLocalNode(context.Context, *LocalNode) error
 	SyncLocalNode(context.Context, *LocalNodeStore)
-	WaitForNodeInformation(context.Context) error
+	WaitForNodeInformation(context.Context, *LocalNodeStore) error
 }
 
 // LocalNodeStoreCell provides the LocalNodeStore instance.
@@ -215,7 +215,7 @@ func (s *LocalNodeStore) Update(update func(*LocalNode)) {
 }
 
 func (s *LocalNodeStore) WaitForNodeInformation(ctx context.Context) error {
-	return s.sync.WaitForNodeInformation(ctx)
+	return s.sync.WaitForNodeInformation(ctx, s)
 }
 
 func NewTestLocalNodeStore(mockNode LocalNode) *LocalNodeStore {
@@ -253,7 +253,7 @@ func (n nopLocalNodeSynchronizer) SyncLocalNode(context.Context, *LocalNodeStore
 }
 
 // WaitForNodeInformation implements [LocalNodeSynchronizer].
-func (n nopLocalNodeSynchronizer) WaitForNodeInformation(context.Context) error {
+func (n nopLocalNodeSynchronizer) WaitForNodeInformation(context.Context, *LocalNodeStore) error {
 	return nil
 }
 

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -31,7 +31,7 @@ func (ts testSynchronizer) SyncLocalNode(ctx context.Context, lns *LocalNodeStor
 	<-ctx.Done()
 }
 
-func (ts testSynchronizer) WaitForNodeInformation(context.Context) error {
+func (ts testSynchronizer) WaitForNodeInformation(context.Context, *LocalNodeStore) error {
 	return nil
 }
 

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -31,6 +31,10 @@ func (ts testSynchronizer) SyncLocalNode(ctx context.Context, lns *LocalNodeStor
 	<-ctx.Done()
 }
 
+func (ts testSynchronizer) WaitForNodeInformation(context.Context) error {
+	return nil
+}
+
 func TestLocalNodeStore(t *testing.T) {
 	var waitObserve sync.WaitGroup
 	var observed []uint32


### PR DESCRIPTION
This commit moves global function `k8s.WaitForNodeInformation` into the `localNodeSynchronizer`. To prevent dependencies to the synchronizer, the `LocalNodeStore` re-exposes the same method and delegates the call to the synchronizer.

This way, the legacy daemon initialization logic no longer needs to dependent on the (k8s/cilium)-node resources.

This step isn't final. Eventually, the wait logic should watch the state db "local node" for the changes.