### PR TITLE
[v1.17] docs: Update docsearch to v4.5.4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:7bc07726f95e26e468f5a14eec6c9422e5eca541@sha256:67220bffa09800d8931f46a5c8c1ee26623b9d84ea99ab21cdeac6e6077b2005
+        uses: docker://quay.io/cilium/docs-builder:6854c3d4369213074055acea3231e7a956b26c3e@sha256:26c0906c1ae1e39ae854ecc6104e336b292093d9be022ceb9f74fd65bd951809
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:6854c3d4369213074055acea3231e7a956b26c3e@sha256:26c0906c1ae1e39ae854ecc6104e336b292093d9be022ceb9f74fd65bd951809
+        uses: docker://quay.io/cilium/docs-builder:65ef418b704ac0930667274f8aec4c692bbd5565@sha256:5ffcfe9a6093eef7b93a1cb21f104e4c9fb9da24bda94f7a6f0df49af3865ae6
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -147,7 +147,7 @@ form of comments inside that file under the ``on`` section and enable the
 event type of ``pull_request``. Additionally, the following section also needs
 to be modified:
 
-   .. code-block:: yaml
+   .. code-block:: text
 
         jobs:
           check_changes:

--- a/Documentation/installation/k8s-install-rancher-existing-nodes.rst
+++ b/Documentation/installation/k8s-install-rancher-existing-nodes.rst
@@ -63,8 +63,44 @@ When the ``Create Custom`` page opens, provide at least a name for the cluster.
 Go through the other configuration options and configure the ones that are
 relevant for your setup.
 
-Next to the ``Cluster Options`` section click the box to ``Edit as YAML``.
-The configuration for the cluster will open up in an editor in the window.
+Add ``HelmChart`` manifests to install Cilium using the RKE2 built-in Helm Operator. 
+Go to the ``Additional Manifests`` section and paste the following YAML. Add relevant values for your Cilium installation.
+
+.. code-block:: yaml
+
+   apiVersion: catalog.cattle.io/v1
+   kind: ClusterRepo
+   metadata:
+     name: cilium
+   spec:
+     url: https://helm.cilium.io
+
+.. code-block:: yaml
+
+   apiVersion: helm.cattle.io/v1
+   kind: HelmChart
+   metadata:
+     name: cilium
+     namespace: kube-system
+   spec:
+     targetNamespace: kube-system
+     createNamespace: false
+     version: v1.18.0
+     chart: cilium
+     repo: https://helm.cilium.io
+     bootstrap: true
+     valuesContent: |-
+       # paste your Cilium values here:
+       k8sServiceHost: 127.0.0.1
+       k8sServicePort: 6443
+       kubeProxyReplacement: true
+
+.. note::
+
+    ``k8sServiceHost`` should be set to ``127.0.0.1`` and ``k8sServicePort`` to ``6443``. Cilium Agent running on control plane nodes will use local address for communication with Kubernetes API process.
+    On Control Plane nodes you can verify this by running:
+
+    .. code-block:: shell-session
 
 .. image:: images/rancher_edit_as_yaml.png
 

--- a/Documentation/installation/requirements-eks.rst
+++ b/Documentation/installation/requirements-eks.rst
@@ -37,10 +37,11 @@ For more information on AWS ENI mode, see :ref:`ipam_eni`.
 
         apiVersion: eksctl.io/v1alpha5
         kind: ClusterConfig
-        ...
+        # ...
         managedNodeGroups:
         - name: ng-1
-          ...
+          # ...
+          #
           # taint nodes so that application pods are
           # not scheduled/executed until Cilium is deployed.
           # Alternatively, see the note above regarding taint effects.

--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -475,16 +475,16 @@ or ``.matchExpressions``.
 
 .. code-block:: yaml
 
-    ---
-    apiVersion: cilium.io/v2alpha1
+    apiVersion: cilium.io/v2
     kind: CiliumPodIPPool
     metadata:
       name: default
       labels:
         pool: blue
 
-    ---
-    apiVersion: cilium.io/v2alpha1
+.. code-block:: yaml
+
+    apiVersion: cilium.io/v2
     kind: CiliumBGPAdvertisement
     metadata:
       name: pod-ip-pool-advert

--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -146,50 +146,55 @@ certain node labels.
 
 .. code-block:: yaml
 
-    ---
-    apiVersion: cilium.io/v2alpha1
-    kind: CiliumPodIPPool
-    metadata:
-      name: dc1-pool
-    spec:
-      ipv4:
-        cidrs:
-          - 10.1.0.0/16
-        maskSize: 24
-    ---
-    apiVersion: cilium.io/v2alpha1
-    kind: CiliumPodIPPool
-    metadata:
-      name: dc2-pool
-    spec:
-      ipv4:
-        cidrs:
-          - 10.2.0.0/16
-        maskSize: 24
-    ---
-    apiVersion: cilium.io/v2
-    kind: CiliumNodeConfig
-    metadata:
-      name: ip-pool-dc1
-      namespace: kube-system
-    spec:
-      defaults:
-        ipam-default-ip-pool: dc1-pool
-      nodeSelector:
-        matchLabels:
-          topology.kubernetes.io/zone: dc1
-    ---
-    apiVersion: cilium.io/v2
-    kind: CiliumNodeConfig
-    metadata:
-      name: ip-pool-dc2
-      namespace: kube-system
-    spec:
-      defaults:
-        ipam-default-ip-pool: dc2-pool
-      nodeSelector:
-        matchLabels:
-          topology.kubernetes.io/zone: dc2
+   apiVersion: cilium.io/v2alpha1
+   kind: CiliumPodIPPool
+   metadata:
+     name: dc1-pool
+   spec:
+     ipv4:
+       cidrs:
+         - 10.1.0.0/16
+       maskSize: 24
+
+.. code-block:: yaml
+
+   apiVersion: cilium.io/v2
+   kind: CiliumNodeConfig
+   metadata:
+     name: ip-pool-dc1
+     namespace: kube-system
+   spec:
+     defaults:
+       ipam-default-ip-pool: dc1-pool
+     nodeSelector:
+       matchLabels:
+         topology.kubernetes.io/zone: dc1
+
+.. code-block:: yaml
+
+   apiVersion: cilium.io/v2alpha1
+   kind: CiliumPodIPPool
+   metadata:
+     name: dc2-pool
+   spec:
+     ipv4:
+       cidrs:
+         - 10.2.0.0/16
+       maskSize: 24
+
+.. code-block:: yaml
+
+   apiVersion: cilium.io/v2
+   kind: CiliumNodeConfig
+   metadata:
+     name: ip-pool-dc2
+     namespace: kube-system
+   spec:
+     defaults:
+       ipam-default-ip-pool: dc2-pool
+     nodeSelector:
+       matchLabels:
+         topology.kubernetes.io/zone: dc2
 
 Allocation Parameters
 ---------------------

