### PR TITLE
ginkgo: remove `Supports IPv4 Fragments`

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -127,14 +127,13 @@ include:
     cliFocus: "K8sAgentHubbleTest"
 
   ###
-  # K8sDatapathServicesTest Checks N/S loadbalancing Supports IPv4 fragments
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and dsr with geneve
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid-DSR with Geneve
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, and Hybrid-DSR with Geneve
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, dsr and Maglev
   - focus: "f11-datapath-service-ns-tc"
-    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Supports|K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC"
 
   ###
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -32,3 +32,75 @@ lb6_clusterip_post_dnat = (
     TCP(sport=tcp_src_one, dport=tcp_dst_one) /
     Raw("S"*1)
 )
+
+# Create two TCP fragments over IPv4:
+# 1. Ether(14) + IP(20) + TCP(20) + Raw(1) = 55B
+# 2. Ether(14) + IP(20) + Raw(1)           = 35B.
+#
+# `id` is in big endian.
+# `frag` (offset) is in 8-byte units. The very last fragment in a sequence is
+#        the only one allowed to have a size not divisible by 8.
+lb4_nodeport_fragment1 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one, flags='MF', frag=0, id=256, proto=6) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(load="S" * 1)
+)
+
+lb4_nodeport_fragment1_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, flags='MF', frag=0, id=256, proto=6) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one) /
+    Raw(load="S" * 1)
+)
+
+lb4_nodeport_fragment2 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_svc_one, flags='', frag=(20+1)//8, id=256, proto=6) /
+    Raw(load="S" * 1)
+)
+
+lb4_nodeport_fragment2_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, flags='', frag=(20+1)//8, id=256, proto=6) /
+    Raw(load="S" * 1)
+)
+
+# Create two TCP fragments over IPv6:
+# 1. Eth(14) + IPv6(40) + IPv6ExtHeader (8B) + TCP(20) + Raw(1) = 83B
+# 2. Eth(14) + IPv6(40) + IPv6ExtHeader (8B) + Raw(1)           = 63B
+#
+# `nh=44` indicates Fragment Header
+# `m=1` is More Fragments (MF)
+# `id` is in big endian.
+# `offset` is in 8-byte units. The very last fragment in a sequence is
+#        the only one allowed to have a size not divisible by 8.
+lb6_nodeport_fragment1 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one, nh=44) /
+    IPv6ExtHdrFragment(offset=0, m=1, id=256, nh=6) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(load="S" * 1)
+)
+
+lb6_nodeport_fragment1_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=44) /
+    IPv6ExtHdrFragment(offset=0, m=1, id=256, nh=6) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one) /
+    Raw(load="S" * 1)
+)
+
+lb6_nodeport_fragment2 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one, nh=44) /
+    IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /
+    Raw(load="S" * 1)
+)
+
+lb6_nodeport_fragment2_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=44) /
+    IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /
+    Raw(load="S" * 1)
+)

