### PR TITLE
node/address: refactor GetCiliumEndpointNodeIP

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -20,13 +20,11 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func setupIPSecSuitePrivileged(tb testing.TB, ipFamily string) {
 	testutils.PrivilegedTest(tb)
-	node.SetTestLocalNodeStore()
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
 	log = hivetest.Logger(tb)
@@ -42,10 +40,6 @@ func setupIPSecSuitePrivileged(tb testing.TB, ipFamily string) {
 		_, remote, err = net.ParseCIDR("2001:0:0:1234::/64")
 		require.NoError(tb, err)
 	}
-
-	tb.Cleanup(func() {
-		node.UnsetTestLocalNodeStore()
-	})
 }
 
 const (

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -33,7 +33,12 @@ func (n *linuxNodeHandler) GetNodeIP(nodeID uint16) string {
 	// Check for local node ID explicitly as local node IPs are not in our maps!
 	if nodeID == 0 {
 		// Returns local node's IPv4 address if available, IPv6 address otherwise.
-		return node.GetCiliumEndpointNodeIP(n.log)
+		ln, err := n.localNodeStore.Get(context.Background())
+		if err != nil {
+			logging.Fatal(n.log, "failed to retrieve local node")
+		}
+
+		return node.GetCiliumEndpointNodeIP(ln)
 	}
 
 	// Otherwise, return one of the IPs matching the given ID.

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -90,8 +90,6 @@ func setupLinuxPrivilegedBaseTestSuite(tb testing.TB, addressing datapath.NodeAd
 	s.enableIPv6 = enableIPv6
 	s.enableIPv4 = enableIPv4
 
-	node.SetTestLocalNodeStore()
-
 	removeDevice(dummyHostDeviceName)
 	removeDevice(dummyExternalDeviceName)
 
@@ -179,7 +177,6 @@ func setupLinuxPrivilegedIPv4AndIPv6TestSuite(tb testing.TB) *linuxPrivilegedIPv
 }
 
 func tearDownTest(_ testing.TB) {
-	node.UnsetTestLocalNodeStore()
 	removeDevice(dummyHostDeviceName)
 	removeDevice(dummyExternalDeviceName)
 }

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -74,13 +73,10 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	client := kvstore.SetupDummy(tb, "etcd")
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	<-s.mgr.InitIdentityAllocator(nil, client)
-	node.SetTestLocalNodeStore()
 
 	tb.Cleanup(func() {
 		metrics.NewLegacyMetrics().EndpointStateCount.SetEnabled(false)
-
 		s.mgr.Close()
-		node.UnsetTestLocalNodeStore()
 	})
 
 	return s

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1050,8 +1050,6 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 					e.runlock()
 					return nil
 				}
-				logger := e.getLogger()
-
 				ln, err := e.localNodeStore.Get(ctx)
 				if err != nil {
 					e.runlock()
@@ -1059,7 +1057,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				}
 
 				ID := e.SecurityIdentity.ID
-				hostIP, err := netip.ParseAddr(node.GetCiliumEndpointNodeIP(logger))
+				hostIP, err := netip.ParseAddr(node.GetCiliumEndpointNodeIP(ln))
 				if err != nil {
 					e.runlock()
 					return controller.NewExitReason("Failed to get node IP")

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -122,6 +122,11 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 					return fmt.Errorf("Kubernetes apiserver is not available")
 				}
 
+				ln, err := epSync.localNodeStore.Get(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get local node: %w", err)
+				}
+
 				cepOwner := e.GetCEPOwner()
 				if cepOwner.IsNil() {
 					scopedLog.Debug("Skipping CiliumEndpoint update because it has no k8s namespace")
@@ -171,7 +176,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 								if err != nil {
 									scopedLog.Debug("Error getting CES store", logfields.Error, err)
 								} else {
-									nodeIP := node.GetCiliumEndpointNodeIP(scopedLog)
+									nodeIP := node.GetCiliumEndpointNodeIP(ln)
 									// Get all CES objects for this node
 									objs, err := cesStore.ByIndex("localNode", nodeIP)
 									if err != nil {
@@ -202,7 +207,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 								if err != nil {
 									scopedLog.Debug("Error getting CEP store", logfields.Error, err)
 								} else {
-									nodeIP := node.GetCiliumEndpointNodeIP(scopedLog)
+									nodeIP := node.GetCiliumEndpointNodeIP(ln)
 									objs, err := cepStore.ByIndex("localNode", nodeIP)
 									if err != nil {
 										scopedLog.Debug("Error getting indexed CiliumEndpoint from store", logfields.Error, err)

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -4,6 +4,7 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -369,9 +370,7 @@ func transformEndpoint(logger *slog.Logger, obj any) (any, error) {
 // CiliumSlimEndpointResource uses the "localNode" IndexFunc to build the resource indexer.
 // The IndexFunc accesses the local node info to get its IP, so it depends on the local node store
 // to initialize it before the first access.
-// To reflect this, the node.LocalNodeStore dependency is explicitly requested in the function
-// signature.
-func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeStore, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
+func CiliumSlimEndpointResource(params CiliumResourceParams, localNodeStore *node.LocalNodeStore, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*types.CiliumEndpoint], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -381,7 +380,7 @@ func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeSt
 	)
 	indexers := cache.Indexers{
 		"localNode": func(obj any) ([]string, error) {
-			return ciliumEndpointLocalPodIndexFunc(params.Logger, obj)
+			return ciliumEndpointLocalPodIndexFunc(params.Logger, localNodeStore, obj)
 		},
 	}
 	return resource.New[*types.CiliumEndpoint](params.Lifecycle, lw, params.MetricsProvider,
@@ -396,7 +395,7 @@ func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeSt
 
 // ciliumEndpointLocalPodIndexFunc is an IndexFunc that indexes only local
 // CiliumEndpoints, by their local Node IP.
-func ciliumEndpointLocalPodIndexFunc(logger *slog.Logger, obj any) ([]string, error) {
+func ciliumEndpointLocalPodIndexFunc(logger *slog.Logger, localNodeStore *node.LocalNodeStore, obj any) ([]string, error) {
 	cep, ok := obj.(*types.CiliumEndpoint)
 	if !ok {
 		return nil, fmt.Errorf("unexpected object type: %T", obj)
@@ -409,7 +408,11 @@ func ciliumEndpointLocalPodIndexFunc(logger *slog.Logger, obj any) ([]string, er
 		)
 		return nil, nil
 	}
-	if cep.Networking.NodeIP == node.GetCiliumEndpointNodeIP(logger) {
+	ln, err := localNodeStore.Get(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local node: %w", err)
+	}
+	if cep.Networking.NodeIP == node.GetCiliumEndpointNodeIP(ln) {
 		indices = append(indices, cep.Networking.NodeIP)
 	}
 	return indices, nil
@@ -418,9 +421,7 @@ func ciliumEndpointLocalPodIndexFunc(logger *slog.Logger, obj any) ([]string, er
 // CiliumEndpointSliceResource uses the "localNode" IndexFunc to build the resource indexer.
 // The IndexFunc accesses the local node info to get its IP, so it depends on the local node store
 // to initialize it before the first access.
-// To reflect this, the node.LocalNodeStore dependency is explicitly requested in the function
-// signature.
-func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeStore, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+func CiliumEndpointSliceResource(params CiliumResourceParams, localNodeStore *node.LocalNodeStore, mp workqueue.MetricsProvider, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
 	if !params.ClientSet.IsEnabled() {
 		return nil, nil
 	}
@@ -430,7 +431,7 @@ func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeS
 	)
 	indexers := cache.Indexers{
 		"localNode": func(obj any) ([]string, error) {
-			return ciliumEndpointSliceLocalPodIndexFunc(params.Logger, obj)
+			return ciliumEndpointSliceLocalPodIndexFunc(localNodeStore, obj)
 		},
 	}
 	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](params.Lifecycle, lw, params.MetricsProvider,
@@ -442,14 +443,19 @@ func CiliumEndpointSliceResource(params CiliumResourceParams, _ *node.LocalNodeS
 
 // ciliumEndpointSliceLocalPodIndexFunc is an IndexFunc that indexes CiliumEndpointSlices
 // by their corresponding Pod, which are running locally on this Node.
-func ciliumEndpointSliceLocalPodIndexFunc(logger *slog.Logger, obj any) ([]string, error) {
+func ciliumEndpointSliceLocalPodIndexFunc(localNodeStore *node.LocalNodeStore, obj any) ([]string, error) {
 	ces, ok := obj.(*cilium_api_v2alpha1.CiliumEndpointSlice)
 	if !ok {
 		return nil, fmt.Errorf("unexpected object type: %T", obj)
 	}
+
+	ln, err := localNodeStore.Get(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local node: %w", err)
+	}
 	indices := []string{}
 	for _, ep := range ces.Endpoints {
-		if ep.Networking.NodeIP == node.GetCiliumEndpointNodeIP(logger) {
+		if ep.Networking.NodeIP == node.GetCiliumEndpointNodeIP(ln) {
 			indices = append(indices, ep.Networking.NodeIP)
 			break
 		}

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -177,12 +177,11 @@ func setDefaultPrefix(logger *slog.Logger, cfg *option.DaemonConfig, device stri
 
 // GetCiliumEndpointNodeIP is the node IP that will be referenced by CiliumEndpoints with endpoints
 // running on this node.
-func GetCiliumEndpointNodeIP(logger *slog.Logger) string {
-	n := getLocalNode(logger)
-	if option.Config.EnableIPv4 && n.Local.UnderlayProtocol == tunnel.IPv4 {
-		return n.GetNodeIP(false).String()
+func GetCiliumEndpointNodeIP(localNode LocalNode) string {
+	if option.Config.EnableIPv4 && localNode.Local.UnderlayProtocol == tunnel.IPv4 {
+		return localNode.GetNodeIP(false).String()
 	}
-	return n.GetNodeIP(true).String()
+	return localNode.GetNodeIP(true).String()
 }
 
 // GetRouterInfo returns additional information for the router, the cilium_host interface.
@@ -269,18 +268,4 @@ func GetEndpointEncryptKeyIndex(localNode LocalNode, wgEnabled, ipsecEnabled boo
 
 	}
 	return 0
-}
-
-func SetTestLocalNodeStore() {
-	if localNode != nil {
-		panic("localNode already set")
-	}
-
-	// Set the localNode global variable temporarily so that the legacy getters
-	// and setters can access it.
-	localNode = NewTestLocalNodeStore(LocalNode{})
-}
-
-func UnsetTestLocalNodeStore() {
-	localNode = nil
 }


### PR DESCRIPTION
Currently, the global function `node.GetCiliumEndpointNodeIP` uses the global `LocalNodeStore` instance to retrieve the local node.

In preparation to eventually get rid of the global field that holds the local node store, this commit refactors the function `GetCiliumEndpointNodeIP` to expect the local node store to be passed as an argument.

This also allows us to get rid of some test related helper functions and makes dependencies explicit.

Note: Not all refactored places properly support context propagation and error handling. For this places, we currently use `context.Background()` and `logging.Fatal`. This is similar to what already happened under the hood.

Note 2: In a later step we might want to refactor the function into a
method of the `LocalNode`. I hesitate to do it in this commit because
IMO it's more endpoint than node related :/
