### PR TITLE
golangci-lint: make .golangci.yaml compatible again with non-custom build

### DIFF
--- a/.custom-gcl.yaml
+++ b/.custom-gcl.yaml
@@ -1,7 +1,7 @@
 # renovate: datasource=docker depName=golangci/golangci-lint
 version: v2.8.0
-name: golangci-lint-cilium
-destination: ./tools/golangci-lint
+name: golangci-lint-kubeapi
+destination: ./tools/golangci-lint-kubeapi
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
   # renovate: datasource=go depName=sigs.k8s.io/kube-api-linter

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -76,14 +76,14 @@ jobs:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v2.8.0
           skip-cache: true
-          args: "--verbose --modules-download-mode=vendor --disable=kubeapilinter"
-      - name: Run kube-api-lint
+          args: "--verbose --modules-download-mode=vendor"
+      - name: Run golangci-lint-kubeapi
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v2.8.0
           skip-cache: true
-          args: "--verbose --modules-download-mode=vendor --enable-only=kubeapilinter ./pkg/k8s/apis/cilium.io/..."
+          args: "--verbose --modules-download-mode=vendor -c tools/golangci-lint-kubeapi/golangci-lint-kubeapi.yaml ./pkg/k8s/apis/cilium.io/..."
 
   precheck:
     runs-on: ubuntu-24.04

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,6 @@ linters:
     - gosec
     - govet
     - ineffassign
-    - kubeapilinter
     - misspell
     - modernize
     - sloglint
@@ -26,21 +25,6 @@ linters:
     - testifylint
     - unused
   settings:
-    custom:
-      kubeapilinter:
-        type: module
-        description: Kube API Linter lints Kube like APIs based on API convetions
-        settings:
-          linters:
-            disable:
-              - "*"
-            enable:
-              - optionalorrequired
-              - duplicatemarkers
-          lintersConfig:
-            optionalorrequired:
-              preferredOptionalMarker: "kubebuilder:validation:Optional"
-              preferredRequiredMarker: "kubebuilder:validation:Required"
     depguard:
       rules:
         main:
@@ -233,13 +217,6 @@ linters:
           - gomodguard
         path: test/
         text: "logrus"
-      - linters:
-          - kubeapilinter
-        path-except: pkg/k8s/apis/cilium\.io/(v2|v2alpha1)/.*types\.go
-      - linters:
-          - kubeapilinter
-        path: pkg/k8s/apis/cilium\.io/(v2|v2alpha1)/.*types\.go
-        text: deepequal-gen
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -430,9 +430,11 @@ custom-lint: ## Run extra local linters
 golangci-lint: ## Run golangci-lint
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION:v%=%),$(GOLANGCILINT_VERSION)))
 	@$(ECHO_CHECK) golangci-lint $(GOLANGCI_LINT_ARGS)
-	$(QUIET) GOLANGCI_LINT_ARGS="$(GOLANGCI_LINT_ARGS)" ./contrib/scripts/golangci-lint.sh
+	$(QUIET) ./contrib/scripts/golangci-lint.sh $(GOLANGCI_LINT_ARGS)
 else
-	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app -e GOLANGCI_LINT_ARGS="$(GOLANGCI_LINT_ARGS)" docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) ./contrib/scripts/golangci-lint.sh
+	$(QUIET) $(CONTAINER_ENGINE) run --rm -ti -v `pwd`:/app -w /app \
+	docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) \
+	./contrib/scripts/golangci-lint.sh $(GOLANGCI_LINT_ARGS)
 endif
 
 golangci-lint-fix: ## Run golangci-lint to automatically fix warnings

--- a/contrib/scripts/golangci-lint.sh
+++ b/contrib/scripts/golangci-lint.sh
@@ -2,10 +2,9 @@
 
 set -euo pipefail
 
-GOLANGCI_LINT_BIN="${GOLANGCI_LINT_BIN:-golangci-lint}"
-GOLANGCI_LINT_ARGS="${GOLANGCI_LINT_ARGS:-}"
-GOLANGCI_LINT_MODULE="${GOLANGCI_LINT_MODULE:-golangci-lint-kubeapi}"
-GOLANGCI_LINT_DIR="${GOLANGCI_LINT_DIR:-tools/golangci-lint-kubeapi}"
+base_bin="golangci-lint"
+custom_dir="tools/golangci-lint-kubeapi"
+custom_bin="${custom_dir}/golangci-lint-kubeapi"
 
 # Return golangci-lint's version string. Expected format: v2.6.2 or
 # v2.6.2-custom-gcl-<hash>.
@@ -15,20 +14,20 @@ get_golangci_version() {
 
 # Check the version of the custom binary and rebuild if it doesn't match the
 # system version.
-if [[ -x "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" ]]; then
-	base="$(get_golangci_version "${GOLANGCI_LINT_BIN}")"
-	custom="$(get_golangci_version "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}")"
+if [[ -x "${custom_bin}" ]]; then
+	base="$(get_golangci_version "${base_bin}")"
+	custom="$(get_golangci_version "${custom_bin}")"
 
-	if [[ $custom =~ $base ]]; then
-		echo "Custom golangci-lint ${custom} matches system version ${base}"
-	else
+	if [[ ! $custom =~ $base ]]; then
 		echo "Custom golangci-lint version ${custom} doesn't match system version ${base}, rebuilding..."
-		"${GOLANGCI_LINT_BIN}" custom
+		"${base_bin}" custom
 	fi
 else
-	"${GOLANGCI_LINT_BIN}" custom
+	"${base_bin}" custom
 fi
 
