### PR TITLE
endpoint, fqdn: remove restoration of deprecated V1 DNSRules

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -189,14 +189,14 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	}
 	defer f.Cleanup()
 
-	if e.DNSRulesV2 != nil {
-		// Note: e.DNSRulesV2 is updated by syncEndpointHeaderFile and regenerateBPF
+	if e.DNSRules != nil {
+		// Note: e.DNSRules is updated by syncEndpointHeaderFile and regenerateBPF
 		// before they call into writeHeaderfile, because GetDNSRules must not be
 		// called with endpoint.mutex held.
 		e.getLogger().Debug(
 			"writing header file with DNSRules",
 			logfields.Path, headerPath,
-			logfields.DNSRulesV2, e.DNSRulesV2,
+			logfields.DNSRules, e.DNSRules,
 		)
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -298,13 +298,6 @@ type Endpoint struct {
 	// status contains the last n state transitions this endpoint went through
 	status *EndpointStatus
 
-	// DNSRules is the collection of current endpoint-specific DNS proxy
-	// rules that conform to using restore.PortProto V1 (that is, they do
-	// **not** take protocol into account). These can be restored during
-	// Cilium restart.
-	// TODO: This can be removed when 1.16 is deprecated.
-	DNSRules restore.DNSRules
-
 	// DNSRulesV2 is the collection of current endpoint-specific DNS proxy
 	// rules that conform to using restore.PortProto V2 (that is, they take
 	// protocol into account). These can be restored during Cilium restart.
@@ -653,7 +646,6 @@ func createEndpoint(logger *slog.Logger, dnsRulesAPI DNSRulesAPI, epBuildQueue E
 		ifName:             ifName,
 		labels:             labels.NewOpLabels(),
 		Options:            option.NewIntOptions(&EndpointMutableOptionLibrary),
-		DNSRules:           nil,
 		DNSRulesV2:         nil,
 		DNSHistory:         fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		DNSZombies:         fqdn.NewDNSZombieMappings(logger, option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -298,10 +298,10 @@ type Endpoint struct {
 	// status contains the last n state transitions this endpoint went through
 	status *EndpointStatus
 
-	// DNSRulesV2 is the collection of current endpoint-specific DNS proxy
+	// DNSRules is the collection of current endpoint-specific DNS proxy
 	// rules that conform to using restore.PortProto V2 (that is, they take
 	// protocol into account). These can be restored during Cilium restart.
-	DNSRulesV2 restore.DNSRules
+	DNSRules restore.DNSRules
 
 	// DNSHistory is the collection of still-valid DNS responses intercepted for
 	// this endpoint.
@@ -646,7 +646,7 @@ func createEndpoint(logger *slog.Logger, dnsRulesAPI DNSRulesAPI, epBuildQueue E
 		ifName:             ifName,
 		labels:             labels.NewOpLabels(),
 		Options:            option.NewIntOptions(&EndpointMutableOptionLibrary),
-		DNSRulesV2:         nil,
+		DNSRules:           nil,
 		DNSHistory:         fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		DNSZombies:         fqdn.NewDNSZombieMappings(logger, option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 		state:              "",

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1239,13 +1239,4 @@ func (e *Endpoint) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
 // endpoint lock must be held.
 func (e *Endpoint) setDNSRulesLocked(rules restore.DNSRules) {
 	e.DNSRulesV2 = rules
-	// Keep V1 in tact in case of a downgrade.
-	e.DNSRules = make(restore.DNSRules)
-	for pp, rules := range rules {
-		proto := pp.Protocol()
-		// Filter out non-UDP/TCP protocol
-		if proto == uint8(u8proto.TCP) || proto == uint8(u8proto.UDP) {
-			e.DNSRules[pp.ToV1()] = rules
-		}
-	}
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1238,5 +1238,5 @@ func (e *Endpoint) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
 // setDNSRulesLocked is called when the Endpoint's DNS policy has been updated.
 // endpoint lock must be held.
 func (e *Endpoint) setDNSRulesLocked(rules restore.DNSRules) {
-	e.DNSRulesV2 = rules
+	e.DNSRules = rules
 }

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -450,7 +450,6 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		NodeMAC:                  e.nodeMAC,
 		SecurityIdentity:         e.SecurityIdentity,
 		Options:                  e.Options,
-		DNSRules:                 e.DNSRules,
 		DNSRulesV2:               e.DNSRulesV2,
 		DNSHistory:               e.DNSHistory,
 		DNSZombies:               e.DNSZombies,
@@ -545,7 +544,7 @@ type serializableEndpoint struct {
 	Options *option.IntOptions
 
 	// DNSRules is the collection of current DNS rules for this endpoint.
-	DNSRules restore.DNSRules
+	DNSRules restore.DNSRules `json:"omitempty"`
 
 	// DNSRulesV2 is the collection of current DNS rules for this endpoint,
 	// that conform to using V2 of the PortProto key.
@@ -633,7 +632,6 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.IPv4IPAMPool = r.IPv4IPAMPool
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
-	ep.DNSRules = r.DNSRules
 	ep.DNSRulesV2 = r.DNSRulesV2
 	ep.DNSHistory = r.DNSHistory
 	ep.DNSZombies = r.DNSZombies

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -450,7 +450,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		NodeMAC:                  e.nodeMAC,
 		SecurityIdentity:         e.SecurityIdentity,
 		Options:                  e.Options,
-		DNSRulesV2:               e.DNSRulesV2,
+		DNSRules:                 e.DNSRules,
 		DNSHistory:               e.DNSHistory,
 		DNSZombies:               e.DNSZombies,
 		K8sPodName:               e.K8sPodName,
@@ -543,12 +543,14 @@ type serializableEndpoint struct {
 	// Options determine the datapath configuration of the endpoint.
 	Options *option.IntOptions
 
-	// DNSRules is the collection of current DNS rules for this endpoint.
-	DNSRules restore.DNSRules `json:"omitempty"`
+	// DNSRulesUnused is the legacy V1 collection of DNS rules for this endpoint.
+	// Keep the original JSON key for backwards compatibility.
+	DNSRulesUnused restore.DNSRules `json:"DNSRules,omitempty"`
 
-	// DNSRulesV2 is the collection of current DNS rules for this endpoint,
+	// DNSRules is the collection of current DNS rules for this endpoint,
 	// that conform to using V2 of the PortProto key.
-	DNSRulesV2 restore.DNSRules
+	// Keep the original JSON key for backwards compatibility.
+	DNSRules restore.DNSRules `json:"DNSRulesV2,omitempty"`
 
 	// DNSHistory is the collection of still-valid DNS responses intercepted for
 	// this endpoint.
@@ -632,7 +634,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.IPv4IPAMPool = r.IPv4IPAMPool
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
-	ep.DNSRulesV2 = r.DNSRulesV2
+	ep.DNSRules = r.DNSRules
 	ep.DNSHistory = r.DNSHistory
 	ep.DNSZombies = r.DNSZombies
 	ep.K8sPodName = r.K8sPodName

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -91,7 +91,7 @@ func (b *fqdnProxyBootstrapper) RestorationNotify(possibleEndpoints map[uint16]*
 	eps := make([]uint16, 0, len(possibleEndpoints))
 	for _, possibleEP := range possibleEndpoints {
 		// Upgrades from old ciliums have this nil
-		if possibleEP.DNSRules != nil || possibleEP.DNSRulesV2 != nil {
+		if possibleEP.DNSRulesV2 != nil {
 			b.proxy.RestoreRules(possibleEP)
 			eps = append(eps, possibleEP.ID)
 		}

--- a/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
+++ b/pkg/fqdn/bootstrap/fqdn_bootstrapper.go
@@ -91,7 +91,7 @@ func (b *fqdnProxyBootstrapper) RestorationNotify(possibleEndpoints map[uint16]*
 	eps := make([]uint16, 0, len(possibleEndpoints))
 	for _, possibleEP := range possibleEndpoints {
 		// Upgrades from old ciliums have this nil
-		if possibleEP.DNSRulesV2 != nil {
+		if possibleEP.DNSRules != nil {
 			b.proxy.RestoreRules(possibleEP)
 			eps = append(eps, possibleEP.ID)
 		}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -357,7 +357,7 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	if ep.IsHost() {
 		p.restoredHost = ep
 	}
-	dnsRules := ep.DNSRulesV2
+	dnsRules := ep.DNSRules
 	restoredRules := make(map[restore.PortProto][]restoredIPRule, len(dnsRules))
 	for pp, dnsRule := range dnsRules {
 		ipRules := make([]restoredIPRule, 0, len(dnsRule))

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -901,7 +901,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 	ep1.Start(uint16(model.ID))
 	t.Cleanup(ep1.Stop)
 
-	ep1.DNSRulesV2 = restored1
+	ep1.DNSRules = restored1
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	require.True(t, exists)
@@ -953,7 +953,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 	ep3.Start(uint16(modelEP3.ID))
 	t.Cleanup(ep3.Stop)
 
-	ep3.DNSRulesV2 = restored3
+	ep3.DNSRules = restored3
 	s.proxy.RestoreRules(ep3)
 	_, exists = s.proxy.restored[epID3]
 	require.True(t, exists)
@@ -1043,7 +1043,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 	require.NoError(t, err, "Could not marshal restored rules to json")
 	require.Equal(t, pretty.String(), string(jsn2))
 
-	ep1.DNSRulesV2 = rules
+	ep1.DNSRules = rules
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	require.True(t, exists)
@@ -1167,7 +1167,7 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 
 	ep1.IPv4 = netip.MustParseAddr("127.0.0.1")
 	ep1.IPv6 = netip.MustParseAddr("::1")
-	ep1.DNSRulesV2 = restored
+	ep1.DNSRules = restored
 	s.proxy.RestoreRules(ep1)
 	_, exists := s.proxy.restored[epID1]
 	require.True(t, exists)
@@ -1200,7 +1200,7 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &invalidRePattern}},
 		restore.IPRule{Re: restore.RuleRegex{Pattern: &validRePattern}},
 	)
-	ep1.DNSRulesV2 = restored
+	ep1.DNSRules = restored
 	s.proxy.RestoreRules(ep1)
 	_, exists = s.proxy.restored[epID1]
 	require.True(t, exists)

--- a/pkg/fqdn/restore/restore.go
+++ b/pkg/fqdn/restore/restore.go
@@ -45,12 +45,6 @@ func MakeV2PortProto(port uint16, proto u8proto.U8proto) PortProto {
 	return PortProto(PortProtoV2 | (uint32(proto) << 16) | uint32(port))
 }
 
-// IsPortV2 returns true if the PortProto
-// is Version 2.
-func (pp PortProto) IsPortV2() bool {
-	return PortProtoV2&pp == PortProtoV2
-}
-
 // Port returns the port of the PortProto
 func (pp PortProto) Port() uint16 {
 	return uint16(pp & 0x0000_ffff)
@@ -60,12 +54,6 @@ func (pp PortProto) Port() uint16 {
 // PortProto. It returns "0" for Version 1.
 func (pp PortProto) Protocol() uint8 {
 	return uint8((pp & 0xff_0000) >> 16)
-}
-
-// ToV1 returns the Version 1 (that is, "port")
-// version of the PortProto.
-func (pp PortProto) ToV1() PortProto {
-	return pp & 0x0000_ffff
 }
 
 // String returns the decimal representation

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1617,8 +1617,6 @@ const (
 
 	Released = "released"
 
-	DNSRulesV2 = "dnsRulesV2"
-
 	BPFHeaderfileHashOld = "old-" + "bpfHeaderfileHash"
 
 	DumpedPolicyMap = "dumpedPolicyMap"


### PR DESCRIPTION
Remove restoration of V1 DNSRules and rename the DNS rules field, maintaining backwards compatibility in the serialized endpoint state.

See commits for details.
