### PR TITLE
loadbalancer/api: include proxy-redirect as backend

### DIFF
--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -183,6 +183,22 @@ func (fe *Frontend) ToModel() *models.Service {
 		spec.BackendAddresses = append(spec.BackendAddresses, backendModel(be))
 	}
 
+	if svc.ProxyRedirect != nil {
+		state, _ := BackendStateActive.String()
+		localhost := "127.0.0.1"
+		if fe.Address.AddrCluster().Is6() {
+			localhost = "::1"
+		}
+
+		spec.BackendAddresses = append(spec.BackendAddresses, &models.BackendAddress{
+			IP:        &localhost,
+			Protocol:  fe.Address.Protocol(),
+			Port:      svc.ProxyRedirect.ProxyPort,
+			State:     state,
+			Preferred: true,
+		})
+	}
+
 	return &models.Service{
 		Spec: spec,
 		Status: &models.ServiceStatus{


### PR DESCRIPTION
Currently, listing services via `cilium-dbg service list` displays no backends for the services that use L7 proxy redirection (e.g. Gateway API / Ingress loadbalancer service).

Example with one K8s Loadbalancer service from a Gateway (all it's services don't contain backend entries)

```
❯ kubectl -n kube-system exec -it cilium-rdcmj -- bash
root@kind-control-plane:/home/cilium# cilium-dbg service list
ID   Frontend                    Service Type   Backend
1    10.96.62.28:80/TCP          ClusterIP      1 => 10.244.1.149:4245/TCP (active)
2    10.96.0.10:53/TCP           ClusterIP      1 => 10.244.1.69:53/TCP (active)
                                                2 => 10.244.1.109:53/TCP (active)
3    10.96.0.10:53/UDP           ClusterIP      1 => 10.244.1.69:53/UDP (active)
                                                2 => 10.244.1.109:53/UDP (active)
4    10.96.0.10:9153/TCP         ClusterIP      1 => 10.244.1.69:9153/TCP (active)
                                                2 => 10.244.1.109:9153/TCP (active)
5    10.96.0.1:443/TCP           ClusterIP      1 => 172.19.0.2:6443/TCP (active)
12   10.96.162.7:443/TCP         ClusterIP      1 => 172.19.0.2:4244/TCP (active)
15   10.96.106.135:80/TCP        ClusterIP      1 => 10.244.1.115:80/TCP (active)
16   10.96.55.103:80/TCP         ClusterIP      1 => 10.244.1.67:80/TCP (active)
17   [::]:30965/TCP              NodePort
19   [::]:30965/TCP/i            NodePort
21   0.0.0.0:30965/TCP           NodePort
23   0.0.0.0:30965/TCP/i         NodePort
25   10.96.245.249:80/TCP        ClusterIP
26   172.19.255.1:80/TCP         LoadBalancer
27   172.19.255.1:80/TCP/i       LoadBalancer
28   [fd00:10:96::d99f]:80/TCP   ClusterIP
```

Even though the actual redirection happens via BPF/iptables TPROXY, it would be nice to display the information about the local redirection to the node-local L7 proxy (Envoy) in some form.

Therefore, this commit changes the frontend model generation to treat the proxy redirection as backend of the service frontend so that it gets rendered in the form `<localhost-addr>:<proxy-port>/<proto> (active)`

Result

```
❯ kubectl -n kube-system exec -it cilium-rdcmj -- bash
root@kind-control-plane:/home/cilium# cilium-dbg service list
ID   Frontend                    Service Type   Backend
1    10.96.62.28:80/TCP          ClusterIP      1 => 10.244.1.149:4245/TCP (active)
2    10.96.0.10:53/TCP           ClusterIP      1 => 10.244.1.69:53/TCP (active)
                                                2 => 10.244.1.109:53/TCP (active)
3    10.96.0.10:53/UDP           ClusterIP      1 => 10.244.1.69:53/UDP (active)
                                                2 => 10.244.1.109:53/UDP (active)
4    10.96.0.10:9153/TCP         ClusterIP      1 => 10.244.1.69:9153/TCP (active)
                                                2 => 10.244.1.109:9153/TCP (active)
5    10.96.0.1:443/TCP           ClusterIP      1 => 172.19.0.2:6443/TCP (active)
12   10.96.162.7:443/TCP         ClusterIP      1 => 172.19.0.2:4244/TCP (active)
15   10.96.106.135:80/TCP        ClusterIP      1 => 10.244.1.115:80/TCP (active)
16   10.96.55.103:80/TCP         ClusterIP      1 => 10.244.1.67:80/TCP (active)
17   [::]:30965/TCP              NodePort       1 => [::1]:14543/TCP (active)
19   [::]:30965/TCP/i            NodePort       1 => [::1]:14543/TCP (active)
21   0.0.0.0:30965/TCP           NodePort       1 => 127.0.0.1:14543/TCP (active)
23   0.0.0.0:30965/TCP/i         NodePort       1 => 127.0.0.1:14543/TCP (active)
25   10.96.245.249:80/TCP        ClusterIP      1 => 127.0.0.1:14543/TCP (active)
26   172.19.255.1:80/TCP         LoadBalancer   1 => 127.0.0.1:14543/TCP (active)
27   172.19.255.1:80/TCP/i       LoadBalancer   1 => 127.0.0.1:14543/TCP (active)
28   [fd00:10:96::d99f]:80/TCP   ClusterIP      1 => [::1]:14543/TCP (active)
```

Note: Related to https://github.com/cilium/cilium/pull/31503 that added the proxy port to the output of `cilium-dbg bpf lb list`