### PR TITLE
Fix minor bug in kubernetes ClusterNetworkPolicy parsing

### DIFF
--- a/pkg/k8s/cluster_network_policy.go
+++ b/pkg/k8s/cluster_network_policy.go
@@ -81,7 +81,7 @@ func kcnpParseNamespacedPod(clusterName string, peer policyv1alpha2.NamespacedPo
 // cluster will be added.
 func kcnpProcessNodeSelector(clusterName string, nodeSelector *metav1.LabelSelector) types.Selectors {
 	ns := toSlimLabelSelector(nodeSelector)
-	es := api.NewESFromK8sLabelSelector(labels.LabelSourceNode+".", ns)
+	es := api.NewESFromK8sLabelSelector(labels.LabelSourceNodeKeyPrefix, ns)
 	es.AddMatchExpression(labels.LabelSourceReservedKeyPrefix+labels.IDNameRemoteNode, slim_metav1.LabelSelectorOpExists, []string{})
 
 	if clusterName != cmtypes.PolicyAnyCluster && !isPodSelectorSelectingCluster(ns) {

--- a/pkg/k8s/cluster_network_policy_test.go
+++ b/pkg/k8s/cluster_network_policy_test.go
@@ -278,7 +278,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			L3: types.ToSelectors(
 				api.NewESFromK8sLabelSelector("", &slim_metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"node.kubernetes.io/hostname":      "node1",
+						"node:kubernetes.io/hostname":      "node1",
 						"k8s:io.cilium.k8s.policy.cluster": clusterName,
 					},
 					MatchExpressions: []slim_metav1.LabelSelectorRequirement{{

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -159,6 +159,9 @@ const (
 	// LabelSourceNode is the label source for remote-nodes.
 	LabelSourceNode = "node"
 
+	// LabelSourceNodeKeyPrefix is the source of node labels as k8s selector key prefix
+	LabelSourceNodeKeyPrefix = LabelSourceNode + SourceDelimiter
+
 	// LabelSourceFQDN is the label source for IPs resolved by fqdn lookups
 	LabelSourceFQDN = "fqdn"
 


### PR DESCRIPTION
See commit message for details.
Fixes #42338
Sample failure: https://github.com/cilium/cilium/actions/runs/22001453906

Edit:
Seems like https://github.com/cilium/cilium/pull/44334 is already merged.
This PR has another followup related to node selector parsing.