### PR TITLE
loadbalancer/healthserver: stabilize proxy-redirect test

### DIFF
--- a/pkg/loadbalancer/healthserver/testdata/healthserver-proxy-redirect.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-proxy-redirect.txtar
@@ -16,10 +16,8 @@ k8s/add service.yaml
 * http/get http://$HEALTHADDR:$HEALTHPORT healthserver.before
 * cmp healthserver.expected healthserver.before
 
-# Simulate proxy redirection
+# Simulate proxy redirection and verify synthetic endpoint count of 1
 svc/set-proxy-redirect test/echo 1000
-
-# Verify synthetic endpoint count of 1
 * http/get http://$HEALTHADDR:$HEALTHPORT healthserver.after
 * cmp healthserver-proxy.expected healthserver.after
 


### PR DESCRIPTION
The newly introduced loadbalancer healthserver script test that tests the health for services with proxy redirection sometimes fails with the following error.

```
    scripttest.go:72: (command "* cmp healthserver-proxy.expected healthserver.after" failed, retrying in 500ms...)
        diff healthserver-proxy.expected healthserver.after
        --- healthserver-proxy.expected
        +++ healthserver.after
        @@ -3,6 +3,6 @@
         Content-Type=application/json
         Date=<omitted>
         X-Content-Type-Options=nosniff
        -X-Load-Balancing-Endpoint-Weight=1
        +X-Load-Balancing-Endpoint-Weight=3
         ---
        -{"service":{"namespace":"test","name":"echo"},"localEndpoints":1}
        +{"service":{"namespace":"test","name":"echo"},"localEndpoints":3}
```

See https://github.com/cilium/cilium/actions/runs/21952595101/job/63407305531

I was also able to reproduce it once locally when executing the test in a loop.

It seems that asynchronous (k8s) event processing can lead to situations where the proxy redirection port (set with `svc/set-proxy-redirect` test helper) is reset.
Even the retry to fetch and compare will always see the same outdated data.

Therefore it seems to be safer to include the call to `svc/set-proxy-redirect test/echo 1000` into the same hive script test section so that it gets retried too in case of a failure (`* `) prefix.

See https://docs.cilium.io/en/stable/contributing/development/hive/#command-reference for more info.

Fixes: https://github.com/cilium/cilium/pull/44286 (introduced the test while fixing an issue)
Fixes: https://github.com/cilium/cilium/issues/44414 :pray: 