### PR TITLE
bpf/tests: add support for scapy packets of 1036-1518 bytes

### DIFF
--- a/bpf/tests/_scapy_selftest.c
+++ b/bpf/tests/_scapy_selftest.c
@@ -175,4 +175,69 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 	return 0;
 }
 
+PKTGEN("tc", "1_test_large_pkts")
+int pktgen_scapy_large_pkts(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(SST_LPKT, sst_lpkt);
+	BUILDER_PUSH_BUF(builder, SST_LPKT);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "1_test_large_pkts")
+int check_scapy_large_pkts(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(SST_LPKT, sst_lpkt);
+
+	/* 1024 byte pkt */
+	ASSERT_CTX_BUF_OFF("assert_lpkt_1", "Ether", ctx, 0, SST_LPKT,
+			   sizeof(BUF(SST_LPKT)));
+
+	test_finish();
+
+	return 0;
+}
+
+PKTGEN("tc", "2_test_xlarge_pkts")
+int pktgen_scapy_xlarge_pkts(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(SST_XLPKT, sst_xlpkt);
+	BUILDER_PUSH_BUF(builder, SST_XLPKT);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+CHECK("tc", "2_test_xlarge_pkts")
+int check_scapy_xlarge_pkts(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	BUF_DECL(SST_XLPKT, sst_xlpkt);
+
+	/**
+	 * 1518 byte pkt (two memcpys due to LLVM builtin ~1024 byte limit)
+	 * Note: this is __SCAPY_MAX_BUF size.
+	 */
+	ASSERT_CTX_BUF_OFF("assert_xlpkt_1", "Ether", ctx, 0, SST_XLPKT,
+			   sizeof(BUF(SST_XLPKT)));
+
+	test_finish();
+
+	return 0;
+}
+
 BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -182,12 +182,11 @@ bool __assert_map_add_failure(const char *name, const __u8 name_len,
 		void *__DATA_END = (void *)(long)(CTX)->data_end;			\
 		__DATA += OFF;								\
 		bool _ok = true;							\
-		__u16 _len = LEN;							\
 											\
 		if (__DATA + (LEN) > __DATA_END) {					\
 			_ok = false;							\
 			test_log("CTX len (%d) - offset (%d) < LEN (%d)",		\
-					 _len + OFF, OFF, LEN);				\
+				 ctx_full_len(CTX), OFF, LEN);				\
 		}									\
 		if ((_BUF_LEN) < (LEN)) {						\
 			_ok = false;							\

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -27,7 +27,10 @@
  *  #1: scapy object (layer)
  */
 #define BUF_DECL(NAME, ...) \
-	const unsigned char BUF(NAME)[] = __SCAPY_BUF_BYTES(NAME)
+	const unsigned char BUF(NAME)[] = __SCAPY_BUF_BYTES(NAME);	\
+	if (sizeof(BUF(NAME)) > __SCAPY_MAX_BUF) {			\
+		__throw_build_bug();					\
+	} do {} while (0)
 
 static __always_inline
 int scapy_memcmp(const void *a, const void *b, const __u16 len)

--- a/bpf/tests/scapy.h
+++ b/bpf/tests/scapy.h
@@ -138,11 +138,11 @@ static struct scapy_assert __scapy_null_assert = {0};
 #ifndef __ASSERT_TRACE_FAIL_LEN
 #define __ASSERT_TRACE_FAIL_LEN(BUF_NAME, _BUF_LEN, LEN)		\
 	test_log("Buffer '" BUF_NAME "' of len (%d) < LEN  (%d)",	\
-			 _BUF_LEN, LEN)
+			 _BUF_LEN, (LEN))
 #endif /* __ASSERT_TRACE_FAIL_LEN */
 
 #ifndef __ASSERT_TRACE_FAIL_BUF
-#define __ASSERT_TRACE_FAIL_BUF(BUF_NAME, _BUF_LEN, LEN)		\
+#define __ASSERT_TRACE_FAIL_BUF(BUF_NAME)				\
 	test_log("CTX and buffer '" BUF_NAME "' content mismatch ")
 #endif /* __ASSERT_TRACE_FAIL_BUF */
 
@@ -197,7 +197,7 @@ bool __assert_map_add_failure(const char *name, const __u8 name_len,
 		}									\
 		if (_ok && scapy_memcmp(__DATA, _BUF, LEN) != 0) {			\
 			_ok = false;							\
-			__ASSERT_TRACE_FAIL_BUF(BUF_NAME, _BUF_LEN, LEN);		\
+			__ASSERT_TRACE_FAIL_BUF(BUF_NAME);				\
 		}									\
 		if (!_ok) {								\
 			if (!__assert_map_add_failure(NAME, sizeof(NAME),		\

--- a/bpf/tests/scapy/selftest_pkt_defs.py
+++ b/bpf/tests/scapy/selftest_pkt_defs.py
@@ -25,5 +25,21 @@ sst_rep_pad = (
         hwsrc=mac_two, hwdst=mac_one) /
     Raw("A"*8)
 )
-
 assert len(bytes(sst_rep_pad)) == (len(bytes(sst_rep)) + 8)
+
+# Testing large packets
+sst_lpkt = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP() /
+    TCP() /
+    Raw(load='S'*970)
+)
+assert len(bytes(sst_lpkt)) == 1024
+
+sst_xlpkt = (
+    Ether(dst=mac_one, src=mac_two) /
+    IP() /
+    TCP() /
+    Raw(load='S'*1464)
+)
+assert len(bytes(sst_xlpkt)) == 1518


### PR DESCRIPTION
This patchset:

* Fixes CTX len trace on pkt len mismatch error
* Throws `build_bug()` if scapy packets exceed 1518 bytes (current `__SCAPY_MAX_BUF`)
* Cleans up `__ASSERT_TRACE_FAIL_BUF()`
* Add support for scapy packets of 1036-1518 (see last commit message for details)


```release-note
bpf/tests: support pkt sizes 1036-1518 bytes
```
