### PR TITLE
ingress/gateway-api: remove EndpointSlice creation

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -48,24 +48,4 @@ spec:
   {{- if and .Values.ingressController.service.externalTrafficPolicy (not .Values.ingressController.hostNetwork.enabled) }}
   externalTrafficPolicy: {{ .Values.ingressController.service.externalTrafficPolicy }}
   {{- end }}
----
-apiVersion: discovery.k8s.io/v1
-kind: EndpointSlice
-metadata:
-  name: {{ .Values.ingressController.service.name }}
-  namespace: {{ include "cilium.namespace" . }}
-  labels:
-    {{- with .Values.commonLabels }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- if .Values.ingressController.service.labels }}
-    {{- toYaml .Values.ingressController.service.labels | nindent 4 }}
-    {{- end }}
-  {{- if .Values.ingressController.service.annotations }}
-  annotations:
-    {{- toYaml .Values.ingressController.service.annotations | nindent 4 }}
-  {{- end }}
-addressType: IPv4
-endpoints: []
-ports: []
 {{- end }}

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -159,8 +158,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.ConfigMap{}, r.enqueueRequestForBackendTLSPolicyConfigMap()).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
-		Owns(&corev1.Service{}).
-		Owns(&discoveryv1.EndpointSlice{})
+		Owns(&corev1.Service{})
 
 	if tlsRouteEnabled {
 		// Watch TLSRoute linked to Gateway

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -34,6 +35,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -59,6 +61,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return controllerruntime.Success()
 		}
 		scopedLog.ErrorContext(ctx, "Unable to get Gateway", logfields.Error, err)
+		return controllerruntime.Fail(err)
+	}
+
+	// Ensure that any existing EndpointSlice from a previous version gets deleted (dummy ingress endpoints are no longer required)
+	// This can be removed in v1.21
+	if err := r.ensureEndpointSliceDeleted(ctx, types.NamespacedName{Namespace: original.Namespace, Name: shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + original.Name)}); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to ensure EndpointSlice deleted", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
 
@@ -269,6 +278,27 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 		return nil
 	})
 	return err
+}
+
+func (r *gammaReconciler) ensureEndpointSliceDeleted(ctx context.Context, name types.NamespacedName) error {
+	eps := discoveryv1.EndpointSlice{}
+
+	if err := r.Client.Get(ctx, name, &eps); err != nil {
+		if k8serrors.IsNotFound(err) {
+			// no longer exists
+			return nil
+		}
+
+		return fmt.Errorf("failed to get existing EndpointSlice (%s): %w", name, err)
+	}
+
+	if err := r.Client.Delete(ctx, &eps); err != nil {
+		return fmt.Errorf("failed to delete existing EndpointSlice (%s): %w", name, err)
+	}
+
+	r.logger.DebugContext(ctx, "Successfully deleted EndpointSlice", logfields.Name, name)
+
+	return nil
 }
 
 func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -97,8 +96,6 @@ func (r *ingressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&networkingv1.Ingress{}, r.forCiliumManagedIngress()).
 		// (LoadBalancer) Service resource with OwnerReference to the Ingress with dedicated loadbalancing mode
 		Owns(&corev1.Service{}).
