### PR TITLE
CODEOWNERS: re-assign operator/identitygc, adjust endpoint team description

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -141,8 +141,8 @@
 #   Maintain the deprecated docker-plugin.
 # - @cilium/endpoint:
 #   Provide background on how the Cilium Endpoint package fits into the overall
-#   agent architecture, relationship with generation of policy / datapath
-#   constructs, serialization and restore from disk.
+#   cluster architecture, lifecycle of endpoints, relationship with generation
+#   of policy / datapath constructs, serialization and restore from disk.
 # - @cilium/envoy:
 #   Maintain the L7 proxy integration with Envoy. This includes the
 #   configurations for Envoy via xDS protocols as well as the extensible
@@ -508,7 +508,7 @@ Makefile* @cilium/build
 /operator/auth @cilium/sig-servicemesh
 /operator/doublewrite @cilium/metrics
 /operator/endpointgc @cilium/endpoint
-/operator/identitygc @cilium/endpoint
+/operator/identitygc @cilium/sig-policy
 /operator/metrics @cilium/metrics
 /operator/pkg/bgp @cilium/sig-bgp
 /operator/pkg/ciliumendpointslice @cilium/sig-scalability

--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -144,8 +144,8 @@ external software and protocols:
   Maintain the deprecated docker-plugin.
 - `@cilium/endpoint <https://github.com/orgs/cilium/teams/endpoint>`__:
   Provide background on how the Cilium Endpoint package fits into the overall
-  agent architecture, relationship with generation of policy / datapath
-  constructs, serialization and restore from disk.
+  cluster architecture, lifecycle of endpoints, relationship with generation
+  of policy / datapath constructs, serialization and restore from disk.
 - `@cilium/envoy <https://github.com/orgs/cilium/teams/envoy>`__:
   Maintain the L7 proxy integration with Envoy. This includes the
   configurations for Envoy via xDS protocols as well as the extensible


### PR DESCRIPTION
Assign operator/identitygc to @cilium/sig-policy instead of @cilium/endpoint based on Joe's feedback. This seems like the more appropriate team based on the description.

Also update the description for the @cilium/endpoint team to cover responsibilities for cluster-wide/k8s considerations and endpoint lifecycle.

Follow-up to commit 11376d5c715b ("CODEOWNERS: add more specific owners for operator subsystems").

Ref. https://github.com/cilium/cilium/pull/44279#pullrequestreview-3780398303