### PR TITLE
docs: Fix some "parsed-literal" blocks

### DIFF
--- a/Documentation/configuration/sbom.rst
+++ b/Documentation/configuration/sbom.rst
@@ -43,12 +43,12 @@ Verify SBOM attestation
 To verify the SBOM in-toto attestation on the supplied Cilium image, run the following command:
 
 .. parsed-literal::
-    
+
     $ TAG=|IMAGE_TAG|
-    $ cosign verify-attestation --certificate-github-workflow-repository cilium/cilium \
-    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-    --certificate-identity-regexp https://github.com/cilium/cilium/.github/workflows \
-    --type spdxjson <IMAGE URI> 2>&1 | head -n 13
+    $ cosign verify-attestation --certificate-github-workflow-repository cilium/cilium \\
+        --certificate-oidc-issuer https://token.actions.githubusercontent.com \\
+        --certificate-identity-regexp https://github.com/cilium/cilium/.github/workflows \\
+        --type spdxjson <IMAGE URI> 2>&1 | head -n 13
 
 For example:
 
@@ -71,7 +71,7 @@ For example:
     GitHub Workflow Name: Image CI Build
     GitHub Workflow Repository: cilium/cilium
     GitHub Workflow Ref: refs/pull/34011/merge
-    
+
 It can be validated that the image was signed using GitHub Actions in the Cilium repository from the ``Certificate subject`` and ``Certificate issuer URL`` fields of the output.
 
 .. note::

--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -50,8 +50,8 @@ several advantages:
 
    .. parsed-literal::
 
-      helm install cilium oci://quay.io/cilium/charts/cilium \
-        |CHART_VERSION| \
+      helm install cilium oci://quay.io/cilium/charts/cilium \\
+        |CHART_VERSION| \\
         --namespace kube-system
 
 .. only:: not stable
@@ -319,8 +319,8 @@ Using OCI Registry
 
    .. parsed-literal::
 
-      helm upgrade cilium oci://quay.io/cilium/charts/cilium \
-        |CHART_VERSION| \
+      helm upgrade cilium oci://quay.io/cilium/charts/cilium \\
+        |CHART_VERSION| \\
         --namespace kube-system
 
 .. only:: not stable
@@ -341,9 +341,9 @@ switching to OCI is straightforward as the charts are identical:
 
    .. parsed-literal::
 
-      helm upgrade cilium oci://quay.io/cilium/charts/cilium \
-        |CHART_VERSION| \
-        --namespace kube-system \
+      helm upgrade cilium oci://quay.io/cilium/charts/cilium \\
+        |CHART_VERSION| \\
+        --namespace kube-system \\
         --reuse-values
 
 .. only:: not stable

--- a/Documentation/installation/k8s-install-migration.rst
+++ b/Documentation/installation/k8s-install-migration.rst
@@ -23,7 +23,7 @@ Background
 ==========
 
 When the kubelet creates a Pod's Sandbox, the installed CNI, as configured in ``/etc/cni/net.d/``,
-is called. The cni will handle the networking for a pod - including allocating 
+is called. The cni will handle the networking for a pod - including allocating
 an ip address, creating & configuring a network interface, and (potentially)
 establishing an overlay network. The Pod's network configuration shares the
 same life cycle as the PodSandbox.
@@ -59,7 +59,7 @@ during migration.
 
 For live migration to work, Cilium will be installed with a separate
 CIDR range and encapsulation port than that of the currently installed CNI. As
-long as Cilium and the existing CNI use a separate IP range, the Linux 
+long as Cilium and the existing CNI use a separate IP range, the Linux
 routing table takes care of separating traffic.
 
 
@@ -84,7 +84,7 @@ Currently, Cilium migration has not been tested with:
 - Migrating from Cilium in chained mode
 - An existing NetworkPolicy provider
 
-During migration, Cilium's  NetworkPolicy and CiliumNetworkPolicy enforcement 
+During migration, Cilium's  NetworkPolicy and CiliumNetworkPolicy enforcement
 will be disabled. Otherwise, traffic from non-Cilium pods may be incorrectly
 dropped. Once the migration process is complete, policy enforcement can
 be re-enabled. If there is an existing NetworkPolicy provider, you may wish to
