### PR TITLE
operator/ztunnel: add namespace enrollment reconciler for SPIRE registration

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -105,6 +105,7 @@ rules:
 {{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled .Values.bgpControlPlane.enabled $secretSyncEnabled }}
   - secrets
 {{- end }}
+  - serviceaccounts
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-operator/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/role.yaml
@@ -114,4 +114,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/operator/auth/watcher.go
+++ b/operator/auth/watcher.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/operator/auth/identity"
 	"github.com/cilium/cilium/operator/auth/spire"
+	ztunnel "github.com/cilium/cilium/operator/pkg/ztunnel/config"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -27,7 +28,8 @@ type params struct {
 	IdentityClient identity.Provider
 	Identity       resource.Resource[*ciliumv2.CiliumIdentity]
 
-	Cfg spire.MutualAuthConfig
+	Cfg           spire.MutualAuthConfig
+	ZtunnelConfig ztunnel.Config
 }
 
 // IdentityWatcher represents the Cilium identities watcher.
@@ -42,7 +44,7 @@ type IdentityWatcher struct {
 }
 
 func registerIdentityWatcher(p params) {
-	if !p.Cfg.Enabled {
+	if !p.Cfg.Enabled || p.ZtunnelConfig.EnableZTunnel {
 		return
 	}
 	iw := &IdentityWatcher{

--- a/operator/pkg/ztunnel/cell.go
+++ b/operator/pkg/ztunnel/cell.go
@@ -5,14 +5,61 @@ package ztunnel
 
 import (
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
 
+	"github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/operator/pkg/ztunnel/config"
+	ztunnelReconciler "github.com/cilium/cilium/operator/pkg/ztunnel/reconciler"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/ztunnel/table"
 )
 
-// Cell provides ztunnel configuration.
+// Cell manages SPIRE enrollment for namespaces when ztunnel encryption is enabled.
 var Cell = cell.Module(
 	"ztunnel",
-	"ZTunnel Configuration",
+	"ZTunnel SPIRE Enrollment",
 
 	cell.Config(config.DefaultConfig),
+	metrics.Metric(ztunnelReconciler.NewMetrics),
+	cell.Provide(
+		k8s.NewNamespaceTableAndReflector,
+		table.NewEnrolledNamespacesTable,
+		ztunnelReconciler.NewServiceAccountTable,
+		ztunnelReconciler.NewEnrollmentReconciler,
+	),
+	cell.Invoke(statedb.Derive("derive-desired-mtls-namespace-enrollments", table.K8sNamespaceToEnrolledNamespace)),
+	cell.Invoke(registerEnrollmentReconciler),
+	cell.Invoke(enableMetrics),
 )
+
+func enableMetrics(cfg config.Config, m *ztunnelReconciler.Metrics) {
+	if cfg.EnableZTunnel {
+		m.EnrollmentOps.SetEnabled(true)
+	}
+}
+
+func registerEnrollmentReconciler(
+	cfg config.Config,
+	params reconciler.Params,
+	ops reconciler.Operations[*table.EnrolledNamespace],
+	tbl statedb.RWTable[*table.EnrolledNamespace],
+) error {
+	if !cfg.EnableZTunnel {
+		return nil
+	}
+	_, err := reconciler.Register(
+		params,
+		tbl,
+		(*table.EnrolledNamespace).Clone,
+		(*table.EnrolledNamespace).SetStatus,
+		(*table.EnrolledNamespace).GetStatus,
+		ops,
+		nil, // no batch operations support
+		reconciler.WithoutPruning(),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/operator/pkg/ztunnel/reconciler/metrics.go
+++ b/operator/pkg/ztunnel/reconciler/metrics.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	LabelOutcome = "outcome"
+	LabelMethod  = "method"
+
+	LabelValueOutcomeSuccess = "success"
+	LabelValueOutcomeFail    = "fail"
+
+	LabelValueMethodUpsert = "upsert"
+	LabelValueMethodDelete = "delete"
+)
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		EnrollmentOps: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Subsystem: "ztunnel",
+			Name:      "enrollment_ops_total",
+			Help:      "Total number of SPIRE enrollment operations for ztunnel mTLS",
+			Disabled:  true,
+		}, []string{LabelMethod, LabelOutcome}),
+	}
+}
+
+type Metrics struct {
+	EnrollmentOps metric.Vec[metric.Counter]
+}

