### PR TITLE
wireguard: remove cleanup code for old userspace devices

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -265,13 +265,7 @@ func (a *Agent) init() error {
 		return fmt.Errorf("failed to load or generate private key: %w", err)
 	}
 
-	// try to remove any old tun devices created by userspace mode
-	link, _ := safenetlink.LinkByName(types.IfaceName)
-	if _, isTuntap := link.(*netlink.Tuntap); isTuntap {
-		_ = netlink.LinkDel(link)
-	}
-
-	link = &netlink.Wireguard{
+	link := &netlink.Wireguard{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: types.IfaceName,
 		},


### PR DESCRIPTION
2578e8ff4dfa ("wireguard: remove deprecated userspace fallback") removed the userspace mode in v1.17, we can now stop cleaning up any network device created for that mode.