### PR TITLE
ginkgo: remove `ClusterIP can be accessed when external access is enabled`

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -155,10 +155,9 @@ include:
 
   ###
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT and Maglev
-  # K8sDatapathServicesTest Checks N/S loadbalancing With ClusterIP external access ClusterIP can be accessed when external access is enabled
   # K8sDatapathServicesTest Checks N/S loadbalancing With host policy Tests NodePort
   - focus: "f14-datapath-service-ns-xdp-2"
-    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT|K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, vxlan|K8sDatapathServicesTest Checks N/S loadbalancing With"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT|K8sDatapathServicesTest Checks N/S loadbalancing With host policy Tests NodePort"
 
   ###
   # K8sDatapathServicesTest Checks device reconfiguration Detects newly added device and reloads datapath

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -12,9 +12,23 @@ lb4_clusterip = (
     Raw("S"*1)
 )
 
+lb4_clusterip_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one) /
+    Raw("S"*1)
+)
+
 lb6_clusterip = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
     TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw("S"*1)
+)
+
+lb6_clusterip_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one) /
     Raw("S"*1)
 )

--- a/bpf/tests/tc_lb4_clusterip.c
+++ b/bpf/tests/tc_lb4_clusterip.c
@@ -27,6 +27,9 @@
 #include "lib/lb.h"
 #include "scapy.h"
 
+/* For checking statistics in conntrack map. */
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
 /* Test that a request from an external client to a ClusterIP service w/o the
  * `bpf-lb-external-clusterip` flag set is denied. The reason is due to the SVC
  * being created w/o the SVC_FLAG_ROUTABLE flag being set in the bpf map,
@@ -81,7 +84,7 @@ int lb4_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 	/* Retrieve drop reason from metadata (bpf/lib/drop.h) */
 	drop_reason = ctx_load_meta(ctx, 2);
 
-	assert(data + sizeof(__u32) <= data_end)
+	assert(data + sizeof(__u32) <= data_end);
 
 	assert(*status_code == CTX_ACT_DROP);
 
@@ -92,6 +95,74 @@ int lb4_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 	BUF_DECL(LB4_CLUSTERIP, lb4_clusterip);
 	ASSERT_CTX_BUF_OFF("lb4_nonroutable_clusterip", "Ether", ctx, sizeof(__u32),
 			   LB4_CLUSTERIP, sizeof(BUF(LB4_CLUSTERIP)));