@@ -274,7 +274,7 @@ Select a node to be migrated. It is not recommended to start with a control-plan
     If using kind, do so with docker:
 
     .. code-block:: shell-session
-    
+
       docker restart $NODE
 
 5.  Validate that the node has been successfully migrated.
@@ -316,16 +316,16 @@ Perform these steps once the cluster is fully migrated.
     - Cilium should be the primary CNI
     - NetworkPolicy should be enforced
     - The Operator can restart unmanaged pods
-    - **Optional**: use :ref:`eBPF_Host_Routing`. Enabling this will cause a short connectivity 
+    - **Optional**: use :ref:`eBPF_Host_Routing`. Enabling this will cause a short connectivity
       interruption on each node as the daemon restarts, but improves networking performance.
 
     You can do this manually, or via the ``cilium`` tool (this will not apply changes to the cluster):
 
     .. parsed-literal::
 
-      $ cilium install |CHART_VERSION| --values values-initial.yaml --dry-run-helm-values \
-        --set operator.unmanagedPodWatcher.restart=true --set cni.customConf=false \
-        --set policyEnforcementMode=default \
+      $ cilium install |CHART_VERSION| --values values-initial.yaml --dry-run-helm-values \\
+        --set operator.unmanagedPodWatcher.restart=true --set cni.customConf=false \\
+        --set policyEnforcementMode=default \\
         --set bpf.hostLegacyRouting=false > values-final.yaml # optional, can cause brief interruptions
       $ diff values-initial.yaml values-final.yaml
 

--- a/Documentation/network/clustermesh/aks-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/aks-clustermesh-prep.rst
@@ -4,12 +4,12 @@
 AKS-to-AKS Clustermesh Preparation
 **********************************
 
-This is a step-by-step guide on how to install and prepare 
-AKS (Azure Kubernetes Service) clusters in BYOCNI mode to meet the requirements 
+This is a step-by-step guide on how to install and prepare
+AKS (Azure Kubernetes Service) clusters in BYOCNI mode to meet the requirements
 for the clustermesh feature.
 
-This guide describes how to install two AKS clusters in BYOCNI (Bring Your Own CNI) 
-mode and connect them together via clustermesh. This guide is not 
+This guide describes how to install two AKS clusters in BYOCNI (Bring Your Own CNI)
+mode and connect them together via clustermesh. This guide is not
 applicable for cross-cloud clustermesh since this guide doesn't expose the node
 IPs outside of the Azure cloud.
 
@@ -32,13 +32,13 @@ Install cluster one
         #  westus2 can be changed to any available location (`az account list-locations`)
         az group create --name "${AZURE_RESOURCE_GROUP}" -l westus2
 
-2.  Create a VNet (virtual network). 
-    Creating a custom VNet is required to ensure that the Node, Pod, and 
+2.  Create a VNet (virtual network).
+    Creating a custom VNet is required to ensure that the Node, Pod, and
     Service CIDRs are unique and they don't overlap with other clusters.
 
     .. note::
-        The example below uses range ``192.168.10.0/24`` range, but you could use any range except for ``169.254.0.0/16``, ``172.30.0.0/16``, 
-        ``172.31.0.0/16``, or ``192.0.2.0/24`` which are 
+        The example below uses range ``192.168.10.0/24`` range, but you could use any range except for ``169.254.0.0/16``, ``172.30.0.0/16``,
+        ``172.31.0.0/16``, or ``192.0.2.0/24`` which are
         `reserved by Azure <https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#prerequisites>`__.
 
     .. code-block:: bash
@@ -87,16 +87,16 @@ Install cluster one
 
     .. parsed-literal::
 
-        cilium install |CHART_VERSION| \
-            --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \
-            --set cluster.id=1 \
+        cilium install |CHART_VERSION| \\
+            --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \\
+            --set cluster.id=1 \\
             --set ipam.operator.clusterPoolIPv4PodCIDRList='{10.10.0.0/16}'
 
 5.  Check the status of Cilium.
 
     .. code-block:: bash
 
-        cilium status   
+        cilium status
 
 6.  Before configuring cluster two, store the name of the current cluster.
 
