### PR TITLE
docs: Update docsearch to v4.5.4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:c3cbf68c945e23a4a717eab7fd1448ceb99e1c8a@sha256:185913958528f99208d9efa6b76f8ef4b4f6559da0b6be2564163b7d2b5dc1e1
+        uses: docker://quay.io/cilium/docs-builder:edfc28f47c6abfb017912a752f4e06274b126a28@sha256:98069787f6f4c375c31ab536558952daf24c1ca521fb05b283d870178bddfd61
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@5e45810d0af338f8a7a6337b0377412ddf973dbc
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@77d60dbce4cc93358fa6156cbafd7c49214b3c89
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 # Sphinx extensions


### PR DESCRIPTION
Pull in the latest theme with newer docsearch plugin version.

Reference: https://github.com/cilium/sphinx_rtd_theme/pull/27
