### PR TITLE
gh: e2e-upgrade: skip disk cleanup when workflow is skipped

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -220,9 +220,6 @@ jobs:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
 
-      - name: Cleanup Disk space in runner
-        uses: ./.github/actions/disk-cleanup
-
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
@@ -304,6 +301,10 @@ jobs:
              SKIP_UPGRADE="true"
           fi
           echo skip_upgrade=${SKIP_UPGRADE} >> $GITHUB_OUTPUT
+
+      - name: Cleanup Disk space in runner
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        uses: ./.github/actions/disk-cleanup
 
       - name: Resolve full kernel version
         id: kernel-version


### PR DESCRIPTION
Most parts of this workflow are skipped when testing patch-level upgrades in the `main` branch. Also skip the initial disk cleanup, which takes around 1 minute.