### PR TITLE
bpf:wireguard: fix packet marking identity check for encrypted packets

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -26,7 +26,7 @@ DECLARE_CONFIG(__u16, wg_port, "Port for the WireGuard interface.")
  * - ctx is a UDP packet;
  * - L4 dport == CONFIG(wg_port);
  * - L4 sport == dport;
- * - valid identity in cluster.
+ * - valid remote node identity.
  */
 static __always_inline bool
 ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, __u32 identity)
@@ -52,8 +52,8 @@ ctx_is_wireguard(struct __ctx_buff *ctx, int l4_off, __u8 protocol, __u32 identi
 	if (l4.sport != l4.dport)
 		return false;
 
-	/* Identity not in cluster. */
-	if (!identity_is_cluster(identity))
+	/* Identity is not a remote node. */
+	if (!identity_is_remote_node(identity))
 		return false;
 
 	/* Cilium-related WireGuard packet to be traced as encrypted. */

--- a/bpf/tests/decrypt_host.h
+++ b/bpf/tests/decrypt_host.h
@@ -2,15 +2,9 @@
  * Copyright Authors of Cilium
  */
 
-#ifdef ENABLE_WIREGUARD
-# define NODE_SPI 255
+#if !defined(ENABLE_WIREGUARD) && !defined(ENABLE_IPSEC)
+# error "At least one of ENABLE_WIREGUARD or ENABLE_IPSEC must be defined
 #endif
-
-#ifdef ENABLE_IPSEC
-# define NODE_SPI 3
-#endif
-
-#define NODE_ID 7
 
 #define ENABLE_IPV4
 #define ENABLE_IPV6
@@ -21,6 +15,7 @@
 
 #include "lib/bpf_host.h"
 
+#include "lib/ipcache.h"
 #include "lib/node.h"
 #include "scapy.h"
 
@@ -73,12 +68,26 @@ int pktgen(struct __ctx_buff *ctx, bool ipv4)
 	return 0;
 }
 
+/* The setup function adds the necessary state to properly pass up the packet to
+ * the stack with the MARK_MAGIC_DECRYPT mark set.
+ * - For WireGuard, this means adding an entry to the IPCache (resolve_srcid_ipv{4,6} in bpf_host)
+ * - For IPSec, this means adding an entry to the node map (lookup_ip{4,6}_node_id in bpf_host)
+ */
 int setup(struct __ctx_buff *ctx, bool ipv4)
 {
+#ifdef ENABLE_IPSEC
 	if (ipv4)
-		node_v4_add_entry(v4_node_one, NODE_ID, NODE_SPI);
+		node_v4_add_entry(v4_node_one, REMOTE_NODE_ID, 3);
 	else
-		node_v6_add_entry((union v6addr *)v6_node_one, NODE_ID, NODE_SPI);
+		node_v6_add_entry((union v6addr *)v6_node_one, REMOTE_NODE_ID, 3);
+#endif
+
+#ifdef ENABLE_WIREGUARD
+	if (ipv4)
+		ipcache_v4_add_entry(v4_node_one, 0, REMOTE_NODE_ID, 0, 255);
+	else
+		ipcache_v6_add_entry((union v6addr *)v6_node_one, 0, REMOTE_NODE_ID, 0, 255);
+#endif
 
 	return netdev_receive_packet(ctx);
 }

--- a/bpf/tests/encryption_helpers_wireguard.c
+++ b/bpf/tests/encryption_helpers_wireguard.c
@@ -67,21 +67,21 @@ int check1(struct __ctx_buff *ctx)
 	protocol = ipv4->protocol;
 
 	/* Valid Wireguard packet. */
-	assert(ctx_is_wireguard(ctx, l4_off, protocol, CLUSTER_IDENTITY));
+	assert(ctx_is_wireguard(ctx, l4_off, protocol, REMOTE_NODE_ID));
 
 	/* Invalid identity within CIDR. */
 	assert(!ctx_is_wireguard(ctx, l4_off, protocol, CIDR_IDENTITY_RANGE_START));
 
 	/* Invalid protocol TCP. */
-	assert(!ctx_is_wireguard(ctx, l4_off, IPPROTO_TCP, CLUSTER_IDENTITY));
+	assert(!ctx_is_wireguard(ctx, l4_off, IPPROTO_TCP, REMOTE_NODE_ID));
 
 	/* Invalid L4 offset. */
-	assert(!ctx_is_wireguard(ctx, l4_off + 2, protocol, CLUSTER_IDENTITY));
+	assert(!ctx_is_wireguard(ctx, l4_off + 2, protocol, REMOTE_NODE_ID));
 
 	udp->source += 1;
 
 	/* Invalid L4 ports mismatching. */
-	assert(!ctx_is_wireguard(ctx, l4_off, protocol, CLUSTER_IDENTITY));
+	assert(!ctx_is_wireguard(ctx, l4_off, protocol, REMOTE_NODE_ID));
 
 	test_finish();
 }


### PR DESCRIPTION
When receiving a WireGuard encrypted packet, we try to mark it accordingly
with MARK_MAGIC_DECRYPT. This has no influence wrt the packet processing
itself, as the packet would be left up for the stack anyway (and redirected
to cilium_wg0 for decryption). However, prior to this commit we were
checking the identity to be within cluster, but that is not what we
want to look for. The packet is encrypted, so the IP addresses will be
node IP. Therefore, we want to make sure that the source identity is
a remote node within the cluster. The previous check `identity_is_cluster`
was always true for REMOTE_NODE_ID, but could be true also for other identities.