-# Execute lint with custom binary
-"${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" run ${GOLANGCI_LINT_ARGS} --disable=kubeapilinter
-"${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" run ${GOLANGCI_LINT_ARGS} --enable-only=kubeapilinter ./pkg/k8s/apis/cilium.io/...
+echo "golangci-lint run" "$@"
+"${base_bin}" run "$@"
+
+echo "golangci-lint-kubeapi run" "$@"
+"${custom_bin}" -c "${custom_dir}/golangci-lint-kubeapi.yaml" run ./pkg/k8s/apis/cilium.io/... "$@"

--- a/contrib/scripts/golangci-lint.sh
+++ b/contrib/scripts/golangci-lint.sh
@@ -4,41 +4,28 @@ set -euo pipefail
 
 GOLANGCI_LINT_BIN="${GOLANGCI_LINT_BIN:-golangci-lint}"
 GOLANGCI_LINT_ARGS="${GOLANGCI_LINT_ARGS:-}"
-GOLANGCI_LINT_MODULE="${GOLANGCI_LINT_MODULE:-golangci-lint-cilium}"
-GOLANGCI_LINT_DIR="${GOLANGCI_LINT_DIR:-tools/golangci-lint}"
+GOLANGCI_LINT_MODULE="${GOLANGCI_LINT_MODULE:-golangci-lint-kubeapi}"
+GOLANGCI_LINT_DIR="${GOLANGCI_LINT_DIR:-tools/golangci-lint-kubeapi}"
 
-# Extract the version string from "golangci-lint --version" output.
-# Expected format:
-#   golangci-lint has version <version> built with ...
-# Returns only the <version> part (e.g., v2.6.2 or v2.6.2-custom-gcl-<hash>)
+# Return golangci-lint's version string. Expected format: v2.6.2 or
+# v2.6.2-custom-gcl-<hash>.
 get_golangci_version() {
-	"$1" --version 2>/dev/null | sed -n 's/^golangci-lint has version \([^ ]*\).*/\1/p'
+	"$1" version --short 2>/dev/null
 }
 
-# If the custom binary already exists:
-# - Parse the base version of the system-installed golangci-lint
-# - Parse the base version of the custom-built golangci-lint
-# - If they differ, remove the old custom binary to trigger a rebuild
+# Check the version of the custom binary and rebuild if it doesn't match the
+# system version.
 if [[ -x "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" ]]; then
-	BASE_VERSION="$(get_golangci_version "${GOLANGCI_LINT_BIN}" || true)"
-	CUSTOM_VERSION_RAW="$(get_golangci_version "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" || true)"
+	base="$(get_golangci_version "${GOLANGCI_LINT_BIN}")"
+	custom="$(get_golangci_version "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}")"
 
-	# Custom version looks like:
-	#   vX.Y.Z-custom-gcl-<hash>
-	# Strip the "-custom-gcl-..." suffix to get the base version.
-	CUSTOM_BASE_VERSION="${CUSTOM_VERSION_RAW%%-custom-gcl-*}"
-
-	# Rebuild the custom binary if:
-	# - version extraction failed, or
-	# - base versions do not match
-	if [[ -z "${BASE_VERSION}" || -z "${CUSTOM_BASE_VERSION}" || "${BASE_VERSION}" != "${CUSTOM_BASE_VERSION}" ]]; then
-		rm -f "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}"
+	if [[ $custom =~ $base ]]; then
+		echo "Custom golangci-lint ${custom} matches system version ${base}"
+	else
+		echo "Custom golangci-lint version ${custom} doesn't match system version ${base}, rebuilding..."
+		"${GOLANGCI_LINT_BIN}" custom
 	fi
-fi
-
-# If the golangci-lint custom module binary does NOT exist,
-# build the custom golangci-lint module using `golangci-lint custom`.
-if  [ ! -x "${GOLANGCI_LINT_DIR}/${GOLANGCI_LINT_MODULE}" ]; then
+else
 	"${GOLANGCI_LINT_BIN}" custom
 fi
 

--- a/tools/golangci-lint-kubeapi/.gitignore
+++ b/tools/golangci-lint-kubeapi/.gitignore
@@ -1,0 +1,1 @@
+golangci-lint-kubeapi

--- a/tools/golangci-lint-kubeapi/golangci-lint-kubeapi.yaml
+++ b/tools/golangci-lint-kubeapi/golangci-lint-kubeapi.yaml
@@ -1,0 +1,38 @@
+version: "2"
+run:
+  modules-download-mode: readonly
+  issues-exit-code: 1
+  tests: true
+  timeout: 60m
+
+linters:
+  default: none
+  enable:
+    - kubeapilinter
+
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: Kube API Linter lints Kube like APIs based on API conventions
+        settings:
+          linters:
+            disable:
+              - "*"
+            enable:
+              - optionalorrequired
+              - duplicatemarkers
+          lintersConfig:
+            optionalorrequired:
+              preferredOptionalMarker: "kubebuilder:validation:Optional"
+              preferredRequiredMarker: "kubebuilder:validation:Required"
+
+  exclusions:
+    rules:
+      - linters:
+          - kubeapilinter
+        path-except: pkg/k8s/apis/cilium\.io/(v2|v2alpha1)/.*types\.go
+      - linters:
+          - kubeapilinter
+        path: pkg/k8s/apis/cilium\.io/(v2|v2alpha1)/.*types\.go
+        text: deepequal-gen

--- a/tools/golangci-lint/.gitignore
+++ b/tools/golangci-lint/.gitignore
@@ -1,2 +1,0 @@
-# custom golangci-lint
-golangci-lint-cilium


### PR DESCRIPTION
- golangci-lint.sh would always rebuild the binary. Simplify the script and fix the rebuild trigger.
- Move kubeapi golangci config to dedicated file so `golangci-lint run` in repo root works again with a default install (e.g. from distro package manager or Docker image)
- Specify `-ti` arguments to the Dockerized makefile target to make it obey ^C