### PR TITLE
nodemap: converted net.IP to netip.Addr, Part of #24246

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -206,9 +207,9 @@ func (n *linuxNodeHandler) deallocateNodeIDLocked(nodeID uint16, nodeIPs map[str
 // Node Manager and in the corresponding BPF map. If any of those map updates
 // fail, both are cancelled and the function returns an error.
 func (n *linuxNodeHandler) mapNodeID(ip string, id uint16, SPI uint8) error {
-	nodeIP := net.ParseIP(ip)
-	if nodeIP == nil {
-		return fmt.Errorf("invalid node IP %s", ip)
+	nodeIP, err := netip.ParseAddr(ip)
+	if err != nil {
+		return fmt.Errorf("invalid node IP %s: %w", ip, err)
 	}
 
 	if err := n.nodeMap.Update(nodeIP, id, SPI); err != nil {
@@ -231,9 +232,9 @@ func (n *linuxNodeHandler) unmapNodeID(ip string) error {
 	if _, exists := n.nodeIDsByIPs[ip]; !exists {
 		return fmt.Errorf("cannot remove IP %s from node ID map as it doesn't exist", ip)
 	}
-	nodeIP := net.ParseIP(ip)
-	if nodeIP == nil {
-		return fmt.Errorf("invalid node IP %s", ip)
+	nodeIP, err := netip.ParseAddr(ip)
+	if err != nil {
+		return fmt.Errorf("invalid node IP %s: %w", ip, err)
 	}
 
 	if err := n.nodeMap.Delete(nodeIP); err != nil {

--- a/pkg/maps/nodemap/fake/node_map_v2.go
+++ b/pkg/maps/nodemap/fake/node_map_v2.go
@@ -5,23 +5,23 @@ package fake
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
 type fakeNodeMapV2 struct {
-	ids map[string]nodemap.NodeValueV2
+	ids map[netip.Addr]nodemap.NodeValueV2
 }
 
 func NewFakeNodeMapV2() *fakeNodeMapV2 {
 	return &fakeNodeMapV2{
-		ids: map[string]nodemap.NodeValueV2{},
+		ids: map[netip.Addr]nodemap.NodeValueV2{},
 	}
 }
 
-func (f fakeNodeMapV2) Update(ip net.IP, nodeID uint16, SPI uint8) error {
-	f.ids[ip.String()] = nodemap.NodeValueV2{
+func (f fakeNodeMapV2) Update(ip netip.Addr, nodeID uint16, SPI uint8) error {
+	f.ids[ip] = nodemap.NodeValueV2{
 		NodeID: nodeID,
 		SPI:    SPI,
 	}
@@ -32,14 +32,14 @@ func (f fakeNodeMapV2) Size() uint32 {
 	return nodemap.DefaultMaxEntries
 }
 
-func (f fakeNodeMapV2) Delete(ip net.IP) error {
-	delete(f.ids, ip.String())
+func (f fakeNodeMapV2) Delete(ip netip.Addr) error {
+	delete(f.ids, ip)
 	return nil
 }
 
 // This function is used only for tests.
-func (f fakeNodeMapV2) Lookup(ip net.IP) (*nodemap.NodeValueV2, error) {
-	if nodeValue, exists := f.ids[ip.String()]; exists {
+func (f fakeNodeMapV2) Lookup(ip netip.Addr) (*nodemap.NodeValueV2, error) {
+	if nodeValue, exists := f.ids[ip]; exists {
 		return &nodeValue, nil
 	}
 	return nil, fmt.Errorf("IP not found in node ID map")

--- a/pkg/maps/nodemap/node_map_v2_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_v2_privileged_test.go
@@ -5,6 +5,7 @@ package nodemap
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/ebpf/rlimit"
@@ -49,9 +50,9 @@ func TestPrivilegedNodeMapV2(t *testing.T) {
 	require.Empty(t, bpfNodeIDMap)
 	require.Empty(t, bpfNodeSPI)
 
-	err = nodeMap.Update(net.ParseIP("10.1.0.0"), 10, 3)
+	err = nodeMap.Update(netip.MustParseAddr("10.1.0.0"), 10, 3)
 	require.NoError(t, err)
-	err = nodeMap.Update(net.ParseIP("10.1.0.1"), 20, 3)
+	err = nodeMap.Update(netip.MustParseAddr("10.1.0.1"), 20, 3)
 	require.NoError(t, err)
 
 	bpfNodeIDMap = map[uint16]string{}
@@ -61,7 +62,7 @@ func TestPrivilegedNodeMapV2(t *testing.T) {
 	require.Len(t, bpfNodeIDMap, 2)
 	require.Len(t, bpfNodeSPI, 2)
 
-	err = nodeMap.Delete(net.ParseIP("10.1.0.0"))
+	err = nodeMap.Delete(netip.MustParseAddr("10.1.0.0"))
 	require.NoError(t, err)
 
 	bpfNodeIDMap = map[uint16]string{}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->
This change migrates the node map API from net.IP to netip.Addr, updating the public interface and conversion logic while preserving the underlying eBPF map ABI.

The kernel-facing data structures remain unchanged and existing tests have been updated accordingly.

For: #24246 

```release-note
Migrated node map IP handling from net.IP to netip.Addr for improved performance and safety.
```
