### PR TITLE
datapath/loader: Add netkit to BPF load tests

### DIFF
--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -11,7 +11,7 @@ import (
 
 func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
 	return func(yield func(*config.BPFLXC) bool) {
-		for permutation := range permute(7) {
+		for permutation := range permute(8) {
 			cfg := config.NewBPFLXC(*config.NewNode())
 			cfg.Node.TracingIPOptionType = 1
 			cfg.Node.DebugLB = true
@@ -23,6 +23,7 @@ func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
 			cfg.HybridRoutingEnabled = permutation[4]
 			cfg.EnableConntrackAccounting = permutation[5]
 			cfg.EnableARPResponder = permutation[6]
+			cfg.EnableNetkit = permutation[7]
 
 			if !yield(cfg) {
 				return


### PR DESCRIPTION
Commit 854473726b ("bpf: Workaround for netkit + L7 policy redirect failure") introduced the enable_netkit load-time config variable.

This commit introduces that variable to BPF loader permutation testing for bpf_lxc.