@@ -124,8 +124,8 @@ arguments.
 2.  Create a VNet in this resource group. Make sure to use a non-overlapping prefix.
 
     .. note::
-        The example below uses range ``192.168.20.0/24``, but you could use any range except for ``169.254.0.0/16``, ``172.30.0.0/16``, 
-        ``172.31.0.0/16``, or ``192.0.2.0/24`` which are 
+        The example below uses range ``192.168.20.0/24``, but you could use any range except for ``169.254.0.0/16``, ``172.30.0.0/16``,
+        ``172.31.0.0/16``, or ``192.0.2.0/24`` which are
         `reserved by Azure <https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#prerequisites>`__.
 
     .. code-block:: bash
@@ -145,7 +145,7 @@ arguments.
             --query id \
             -o tsv)
 
-3.  Create an AKS cluster without CNI and request to use your custom VNet and 
+3.  Create an AKS cluster without CNI and request to use your custom VNet and
     subnet.
 
     During creation use ``"10.20.0.0/16"`` as the pod CIDR and
@@ -174,9 +174,9 @@ arguments.
 
     .. parsed-literal::
 
-        cilium install |CHART_VERSION| \
-            --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \
-            --set cluster.id=2 \
+        cilium install |CHART_VERSION| \\
+            --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \\
+            --set cluster.id=2 \\
             --set ipam.operator.clusterPoolIPv4PodCIDRList='{10.20.0.0/16}'
 
 5.  Check the status of Cilium.
@@ -185,7 +185,7 @@ arguments.
 
         cilium status
 
-6.  Before configuring peering and clustermesh, store the current cluster 
+6.  Before configuring peering and clustermesh, store the current cluster
     name.
 
     .. code-block:: bash
@@ -215,7 +215,7 @@ following commands.
         --remote-vnet "${VNET_ID}" \
         --allow-vnet-access
 
-This allows outbound traffic from cluster one to cluster two. To allow 
+This allows outbound traffic from cluster one to cluster two. To allow
 bi-directional traffic, add a peering to the other direction as well.
 
 .. code-block:: bash
@@ -232,5 +232,5 @@ bi-directional traffic, add a peering to the other direction as well.
         --remote-vnet "${VNET_ID}" \
         --allow-vnet-access
 
-Node-to-node traffic between clusters is now possible. All requirements for 
+Node-to-node traffic between clusters is now possible. All requirements for
 clustermesh are met. Enabling clustermesh is explained in :ref:`gs_clustermesh`.

--- a/Documentation/network/clustermesh/gke-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/gke-clustermesh-prep.rst
@@ -4,8 +4,8 @@
 GKE-to-GKE Clustermesh Preparation
 **********************************
 
-This is a step-by-step guide on how to install and prepare 
-Google Kubernetes Engine (GKE) clusters to meet the requirements 
+This is a step-by-step guide on how to install and prepare
+Google Kubernetes Engine (GKE) clusters to meet the requirements
 for the clustermesh feature.
 
 This guide describes how to deploy two zonal, single node GKE clusters
@@ -42,7 +42,7 @@ Create VPC
 Deploy clusters
 ###############
 
-1.  Set additional environment variables for values that will be reused in 
+1.  Set additional environment variables for values that will be reused in
     later steps.
 
     .. code-block:: bash
@@ -58,7 +58,7 @@ Deploy clusters
 
     .. note::
 
-        You can use different pod and services CIDRs than in the example, but make sure 
+        You can use different pod and services CIDRs than in the example, but make sure
         they meet the IP address range `rules <https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#cluster_sizing>`__. But most
         importantly, make sure they do not overlap with the pods and services CIDRs in
         your other cluster(s).
@@ -83,7 +83,7 @@ Deploy clusters
         gcloud container clusters get-credentials ${CLUSTER} \
           --zone ${ZONE} \
           --project ${PROJECT_ID}
- 
+
     The node taint is used to prevent pods from being deployed/started until Cilium
     has been installed.
 
@@ -93,18 +93,17 @@ Deploy clusters
 
         Be sure to assign a unique ``cluster.id`` to each cluster.
 
-    .. code-block:: bash
+    .. parsed-literal::
 
