### PR TITLE
bpf/tests: minor fix ups

### DIFF
--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -202,8 +202,8 @@ int overlay_to_lxc_syn_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x1df4))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x7d94))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x7d94));
 
 	/* Check ingress conntrack state is in the default CT */
 	tuple.daddr   = CLIENT_NODE_IP;
@@ -298,8 +298,8 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x1de4))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x7d84))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x7d84));
 
 	/* Make sure we hit the conntrack entry */
 	tuple.saddr   = BACKEND_IP;
@@ -391,8 +391,8 @@ int overlay_to_lxc_ack_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x1de6))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x7d86))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x7d86));
 
 	/* Make sure we hit the conntrack entry */
 	tuple.daddr   = CLIENT_NODE_IP;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -233,8 +233,8 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x777f))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xd71f))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd71f));
 
 	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
 	if (meta != 1)
@@ -326,8 +326,8 @@ int to_overlay_synack_check(struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_INTER_CLUSTER_SNAT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x776f))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xd70f))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd70f));
 
 	test_finish();
 }
@@ -400,8 +400,8 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x7771))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xd711))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd711));
 
 	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
 	if (meta != 1)

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -209,8 +209,8 @@ int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd64b))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x35ec))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x35ec));
 
 	/* Check service conntrack state is in the default CT */
 	tuple.daddr = FRONTEND_IP;
@@ -316,8 +316,8 @@ int overlay_to_lxc_synack_check(struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port is not client port");
 
-	if (l4->check != bpf_htons(0x6325))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xc2c5))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xc2c5));
 
 	/* Make sure we hit the conntrack entry */
 	tuple.daddr   = CLIENT_IP;
@@ -406,8 +406,8 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd63d))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x35de))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x35de));
 
 	/* Make sure we hit the conntrack entry */
 	tuple.daddr   = CLIENT_IP;

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -229,8 +229,8 @@ int to_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x777e))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xd71e))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd71e));
 
 	tuple.daddr = BACKEND_IP;
 	tuple.saddr = CLIENT_IP;
@@ -331,8 +331,8 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port hasn't been RevSNATed to client port");
 
-	if (l4->check != bpf_htons(0x2fc5))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x8f65))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x8f65));
 
 	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
 	if (meta != 1)
@@ -428,8 +428,8 @@ int to_overlay_ack_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x7770))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xd710))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd710));
 
 	test_finish();
 }

--- a/bpf/tests/ipsec_from_network_generic.h
+++ b/bpf/tests/ipsec_from_network_generic.h
@@ -147,7 +147,7 @@ int ipv4_not_decrypted_ipsec_from_network_check(__maybe_unused const struct __ct
 
 	payload = (void *)l4 + sizeof(struct ip_esp_hdr);
 	if ((void *)payload + sizeof(default_data) > data_end)
-		test_fatal("paylaod out of bounds\n");
+		test_fatal("payload out of bounds");
 
 	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
 		test_fatal("tcp payload was changed");
@@ -256,7 +256,7 @@ int ipv6_not_decrypted_ipsec_from_network_check(__maybe_unused const struct __ct
 
 	payload = (void *)l4 + sizeof(struct ip_esp_hdr);
 	if ((void *)payload + sizeof(default_data) > data_end)
-		test_fatal("paylaod out of bounds\n");
+		test_fatal("payload out of bounds");
 
 	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
 		test_fatal("tcp payload was changed");
@@ -361,12 +361,12 @@ int ipv4_decrypted_ipsec_from_network_check(__maybe_unused const struct __ctx_bu
 	if (l4->dest != tcp_svc_one)
 		test_fatal("dst TCP port was changed");
 
-	if (l4->check != bpf_htons(0x589c))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xb83c))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xb83c));
 
 	payload = (void *)l4 + sizeof(struct tcphdr);
 	if ((void *)payload + sizeof(default_data) > data_end)
-		test_fatal("paylaod out of bounds\n");
+		test_fatal("payload out of bounds");
 
 	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
 		test_fatal("tcp payload was changed");
@@ -468,12 +468,12 @@ int ipv6_decrypted_ipsec_from_network_check(__maybe_unused const struct __ctx_bu
 	if (l4->dest != tcp_svc_one)
 		test_fatal("dst TCP port was changed");
 
-	if (l4->check != bpf_htons(0xdfe3))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3f84))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x3f84));
 
 	payload = (void *)l4 + sizeof(struct tcphdr);
 	if ((void *)payload + sizeof(default_data) > data_end)