--- a/operator/pkg/ztunnel/reconciler/reconciler.go
+++ b/operator/pkg/ztunnel/reconciler/reconciler.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/operator/auth/spire"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/ztunnel/table"
+)
+
+// requeueNamespace marks an enrolled namespace as pending so the reconciler
+// will re-reconcile it on transient SPIRE failures.
+func requeueNamespace(db *statedb.DB, enrolledTbl statedb.RWTable[*table.EnrolledNamespace], namespace string) {
+	txn := db.WriteTxn(enrolledTbl)
+	ns, _, found := enrolledTbl.Get(txn, table.EnrolledNamespacesNameIndex.Query(namespace))
+	if found {
+		clone := ns.Clone()
+		clone.Status = reconciler.StatusPending()
+		enrolledTbl.Insert(txn, clone)
+	}
+	txn.Commit()
+}
+
+// SpireClient is the interface for interacting with SPIRE for enrollment purposes.
+type SpireClient interface {
+	UpsertBatch(ctx context.Context, ids []string) error
+	DeleteBatch(ctx context.Context, ids []string) error
+	Upsert(ctx context.Context, id string) error
+	Delete(ctx context.Context, id string) error
+	Initialized() <-chan struct{}
+}
+
+type params struct {
+	cell.In
+
+	DB                     *statedb.DB
+	ServiceAccountTable    statedb.Table[ServiceAccount]
+	EnrolledNamespaceTable statedb.RWTable[*table.EnrolledNamespace]
+	SpireClient            *spire.Client
+	Logger                 *slog.Logger
+	Lifecycle              cell.Lifecycle
+	Metrics                *Metrics
+}
+
+type EnrollmentReconciler struct {
+	db                     *statedb.DB
+	logger                 *slog.Logger
+	spireClient            SpireClient
+	serviceAccountTable    statedb.Table[ServiceAccount]
+	enrolledNamespaceTable statedb.RWTable[*table.EnrolledNamespace]
+	metrics                *Metrics
+	cancel                 context.CancelFunc
+}
+
+func NewEnrollmentReconciler(cfg params) reconciler.Operations[*table.EnrolledNamespace] {
+	ops := &EnrollmentReconciler{
+		logger:                 cfg.Logger,
+		spireClient:            cfg.SpireClient,
+		db:                     cfg.DB,
+		serviceAccountTable:    cfg.ServiceAccountTable,
+		enrolledNamespaceTable: cfg.EnrolledNamespaceTable,
+		metrics:                cfg.Metrics,
+	}
+	if cfg.SpireClient != nil {
+		cfg.Lifecycle.Append(ops)
+	}
+	return ops
+}
+
+func (ops *EnrollmentReconciler) Delete(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, ns *table.EnrolledNamespace) error {
+	// Namespace was enrolled, remove all service accounts in the namespace from the CA.
+	sas := ops.serviceAccountTable.List(txn, ServiceAccountNamespaceIndex.Query(ns.Name))
+	ids := []string{}
+	for sa := range sas {
+		ids = append(ids, fmt.Sprintf("%s/%s", sa.Namespace, sa.Name))
+	}
+	if len(ids) == 0 {
+		ops.logger.Info("No service accounts found in deleted enrolled namespace", logfields.K8sNamespace, ns.Name)
+		return nil
+	}
+	err := ops.spireClient.DeleteBatch(ctx, ids)
+	if err != nil {
+		ops.logger.Error("failed to delete CA entries for deleted enrolled namespace",
+			logfields.K8sNamespace, ns.Name,
+			logfields.Error, err.Error())
+		ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodDelete, LabelValueOutcomeFail).Add(float64(len(ids)))
+		return err
+	}
+	ops.logger.Info("Deleted CA entries for deleted enrolled namespace",
+		logfields.K8sNamespace, ns.Name,
+		logfields.Count, len(ids))
+	ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodDelete, LabelValueOutcomeSuccess).Add(float64(len(ids)))
+	return nil
+}
+
+// Prune unexpected entries.
+func (ops *EnrollmentReconciler) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*table.EnrolledNamespace, statedb.Revision]) error {
+	return nil
+}
+
+func (ops *EnrollmentReconciler) Update(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, ns *table.EnrolledNamespace) error {
+	ops.logger.Debug("Reconciling namespace", logfields.K8sNamespace, ns.Name)
+
+	// Namespace is enrolled, ensure all service accounts in the namespace are
+	// present in the CA.
+	sas := ops.serviceAccountTable.List(txn, ServiceAccountNamespaceIndex.Query(ns.Name))
+	var ids []string
+	for sa := range sas {
+		ids = append(ids, fmt.Sprintf("%s/%s", sa.Namespace, sa.Name))
+	}
+	if len(ids) == 0 {
+		ops.logger.Info("No service accounts found in enrolled namespace", logfields.K8sNamespace, ns.Name)
+		return nil
+	}
+	err := ops.spireClient.UpsertBatch(ctx, ids)
+	if err != nil {
+		ops.logger.Error("failed to upsert CA entries for enrolled namespace",
+			logfields.K8sNamespace, ns.Name,
+			logfields.Error, err.Error())
+		ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodUpsert, LabelValueOutcomeFail).Add(float64(len(ids)))
+		return err
+	}
+	ops.logger.Info("Upserted CA entries for enrolled namespace",
+		logfields.K8sNamespace, ns.Name,
+		logfields.Count, len(ids))
+	ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodUpsert, LabelValueOutcomeSuccess).Add(float64(len(ids)))
+	return nil
+}
+
+var _ reconciler.Operations[*table.EnrolledNamespace] = &EnrollmentReconciler{}
+
+func (ops *EnrollmentReconciler) Start(cell.HookContext) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	ops.cancel = cancel
+
+	go func() {
+		ops.logger.Info("Starting mTLS enrollment reconciler")
+
+		// Wait for tables to initialize before processing changes.
+		_, saInit := ops.serviceAccountTable.Initialized(ops.db.ReadTxn())
+		select {
+		case <-ctx.Done():
+			return
+		case <-saInit:
+		}
+		ops.logger.Info("ServiceAccount table initialized")
+
+		_, nsInit := ops.enrolledNamespaceTable.Initialized(ops.db.ReadTxn())
+		select {
+		case <-ctx.Done():
+			return
+		case <-nsInit:
+		}
+		ops.logger.Info("EnrolledNamespace table initialized")
+
+		wtxn := ops.db.WriteTxn(ops.serviceAccountTable)
+		changeIterator, err := ops.serviceAccountTable.Changes(wtxn)
+		wtxn.Commit()
+		if err != nil {
+			ops.logger.Error("failed to create change iterator", logfields.Error, err.Error())
+			return
+		}
+
+		// Wait for SPIRE client to initialize.
+		select {
+		case <-ctx.Done():
+			return
+		case <-ops.spireClient.Initialized():
+		}
+		ops.logger.Info("SPIRE client initialized")
+
+		for {
+			changes, watch := changeIterator.Next(ops.db.ReadTxn())
+			for change := range changes {
+				sa := change.Object
+				id := fmt.Sprintf("%s/%s", sa.Namespace, sa.Name)
+				if change.Deleted {
+					ops.logger.Debug("ServiceAccount deleted", logfields.Name, sa.Name)
+					if err := ops.spireClient.Delete(ctx, id); err != nil {
+						ops.logger.Error("failed to delete CA entry",
+							logfields.Error, err.Error(),
+							logfields.Identity, id)
+						ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodDelete, LabelValueOutcomeFail).Inc()
+						requeueNamespace(ops.db, ops.enrolledNamespaceTable, sa.Namespace)
+					} else {
+						ops.logger.Info("CA entry deleted", logfields.Identity, id)
+						ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodDelete, LabelValueOutcomeSuccess).Inc()
+					}
+				} else {
+					ops.logger.Debug("ServiceAccount added/updated", logfields.Name, sa.Name)
+					_, _, found := ops.enrolledNamespaceTable.Get(ops.db.ReadTxn(), table.EnrolledNamespacesNameIndex.Query(sa.Namespace))
+					if !found {
+						ops.logger.Debug("Namespace not enrolled for mTLS", logfields.K8sNamespace, sa.Namespace)
+						continue
+					}
+					if err := ops.spireClient.Upsert(ctx, id); err != nil {
+						ops.logger.Error("failed to upsert CA entry",
+							logfields.Error, err.Error(),
+							logfields.Identity, id)
+						ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodUpsert, LabelValueOutcomeFail).Inc()
+						requeueNamespace(ops.db, ops.enrolledNamespaceTable, sa.Namespace)
+					} else {
+						ops.logger.Info("CA entry upserted", logfields.Identity, id)
+						ops.metrics.EnrollmentOps.WithLabelValues(LabelValueMethodUpsert, LabelValueOutcomeSuccess).Inc()
+					}
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-watch:
+			}
+		}
+	}()
+	return nil
+}
+
+func (ops *EnrollmentReconciler) Stop(cell.HookContext) error {
+	if ops.cancel != nil {
+		ops.cancel()
+	}
+	ops.logger.Info("Stopping reconciler")
+	return nil
+}
+
+var _ cell.HookInterface = &EnrollmentReconciler{}