-        cilium install \
-            --version |CHART_VERSION| \
-            --set cluster.id=1 \
+        cilium install |CHART_VERSION| \\
+            --set cluster.id=1 \\
             --set cluster.name=${CLUSTER}
 
 3.  Check the status of Cilium.
 
     .. code-block:: bash
 
-        cilium status   
+        cilium status
 
 4.  For each GKE cluster, save its context in an environment variable for use in
     the clustermesh setup process.
@@ -122,7 +121,7 @@ Peering VPC networks
 Google Cloud's VPCs are global in scope, so subnets within the same VPC can already communicate
 with each other internally -- regardless of region. So there is no VPC peering required!
 
-Node-to-node traffic between clusters is now possible. All requirements for 
+Node-to-node traffic between clusters is now possible. All requirements for
 clustermesh are met. Enabling clustermesh is explained in :ref:`gs_clustermesh`.
 
 Please reference environment variables exported in step 4 for any commands that require

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -47,15 +47,15 @@ configure CoreDNS manually, you need to execute the following steps:
       kubectl apply -f |SCM_WEB|\/vendor/sigs.k8s.io/mcs-api/config/crd/multicluster.x-k8s.io_serviceimports.yaml
 
       # Adding RBAC to read ServiceImports
-      kubectl create clusterrole coredns-mcsapi \
+      kubectl create clusterrole coredns-mcsapi \\
          --verb=list,watch --resource=serviceimports.multicluster.x-k8s.io
-      kubectl create clusterrolebinding coredns-mcsapi \
+      kubectl create clusterrolebinding coredns-mcsapi \\
          --clusterrole=coredns-mcsapi --serviceaccount=kube-system:coredns
 
       # Configure CoreDNS to support MCS-API
-      kubectl get configmap -n kube-system coredns -o yaml | \
-         sed -e 's/cluster\.local/cluster.local clusterset.local/g' | \
-         sed -E 's/^(.*)kubernetes(.*)\{/\1kubernetes\2{\n\1   multicluster clusterset.local/' | \
+      kubectl get configmap -n kube-system coredns -o yaml | \\
+         sed -e 's/cluster\.local/cluster.local clusterset.local/g' | \\
+         sed -E 's/^(.*)kubernetes(.*)\{/\1kubernetes\2{\n\1   multicluster clusterset.local/' | \\
          kubectl replace -f-
 
       # Rollout CoreDNS to apply the change

--- a/Documentation/network/servicemesh/installation.rst
+++ b/Documentation/network/servicemesh/installation.rst
@@ -55,9 +55,9 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \
-                --set kubeProxyReplacement=true \
-                --set ingressController.enabled=true \
+            $ cilium install |CHART_VERSION| \\
+                --set kubeProxyReplacement=true \\
+                --set ingressController.enabled=true \\
                 --set ingressController.loadbalancerMode=dedicated
 
         Cilium can become the default ingress controller by setting the
@@ -69,17 +69,17 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \
-                --set kubeProxyReplacement=true \
+            $ cilium install |CHART_VERSION| \\
+                --set kubeProxyReplacement=true \\
                 --set envoyConfig.enabled=true
 
         Additionally, the proxy load-balancing feature can be configured with the ``loadBalancer.l7.backend=envoy`` flag.
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \
-                --set kubeProxyReplacement=true \
-                --set envoyConfig.enabled=true \
+            $ cilium install |CHART_VERSION| \\
+                --set kubeProxyReplacement=true \\
+                --set envoyConfig.enabled=true \\
                 --set loadBalancer.l7.backend=envoy
 
         Next you can check the status of the Cilium agent and operator:

--- a/Documentation/network/servicemesh/tls-default-certificate.rst
+++ b/Documentation/network/servicemesh/tls-default-certificate.rst
@@ -45,8 +45,8 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \
-                --set kubeProxyReplacement=true \
-                --set ingressController.enabled=true \
-                --set ingressController.defaultSecretNamespace=kube-system \
+            $ cilium install |CHART_VERSION| \\
+                --set kubeProxyReplacement=true \\
+                --set ingressController.enabled=true \\
+                --set ingressController.defaultSecretNamespace=kube-system \\
                 --set ingressController.defaultSecretName=default-cert

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -145,11 +145,11 @@ enable via ``hubble.metrics.enabled``.
 Installation with a dynamic metrics exporter
 --------------------------------------------
 