--- a/bpf/tests/tc_nodeport_lb4_fragments.c
+++ b/bpf/tests/tc_nodeport_lb4_fragments.c
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_IPV4_FRAGMENTS
+#define ENABLE_NODEPORT
+
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
+#include "lib/endpoint.h"
+#include "lib/lb.h"
+#include "scapy.h"
+
+#define CLIENT_IP	v4_ext_one
+#define CLIENT_PORT	tcp_src_one
+
+#define FRONTEND_IP	v4_svc_one
+#define FRONTEND_PORT	tcp_svc_one
+
+#define BACKEND_IP	v4_pod_one
+#define BACKEND_PORT	tcp_dst_one
+
+#define NAT_REV_INDEX	1
+#define BACKEND_COUNT	1
+#define BACKEND_ID	124
+#define BACKEND_IFINDEX	11
+
+/* Expected CT tuple to check for conntrack */
+#define EXPECTED_CT_TUPLE {\
+	.saddr = CLIENT_IP, \
+	.sport = FRONTEND_PORT, \
+	.daddr = FRONTEND_IP, \
+	.dport = CLIENT_PORT, \
+	.nexthdr = IPPROTO_TCP, \
+	.flags = TUPLE_F_SERVICE }
+
+/* Expected fragment ID to check for conntrack */
+#define EXPECTED_FRAG_ID { \
+	.saddr = CLIENT_IP, \
+	.daddr = FRONTEND_IP, \
+	.id = bpf_htons(256), \
+	.proto = IPPROTO_TCP }
+
+/* Expected metrics key to check for fragment-related metrics */
+#define EXPECTED_METRIC_KEY { \
+	.reason = REASON_FRAG_PACKET, \
+	.dir = METRIC_SERVICE }
+
+/* Test that the 1st fragment of an external-to-nodeport request is handled correctly */
+PKTGEN("tc", "tc_nodeport_lb4_fragments_1")
+int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB4_NODEPORT_FRAGMENT1, lb4_nodeport_fragment1);
+	BUILDER_PUSH_BUF(builder, LB4_NODEPORT_FRAGMENT1);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_fragments_1")
+int nodeport_lb4_fragments_1_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
+			      (__u8 *)mac_one, (__u8 *)mac_two);
+	lb_v4_add_service_with_flags(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, BACKEND_COUNT,
+				     NAT_REV_INDEX, SVC_FLAG_ROUTABLE | SVC_FLAG_NODEPORT, 0);
+	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, BACKEND_COUNT, BACKEND_ID,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb4_fragments_1")
+int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
+{
+	__u32 *status_code;
+	void *data_end;
+	void *data;
+	struct ct_entry *ct_entry;
+	struct ipv4_frag_l4ports *l4ports;
+	struct ipv4_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
+	struct ipv4_frag_id expected_frag_id = EXPECTED_FRAG_ID;
+	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
+	__u64 count = 1;
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+
+	/* Ensure packet offset and status code. */
+	assert(data + sizeof(__u32) <= data_end);
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Ensure fragment L4 ports are being tracked. */
+	l4ports = map_lookup_elem(&cilium_ipv4_frag_datagrams, &expected_frag_id);
+	assert(l4ports);
+	assert(l4ports->dport == FRONTEND_PORT);
+	assert(l4ports->sport == CLIENT_PORT);
+
+	/* Ensure fragment-related metrics are updated accordingly. */
+	assert_metrics_count(metric_key, count);
+
+	/* Ensure packet has been DNAT correctly. */
+	BUF_DECL(LB4_NODEPORT_FRAGMENT1_POST_DNAT, lb4_nodeport_fragment1_post_dnat);
+	ASSERT_CTX_BUF_OFF("tcp4_first_fragment_ok", "Ether", ctx, sizeof(__u32),
+			   LB4_NODEPORT_FRAGMENT1_POST_DNAT,
+			   sizeof(BUF(LB4_NODEPORT_FRAGMENT1_POST_DNAT)));
+
+	/* Ensure CT entry is updated accordingly (SVC). */
+	ct_entry = map_lookup_elem(get_ct_map4(&expected_ct_tuple), &expected_ct_tuple);
+	assert(ct_entry);
+	assert(ct_entry->packets == count);
+	assert(ct_entry->bytes == sizeof(BUF(LB4_NODEPORT_FRAGMENT1_POST_DNAT)));
+
+	test_finish();
+}
+
+/* Test that the 2nd fragment of an external-to-nodeport request is handled correctly */
+PKTGEN("tc", "tc_nodeport_lb4_fragments_2")
+int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB4_NODEPORT_FRAGMENT2, lb4_nodeport_fragment2);
+	BUILDER_PUSH_BUF(builder, LB4_NODEPORT_FRAGMENT2);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb4_fragments_2")
+int nodeport_lb4_fragments_2_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb4_fragments_2")
+int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
+{
+	__u32 *status_code;
+	void *data_end;
+	void *data;
+	struct ct_entry *ct_entry;
+	struct ipv4_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
+	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
+	__u64 count = 2;
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+
+	/* Ensure packet offset and status code. */
+	assert(data + sizeof(__u32) <= data_end);
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Ensure fragment-related metrics are updated accordingly. */
+	assert_metrics_count(metric_key, count);
+
+	/* Ensure packet has been DNAT correctly. */
+	BUF_DECL(LB4_NODEPORT_FRAGMENT1_POST_DNAT, lb4_nodeport_fragment1_post_dnat);
+	BUF_DECL(LB4_NODEPORT_FRAGMENT2_POST_DNAT, lb4_nodeport_fragment2_post_dnat);
+	ASSERT_CTX_BUF_OFF("tcp4_second_fragment_ok", "Ether", ctx, sizeof(__u32),
+			   LB4_NODEPORT_FRAGMENT2_POST_DNAT,
+			   sizeof(BUF(LB4_NODEPORT_FRAGMENT2_POST_DNAT)));
+
+	/* Ensure CT entry is updated accordingly (SVC). */
+	ct_entry = map_lookup_elem(get_ct_map4(&expected_ct_tuple), &expected_ct_tuple);
+	assert(ct_entry);
+	assert(ct_entry->packets == count);
+	assert(ct_entry->bytes == sizeof(BUF(LB4_NODEPORT_FRAGMENT1_POST_DNAT)) +
+				  sizeof(BUF(LB4_NODEPORT_FRAGMENT2_POST_DNAT)));
+
+	test_finish();
+}

