### PR TITLE
options: Migrate `VtepCidrMask` from `net.IP` to `netip.Addr`

### DIFF
--- a/pkg/datapath/config/endpoint.go
+++ b/pkg/datapath/config/endpoint.go
@@ -4,8 +4,6 @@
 package config
 
 import (
-	"net"
-
 	"github.com/cilium/cilium/pkg/byteorder"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -45,7 +43,7 @@ func Endpoint(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfigur
 	cfg.EnableNetkit = lnc.DatapathIsNetkit
 
 	if option.Config.EnableVTEP {
-		cfg.VTEPMask = byteorder.NetIPv4ToHost32(net.IP(option.Config.VtepCidrMask))
+		cfg.VTEPMask = byteorder.NetIPAddrToHost32(option.Config.VtepCidrMask)
 	}
 
 	cfg.AllowICMPFragNeeded = option.Config.AllowICMPFragNeeded

--- a/pkg/datapath/config/host.go
+++ b/pkg/datapath/config/host.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 
 	"github.com/vishvananda/netlink"
@@ -40,7 +39,7 @@ func CiliumHost(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfig
 	}
 
 	if option.Config.EnableVTEP {
-		cfg.VTEPMask = byteorder.NetIPv4ToHost32(net.IP(option.Config.VtepCidrMask))
+		cfg.VTEPMask = byteorder.NetIPAddrToHost32(option.Config.VtepCidrMask)
 	}
 
 	if option.Config.EnableL2Announcements {
@@ -88,7 +87,7 @@ func CiliumNet(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfigu
 	}
 
 	if option.Config.EnableVTEP {
-		cfg.VTEPMask = byteorder.NetIPv4ToHost32(net.IP(option.Config.VtepCidrMask))
+		cfg.VTEPMask = byteorder.NetIPAddrToHost32(option.Config.VtepCidrMask)
 	}
 
 	cfg.AllowICMPFragNeeded = option.Config.AllowICMPFragNeeded
@@ -146,7 +145,7 @@ func Netdev(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfigurat
 	}
 
 	if option.Config.EnableVTEP {
-		cfg.VTEPMask = byteorder.NetIPv4ToHost32(net.IP(option.Config.VtepCidrMask))
+		cfg.VTEPMask = byteorder.NetIPAddrToHost32(option.Config.VtepCidrMask)
 	}
 
 	if option.Config.EnableL2Announcements {

--- a/pkg/datapath/config/overlay.go
+++ b/pkg/datapath/config/overlay.go
@@ -4,8 +4,6 @@
 package config
 
 import (
-	"net"
-
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/byteorder"
@@ -24,7 +22,7 @@ func Overlay(lnc *datapath.LocalNodeConfiguration, link netlink.Link) any {
 	cfg.EnableNetkit = lnc.DatapathIsNetkit
 
 	if option.Config.EnableVTEP {
-		cfg.VTEPMask = byteorder.NetIPv4ToHost32(net.IP(option.Config.VtepCidrMask))
+		cfg.VTEPMask = byteorder.NetIPAddrToHost32(option.Config.VtepCidrMask)
 	}
 
 	cfg.EncryptionStrictIngress = option.Config.EnableEncryptionStrictModeIngress

--- a/pkg/maps/vtep/vtep.go
+++ b/pkg/maps/vtep/vtep.go
@@ -55,7 +55,8 @@ func newKey(ip net.IP) Key {
 	result := Key{}
 
 	if ip4 := ip.To4(); ip4 != nil {
-		ip4.Mask(net.IPMask(option.Config.VtepCidrMask))
+		maskBytes := option.Config.VtepCidrMask.As4()
+		ip4.Mask(net.IPMask(maskBytes[:]))
 		copy(result.IP[:], ip4)
 	}
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1753,7 +1753,7 @@ type DaemonConfig struct {
 	EnableVTEP bool
 
 	// VtepMask VTEP Mask
-	VtepCidrMask net.IP
+	VtepCidrMask netip.Addr
 
 	// TCFilterPriority sets the priority of the cilium tc filter, enabling other
 	// filters to be inserted prior to the cilium filter.
@@ -3263,9 +3263,9 @@ func getPossibleCPUs(logger *slog.Logger) int {
 func (c *DaemonConfig) validateVTEP(vp *viper.Viper) error {
 	vtepCidrMask := vp.GetString(VtepMask)
 
-	mask := net.ParseIP(vtepCidrMask)
-	if mask == nil {
-		return fmt.Errorf("Invalid VTEP CIDR Mask: %v", vtepCidrMask)
+	mask, err := netip.ParseAddr(vtepCidrMask)
+	if err != nil {
+		return fmt.Errorf("invalid VTEP CIDR Mask: %w", err)
 	}
 	c.VtepCidrMask = mask
 


### PR DESCRIPTION
Migrate `VtepCidrMask` option from `net.IP` to `netip.Addr`

Related: #24246