-		test_fatal("paylaod out of bounds\n");
+		test_fatal("payload out of bounds");
 
 	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
 		test_fatal("tcp payload was changed");

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -166,8 +166,8 @@ int l4lb_health_check_host_check(const struct __ctx_buff *ctx)
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0xba00))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x19a1))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x19a1));
 
 	test_finish();
 }

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -193,8 +193,8 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_check(const struct __ctx_buff *ctx
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst TCP port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd7d0))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3771))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x3771));
 
 	test_finish();
 }
@@ -368,8 +368,8 @@ int nodeport_geneve_dsr_lb_xdp_fwd_check(__maybe_unused const struct __ctx_buff 
 	if (tcp_inner->dest != BACKEND_PORT)
 		test_fatal("innerDstPort hasn't been NATed to backend port");
 
-	if (tcp_inner->check != bpf_htons(0xd7cf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(tcp_inner->check));
+	if (tcp_inner->check != bpf_htons(0x3770))
+		test_fatal("L4 checksum is invalid: %x != %x", tcp_inner->check, bpf_htons(0x3770));
 
 	test_finish();
 }

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -453,8 +453,8 @@ struct tcphdr *pktgen__push_default_tcphdr(struct pktgen *builder)
 		return 0;
 
 	hdr->syn = 1;
-	hdr->seq = 123456;
-	hdr->window = 65535;
+	hdr->seq = bpf_htonl(123456);
+	hdr->window = bpf_htons(65535);
 
 	/* In most cases the doff is 5, so a good default if we can't
 	 * calc the actual offset

--- a/bpf/tests/scapy/pkt_defs_common.py
+++ b/bpf/tests/scapy/pkt_defs_common.py
@@ -80,7 +80,10 @@ tcp_svc_one   = 80
 tcp_svc_two   = 443
 tcp_svc_three = 53
 
-default_data = "Should not change!!"
+# Default payload data for tests. Note this includes a trailing
+# NUL-terminating byte for consistency with the C macro. This is
+# to ensure consistency in things like IP checksum values.
+default_data = b"Should not change!!\x00"
 
 # Utility functions
 def v6_get_ns_addr(v6_addr:str) -> str:

--- a/bpf/tests/tc_nodeport_l3_dev.h
+++ b/bpf/tests/tc_nodeport_l3_dev.h
@@ -363,24 +363,28 @@ l3_check:
 
 	if (is_ipv4)
 		if (is_host) {
-			if (l4->check != bpf_htons(0xb1ed))
-				test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+			if (l4->check != bpf_htons(0x118e))
+				test_fatal("L4 checksum is invalid: %x != %x",
+					   l4->check, bpf_htons(0x118e));
 		} else {
-			if (l4->check != bpf_htons(0x589c))
-				test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+			if (l4->check != bpf_htons(0xb83c))
+				test_fatal("L4 checksum is invalid: %x != %x",
+					   l4->check, bpf_htons(0xb83c));
 		}
 	else
 		if (is_host) {
-			if (l4->check != bpf_htons(0xdfe1))
-				test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+			if (l4->check != bpf_htons(0x3f82))
+				test_fatal("L4 checksum is invalid: %x != %x",
+					   l4->check, bpf_htons(0x3f82));
 		} else {
-			if (l4->check != bpf_htons(0xdfe3))
-				test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+			if (l4->check != bpf_htons(0x3f84))
+				test_fatal("L4 checksum is invalid: %x != %x",
+					   l4->check, bpf_htons(0x843f));
 		}
 
 	payload = (void *)l4 + sizeof(struct tcphdr);
 	if ((void *)payload + sizeof(default_data) > data_end)
-		test_fatal("paylaod out of bounds\n");
+		test_fatal("payload out of bounds");
 
 	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
 		test_fatal("tcp payload was changed");

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -243,8 +243,8 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0xd7d0))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3771))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x3771));
 
 	struct ipv4_ct_tuple tuple;
 	struct ct_entry *ct_entry;
@@ -350,8 +350,8 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x01a9))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6149))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x6149));
 
 	test_finish();
 }
@@ -505,8 +505,8 @@ int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0xcccf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x2c70))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x2c70));
 
 	struct ipv4_ct_tuple tuple;
 	struct ct_entry *ct_entry;
@@ -619,8 +619,8 @@ int nodeport_dsr_backend_redirect_reply_check(struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0xcccf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x2c70))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x2c70));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_dsr_ipip.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_ipip.c
@@ -182,8 +182,8 @@ int nodeport_dsr_ipip_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 		test_fatal("src port has changed");
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("dst port has changed");
-	if (l4->check != bpf_htons(0x01a8))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6148))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x6148));
 
 	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
 	if (!tunnel_key)

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -156,8 +156,8 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd7cf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3770))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x3770));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -159,8 +159,8 @@ int nodeport_nat_backend_check(const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x3c62))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x9c02))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x9c02));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -262,8 +262,8 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst TCP port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd7d0))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3771))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x3771));
 
 	test_finish();
 }
@@ -355,8 +355,8 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x01a9))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6149))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x6149));
 
 	test_finish();
 }
@@ -450,8 +450,8 @@ int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst TCP port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xcccf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x2c70))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x2c70));
 
 	test_finish();
 }
@@ -545,8 +545,8 @@ int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0xcccf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x2c70))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x2c70));
 
 	test_finish();
 }
@@ -648,7 +648,7 @@ int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
 		test_fatal("dst port hasn't been NATed to backend port");
 
 	if (l4->check != bpf_htons(0x699a))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x699a));
 
 	test_finish();
 }
@@ -822,8 +822,8 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port hasn't been RevNATed to client port");
 
-	if (l4->check != bpf_htons(0x1a8))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6148))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x6148));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_wildcard_drop.c
+++ b/bpf/tests/tc_nodeport_lb4_wildcard_drop.c
@@ -151,8 +151,8 @@ static __always_inline int validate_packet(const struct __ctx_buff *ctx,
 		assert(l4->source == CLIENT_PORT);
 		assert(l4->dest == dport);
 		assert(l4->syn == 1);
-		assert(l4->seq == 123456);
-		assert(l4->window == 65535);
+		assert(l4->seq == bpf_ntohl(123456));
+		assert(l4->window == bpf_ntohs(65535));
 		assert(l4->doff == 5);
 
 		break;

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -350,8 +350,8 @@ int check_reply(const struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x2dbc))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x8d5c))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x8d5c));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb6_dsr_ipip.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_ipip.c
@@ -191,8 +191,8 @@ int nodeport_dsr_ipip6_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 		test_fatal("src port has changed");
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("dst port has changed");
-	if (l4->check != bpf_htons(0x2dbc))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x8d5c))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x8d5c));
 
 	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
 	if (!tunnel_key)

--- a/bpf/tests/tc_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_lb.c
@@ -167,8 +167,8 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0x0d7c))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6d1c))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x6d1c));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb6_wildcard_drop.c
+++ b/bpf/tests/tc_nodeport_lb6_wildcard_drop.c
@@ -150,8 +150,8 @@ static __always_inline int validate_packet(const struct __ctx_buff *ctx,
 		assert(l4->source == CLIENT_PORT);
 		assert(l4->dest == dport);
 		assert(l4->syn == 1);
-		assert(l4->seq == 123456);
-		assert(l4->window == 65535);
+		assert(l4->seq == bpf_htonl(123456));
+		assert(l4->window == bpf_htons(65535));
 		assert(l4->doff == 5);
 
 		break;

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -191,7 +191,7 @@ int tc_nodeport_lb_terminating_backend_0_check(const struct __ctx_buff *ctx)
 		test_fatal("dst port hasn't been NATed to backend port");
 
 	if (l4->check != bpf_htons(0x699a))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x699a));
 
 	test_finish();
 }
@@ -295,7 +295,7 @@ int tc_nodeport_lb_terminating_backend_1_check(const struct __ctx_buff *ctx)
 		test_fatal("dst port hasn't been NATed to backend port");
 
 	if (l4->check != bpf_htons(0x699a))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x699a));
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -147,8 +147,8 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port incorrect");
 
-	if (l4->check != bpf_htons(0xb846))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x17e7))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x17e7));
 
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_entry *ct_entry;
@@ -272,8 +272,8 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port changed");
 
-	if (l4->check != bpf_htons(0xb846))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x17e7))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x17e7));
 
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_entry *ct_entry;
@@ -380,8 +380,8 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_src_one)
 		test_fatal("dst TCP port changed");
 
-	if (l4->check != bpf_htons(0xb836))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x17d7))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x17d7));
 
 	test_finish();
 }
@@ -470,8 +470,8 @@ int hairpin_flow_reverse_ingress_check(const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_src_one)
 		test_fatal("dst TCP port incorrect");
 
-	if (l4->check != bpf_htons(0x6325))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xc2c5))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xc2c5));
 
 	test_finish();
 }
@@ -612,8 +612,8 @@ int hairpin_flow_forward_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port incorrect");
 
-	if (l4->check != bpf_htons(0x88f8))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xe898))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xe898));
 
 	struct ipv6_ct_tuple tuple = {};
 	struct ct_entry *ct_entry;
@@ -726,8 +726,8 @@ int hairpin_flow_forward_ingress_check_v6(__maybe_unused const struct __ctx_buff
 	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port changed");
 
-	if (l4->check != bpf_htons(0x88f8))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xe898))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xe898));
 
 	struct ipv6_ct_tuple tuple = {};
 	struct ct_entry *ct_entry;
@@ -829,8 +829,8 @@ int hairpin_flow_rev_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_src_one)
 		test_fatal("dst TCP port changed");
 
-	if (l4->check != bpf_htons(0x88e8))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0xe888))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xe888));
 
 	test_finish();
 }
@@ -913,8 +913,8 @@ int hairpin_flow_reverse_ingress_check_v6(const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_src_one)
 		test_fatal("dst TCP port incorrect");
 
-	if (l4->check != bpf_htons(0xdfd1))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3f72))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x3f72));
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb4_dsr_ipip.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_ipip.c
@@ -175,8 +175,8 @@ int nodeport_dsr_ipip_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 		test_fatal("innerSrcPort has changed");
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("innerDstPort has changed");
-	if (l4->check != bpf_htons(0x01a8))
-		test_fatal("inner L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6148))
+		test_fatal("inner L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x6148));
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -166,8 +166,8 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd7cf))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3770))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x3770));
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -139,8 +139,8 @@ int nodeport_nat_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port has changed");
 
-	if (l4->check != bpf_htons(0x3c62))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x9c02))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x9c02));
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -198,8 +198,8 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst TCP port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0xd7d0))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x3771))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x3771));
 
 	test_finish();
 }
@@ -497,8 +497,8 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 	if (l4->dest != CLIENT_PORT)
 		test_fatal("dst port hasn't been RevNATed to client port");
 
-	if (l4->check != bpf_htons(0x01a8))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6148))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x6148));
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -175,7 +175,7 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 		test_fatal("dst port != backend port");
 
 	if (l4->check != bpf_htons(0xc9ee))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0xc9ee));
 
 	char msg[20] = "Should not change!!";
 

--- a/bpf/tests/xdp_nodeport_lb6_dsr_ipip.c
+++ b/bpf/tests/xdp_nodeport_lb6_dsr_ipip.c
@@ -181,8 +181,8 @@ int nodeport_dsr_ipip6_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 		test_fatal("innerSrcPort has changed");
 	if (l4->dest != FRONTEND_PORT)
 		test_fatal("innerDstPort has changed");
-	if (l4->check != bpf_htons(0x2dbc))
-		test_fatal("inner L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x8d5c))
+		test_fatal("inner L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x8d5c));
 
 	test_finish();
 }

--- a/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb6_dsr_lb.c
@@ -177,8 +177,8 @@ int nodeport_dsr_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
-	if (l4->check != bpf_htons(0x0d7c))
-		test_fatal("L4 checksum is invalid: %x", bpf_htons(l4->check));
+	if (l4->check != bpf_htons(0x6d1c))
+		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_ntohs(0x6d1c));
 
 	test_finish();
 }


### PR DESCRIPTION
When starting to build out BPF tests for netkit, it became apparent that there were a few data issues between pktgen-based packets and scapy-defined packets.

1. pktgen sets TCP seq/win values in host byte order, meaning calculated TCP checksums are wrong. This becomes a problem when you migrate a packet definition to scapy, which sets correct byte order, and thus the correct TCP checksum values.

2. pktgen's `default_data` string includes a NUL-terminating character, but scapy's does not. This leads to packet lengths being different, and causes differences in L3 checksum values.

This commit fixes these issues and updates all affected tests to include new checksum values.

```release-note
Fix byte ordering of TCP fields in BPF integration tests.
```