--- a/operator/pkg/ztunnel/reconciler/reconciler_test.go
+++ b/operator/pkg/ztunnel/reconciler/reconciler_test.go
@@ -1,0 +1,511 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/ztunnel/table"
+)
+
+func newTestK8sNamespace(name string, labels map[string]string) daemonk8s.Namespace {
+	return daemonk8s.Namespace{
+		Name:   name,
+		Labels: labels,
+	}
+}
+
+// mockSpireClient implements SpireClient for testing.
+type mockSpireClient struct {
+	upsertBatchFunc func(ctx context.Context, ids []string) error
+	deleteBatchFunc func(ctx context.Context, ids []string) error
+	upsertFunc      func(ctx context.Context, id string) error
+	deleteFunc      func(ctx context.Context, id string) error
+	initialized     chan struct{}
+}
+
+func newMockSpireClient() *mockSpireClient {
+	ch := make(chan struct{})
+	close(ch)
+	return &mockSpireClient{
+		initialized: ch,
+	}
+}
+
+func (m *mockSpireClient) UpsertBatch(ctx context.Context, ids []string) error {
+	if m.upsertBatchFunc != nil {
+		return m.upsertBatchFunc(ctx, ids)
+	}
+	return nil
+}
+
+func (m *mockSpireClient) DeleteBatch(ctx context.Context, ids []string) error {
+	if m.deleteBatchFunc != nil {
+		return m.deleteBatchFunc(ctx, ids)
+	}
+	return nil
+}
+
+func (m *mockSpireClient) Upsert(ctx context.Context, id string) error {
+	if m.upsertFunc != nil {
+		return m.upsertFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockSpireClient) Delete(ctx context.Context, id string) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id)
+	}
+	return nil
+}
+
+func (m *mockSpireClient) Initialized() <-chan struct{} {
+	return m.initialized
+}
+
+func setupTest(t *testing.T) (*statedb.DB, statedb.RWTable[*table.EnrolledNamespace], statedb.RWTable[ServiceAccount], *mockSpireClient, *EnrollmentReconciler) {
+	db := statedb.New()
+
+	enrolledTbl, err := table.NewEnrolledNamespacesTable(db)
+	require.NoError(t, err)
+
+	saTbl, err := statedb.NewTable(db, "serviceaccounts",
+		ServiceAccountNamespacedNameIndex,
+		ServiceAccountNamespaceIndex,
+	)
+	require.NoError(t, err)
+
+	mock := newMockSpireClient()
+	logger := hivetest.Logger(t)
+
+	ops := &EnrollmentReconciler{
+		db:                     db,
+		logger:                 logger,
+		spireClient:            mock,
+		serviceAccountTable:    saTbl,
+		enrolledNamespaceTable: enrolledTbl,
+		metrics:                NewMetrics(),
+	}
+
+	return db, enrolledTbl, saTbl, mock, ops
+}
+
+func insertServiceAccounts(_ *testing.T, db *statedb.DB, saTbl statedb.RWTable[ServiceAccount], namespace string, names ...string) {
+	txn := db.WriteTxn(saTbl)
+	for _, name := range names {
+		saTbl.Insert(txn, ServiceAccount{
+			ServiceAccount: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			},
+		})
+	}
+	txn.Commit()
+}
+
+// getMetric reads the current value of a counter with the given label values.
+func getMetric(m *Metrics, method, outcome string) float64 {
+	return m.EnrollmentOps.WithLabelValues(method, outcome).Get()
+}
+
+func TestEnrollmentReconciler_Update(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespace     string
+		saNames       []string
+		upsertErr     error
+		wantErr       bool
+		wantUpsertIDs []string
+	}{
+		{
+			name:          "upserts service accounts in namespace",
+			namespace:     "test-ns",
+			saNames:       []string{"sa1", "sa2"},
+			wantErr:       false,
+			wantUpsertIDs: []string{"test-ns/sa1", "test-ns/sa2"},
+		},
+		{
+			name:      "upsert batch error",
+			namespace: "test-ns",
+			saNames:   []string{"sa1"},
+			upsertErr: fmt.Errorf("spire server unavailable"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _, saTbl, mock, ops := setupTest(t)
+
+			if len(tt.saNames) > 0 {
+				insertServiceAccounts(t, db, saTbl, tt.namespace, tt.saNames...)
+			}
+
+			var gotIDs []string
+			mock.upsertBatchFunc = func(ctx context.Context, ids []string) error {
+				gotIDs = ids
+				return tt.upsertErr
+			}
+
+			ns := &table.EnrolledNamespace{
+				Name:   tt.namespace,
+				Status: reconciler.StatusPending(),
+			}
+			err := ops.Update(t.Context(), db.ReadTxn(), 0, ns)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, float64(len(tt.saNames)),
+					getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeFail))
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, tt.wantUpsertIDs, gotIDs)
+				require.Equal(t, float64(len(tt.saNames)),
+					getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeSuccess))
+			}
+		})
+	}
+}
+
+func TestEnrollmentReconciler_Delete(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespace     string
+		saNames       []string
+		deleteErr     error
+		wantErr       bool
+		wantDeleteIDs []string
+	}{
+		{
+			name:          "deletes service accounts in namespace",
+			namespace:     "test-ns",
+			saNames:       []string{"sa1", "sa2"},
+			wantErr:       false,
+			wantDeleteIDs: []string{"test-ns/sa1", "test-ns/sa2"},
+		},
+		{
+			name:      "delete batch error",
+			namespace: "test-ns",
+			saNames:   []string{"sa1"},
+			deleteErr: fmt.Errorf("spire server unavailable"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, _, saTbl, mock, ops := setupTest(t)
+
+			if len(tt.saNames) > 0 {
+				insertServiceAccounts(t, db, saTbl, tt.namespace, tt.saNames...)
+			}
+
+			var gotIDs []string
+			mock.deleteBatchFunc = func(ctx context.Context, ids []string) error {
+				gotIDs = ids
+				return tt.deleteErr
+			}
+
+			ns := &table.EnrolledNamespace{
+				Name:   tt.namespace,
+				Status: reconciler.StatusPending(),
+			}
+			err := ops.Delete(t.Context(), db.ReadTxn(), 0, ns)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, float64(len(tt.saNames)),
+					getMetric(ops.metrics, LabelValueMethodDelete, LabelValueOutcomeFail))
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, tt.wantDeleteIDs, gotIDs)
+				require.Equal(t, float64(len(tt.saNames)),
+					getMetric(ops.metrics, LabelValueMethodDelete, LabelValueOutcomeSuccess))
+			}
+		})
+	}
+}
+
+func TestEnrollmentReconciler_Update_OnlyIncludesMatchingNamespace(t *testing.T) {
+	db, _, saTbl, mock, ops := setupTest(t)
+
+	// Insert SAs in two different namespaces.
+	insertServiceAccounts(t, db, saTbl, "enrolled-ns", "sa1", "sa2")
+	insertServiceAccounts(t, db, saTbl, "other-ns", "sa3")
+
+	var gotIDs []string
+	mock.upsertBatchFunc = func(ctx context.Context, ids []string) error {
+		gotIDs = ids
+		return nil
+	}
+
+	// Update should only include SAs from "enrolled-ns".
+	ns := &table.EnrolledNamespace{
+		Name:   "enrolled-ns",
+		Status: reconciler.StatusPending(),
+	}
+	err := ops.Update(t.Context(), db.ReadTxn(), 0, ns)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"enrolled-ns/sa1", "enrolled-ns/sa2"}, gotIDs)
+}
+
+// initializeTables marks both SA and enrolled namespace tables as initialized
+// so that Start() can proceed past its initialization checks.
+func initializeTables(db *statedb.DB, saTbl statedb.RWTable[ServiceAccount], enrolledTbl statedb.RWTable[*table.EnrolledNamespace]) {
+	txn := db.WriteTxn(saTbl, enrolledTbl)
+	completeSA := saTbl.RegisterInitializer(txn, "test")
+	completeNS := enrolledTbl.RegisterInitializer(txn, "test")
+	completeSA(txn)
+	completeNS(txn)
+	txn.Commit()
+}
+
+func enrollNamespace(db *statedb.DB, enrolledTbl statedb.RWTable[*table.EnrolledNamespace], name string) {
+	txn := db.WriteTxn(enrolledTbl)
+	enrolledTbl.Insert(txn, &table.EnrolledNamespace{
+		Name:   name,
+		Status: reconciler.StatusPending(),
+	})
+	txn.Commit()
+}
+
+func deleteServiceAccount(db *statedb.DB, saTbl statedb.RWTable[ServiceAccount], namespace, name string) {
+	txn := db.WriteTxn(saTbl)
+	saTbl.Delete(txn, ServiceAccount{
+		ServiceAccount: &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+	})
+	txn.Commit()
+}
+
+func TestEnrollmentReconciler_Start_UpsertOnSACreate(t *testing.T) {
+	db, enrolledTbl, saTbl, mock, ops := setupTest(t)
+	initializeTables(db, saTbl, enrolledTbl)
+
+	// Enroll a namespace before starting.
+	enrollNamespace(db, enrolledTbl, "enrolled-ns")
+
+	upserted := make(chan string, 10)
+	mock.upsertFunc = func(_ context.Context, id string) error {
+		upserted <- id
+		return nil
+	}
+
+	require.NoError(t, ops.Start(t.Context()))
+	defer ops.Stop(nil)
+
+	// Add a service account in the enrolled namespace.
+	insertServiceAccounts(t, db, saTbl, "enrolled-ns", "sa1")
+
+	select {
+	case id := <-upserted:
+		require.Equal(t, "enrolled-ns/sa1", id)
+		require.Equal(t, float64(1),
+			getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeSuccess))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upsert")
+	}
+}
+
+func TestEnrollmentReconciler_Start_SkipNonEnrolledNamespace(t *testing.T) {
+	db, enrolledTbl, saTbl, mock, ops := setupTest(t)
+	initializeTables(db, saTbl, enrolledTbl)
+
+	// Enroll "enrolled-ns" but NOT "other-ns".
+	enrollNamespace(db, enrolledTbl, "enrolled-ns")
+
+	upserted := make(chan string, 10)
+	mock.upsertFunc = func(_ context.Context, id string) error {
+		upserted <- id
+		return nil
+	}
+
+	require.NoError(t, ops.Start(t.Context()))
+	defer ops.Stop(nil)
+
+	// Add a service account in the non-enrolled namespace first.
+	insertServiceAccounts(t, db, saTbl, "other-ns", "sa1")
+
+	// Then add one in the enrolled namespace. When we see this upsert,
+	// we know the watcher has processed past the non-enrolled SA.
+	insertServiceAccounts(t, db, saTbl, "enrolled-ns", "sentinel")
+
+	select {
+	case id := <-upserted:
+		require.Equal(t, "enrolled-ns/sentinel", id, "only the enrolled namespace SA should be upserted")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for sentinel upsert")
+	}
+}
+
+func TestEnrollmentReconciler_Start_DeleteOnSARemove(t *testing.T) {
+	db, enrolledTbl, saTbl, mock, ops := setupTest(t)
+	initializeTables(db, saTbl, enrolledTbl)
+
+	enrollNamespace(db, enrolledTbl, "enrolled-ns")
+
+	// Pre-populate a SA so we can delete it.
+	insertServiceAccounts(t, db, saTbl, "enrolled-ns", "sa1")
+
+	upserted := make(chan string, 10)
+	deleted := make(chan string, 10)
+	mock.upsertFunc = func(_ context.Context, id string) error {
+		upserted <- id
+		return nil
+	}
+	mock.deleteFunc = func(_ context.Context, id string) error {
+		deleted <- id
+		return nil
+	}
+
+	require.NoError(t, ops.Start(t.Context()))
+	defer ops.Stop(nil)
+
+	// Wait for the initial SA creation to be processed.
+	select {
+	case <-upserted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial upsert")
+	}
+
+	// Now delete the SA.
+	deleteServiceAccount(db, saTbl, "enrolled-ns", "sa1")
+
+	select {
+	case id := <-deleted:
+		require.Equal(t, "enrolled-ns/sa1", id)
+		require.Equal(t, float64(1),
+			getMetric(ops.metrics, LabelValueMethodDelete, LabelValueOutcomeSuccess))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for delete")
+	}
+}
+
+func TestEnrollmentReconciler_Start_ErrorMetricsAndRequeue(t *testing.T) {
+	db, enrolledTbl, saTbl, mock, ops := setupTest(t)
+	initializeTables(db, saTbl, enrolledTbl)
+
+	enrollNamespace(db, enrolledTbl, "enrolled-ns")
+
+	upsertCalled := make(chan struct{}, 10)
+	mock.upsertFunc = func(_ context.Context, id string) error {
+		upsertCalled <- struct{}{}
+		return fmt.Errorf("spire unavailable")
+	}
+
+	require.NoError(t, ops.Start(t.Context()))
+	defer ops.Stop(nil)
+
+	// Add a SA — upsert should be called even though it errors.
+	insertServiceAccounts(t, db, saTbl, "enrolled-ns", "sa1")
+
+	select {
+	case <-upsertCalled:
+		require.Equal(t, float64(1),
+			getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeFail))
+
+		// Verify the namespace was requeued to pending for re-reconciliation.
+		ns, _, found := enrolledTbl.Get(db.ReadTxn(), table.EnrolledNamespacesNameIndex.Query("enrolled-ns"))
+		require.True(t, found)
+		require.Equal(t, reconciler.StatusKindPending, ns.Status.Kind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upsert call")
+	}
+}
+
+func TestEnrollmentReconciler_Start_WaitsForSpireInit(t *testing.T) {
+	db, enrolledTbl, saTbl, _, ops := setupTest(t)
+	initializeTables(db, saTbl, enrolledTbl)
+
+	enrollNamespace(db, enrolledTbl, "enrolled-ns")
+
+	// Create a mock with uninitialized SPIRE client.
+	spireInitCh := make(chan struct{})
+	mock := &mockSpireClient{
+		initialized: spireInitCh,
+	}
+	upserted := make(chan string, 10)
+	mock.upsertFunc = func(_ context.Context, id string) error {
+		upserted <- id
+		return nil
+	}
+	ops.spireClient = mock
+
+	require.NoError(t, ops.Start(t.Context()))
+	defer ops.Stop(nil)
+
+	// Add a SA before SPIRE is initialized.
+	insertServiceAccounts(t, db, saTbl, "enrolled-ns", "sa1")
+
+	// Verify that no upsert happens while SPIRE is not initialized.
+	select {
+	case id := <-upserted:
+		t.Fatalf("unexpected upsert before SPIRE init: %s", id)
+	case <-time.After(200 * time.Millisecond):
+		// Expected.
+	}
+
+	// Now initialize SPIRE.
+	close(spireInitCh)
+
+	// The SA change should be processed now.
+	select {
+	case id := <-upserted:
+		require.Equal(t, "enrolled-ns/sa1", id)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upsert after SPIRE init")
+	}
+}
+
+func TestK8sNamespaceToEnrolledNamespace_LabelMatching(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     map[string]string
+		deleted    bool
+		wantResult statedb.DeriveResult
+	}{
+		{
+			name:       "enrolled namespace",
+			labels:     map[string]string{"io.cilium/mtls-enabled": "true"},
+			wantResult: statedb.DeriveInsert,
+		},
+		{
+			name:       "not enrolled - label missing",
+			labels:     map[string]string{},
+			wantResult: statedb.DeriveDelete,
+		},
+		{
+			name:       "enrolled but deleted",
+			labels:     map[string]string{"io.cilium/mtls-enabled": "true"},
+			deleted:    true,
+			wantResult: statedb.DeriveDelete,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := newTestK8sNamespace(tt.name, tt.labels)
+			_, result := table.K8sNamespaceToEnrolledNamespace(ns, tt.deleted)
+			require.Equal(t, tt.wantResult, result)
+		})
+	}
+}

