### PR TITLE
loader: XDP attach type fallback logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/cilium/charts v0.0.0-20260213195402-3d62b3c13114
 	github.com/cilium/coverbee v0.3.3-0.20240723084546-664438750fce
 	github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
-	github.com/cilium/ebpf v0.20.1-0.20260108141042-f7e80f49188b
+	github.com/cilium/ebpf v0.20.1-0.20260218191617-ee67e7f43dd9
 	github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c
 	github.com/cilium/fake v0.7.0
 	github.com/cilium/hive v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62 h1:MOWY9eqnrr
 github.com/cilium/deepequal-gen v0.0.0-20241016021505-f57df2fe2e62/go.mod h1:9EU8oWNwEP6f98xJz/YjWw7yOLHK7p90MKmaPu1wBcE=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
-github.com/cilium/ebpf v0.20.1-0.20260108141042-f7e80f49188b h1:ubt7adiPfM2/6QrjNI8T+LAe4J7KHVkAMbEJ3+LLTXk=
-github.com/cilium/ebpf v0.20.1-0.20260108141042-f7e80f49188b/go.mod h1:dM+AMI6FkW5LOkzikdefUmzK0z81o7GqiKXon7D1F58=
+github.com/cilium/ebpf v0.20.1-0.20260218191617-ee67e7f43dd9 h1:hQW7n5ePt/HDgeZLcyT3pFENyfa6vmaGU7M+tq2pa64=
+github.com/cilium/ebpf v0.20.1-0.20260218191617-ee67e7f43dd9/go.mod h1:EGj6HpG/oejvbTAsMWwlA4UbMU7WBAgILd+9OSvcDTc=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba h1:Ddc5e+pz0/nY0XiAEW/UcIlvnaHACSuF77ePyMNX510=
 github.com/cilium/endpointslice v0.29.4-0.20240409195643-982ad68ab7ba/go.mod h1:9MPoeojWVEBLFnioKXTvRoqGWTs9Dt252r1ACFsi8K8=
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1:+/SPdDam5Mha4QzOByEoBE7hfq8aUxnioItyKM48U6M=

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1869,4 +1869,8 @@ const (
 	BackendTLSPolicyName = "backendTLSPolicyName"
 
 	ConfigMapName = "configMapName"
+
+	AttachType = "attachType"
+
+	WithFrags = "withFrags"
 )

--- a/vendor/github.com/cilium/ebpf/Makefile
+++ b/vendor/github.com/cilium/ebpf/Makefile
@@ -36,10 +36,16 @@ endif
 IMAGE := $(shell cat ${REPODIR}/testdata/docker/IMAGE)
 VERSION := $(shell cat ${REPODIR}/testdata/docker/VERSION)
 
+TARGETS_EL := \
+	testdata/linked1 \
+	testdata/linked2 \
+	testdata/linked
+
 TARGETS := \
 	testdata/loader-clang-14 \
 	testdata/loader-clang-17 \
 	testdata/loader-$(CLANG) \
+	testdata/loader_nobtf \
 	testdata/manyprogs \
 	testdata/btf_map_init \
 	testdata/invalid_map \
@@ -70,6 +76,8 @@ TARGETS := \
 	btf/testdata/tags \
 	cmd/bpf2go/testdata/minimal
 