-To deploy Cilium with Hubble dynamic metrics enabled, you need to enable Hubble 
+To deploy Cilium with Hubble dynamic metrics enabled, you need to enable Hubble
 with ``hubble.enabled=true`` and ``hubble.metrics.dynamic.enabled=true``.
 
 In this example, a ``ConfigMap`` with a set of metrics will be applied before
-enabling the exporter, but the desired set of metrics (together with the 
+enabling the exporter, but the desired set of metrics (together with the
 ``ConfigMap``) can be created during installation.
 
 See the :ref:`helm_reference` (keys with ``hubble.metrics.dynamic.*``)
@@ -229,7 +229,7 @@ See the :ref:`helm_reference` (keys with ``hubble.metrics.dynamic.*``)
             - destination_pod:
               - default/
             name: policy
-    
+
 Deploy the :term:`ConfigMap`:
 
 .. code-block:: shell-session
@@ -405,11 +405,11 @@ For large clusters, consider disabling high-cardinality metrics like
 
       Use the ``prometheus.metrics`` value:
 
-      .. code-block:: shell-session
+      .. parsed-literal::
 
-         helm install cilium cilium/cilium --version |CHART_VERSION| \
-             --namespace kube-system \
-             --set prometheus.enabled=true \
+         helm install cilium cilium/cilium |CHART_VERSION| \\
+             --namespace kube-system \\
+             --set prometheus.enabled=true \\
              --set prometheus.metrics="{-cilium_node_connectivity_status,-cilium_node_connectivity_latency_seconds}"
 
    .. group-tab:: CLI

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -46,7 +46,7 @@ be performed.
    between nodes.
    This is also important for cloud environments where security groups (or VPC firewall rules)
    are used to control traffic between nodes. In such cases, ensure that the
-   security groups allow ESP traffic between the nodes in the cluster. 
+   security groups allow ESP traffic between the nodes in the cluster.
    This applies to AWS, Azure and GCP.
    The default firewall rules for the cluster's subnet may not allow ESP.
 
@@ -84,7 +84,7 @@ following command:
 
        .. parsed-literal::
 
-          $ kubectl create -n kube-system secret generic cilium-ipsec-keys \
+          $ kubectl create -n kube-system secret generic cilium-ipsec-keys \\
               --from-literal=keys="3+ rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"
 
        .. attention::
@@ -118,8 +118,8 @@ Enable Encryption in Cilium
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \
-             --set encryption.enabled=true \
+          cilium install |CHART_VERSION| \\
+             --set encryption.enabled=true \\
              --set encryption.type=ipsec
 
     .. group-tab:: Helm
@@ -167,9 +167,9 @@ interface as follows:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \
-             --set encryption.enabled=true \
-             --set encryption.type=ipsec \
+          cilium install |CHART_VERSION| \\
+             --set encryption.enabled=true \\
+             --set encryption.type=ipsec \\
              --set encryption.ipsec.interface=ethX
 
     .. group-tab:: Helm

--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -61,8 +61,8 @@ on how to install the kernel module on your Linux distribution.
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \
-             --set encryption.enabled=true \
+          cilium install |CHART_VERSION| \\
+             --set encryption.enabled=true \\
              --set encryption.type=wireguard
 
     .. group-tab:: Helm
@@ -230,9 +230,9 @@ options:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \
-             --set encryption.enabled=true \
-             --set encryption.type=wireguard \
+          cilium install |CHART_VERSION| \\
+             --set encryption.enabled=true \\
+             --set encryption.type=wireguard \\
              --set encryption.nodeEncryption=true
 
     .. group-tab:: Helm


### PR DESCRIPTION
Fix some of the formatting for generated HTML docs: use `parsed-literal` blocks instead of the `code-block` directive for a few instances where substitution patterns have to be replaced by Sphinx, remove the redundant `--version` argument already provided by `|CHART_VERSION|`, and adjust markers for line splitting.

Issues found while reviewing https://github.com/cilium/cilium/pull/44380.