--- a/operator/pkg/ztunnel/reconciler/serviceaccount_table.go
+++ b/operator/pkg/ztunnel/reconciler/serviceaccount_table.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/cilium/operator/pkg/ztunnel/config"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ServiceAccount struct {
+	*corev1.ServiceAccount
+}
+
+func (sa ServiceAccount) TableHeader() []string {
+	return []string{"Namespace", "Name"}
+}
+
+func (sa ServiceAccount) TableRow() []string {
+	return []string{sa.Namespace, sa.Name}
+}
+
+var _ statedb.TableWritable = ServiceAccount{}
+
+var ServiceAccountNamespaceIndex = statedb.Index[ServiceAccount, string]{
+	Name: "serviceaccount-namespace",
+	FromObject: func(sa ServiceAccount) index.KeySet {
+		return index.NewKeySet(index.String(sa.Namespace))
+	},
+	FromKey: index.String,
+	Unique:  false,
+}
+
+var ServiceAccountNamespacedNameIndex = statedb.Index[ServiceAccount, string]{
+	Name: "serviceaccount-name",
+	FromObject: func(sa ServiceAccount) index.KeySet {
+		return index.NewKeySet(index.String(sa.Namespace + "/" + sa.Name))
+	},
+	FromKey: index.String,
+	Unique:  true,
+}
+
+func NewServiceAccountTable(jg job.Group, db *statedb.DB, cs client.Clientset, zcfg config.Config) (statedb.Table[ServiceAccount], error) {
+	serviceAccounts, err := statedb.NewTable(
+		db,
+		"serviceaccounts",
+		ServiceAccountNamespacedNameIndex,
+		ServiceAccountNamespaceIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !cs.IsEnabled() || !zcfg.EnableZTunnel {
+		return serviceAccounts, nil
+	}
+
+	cfg := serviceAccountReflectorConfig(cs, serviceAccounts)
+	err = k8s.RegisterReflector(jg, db, cfg)
+	return serviceAccounts, err
+}
+
+func serviceAccountReflectorConfig(cs client.Clientset, serviceAccounts statedb.RWTable[ServiceAccount]) k8s.ReflectorConfig[ServiceAccount] {
+	lw := utils.ListerWatcherFromTyped(cs.CoreV1().ServiceAccounts(""))
+	return k8s.ReflectorConfig[ServiceAccount]{
+		Name:          "k8s-serviceaccounts",
+		Table:         serviceAccounts,
+		ListerWatcher: lw,
+		MetricScope:   "ServiceAccount",
+		Transform: func(txn statedb.ReadTxn, obj any) (ServiceAccount, bool) {
+			serviceAccount, ok := obj.(*corev1.ServiceAccount)
+			if !ok {
+				return ServiceAccount{}, false
+			}
+			return ServiceAccount{ServiceAccount: serviceAccount}, true
+		},
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Add ztunnel namespace enrollment support to the Cilium operator:

- Add enrollment reconciler that watches namespaces with `io.cilium/mtls-enabled` label
- Integrate with SPIRE client to register/deregister workload identities
- Add ServiceAccount table for tracking service accounts in enrolled namespaces
- Add Prometheus metrics (`cilium_operator_ztunnel_enrollment_ops_total`) for tracking enrollment operations, enabled only when ztunnel is active
- Update operator RBAC for namespace and serviceaccount access

The operator registers SPIFFE identities with SPIRE for all service
accounts in namespaces labeled with `io.cilium/mtls-enabled=true`.

Closes https://github.com/cilium/cilium/issues/44350

```release-note
The operator registers SPIFFE identities with SPIRE for all service accounts in namespaces labeled with `io.cilium/mtls-enabled=true` if ztunnel is enabled.
```