--- a/bpf/tests/tc_nodeport_lb6_fragments.c
+++ b/bpf/tests/tc_nodeport_lb6_fragments.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV6
+#define ENABLE_IPV6_FRAGMENTS
+#define ENABLE_NODEPORT
+
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
+#include "lib/endpoint.h"
+#include "lib/lb.h"
+#include "scapy.h"
+
+#define CLIENT_IP	v6_ext_node_one
+#define CLIENT_PORT	tcp_src_one
+
+#define FRONTEND_IP	v6_svc_one
+#define FRONTEND_PORT	tcp_svc_one
+
+#define BACKEND_IP	v6_pod_one
+#define BACKEND_PORT	tcp_dst_one
+
+#define NAT_REV_INDEX	1
+#define BACKEND_COUNT	1
+#define BACKEND_ID	124
+#define BACKEND_IFINDEX	11
+
+/* Expected CT tuple to check for conntrack */
+#define EXPECTED_CT_TUPLE {\
+	.saddr = *(union v6addr *)CLIENT_IP, \
+	.sport = FRONTEND_PORT, \
+	.daddr = *(union v6addr *)FRONTEND_IP, \
+	.dport = CLIENT_PORT, \
+	.nexthdr = IPPROTO_TCP, \
+	.flags = TUPLE_F_SERVICE }
+
+/* Expected fragment ID to check for conntrack */
+#define EXPECTED_FRAG_ID { \
+	.saddr = *(union v6addr *)CLIENT_IP, \
+	.daddr = *(union v6addr *)FRONTEND_IP, \
+	.id = bpf_htonl(256), \
+	.proto = IPPROTO_TCP }
+
+/* Expected metrics key to check for fragment-related metrics */
+#define EXPECTED_METRIC_KEY { \
+	.reason = REASON_FRAG_PACKET, \
+	.dir = METRIC_SERVICE }
+
+/* Test that the 1st fragment of an external-to-nodeport request is handled correctly */
+PKTGEN("tc", "tc_nodeport_lb6_fragment1")
+int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB6_NODEPORT_FRAGMENT1, lb6_nodeport_fragment1);
+	BUILDER_PUSH_BUF(builder, LB6_NODEPORT_FRAGMENT1);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_fragment1")
+int nodeport_lb6_fragment1_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v6_add_entry((union v6addr *)BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0,
+			      (__u8 *)mac_one, (__u8 *)mac_two);
+	lb_v6_add_service_with_flags((union v6addr *)FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP,
+				     BACKEND_COUNT, NAT_REV_INDEX,
+				     SVC_FLAG_ROUTABLE | SVC_FLAG_NODEPORT, 0);
+	lb_v6_add_backend((union v6addr *)FRONTEND_IP, FRONTEND_PORT, BACKEND_COUNT, BACKEND_ID,
+			  (union v6addr *)BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb6_fragment1")
+int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
+{
+	__u32 *status_code;
+	void *data_end;
+	void *data;
+	struct ipv6_frag_l4ports *l4ports;
+	struct ct_entry *ct_entry;
+	struct ipv6_frag_id expected_frag_id = EXPECTED_FRAG_ID;
+	struct ipv6_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
+	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
+	__u64 count = 1;
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+
+	/* Ensure packet offset and status code. */
+	assert(data + sizeof(__u32) <= data_end);
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Ensure fragment L4 ports are being tracked. */
+	l4ports = map_lookup_elem(&cilium_ipv6_frag_datagrams, &expected_frag_id);
+	assert(l4ports);
+	assert(l4ports->dport == FRONTEND_PORT);
+	assert(l4ports->sport == CLIENT_PORT);
+
+	/* Ensure fragment-related metrics are updated accordingly. */
+	assert_metrics_count(metric_key, count);
+
+	/* Ensure packet has been DNAT correctly. */
+	BUF_DECL(LB6_NODEPORT_FRAGMENT1_POST_DNAT, lb6_nodeport_fragment1_post_dnat);
+	ASSERT_CTX_BUF_OFF("tcp6_first_fragment_ok", "Ether", ctx, sizeof(__u32),
+			   LB6_NODEPORT_FRAGMENT1_POST_DNAT,
+			   sizeof(BUF(LB6_NODEPORT_FRAGMENT1_POST_DNAT)));
+
+	/* Ensure CT entry is updated accordingly (SVC). */
+	ct_entry = map_lookup_elem(get_ct_map6(&expected_ct_tuple), &expected_ct_tuple);
+	assert(ct_entry);
+	assert(ct_entry->packets == count);
+	assert(ct_entry->bytes == sizeof(BUF(LB6_NODEPORT_FRAGMENT1_POST_DNAT)));
+
+	test_finish();
+}
+
+/* Test that the 2nd fragment of an external-to-nodeport request is handled correctly */
+PKTGEN("tc", "tc_nodeport_lb6_fragment2")
+int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(LB6_NODEPORT_FRAGMENT2, lb6_nodeport_fragment2);
+	BUILDER_PUSH_BUF(builder, LB6_NODEPORT_FRAGMENT2);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_lb6_fragment2")
+int nodeport_lb6_fragment2_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_nodeport_lb6_fragment2")
+int nodeport_lb6_fragment2_check(struct __ctx_buff *ctx)
+{
+	__u32 *status_code;
+	void *data_end;
+	void *data;
+	struct ct_entry *ct_entry;
+	struct ipv6_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
+	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
+	__u64 count = 2;
+
+	test_init();
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	status_code = data;
+
+	/* Ensure packet offset and status code. */
+	assert(data + sizeof(__u32) <= data_end);
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Ensure fragment-related metrics are updated accordingly. */
+	assert_metrics_count(metric_key, count);
+
+	/* Ensure packet has been DNAT correctly. */
+	BUF_DECL(LB6_NODEPORT_FRAGMENT1_POST_DNAT, lb6_nodeport_fragment1_post_dnat);
+	BUF_DECL(LB6_NODEPORT_FRAGMENT2_POST_DNAT, lb6_nodeport_fragment2_post_dnat);
+	ASSERT_CTX_BUF_OFF("tcp6_second_fragment_ok", "Ether", ctx, sizeof(__u32),
+			   LB6_NODEPORT_FRAGMENT2_POST_DNAT,
+			   sizeof(BUF(LB6_NODEPORT_FRAGMENT2_POST_DNAT)));
+
+	/* Ensure CT entry is updated accordingly (SVC). */
+	ct_entry = map_lookup_elem(get_ct_map6(&expected_ct_tuple), &expected_ct_tuple);
+	assert(ct_entry);
+	assert(ct_entry->packets == count);
+	assert(ct_entry->bytes == sizeof(BUF(LB6_NODEPORT_FRAGMENT1_POST_DNAT)) +
+				  sizeof(BUF(LB6_NODEPORT_FRAGMENT2_POST_DNAT)));
+
+	test_finish();
+}

--- a/test/helpers/wrappers.go
+++ b/test/helpers/wrappers.go
@@ -4,9 +4,7 @@
 package helpers
 
 import (
-	"context"
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -148,14 +146,4 @@ func OpenSSLShowCerts(host string, port uint16, serverName string) string {
 		serverNameFlag = fmt.Sprintf("-servername %q", serverName)
 	}
 	return fmt.Sprintf("openssl s_client -connect %s:%d %s -showcerts | openssl x509 -outform PEM", host, port, serverNameFlag)
-}
-
-// GetBPFPacketsCount returns the number of packets for a given drop reason and
-// direction by parsing BPF metrics.
-func GetBPFPacketsCount(kubectl *Kubectl, pod, reason, direction string) (int, error) {
-	cmd := fmt.Sprintf("cilium-dbg bpf metrics list -o json | jq '[.[] | select(.reason == \"%s\") | select(.direction == \"%s\").packets] | add'", reason, direction)
-
-	res := kubectl.CiliumExecMustSucceed(context.TODO(), pod, cmd)
-
-	return strconv.Atoi(strings.TrimSpace(res.Stdout()))
 }

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -581,15 +581,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 			testNodePortExternal(kubectl, ni, false, true, false)
 		})
 
-		It("Supports IPv4 fragments", func() {
-			options := map[string]string{"bpf.ctAccounting": "true"}
-
-			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
-
-			kubectl.CiliumPreFlightCheck()
-			testIPv4FragmentSupport(kubectl, ni)
-		})
-
 		Context("With host policy", func() {
 			hostPolicyFilename := "ccnp-host-policy-nodeport-tests.yaml"
 			var ccnpHostPolicy string


### PR DESCRIPTION
Please refer to commit descriptions:

1. add BPF unit test for n/s loadbalancing of fragments
2. remove the related Ginkgo test

Related: https://github.com/cilium/cilium/issues/44168.