### PR TITLE
ztunnel/test: remove service creation for echo-same-node and echo-other-node

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -869,17 +869,6 @@ func DeployZtunnelTestEnv(ctx context.Context, t *Test, ct *ConnectivityTest) er
 			}
 		}
 
-		// Create service for echo-same-node
-		_, err = client.GetService(ctx, nsConfig.name, echoSameNodeDeploymentName, metav1.GetOptions{})
-		if err != nil {
-			ct.Logf("✨ [%s] Deploying %s service in namespace %s...", client.ClusterName(), echoSameNodeDeploymentName, nsConfig.name)
-			svc := newService(echoSameNodeDeploymentName, map[string]string{"name": echoSameNodeDeploymentName}, serviceLabels, "http", 8080, ct.Params().ServiceType)
-			_, err = client.CreateService(ctx, nsConfig.name, svc, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create service %s in namespace %s: %w", echoSameNodeDeploymentName, nsConfig.name, err)
-			}
-		}
-
 		// Create echo-other-node deployment
 		_, err = client.GetDeployment(ctx, nsConfig.name, echoOtherNodeDeploymentName, metav1.GetOptions{})
 		if err != nil {
@@ -919,17 +908,6 @@ func DeployZtunnelTestEnv(ctx context.Context, t *Test, ct *ConnectivityTest) er
 			_, err = client.CreateDeployment(ctx, nsConfig.name, echoOtherNodeDeployment, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("unable to create deployment %s in namespace %s: %w", echoOtherNodeDeploymentName, nsConfig.name, err)
-			}
-		}
-
-		// Create service for echo-other-node
-		_, err = client.GetService(ctx, nsConfig.name, echoOtherNodeDeploymentName, metav1.GetOptions{})
-		if err != nil {
-			ct.Logf("✨ [%s] Deploying %s service in namespace %s...", client.ClusterName(), echoOtherNodeDeploymentName, nsConfig.name)
-			svc := newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, serviceLabels, "http", 8080, ct.Params().ServiceType)
-			_, err = client.CreateService(ctx, nsConfig.name, svc, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create service %s in namespace %s: %w", echoOtherNodeDeploymentName, nsConfig.name, err)
 			}
 		}
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Remove service creation for echo-same-node and echo-other-node as we don't use it yet.

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
