### PR TITLE
ICMP: support type 0

### DIFF
--- a/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-zero.yaml
+++ b/cilium-cli/connectivity/builder/manifests/echo-ingress-icmp-zero.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-ingress-from-client2-icmp-zero
+spec:
+  description: "Allow only ICMP type zero"
+  endpointSelector:
+    matchLabels:
+      kind: client
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        other: client
+      matchExpressions:
+      - { key: io.cilium.k8s.policy.cluster, operator: Exists }
+    icmps:
+    - fields:
+      - family: IPv4
+        type: 0
+      - family: IPv6
+        type: 0

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1574,10 +1574,7 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 				continue
 			}
 
-			port := l4.Port
-			if port == 0 && l4.PortName != "" {
-				port = ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto)
-			}
+			port := l4.ResolvePort(ep.GetNamedPort)
 
 			// Skip if a named port can not be resolved (yet)
 			// wildcard port already taken care of above
@@ -1665,7 +1662,7 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 			// NPDS supports port ranges.
 			PerPortPolicies = append(PerPortPolicies, &cilium.PortNetworkPolicy{
 				Port:     uint32(port),
-				EndPort:  uint32(l4.EndPort),
+				EndPort:  uint32(l4.GetEndPort()),
 				Protocol: protocol,
 				Rules:    envoypolicy.SortPortNetworkPolicyRules(rules),
 			})

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -296,7 +296,7 @@ func NewKeyFromPolicyKey(pk policyTypes.Key) PolicyKey {
 		Identity:         uint32(pk.Identity),
 		TrafficDirection: uint8(pk.TrafficDirection()),
 		Nexthdr:          uint8(pk.Nexthdr),
-		DestPortNetwork:  byteorder.HostToNetwork16(pk.DestPort),
+		DestPortNetwork:  byteorder.HostToNetwork16(pk.StartPort()),
 	}
 }
 

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -181,7 +181,7 @@ func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint3
 		//  - ports:
 		//    - port: 80
 		//      protocol: TCP // protocol is optional for this match.
