### PR TITLE
vendor: Bump to StateDB v0.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.6.1
+	github.com/cilium/statedb v0.6.2
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.6.1 h1:Ph3W1oFBljcTMuSyJpUXOJ+ud+4+4DeysddHTnXjiy0=
-github.com/cilium/statedb v0.6.1/go.mod h1:2mLzaSUFAmsM7IoBauszr0YQHUjVV1YcIFFQxnJDlfc=
+github.com/cilium/statedb v0.6.2 h1:pgLlz4tEmPEuY9PRPtN+JvSqwJjmjzcxPmu2uxW9bQ8=
+github.com/cilium/statedb v0.6.2/go.mod h1:2mLzaSUFAmsM7IoBauszr0YQHUjVV1YcIFFQxnJDlfc=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/lpm_index.go
+++ b/vendor/github.com/cilium/statedb/lpm_index.go
@@ -312,7 +312,7 @@ func (l *lpmIndexTxn) insert(key index.Key, obj object) (old object, hadOld bool
 }
 
 // modify implements tableIndexTxn.
-func (l *lpmIndexTxn) modify(key index.Key, obj object, mod func(old, new object) object) (old object, hadOld bool, watch <-chan struct{}) {
+func (l *lpmIndexTxn) modify(key index.Key, obj object, mod func(old, new object) object) (old object, newObj object, hadOld bool, watch <-chan struct{}) {
 	panic("LPM index cannot be the primary index")
 }
 

--- a/vendor/github.com/cilium/statedb/part/tree.go
+++ b/vendor/github.com/cilium/statedb/part/tree.go
@@ -127,7 +127,7 @@ func (t *Tree[T]) Insert(key []byte, value T) (old T, hadOld bool, tree Tree[T])
 // Returns the old value if it exists.
 func (t *Tree[T]) Modify(key []byte, value T, mod func(T, T) T) (old T, hadOld bool, tree Tree[T]) {
 	txn := t.Txn()
-	old, hadOld = txn.Modify(key, value, mod)
+	old, _, hadOld = txn.Modify(key, value, mod)
 	tree = txn.CommitAndNotify()
 	return
 }

--- a/vendor/github.com/cilium/statedb/part_index.go
+++ b/vendor/github.com/cilium/statedb/part_index.go
@@ -321,7 +321,7 @@ func (r *partIndexTxn) len() int {
 }
 
 // modify implements tableIndexTxn.
-func (r *partIndexTxn) modify(key index.Key, obj object, mod func(old, new object) object) (old object, hadOld bool, watch <-chan struct{}) {
+func (r *partIndexTxn) modify(key index.Key, obj object, mod func(old, new object) object) (old object, newObj object, hadOld bool, watch <-chan struct{}) {
 	return r.tx.ModifyWatch(key, obj, mod)
 }
 

--- a/vendor/github.com/cilium/statedb/table.go
+++ b/vendor/github.com/cilium/statedb/table.go
@@ -486,7 +486,7 @@ func (t *genTable[Obj]) InsertWatch(txn WriteTxn, obj Obj) (oldObj Obj, hadOld b
 
 func (t *genTable[Obj]) Modify(txn WriteTxn, obj Obj, merge func(old, new Obj) Obj) (oldObj Obj, hadOld bool, err error) {
 	mergeObjects := func(old object, new object) object {
-		new.data = merge(old.data.(Obj), obj)
+		new.data = merge(old.data.(Obj), new.data.(Obj))
 		return new
 	}
 	var old object

--- a/vendor/github.com/cilium/statedb/types.go
+++ b/vendor/github.com/cilium/statedb/types.go
@@ -414,7 +414,7 @@ type tableIndexTxn interface {
 	tableIndex
 
 	insert(key index.Key, obj object) (old object, hadOld bool, watch <-chan struct{})
-	modify(key index.Key, obj object, mod func(old, new object) object) (old object, hadOld bool, watch <-chan struct{})
+	modify(key index.Key, obj object, mod func(old, new object) object) (old object, new object, hadOld bool, watch <-chan struct{})
 	delete(key index.Key) (old object, hadOld bool)
 	reindex(primaryKey index.Key, old object, new object)
 }

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -139,7 +139,9 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 	if merge == nil {
 		oldObj, oldExists, watch = idIndexTxn.insert(idKey, obj)
 	} else {
-		oldObj, oldExists, watch = idIndexTxn.modify(idKey, obj, merge)
+		// Insert the object into the primary index. This returns the merged new
+		// object which we'll then insert into the secondary indexes.
+		oldObj, obj, oldExists, watch = idIndexTxn.modify(idKey, obj, merge)
 	}
 
 	// Sanity check: is the same object being inserted back and thus the

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -329,7 +329,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.6.1
+# github.com/cilium/statedb v0.6.2
 ## explicit; go 1.25
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This fixes a regression in the Modify() method where the secondary indexes were updated with the new object without the result of the merge(). https://github.com/cilium/statedb/pull/141.

Marking as `release-note/misc` as this didn't make into any release and was in `main` for only a very short time.