-		// EndpointSlice resource with OwnerReference to the Ingress with dedicated loadbalancing mode
-		Owns(&discoveryv1.EndpointSlice{}).
 		// CiliumEnvoyConfig resource with OwnerReference to the Ingress with dedicated loadbalancing mode
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		// Watching shared loadbalancer Service and reconcile all shared Cilium Ingresses.

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -92,10 +92,6 @@ func TestReconcile(t *testing.T) {
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
 
-		eps := discoveryv1.EndpointSlice{}
-		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
-
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.NoError(t, err, "Dedicated CiliumEnvoyConfig should exist")
@@ -147,10 +143,6 @@ func TestReconcile(t *testing.T) {
 		svc := corev1.Service{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
-
-		eps := discoveryv1.EndpointSlice{}
-		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -204,7 +196,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &discoveryv1.EndpointSlice{})
-		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
+		require.True(t, k8sApiErrors.IsNotFound(err), "EndpointSlice should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
@@ -325,7 +317,7 @@ func TestReconcile(t *testing.T) {
 
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should not exist for shared Ingress")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer EndpointSlice should not exist for shared Ingress")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -387,7 +379,7 @@ func TestReconcile(t *testing.T) {
 
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer EndpointSlice should not exist at all")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -523,7 +515,7 @@ func TestReconcile(t *testing.T) {
 
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should be cleaned up")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer EndpointSlice should be cleaned up")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -856,18 +848,6 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
-				&discoveryv1.EndpointSlice{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test",
-						Name:      "cilium-ingress-test",
-						Annotations: map[string]string{
-							"additional.annotation/test-annotation": "test",
-						},
-						Labels: map[string]string{
-							"additional.label/test-label": "test",
-						},
-					},
-				},
 				&ciliumv2.CiliumEnvoyConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
@@ -906,13 +886,6 @@ func TestReconcile(t *testing.T) {
 
 		require.Contains(t, svc.Labels, "additional.label/test-label", "Existing labels should not be deleted")
 		require.Contains(t, svc.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")
-
-		eps := discoveryv1.EndpointSlice{}
-		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.NoError(t, err)
-
-		require.Contains(t, eps.Labels, "additional.label/test-label", "Existing labels should not be deleted")
-		require.Contains(t, eps.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -1008,7 +981,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &discoveryv1.EndpointSlice{})
-		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
+		require.True(t, k8sApiErrors.IsNotFound(err), "EndpointSlice should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
@@ -1066,7 +1039,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &discoveryv1.EndpointSlice{})
-		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
+		require.True(t, k8sApiErrors.IsNotFound(err), "EndpointSlice should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1171,12 +1171,11 @@ type fakeDedicatedIngressTranslator struct {
 	model *model.Model
 }
 
-func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
 	r.model = model
 
 	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
-		&discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		nil
 }
 

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -24,7 +24,7 @@ import (
 var _ translation.Translator = (*gatewayAPITranslator)(nil)
 
 const (
-	ciliumGatewayPrefix = "cilium-gateway-"
+	CiliumGatewayPrefix = "cilium-gateway-"
 	// Deprecated: owningGatewayLabel will be removed later in favour of gatewayNameLabel
 	owningGatewayLabel = "io.cilium.gateway/owning-gateway"
 	gatewayNameLabel   = "gateway.networking.k8s.io/gateway-name"
@@ -77,7 +77,7 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	// generatedName is the name of the generated objects.
 	// for Gateways, this is "cilium-gateway-<servicename>"
 	// for GAMMA, this is just "<servicename>"
-	generatedName := ciliumGatewayPrefix + source.Name
+	generatedName := CiliumGatewayPrefix + source.Name
 
 	// TODO: remove this hack
 	if source.Kind == "Service" {
@@ -133,7 +133,7 @@ func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *mode
 
 	res := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      shortener.ShortenK8sResourceName(ciliumGatewayPrefix + owner.Name),
+			Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
 			Namespace: owner.Namespace,
 			Labels: mergeMap(map[string]string{
 				owningGatewayLabel: shortenName,

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -79,7 +79,7 @@ func Test_translator_Translate(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, _, err := trans.Translate(input)
+			cec, svc, err := trans.Translate(input)
 
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
@@ -193,7 +193,7 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					expectedService := &corev1.Service{}
 					readOutput(t, fmt.Sprintf("testdata/%s/%s/service-output.yaml", tt.name, translatorCase.name), expectedService)
 
-					cec, svc, ep, err := trans.Translate(input)
+					cec, svc, err := trans.Translate(input)
 					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 					require.Equal(t, expectedService, svc, "Service mismatch")
 
@@ -201,7 +201,6 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					if len(diffOutput) != 0 {
 						t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
 					}
-					require.NotNil(t, ep)
 				})
 			}
 		})
@@ -247,7 +246,7 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, ep, err := trans.Translate(input)
+			cec, svc, err := trans.Translate(input)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
 			diffOutput := cmp.Diff(output, cec, protocmp.Transform())
@@ -257,8 +256,6 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 
 			require.NotNil(t, svc)
 			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
-
-			require.NotNil(t, ep)
 		})
 	}
 }

--- a/operator/pkg/model/translation/types.go
+++ b/operator/pkg/model/translation/types.go
@@ -5,18 +5,17 @@ package translation
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
-// Translator is the interface to take the model and generate required CiliumEnvoyConfig,
-// LoadBalancer Service, Endpoint, etc.
+// Translator is the interface to take the model and generate required CiliumEnvoyConfig
+// and LoadBalancer Service.
 //
 // Different use cases (e.g. Ingress, Gateway API) can provide its own generation logic.
 type Translator interface {
-	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error)
+	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error)
 }
 
 // CECTranslator is the interface to take the model and generate required CiliumEnvoyConfig.

--- a/pkg/loadbalancer/tests/testdata/ingress.txtar
+++ b/pkg/loadbalancer/tests/testdata/ingress.txtar
@@ -7,7 +7,7 @@
 hive/start
 
 # Add the service and endpoints
-k8s/add svc-ingress.yaml eps-ingress.yaml
+k8s/add svc-ingress.yaml
 
 # Validate
 db/cmp services services.table
@@ -72,29 +72,3 @@ spec:
   type: LoadBalancer
 status:
   loadBalancer: {}
-
--- eps-ingress.yaml --
-addressType: IPv4
-apiVersion: discovery.k8s.io/v1
-endpoints: []
-kind: EndpointSlice
-metadata:
-  creationTimestamp: "2025-03-25T10:13:20Z"
-  generateName: cilium-ingress-basic-ingress-
-  generation: 1
-  labels:
-    cilium.io/ingress: "true"
-    endpointslice.kubernetes.io/managed-by: endpointslicemirroring-controller.k8s.io
-    kubernetes.io/service-name: cilium-ingress-basic-ingress
-  name: cilium-ingress-basic-ingress-gjh2c
-  namespace: default
-  ownerReferences:
-  - apiVersion: v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Endpoints
-    name: cilium-ingress-basic-ingress
-    uid: 9465c03a-ea0e-42bf-bd8d-56aabc86fcc2
-  resourceVersion: "126851"
-  uid: d93afa57-70a6-4b66-8906-16e53df84b3f
-ports: []


### PR DESCRIPTION
Since dummy Ingress endpoints no longer need to be created, it's no longer necessary to create the `EndpointSlice`s for Cilium Ingress & Gateway API either. See commit messages for more detail.

Follow up of https://github.com/cilium/cilium/pull/43558
Fixes: https://github.com/cilium/cilium/issues/19262