### PR TITLE
envoy: Add circuit breaker configuration for ingress, egress, and external envoy

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
@@ -167,6 +167,8 @@ staticResources:
     circuitBreakers:
       thresholds:
       - maxRetries: {{ .Values.envoy.maxConcurrentRetries }}
+        maxConnections: {{ .Values.envoy.clusterMaxConnections }}
+        maxRequests: {{ .Values.envoy.clusterMaxRequests }}
     lbPolicy: "CLUSTER_PROVIDED"
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -183,6 +185,8 @@ staticResources:
     circuitBreakers:
       thresholds:
       - maxRetries: {{ .Values.envoy.maxConcurrentRetries }}
+        maxConnections: {{ .Values.envoy.clusterMaxConnections }}
+        maxRequests: {{ .Values.envoy.clusterMaxRequests }}
     lbPolicy: "CLUSTER_PROVIDED"
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -204,6 +208,8 @@ staticResources:
     circuitBreakers:
       thresholds:
       - maxRetries: {{ .Values.envoy.maxConcurrentRetries }}
+        maxConnections: {{ .Values.envoy.clusterMaxConnections }}
+        maxRequests: {{ .Values.envoy.clusterMaxRequests }}
     lbPolicy: "CLUSTER_PROVIDED"
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
@@ -220,6 +226,8 @@ staticResources:
     circuitBreakers:
       thresholds:
       - maxRetries: {{ .Values.envoy.maxConcurrentRetries }}
+        maxConnections: {{ .Values.envoy.clusterMaxConnections }}
+        maxRequests: {{ .Values.envoy.clusterMaxRequests }}
     lbPolicy: "CLUSTER_PROVIDED"
     typedExtensionProtocolOptions:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -451,6 +451,7 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 							TypedConfig: toAny(&cilium.UpstreamTlsWrapperContext{}),
 						},
 					},
+					CircuitBreakers: clusterRetryLimits,
 				},
 				{
 					Name:                          ingressClusterName,
@@ -459,6 +460,7 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 					CleanupInterval:               &durationpb.Duration{Seconds: config.connectTimeout, Nanos: 500000000},
 					LbPolicy:                      envoy_config_cluster.Cluster_CLUSTER_PROVIDED,
 					TypedExtensionProtocolOptions: useDownstreamProtocol,
+					CircuitBreakers:               clusterRetryLimits,
 				},
 				{
 					Name:                          ingressTLSClusterName,
@@ -473,6 +475,7 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 							TypedConfig: toAny(&cilium.UpstreamTlsWrapperContext{}),
 						},
 					},
+					CircuitBreakers: clusterRetryLimits,
 				},
 				{
 					Name:                 CiliumXDSClusterName,


### PR DESCRIPTION
see commits

```release-note
Added circuit breaker configuration (max connections, requests, and retries) for Cilium Envoy ingress, egress, and external envoy.
```