+
+	test_finish();
+}
+
+/* Test that a request from an external client to a routable ClusterIP service
+ * is allowed. The reason is due to the SVC being created with the SVC_FLAG_ROUTABLE
+ * flag set, leading to the datapath correctly accepting and DNAT the packet.
+ */
+PKTGEN("tc", "tc_lb4_routable_clusterip")
+int lb4_routable_clusterip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB4_CLUSTERIP, lb4_clusterip);
+	BUILDER_PUSH_BUF(builder, LB4_CLUSTERIP);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lb4_routable_clusterip")
+int lb4_routable_clusterip_setup(struct __ctx_buff *ctx)
+{
+	/* Endpoint and backend added in previous setup, simply change SVC flags. */
+	lb_v4_add_service_with_flags(FRONTEND_IP, FRONTEND_PORT,
+				     IPPROTO_TCP, BACKEND_COUNT, NAT_REV_INDEX,
+				     SVC_FLAG_ROUTABLE, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lb4_routable_clusterip")
+int lb4_routable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ct_entry *ct_entry;
+	struct ipv4_ct_tuple tuple = {
+		.saddr   = CLIENT_IP,
+		.sport   = FRONTEND_PORT,
+		.daddr   = FRONTEND_IP,
+		.dport   = CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = TUPLE_F_SERVICE,
+	};
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+
+	assert(data + sizeof(__u32) <= data_end);
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Ensure CT entry is updated accordingly (SVC). */
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	assert(ct_entry);
+	assert(ct_entry->packets == 1);
+	assert(ct_entry->bytes == ctx_full_len(ctx) - sizeof(__u32));
+
+	BUF_DECL(LB4_CLUSTERIP_POST_DNAT, lb4_clusterip_post_dnat);
+	ASSERT_CTX_BUF_OFF("lb4_routable_clusterip", "Ether", ctx, sizeof(__u32),
+			   LB4_CLUSTERIP_POST_DNAT, sizeof(BUF(LB4_CLUSTERIP_POST_DNAT)));
 
 	test_finish();
 }

--- a/bpf/tests/tc_lb6_clusterip.c
+++ b/bpf/tests/tc_lb6_clusterip.c
@@ -27,6 +27,9 @@
 #include "lib/lb.h"
 #include "scapy.h"
 
+/* For checking statistics in conntrack map. */
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
 /* Test that a request from an external client to a ClusterIP service w/o the
  * `bpf-lb-external-clusterip` flag set is denied. The reason is due to the SVC
  * being created w/o the SVC_FLAG_ROUTABLE flag being set in the bpf map,
@@ -92,6 +95,74 @@ int lb6_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 	BUF_DECL(LB6_CLUSTERIP, lb6_clusterip);
 	ASSERT_CTX_BUF_OFF("lb6_nonroutable_clusterip", "Ether", ctx, sizeof(__u32),
 			   LB6_CLUSTERIP, sizeof(BUF(LB6_CLUSTERIP)));
+
+	test_finish();
+}
+
+/* Test that a request from an external client to a routable ClusterIP service
+ * is allowed. The reason is due to the SVC being created with the SVC_FLAG_ROUTABLE
+ * flag set, leading to the datapath correctly accepting and DNAT the packet.
+ */
+PKTGEN("tc", "tc_lb6_routable_clusterip")
+int lb6_routable_clusterip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB6_CLUSTERIP, lb6_clusterip);
+	BUILDER_PUSH_BUF(builder, LB6_CLUSTERIP);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_lb6_routable_clusterip")
+int lb6_routable_clusterip_setup(struct __ctx_buff *ctx)
+{
+	/* Endpoint and backend added in previous setup, simply change SVC flags. */
+	lb_v6_add_service_with_flags((union v6addr *)FRONTEND_IP, FRONTEND_PORT,
+				     IPPROTO_TCP, BACKEND_COUNT, NAT_REV_INDEX,
+				     SVC_FLAG_ROUTABLE, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_lb6_routable_clusterip")
+int lb6_routable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ct_entry *ct_entry;
+	struct ipv6_ct_tuple tuple = {
+		.saddr   = *(union v6addr *)CLIENT_IP,
+		.daddr   = *(union v6addr *)FRONTEND_IP,
+		.sport   = FRONTEND_PORT,
+		.dport   = CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = TUPLE_F_SERVICE,
+	};
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+
+	assert(data + sizeof(__u32) <= data_end);
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Ensure CT entry is updated accordingly (SVC). */
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	assert(ct_entry);
+	assert(ct_entry->packets == 1);
+	assert(ct_entry->bytes == ctx_full_len(ctx) - sizeof(__u32));
+
+	BUF_DECL(LB6_CLUSTERIP_POST_DNAT, lb6_clusterip_post_dnat);
+	ASSERT_CTX_BUF_OFF("lb6_routable_clusterip", "Ether", ctx, sizeof(__u32),
+			   LB6_CLUSTERIP_POST_DNAT, sizeof(BUF(LB6_CLUSTERIP_POST_DNAT)));
 
 	test_finish();
 }

--- a/pkg/loadbalancer/tests/testdata/clusterip-allowed.txtar
+++ b/pkg/loadbalancer/tests/testdata/clusterip-allowed.txtar
@@ -1,0 +1,107 @@
+#! --bpf-lb-external-clusterip=true --node-port-algorithm=maglev
+
+# This test verifies that ClusterIP services are routable (i.e., can be accessed
+# from outside like a nodeWithoutCilium) when bpf-lb-external-clusterip is enabled.
+# In addition, it verifies that we also see the service entry related to the
+# NodePort algorithm Maglev.
+
+# Start the test application
+hive start
+
+# Add the service and endpoints
+k8s/add service.yaml
+db/cmp services services.table
+k8s/add endpointslice.yaml
+db/cmp backends backends.table 
+db/cmp frontends frontends.table
+
+# Verify that the [loadbalancer.InitWaitFunc] returns.
+test/init-wait
+
+# Check the BPF maps
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Cleanup
+k8s/delete service.yaml endpointslice.yaml
+
+# Check that BPF maps are emptied as otherwise the reconciler might
+# not have yet processed the deletion
+* db/empty services frontends backends
+* lb/maps-empty
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Cluster         SessionAffinity=42s
+
+-- frontends.table --
+Address               Type        ServiceName   PortName   Backends           Status
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP  Done
+
+-- backends.table --
+Address             Instances          Shadows
+10.244.1.1:80/TCP   test/echo (http)
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 42
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  targetRef:
+    kind: Pod
+    name: echo-757d4cb97f-9gmf7
+    namespace: test
+    uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- lbmaps.expected --
+AFF: ID=1 BEID=1
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+MAGLEV: ID=1 INNER=[1(1021)]
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=42 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+sessionAffinity
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+sessionAffinity

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -96,21 +96,6 @@ func testCurlFromPodsFail(kubectl *helpers.Kubectl, clientPodLabel, url string) 
 	}
 }
 
-func curlClusterIPFromExternalHost(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) *helpers.CmdRes {
-	clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, appServiceName)
-	ExpectWithOffset(1, err).Should(BeNil(), "Cannot get service %s", appServiceName)
-	_, err = netip.ParseAddr(clusterIP)
-	ExpectWithOffset(1, err).Should(BeNil(), "Cannot parse IP %q", clusterIP)
-	httpSVCURL := fmt.Sprintf("http://%s/", net.JoinHostPort(clusterIP, "80"))
-
-	By("testing external connectivity via cluster IP %s", clusterIP)
-
-	status := kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName, helpers.CurlFail(httpSVCURL))
-	ExpectWithOffset(1, status).Should(helpers.CMDSuccess(), "cannot curl to service IP from host: %s", status.CombineOutput())
-
-	return kubectl.ExecInHostNetNS(context.TODO(), ni.OutsideNodeName, helpers.CurlFail(httpSVCURL))
-}
-
 func waitPodsDs(kubectl *helpers.Kubectl, groups []string) {
 	for _, pod := range groups {
 		err := kubectl.WaitforPods(helpers.DefaultNamespace, fmt.Sprintf("-l %s", pod), helpers.HelperTimeout)


### PR DESCRIPTION
Complementary PR of https://github.com/cilium/cilium/pull/44192 ✂️ 

Pleaser refer to commit messages:

1. Add script test for the complementary behavior (SVC ClusterIP routable)
2. Add bpf unit test for IPv4/6
3. Remove Ginkgo test.

Related: https://github.com/cilium/cilium/issues/44168.