### PR TITLE
fix: helm intervalSeconds integer value render bug

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1380,11 +1380,7 @@ data:
 
 {{- if .Values.operator.unmanagedPodWatcher.restart }}
   {{- $interval := .Values.operator.unmanagedPodWatcher.intervalSeconds }}
-  {{- if kindIs "float64" $interval }}
   unmanaged-pod-watcher-interval: {{ printf "%ds" (int $interval) | quote }}
-  {{- else }}
-  unmanaged-pod-watcher-interval: {{ $interval | quote }}
-  {{- end }}
 {{- else }}
   unmanaged-pod-watcher-interval: "0"
 {{- end }}


### PR DESCRIPTION
`operator.unmanagedPodWatcher.intervalSeconds` is always  of an integral type, this constraint is also defined in the JSON schema.
There is no need to check if it kind is float64, which even causes bug when helm parses it as `json.Number` or `int64`.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #44206

```release-note
fix: helm value rendering bug for operator.unmanagedPodWatcher.intervalSeconds 
```
