### PR TITLE
ipsec: Add configurable jitter to key file watcher to prevent thundering herd

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -254,6 +254,14 @@ to all clusters in the mesh. You might need to increase the transition time to
 allow for the new keys to be deployed and applied across all clusters,
 which you can do with the agent flag ``ipsec-key-rotation-duration``.
 
+In large clusters, key rotation can cause a "thundering herd" effect where all
+agents detect the key change simultaneously and update their CiliumNode resources
+at once, potentially overwhelming the Kubernetes API server. To mitigate this, 
+Cilium applies a random jitter delay before loading new keys. The jitter is
+randomly selected from ``[0, keyRotationDuration/10]``, ensuring agents have
+sufficient time to load new keys before the old keys are removed while spreading
+the load on the Kubernetes API server.
+
 Monitoring
 ==========
 

--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -120,6 +120,15 @@ func (c Config) DNSProxyInsecureSkipTransparentModeCheckEnabled() bool {
 	return c.DNSProxyInsecureSkipTransparentModeCheck
 }
 
+// MaxKeyRotationJitter returns the maximum jitter duration to apply after
+// detecting a key file change before loading new keys. Jitter is set to 1/10
+// of the key rotation duration to prevent thundering herd on the K8s API server
+// while ensuring agents have sufficient time to load new keys before the old
+// keys are removed.
+func (c Config) MaxKeyRotationJitter() time.Duration {
+	return c.IPsecKeyRotationDuration / 10
+}
+
 var defaultEnableConfig = EnableConfig{
 	EnableIPsec: false,
 }

--- a/pkg/datapath/linux/ipsec/cell_test.go
+++ b/pkg/datapath/linux/ipsec/cell_test.go
@@ -328,3 +328,38 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 		})
 	})
 }
+
+func TestMaxKeyRotationJitter(t *testing.T) {
+	tests := []struct {
+		name             string
+		rotationDuration time.Duration
+		expectedJitter   time.Duration
+	}{
+		{
+			name:             "jitter is 1/10 of rotation duration when enabled",
+			rotationDuration: 10 * time.Second,
+			expectedJitter:   1 * time.Second,
+		},
+		{
+			name:             "jitter with default rotation duration",
+			rotationDuration: 5 * time.Minute,
+			expectedJitter:   30 * time.Second,
+		},
+		{
+			name:             "jitter returns 0 when rotation duration is 0",
+			rotationDuration: 0,
+			expectedJitter:   0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := Config{
+				UserConfig: UserConfig{
+					IPsecKeyRotationDuration: tc.rotationDuration,
+				},
+			}
+			assert.Equal(t, tc.expectedJitter, config.MaxKeyRotationJitter())
+		})
+	}
+}


### PR DESCRIPTION
Adds a configurable jitter delay to the IPsec key file watcher to prevent a thundering herd on the Kubernetes API server during key rotation in large clusters. 

```release-note
Add jitter delay to the IPsec key file watcher for key rotations, to avoid thundering herd problem on Cilium agents.
```
Fixes: #42721