-		key = policy.KeyForDirection(key.TrafficDirection()).WithPortProto(key.Nexthdr, key.DestPort)
+		key = policy.KeyForDirection(key.TrafficDirection()).WithPaddedPortProtoPrefix(key.Nexthdr, key.DestPort, 16)
 	case monitorAPI.PolicyMatchProtoOnly:
 		// Check for protocol-only policies.
 		//

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -199,7 +199,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check port-only rule.
-	policyKey = policy.EgressKey().WithPort(uint16(dstPort))
+	policyKey = policy.EgressKey().WithPortProto(u8proto.TCP, uint16(dstPort))
 	ep = &testutils.FakeEndpointInfo{
 		ID:           uint64(localID),
 		IPv4:         net.ParseIP(localIP),

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -548,9 +548,9 @@ type L4Filter struct {
 	U8Proto u8proto.U8proto `json:"-"`
 	// Port is the destination port to allow. Port 0 indicates that all traffic
 	// is allowed at L4.
-	Port uint16 `json:"port"`
+	Port types.PaddedPort `json:"port"`
 	// EndPort is zero for a singular port
-	EndPort uint16 `json:"endPort,omitempty"`
+	EndPort types.PaddedPort `json:"endPort,omitempty"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
 	PortName string      `json:"port-name,omitempty"`
@@ -603,7 +603,7 @@ func (l4 *L4Filter) GetIngress() bool {
 //
 // Use ResolvePort to handle the named-port case as well.
 func (l4 *L4Filter) GetPort() uint16 {
-	return l4.Port
+	return l4.Port.Unpad(l4.U8Proto)
 }
 
 // GetEndPort returns the end port of the filter's port range.
@@ -612,7 +612,7 @@ func (l4 *L4Filter) GetEndPort() uint16 {
 	if l4.EndPort == 0 {
 		return l4.GetPort()
 	}
-	return l4.EndPort
+	return l4.EndPort.Unpad(l4.U8Proto)
 }
 
 type LookupNamedPortFunc func(ingress bool, name string, proto u8proto.U8proto) uint16
@@ -678,7 +678,7 @@ func (c *ChangeState) Size() int {
 }
 
 // generateWildcardMapStateEntry creates map state entry for wildcard selector in the filter.
-func (l4 *L4Filter) generateWildcardMapStateEntry(logger *slog.Logger, p *EndpointPolicy, port uint16, tierPriority, nextTierPriority types.Priority) mapStateEntry {
+func (l4 *L4Filter) generateWildcardMapStateEntry(logger *slog.Logger, p *EndpointPolicy, port types.PaddedPort, tierPriority, nextTierPriority types.Priority) mapStateEntry {
 	if l4.wildcard != nil {
 		currentRule := l4.PerSelectorPolicies[l4.wildcard]
 		cs := l4.wildcard
@@ -691,11 +691,13 @@ func (l4 *L4Filter) generateWildcardMapStateEntry(logger *slog.Logger, p *Endpoi
 }
 
 // makeMapStateEntry creates a mapStateEntry for the given selector and policy for the Endpoint.
-func (l4 *L4Filter) makeMapStateEntry(logger *slog.Logger, p *EndpointPolicy, port uint16, cs CachedSelector, currentRule *PerSelectorPolicy, tierPriority, nextTierPriority types.Priority) mapStateEntry {
+// note: port here is required, as it may be the result of a named port resolution. Don't read
+// from l4.Port.
+func (l4 *L4Filter) makeMapStateEntry(logger *slog.Logger, p *EndpointPolicy, port types.PaddedPort, cs CachedSelector, currentRule *PerSelectorPolicy, tierPriority, nextTierPriority types.Priority) mapStateEntry {
 	var proxyPort uint16
 	if currentRule.IsRedirect() {
 		var err error
-		proxyPort, err = p.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port, currentRule.GetListener())
+		proxyPort, err = p.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port.Unpad(l4.U8Proto), currentRule.GetListener())
 		if err != nil {
 			// Skip unrealized redirects; this happens routineously just
 			// before new redirects are realized. Once created, we are called
@@ -749,10 +751,11 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, tierPriority, nextTierPriori
 
 	// resolve named port
 	if port == 0 && l4.PortName != "" {
-		port = p.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
-		if port == 0 {
+		np := p.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
+		if np == 0 {
 			return // nothing to be done for undefined named port
 		}
+		port = types.PadPort(proto, np)
 	}
 
 	tierMaxPrecedence := tierPriority.ToTierMaxPrecedence()
@@ -760,7 +763,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, tierPriority, nextTierPriori
 	var keysToAdd []Key
 	for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
 		keysToAdd = append(keysToAdd,
-			KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+			KeyForDirection(direction).WithPaddedPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 	}
 
 	// Compute the wildcard entry, if present.
@@ -970,29 +973,29 @@ func createL4Filter(policyCtx PolicyContext, entry *types.PolicyEntry, portRule 
 	origin := policyCtx.Origin()
 	tier, priority := policyCtx.Priority()
 
-	portName := ""
-	p := uint64(0)
-	if iana.IsSvcName(port.Port) {
-		portName = port.Port
-	} else {
-		// already validated via PortRule.Validate()
-		p, _ = strconv.ParseUint(port.Port, 0, 16)
-	}
-
-	// already validated via L4Proto.Validate(), never "ANY"
-	// NOTE: "ANY" for wildcarded port/proto!
-	u8p, _ := u8proto.ParseProtocol(string(port.Protocol))
-
 	l4 := &L4Filter{
 		Tier:                tier,
-		Port:                uint16(p),            // 0 for L3-only rules and named ports
-		EndPort:             uint16(port.EndPort), // 0 for a single port, > 'Port' for a range
-		PortName:            portName,             // non-"" for named ports
 		Protocol:            port.Protocol,
-		U8Proto:             u8p,
 		PerSelectorPolicies: make(L7DataMap),
 		RuleOrigin:          make(map[CachedSelector]ruleOrigin), // Filled in below.
 		Ingress:             entry.Ingress,
+	}
+
+	// At this point, the Protocol will never be ANY except for L3 wildcard with no port.
+	if port.Protocol != api.ProtoAny {
+		// already validated
+		l4.U8Proto, _ = u8proto.ParseProtocol(string(port.Protocol))
+
+		if iana.IsSvcName(port.Port) {
+			l4.PortName = port.Port
+		} else {
+			// already validated via PortRule.Validate()
+			p, _ := strconv.ParseUint(port.Port, 0, 16)
+			l4.Port = types.PadPort(l4.U8Proto, uint16(p))
+			if port.EndPort > 0 {
+				l4.EndPort = types.PadPort(l4.U8Proto, uint16(port.EndPort))
+			}
+		}
 	}
 
 	peerEndpoints := entry.L3
@@ -1326,7 +1329,7 @@ func NewL4PolicyMapWithValues(initMap map[string]*L4Filter) L4PolicyMaps {
 }
 
 type portProtoKey struct {
-	Port, EndPort uint16
+	Port, EndPort types.PaddedPort
 	Proto         uint8
 }
 
@@ -1357,8 +1360,8 @@ func parsePortProtocol(port, protocol string) (uint16, uint8) {
 // makePolicyMapKey creates a protocol-port uint32 with the
 // upper 16 bits containing the protocol and the lower 16
 // bits containing the port.
-func makePolicyMapKey(port, mask uint16, proto uint8) uint32 {
-	return (uint32(proto) << 16) | uint32(port&mask)
+func makePolicyMapKey(port types.PaddedPort, mask uint16, proto uint8) uint32 {
+	return (uint32(proto) << 16) | uint32(uint16(port)&mask)
 }
 
 // Upsert L4Filter adds an L4Filter indexed by protocol/port-endPort.
@@ -1370,8 +1373,8 @@ func (l4M *L4PolicyMap) Upsert(port string, endPort uint16, protocol string, l4 
 
 	portU, protoU := parsePortProtocol(port, protocol)
 	ppK := portProtoKey{
-		Port:    portU,
-		EndPort: endPort,
+		Port:    types.PadPort(u8proto.U8proto(protoU), portU),
+		EndPort: types.PadPort(u8proto.U8proto(protoU), endPort),
 		Proto:   protoU,
 	}
 	_, indexExists := l4M.RangePortMap[ppK]
@@ -1379,7 +1382,7 @@ func (l4M *L4PolicyMap) Upsert(port string, endPort uint16, protocol string, l4 
 	// We do not need to reindex a key that already exists,
 	// even if the filter changed.
 	if !indexExists {
-		for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
+		for _, mp := range PortRangeToMaskedPorts(ppK.Port, ppK.EndPort) {
 			k := makePolicyMapKey(mp.port, mp.mask, protoU)
 			prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
 			portProtoSet, ok := l4M.RangePortIndex.ExactLookup(prefix, k)
@@ -1401,15 +1404,15 @@ func (l4M *L4PolicyMap) Delete(port string, endPort uint16, protocol string) {
 
 	portU, protoU := parsePortProtocol(port, protocol)
 	ppK := portProtoKey{
-		Port:    portU,
-		EndPort: endPort,
+		Port:    types.PadPort(u8proto.U8proto(protoU), portU),
+		EndPort: types.PadPort(u8proto.U8proto(protoU), endPort),
 		Proto:   protoU,
 	}
 	_, indexExists := l4M.RangePortMap[ppK]
 	delete(l4M.RangePortMap, ppK)
 	// Only delete the index if the key exists.
 	if indexExists {
-		for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
+		for _, mp := range PortRangeToMaskedPorts(ppK.Port, ppK.EndPort) {
 			k := makePolicyMapKey(mp.port, mp.mask, protoU)
 			prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
 			portProtoSet, ok := l4M.RangePortIndex.ExactLookup(prefix, k)
@@ -1432,8 +1435,8 @@ func (l4M *L4PolicyMap) ExactLookup(port string, endPort uint16, protocol string
 
 	portU, protoU := parsePortProtocol(port, protocol)
 	ppK := portProtoKey{
-		Port:    portU,
-		EndPort: endPort,
+		Port:    types.PadPort(u8proto.U8proto(protoU), portU),
+		EndPort: types.PadPort(u8proto.U8proto(protoU), endPort),
 		Proto:   protoU,
 	}
 	return l4M.RangePortMap[ppK]
@@ -1652,15 +1655,16 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 		port := l4.Port
 		// resolve named port
 		if port == 0 && l4.PortName != "" {
-			port = epPolicy.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
+			np := epPolicy.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
 			if port == 0 {
 				continue
 			}
+			port = types.PadPort(l4.U8Proto, np)
 		}
 		var proxyPort uint16
 		if redirect {
 			var err error
-			proxyPort, err = epPolicy.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port, listener)
+			proxyPort, err = epPolicy.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port.Unpad(l4.U8Proto), listener)
 			if err != nil {
 				logger.Warn(
 					"AccumulateMapChanges: Missing redirect.",
@@ -1679,7 +1683,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 		var keysToAdd []Key
 		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
 			keysToAdd = append(keysToAdd,
-				KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+				KeyForDirection(direction).WithPaddedPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
 		}
 
 		value := newMapStateEntry(priority, tierPriority, nextTierPriority, derivedFrom, proxyPort, listenerPriority, verdict, authReq)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -191,10 +191,10 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 		expected[i].ForEach(func(l4 *L4Filter) bool {
 			port := l4.PortName
 			if len(port) == 0 {
-				port = fmt.Sprintf("%d", l4.Port)
+				port = fmt.Sprintf("%d", l4.GetPort())
 			}
 
-			l4B := actual[i].ExactLookup(port, l4.EndPort, string(l4.Protocol))
+			l4B := actual[i].ExactLookup(port, l4.EndPort.Unpad(l4.U8Proto), string(l4.Protocol))
 			require.NotNil(t, l4B, "Port Protocol lookup failed: [Port: %s, EndPort: %d, Protocol: %s]", port, l4.EndPort, string(l4.Protocol))
 
 			// If no available IDs are provided, we assume the same pointer for

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -485,8 +485,8 @@ func TestL4PolicyMapPortRangeOverlaps(t *testing.T) {
 			startFilter := &L4Filter{
 				U8Proto:  u8proto.TCP,
 				Protocol: api.ProtoTCP,
-				Port:     portRange.startPort,
-				EndPort:  portRange.endPort,
+				Port:     types.PadPort(u8proto.TCP, portRange.startPort),
+				EndPort:  types.PadPort(u8proto.TCP, portRange.endPort),
 			}
 			startPort := fmt.Sprintf("%d", portRange.startPort)
 			l4Map.Upsert(startPort, portRange.endPort, "TCP", startFilter)
@@ -506,8 +506,8 @@ func TestL4PolicyMapPortRangeOverlaps(t *testing.T) {
 				altFilter := &L4Filter{
 					U8Proto:  u8proto.TCP,
 					Protocol: api.ProtoTCP,
-					Port:     altPR.startPort,
-					EndPort:  altPR.endPort,
+					Port:     types.PadPort(u8proto.TCP, altPR.startPort),
+					EndPort:  types.PadPort(u8proto.TCP, altPR.endPort),
 				}
 				// Upsert overlapping port range.
 				l4Map.Upsert(altStartPort, altPR.endPort, "TCP", altFilter)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -408,7 +408,7 @@ func (ms *mapState) LPMAncestors(key Key) iter.Seq2[Key, mapStateEntry] {
 // 'key' must not have a wildcard identity or port.
 func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
 	// Validate that the search key has no wildcards
-	if key.Identity == 0 || key.Nexthdr == 0 || key.DestPort == 0 || key.EndPort() != key.DestPort {
+	if key.Identity == 0 || key.Nexthdr == 0 || key.DestPort == 0 || key.EndPort() != key.StartPort() {
 		ms.logger.Error(
 			"invalid key for Lookup",
 			logfields.Stacktrace, hclog.Stacktrace(),

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -306,7 +306,7 @@ func TestPolicyKeyTrafficDirection(t *testing.T) {
 func (ms *mapState) validatePortProto(t *testing.T) {
 	ms.forEach(func(k Key, _ mapStateEntry) bool {
 		if k.Nexthdr == 0 {
-			require.Equal(t, uint16(0), k.DestPort)
+			require.EqualValues(t, 0, k.DestPort)
 		}
 		return true
 	})

--- a/pkg/policy/portrange_test.go
+++ b/pkg/policy/portrange_test.go
@@ -8,14 +8,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/policy/types"
 )
 
 // maskedPorts have to be sorted for this check
-func validateMaskedPorts(t *testing.T, maskedPorts []MaskedPort, start, end uint16) {
+func validateMaskedPorts(t *testing.T, maskedPorts []MaskedPort, start, end types.PaddedPort) {
 	// Wildcard case.
 	if start == 0 && end == 0 {
 		require.Len(t, maskedPorts, 1)
-		require.Equal(t, uint16(0), maskedPorts[0].port)
+		require.Equal(t, types.PaddedPort(0), maskedPorts[0].port)
 		require.Equal(t, uint16(0), maskedPorts[0].mask)
 		return
 	}
@@ -23,10 +25,10 @@ func validateMaskedPorts(t *testing.T, maskedPorts []MaskedPort, start, end uint
 	require.NotEmpty(t, maskedPorts)
 	// validate that range elements are continuous and non-overlapping
 	first := maskedPorts[0].port
-	last := first + ^maskedPorts[0].mask
+	last := first + types.PaddedPort(^maskedPorts[0].mask)
 	for i := 1; i < len(maskedPorts); i++ {
 		require.Equal(t, maskedPorts[i].port, last+1)
-		last = maskedPorts[i].port + ^maskedPorts[i].mask
+		last = maskedPorts[i].port + types.PaddedPort(^maskedPorts[i].mask)
 	}
 	// Check that the computed range matches the given range
 	require.Equal(t, first, start)
@@ -35,7 +37,7 @@ func validateMaskedPorts(t *testing.T, maskedPorts []MaskedPort, start, end uint
 
 func TestPortRange(t *testing.T) {
 	type testCase struct {
-		start, end uint16
+		start, end types.PaddedPort
 		expected   []MaskedPort
 	}
 

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -471,7 +471,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorB: {labelsL4}}),
 		},
 		"8/ICMP": {
-			Port:     8,
+			Port:     0xff08,
 			Protocol: api.ProtoICMP,
 			U8Proto:  0x1,
 			PerSelectorPolicies: L7DataMap{
@@ -481,7 +481,7 @@ func TestWildcardL3RulesEgressDeny(t *testing.T) {
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorB: {labelsICMP}}),
 		},
 		"128/ICMPV6": {
-			Port:     128,
+			Port:     0xff80,
 			Protocol: api.ProtoICMPv6,
 			U8Proto:  0x3A,
 			PerSelectorPolicies: L7DataMap{

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -377,7 +377,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar1: {labelsL3}}),
 		},
 		"8/ICMP": {
-			Port:     8,
+			Port:     0xff08,
 			Protocol: api.ProtoICMP,
 			U8Proto:  0x1,
 			PerSelectorPolicies: L7DataMap{
@@ -387,7 +387,7 @@ func TestWildcardL3RulesIngress(t *testing.T) {
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMP}}),
 		},
 		"128/ICMPV6": {
-			Port:     128,
+			Port:     0xff80,
 			Protocol: api.ProtoICMPv6,
 			U8Proto:  0x3A,
 			PerSelectorPolicies: L7DataMap{
@@ -719,7 +719,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsHTTP}}),
 		},
 		"8/ICMP": {
-			Port:     8,
+			Port:     0xff08,
 			Protocol: api.ProtoICMP,
 			U8Proto:  0x1,
 			PerSelectorPolicies: L7DataMap{
@@ -729,7 +729,7 @@ func TestWildcardL3RulesEgress(t *testing.T) {
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorBar2: {labelsICMP}}),
 		},
 		"128/ICMPV6": {
-			Port:     128,
+			Port:     0xff80,
 			Protocol: api.ProtoICMPv6,
 			U8Proto:  0x3A,
 			PerSelectorPolicies: L7DataMap{

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -924,7 +924,7 @@ func TestICMPPolicy(t *testing.T) {
 	}
 
 	expectedIn := NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMP/8": {
-		Port:     8,
+		Port:     0xff08,
 		Protocol: api.ProtoICMP,
 		U8Proto:  u8proto.ProtoIDs["icmp"],
 		Ingress:  true,
@@ -936,7 +936,7 @@ func TestICMPPolicy(t *testing.T) {
 	}})
 
 	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMP/9": {
-		Port:     9,
+		Port:     0xff09,
 		Protocol: api.ProtoICMP,
 		U8Proto:  u8proto.ProtoIDs["icmp"],
 		Ingress:  false,
@@ -971,7 +971,7 @@ func TestICMPPolicy(t *testing.T) {
 
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{
 		"ICMP/8": {
-			Port:     8,
+			Port:     0xff08,
 			Protocol: api.ProtoICMP,
 			U8Proto:  u8proto.ProtoIDs["icmp"],
 			Ingress:  true,
@@ -1013,7 +1013,7 @@ func TestICMPPolicy(t *testing.T) {
 	}
 
 	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMPV6/128": {
-		Port:     128,
+		Port:     0xff80,
 		Protocol: api.ProtoICMPv6,
 		U8Proto:  u8proto.ProtoIDs["icmp"],
 		Ingress:  true,
@@ -1762,7 +1762,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 
 	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
-	require.Equal(t, uint16(80), filter.Port)
+	require.EqualValues(t, 80, filter.Port)
 	require.True(t, filter.Ingress)
 
 	require.Len(t, filter.PerSelectorPolicies, 1)
@@ -1795,7 +1795,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 	require.Len(t, pol.L4Policy.Ingress.PortRules, 1)
 	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookup("port-80", 0, "TCP")
 	require.NotNil(t, filter)
-	require.Equal(t, uint16(0), filter.Port)
+	require.EqualValues(t, 0, filter.Port)
 	require.Equal(t, "port-80", filter.PortName)
 	require.True(t, filter.Ingress)
 
@@ -1855,7 +1855,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
 	filter := pol.L4Policy.Egress.PortRules[0].ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
-	require.Equal(t, uint16(80), filter.Port)
+	require.EqualValues(t, 80, filter.Port)
 	require.False(t, filter.Ingress)
 
 	require.Len(t, filter.PerSelectorPolicies, 1)
@@ -1892,7 +1892,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
 	filter := pol.L4Policy.Egress.PortRules[0].ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
-	require.Equal(t, uint16(80), filter.Port)
+	require.EqualValues(t, 80, filter.Port)
 	require.False(t, filter.Ingress)
 
 	require.Len(t, filter.PerSelectorPolicies, 3)
@@ -1928,7 +1928,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
 	filter := pol.L4Policy.Egress.PortRules[0].ExactLookup("80", 0, "TCP")
 	require.NotNil(t, filter)
-	require.Equal(t, uint16(80), filter.Port)
+	require.EqualValues(t, 80, filter.Port)
 	require.False(t, filter.Ingress)
 
 	require.Len(t, filter.PerSelectorPolicies, 1)

--- a/pkg/policy/types/types.go
+++ b/pkg/policy/types/types.go
@@ -168,9 +168,13 @@ func (k LPMKey) IsEgress() bool {
 	return k.TrafficDirection() == trafficdirection.Egress
 }
 
+func (k LPMKey) StartPort() uint16 {
+	return k.DestPort
+}
+
 // EndPort returns the end-port of the Key based on the Mask.
 func (k LPMKey) EndPort() uint16 {
-	return k.DestPort + uint16(0xffff)>>k.PortPrefixLen()
+	return k.StartPort() + uint16(0xffff)>>k.PortPrefixLen()
 }
 
 // Covers returns true if 'k' matches all traffic that 'c' matcches.

--- a/pkg/policy/types/types.go
+++ b/pkg/policy/types/types.go
@@ -16,6 +16,28 @@ import (
 // to binary minus the sizeof the identity field (which is not indexed).
 const MapStatePrefixLen = uint(32)
 
+// PaddedPort is a marker type to indicate that the ICMP type
+// has been padded with 0xff. This is because ICMP type 0 (which we
+// represent as a port) is valid, but we use 0 as a not-present value.
+type PaddedPort uint16
+
+func PadPort(proto u8proto.U8proto, port uint16) PaddedPort {
+	if proto.IsICMP() {
+		return PaddedPort(port | 0xff00)
+	}
+	return PaddedPort(port)
+}
+
+func (p PaddedPort) Unpad(proto u8proto.U8proto) uint16 {
+	port := uint16(p)
+
+	// ICMP is padded with 0xff, remove padding
+	if proto.IsICMP() && port > 0 {
+		port &= 0x00ff
+	}
+	return port
+}
+
 // Key is the userspace representation of a policy key in BPF. It is
 // intentionally duplicated from pkg/maps/policymap to avoid pulling in the
 // BPF dependency to this package.
@@ -26,7 +48,7 @@ type LPMKey struct {
 	Nexthdr u8proto.U8proto
 	// DestPort is the port at L4 to / from which traffic is allowed, in
 	// host-byte order.
-	DestPort uint16
+	DestPort PaddedPort
 }
 
 type Key struct {
@@ -73,21 +95,13 @@ func (k Key) WithProto(proto u8proto.U8proto) Key {
 	return k
 }
 
-func (k Key) WithPort(port uint16) Key {
-	k.DestPort = port
-	k.bits &= directionBitMask
+func (k Key) WithPaddedPortProtoPrefix(proto u8proto.U8proto, port PaddedPort, prefixLen uint8) Key {
+	k.Nexthdr = proto
 
-	if port != 0 {
-		// non-wildcarded port
-		k.bits |= 16
-	}
-	return k
-}
-
-func (k Key) WithPortPrefix(port uint16, prefixLen uint8) Key {
-	if prefixLen > 16 || port != 0 && prefixLen == 0 {
+	if prefixLen > 16 || (port != 0 && prefixLen == 0) {
 		prefixLen = 16
 	}
+
 	// set up the port wildcard
 	k.DestPort = port & (0xffff << (16 - prefixLen))
 	k.bits = k.bits&directionBitMask | prefixLen
@@ -95,11 +109,15 @@ func (k Key) WithPortPrefix(port uint16, prefixLen uint8) Key {
 }
 
 func (k Key) WithPortProto(proto u8proto.U8proto, port uint16) Key {
-	return k.WithProto(proto).WithPort(port)
+	prefixLen := uint8(16)
+	if port == 0 {
+		prefixLen = 0
+	}
+	return k.WithPortProtoPrefix(proto, port, prefixLen)
 }
 
 func (k Key) WithPortProtoPrefix(proto u8proto.U8proto, port uint16, prefixLen uint8) Key {
-	return k.WithProto(proto).WithPortPrefix(port, prefixLen)
+	return k.WithPaddedPortProtoPrefix(proto, PadPort(proto, port), prefixLen)
 }
 
 func (k Key) WithTCPPort(port uint16) Key {
@@ -169,7 +187,7 @@ func (k LPMKey) IsEgress() bool {
 }
 
 func (k LPMKey) StartPort() uint16 {
-	return k.DestPort
+	return k.DestPort.Unpad(k.Nexthdr)
 }
 
 // EndPort returns the end-port of the Key based on the Mask.
@@ -207,7 +225,7 @@ func (k LPMKey) PortIsBroader(c Key) bool {
 	kPrefixLen := k.PortPrefixLen()
 	cPrefixLen := c.PortPrefixLen()
 	return kPrefixLen < cPrefixLen &&
-		k.DestPort^c.DestPort&(uint16(0xffff)<<(16-kPrefixLen)) == 0
+		k.DestPort^c.DestPort&(PaddedPort(0xffff)<<(16-kPrefixLen)) == 0
 }
 
 // PortIsEqual returns true if the port ranges
@@ -241,7 +259,7 @@ func (k LPMKey) CommonPrefix(b LPMKey) uint {
 	if v < 9 {
 		return uint(v)
 	}
-	return uint(v + bits.LeadingZeros16(k.DestPort^b.DestPort))
+	return uint(v + bits.LeadingZeros16(uint16(k.DestPort^b.DestPort)))
 }
 
 // BitValueAt implements the BitValueAt method for the

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -71,3 +71,7 @@ func FromNumber(proto uint8) (U8proto, error) {
 	}
 	return U8proto(proto), nil
 }
+
+func (p U8proto) IsICMP() bool {
+	return p == ICMP || p == ICMPv6
+}


### PR DESCRIPTION
The policy code internally treats port 0 as either a wildcard or non-existing, depending on the context. This is fine for TCP, UDP, and SCTP, as port 0 is invalid in those protocols.

However, we also use the L4 port to represent ICMP type, and type 0 **is valid**.

The fix is mechanical but somewhat involved: pad all ICMP ports with 0xff00. This is safe because the ICMP type itself is an 8-bit number. To help prevent bugs, this adds a new type, `PaddedPort` which is just a uint16 but indicates that ICMP values have a different internal representation

```release-note
Fixes a bug where ICMP type 0 was incorrectly handled in network policy.
```
