### PR TITLE
bpf/tests: error when scapy pkts are > 1024 bytes

### DIFF
--- a/bpf/tests/_scapy_selftest.c
+++ b/bpf/tests/_scapy_selftest.c
@@ -175,4 +175,33 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 	return 0;
 }
 
+PKTGEN("tc", "1_test_large_pkts")
+int pktgen_scapy_large_pkts(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(SST_XLPKT, sst_xlpkt);
+	BUILDER_PUSH_BUF(builder, SST_XLPKT);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "1_test_large_pkts")
+int check_scapy_large_pkts(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(SST_XLPKT, sst_xlpkt);
+
+	ASSERT_CTX_BUF_OFF("assert_xlpkt_1", "Ether", ctx, 0, SST_XLPKT,
+			   sizeof(BUF(SST_XLPKT)));
+	test_finish();
+
+	return 0;
+}
+
 BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -77,7 +77,7 @@ void scapy_strncpy(char *dst, const char *src, const __u8 len)
 }
 
 static __always_inline
-void *scapy__push_data(struct pktgen *builder, void *data, int len)
+void *scapy__push_data(struct pktgen *builder, void *data, const int len)
 {
 	void *pkt_data = pktgen__push_data_room(builder, len);
 

--- a/bpf/tests/scapy/parser.py
+++ b/bpf/tests/scapy/parser.py
@@ -37,6 +37,13 @@ def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
             except Exception as e:
                 raise Exception(f"Unknown scapy buffer '{scapy_buf}'. Please make sure it's defined under scapy/*_pkt_defs.py")
 
+            # LLVM builtins have a limitation of ~1024 bytes for memcpy/memcmp
+            # Even when reimplementing a custom (innefficient) memcpy/memset,
+            # the LLVM optimizer converts the code to use the builtins. So far
+            # there is no easy way to work-around this, so warn the user.
+            if len(buf) > 1024:
+                raise Exception(f"Packets can't be larger than 1024 bytes at the moment")
+
             if name in bufs and buf != bufs[name]["buf"]:
                 raise Exception(f"Mismatching packet definitions with name '{name}'; found '{scapy_buf}' and '{bufs[name]}'.")
 

--- a/bpf/tests/scapy/selftest_pkt_defs.py
+++ b/bpf/tests/scapy/selftest_pkt_defs.py
@@ -25,5 +25,13 @@ sst_rep_pad = (
         hwsrc=mac_two, hwdst=mac_one) /
     Raw("A"*8)
 )
-
 assert len(bytes(sst_rep_pad)) == (len(bytes(sst_rep)) + 8)
+
+# Testing large packets
+sst_xlpkt = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP() /
+    TCP() /
+    Raw(load='S'*970)
+)
+assert len(bytes(sst_xlpkt)) == 1024


### PR DESCRIPTION
Commit e80be9ebff work-arounded the 128 byte limitation of the cilium builtins implemention by reimplementing (hack, innefficiently as noted in the commit msg) a simple version of memcpy/memcmp to be used by scapy assert checks (only).

Unfortunately, when buffers exceed ~1036 bytes, the clang/LLVM optimizer removes this code and (attempts to) use built-in instead (even at O1). Since the builtin has a hard limit of 128 8-byte words [1] (thanks Daniel Borkmann for the pointer), this leads to:

```
In file included from _scapy_selftest.c:12:
./scapy.h:64:23: error: A call to built-in function 'memcpy' is not supported.
   64 |                 *(__u64 *)(dst + i) = *(__u64 *)(src + i);
      |                                     ^
./scapy.h:64:23: error: A call to built-in function 'memcpy' is not supported.
./scapy.h:64:23: error: A call to built-in function 'memcpy' is not supported.
./scapy.h:64:23: error: A call to built-in function 'memcpy' is not supported.
```

or if directly using `__bpf_memcpy_builtin()` (which calls `__builtin_memcpy()`):

```
In file included from _scapy_selftest.c:7:
In file included from ./pktgen.h:7:
/home/msuneclo/dev/cilium/bpf/include/bpf/builtins.h:165:2: error: A call to built-in function 'memcpy' is not supported.
  165 |         __builtin_memcpy(d, s, len);
```
Marking the memcpy/memset function as noopt either blows complexity or stack limits, depending on the version.

Since I couldn't find (yet) a way to work-around this limitation, make sure a meaningful error to developers is emitted if we are in this specific situation.

[1] https://github.com/llvm/llvm-project/blob/a6929f7937696bb07788be6428fdcf1bf36775b5/llvm/lib/Target/BPF/BPFSelectionDAGInfo.h#L34


Reported-by: Simone Magnani <simone.magnani@isovalent.com>


```release-note
BPF unit tests: error and warn when packets exceed 1024 bytes.
```