### PR TITLE
k8s/client/fake: let update operations respect resource versioning

### DIFF
--- a/operator/pkg/bgp/cluster_test.go
+++ b/operator/pkg/bgp/cluster_test.go
@@ -1606,12 +1606,14 @@ func TestRouterIDAllocation(t *testing.T) {
 }
 
 func upsertNode(req *require.Assertions, ctx context.Context, f *fixture, node *v2.CiliumNode) {
-	_, err := f.nodeClient.Get(ctx, node.Name, meta_v1.GetOptions{})
+	existing, err := f.nodeClient.Get(ctx, node.Name, meta_v1.GetOptions{})
 	if err != nil && k8sErrors.IsNotFound(err) {
 		_, err = f.nodeClient.Create(ctx, node, meta_v1.CreateOptions{})
 	} else if err != nil {
 		req.Fail(err.Error())
 	} else {
+		node = node.DeepCopy()
+		node.SetResourceVersion(existing.GetResourceVersion())
 		_, err = f.nodeClient.Update(ctx, node, meta_v1.UpdateOptions{})
 	}
 	req.NoError(err)
@@ -1629,6 +1631,7 @@ func upsertBGPCC(req *require.Assertions, ctx context.Context, f *fixture, bgpcc
 		req.Fail(err.Error())
 	} else {
 		bgpcc.SetUID(existing.GetUID())
+		bgpcc.SetResourceVersion(existing.GetResourceVersion())
 		_, err = f.bgpcClient.Update(ctx, bgpcc, meta_v1.UpdateOptions{})
 	}
 	req.NoError(err)
@@ -1639,22 +1642,26 @@ func upsertBGPPC(req *require.Assertions, ctx context.Context, f *fixture, bgppc
 		return
 	}
 
-	_, err := f.bgpcClient.Get(ctx, bgppc.Name, meta_v1.GetOptions{})
+	existing, err := f.bgpcClient.Get(ctx, bgppc.Name, meta_v1.GetOptions{})
 	if err != nil && k8sErrors.IsNotFound(err) {
 		_, err = f.bgppcClient.Create(ctx, bgppc, meta_v1.CreateOptions{})
 	} else if err != nil {
 		req.Fail(err.Error())
 	} else {
+		bgppc = bgppc.DeepCopy()
+		bgppc.SetResourceVersion(existing.ResourceVersion)
 		_, err = f.bgppcClient.Update(ctx, bgppc, meta_v1.UpdateOptions{})
 	}
 	req.NoError(err)
 }
 
 func upsertNodeOverrides(req *require.Assertions, ctx context.Context, f *fixture, nodeOverride *v2.CiliumBGPNodeConfigOverride) {
-	_, err := f.bgpncoClient.Get(ctx, nodeOverride.Name, meta_v1.GetOptions{})
+	existing, err := f.bgpncoClient.Get(ctx, nodeOverride.Name, meta_v1.GetOptions{})
 	if err != nil && k8sErrors.IsNotFound(err) {
 		_, err = f.bgpncoClient.Create(ctx, nodeOverride, meta_v1.CreateOptions{})
 	} else {
+		nodeOverride = nodeOverride.DeepCopy()
+		nodeOverride.SetResourceVersion(existing.ResourceVersion)
 		_, err = f.bgpncoClient.Update(ctx, nodeOverride, meta_v1.UpdateOptions{})
 	}
 	req.NoError(err)

--- a/operator/pkg/ciliumidentity/controller_test.go
+++ b/operator/pkg/ciliumidentity/controller_test.go
@@ -318,7 +318,8 @@ func TestUpdatePodLabels(t *testing.T) {
 	}
 
 	// Create the first pod.
-	if _, err := fakeClient.Slim().CoreV1().Pods(pod1.Namespace).Create(ctx, pod1, metav1.CreateOptions{}); err != nil {
+	current, err := fakeClient.Slim().CoreV1().Pods(pod1.Namespace).Create(ctx, pod1, metav1.CreateOptions{})
+	if err != nil {
 		t.Fatalf("create pod: %v", err)
 	}
 
@@ -333,6 +334,7 @@ func TestUpdatePodLabels(t *testing.T) {
 	ev.Done(nil)
 
 	// Update labels of the first pod.
+	pod1b.SetResourceVersion(current.GetResourceVersion())
 	if _, err := fakeClient.Slim().CoreV1().Pods(pod1b.Namespace).Update(ctx, pod1b, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update pod: %v", err)
 	}

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -769,7 +769,7 @@ func Test_LocalNodeCIDRsSyncer(t *testing.T) {
 	startLocalNodeAllocCIDRsSync(true, true, jg, localNode, localNodeStore)
 
 	// create local node
-	_, err := clientset.CiliumV2().CiliumNodes().Create(t.Context(), currentNode, metav1.CreateOptions{})
+	currentNode, err := clientset.CiliumV2().CiliumNodes().Create(t.Context(), currentNode, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	// Check that the local node store has been updated
@@ -806,7 +806,7 @@ func Test_LocalNodeCIDRsSyncer(t *testing.T) {
 	)
 
 	// update local node
-	_, err = clientset.CiliumV2().CiliumNodes().Update(t.Context(), currentNode, metav1.UpdateOptions{})
+	currentNode, err = clientset.CiliumV2().CiliumNodes().Update(t.Context(), currentNode, metav1.UpdateOptions{})
 	assert.NoError(t, err)
 
 	// Check that the local node store has been updated

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -289,7 +289,14 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 				case "add":
 					trackerErr = tc.tracker.Add(o)
 				case "update":
-					trackerErr = tc.tracker.Update(gvr, o, ns)
+					strict, _ := s.Flags.GetBool("strict")
+					if strict {
+						trackerErr = tc.tracker.Update(gvr, o, ns)
+					} else {
+						// Patch does not check for conflicts.
+						trackerErr = tc.tracker.Patch(gvr, o, ns)
+					}
+
 				case "delete":
 					trackerErr = tc.tracker.Delete(gvr, ns, name)
 				}
@@ -332,6 +339,10 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 			script.CmdUsage{
 				Summary: "Update K8s object(s) in the object trackers",
 				Args:    "files...",
+				Flags: func(fs *pflag.FlagSet) {
+					fs.Bool("strict", false,
+						"Enable strict optimistic concurrency control")
+				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
 				if len(args) == 0 {

--- a/pkg/k8s/client/testutils/object_tracker.go
+++ b/pkg/k8s/client/testutils/object_tracker.go
@@ -491,16 +491,17 @@ func (s *statedbObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.
 // The reactor functions take care of actually processing the patch
 // (objectTrackerReact.Patch in client-go/testing/fixture.go).
 func (s *statedbObjectTracker) Patch(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.PatchOptions) error {
-	return s.updateOrPatch("Patch", gvr, obj, ns)
+	return s.updateOrPatch("Patch", gvr, obj, ns, false)
 }
 
 // Update updates an existing object in the tracker in the specified namespace.
-// If the object does not exist an error is returned.
+// If the object does not exist, or the resource version of the provided object
+// does not match the stored one, an error is returned.
 func (s *statedbObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.UpdateOptions) error {
-	return s.updateOrPatch("Update", gvr, obj, ns)
+	return s.updateOrPatch("Update", gvr, obj, ns, true)
 }
 
-func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.UpdateOptions) error {
+func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersionResource, obj runtime.Object, ns string, checkConflict bool) error {
 	gvks, _, err := s.scheme.ObjectKinds(obj)
 	if err != nil {
 		s.log.Debug(what, logfields.Error, err)
@@ -526,7 +527,11 @@ func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersio
 	fillTypeMetaIfNeeded(obj, gvks[0])
 
 	wtxn := s.db.WriteTxn(s.tbl)
+	defer wtxn.Abort()
+
 	version := s.tbl.Revision(wtxn) + 1
+
+	newRV := newMeta.GetResourceVersion()
 	newMeta.SetResourceVersion(strconv.FormatUint(version, 10))
 
 	log := s.log.With(
@@ -538,12 +543,27 @@ func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersio
 		object{objectId: newObjectId(s.domain, gvr, ns, newMeta.GetName()), o: obj, kind: gvk.Kind},
 	)
 	if !found || oldObj.deleted {
-		wtxn.Abort()
 		gr := gvr.GroupResource()
 		err := apierrors.NewNotFound(gr, newMeta.GetName())
 		log.Debug(what, logfields.Error, err)
 		return err
 	}
+
+	oldMeta, err := meta.Accessor(oldObj.o)
+	if err != nil {
+		s.log.Debug(what, logfields.Error, err)
+		return err
+	}
+
+	oldRV := oldMeta.GetResourceVersion()
+	if checkConflict && oldRV != newRV {
+		err = apierrors.NewConflict(gvr.GroupResource(), newMeta.GetName(),
+			fmt.Errorf("the object has been modified; resource version mismatch, current %q, got %q", oldRV, newRV),
+		)
+		s.log.Debug(what, logfields.Error, err)
+		return err
+	}
+
 	wtxn.Commit()
 	log.Debug(what)
 	return nil

--- a/pkg/k8s/client/testutils/object_tracker.go
+++ b/pkg/k8s/client/testutils/object_tracker.go
@@ -192,12 +192,10 @@ func (s *statedbObjectTracker) addList(obj runtime.Object) error {
 
 // fillTypeMetaIfNeeded sets the [metav1.TypeMeta] in the object if it's not already set based
 // on the GroupVersionKind found from the schema.
-func fillTypeMetaIfNeeded(obj runtime.Object, gvk schema.GroupVersionKind) runtime.Object {
+func fillTypeMetaIfNeeded(obj runtime.Object, gvk schema.GroupVersionKind) {
 	if obj.GetObjectKind().GroupVersionKind().Empty() {
-		obj = obj.DeepCopyObject()
 		obj.GetObjectKind().SetGroupVersionKind(gvk)
 	}
-	return obj
 }
 
 // Add adds an object to the tracker. If object being added
@@ -244,7 +242,7 @@ func (s *statedbObjectTracker) Add(obj runtime.Object) error {
 			gvr.Version = ""
 		}
 
-		obj = fillTypeMetaIfNeeded(obj, gvk)
+		fillTypeMetaIfNeeded(obj, gvk)
 
 		s.log.Debug(
 			"Add",
@@ -342,7 +340,7 @@ func (s *statedbObjectTracker) Create(gvr schema.GroupVersionResource, obj runti
 		newMeta.SetNamespace(ns)
 	}
 
-	obj = fillTypeMetaIfNeeded(obj, gvks[0])
+	fillTypeMetaIfNeeded(obj, gvks[0])
 
 	wtxn := s.db.WriteTxn(s.tbl)
 	version := s.tbl.Revision(wtxn) + 1
@@ -525,7 +523,7 @@ func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersio
 		newMeta.SetNamespace(ns)
 	}
 
-	obj = fillTypeMetaIfNeeded(obj, gvks[0])
+	fillTypeMetaIfNeeded(obj, gvks[0])
 
 	wtxn := s.db.WriteTxn(s.tbl)
 	version := s.tbl.Revision(wtxn) + 1

--- a/pkg/k8s/client/testutils/object_tracker_test.go
+++ b/pkg/k8s/client/testutils/object_tracker_test.go
@@ -45,6 +45,7 @@ func TestStateDBObjectTracker_fillTypeMeta(t *testing.T) {
 	n := nodeAny.(*v1.Node)
 	require.Equal(t, "Node", n.TypeMeta.Kind)
 	require.Equal(t, "v1", n.TypeMeta.APIVersion)
+	require.Equal(t, "1", n.GetResourceVersion())
 
 	node.Name = "test2"
 
@@ -55,14 +56,18 @@ func TestStateDBObjectTracker_fillTypeMeta(t *testing.T) {
 	n = nodeAny.(*v1.Node)
 	require.Equal(t, "Node", n.TypeMeta.Kind)
 	require.Equal(t, "v1", n.TypeMeta.APIVersion)
+	require.Equal(t, "2", n.GetResourceVersion())
 
-	err = ot.Update(gvr, node.DeepCopy(), "")
+	update := node.DeepCopy()
+	update.SetResourceVersion(n.GetResourceVersion())
+	err = ot.Update(gvr, update, "")
 	require.NoError(t, err, "Update")
 	nodeAny, err = ot.Get(gvr, "", "test2")
 	require.NoError(t, err)
 	n = nodeAny.(*v1.Node)
 	require.Equal(t, "Node", n.TypeMeta.Kind)
 	require.Equal(t, "v1", n.TypeMeta.APIVersion)
+	require.Equal(t, "3", n.GetResourceVersion())
 
 	// A cilium node without the TypeMeta. This tests that the
 	// APIVersion is correctly set when Group is non-empty.
@@ -83,5 +88,6 @@ func TestStateDBObjectTracker_fillTypeMeta(t *testing.T) {
 	cn := ciliumNodeAny.(*ciliumv2.CiliumNode)
 	require.Equal(t, "CiliumNode", cn.TypeMeta.Kind)
 	require.Equal(t, "cilium.io/v2", cn.TypeMeta.APIVersion)
+	require.Equal(t, "4", cn.GetResourceVersion())
 
 }

--- a/pkg/k8s/client/testutils/testdata/conflicts.txtar
+++ b/pkg/k8s/client/testutils/testdata/conflicts.txtar
@@ -1,0 +1,39 @@
+#!
+
+hive/start
+
+# Add object
+k8s/add service.v1.yaml
+
+# By default, updates ignore the resource version and shall succeed.
+k8s/update service.v2.yaml
+
+# Updates in strict mode shall fail if the resource version does not match.
+! k8s/update --strict service.v1.yaml
+! k8s/update --strict service.v2.yaml
+
+# Updates in strict mode shall succeed if the resource version does match.
+k8s/get v1.services test/echo -o service.v3.yaml
+replace 10.96.1.2 10.96.1.3 service.v3.yaml
+k8s/update --strict service.v3.yaml
+
+###
+
+-- service.v1.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.1.1
+
+-- service.v2.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "foo"
+spec:
+  clusterIP: 10.96.1.2

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -183,7 +183,11 @@ func (cpt *ControlPlaneTest) UpdateObjects(objs ...k8sRuntime.Object) *ControlPl
 				accepted = true
 
 				if _, err := td.tracker.Get(gvr, ns, name); err == nil {
-					if err := td.tracker.Update(gvr, obj, ns); err != nil {
+					// We use Patch, instead of Update, as the latter additionally
+					// enforces optimistic concurrency control (i.e., it returns
+					// an error if the resource version does not match), which we
+					// don't need in this context.
+					if err := td.tracker.Patch(gvr, obj, ns); err != nil {
 						t.Fatalf("Failed to update object %T: %s", obj, err)
 					}
 				} else {


### PR DESCRIPTION
Currently, the statedb object tracker backing the fake kubernetes client used for testing purposes does not respect resource versioning, and allows update operations to succeed regardless of the provided resource version. While convenient for the `k8s/update` command itself, this approach is problematic in case of controllers acting on the same resources, as it can lead to objects being unexpectedly reverted to incorrect versions, due to the missing optimistic concurrency control.

Let's get this fixed by extending the update implementation to additionally compare the resource version of the stored and provided objects, and reject the update in case they do not match, as the real Kubernetes API Server would do. By default, the k8s/update command still ignores the provided resource version, letting the update succeed regardless: this matches the desired behavior in the vast majority of the tests, and avoids the need for complex operations to set the expected resource version. Still, if necessary, the stricter behavior can be enabled via the dedicated flag.