### PR TITLE
linux-desired-device: add goleak detector in script tests

### DIFF
--- a/pkg/datapath/linux/device/scripttest/device_test.go
+++ b/pkg/datapath/linux/device/scripttest/device_test.go
@@ -82,6 +82,10 @@ func (d desiredVlanDevice) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func TestMain(m *testing.M) {
+	testutils.GoleakVerifyTestMain(m)
+}
+
 func TestPrivilegedScript(t *testing.T) {
 	testutils.PrivilegedTest(t)
 

--- a/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
@@ -17,6 +17,8 @@ remove-owner owner1
 sleep 1s
 db/cmp devices devices.table
 
+hive/stop
+
 -- devices.table --
 Name      Type     OperStatus
 lo        device   down

--- a/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
@@ -31,6 +31,8 @@ finish-initializer owner1
 db/cmp desired-devices desired-device.2.table
 db/cmp devices devices.2.table
 
+hive/stop
+
 -- eth0.10.yaml --
 name: eth0.10
 parentDevice: eth0

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
@@ -26,6 +26,8 @@ add-device owner2 eth0.20-updated.yaml
 db/cmp desired-devices desired-device.3.table
 db/cmp devices devices.3.table
 
+hive/stop
+
 -- eth0.10.yaml --
 name: eth0.10
 parentDevice: eth0


### PR DESCRIPTION
Add GoleakVerifyTestMain in script tests and explicit hive/stop in the script tests.

