### PR TITLE
bpf, datapath: move CIDR identity range to runtime config

### DIFF
--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -7,6 +7,22 @@
 
 #include "dbg.h"
 #include "clustermesh.h"
+
+/**
+ * Minimal numeric identity value for a local (CIDR) identity.
+ *
+ * It must be in sync with the constant identity.MinLocalIdentity
+ * defined in the numericidentity.go file.
+ */
+#define CIDR_IDENTITY_RANGE_START ((1 << 24) + 1)
+/**
+ * Maximal numeric identity value for a local (CIDR) identity.
+ *
+ * It must be in sync with the constant identity.MaxLocalIdentity
+ * defined in the numericidentity.go file.
+ */
+#define CIDR_IDENTITY_RANGE_END ((1 << 24) + (1 << 16) - 1)
+
 /**
  * get_identity - returns source identity from the mark field
  *

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -177,9 +177,6 @@ break; \
 } \
 return false;
 
-#define CIDR_IDENTITY_RANGE_START ((1 << 24) + 1)
-#define CIDR_IDENTITY_RANGE_END   ((1 << 24) + (1<<16) - 1)
-
 /*
  *   **** WARNING, THIS FILE IS DEPRECATED, SEE COMMENT AT THE TOP ****
  */

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -513,9 +513,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["DISABLE_EXTERNAL_IP_MITIGATION"] = "1"
 	}
 
-	cDefinesMap["CIDR_IDENTITY_RANGE_START"] = fmt.Sprintf("%d", identity.MinLocalIdentity)
-	cDefinesMap["CIDR_IDENTITY_RANGE_END"] = fmt.Sprintf("%d", identity.MaxLocalIdentity)
-
 	if option.Config.TunnelingEnabled() {
 		cDefinesMap["TUNNEL_MODE"] = "1"
 	}


### PR DESCRIPTION
This commit replaces CIDR identity range macros with CONFIG values so BPF programs and tests consume cidr_identity_range_start/end at runtime.
The Go datapath now populates these fields across host, endpoint, overlay, WireGuard, XDP, and socket LB configs.