### PR TITLE
pkg/subnet: Fix tag in config subnets field

### DIFF
--- a/pkg/subnet/config.go
+++ b/pkg/subnet/config.go
@@ -14,7 +14,7 @@ var DefaultConfig = Config{
 }
 
 type Config struct {
-	Subnets string `json:"subnet-topology,omitempty"`
+	Subnets string `mapstructure:"subnet-topology,omitempty"`
 }
 
 func (cfg Config) Flags(flags *pflag.FlagSet) {


### PR DESCRIPTION
The Subnets field in the config was declaring a json tag, leading to a failure of the agent `hive` command (see below). This is due to the fact that the hive relies on a mapstructure Decoder, not a Json one, and therefore require a mapstructure tag when the config field name is not equal to the flag name.

Fix the tag on the field using a mapstructure one.

```
make -C daemon/ && ./daemon/cilium-agent hive
...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xacd46e]

goroutine 1 [running]:
github.com/cilium/hive/cell.(*InfoNode).Print(0xc000b540f0, 0xa?, 0xc000cba750)
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/cilium/hive/cell/info.go:109 +0x12e
github.com/cilium/hive/cell.(*InfoNode).Print(0xc000a9bdd0, 0x6?, 0xc000cba750)
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/cilium/hive/cell/info.go:109 +0x134
github.com/cilium/hive/cell.(*InfoNode).Print(0xc000a799b0, 0x2?, 0xc000cba750)
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/cilium/hive/cell/info.go:109 +0x134
github.com/cilium/hive.(*Hive).PrintObjects(0xc0009554a0, {0x51e1240, 0xc0000c0030}, 0x0?)
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/cilium/hive/hive.go:459 +0x18f
github.com/cilium/hive.(*Hive).Command.func1(0xc000e0fc00?, {0x4b05b96?, 0x4?, 0x4b05aca?})
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/cilium/hive/command.go:21 +0x2d
github.com/spf13/cobra.(*Command).execute(0xc000953508, {0x86bac20, 0x0, 0x0})
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/spf13/cobra/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0xc000952f08)
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/spf13/cobra/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	/home/ffalzoi/cilium/cilium-2/vendor/github.com/spf13/cobra/command.go:1071
github.com/cilium/cilium/daemon/cmd.Execute(0x4d769d0?)
	/home/ffalzoi/cilium/cilium-2/daemon/cmd/root.go:89 +0x13
main.main()
	/home/ffalzoi/cilium/cilium-2/daemon/main.go:15 +0x1f
```

Fixes: d395d73ad3 ("pkg/subnet: Add subnet config watcher and manager")
