### PR TITLE
test: fix goleak check in combination with script tests

### DIFF
--- a/clustermesh-apiserver/clustermesh/main_test.go
+++ b/clustermesh-apiserver/clustermesh/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/clustermesh-apiserver/clustermesh/script_test.go
+++ b/clustermesh-apiserver/clustermesh/script_test.go
@@ -34,20 +34,12 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
-	t.Cleanup(func() {
-		testutils.GoleakVerifyNone(t,
-			testutils.GoleakIgnoreCurrent(),
-		)
-	})
-
 	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption

--- a/clustermesh-apiserver/clustermesh/users_mgmt_test.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/testutils"
 )
 
 const (
@@ -56,10 +55,6 @@ func (f *fakeUserMgmtClient) UserEnforceAbsence(_ context.Context, name string) 
 }
 
 func TestUsersManagement(t *testing.T) {
-	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
-	leakOpts := testutils.GoleakIgnoreCurrent()
-	t.Cleanup(func() { testutils.GoleakVerifyNone(t, leakOpts) })
-
 	var client fakeUserMgmtClient
 	client.init()
 

--- a/clustermesh-apiserver/mcsapi-coredns-cfg/main_test.go
+++ b/clustermesh-apiserver/mcsapi-coredns-cfg/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapiCorednsCfg_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go
+++ b/clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go
@@ -23,20 +23,12 @@ import (
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	// Catch any leaked goroutines. Ignoring goroutines possibly left by other tests.
-	t.Cleanup(func() {
-		testutils.GoleakVerifyNone(t,
-			testutils.GoleakIgnoreCurrent(),
-		)
-	})
-
 	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption

--- a/operator/pkg/kvstore/nodesgc/main_test.go
+++ b/operator/pkg/kvstore/nodesgc/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodesgc_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/operator/pkg/kvstore/nodesgc/script_test.go
+++ b/operator/pkg/kvstore/nodesgc/script_test.go
@@ -31,15 +31,12 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	defer testutils.GoleakVerifyNone(t)
-
 	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption

--- a/operator/watchers/main_test.go
+++ b/operator/watchers/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/operator/watchers/script_test.go
+++ b/operator/watchers/script_test.go
@@ -32,21 +32,12 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	// Catch any leaked goroutines.
-	t.Cleanup(func() {
-		testutils.GoleakVerifyNone(t,
-			// Ignore goroutines possibly left by other tests.
-			testutils.GoleakIgnoreCurrent(),
-		)
-	})
-
 	version.Force(k8sTestutils.DefaultVersion)
 
 	var opts []hivetest.LogOption

--- a/pkg/ciliumenvoyconfig/main_test.go
+++ b/pkg/ciliumenvoyconfig/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/pkg/ciliumenvoyconfig/script_test.go
+++ b/pkg/ciliumenvoyconfig/script_test.go
@@ -58,16 +58,12 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/source"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	// Catch any leaked goroutines.
-	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
-
 	version.Force(k8sTestutils.DefaultVersion)
 	setup := func(t testing.TB, args []string) *script.Engine {
 		fakeEnvoy := &fakeEnvoySyncerAndPolicyTrigger{

--- a/pkg/datapath/linux/backend_neighbors_test.go
+++ b/pkg/datapath/linux/backend_neighbors_test.go
@@ -16,16 +16,10 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/neighbor"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/loadbalancer"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 func TestBackendNeighborSync(t *testing.T) {
-	// Ignore all the currently running goroutines spawned
-	// by prior tests or by package init() functions.
-	goleakOpt := testutils.GoleakIgnoreCurrent()
-	t.Cleanup(func() { testutils.GoleakVerifyNone(t, goleakOpt) })
-
 	var (
 		db             *statedb.DB
 		backends       statedb.RWTable[*loadbalancer.Backend]

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -35,24 +35,8 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-func devicesControllerTestSetup(t *testing.T) {
-	t.Cleanup(func() {
-		testutils.GoleakVerifyNone(
-			t,
-			testutils.GoleakIgnoreCurrent(),
-			// Ignore loop() and the netlink goroutines. These are left behind as netlink library has a bug
-			// that causes it to be stuck in Recvfrom even after stop channel closes.
-			// This is fixed by https://github.com/vishvananda/netlink/pull/793, but that has not been merged.
-			// These goroutines will terminate after any route or address update.
-			testutils.GoleakIgnoreTopFunction("github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).loop"),
-			testutils.GoleakIgnoreTopFunction("syscall.Syscall6"), // Recvfrom
-		)
-	})
-}
-
 func TestPrivilegedDevicesControllerScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
-	devicesControllerTestSetup(t)
 
 	setup := func(t testing.TB, args []string) *script.Engine {
 		var err error

--- a/pkg/datapath/linux/main_test.go
+++ b/pkg/datapath/linux/main_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m,
+		// When IPSec is enabled, [linuxNodeHandler] attempts to register IPSec metrics.
+		// Eventually, [metrics.withRegistry] spawns a goroutine to wait for the registry
+		// promise to resolve, but given that it gets never resolved, is is leaked.
+		testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/metrics.withRegistry.func1"),
+	)
+}

--- a/pkg/datapath/linux/route/reconciler/scripttest/main_test.go
+++ b/pkg/datapath/linux/route/reconciler/scripttest/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package scripttest
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/pkg/datapath/linux/route/reconciler/scripttest/reconciler_test.go
+++ b/pkg/datapath/linux/route/reconciler/scripttest/reconciler_test.go
@@ -34,8 +34,6 @@ import (
 func TestPrivilegedScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
-	defer testutils.GoleakVerifyNone(t)
-
 	// When certain kernel modules are loaded, the kernel will by default try
 	// to create fallback devices in newly created network namespaces.
 	// Setting net.core.fb_tunnels_only_for_init=2 will prevent the kernel from

--- a/pkg/datapath/linux/route/reconciler/scripttest/testdata/priority.txtar
+++ b/pkg/datapath/linux/route/reconciler/scripttest/testdata/priority.txtar
@@ -33,6 +33,9 @@ db/cmp desired-routes expected-desired-3.table
 route/list --table=2000
 * cmp stdout expected-routes.txt
 
+# Stop hive properly
+hive/stop
+
 -- eth0-200-101.yaml --
 table: 2000
 prefix: "10.2.3.4/32"

--- a/pkg/dynamicconfig/main_test.go
+++ b/pkg/dynamicconfig/main_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dynamicconfig_test
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}

--- a/pkg/dynamicconfig/script_test.go
+++ b/pkg/dynamicconfig/script_test.go
@@ -22,16 +22,12 @@ import (
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/k8s/version"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	// Catch any leaked goroutines.
-	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
-
 	nodeTypes.SetName("testnode")
 
 	version.Force(k8sTestutils.DefaultVersion)

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -51,8 +51,6 @@ import (
 var debug = flag.Bool("debug", false, "Enable debug logging")
 
 func TestScript(t *testing.T) {
-	defer testutils.GoleakVerifyNone(t)
-
 	version.Force(k8sTestutils.DefaultVersion)
 	nodeTypes.SetName("testnode")
 


### PR DESCRIPTION
Currently, multiple script tests are intended to validate that no goroutines are leaked once the tests end, deferring the invocation of the dedicated [testutils.GoleakVerifyNone] function. However, the underlying [goleak.VerifyNone] utility is incompatible with t.Parallel \[1], which is set by default by script tests, and no check is actually performed.

Let's get this fixed by using [goleak.VerifyTestMain] instead, as also suggested by goleak documentation itself. This commit fixes all occurrences spotted via:

$ git grep -l GoleakVerifyNone | xargs grep -l testdata

It is worth additionally mentioning that:

* GoleakVerifyTestMain was already invoked in the redirectpolicy package, and is thus not added;
* The functions previously ignored in the devices_controller tests do not appear to be necessary anymore, and have been omitted; yet, we need to additionally ignore one metrics related goroutine that is otherwise flagged when IPSec is enabled;
* One of the script tests in the route/reconciler package did not correctly stop the hive, causing a few goroutines to be leaked.

Ideally we should have a linter to catch this problem directly in CI, but that's deferred for the future.

\[1]: https://pkg.go.dev/go.uber.org/goleak#VerifyNone

Tentatively marked for backport to v1.19 as well, given that it is a test only change.