### PR TITLE
ingress: add 443 as listener in cec

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -228,8 +228,11 @@ func (r *ingressReconciler) buildSharedResources(ctx context.Context) (*ciliumv2
 			m.HTTP = append(m.HTTP, ingestion.Ingress(r.logger, item, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 		}
 	}
-
-	return r.cecTranslator.Translate(r.ciliumNamespace, r.sharedResourcesName, m)
+	cec, err := r.cecTranslator.Translate(r.ciliumNamespace, r.sharedResourcesName, m)
+	if len(cec.Spec.Services) > 0 {
+		cec.Spec.Services[0].Ports = append(cec.Spec.Services[0].Ports, 443)
+	}
+	return cec, err
 }
 
 func (r *ingressReconciler) getSharedListenerPorts() (uint32, uint32, uint32) {


### PR DESCRIPTION
<!-- Description of change -->
We saw that there was an issue where AWS' nlb on an ingress with a `shared` loadbalancer would report an unhealthy port 443 after an version upgrade from 1.14 to 1.17. 

This adds port 443 to the cec for an ingress that opens the listener to receive healthchecks.
Testing with `nc` on port 80 and port 443 both now output a successful connection

Related to https://github.com/cilium/cilium/issues/34093, specifically this [comment](https://github.com/cilium/cilium/issues/34093#issuecomment-2377631220). 

```release-note
ingress: Ensure that the shared ingress exposes port 443 so that it can pass upstream loadbalancer health checks.
```

