### PR TITLE
sysdump: Use label selectors for Hubble UI/Relay deployment collection

### DIFF
--- a/cilium-cli/sysdump/client.go
+++ b/cilium-cli/sysdump/client.go
@@ -68,6 +68,7 @@ type KubernetesClient interface {
 	ListCiliumNodeConfigs(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumNodeConfigList, error)
 	ListCiliumPodIPPools(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumPodIPPoolList, error)
 	ListDaemonSet(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DaemonSetList, error)
+	ListDeployment(ctx context.Context, namespace string, o metav1.ListOptions) (*appsv1.DeploymentList, error)
 	ListEvents(ctx context.Context, o metav1.ListOptions) (*corev1.EventList, error)
 	ListEndpoints(ctx context.Context, o metav1.ListOptions) (*corev1.EndpointsList, error)
 	ListEndpointSlices(ctx context.Context, o metav1.ListOptions) (*discoveryv1.EndpointSliceList, error)

--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -33,8 +33,6 @@ const (
 	ciliumEnvoyConfigMapName           = defaults.EnvoyConfigMapName
 	hubbleRelayConfigMapName           = defaults.RelayConfigMapName
 	hubbleRelayContainerName           = defaults.RelayContainerName
-	hubbleRelayDeploymentName          = defaults.RelayDeploymentName
-	hubbleUIDeploymentName             = defaults.HubbleUIDeploymentName
 	hubbleGenerateCertsCronJob         = defaults.HubbleGenerateCertsCronJobName
 	spireServerContainerName           = "spire-server"
 	redacted                           = "XXXXXX"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1023,16 +1023,20 @@ func (c *Collector) Run() error {
 			Description: "Collecting the Hubble Relay deployment",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
-				v, err := c.Client.GetDeployment(ctx, c.Options.CiliumNamespace, hubbleRelayDeploymentName, metav1.GetOptions{})
+				deployments, err := c.Client.ListDeployment(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
+					LabelSelector: c.Options.HubbleRelayLabelSelector,
+				})
 				if err != nil {
-					if k8sErrors.IsNotFound(err) {
-						c.logWarn("Deployment %q not found in namespace %q - this is expected if Hubble is not enabled", hubbleRelayDeploymentName, c.Options.CiliumNamespace)
-						return nil
-					}
 					return fmt.Errorf("failed to collect the Hubble Relay deployment: %w", err)
 				}
-				if err := c.WriteYAML(hubbleRelayDeploymentFileName, v); err != nil {
-					return fmt.Errorf("failed to collect the Hubble Relay deployment: %w", err)
+				if len(deployments.Items) == 0 {
+					c.logWarn("Deployment with label %q not found in namespace %q - this is expected if Hubble is not enabled", c.Options.HubbleRelayLabelSelector, c.Options.CiliumNamespace)
+					return nil
+				}
+				for i := range deployments.Items {
+					if err := c.WriteYAML(hubbleRelayDeploymentFileName, &deployments.Items[i]); err != nil {
+						return fmt.Errorf("failed to collect the Hubble Relay deployment %q: %w", deployments.Items[i].Name, err)
+					}
 				}
 				return nil
 			},
@@ -1041,16 +1045,20 @@ func (c *Collector) Run() error {
 			Description: "Collecting the Hubble UI deployment",
 			Quick:       true,
 			Task: func(ctx context.Context) error {
-				v, err := c.Client.GetDeployment(ctx, c.Options.CiliumNamespace, hubbleUIDeploymentName, metav1.GetOptions{})
+				deployments, err := c.Client.ListDeployment(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
+					LabelSelector: c.Options.HubbleUILabelSelector,
+				})
 				if err != nil {
-					if k8sErrors.IsNotFound(err) {
-						c.logWarn("Deployment %q not found in namespace %q - this is expected if Hubble UI is not enabled", hubbleUIDeploymentName, c.Options.CiliumNamespace)
-						return nil
-					}
 					return fmt.Errorf("failed to collect the Hubble UI deployment: %w", err)
 				}
-				if err := c.WriteYAML(hubbleUIDeploymentFileName, v); err != nil {
-					return fmt.Errorf("failed to collect the Hubble UI deployment: %w", err)
+				if len(deployments.Items) == 0 {
+					c.logWarn("Deployment with label %q not found in namespace %q - this is expected if Hubble UI is not enabled", c.Options.HubbleUILabelSelector, c.Options.CiliumNamespace)
+					return nil
+				}
+				for i := range deployments.Items {
+					if err := c.WriteYAML(hubbleUIDeploymentFileName, &deployments.Items[i]); err != nil {
+						return fmt.Errorf("failed to collect the Hubble UI deployment %q: %w", deployments.Items[i].Name, err)
+					}
 				}
 				return nil
 			},

--- a/cilium-cli/sysdump/sysdump_test.go
+++ b/cilium-cli/sysdump/sysdump_test.go
@@ -512,6 +512,10 @@ func (c *fakeClient) GetDeployment(_ context.Context, _, _ string, _ metav1.GetO
 	return nil, nil
 }
 
+func (c *fakeClient) ListDeployment(_ context.Context, _ string, _ metav1.ListOptions) (*appsv1.DeploymentList, error) {
+	return &appsv1.DeploymentList{}, nil
+}
+
 func (c *fakeClient) GetLogs(_ context.Context, _, _, _ string, _ corev1.PodLogOptions, _ io.Writer) error {
 	panic("implement me")
 }


### PR DESCRIPTION
Previously, sysdump collected Hubble UI and Hubble Relay deployments using hardcoded deployment names ('hubble-ui', 'hubble-relay'). This caused the collection to fail when users deployed Hubble components with custom names (e.g., 'hubble-ui-blue'), even when the correct labels were provided via --hubble-ui-labels or --hubble-relay-labels.

This change updates the deployment collection to use ListDeployment with the configured label selectors instead of GetDeployment with hardcoded names. This makes deployment collection consistent with pod log collection, which already uses label selectors.

Fixes the issue where:
  cilium sysdump --hubble-ui-labels k8s-app=hubble-ui-blue
would still fail with 'Deployment hubble-ui not found'.