+HEADERS := $(wildcard testdata/*.h)
+
 .PHONY: all clean container-all container-shell generate
 
 .DEFAULT_TARGET = container-all
@@ -93,7 +101,7 @@ clean:
 format:
 	find . -type f -name "*.c" | xargs clang-format -i
 
-all: format $(addsuffix -el.elf,$(TARGETS)) $(addsuffix -eb.elf,$(TARGETS)) update-external-deps
+all: format testdata update-external-deps
 	ln -srf testdata/loader-$(CLANG)-el.elf testdata/loader-el.elf
 	ln -srf testdata/loader-$(CLANG)-eb.elf testdata/loader-eb.elf
 	$(MAKE) generate
@@ -103,21 +111,32 @@ generate:
 	go generate -run "gentypes" ./...
 	go generate -skip "(gentypes|stringer)" ./...
 
-testdata/loader-%-el.elf: testdata/loader.c
+testdata: $(addsuffix -el.elf,$(TARGETS)) $(addsuffix -eb.elf,$(TARGETS)) $(addsuffix -el.elf,$(TARGETS_EL))
+
+testdata/loader-%-el.elf: testdata/loader.c $(HEADERS)
 	$* $(CFLAGS) -target bpfel -c $< -o $@
 	$(STRIP) -g $@
 
-testdata/loader-%-eb.elf: testdata/loader.c
+testdata/loader-%-eb.elf: testdata/loader.c $(HEADERS)
 	$* $(CFLAGS) -target bpfeb -c $< -o $@
 	$(STRIP) -g $@
 
-%-el.elf: %.c
+testdata/loader_nobtf-el.elf: testdata/loader.c $(HEADERS)
+	$(CLANG) $(CFLAGS) -g0 -D__NOBTF__ -target bpfel -c $< -o $@
+
+testdata/loader_nobtf-eb.elf: testdata/loader.c $(HEADERS)
+	$(CLANG) $(CFLAGS) -g0 -D__NOBTF__ -target bpfeb -c $< -o $@
+
+%-el.elf: %.c $(HEADERS)
 	$(CLANG) $(CFLAGS) -target bpfel -c $< -o $@
 	$(STRIP) -g $@
 
-%-eb.elf : %.c
+%-eb.elf: %.c $(HEADERS)
 	$(CLANG) $(CFLAGS) -target bpfeb -c $< -o $@
 	$(STRIP) -g $@
+
+testdata/linked-el.elf: testdata/linked1-el.elf testdata/linked2-el.elf
+	bpftool gen object $@ $^
 
 .PHONY: update-external-deps
 update-external-deps:

--- a/vendor/github.com/cilium/ebpf/asm/instruction.go
+++ b/vendor/github.com/cilium/ebpf/asm/instruction.go
@@ -2,10 +2,12 @@ package asm
 
 import (
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"math"
 	"sort"
@@ -41,6 +43,14 @@ type Instruction struct {
 
 	// Metadata contains optional metadata about this instruction.
 	Metadata Metadata
+}
+
+// Width returns how many raw BPF instructions the Instruction occupies within
+// an instruction stream. For example, an Instruction encoding a 64-bit value
+// will typically occupy 2 raw instructions, while a 32-bit constant can be
+// encoded in a single raw instruction.
+func (ins *Instruction) Width() RawInstructionOffset {
+	return RawInstructionOffset(ins.OpCode.rawInstructions())
 }
 
 // Unmarshal decodes a BPF instruction.
@@ -745,18 +755,72 @@ func (insns Instructions) Marshal(w io.Writer, bo binary.ByteOrder) error {
 // It mirrors bpf_prog_calc_tag in the kernel and so can be compared
 // to ProgramInfo.Tag to figure out whether a loaded program matches
 // certain instructions.
+//
+// Deprecated: The value produced by this method no longer matches tags produced
+// by the kernel since Linux 6.18. Use [Instructions.HasTag] instead.
 func (insns Instructions) Tag(bo binary.ByteOrder) (string, error) {
+	// We cannot determine which hashing function to use without probing the kernel.
+	// So use the legacy SHA-1 implementation and deprecate this method.
+	return insns.tagSha1(bo)
+}
+
+// HasTag returns true if the given tag matches the kernel tag of insns.
+func (insns Instructions) HasTag(tag string, bo binary.ByteOrder) (bool, error) {
+	sha256Tag, err := insns.tagSha256(bo)
+	if err != nil {
+		return false, fmt.Errorf("hashing sha256: %w", err)
+	}
+	if tag == sha256Tag {
+		return true, nil
+	}
+
+	sha1Tag, err := insns.tagSha1(bo)
+	if err != nil {
+		return false, fmt.Errorf("hashing sha1: %w", err)
+	}
+
+	return tag == sha1Tag, nil
+}
+
+// tagSha1 calculates the kernel tag for a series of instructions.
+//
+// It mirrors bpf_prog_calc_tag in kernels up to v6.18 and can be compared to
+// ProgramInfo.Tag to figure out whether a loaded Program matches insns.
+func (insns Instructions) tagSha1(bo binary.ByteOrder) (string, error) {
 	h := sha1.New()
+	if err := insns.hash(h, bo); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)[:sys.BPF_TAG_SIZE]), nil
+}
+
+// tagSha256 calculates the kernel tag for a series of instructions.
+//
+// It mirrors bpf_prog_calc_tag in the kernel and can be compared to
+// ProgramInfo.Tag to figure out whether a loaded Program matches insns.
+func (insns Instructions) tagSha256(bo binary.ByteOrder) (string, error) {
+	h := sha256.New()
+	if err := insns.hash(h, bo); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)[:sys.BPF_TAG_SIZE]), nil
+}
+
+// hash calculates the hash of the instruction stream. Map load instructions
+// are zeroed out, since these contain map file descriptors or pointers to
+// maps, which will be different from load to load and would make the hash
+// non-deterministic.
+func (insns Instructions) hash(h hash.Hash, bo binary.ByteOrder) error {
 	for i, ins := range insns {
 		if ins.IsLoadFromMap() {
 			ins.Constant = 0
 		}
 		_, err := ins.Marshal(h, bo)
 		if err != nil {
-			return "", fmt.Errorf("instruction %d: %w", i, err)
+			return fmt.Errorf("instruction %d: %w", i, err)
 		}
 	}
-	return hex.EncodeToString(h.Sum(nil)[:sys.BPF_TAG_SIZE]), nil
+	return nil
 }
 
 // encodeFunctionReferences populates the Offset (or Constant, depending on

--- a/vendor/github.com/cilium/ebpf/btf/dedup.go
+++ b/vendor/github.com/cilium/ebpf/btf/dedup.go
@@ -1,0 +1,633 @@
+package btf
+
+import (
+	"errors"
+	"fmt"
+	"hash/maphash"
+	"slices"
+)
+
+// deduper deduplicates BTF types by finding all types in a Type graph that are
+// Equivalent and replaces them with a single instance.
+//
+// See doc comments in types.go to understand the various ways in which Types
+// can relate to each other and how they are compared for equality. We separate
+// Identity (same memory location), Equivalence (same shape/layout), and
+// Compatibility (CO-RE compatible) to be explicit about intent.
+//
+// This deduper opportunistically uses a combination of Identity and Equivalence
+// to find types that can be deduplicated.
+type deduper struct {
+	visited   map[Type]struct{}
+	hashCache map[hashCacheKey]uint64
+
+	// Set of types that have been deduplicated.
+	done map[Type]Type
+
+	// Map of hash to types with that hash.
+	hashed  map[uint64][]Type
+	eqCache map[typKey]bool
+
+	seed maphash.Seed
+}
+
+func newDeduper() *deduper {
+	return &deduper{
+		make(map[Type]struct{}),
+		make(map[hashCacheKey]uint64),
+		make(map[Type]Type),
+		make(map[uint64][]Type),
+		make(map[typKey]bool),
+		maphash.MakeSeed(),
+	}
+}
+
+func (d *deduper) deduplicate(t Type) (Type, error) {
+	// If we have already attempted to deduplicate this exact type, return the
+	// result.
+	if done, ok := d.done[t]; ok {
+		return done, nil
+	}
+
+	// Visit the subtree, if a type has children, attempt to replace it with a
+	// deduplicated version of those children.
+	for t := range postorder(t, d.visited) {
+		for c := range children(t) {
+			var err error
+			*c, err = d.hashInsert(*c)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Finally, deduplicate the root type itself.
+	return d.hashInsert(t)
+}
+
+// hashInsert attempts to deduplicate t by hashing it and comparing against
+// other types with the same hash. Returns the Type to be used as the common
+// substitute at this position in the graph.
+func (d *deduper) hashInsert(t Type) (Type, error) {
+	// If we have deduplicated this type before, return the result of that
+	// deduplication.
+	if done, ok := d.done[t]; ok {
+		return done, nil
+	}
+
+	// Compute the hash of this type. Types with the same hash are candidates for
+	// deduplication.
+	hash, err := d.hash(t, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	// A hash collision is possible, so we need to compare against all candidates
+	// with the same hash.
+	for _, candidate := range d.hashed[hash] {
+		// Pre-size the visited slice, experimentation on VMLinux shows a capacity
+		// of 16 to give the best performance.
+		const visitedCapacity = 16
+		err := d.typesEquivalent(candidate, t, make([]Type, 0, visitedCapacity))
+		if errors.Is(err, errNotEquivalent) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Found a Type that's both Equivalent and hashes to the same value, choose
+		// it as the deduplicated version.
+		d.done[t] = candidate
+
+		return candidate, nil
+	}
+
+	d.hashed[hash] = append(d.hashed[hash], t)
+
+	return t, nil
+}
+
+// The hash of a Type is the same given its pointer and depth budget.
+type hashCacheKey struct {
+	t           Type
+	depthBudget int
+}
+
+// hash computes a hash for t. The produced hash is the same for Types which
+// are similar. The hash can collide such that two different Types may produce
+// the same hash, so equivalence must be checked explicitly. It will recurse
+// into children. The initial call should use a depthBudget of -1.
+func (d *deduper) hash(t Type, depthBudget int) (uint64, error) {
+	if depthBudget == 0 {
+		return 0, nil
+	}
+
+	h := &maphash.Hash{}
+	h.SetSeed(d.seed)
+
+	switch t := t.(type) {
+	case *Void:
+		maphash.WriteComparable(h, kindUnknown)
+
+	case *Int:
+		maphash.WriteComparable(h, kindInt)
+		maphash.WriteComparable(h, *t)
+
+	case *Pointer:
+		maphash.WriteComparable(h, kindPointer)
+		// If the depth budget is positive, decrement it every time we follow a
+		// pointer.
+		if depthBudget > 0 {
+			depthBudget--
+		}
+
+		// If this is the first time we are following a pointer, set the depth
+		// budget. This limits amount of recursion we do when hashing pointers that
+		// form cycles. This is cheaper than tracking visited types and works
+		// because hash collisions are allowed.
+		if depthBudget < 0 {
+			depthBudget = 1
+
+			// Double pointers are common in C. However, with a depth budget of 1, all
+			// double pointers would hash the same, causing a performance issue when
+			// checking equivalence. So we give double pointers a bit more budget.
+			if _, ok := t.Target.(*Pointer); ok {
+				depthBudget = 2
+			}
+		}
+		sub, err := d.hash(t.Target, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Array:
+		maphash.WriteComparable(h, kindArray)
+		maphash.WriteComparable(h, t.Nelems)
+		sub, err := d.hash(t.Index, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+		_, err = d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Struct, *Union:
+		// Check the cache to avoid recomputing the hash for this type and depth
+		// budget.
+		key := hashCacheKey{t, depthBudget}
+		if cached, ok := d.hashCache[key]; ok {
+			return cached, nil
+		}
+
+		var members []Member
+		switch t := t.(type) {
+		case *Struct:
+			maphash.WriteComparable(h, kindStruct)
+			maphash.WriteComparable(h, t.Name)
+			maphash.WriteComparable(h, t.Size)
+			members = t.Members
+
+		case *Union:
+			maphash.WriteComparable(h, kindUnion)
+			maphash.WriteComparable(h, t.Name)
+			maphash.WriteComparable(h, t.Size)
+			members = t.Members
+		}
+
+		maphash.WriteComparable(h, len(members))
+		for _, m := range members {
+			maphash.WriteComparable(h, m.Name)
+			maphash.WriteComparable(h, m.Offset)
+			sub, err := d.hash(m.Type, depthBudget)
+			if err != nil {
+				return 0, err
+			}
+			maphash.WriteComparable(h, sub)
+		}
+
+		sum := h.Sum64()
+		d.hashCache[key] = sum
+		return sum, nil
+
+	case *Enum:
+		maphash.WriteComparable(h, kindEnum)
+		maphash.WriteComparable(h, t.Name)
+		maphash.WriteComparable(h, t.Size)
+		maphash.WriteComparable(h, t.Signed)
+		for _, v := range t.Values {
+			maphash.WriteComparable(h, v)
+		}
+
+	case *Fwd:
+		maphash.WriteComparable(h, kindForward)
+		maphash.WriteComparable(h, *t)
+
+	case *Typedef:
+		maphash.WriteComparable(h, kindTypedef)
+		maphash.WriteComparable(h, t.Name)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Volatile:
+		maphash.WriteComparable(h, kindVolatile)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Const:
+		maphash.WriteComparable(h, kindConst)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Restrict:
+		maphash.WriteComparable(h, kindRestrict)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Func:
+		maphash.WriteComparable(h, kindFunc)
+		maphash.WriteComparable(h, t.Name)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *FuncProto:
+		// It turns out that pointers to function prototypes are common in C code,
+		// function pointers. Function prototypes frequently have similar patterns
+		// of [ptr, ptr] -> int, or [ptr, ptr, ptr] -> int. Causing frequent hash
+		// collisions, for the default depth budget of 1. So allow one additional
+		// level of pointers when we encounter a function prototype.
+		if depthBudget >= 0 {
+			depthBudget++
+		}
+
+		maphash.WriteComparable(h, kindFuncProto)
+		for _, p := range t.Params {
+			maphash.WriteComparable(h, p.Name)
+			sub, err := d.hash(p.Type, depthBudget)
+			if err != nil {
+				return 0, err
+			}
+			maphash.WriteComparable(h, sub)
+		}
+		sub, err := d.hash(t.Return, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Var:
+		maphash.WriteComparable(h, kindVar)
+		maphash.WriteComparable(h, t.Name)
+		maphash.WriteComparable(h, t.Linkage)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Datasec:
+		maphash.WriteComparable(h, kindDatasec)
+		maphash.WriteComparable(h, t.Name)
+		for _, v := range t.Vars {
+			maphash.WriteComparable(h, v.Offset)
+			maphash.WriteComparable(h, v.Size)
+			sub, err := d.hash(v.Type, depthBudget)
+			if err != nil {
+				return 0, err
+			}
+			maphash.WriteComparable(h, sub)
+		}
+
+	case *declTag:
+		maphash.WriteComparable(h, kindDeclTag)
+		maphash.WriteComparable(h, t.Value)
+		maphash.WriteComparable(h, t.Index)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *TypeTag:
+		maphash.WriteComparable(h, kindTypeTag)
+		maphash.WriteComparable(h, t.Value)
+		sub, err := d.hash(t.Type, depthBudget)
+		if err != nil {
+			return 0, err
+		}
+		maphash.WriteComparable(h, sub)
+
+	case *Float:
+		maphash.WriteComparable(h, kindFloat)
+		maphash.WriteComparable(h, *t)
+
+	default:
+		return 0, fmt.Errorf("unsupported type for hashing: %T", t)
+	}
+
+	return h.Sum64(), nil
+}
+
+type typKey struct {
+	a Type
+	b Type
+}
+
+var errNotEquivalent = errors.New("types are not equivalent")
+
+// typesEquivalent checks if two types are Equivalent.
+func (d *deduper) typesEquivalent(ta, tb Type, visited []Type) error {
+	// Fast path: if Types are Identical, they are also Equivalent.
+	if ta == tb {
+		return nil
+	}
+
+	switch a := ta.(type) {
+	case *Void:
+		if _, ok := tb.(*Void); ok {
+			return nil
+		}
+		return errNotEquivalent
+
+	case *Int:
+		b, ok := tb.(*Int)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name || a.Size != b.Size || a.Encoding != b.Encoding {
+			return errNotEquivalent
+		}
+		return nil
+
+	case *Enum:
+		b, ok := tb.(*Enum)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name || len(a.Values) != len(b.Values) {
+			return errNotEquivalent
+		}
+		for i := range a.Values {
+			if a.Values[i].Name != b.Values[i].Name || a.Values[i].Value != b.Values[i].Value {
+				return errNotEquivalent
+			}
+		}
+		return nil
+
+	case *Fwd:
+		b, ok := tb.(*Fwd)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name || a.Kind != b.Kind {
+			return errNotEquivalent
+		}
+		return nil
+
+	case *Float:
+		b, ok := tb.(*Float)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name || a.Size != b.Size {
+			return errNotEquivalent
+		}
+		return nil
+
+	case *Array:
+		b, ok := tb.(*Array)
+		if !ok {
+			return errNotEquivalent
+		}
+
+		if a.Nelems != b.Nelems {
+			return errNotEquivalent
+		}
+		if err := d.typesEquivalent(a.Index, b.Index, visited); err != nil {
+			return err
+		}
+		if err := d.typesEquivalent(a.Type, b.Type, visited); err != nil {
+			return err
+		}
+		return nil
+
+	case *Pointer:
+		b, ok := tb.(*Pointer)
+		if !ok {
+			return errNotEquivalent
+		}
+
+		// Detect cycles by tracking visited types. Assume types are Equivalent if
+		// we have already visited this type in the current Equivalence check.
+		if slices.Contains(visited, ta) {
+			return nil
+		}
+		visited = append(visited, ta)
+
+		return d.typesEquivalent(a.Target, b.Target, visited)
+
+	case *Struct, *Union:
+		// Use a cache to avoid recomputation. We only do this for composite types
+		// since they are where types fan out the most. For other types, the
+		// overhead of the lookup and update outweighs performance benefits.
+		cacheKey := typKey{a: ta, b: tb}
+		if equal, ok := d.eqCache[cacheKey]; ok {
+			if equal {
+				return nil
+			}
+			return errNotEquivalent
+		}
+
+		compErr := d.compositeEquivalent(ta, tb, visited)
+		d.eqCache[cacheKey] = compErr == nil
+
+		return compErr
+
+	case *Typedef:
+		b, ok := tb.(*Typedef)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name {
+			return errNotEquivalent
+		}
+		return d.typesEquivalent(a.Type, b.Type, visited)
+
+	case *Volatile:
+		b, ok := tb.(*Volatile)
+		if !ok {
+			return errNotEquivalent
+		}
+		return d.typesEquivalent(a.Type, b.Type, visited)
+
+	case *Const:
+		b, ok := tb.(*Const)
+		if !ok {
+			return errNotEquivalent
+		}
+		return d.typesEquivalent(a.Type, b.Type, visited)
+
+	case *Restrict:
+		b, ok := tb.(*Restrict)
+		if !ok {
+			return errNotEquivalent
+		}
+		return d.typesEquivalent(a.Type, b.Type, visited)
+
+	case *Func:
+		b, ok := tb.(*Func)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name {
+			return errNotEquivalent
+		}
+		return d.typesEquivalent(a.Type, b.Type, visited)
+
+	case *FuncProto:
+		b, ok := tb.(*FuncProto)
+		if !ok {
+			return errNotEquivalent
+		}
+
+		if err := d.typesEquivalent(a.Return, b.Return, visited); err != nil {
+			return err
+		}
+		if len(a.Params) != len(b.Params) {
+			return errNotEquivalent
+		}
+		for i := range a.Params {
+			if a.Params[i].Name != b.Params[i].Name {
+				return errNotEquivalent
+			}
+			if err := d.typesEquivalent(a.Params[i].Type, b.Params[i].Type, visited); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case *Var:
+		b, ok := tb.(*Var)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name {
+			return errNotEquivalent
+		}
+		if err := d.typesEquivalent(a.Type, b.Type, visited); err != nil {
+			return err
+		}
+		if a.Linkage != b.Linkage {
+			return errNotEquivalent
+		}
+		return nil
+
+	case *Datasec:
+		b, ok := tb.(*Datasec)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Name != b.Name || len(a.Vars) != len(b.Vars) {
+			return errNotEquivalent
+		}
+		for i := range a.Vars {
+			if a.Vars[i].Offset != b.Vars[i].Offset ||
+				a.Vars[i].Size != b.Vars[i].Size {
+				return errNotEquivalent
+			}
+
+			if err := d.typesEquivalent(a.Vars[i].Type, b.Vars[i].Type, visited); err != nil {
+				return err
+			}
+		}
+		return nil
+
+	case *declTag:
+		b, ok := tb.(*declTag)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Value != b.Value || a.Index != b.Index {
+			return errNotEquivalent
+		}
+		return d.typesEquivalent(a.Type, b.Type, visited)
+
+	case *TypeTag:
+		b, ok := tb.(*TypeTag)
+		if !ok {
+			return errNotEquivalent
+		}
+		if a.Value != b.Value {
+			return errNotEquivalent
+		}
+		if err := d.typesEquivalent(a.Type, b.Type, visited); err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported type for equivalence: %T", a)
+	}
+}
+
+// compositeEquivalent checks if two composite types (Struct or Union) are
+// Equivalent.
+func (d *deduper) compositeEquivalent(at, bt Type, visited []Type) error {
+	var ma, mb []Member
+	switch a := at.(type) {
+	case *Struct:
+		b, ok := bt.(*Struct)
+		if !ok {
+			return errNotEquivalent
+		}
+
+		if a.Name != b.Name || a.Size != b.Size || len(a.Members) != len(b.Members) {
+			return errNotEquivalent
+		}
+		ma = a.Members
+		mb = b.Members
+
+	case *Union:
+		b, ok := bt.(*Union)
+		if !ok {
+			return errNotEquivalent
+		}
+
+		if a.Name != b.Name || a.Size != b.Size || len(a.Members) != len(b.Members) {
+			return errNotEquivalent
+		}
+		ma = a.Members
+		mb = b.Members
+	}
+
+	for i := range ma {
+		if ma[i].Name != mb[i].Name || ma[i].Offset != mb[i].Offset {
+			return errNotEquivalent
+		}
+
+		if err := d.typesEquivalent(ma[i].Type, mb[i].Type, visited); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/cilium/ebpf/info.go
+++ b/vendor/github.com/cilium/ebpf/info.go
@@ -708,27 +708,20 @@ func (pi *ProgramInfo) Instructions() (asm.Instructions, error) {
 				return nil, fmt.Errorf("unable to get BTF spec: %w", err)
 			}
 
-			lineInfos, err := btf.LoadLineInfos(
-				bytes.NewReader(pi.lineInfos),
-				internal.NativeEndian,
-				pi.numLineInfos,
-				spec,
-			)
+			lineInfos, err := btf.LoadLineInfos(bytes.NewReader(pi.lineInfos), internal.NativeEndian, pi.numLineInfos, spec)
 			if err != nil {
 				return nil, fmt.Errorf("parse line info: %w", err)
 			}
 
-			funcInfos, err := btf.LoadFuncInfos(
-				bytes.NewReader(pi.funcInfos),
-				internal.NativeEndian,
-				pi.numFuncInfos,
-				spec,
-			)
+			funcInfos, err := btf.LoadFuncInfos(bytes.NewReader(pi.funcInfos), internal.NativeEndian, pi.numFuncInfos, spec)
 			if err != nil {
 				return nil, fmt.Errorf("parse func info: %w", err)
 			}
 
-			btf.AssignMetadataToInstructions(insns, funcInfos, lineInfos, btf.CORERelocationInfos{})
+			iter := insns.Iterate()
+			for iter.Next() {
+				assignMetadata(iter.Ins, iter.Offset, &funcInfos, &lineInfos, nil)
+			}
 		}
 	}
 

--- a/vendor/github.com/cilium/ebpf/internal/sys/syscall.go
+++ b/vendor/github.com/cilium/ebpf/internal/sys/syscall.go
@@ -72,7 +72,27 @@ func (i *KprobeMultiLinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 
+func (i *UprobeMultiLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *RawTracepointLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
 func (i *KprobeLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *UprobeLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *TracepointLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *EventLinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 

--- a/vendor/github.com/cilium/ebpf/internal/unix/types_linux.go
+++ b/vendor/github.com/cilium/ebpf/internal/unix/types_linux.go
@@ -32,6 +32,7 @@ const (
 	F_DUPFD_CLOEXEC           = linux.F_DUPFD_CLOEXEC
 	EPOLL_CTL_ADD             = linux.EPOLL_CTL_ADD
 	EPOLL_CLOEXEC             = linux.EPOLL_CLOEXEC
+	O_RDONLY                  = linux.O_RDONLY
 	O_CLOEXEC                 = linux.O_CLOEXEC
 	O_NONBLOCK                = linux.O_NONBLOCK
 	PROT_NONE                 = linux.PROT_NONE
@@ -73,6 +74,7 @@ const (
 	BPF_RB_FORCE_WAKEUP       = linux.BPF_RB_FORCE_WAKEUP
 	AF_UNSPEC                 = linux.AF_UNSPEC
 	IFF_UP                    = linux.IFF_UP
+	CLONE_NEWNET              = linux.CLONE_NEWNET
 )
 
 type Statfs_t = linux.Statfs_t
@@ -209,4 +211,12 @@ func SchedGetaffinity(pid int, set *CPUSet) error {
 
 func Auxv() ([][2]uintptr, error) {
 	return linux.Auxv()
+}
+
+func Unshare(flag int) error {
+	return linux.Unshare(flag)
+}
+
+func Setns(fd int, nstype int) error {
+	return linux.Setns(fd, nstype)
 }

--- a/vendor/github.com/cilium/ebpf/link/link_other.go
+++ b/vendor/github.com/cilium/ebpf/link/link_other.go
@@ -111,9 +111,9 @@ func wrapRawLink(raw *RawLink) (_ Link, err error) {
 }
 
 type TracingInfo struct {
-	AttachType  sys.AttachType
-	TargetObjId uint32
-	TargetBtfId sys.TypeID
+	AttachType     sys.AttachType
+	TargetObjectId uint32
+	TargetBtfId    sys.TypeID
 }
 
 type CgroupInfo struct {
@@ -123,7 +123,7 @@ type CgroupInfo struct {
 }
 
 type NetNsInfo struct {
-	NetnsIno   uint32
+	NetnsInode uint32
 	AttachType sys.AttachType
 }
 
@@ -137,10 +137,10 @@ type XDPInfo struct {
 }
 
 type NetfilterInfo struct {
-	Pf       uint32
-	Hooknum  uint32
-	Priority int32
-	Flags    uint32
+	ProtocolFamily NetfilterProtocolFamily
+	Hook           NetfilterInetHook
+	Priority       int32
+	Flags          uint32
 }
 
 type NetkitInfo struct {
@@ -148,24 +148,94 @@ type NetkitInfo struct {
 	AttachType sys.AttachType
 }
 
+type RawTracepointInfo struct {
+	Name string
+}
+
 type KprobeMultiInfo struct {
-	count  uint32
-	flags  uint32
-	missed uint64
+	// Count is the number of addresses hooked by the kprobe.
+	Count   uint32
+	Flags   uint32
+	Missed  uint64
+	addrs   []uint64
+	cookies []uint64
 }
 
-// AddressCount is the number of addresses hooked by the kprobe.
-func (kpm *KprobeMultiInfo) AddressCount() (uint32, bool) {
-	return kpm.count, kpm.count > 0
+type KprobeMultiAddress struct {
+	Address uint64
+	Cookie  uint64
 }
 
-func (kpm *KprobeMultiInfo) Flags() (uint32, bool) {
-	return kpm.flags, kpm.count > 0
+// Addresses are the addresses hooked by the kprobe.
+func (kpm *KprobeMultiInfo) Addresses() ([]KprobeMultiAddress, bool) {
+	if kpm.addrs == nil || len(kpm.addrs) != len(kpm.cookies) {
+		return nil, false
+	}
+	addrs := make([]KprobeMultiAddress, len(kpm.addrs))
+	for i := range kpm.addrs {
+		addrs[i] = KprobeMultiAddress{
+			Address: kpm.addrs[i],
+			Cookie:  kpm.cookies[i],
+		}
+	}
+	return addrs, true
 }
 
-func (kpm *KprobeMultiInfo) Missed() (uint64, bool) {
-	return kpm.missed, kpm.count > 0
+type UprobeMultiInfo struct {
+	Count         uint32
+	Flags         uint32
+	Missed        uint64
+	offsets       []uint64
+	cookies       []uint64
+	refCtrOffsets []uint64
+	// File is the path that the file the uprobe was attached to
+	// had at creation time.
+	//
+	// However, due to various circumstances (differing mount namespaces,
+	// file replacement, ...), this path may not point to the same binary
+	// the uprobe was originally attached to.
+	File string
+	pid  uint32
 }
+
+type UprobeMultiOffset struct {
+	Offset         uint64
+	Cookie         uint64
+	ReferenceCount uint64
+}
+
+// Offsets returns the offsets that the uprobe was attached to along with the related cookies and ref counters.
+func (umi *UprobeMultiInfo) Offsets() ([]UprobeMultiOffset, bool) {
+	if umi.offsets == nil || len(umi.cookies) != len(umi.offsets) || len(umi.refCtrOffsets) != len(umi.offsets) {
+		return nil, false
+	}
+	var adresses = make([]UprobeMultiOffset, len(umi.offsets))
+	for i := range umi.offsets {
+		adresses[i] = UprobeMultiOffset{
+			Offset:         umi.offsets[i],
+			Cookie:         umi.cookies[i],
+			ReferenceCount: umi.refCtrOffsets[i],
+		}
+	}
+	return adresses, true
+}
+
+// Pid returns the process ID that this uprobe is attached to.
+//
+// If it does not exist, the uprobe will trigger for all processes.
+func (umi *UprobeMultiInfo) Pid() (uint32, bool) {
+	return umi.pid, umi.pid > 0
+}
+
+const (
+	PerfEventUnspecified = sys.BPF_PERF_EVENT_UNSPEC
+	PerfEventUprobe      = sys.BPF_PERF_EVENT_UPROBE
+	PerfEventUretprobe   = sys.BPF_PERF_EVENT_URETPROBE
+	PerfEventKprobe      = sys.BPF_PERF_EVENT_KPROBE
+	PerfEventKretprobe   = sys.BPF_PERF_EVENT_KRETPROBE
+	PerfEventTracepoint  = sys.BPF_PERF_EVENT_TRACEPOINT
+	PerfEventEvent       = sys.BPF_PERF_EVENT_EVENT
+)
 
 type PerfEventInfo struct {
 	Type  sys.PerfEventType
@@ -177,17 +247,50 @@ func (r *PerfEventInfo) Kprobe() *KprobeInfo {
 	return e
 }
 
+func (r *PerfEventInfo) Uprobe() *UprobeInfo {
+	e, _ := r.extra.(*UprobeInfo)
+	return e
+}
+
+func (r *PerfEventInfo) Tracepoint() *TracepointInfo {
+	e, _ := r.extra.(*TracepointInfo)
+	return e
+}
+
+func (r *PerfEventInfo) Event() *EventInfo {
+	e, _ := r.extra.(*EventInfo)
+	return e
+}
+
 type KprobeInfo struct {
-	address uint64
-	missed  uint64
+	Address  uint64
+	Missed   uint64
+	Function string
+	Offset   uint32
 }
 
-func (kp *KprobeInfo) Address() (uint64, bool) {
-	return kp.address, kp.address > 0
+type UprobeInfo struct {
+	// File is the path that the file the uprobe was attached to
+	// had at creation time.
+	//
+	// However, due to various circumstances (differing mount namespaces,
+	// file replacement, ...), this path may not point to the same binary
+	// the uprobe was originally attached to.
+	File                 string
+	Offset               uint32
+	Cookie               uint64
+	OffsetReferenceCount uint64
 }
 
-func (kp *KprobeInfo) Missed() (uint64, bool) {
-	return kp.missed, kp.address > 0
+type TracepointInfo struct {
+	Tracepoint string
+	Cookie     uint64
+}
+
+type EventInfo struct {
+	Config uint64
+	Type   uint32
+	Cookie uint64
 }
 
 // Tracing returns tracing type-specific link info.
@@ -254,10 +357,26 @@ func (r Info) KprobeMulti() *KprobeMultiInfo {
 	return e
 }
 
+// UprobeMulti returns uprobe-multi type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) UprobeMulti() *UprobeMultiInfo {
+	e, _ := r.extra.(*UprobeMultiInfo)
+	return e
+}
+
 // PerfEvent returns perf-event type-specific link info.
 //
 // Returns nil if the type-specific link info isn't available.
 func (r Info) PerfEvent() *PerfEventInfo {
 	e, _ := r.extra.(*PerfEventInfo)
+	return e
+}
+
+// RawTracepoint returns raw-tracepoint type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) RawTracepoint() *RawTracepointInfo {
+	e, _ := r.extra.(*RawTracepointInfo)
 	return e
 }

--- a/vendor/github.com/cilium/ebpf/link/netns.go
+++ b/vendor/github.com/cilium/ebpf/link/netns.go
@@ -44,7 +44,7 @@ func (ns *NetNsLink) Info() (*Info, error) {
 		return nil, fmt.Errorf("netns link info: %s", err)
 	}
 	extra := &NetNsInfo{
-		NetnsIno:   info.NetnsIno,
+		NetnsInode: info.NetnsIno,
 		AttachType: info.AttachType,
 	}
 

--- a/vendor/github.com/cilium/ebpf/link/raw_tracepoint.go
+++ b/vendor/github.com/cilium/ebpf/link/raw_tracepoint.go
@@ -91,3 +91,19 @@ var _ Link = (*rawTracepoint)(nil)
 func (rt *rawTracepoint) Update(_ *ebpf.Program) error {
 	return fmt.Errorf("update raw_tracepoint: %w", ErrNotSupported)
 }
+
+func (rt *rawTracepoint) Info() (*Info, error) {
+	var info sys.RawTracepointLinkInfo
+	name, err := queryInfoWithString(rt.fd, &info, &info.TpName, &info.TpNameLen)
+	if err != nil {
+		return nil, err
+	}
+	return &Info{
+		info.Type,
+		info.Id,
+		ebpf.ProgramID(info.ProgId),
+		&RawTracepointInfo{
+			Name: name,
+		},
+	}, nil
+}

--- a/vendor/github.com/cilium/ebpf/link/tracing.go
+++ b/vendor/github.com/cilium/ebpf/link/tracing.go
@@ -26,9 +26,9 @@ func (f *tracing) Info() (*Info, error) {
 		return nil, fmt.Errorf("tracing link info: %s", err)
 	}
 	extra := &TracingInfo{
-		TargetObjId: info.TargetObjId,
-		TargetBtfId: info.TargetBtfId,
-		AttachType:  info.AttachType,
+		TargetObjectId: info.TargetObjId,
+		TargetBtfId:    info.TargetBtfId,
+		AttachType:     info.AttachType,
 	}
 
 	return &Info{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -293,7 +293,7 @@ github.com/cilium/deepequal-gen/generators
 # github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a
 ## explicit; go 1.18
 github.com/cilium/dns
-# github.com/cilium/ebpf v0.20.1-0.20260108141042-f7e80f49188b
+# github.com/cilium/ebpf v0.20.1-0.20260218191617-ee67e7f43dd9
 ## explicit; go 1.24.0
 github.com/cilium/ebpf
 github.com/cilium/ebpf/asm


### PR DESCRIPTION
Due to changes in newer kernels and the cilium/ebpf library, XDP programs will in future be loaded as ebpf.AttachXDP. However, older Cilium versions will have already created links with ebpf.AttachNone programs. The kernel does not allow us to change the program of a link if its attach type does not match.

This means that we can only use the new XDP attach type when a link is newly created. This commit adds logic which detects errors on link update and attempts to load and attach with the other attach type instead. So when upgrading from an older version to a newer version, new links are created as XDP attach type, but existing links will remain using the AttachNone. On downgrade, all links will be created with AttachNone, and existing links will continue to use AttachXDP.

Fixes: #44063

```release-note
Enable Cilium upgrade and downgrade when existing XDP attach types differ from new XDP programs
```
