### PR TITLE
Fix key rotation race condition by configuring XFRM before advertising new SPI to other nodes

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1261,6 +1261,15 @@ func (a *Agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, 
 				continue
 			}
 
+			// AllNodeValidateImplementation will eventually call
+			// nodeUpdate(), which is responsible for updating the
+			// IPSec policies and states for all the different EPs
+			// with ipsec.UpsertIPsecEndpoint(). We do this before
+			// advertising the new SPI to ensure our ingress XFRM
+			// states are ready before peers start sending traffic
+			// encrypted with the new key.
+			nodeHandler.AllNodeValidateImplementation()
+
 			// Update the IPSec key identity in the local node.
 			// This will set addrs.ipsecKeyIdentity in the node
 			// package, and eventually trigger an update to
@@ -1268,12 +1277,6 @@ func (a *Agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, 
 			a.localNode.Update(func(ln *node.LocalNode) {
 				ln.EncryptionKey = spi
 			})
-
-			// AllNodeValidateImplementation will eventually call
-			// nodeUpdate(), which is responsible for updating the
-			// IPSec policies and states for all the different EPs
-			// with ipsec.UpsertIPsecEndpoint()
-			nodeHandler.AllNodeValidateImplementation()
 
 			// Push SPI update into BPF datapath now that XFRM state
 			// is configured.

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -448,6 +448,7 @@ func (a *Agent) xfrmStateReplace(new *netlink.XfrmState, remoteRebooted bool) er
 	if !deletedSomething {
 		return firstAttemptErr
 	}
+	scopedLog.Info("Retrying XFRM state add after deleting conflicting state")
 	return a.xfrmStateCache.XfrmStateAdd(new)
 }
 
@@ -1199,6 +1200,7 @@ func (a *Agent) setIPSecSPI(spi uint8) error {
 		return err
 	}
 	a.spi = spi
+	a.log.Debug("Updated BPF encrypt map with new SPI", logfields.SPI, spi)
 	return nil
 }
 
@@ -1260,6 +1262,10 @@ func (a *Agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, 
 				a.log.Error("Failed to load IPsec keyfile", logfields.Error, err)
 				continue
 			}
+			a.log.Info("Loaded IPsec keyfile",
+				logfields.SPI, spi,
+				logfields.Path, keyfilePath,
+			)
 
 			// AllNodeValidateImplementation will eventually call
 			// nodeUpdate(), which is responsible for updating the


### PR DESCRIPTION
Fix IPSec key rotation race by setting up XFRM states before advertising new key

During IPSec key rotation, the current code advertises the new key via CiliumNode CRD
before configuring XFRM states. Under CPU contention of the control plane / worker nodes, completing `AllNodeValidateImplementation()`
can take an extended amount of time, during which peers may learn about the new key and start sending
traffic encrypted with it. In my understanding we currntly rely on eventual consistency. In the case of this inconsistency, our ingress XFRM states aren't ready yet, these packets
are dropped, causing `cilium_ipsec_xfrm_error{error="no_state", type="inbound"}` errors
and service disruption.

This was observed in one of our clusters after upgrading to Cilium 1.17, which doubled the number
of XFRM states due to encrypted overlay support (from ~1,620 to ~3,240 keys on an ~1000 node
cluster). The increased CPU load during rotation widened the race window significantly.

According to the [IPSec documentation](https://docs.cilium.io/en/stable/security/network/encryption-ipsec/):

> During transition the new and old keys will be in use. The Cilium agent keeps per
> endpoint data on which key is used by each endpoint and will use the correct key
> if either side has not yet been updated.

This per-endpoint tracking relies on the BPF datapath selecting `min(local_key, peer_key)`.
However, this assumes XFRM states are configured before peers learn about the new key.
When CiliumNode CRD propagation outpaces XFRM setup, peers select the new key but
the receiving node cannot decrypt it.

The fix swaps the order of operations in `keyfileWatcher`:

```
Before: load key → advertise → setup XFRM → update BPF
After:  load key → setup XFRM → advertise → update BPF
```

By setting up XFRM states before advertising, we ensure ingress is ready before peers
start sending traffic with the new key. The `localNode.Update()` call triggers an
async observer that updates the CiliumNode CRD, so peers only learn about the new key
after XFRM configuration is complete.

The BPF min-key selection logic ensures outbound traffic remains safe during the
transition, as the BPF encrypt map is updated last.

### Logging Improvements

This PR also adds logging to improve observability during key rotation:

| Level | Message | Location |
|-------|---------|----------|
| Info | "Loaded IPsec keyfile" | `keyfileWatcher` |
| Info | "Retrying XFRM state add after deleting conflicting state" | `xfrmStateReplace` |
| Debug | "Updated BPF encrypt map with new SPI" | `setIPSecSPI` |

This helps diagnose key rotation timing by showing: key load → XFRM setup → BPF update sequence.

Fixes: #29319

```release-note
Fix IPSec key rotation race condition where packets were dropped due to XFRM states not being ready when peers started using the new key. Also adds logging for key rotation flow.
```
