### PR TITLE
ci: e2e: add `kernel` to workflow job names

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -187,9 +187,9 @@ jobs:
   setup-and-test:
     needs: [wait-for-images, generate-matrix]
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }})'
+    name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }}, ${{ matrix.kernel }})'
     env:
-      job_name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }})'
+      job_name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }}, ${{ matrix.kernel }})'
     strategy:
       fail-fast: false
       max-parallel: 100


### PR DESCRIPTION
As a follow-up of changes introduced in https://github.com/cilium/cilium/pull/44126
to improve the readability of workflow job names in the GitHub UI, this
commit adds the `kernel` parameter to the name too. In OpenSearch,
it would be good to differentiate these jobs by the used kernel.
Given the kernel is a parameter that may vary frequently, it is good to be
able to differentiate runs that used the same configuration but different
kernels. That's also good in case of regressions when changing kernel.
    
The result will be `Setup & Test (ipsec-1, minor, 5.10)`.