### PR TITLE
vendor: Bump to StateDB v0.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v0.0.1
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.6.2
+	github.com/cilium/statedb v0.6.3
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.6.2 h1:pgLlz4tEmPEuY9PRPtN+JvSqwJjmjzcxPmu2uxW9bQ8=
-github.com/cilium/statedb v0.6.2/go.mod h1:2mLzaSUFAmsM7IoBauszr0YQHUjVV1YcIFFQxnJDlfc=
+github.com/cilium/statedb v0.6.3 h1:SfZ8c/34BseSeKkx2rINeHP8fCzyCUrcKbMlxqI/uxs=
+github.com/cilium/statedb v0.6.3/go.mod h1:2mLzaSUFAmsM7IoBauszr0YQHUjVV1YcIFFQxnJDlfc=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/db.go
+++ b/vendor/github.com/cilium/statedb/db.go
@@ -205,7 +205,12 @@ func (db *DB) WriteTxn(tables ...TableMeta) WriteTxn {
 	txn.smus.Lock()
 	acquiredAt := time.Now()
 
-	txn.tableEntries = slices.Clone(*db.root.Load())
+	txn.oldRoot = db.root.Load()
+
+	// Clone the root. This new allocation will become the new root when
+	// we commit.
+	txn.tableEntries = slices.Clone(*txn.oldRoot)
+
 	txn.handle = db.handleName
 	txn.acquiredAt = acquiredAt
 

--- a/vendor/github.com/cilium/statedb/iterator.go
+++ b/vendor/github.com/cilium/statedb/iterator.go
@@ -166,7 +166,7 @@ type changeIterator[Obj any] struct {
 }
 
 func (it *changeIterator[Obj]) refresh(txn ReadTxn) {
-	tableEntry := txn.root()[it.table.tablePos()]
+	tableEntry := txn.committedRoot()[it.table.tablePos()]
 	if it.iter != nil && tableEntry.locked {
 		var obj Obj
 		panic(fmt.Sprintf("Table[%T].Changes().Next() called with the target table locked. This is not supported.", obj))

--- a/vendor/github.com/cilium/statedb/read_txn.go
+++ b/vendor/github.com/cilium/statedb/read_txn.go
@@ -36,6 +36,11 @@ func (r *readTxn) root() dbRoot {
 	return dbRoot(*r)
 }
 
+// committedRoot implements ReadTxn.
+func (r *readTxn) committedRoot() dbRoot {
+	return dbRoot(*r)
+}
+
 // WriteJSON marshals out the database as JSON into the given writer.
 // If tables are given then only these tables are written.
 func (r *readTxn) WriteJSON(w io.Writer, tables ...string) error {

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -32,6 +32,7 @@ type writeTxnState struct {
 	acquiredAt time.Time     // the time at which the transaction acquired the locks
 	duration   atomic.Uint64 // the transaction duration after it finished
 
+	oldRoot      *dbRoot                  // snapshot of the root at the time WriteTxn was called
 	tableEntries []*tableEntry            // table entries being modified
 	numTxns      int                      // number of index transactions opened
 	smus         internal.SortableMutexes // the (sorted) table locks
@@ -42,6 +43,10 @@ type writeTxnState struct {
 
 func (txn *writeTxnState) unwrap() *writeTxnState {
 	return txn
+}
+
+func (txn *writeTxnState) committedRoot() dbRoot {
+	return *txn.oldRoot
 }
 
 func (txn *writeTxnState) root() dbRoot {
@@ -286,6 +291,7 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 // and returns it to the pool.
 func (handle *writeTxnHandle) returnToPool() {
 	txn := handle.writeTxnState
+	txn.oldRoot = nil
 	txn.tableEntries = nil
 	txn.numTxns = 0
 	clear(txn.smus)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -329,7 +329,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.6.2
+# github.com/cilium/statedb v0.6.3
 ## explicit; go 1.25
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This restores the ability to use Changes() against a WriteTxn that is targeting the same table as Changes().