### PR TITLE
ginkgo: remove `ClusterIP cannot be accessed externally when access is disabled`

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -127,7 +127,6 @@ include:
     cliFocus: "K8sAgentHubbleTest"
 
   ###
-  # K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP cannot be accessed externally when access is disabled
   # K8sDatapathServicesTest Checks N/S loadbalancing Supports IPv4 fragments
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and dsr with geneve
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid-DSR with Geneve
@@ -135,7 +134,7 @@ include:
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, dsr and Maglev
   - focus: "f11-datapath-service-ns-tc"
-    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP|K8sDatapathServicesTest Checks N/S loadbalancing Supports|K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Supports|K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC"
 
   ###
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -1,0 +1,20 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+
+from pkt_defs_common import *
+
+lb4_clusterip = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw("S"*1)
+)
+
+lb6_clusterip = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw("S"*1)
+)

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -13,3 +13,4 @@ from tc_l2_announce6_pkt_defs import *
 from wg_from_netdev_pkt_defs import *
 from tc_wireguard_from_overlay_pkt_defs import *
 from icmp_err_revnat_pkt_defs import *
+from lb_pkt_defs import *

--- a/bpf/tests/tc_lb4_clusterip.c
+++ b/bpf/tests/tc_lb4_clusterip.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		tcp_src_one
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_PORT		tcp_svc_one
+
+#define BACKEND_IP		v4_pod_one
+#define BACKEND_PORT		tcp_dst_one
+
+#define NAT_REV_INDEX		1
+#define BACKEND_COUNT		1
+#define BACKEND_IFINDEX		11
+#define BACKEND_ID		124
+
+#include "lib/bpf_host.h"
+#include "lib/endpoint.h"
+#include "lib/lb.h"
+#include "scapy.h"
+
+/* Test that a request from an external client to a ClusterIP service w/o the
+ * `bpf-lb-external-clusterip` flag set is denied. The reason is due to the SVC
+ * being created w/o the SVC_FLAG_ROUTABLE flag being set in the bpf map,
+ * leading to the datapath dropping the packet with the reason code
+ * DROP_IS_CLUSTER_IP, and the respective BPF metric updated accordingly.
+ */
+PKTGEN("tc", "tc_lb4_nonroutable_clusterip")
+int lb4_nonroutable_clusterip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB4_CLUSTERIP, lb4_clusterip);
+	BUILDER_PUSH_BUF(builder, LB4_CLUSTERIP);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lb4_nonroutable_clusterip")
+int lb4_nonroutable_clusterip_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
+			      (__u8 *)mac_one, (__u8 *)mac_two);
+	lb_v4_add_service_with_flags(FRONTEND_IP, FRONTEND_PORT,
+				     IPPROTO_TCP, BACKEND_COUNT, NAT_REV_INDEX,
+				     0, 0);
+	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, BACKEND_COUNT, BACKEND_ID,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lb4_nonroutable_clusterip")
+int lb4_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code, drop_reason;
+	__u64 count = 1;
+	struct metrics_key key = {
+		.reason = -DROP_IS_CLUSTER_IP,
+		.dir = METRIC_INGRESS,
+	};
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+	/* Retrieve drop reason from metadata (bpf/lib/drop.h) */
+	drop_reason = ctx_load_meta(ctx, 2);
+
+	assert(data + sizeof(__u32) <= data_end)
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	assert(drop_reason == -DROP_IS_CLUSTER_IP);
+
+	assert_metrics_count(key, count);
+
+	BUF_DECL(LB4_CLUSTERIP, lb4_clusterip);
+	ASSERT_CTX_BUF_OFF("lb4_nonroutable_clusterip", "Ether", ctx, sizeof(__u32),
+			   LB4_CLUSTERIP, sizeof(BUF(LB4_CLUSTERIP)));
+
+	test_finish();
+}

