### PR TITLE
tests: Ignore identity manager related error in versions < 1.18

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -71,8 +71,8 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, certloaderInitialLoadWarn}
 
 	if ciliumVersion.LT(semver.MustParse("1.18.0")) {
-		errorLogExceptions = append(errorLogExceptions, linkNotFound)
-		warningLogExceptions = append(warningLogExceptions, linkNotFound)
+		errorLogExceptions = append(errorLogExceptions, linkNotFound, removeInexistentID)
+		warningLogExceptions = append(warningLogExceptions, linkNotFound, removeInexistentID)
 	}
 
 	// The list is adopted from cilium/cilium/test/helper/utils.go
@@ -422,7 +422,8 @@ const (
 	failedToListCRDs     stringMatcher = "the server could not find the requested resource" // cf. https://github.com/cilium/cilium/issues/16425
 	failedToUpdateLock   stringMatcher = "Failed to update lock:"
 	failedToReleaseLock  stringMatcher = "Failed to release lock:"
-	nilDetailsForService stringMatcher = "retrieved nil details for Service" // from: https://github.com/cilium/cilium/issues/35595
+	nilDetailsForService stringMatcher = "retrieved nil details for Service"                    // from: https://github.com/cilium/cilium/issues/35595
+	removeInexistentID   stringMatcher = "removing identity not added to the identity manager!" // from https://github.com/cilium/cilium/issues/16419
 
 	// warnings
 	cantEnableJIT               stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.


### PR DESCRIPTION
Due to https://github.com/cilium/cilium/pull/42661 and
https://github.com/cilium/cilium/pull/42662 not being backported yet to
v1.17, CI fails in the upgrade/downgrade test with this error.
Therefore, we must add it to the ignore list until the PRs are at least
backported to v1.17.

The error was removed from the ignore list in
https://github.com/cilium/cilium/pull/42982.

Suggested-by: Marco Iorio <marco.iorio@isovalent.com>
Suggested-by: Casey Callendrello <cdc@isovalent.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
