### PR TITLE
helm/ztunnel: bind health check to localhost

### DIFF
--- a/install/kubernetes/cilium/templates/ztunnel/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/ztunnel/daemonset.yaml
@@ -88,6 +88,7 @@ spec:
             httpGet:
               path: /healthz/ready
               port: {{ .Values.encryption.ztunnel.healthPort }}
+              host: "127.0.0.1"
               scheme: HTTP
             initialDelaySeconds: {{ .Values.encryption.ztunnel.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.encryption.ztunnel.readinessProbe.periodSeconds }}


### PR DESCRIPTION
Add host field to readiness probe to bind the health check port `15021` to `127.0.0.1` instead of `0.0.0.0`. This reduces attack surface by ensuring the health check endpoint is only accessible from localhost (kubelet runs on same node).

Related PR: https://github.com/cilium/ztunnel/pull/2

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
helm/ztunnel: Add host field to readiness probe to bind the health check port 15021 to 127.0.0.1 instead of 0.0.0.0
```