--- a/bpf/tests/tc_lb6_clusterip.c
+++ b/bpf/tests/tc_lb6_clusterip.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+
+#define CLIENT_IP		v6_ext_node_one
+#define CLIENT_PORT		tcp_src_one
+
+#define FRONTEND_IP		v6_svc_one
+#define FRONTEND_PORT		tcp_svc_one
+
+#define BACKEND_IP		v6_pod_one
+#define BACKEND_PORT		tcp_dst_one
+
+#define NAT_REV_INDEX		1
+#define BACKEND_COUNT		1
+#define BACKEND_IFINDEX		11
+#define BACKEND_ID		124
+
+#include "lib/bpf_host.h"
+#include "lib/endpoint.h"
+#include "lib/lb.h"
+#include "scapy.h"
+
+/* Test that a request from an external client to a ClusterIP service w/o the
+ * `bpf-lb-external-clusterip` flag set is denied. The reason is due to the SVC
+ * being created w/o the SVC_FLAG_ROUTABLE flag being set in the bpf map,
+ * leading to the datapath dropping the packet with the reason code
+ * DROP_IS_CLUSTER_IP, and the respective BPF metric updated accordingly.
+ */
+PKTGEN("tc", "tc_lb6_nonroutable_clusterip")
+int lb6_nonroutable_clusterip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB6_CLUSTERIP, lb6_clusterip);
+	BUILDER_PUSH_BUF(builder, LB6_CLUSTERIP);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lb6_nonroutable_clusterip")
+int lb6_nonroutable_clusterip_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v6_add_entry((union v6addr *)BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0,
+			      (__u8 *)mac_one, (__u8 *)mac_two);
+	lb_v6_add_service_with_flags((union v6addr *)FRONTEND_IP, FRONTEND_PORT,
+				     IPPROTO_TCP, BACKEND_COUNT, NAT_REV_INDEX,
+				     0, 0);
+	lb_v6_add_backend((union v6addr *)FRONTEND_IP, FRONTEND_PORT, BACKEND_COUNT, BACKEND_ID,
+			  (union v6addr *)BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lb6_nonroutable_clusterip")
+int lb6_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code, drop_reason;
+	__u64 count = 1;
+	struct metrics_key key = {
+		.reason = -DROP_IS_CLUSTER_IP,
+		.dir = METRIC_INGRESS,
+	};
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+	/* Retrieve drop reason from metadata (bpf/lib/drop.h) */
+	drop_reason = ctx_load_meta(ctx, 2);
+
+	assert(data + sizeof(__u32) <= data_end);
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	assert(drop_reason == -DROP_IS_CLUSTER_IP);
+
+	assert_metrics_count(key, count);
+
+	BUF_DECL(LB6_CLUSTERIP, lb6_clusterip);
+	ASSERT_CTX_BUF_OFF("lb6_nonroutable_clusterip", "Ether", ctx, sizeof(__u32),
+			   LB6_CLUSTERIP, sizeof(BUF(LB6_CLUSTERIP)));
+
+	test_finish();
+}

--- a/pkg/loadbalancer/tests/testdata/clusterip.txtar
+++ b/pkg/loadbalancer/tests/testdata/clusterip.txtar
@@ -1,4 +1,4 @@
-#! 
+#! --bpf-lb-external-clusterip=false
 
 # Start the test application
 hive start

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -630,13 +630,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 			})
 		})
 
-		It("ClusterIP cannot be accessed externally when access is disabled",
-			func() {
-				Expect(curlClusterIPFromExternalHost(kubectl, ni)).
-					ShouldNot(helpers.CMDSuccess(),
-						"External host %s unexpectedly connected to ClusterIP when lbExternalClusterIP was unset", ni.OutsideNodeName)
-			})
-
 		Context("With ClusterIP external access", func() {
 			var (
 				svcIP string


### PR DESCRIPTION
Please refer to commit messages:

1. simple refactor to explicit an agent flag in clusterip.txtar, no functionale changes
2. add new BPF test to check this behavior for IPv4/6
4. remove Ginkgo test.

Related: https://github.com/cilium/cilium/issues/44168.