### PR TITLE
clustermesh: move cluster ID shift/bits state into ClusterInfo

### DIFF
--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -16,8 +16,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	cacheKey "github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -229,8 +229,12 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend all
 	//
 	// FIXME: add options to handle clustermesh with this constructor parameter:
 	//    allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID<<identity.ClusterIDShift)))
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	clusterInfo := cmtypes.ClusterInfo{
+		ID:                   option.Config.ClusterID,
+		MaxConnectedClusters: option.Config.MaxConnectedClusters,
+	}
+	minID := idpool.ID(clusterInfo.MinimalAllocationIdentity(option.Config.ClusterID))
+	maxID := idpool.ID(clusterInfo.MaximumAllocationIdentity(option.Config.ClusterID))
 	crdAllocator, err = allocator.NewAllocator(log, &cacheKey.GlobalIdentity{}, crdBackend, allocator.WithMax(maxID), allocator.WithMin(minID))
 	if err != nil {
 		logging.Fatal(log, "Unable to initialize Identity Allocator with CRD backend to allocate identities with already allocated IDs", logfields.Error, err)

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/allocator"
-	ciliumIdentity "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/idpool"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
@@ -23,8 +22,8 @@ func (igc *GC) startKVStoreModeGC(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize kvstore backend for identity allocation")
 	}
 
-	minID := idpool.ID(ciliumIdentity.GetMinimalAllocationIdentity(igc.clusterInfo.ID))
-	maxID := idpool.ID(ciliumIdentity.GetMaximumAllocationIdentity(igc.clusterInfo.ID))
+	minID := idpool.ID(igc.clusterInfo.MinimalAllocationIdentity(igc.clusterInfo.ID))
+	maxID := idpool.ID(igc.clusterInfo.MaximumAllocationIdentity(igc.clusterInfo.ID))
 	igc.logger.InfoContext(ctx, "Garbage Collecting kvstore identities between range",
 		logfields.Min, minID,
 		logfields.Max, maxID,

--- a/operator/pkg/ciliumidentity/reconciler.go
+++ b/operator/pkg/ciliumidentity/reconciler.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	operator_k8s "github.com/cilium/cilium/operator/k8s"
-	"github.com/cilium/cilium/pkg/identity"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity/basicallocator"
 	"github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -66,8 +66,12 @@ func newReconciler(
 ) (*reconciler, error) {
 	logger.InfoContext(ctx, "Creating CID controller Operator reconciler")
 
-	minIDValue := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
-	maxIDValue := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	clusterInfo := cmtypes.ClusterInfo{
+		ID:                   option.Config.ClusterID,
+		MaxConnectedClusters: option.Config.MaxConnectedClusters,
+	}
+	minIDValue := idpool.ID(clusterInfo.MinimalAllocationIdentity(option.Config.ClusterID))
+	maxIDValue := idpool.ID(clusterInfo.MaximumAllocationIdentity(option.Config.ClusterID))
 	idAllocator := basicallocator.NewBasicIDAllocator(minIDValue, maxIDValue)
 
 	nsStore, err := namespace.Store(ctx)

--- a/operator/pkg/kvstore/locksweeper/locksweeper.go
+++ b/operator/pkg/kvstore/locksweeper/locksweeper.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/idpool"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -48,8 +47,8 @@ func runLockSweeper(p params) {
 		logging.Fatal(p.Logger, "Unable to initialize kvstore backend for stale locks collection", logfields.Error, err)
 	}
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(p.ClusterInfo.ID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(p.ClusterInfo.ID))
+	minID := idpool.ID(p.ClusterInfo.MinimalAllocationIdentity(p.ClusterInfo.ID))
+	maxID := idpool.ID(p.ClusterInfo.MaximumAllocationIdentity(p.ClusterInfo.ID))
 	a := allocator.NewAllocatorForGC(p.Logger, backend, allocator.WithMin(minID), allocator.WithMax(maxID))
 
 	keysToDelete := map[string]kvstore.Value{}

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -276,7 +276,9 @@ func (rc *remoteCluster) ipCacheWatcherOpts(config *cmtypes.CiliumClusterConfig)
 
 	if config != nil {
 		opts = append(opts, ipcache.WithCachedPrefix(config.Capabilities.Cached))
-		opts = append(opts, ipcache.WithIdentityValidator(config.ID))
+		opts = append(opts, ipcache.WithIdentityValidator(cmtypes.ClusterInfo{
+			MaxConnectedClusters: option.Config.MaxConnectedClusters,
+		}, config.ID))
 	}
 
 	if rc.ipCacheWatcherExtraOpts != nil {

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -574,7 +574,7 @@ func TestIPCacheWatcherOpts(t *testing.T) {
 		{
 			name: "with extra opts",
 			extra: func(config *types.CiliumClusterConfig) []ipcache.IWOpt {
-				return []ipcache.IWOpt{ipcache.WithClusterID(10), ipcache.WithIdentityValidator(25)}
+				return []ipcache.IWOpt{ipcache.WithClusterID(10), ipcache.WithIdentityValidator(types.DefaultClusterInfo, 25)}
 			},
 			expected: 2,
 		},

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -6,11 +6,13 @@ package types
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/defaults"
+	identitynumeric "github.com/cilium/cilium/pkg/identity/numericidentity"
 )
 
 const (
@@ -114,4 +116,41 @@ type CiliumClusterConfigCapabilities struct {
 	// Whether or not MCS-API ServiceExports is enabled by the cluster.
 	// Additionally a nil values means that it's not supported.
 	ServiceExportsEnabled *bool `json:"serviceExportsEnabled,omitempty"`
+}
+
+func (c ClusterInfo) configuredMaxConnectedClusters() uint32 {
+	if c.MaxConnectedClusters == 0 {
+		return defaults.MaxConnectedClusters
+	}
+	return c.MaxConnectedClusters
+}
+
+// GetClusterIDBits returns the number of bits that represent a cluster ID in a
+// numeric identity for this cluster configuration.
+func (c ClusterInfo) GetClusterIDBits() uint32 {
+	return uint32(math.Log2(float64(c.configuredMaxConnectedClusters() + 1)))
+}
+
+// GetClusterIDShift returns the number of bits to shift a cluster ID in a
+// numeric identity for this cluster configuration.
+func (c ClusterInfo) GetClusterIDShift() uint32 {
+	return identitynumeric.Bitlength - c.GetClusterIDBits()
+}
+
+// MinimalAllocationIdentity returns the minimal numeric identity not used for
+// reserved purposes for the given cluster ID under this cluster configuration.
+func (c ClusterInfo) MinimalAllocationIdentity(clusterID uint32) uint32 {
+	if clusterID > 0 {
+		// For ClusterID > 0, the identity range just starts from cluster shift,
+		// no well-known-identities need to be reserved from the range.
+		return (1 << c.GetClusterIDShift()) * clusterID
+	}
+	return identitynumeric.MinimalIdentity
+}
+
+// MaximumAllocationIdentity returns the maximum numeric identity that should be
+// handed out by the identity allocator for the given cluster ID under this
+// cluster configuration.
+func (c ClusterInfo) MaximumAllocationIdentity(clusterID uint32) uint32 {
+	return (1<<c.GetClusterIDShift())*(clusterID+1) - 1
 }

--- a/pkg/datapath/config/node.go
+++ b/pkg/datapath/config/node.go
@@ -4,14 +4,16 @@
 package config
 
 import (
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func NodeConfig(lnc *Config) Node {
 	node := *NewNode()
-	node.ClusterIDBits = identity.GetClusterIDBits()
+	node.ClusterIDBits = cmtypes.ClusterInfo{
+		MaxConnectedClusters: option.Config.MaxConnectedClusters,
+	}.GetClusterIDBits()
 
 	node.CiliumHostIfIndex = lnc.CiliumHostIfIndex
 	node.CiliumHostMAC.Addr = lnc.CiliumHostMAC.As6()

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -117,12 +118,13 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 
 	// Initialize the endpoints.
 	endpoints := make([]*endpoint.Endpoint, nEndpoints)
+	clusterInfo := cmtypes.ClusterInfo{MaxConnectedClusters: option.Config.MaxConnectedClusters}
 	for i := range endpoints {
 		endpoints[i] = &endpoint.Endpoint{
 			ID:   uint16(i),
 			IPv4: netip.MustParseAddr(fmt.Sprintf("10.96.%d.%d", i/256, i%256)),
 			SecurityIdentity: &identity.Identity{
-				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
+				ID: identity.NumericIdentity(i % int(clusterInfo.MaximumAllocationIdentity(option.Config.ClusterID))),
 			},
 			DNSZombies: &fqdn.DNSZombieMappings{
 				Mutex: lock.Mutex{},

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -239,8 +239,9 @@ func TestNameManagerGCConsistency(t *testing.T) {
 		logger: logger,
 		eps:    make(sets.Set[*endpoint.Endpoint]),
 	}
+	clusterInfo := cmtypes.ClusterInfo{MaxConnectedClusters: option.Config.MaxConnectedClusters}
 	ep := &endpoint.Endpoint{ID: uint16(1), IPv4: netip.MustParseAddr("10.96.0.1"), SecurityIdentity: &identity.Identity{
-		ID: identity.NumericIdentity(int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
+		ID: identity.NumericIdentity(int(clusterInfo.MaximumAllocationIdentity(option.Config.ClusterID))),
 	},
 		DNSZombies: fqdn.NewDNSZombieMappings(logger, 10000, 10000),
 		DNSHistory: fqdn.NewDNSCache(1),

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -710,14 +710,13 @@ func testCheckpointRestore(t *testing.T, testConfig testConfig) {
 }
 
 func TestClusterIDValidator(t *testing.T) {
-	const (
-		cid   = 5
-		minID = cid << 16
-		maxID = minID + 65535
-	)
+	const cid = 5
+	cinfo := cmtypes.DefaultClusterInfo
+	minID := idpool.ID(cinfo.MinimalAllocationIdentity(cid))
+	maxID := idpool.ID(cinfo.MaximumAllocationIdentity(cid))
 
 	var (
-		validator = clusterIDValidator(cid)
+		validator = clusterIDValidator(cinfo, cid)
 		key       = &cacheKey.GlobalIdentity{}
 	)
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -21,6 +21,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/key"
@@ -106,12 +107,15 @@ type CachingIdentityAllocator struct {
 
 	// syncInterval is the periodic synchronization interval of the allocated identities.
 	syncInterval time.Duration
+
+	clusterInfo cmtypes.ClusterInfo
 }
 
 type AllocatorConfig struct {
 	EnableOperatorManageCIDs bool
 	Timeout                  time.Duration
 	SyncInterval             time.Duration
+	ClusterInfo              cmtypes.ClusterInfo
 	maxAllocAttempts         int
 }
 
@@ -218,8 +222,8 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 	m.logger.Info("Initializing identity allocator")
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	minID := idpool.ID(m.clusterInfo.MinimalAllocationIdentity(option.Config.ClusterID))
+	maxID := idpool.ID(m.clusterInfo.MaximumAllocationIdentity(option.Config.ClusterID))
 
 	m.logger.Info(
 		"Allocating identities between range",
@@ -306,7 +310,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 		allocOptions := []allocator.AllocatorOption{
 			allocator.WithMax(maxID), allocator.WithMin(minID),
 			allocator.WithEvents(events), allocator.WithSyncInterval(m.syncInterval),
-			allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID << identity.GetClusterIDShift())),
+			allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID << m.clusterInfo.GetClusterIDShift())),
 		}
 		if m.operatorIDManagement {
 			allocOptions = append(allocOptions, allocator.WithOperatorIDManagement())
@@ -392,6 +396,7 @@ func NewCachingIdentityAllocator(logger *slog.Logger, owner IdentityAllocatorOwn
 		maxAllocAttempts:                   config.maxAllocAttempts,
 		timeout:                            config.Timeout,
 		syncInterval:                       config.SyncInterval,
+		clusterInfo:                        config.ClusterInfo,
 	}
 	if option.Config.RunDir != "" { // disable checkpointing if this is a unit test
 		m.checkpointPath = filepath.Join(option.Config.StateDir, CheckpointFile)
@@ -938,7 +943,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, remo
 	remoteAlloc, err := allocator.NewAllocator(m.logger,
 		&key.GlobalIdentity{}, remoteAllocatorBackend,
 		allocator.WithEvents(m.IdentityAllocator.GetEvents()), allocator.WithoutGC(), allocator.WithoutAutostart(),
-		allocator.WithCacheValidator(clusterIDValidator(remoteID)),
+		allocator.WithCacheValidator(clusterIDValidator(m.clusterInfo, remoteID)),
 		allocator.WithCacheValidator(clusterNameValidator(remoteName)),
 	)
 	if err != nil {
@@ -1025,9 +1030,9 @@ func (m *CachingIdentityAllocator) LocalIdentityChanges() stream.Observable[Iden
 
 // clusterIDValidator returns a validator ensuring that the identity ID belongs
 // to the ClusterID range.
-func clusterIDValidator(clusterID uint32) allocator.CacheValidator {
-	min := idpool.ID(identity.GetMinimalAllocationIdentity(clusterID))
-	max := idpool.ID(identity.GetMaximumAllocationIdentity(clusterID))
+func clusterIDValidator(cinfo cmtypes.ClusterInfo, clusterID uint32) allocator.CacheValidator {
+	min := idpool.ID(cinfo.MinimalAllocationIdentity(clusterID))
+	max := idpool.ID(cinfo.MaximumAllocationIdentity(clusterID))
 
 	return func(_ allocator.AllocatorChangeKind, id idpool.ID, _ allocator.AllocatorKey) error {
 		if id < min || id > max {

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
@@ -69,6 +70,7 @@ type identityAllocatorParams struct {
 	Lifecycle      cell.Lifecycle
 	IDUpdater      policycell.IdentityUpdater
 	LocalNodeStore *node.LocalNodeStore
+	ClusterInfo    cmtypes.ClusterInfo
 
 	IdentityHandlers []identity.UpdateIdentities `group:"identity-handlers"`
 
@@ -123,6 +125,7 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 			EnableOperatorManageCIDs: isOperatorManageCIDsEnabled,
 			Timeout:                  params.Config.IdentityAllocationTimeout,
 			SyncInterval:             params.Config.IdentityAllocationSyncInterval,
+			ClusterInfo:              params.ClusterInfo,
 		}
 
 		// Allocator: allocates local and cluster-wide security identities.

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -10,10 +10,10 @@ import (
 	"net/netip"
 	"sort"
 	"strconv"
-	"sync"
 	"unsafe"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	identitynumeric "github.com/cilium/cilium/pkg/identity/numericidentity"
 	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -71,7 +71,7 @@ const (
 
 	// MinimalNumericIdentity represents the minimal numeric identity not
 	// used for reserved purposes.
-	MinimalNumericIdentity = NumericIdentity(256)
+	MinimalNumericIdentity = NumericIdentity(identitynumeric.MinimalIdentity)
 
 	// UserReservedNumericIdentity represents the minimal numeric identity that
 	// can be used by users for reserved purposes.
@@ -80,20 +80,6 @@ const (
 	// InvalidIdentity is the identity assigned if the identity is invalid
 	// or not determined yet
 	InvalidIdentity = NumericIdentity(0)
-)
-
-var (
-	// clusterIDInit ensures that clusterIDBits and clusterIDShift can only be
-	// set once, and only if we haven't used either value elsewhere already.
-	clusterIDInit sync.Once
-
-	// clusterIDBits is the number of bits that represent a cluster ID in a
-	// numeric identity
-	clusterIDBits uint32
-
-	// clusterIDShift is the number of bits to shift a cluster ID in a numeric
-	// identity and is equal to the number of bits that represent a cluster-local identity.
-	clusterIDShift uint32
 )
 
 const (
@@ -320,47 +306,6 @@ func InitWellKnownIdentities(c Configuration, cinfo cmtypes.ClusterInfo) int {
 	return len(WellKnown)
 }
 
-// GetClusterIDShift returns the number of bits to shift a cluster ID in a numeric
-// identity and is equal to the number of bits that represent a cluster-local identity.
-// A sync.Once is used to ensure we only initialize clusterIDShift once.
-func GetClusterIDShift() uint32 {
-	clusterIDInit.Do(initClusterIDShift)
-	return clusterIDShift
-}
-
-// GetClusterIDBits returns the number of bits that represent a cluster ID in a numeric identity
-// A sync.Once is used to ensure we only initialize clusterIDBits once.
-func GetClusterIDBits() uint32 {
-	clusterIDInit.Do(initClusterIDShift)
-	return clusterIDBits
-}
-
-// initClusterIDShift sets variables that control the bit allocation of cluster
-// ID in a numeric identity.
-func initClusterIDShift() {
-	// ClusterIDLen is the number of bits that represent a cluster ID in a numeric identity
-	clusterIDBits = uint32(math.Log2(float64(cmtypes.ClusterIDMax + 1)))
-	// ClusterIDShift is the number of bits to shift a cluster ID in a numeric identity
-	clusterIDShift = NumericIdentityBitlength - clusterIDBits
-}
-
-// GetMinimalNumericIdentity returns the minimal numeric identity not used for
-// reserved purposes.
-func GetMinimalAllocationIdentity(clusterID uint32) NumericIdentity {
-	if clusterID > 0 {
-		// For ClusterID > 0, the identity range just starts from cluster shift,
-		// no well-known-identities need to be reserved from the range.
-		return NumericIdentity((1 << GetClusterIDShift()) * clusterID)
-	}
-	return MinimalNumericIdentity
-}
-
-// GetMaximumAllocationIdentity returns the maximum numeric identity that
-// should be handed out by the identity allocator.
-func GetMaximumAllocationIdentity(clusterID uint32) NumericIdentity {
-	return NumericIdentity((1<<GetClusterIDShift())*(clusterID+1) - 1)
-}
-
 var (
 	reservedIdentities = map[string]NumericIdentity{
 		labels.IDNameHost:          ReservedIdentityHost,
@@ -443,7 +388,7 @@ type NumericIdentity uint32
 
 // NumericIdentityBitlength is the number of bits used on the wire for a
 // NumericIdentity
-const NumericIdentityBitlength = 24
+const NumericIdentityBitlength = identitynumeric.Bitlength
 
 // MaxNumericIdentity is the maximum value of a NumericIdentity.
 const MaxNumericIdentity = math.MaxUint32
@@ -501,8 +446,8 @@ func (id NumericIdentity) IsReservedIdentity() bool {
 }
 
 // ClusterID returns the cluster ID associated with the identity
-func (id NumericIdentity) ClusterID() uint32 {
-	return (uint32(id) >> uint32(GetClusterIDShift())) & cmtypes.ClusterIDMax
+func (id NumericIdentity) ClusterID(cinfo cmtypes.ClusterInfo) uint32 {
+	return (uint32(id) >> cinfo.GetClusterIDShift()) & cmtypes.ClusterIDMax
 }
 
 // GetAllReservedIdentities returns a list of all reserved numeric identities

--- a/pkg/identity/numericidentity/constants.go
+++ b/pkg/identity/numericidentity/constants.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package numericidentity contains low-level constants shared by components
+// that need to reason about numeric identity wire layout without importing the
+// higher-level identity package.
+package numericidentity
+
+const (
+	// Bitlength is the number of bits used on the wire for a numeric identity.
+	Bitlength = 24
+
+	// MinimalIdentity is the first numeric identity value that is not reserved.
+	// Global identity allocation for cluster ID 0 starts at this value.
+	MinimalIdentity = 256
+)

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -4,7 +4,6 @@
 package identity
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,13 +16,14 @@ func TestLocalIdentity(t *testing.T) {
 	localID := NumericIdentity(IdentityScopeLocal | 1)
 	require.True(t, localID.HasLocalScope())
 
-	maxClusterID := NumericIdentity(cmtypes.ClusterIDMax | 1)
+	maxClusterID := NumericIdentity(cmtypes.DefaultClusterInfo.MaxConnectedClusters | 1)
 	require.False(t, maxClusterID.HasLocalScope())
 
 	require.False(t, ReservedIdentityWorld.HasLocalScope())
 }
 
 func TestClusterID(t *testing.T) {
+	cinfo := cmtypes.DefaultClusterInfo
 	tbl := []struct {
 		identity  uint32
 		clusterID uint32
@@ -49,13 +49,13 @@ func TestClusterID(t *testing.T) {
 			clusterID: cmtypes.ClusterIDMin,
 		},
 		{
-			identity:  cmtypes.ClusterIDMax << 16,
-			clusterID: cmtypes.ClusterIDMax,
+			identity:  cinfo.MaxConnectedClusters << cinfo.GetClusterIDShift(),
+			clusterID: cinfo.MaxConnectedClusters,
 		},
 	}
 
 	for _, item := range tbl {
-		require.Equal(t, item.clusterID, NumericIdentity(item.identity).ClusterID())
+		require.Equal(t, item.clusterID, NumericIdentity(item.identity).ClusterID(cinfo))
 	}
 }
 
@@ -81,8 +81,6 @@ func TestAsUint32Slice(t *testing.T) {
 }
 
 func TestGetClusterIDShift(t *testing.T) {
-	resetClusterIDInit := func() { clusterIDInit = sync.Once{} }
-
 	tests := []struct {
 		name                   string
 		maxConnectedClusters   uint32
@@ -103,28 +101,11 @@ func TestGetClusterIDShift(t *testing.T) {
 		},
 	}
 
-	// cleanup state from any previous tests
-	resetClusterIDInit()
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Cleanup(resetClusterIDInit)
 			cinfo := cmtypes.ClusterInfo{MaxConnectedClusters: tt.maxConnectedClusters}
-			cinfo.InitClusterIDMax()
-			assert.Equal(t, tt.expectedClusterIDShift, GetClusterIDShift())
-			assert.Equal(t, tt.expectedClusterIDBits, GetClusterIDBits())
-
-			// ensure we cannot change the clusterIDShift after it has been initialized
-			for _, tc := range tests {
-				if tc.name == tt.name {
-					// skip the current test case itself
-					continue
-				}
-				newCinfo := cmtypes.ClusterInfo{MaxConnectedClusters: tc.maxConnectedClusters}
-				newCinfo.InitClusterIDMax()
-				assert.NotEqual(t, tc.expectedClusterIDShift, GetClusterIDShift())
-				assert.NotEqual(t, tc.expectedClusterIDBits, GetClusterIDBits())
-			}
+			assert.Equal(t, tt.expectedClusterIDShift, cinfo.GetClusterIDShift())
+			assert.Equal(t, tt.expectedClusterIDBits, cinfo.GetClusterIDBits())
 		})
 	}
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -288,10 +288,10 @@ func WithCachedPrefix(cached bool) IWOpt {
 
 // WithIdentityValidator registers a validation function to ensure that the
 // observed IPs are associated with an identity belonging to the expected range.
-func WithIdentityValidator(clusterID uint32) IWOpt {
+func WithIdentityValidator(cinfo cmtypes.ClusterInfo, clusterID uint32) IWOpt {
 	return func(opts *iwOpts) {
-		min := identity.GetMinimalAllocationIdentity(clusterID)
-		max := identity.GetMaximumAllocationIdentity(clusterID)
+		min := identity.NumericIdentity(cinfo.MinimalAllocationIdentity(clusterID))
+		max := identity.NumericIdentity(cinfo.MaximumAllocationIdentity(clusterID))
 
 		validator := func(pair *identity.IPIdentityPair) error {
 			switch {

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kvstore"
 	storepkg "github.com/cilium/cilium/pkg/kvstore/store"
@@ -51,8 +52,9 @@ func (fb *fakeBackend) ListAndWatch(ctx context.Context, prefix string) kvstore.
 		return out
 	}
 
+	cinfo := cmtypes.DefaultClusterInfo
 	id := func(clusterID, localID uint32) identity.NumericIdentity {
-		return identity.NumericIdentity(clusterID<<identity.GetClusterIDShift() | localID)
+		return identity.NumericIdentity(clusterID<<cinfo.GetClusterIDShift() | localID)
 	}
 
 	fb.prefix = prefix
@@ -162,18 +164,19 @@ func TestIPIdentityWatcher(t *testing.T) {
 		require.Equal(t, NewEvent("delete", "10.0.0.1", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "f00d::a00:0:0:c164", src), eventually(ipcache.events))
 		require.True(t, synced, "The on-sync callback should have been executed")
-	}, "cilium/state/ip/v1/default/", WithIdentityValidator(10)))
+	}, "cilium/state/ip/v1/default/", WithIdentityValidator(cmtypes.DefaultClusterInfo, 10)))
 }
 
 func TestIdentityValidator(t *testing.T) {
 	const (
-		cid   = 5
-		minID = cid << 16
-		maxID = minID + 65535
+		cid = 5
 	)
+	cinfo := cmtypes.DefaultClusterInfo
+	minID := identity.NumericIdentity(cinfo.MinimalAllocationIdentity(cid))
+	maxID := identity.NumericIdentity(cinfo.MaximumAllocationIdentity(cid))
 
 	var opts iwOpts
-	WithIdentityValidator(cid)(&opts)
+	WithIdentityValidator(cinfo, cid)(&opts)
 
 	require.Len(t, opts.validators, 1, "The validator should have been configured")
 	validator := opts.validators[0]

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
-	"github.com/cilium/cilium/pkg/identity"
 	k8smetrics "github.com/cilium/cilium/pkg/k8s/metrics"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -506,8 +505,8 @@ func (d *statusCollector) getBPFMapStatus() *models.BPFMapStatus {
 
 func (d *statusCollector) getIdentityRange() *models.IdentityRange {
 	s := &models.IdentityRange{
-		MinIdentity: int64(identity.GetMinimalAllocationIdentity(d.statusParams.ClusterInfo.ID)),
-		MaxIdentity: int64(identity.GetMaximumAllocationIdentity(d.statusParams.ClusterInfo.ID)),
+		MinIdentity: int64(d.statusParams.ClusterInfo.MinimalAllocationIdentity(d.statusParams.ClusterInfo.ID)),
+		MaxIdentity: int64(d.statusParams.ClusterInfo.MaximumAllocationIdentity(d.statusParams.ClusterInfo.ID)),
 	}
 
 	return s


### PR DESCRIPTION
Please see description per-commit.

This is an attempt to address this comment: https://github.com/cilium/cilium/pull/43507#discussion_r2685359356