### PR TITLE
bgp: Introduce bgp/routes Hive Shell command

### DIFF
--- a/pkg/bgp/agent/routermgr.go
+++ b/pkg/bgp/agent/routermgr.go
@@ -39,6 +39,9 @@ type BGPRouterManager interface {
 	// GetRoutesLegacy fetches BGP routes from underlying routing daemon's RIBs.
 	GetRoutesLegacy(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 
+	// GetRoutes fetches BGP routes from underlying routing daemon's RIBs.
+	GetRoutes(ctx context.Context, req *GetRoutesRequest) (*GetRoutesResponse, error)
+
 	// GetRoutePolicies fetches BGP routing policies from underlying routing daemon.
 	GetRoutePolicies(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
 
@@ -58,4 +61,22 @@ type GetPeersResponse struct {
 type InstancePeerStates struct {
 	Name  string
 	Peers []types.PeerState
+}
+
+// GetRoutesRequest is a request for GetRoutes method.
+type GetRoutesRequest struct {
+	TableType types.TableType
+	Family    types.Family
+}
+
+// GetRoutesResponse is the response type for GetRoutes method.
+type GetRoutesResponse struct {
+	Instances []InstanceRoutes
+}
+
+// InstanceRoutes holds routes for a specific BGP instance.
+type InstanceRoutes struct {
+	InstanceName string
+	NeighborName string
+	Routes       []*types.Route
 }

--- a/pkg/bgp/agent/routermgr.go
+++ b/pkg/bgp/agent/routermgr.go
@@ -36,8 +36,8 @@ type BGPRouterManager interface {
 	// the future.
 	GetPeersLegacy(ctx context.Context) ([]*models.BgpPeer, error)
 
-	// GetRoutes fetches BGP routes from underlying routing daemon's RIBs.
-	GetRoutes(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
+	// GetRoutesLegacy fetches BGP routes from underlying routing daemon's RIBs.
+	GetRoutesLegacy(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 
 	// GetRoutePolicies fetches BGP routing policies from underlying routing daemon.
 	GetRoutePolicies(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)

--- a/pkg/bgp/api/get_routes.go
+++ b/pkg/bgp/api/get_routes.go
@@ -28,7 +28,7 @@ func (h *getRoutesHandler) Handle(params restapi.GetBgpRoutesParams) middleware.
 	if h.controller == nil {
 		return api.Error(http.StatusNotImplemented, agent.ErrBGPControlPlaneDisabled)
 	}
-	routes, err := h.controller.BGPMgr.GetRoutes(params.HTTPRequest.Context(), params)
+	routes, err := h.controller.BGPMgr.GetRoutesLegacy(params.HTTPRequest.Context(), params)
 	if err != nil {
 		return api.Error(http.StatusInternalServerError, fmt.Errorf("failed to get routes: %w", err))
 	}

--- a/pkg/bgp/commands/cell.go
+++ b/pkg/bgp/commands/cell.go
@@ -15,6 +15,7 @@ var Cell = cell.Provide(BGPCommands)
 
 func BGPCommands(bgpMgr agent.BGPRouterManager) hive.ScriptCmdsOut {
 	return hive.NewScriptCmds(map[string]script.Cmd{
-		"bgp/peers": BGPPeersCmd(bgpMgr),
+		"bgp/peers":  BGPPeersCmd(bgpMgr),
+		"bgp/routes": BGPRoutesCmd(bgpMgr),
 	})
 }

--- a/pkg/bgp/commands/cell.go
+++ b/pkg/bgp/commands/cell.go
@@ -15,6 +15,6 @@ var Cell = cell.Provide(BGPCommands)
 
 func BGPCommands(bgpMgr agent.BGPRouterManager) hive.ScriptCmdsOut {
 	return hive.NewScriptCmds(map[string]script.Cmd{
-		"bgp/peers": BGPPPeersCmd(bgpMgr),
+		"bgp/peers": BGPPeersCmd(bgpMgr),
 	})
 }

--- a/pkg/bgp/commands/routes.go
+++ b/pkg/bgp/commands/routes.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/bgp/agent"
+	"github.com/cilium/cilium/pkg/bgp/api"
+	"github.com/cilium/cilium/pkg/bgp/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func BGPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "List BGP routes on Cilium",
+			Args:    "<table type> <afi> <safi>",
+			Flags: func(fs *pflag.FlagSet) {
+				addOutFileFlag(fs)
+				fs.Bool("no-age", false, "Do not show Age column for testing purpose")
+			},
+			Detail: []string{
+				"List routes in the BGP Control Plane's RIBs",
+				"",
+				"table type: \"loc\" (loc-rib), \"in\" (adj-rib-in), or \"out\" (adj-rib-out).",
+				"afi: Address Family Identifier (e.g. ipv4, ipv6).",
+				"safi: Subsequent Address Family Identifier (e.g. unicast).",
+				"peer name: optional, only for adj-rib-in/out.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) < 3 {
+				return nil, fmt.Errorf("BGP routes command requires <table type> <afi> <safi>")
+			}
+			tableType, err := parseTableTypeArg(args[0])
+			if err != nil {
+				return nil, err
+			}
+			afi := types.ParseAfi(args[1])
+			if afi == types.AfiUnknown {
+				return nil, fmt.Errorf("unknown AFI %s", args[1])
+			}
+			safi := types.ParseSafi(args[2])
+			if safi == types.SafiUnknown {
+				return nil, fmt.Errorf("unknown SAFI %s", args[2])
+			}
+			req := &agent.GetRoutesRequest{
+				TableType: tableType,
+				Family: types.Family{
+					Afi:  afi,
+					Safi: safi,
+				},
+			}
+
+			return func(*script.State) (stdout, stderr string, err error) {
+				noAge, err := s.Flags.GetBool("no-age")
+				if err != nil {
+					return "", "", err
+				}
+
+				tw, buf, f, err := getCmdTabWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
+
+				res, err := bgpMgr.GetRoutes(s.Context(), req)
+				if err != nil {
+					return "", "", err
+				}
+
+				printPeer := tableType == types.TableTypeAdjRIBIn || tableType == types.TableTypeAdjRIBOut
+				PrintRoutes(tw, res.Instances, printPeer, noAge)
+				tw.Flush()
+
+				return buf.String(), "", nil
+			}, nil
+		},
+	)
+}
+
+func parseTableTypeArg(arg string) (types.TableType, error) {
+	switch arg {
+	case "loc":
+		return types.TableTypeLocRIB, nil
+	case "in":
+		return types.TableTypeAdjRIBIn, nil
+	case "out":
+		return types.TableTypeAdjRIBOut, nil
+	default:
+		return types.TableTypeUnknown, fmt.Errorf("unknown table type %s", arg)
+	}
+}
+
+func PrintRoutes(tw *tabwriter.Writer, instances []agent.InstanceRoutes, printPeer bool, noAge bool) {
+	type row struct {
+		Instance string
+		Peer     string
+		Prefix   string
+		NextHop  string
+		Best     string
+		Age      string
+	}
+
+	var rows []row
+	for _, instance := range instances {
+		for _, route := range instance.Routes {
+			for _, path := range route.Paths {
+				r := row{
+					Instance: instance.InstanceName,
+					Peer:     instance.NeighborName,
+					Prefix:   route.Prefix,
+					NextHop:  api.NextHopFromPathAttributes(path.PathAttributes),
+					Best:     strconv.FormatBool(path.Best),
+					Age:      time.Duration(path.AgeNanoseconds).Truncate(time.Second).String(),
+				}
+				if noAge {
+					r.Age = "-"
+				}
+				rows = append(rows, r)
+			}
+		}
+	}
+
+	slices.SortFunc(rows, func(a, b row) int {
+		c := strings.Compare(a.Instance, b.Instance)
+		if c != 0 {
+			return c
+		}
+		c = strings.Compare(a.Peer, b.Peer)
+		if c != 0 {
+			return c
+		}
+		return strings.Compare(a.Prefix, b.Prefix)
+	})
+
+	rows = slices.Insert(rows, 0, row{
+		Instance: "Instance",
+		Peer:     "Peer",
+		Prefix:   "Prefix",
+		NextHop:  "NextHop",
+		Best:     "Best",
+		Age:      "Age",
+	})
+
+	prevInstance := ""
+	prevPeer := ""
+	prevPrefix := ""
+	for i, row := range rows {
+		if i != 0 {
+			if row.Instance == prevInstance {
+				row.Instance = ""
+			}
+			if row.Instance == "" && row.Peer == prevPeer {
+				row.Peer = ""
+			}
+			if row.Instance == "" && row.Peer == "" && row.Prefix == prevPrefix {
+				row.Prefix = ""
+			}
+		}
+
+		if printPeer {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", row.Instance, row.Peer, row.Prefix, row.NextHop, row.Age)
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", row.Instance, row.Prefix, row.NextHop, row.Best, row.Age)
+		}
+
+		if row.Instance != "" {
+			prevInstance = row.Instance
+		}
+		if row.Peer != "" {
+			prevPeer = row.Peer
+		}
+		if row.Prefix != "" {
+			prevPrefix = row.Prefix
+		}
+	}
+}

--- a/pkg/bgp/gobgp/state.go
+++ b/pkg/bgp/gobgp/state.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/netip"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
 
@@ -63,6 +64,11 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context, req *types.GetPeerStateR
 					state.Name = pd.Name
 				}
 			}
+			// We can just ignore error here. In that case, the
+			// addr is invalid. Caller is responsible for handling
+			// the invalid case.
+			addr, _ := netip.ParseAddr(peer.Conf.NeighborAddress)
+			state.Address = addr
 		}
 
 		if peer.State != nil {

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -257,8 +257,8 @@ func (m *BGPRouterManager) GetPeersLegacy(ctx context.Context) ([]*models.BgpPee
 	return res, nil
 }
 
-// GetRoutes retrieves routes from the RIB of underlying router
-func (m *BGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
+// GetRoutesLegacy retrieves routes from the RIB of underlying router
+func (m *BGPRouterManager) GetRoutesLegacy(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -295,7 +295,7 @@ func (m *BGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpR
 			}
 			for _, peer := range getPeerResp.Peers {
 				params.Neighbor = &peer.PeerAddress
-				routes, err := m.getRoutesFromInstance(ctx, i, params)
+				routes, err := m.getRoutesFromInstanceLegacy(ctx, i, params)
 				if err != nil {
 					return nil, err
 				}
@@ -303,7 +303,7 @@ func (m *BGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpR
 			}
 		} else {
 			// get routes with provided params
-			routes, err := m.getRoutesFromInstance(ctx, i, params)
+			routes, err := m.getRoutesFromInstanceLegacy(ctx, i, params)
 			if err != nil {
 				return nil, err
 			}
@@ -313,8 +313,8 @@ func (m *BGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpR
 	return res, nil
 }
 
-// getRoutesFromInstance retrieves routes from the RIB of the specified BGP instance
-func (m *BGPRouterManager) getRoutesFromInstance(ctx context.Context, i *instance.BGPInstance, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
+// getRoutesFromInstanceLegacy retrieves routes from the RIB of the specified BGP instance
+func (m *BGPRouterManager) getRoutesFromInstanceLegacy(ctx context.Context, i *instance.BGPInstance, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
 	if i.Config.LocalASN == nil {
 		return nil, fmt.Errorf("local ASN not set for instance")
 	}

--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -44,8 +44,8 @@ var (
 	safiUnicast           = "unicast"
 )
 
-// TestGetRoutes tests GetRoutes API of the Manager.
-func TestGetRoutes(t *testing.T) {
+// TestGetRoutesLegacy tests GetRoutes API of the Manager.
+func TestGetRoutesLegacy(t *testing.T) {
 
 	var table = []struct {
 		// name of the test case
@@ -197,7 +197,7 @@ func TestGetRoutes(t *testing.T) {
 			}
 
 			// retrieve routes from server's local RIB and
-			routes, err := brm.GetRoutes(context.Background(), restapi.GetBgpRoutesParams{
+			routes, err := brm.GetRoutesLegacy(context.Background(), restapi.GetBgpRoutesParams{
 				RouterAsn: tt.routerASN,
 				TableType: tt.tableType,
 				Afi:       tt.afi,

--- a/pkg/bgp/mock/mocks.go
+++ b/pkg/bgp/mock/mocks.go
@@ -39,7 +39,7 @@ type MockBGPRouterManager struct {
 	ReconcileInstances_ func(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
 	GetPeers_           func(ctx context.Context, req *agent.GetPeersRequest) (*agent.GetPeersResponse, error)
 	GetPeersLegacy_     func(ctx context.Context) ([]*models.BgpPeer, error)
-	GetRoutes_          func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
+	GetRoutesLegacy_    func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	GetRoutePolicies_   func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
 	Stop_               func(cell.HookContext) error
 }
@@ -56,8 +56,8 @@ func (m *MockBGPRouterManager) GetPeersLegacy(ctx context.Context) ([]*models.Bg
 	return m.GetPeersLegacy_(ctx)
 }
 
-func (m *MockBGPRouterManager) GetRoutes(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
-	return m.GetRoutes_(ctx, params)
+func (m *MockBGPRouterManager) GetRoutesLegacy(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {
+	return m.GetRoutesLegacy_(ctx, params)
 }
 
 func (m *MockBGPRouterManager) GetRoutePolicies(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error) {

--- a/pkg/bgp/mock/mocks.go
+++ b/pkg/bgp/mock/mocks.go
@@ -39,6 +39,7 @@ type MockBGPRouterManager struct {
 	ReconcileInstances_ func(ctx context.Context, bgpnc *v2.CiliumBGPNodeConfig, ciliumNode *v2.CiliumNode) error
 	GetPeers_           func(ctx context.Context, req *agent.GetPeersRequest) (*agent.GetPeersResponse, error)
 	GetPeersLegacy_     func(ctx context.Context) ([]*models.BgpPeer, error)
+	GetRoutes_          func(ctx context.Context, req *agent.GetRoutesRequest) (*agent.GetRoutesResponse, error)
 	GetRoutesLegacy_    func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	GetRoutePolicies_   func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
 	Stop_               func(cell.HookContext) error
@@ -54,6 +55,10 @@ func (m *MockBGPRouterManager) GetPeers(ctx context.Context, req *agent.GetPeers
 
 func (m *MockBGPRouterManager) GetPeersLegacy(ctx context.Context) ([]*models.BgpPeer, error) {
 	return m.GetPeersLegacy_(ctx)
+}
+
+func (m *MockBGPRouterManager) GetRoutes(ctx context.Context, req *agent.GetRoutesRequest) (*agent.GetRoutesResponse, error) {
+	return m.GetRoutes_(ctx, req)
 }
 
 func (m *MockBGPRouterManager) GetRoutesLegacy(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error) {

--- a/pkg/bgp/test/commands/bgp.go
+++ b/pkg/bgp/test/commands/bgp.go
@@ -13,89 +13,14 @@ import (
 )
 
 const (
-	peerFlag      = "peer"
-	peerFlagShort = "p"
-
 	routerASNFlag      = "router-asn"
 	routerASNFlagShort = "r"
 )
 
 func BGPScriptCmds(bgpMgr agent.BGPRouterManager) map[string]script.Cmd {
 	return map[string]script.Cmd{
-		"bgp/routes":         BGPPRoutesCmd(bgpMgr),
 		"bgp/route-policies": BGPPRoutePolicies(bgpMgr),
 	}
-}
-
-func BGPPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
-	return script.Command(
-		script.CmdUsage{
-			Summary: "List BGP routes on Cilium",
-			Args:    "[available|advertised] [afi] [safi]",
-			Flags: func(fs *pflag.FlagSet) {
-				fs.StringP(peerFlag, peerFlagShort, "", "IP address of the peer. If provided, routes advertised to the specified peer are listed.")
-				fs.Uint32P(routerASNFlag, routerASNFlagShort, 0, "ASN number of the Cilium router instance. Lists routes of all instances if omitted.")
-				addOutFileFlag(fs)
-			},
-			Detail: []string{
-				"List routes in the BGP Control Plane's RIBs",
-				"",
-				"'available' lists routes from the local RIB, 'advertised' lists routes from the RIB-OUT of BGP peer(s).",
-				"When none of them is provided, lists 'available' routes",
-				"",
-				"'afi' is Address Family Indicator, defaults to 'ipv4'.",
-				"'safi' is Subsequent Address Family Identifier, defaults to 'unicast'.",
-			},
-		},
-		func(s *script.State, args ...string) (script.WaitFunc, error) {
-			peer, err := s.Flags.GetString(peerFlag)
-			if err != nil {
-				return nil, err
-			}
-			asn, err := s.Flags.GetUint32(routerASNFlag)
-			if err != nil {
-				return nil, err
-			}
-			return func(*script.State) (stdout, stderr string, err error) {
-				tw, buf, f, err := getCmdTabWriter(s)
-				if err != nil {
-					return "", "", err
-				}
-				if f != nil {
-					defer f.Close()
-				}
-
-				params := restapi.GetBgpRoutesParams{
-					TableType: "loc-rib",
-					Afi:       "ipv4",
-					Safi:      "unicast",
-				}
-				if len(args) > 0 && args[0] == "advertised" {
-					params.TableType = "adj-rib-out"
-				}
-				if len(args) > 1 && args[1] != "" {
-					params.Afi = args[1]
-				}
-				if len(args) > 2 && args[2] != "" {
-					params.Safi = args[2]
-				}
-				if peer != "" {
-					params.Neighbor = &peer
-				}
-				if asn != 0 {
-					asn64 := int64(asn)
-					params.RouterAsn = &asn64
-				}
-				routes, err := bgpMgr.GetRoutesLegacy(s.Context(), params)
-				if err != nil {
-					return "", "", err
-				}
-				err = api.PrintBGPRoutesTable(tw, routes, params.TableType == "adj-rib-out", false)
-
-				return buf.String(), "", err
-			}, nil
-		},
-	)
 }
 
 func BGPPRoutePolicies(bgpMgr agent.BGPRouterManager) script.Cmd {

--- a/pkg/bgp/test/commands/bgp.go
+++ b/pkg/bgp/test/commands/bgp.go
@@ -86,7 +86,7 @@ func BGPPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					asn64 := int64(asn)
 					params.RouterAsn = &asn64
 				}
-				routes, err := bgpMgr.GetRoutes(s.Context(), params)
+				routes, err := bgpMgr.GetRoutesLegacy(s.Context(), params)
 				if err != nil {
 					return "", "", err
 				}

--- a/pkg/bgp/test/commands/gobgp.go
+++ b/pkg/bgp/test/commands/gobgp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/cilium/hive/script"
 	gobgpapi "github.com/osrg/gobgp/v3/api"
+	"github.com/osrg/gobgp/v3/pkg/apiutil"
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 	"github.com/osrg/gobgp/v3/pkg/server"
 	"github.com/spf13/pflag"
 
@@ -93,12 +96,13 @@ func (ctx *GoBGPCmdContext) Cleanup() {
 
 func GoBGPScriptCmds(ctx *GoBGPCmdContext) map[string]script.Cmd {
 	return map[string]script.Cmd{
-		"gobgp/add-server":    GoBGPAddServerCmd(ctx),
-		"gobgp/delete-server": GoBGPDeleteServerCmd(ctx),
-		"gobgp/add-peer":      GoBGPAddPeerCmd(ctx),
-		"gobgp/wait-state":    GoBGPWaitStateCmd(ctx),
-		"gobgp/peers":         GoBGPPeersCmd(ctx),
-		"gobgp/routes":        GoBGPRoutesCmd(ctx),
+		"gobgp/add-server":      GoBGPAddServerCmd(ctx),
+		"gobgp/delete-server":   GoBGPDeleteServerCmd(ctx),
+		"gobgp/add-peer":        GoBGPAddPeerCmd(ctx),
+		"gobgp/wait-state":      GoBGPWaitStateCmd(ctx),
+		"gobgp/peers":           GoBGPPeersCmd(ctx),
+		"gobgp/routes":          GoBGPRoutesCmd(ctx),
+		"gobgp/advertise-route": GoBGPAdvertiseRouteCmd(ctx),
 	}
 }
 
@@ -463,6 +467,62 @@ func GoBGPRoutesCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 				}
 				tw.Flush()
 				return buf.String(), "", err
+			}, nil
+		},
+	)
+}
+
+func GoBGPAdvertiseRouteCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Advertise route on the GoBGP server",
+			Args:    "<prefix>",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP(serverNameFlag, serverNameFlagShort, "", "Name of the GoBGP server instance. Can be omitted if only one instance is active.")
+			},
+		},
+		func(s *script.State, args ...string) (waitFunc script.WaitFunc, err error) {
+			if len(args) < 1 {
+				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/advertise-route <prefix>'")
+			}
+
+			prefix, err := netip.ParsePrefix(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("could not parse prefix: %w", err)
+			}
+
+			gobgpServer, err := getGoBGPServer(s, cmdCtx)
+			if err != nil {
+				return nil, err
+			}
+
+			return func(s *script.State) (stdout, stderr string, err error) {
+				originAttr := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP)
+
+				var path *gobgpapi.Path
+				switch {
+				case prefix.Addr().Is4():
+					nlri := bgp.NewIPAddrPrefix(uint8(prefix.Bits()), prefix.Addr().String())
+					nextHopAttr := bgp.NewPathAttributeNextHop("0.0.0.0")
+					path, err = apiutil.NewPath(nlri, false, []bgp.PathAttributeInterface{originAttr, nextHopAttr}, time.Now())
+					if err != nil {
+						return "", "", fmt.Errorf("could not create path: %w", err)
+					}
+				case prefix.Addr().Is6():
+					nlri := bgp.NewIPv6AddrPrefix(uint8(prefix.Bits()), prefix.Addr().String())
+					mpReachNLRIAttr := bgp.NewPathAttributeMpReachNLRI("::", []bgp.AddrPrefixInterface{nlri})
+					path, err = apiutil.NewPath(nlri, false, []bgp.PathAttributeInterface{originAttr, mpReachNLRIAttr}, time.Now())
+					if err != nil {
+						return "", "", fmt.Errorf("could not create path: %w", err)
+					}
+				}
+
+				_, err = gobgpServer.AddPath(s.Context(), &gobgpapi.AddPathRequest{
+					TableType: gobgpapi.TableType_GLOBAL,
+					Path:      path,
+				})
+
+				return "", "", err
 			}, nil
 		},
 	)

--- a/pkg/bgp/test/testdata/README.md
+++ b/pkg/bgp/test/testdata/README.md
@@ -47,7 +47,7 @@ bgp/peers [-o] [--out=string]
 	List BGP peers on Cilium
 bgp/route-policies [-or] [--out=string] [--router-asn=uint32]
 	List BGP route policies on Cilium
-bgp/routes [-opr] [--out=string] [--peer=string] [--router-asn=uint32] [available|advertised] [afi] [safi]
+bgp/routes [--no-age] <table type> <afi> <safi>
 	List BGP routes on Cilium
 ```
 

--- a/pkg/bgp/test/testdata/commands.txtar
+++ b/pkg/bgp/test/testdata/commands.txtar
@@ -1,0 +1,190 @@
+#! --test-peering-ips=fd00:10:99:7::1,fd00:10:99:7::2,fd00:10:99:7::3,fd00:10:99:7::4,fd00:10:99:7::5,fd00:10:99:7::6
+
+# Start the hive
+hive start
+
+# Configure GoBGP servers
+gobgp/add-server server0 65000 fd00:10:99:7::1 1790 --router-id 10.99.7.1
+gobgp/add-server server1 65000 fd00:10:99:7::2 1790 --router-id 10.99.7.2
+gobgp/add-server server2 65001 fd00:10:99:7::3 1790 --router-id 10.99.7.3
+gobgp/add-server server3 65001 fd00:10:99:7::4 1790 --router-id 10.99.7.4
+
+# Configure peers on GoBGP
+gobgp/add-peer -s server0 fd00:10:99:7::5 65000
+gobgp/add-peer -s server1 fd00:10:99:7::5 65000
+gobgp/add-peer -s server2 fd00:10:99:7::6 65001
+gobgp/add-peer -s server3 fd00:10:99:7::6 65001
+
+# Advertise routes on GoBGP
+gobgp/advertise-route -s server0 10.0.0.0/24
+gobgp/advertise-route -s server1 10.0.0.0/24
+gobgp/advertise-route -s server2 10.0.1.0/24
+gobgp/advertise-route -s server3 10.0.2.0/24
+gobgp/advertise-route -s server0 fd00:10:0::/64
+gobgp/advertise-route -s server1 fd00:10:0::/64
+gobgp/advertise-route -s server2 fd00:10:1::/64
+gobgp/advertise-route -s server3 fd00:10:2::/64
+
+# Configure BGP on Cilium
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+
+# Wait for peerings to be established
+gobgp/wait-state -s server0 fd00:10:99:7::5 ESTABLISHED
+gobgp/wait-state -s server1 fd00:10:99:7::5 ESTABLISHED
+gobgp/wait-state -s server2 fd00:10:99:7::6 ESTABLISHED
+gobgp/wait-state -s server3 fd00:10:99:7::6 ESTABLISHED
+
+# Test peers
+bgp/peers --no-uptime -o bgp-peers.actual
+* cmp bgp-peers.expected bgp-peers.actual
+
+# Test IPv4 loc-rib
+bgp/routes loc ipv4 unicast --no-age -o bgp-routes-loc-ipv4-unicast.actual
+* cmp bgp-routes-loc-ipv4-unicast.expected bgp-routes-loc-ipv4-unicast.actual
+
+# Test IPv6 loc-rib
+bgp/routes loc ipv6 unicast --no-age -o bgp-routes-loc-ipv6-unicast.actual
+* cmp bgp-routes-loc-ipv6-unicast.expected bgp-routes-loc-ipv6-unicast.actual
+
+# Test IPv4 adj-rib-out
+bgp/routes out ipv4 unicast --no-age -o bgp-routes-out-ipv4-unicast.actual
+* cmp bgp-routes-out-ipv4-unicast.expected bgp-routes-out-ipv4-unicast.actual
+
+# Test IPv6 adj-rib-out
+bgp/routes out ipv6 unicast --no-age -o bgp-routes-out-ipv6-unicast.actual
+* cmp bgp-routes-out-ipv6-unicast.expected bgp-routes-out-ipv6-unicast.actual
+
+# Test IPv4 adj-rib-in
+bgp/routes in ipv4 unicast --no-age -o bgp-routes-in-ipv4-unicast.actual
+* cmp bgp-routes-in-ipv4-unicast.expected bgp-routes-in-ipv4-unicast.actual
+
+# Test IPv6 adj-rib-in
+bgp/routes in ipv6 unicast --no-age -o bgp-routes-in-ipv6-unicast.actual
+* cmp bgp-routes-in-ipv6-unicast.expected bgp-routes-in-ipv6-unicast.actual
+
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  ipam:
+    podCIDRs:
+    - 10.244.0.0/24
+    - fd00:10:244::/64
+
+-- bgp-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - name: instance0
+    localASN: 65000
+    routerID: 10.99.7.5
+    peers:
+    - name: peer0
+      peerASN: 65000
+      peerAddress: fd00:10:99:7::1
+      localAddress: fd00:10:99:7::5
+      peerConfigRef:
+        name: test-peer-config
+    - name: peer1
+      peerASN: 65000
+      peerAddress: fd00:10:99:7::2
+      localAddress: fd00:10:99:7::5
+      peerConfigRef:
+        name: test-peer-config
+  - name: instance1
+    localASN: 65001
+    routerID: 10.99.7.6
+    peers:
+    - name: peer0
+      peerASN: 65001
+      peerAddress: fd00:10:99:7::3
+      localAddress: fd00:10:99:7::6
+      peerConfigRef:
+        name: test-peer-config
+    - name: peer1
+      peerASN: 65001
+      peerAddress: fd00:10:99:7::4
+      localAddress: fd00:10:99:7::6
+      peerConfigRef:
+        name: test-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: test-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    connectRetryTimeSeconds: 1
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+  - afi: ipv6
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: bgp
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: test-advertisement
+  labels:
+    advertise: bgp
+spec:
+  advertisements:
+  - advertisementType: PodCIDR
+
+-- bgp-peers.expected --
+Instance    Peer    Session State   Uptime   Family         Received   Accepted   Advertised
+instance0   peer0   established     -        ipv4-unicast   1          1          1
+                                             ipv6-unicast   1          1          1
+            peer1   established     -        ipv4-unicast   1          1          1
+                                             ipv6-unicast   1          1          1
+instance1   peer0   established     -        ipv4-unicast   1          1          1
+                                             ipv6-unicast   1          1          1
+            peer1   established     -        ipv4-unicast   1          1          1
+                                             ipv6-unicast   1          1          1
+-- bgp-routes-loc-ipv4-unicast.expected --
+Instance    Prefix          NextHop   Best   Age
+instance0   10.244.0.0/24   0.0.0.0   true   -
+instance1   10.244.0.0/24   0.0.0.0   true   -
+-- bgp-routes-loc-ipv6-unicast.expected --
+Instance    Prefix             NextHop   Best   Age
+instance0   fd00:10:244::/64   ::        true   -
+instance1   fd00:10:244::/64   ::        true   -
+-- bgp-routes-out-ipv4-unicast.expected --
+Instance    Peer    Prefix          NextHop           Age
+instance0   peer0   10.244.0.0/24   fd00:10:99:7::5   -
+            peer1   10.244.0.0/24   fd00:10:99:7::5   -
+instance1   peer0   10.244.0.0/24   fd00:10:99:7::6   -
+            peer1   10.244.0.0/24   fd00:10:99:7::6   -
+-- bgp-routes-out-ipv6-unicast.expected --
+Instance    Peer    Prefix             NextHop           Age
+instance0   peer0   fd00:10:244::/64   fd00:10:99:7::5   -
+            peer1   fd00:10:244::/64   fd00:10:99:7::5   -
+instance1   peer0   fd00:10:244::/64   fd00:10:99:7::6   -
+            peer1   fd00:10:244::/64   fd00:10:99:7::6   -
+-- bgp-routes-in-ipv4-unicast.expected --
+Instance    Peer    Prefix        NextHop           Age
+instance0   peer0   10.0.0.0/24   fd00:10:99:7::1   -
+            peer1   10.0.0.0/24   fd00:10:99:7::2   -
+instance1   peer0   10.0.1.0/24   fd00:10:99:7::3   -
+            peer1   10.0.2.0/24   fd00:10:99:7::4   -
+-- bgp-routes-in-ipv6-unicast.expected --
+Instance    Peer    Prefix           NextHop           Age
+instance0   peer0   fd00:10::/64     fd00:10:99:7::1   -
+            peer1   fd00:10::/64     fd00:10:99:7::2   -
+instance1   peer0   fd00:10:1::/64   fd00:10:99:7::3   -
+            peer1   fd00:10:2::/64   fd00:10:99:7::4   -

--- a/pkg/bgp/test/testdata/peering-multi-instance.txtar
+++ b/pkg/bgp/test/testdata/peering-multi-instance.txtar
@@ -75,7 +75,7 @@ bgp/peers -o peers.actual --no-uptime
 * cmp cilium-peers.expected peers.actual
 
 # Validate advertised routes on Cilium
-bgp/routes -o routes.actual advertised
+bgp/routes -o routes.actual --no-age out ipv4 unicast
 * cmp cilium-routes.expected routes.actual
 
 # Validate route-policies on Cilium
@@ -242,13 +242,13 @@ tor-65001   gobgp-peer-1   established     -        ipv4-unicast   0          0 
             gobgp-peer-2   established     -        ipv4-unicast   0          0          2
 tor-65002   gobgp-peer-3   established     -        ipv4-unicast   0          0          2
 -- cilium-routes.expected --
-VRouter   Peer          Prefix            NextHop       Attrs
-65001     10.99.0.101   10.244.0.0/24     10.99.0.110   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.110}]
-65001     10.99.0.101   10.96.50.104/32   10.99.0.110   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.110}]
-65001     10.99.0.102   10.244.0.0/24     10.99.0.110   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.110}]
-65001     10.99.0.102   10.96.50.104/32   10.99.0.110   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.0.110}]
-65002     10.99.0.103   10.244.0.0/24     10.99.0.110   [{Origin: i} {AsPath: 65002} {Nexthop: 10.99.0.110}]
-65002     10.99.0.103   10.96.50.104/32   10.99.0.110   [{Origin: i} {AsPath: 65002} {Nexthop: 10.99.0.110}]
+Instance    Peer           Prefix            NextHop       Age
+tor-65001   gobgp-peer-1   10.244.0.0/24     10.99.0.110   -
+                           10.96.50.104/32   10.99.0.110   -
+            gobgp-peer-2   10.244.0.0/24     10.99.0.110   -
+                           10.96.50.104/32   10.99.0.110   -
+tor-65002   gobgp-peer-3   10.244.0.0/24     10.99.0.110   -
+                           10.96.50.104/32   10.99.0.110   -
 -- cilium-route-policies.expected --
 VRouter   Policy Name                                     Type     Match Peers   Match Families   Match Prefixes (Min..Max Len)   RIB Action   Path Actions
 65001     allow-local                                     import                                                                  accept       

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -144,6 +144,9 @@ type PeerState struct {
 	// Name of the peer
 	Name string
 
+	// Address of the peer
+	Address netip.Addr
+
 	// BGP peer state
 	SessionState SessionState
 


### PR DESCRIPTION
This is a preparation work to renew the current cilium-dbg bgp routes command output to reflect BGPv2 structure better. Introducing bgp/routes Hive Shell command which eventually become a backend of the cilium-dbg bgp routes command. Note that this PR doesn't replace cilium-dbg bpf routes. It will be covered in the separate PR. Please review commit-by-commit.

```release-note
bgp: Introduce bgp/routes Hive Shell command
```
