### PR TITLE
docs: fix duplicate --version in Helm OCI examples

### DIFF
--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -51,7 +51,7 @@ several advantages:
    .. parsed-literal::
 
       helm install cilium oci://quay.io/cilium/charts/cilium \
-        --version |CHART_VERSION| \
+        |CHART_VERSION| \
         --namespace kube-system
 
 .. only:: not stable
@@ -320,7 +320,7 @@ Using OCI Registry
    .. parsed-literal::
 
       helm upgrade cilium oci://quay.io/cilium/charts/cilium \
-        --version |CHART_VERSION| \
+        |CHART_VERSION| \
         --namespace kube-system
 
 .. only:: not stable
@@ -342,7 +342,7 @@ switching to OCI is straightforward as the charts are identical:
    .. parsed-literal::
 
       helm upgrade cilium oci://quay.io/cilium/charts/cilium \
-        --version |CHART_VERSION| \
+        |CHART_VERSION| \
         --namespace kube-system \
         --reuse-values
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

**Description:**

In the stable docs, `|CHART_VERSION|` is substituted with `--version <release>` (e.g. `--version 1.19.0`). The Helm OCI examples had an extra literal `--version` before `|CHART_VERSION|`, which produced a duplicate flag in the rendered output (e.g. `--version --version 1.19.0`). 

```release-note
docs: Fix duplicate `--version` in Helm OCI install/upgrade documentation examples.
```