--- a/Documentation/network/egress-gateway/egress-gateway.rst
+++ b/Documentation/network/egress-gateway/egress-gateway.rst
@@ -161,7 +161,7 @@ It can also be done using ``matchExpressions``:
 
 Moreover, multiple ``podSelector`` can be specified:
 
-.. code-block:: yaml
+.. code-block:: text
 
     selectors:
     - podSelector:

--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -100,27 +100,29 @@ The pool will allocate to any service if no service selector is specified.
 
 .. code-block:: yaml
 
-    apiVersion: "cilium.io/v2alpha1"
-    kind: CiliumLoadBalancerIPPool
-    metadata:
-      name: "blue-pool"
-    spec:
-      blocks:
-      - cidr: "20.0.10.0/24"
-      serviceSelector:
-        matchExpressions:
-          - {key: color, operator: In, values: [blue, cyan]}
-    ---
-    apiVersion: "cilium.io/v2alpha1"
-    kind: CiliumLoadBalancerIPPool
-    metadata:
-      name: "red-pool"
-    spec:
-      blocks:
-      - cidr: "20.0.10.0/24"
-      serviceSelector:
-        matchLabels:
-          color: red
+   apiVersion: "cilium.io/v2"
+   kind: CiliumLoadBalancerIPPool
+   metadata:
+     name: "blue-pool"
+   spec:
+     blocks:
+     - cidr: "20.0.10.0/24"
+     serviceSelector:
+       matchExpressions:
+         - {key: color, operator: In, values: [blue, cyan]}
+
+.. code-block:: yaml
+
+   apiVersion: "cilium.io/v2"
+   kind: CiliumLoadBalancerIPPool
+   metadata:
+     name: "red-pool"
+   spec:
+     blocks:
+     - cidr: "20.0.10.0/24"
+     serviceSelector:
+       matchLabels:
+         color: red
 
 There are a few special purpose selector fields which don't match on labels but
 instead on other metadata like ``.meta.name`` or ``.meta.namespace``.
@@ -483,7 +485,9 @@ Services that have the same sharing key annotation will share the same IP or set
     type: LoadBalancer
     ports:
     - port: 1234
-  ---
+
+.. code-block:: yaml
+
   apiVersion: v1
   kind: Service
   metadata:

--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -75,12 +75,12 @@ this attribute can also be set via helm option ``--set labels=<values>``.
 
     apiVersion: v1
     data:
-    ...
+    # ...
       kube-proxy-replacement: "true"
       labels:  "io\\.kubernetes\\.pod\\.namespace k8s-app app name"
       enable-ipv4-masquerade: "true"
       monitor-aggregation: medium
-    ...
+    # ...
 
 .. note:: The double backslash in ``\\.`` is required to escape the slash in
           the YAML string so that the regular expression contains ``\.``.

--- a/Documentation/operations/performance/scalability/report.rst
+++ b/Documentation/operations/performance/scalability/report.rst
@@ -241,9 +241,11 @@ of ports. In the end we will have 250 different policies selecting 10000 pods.
       egress:
         - toPorts:
           - ports:
-            - port: "[0-125]+80" // from 80 to 12580
+            - port: "[0-125]+80" # from 80 to 12580
               protocol: TCP
-    ---
+
+.. code-block:: yaml
+
     apiVersion: "cilium.io/v2"
     kind: CiliumNetworkPolicy
     metadata:
@@ -259,7 +261,7 @@ of ports. In the end we will have 250 different policies selecting 10000 pods.
       ingress:
       - toPorts:
         - ports:
-          - port: '[126-250]+80' // from 12680 to 25080
+          - port: '[126-250]+80' # from 12680 to 25080
             protocol: TCP
           rules:
             http:

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@5e45810d0af338f8a7a6337b0377412ddf973dbc
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@77d60dbce4cc93358fa6156cbafd7c49214b3c89
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 # Sphinx extensions

--- a/Documentation/security/policy/kubernetes.rst
+++ b/Documentation/security/policy/kubernetes.rst
@@ -212,7 +212,7 @@ resource like this:
           name: my-pod
         spec:
           serviceAccountName: leia
-          ...
+          # ...
 
 Example
 ^^^^^^^


### PR DESCRIPTION
v1.17 backports 2026-02-09

- [ ] #44233 -- docs: Update docsearch to v4.5.4 (@joestringer)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
44233
```

Related: https://github.com/cilium/cilium/pull/43700