### PR TITLE
docs: prevent automatic curl decompression on macOS

### DIFF
--- a/Documentation/observability/hubble/setup.rst
+++ b/Documentation/observability/hubble/setup.rst
@@ -129,7 +129,7 @@ Select the tab for your platform below and install the latest release of Hubble 
          HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/master/stable.txt)
          HUBBLE_ARCH=amd64
          if [ "$(uname -m)" = "arm64" ]; then HUBBLE_ARCH=arm64; fi
-         curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
+         curl -L --fail --remote-name-all --no-compressed https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
          shasum -a 256 -c hubble-darwin-${HUBBLE_ARCH}.tar.gz.sha256sum
          sudo tar xzvfC hubble-darwin-${HUBBLE_ARCH}.tar.gz /usr/local/bin
          rm hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
This PR adds the `--no-compressed` flag to the Hubble installation `curl` command for macOS. This prevents `curl` from automatically decompressing the downloaded archive, which causes the subsequent `shasum` verification (expecting a compressed file) and `tar` extraction (expecting a compressed input) to fail.

The current command works on bash 3.2 but not on zsh 5.9 (arm64-apple-darwin25.0), which is the default.

I tried this on a brand new device without any .zshrc customisation and the problem is still the same. What I noticed though is that pasting the command also escapes the curly brackets in the curl command:

```bash
HUBBLE_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/hubble/main/stable.txt)
HUBBLE_ARCH=amd64
if [ "$(uname -m)" = "arm64" ]; then HUBBLE_ARCH=arm64; fi
curl -L --fail --remote-name-all https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-darwin-$\{HUBBLE_ARCH\}.tar.gz\{,.sha256sum\}
shasum -a 256 -c hubble-darwin-${HUBBLE_ARCH}.tar.gz.sha256sum
sudo tar xzvfC hubble-darwin-${HUBBLE_ARCH}.tar.gz /usr/local/bin
rm hubble-darwin-${HUBBLE_ARCH}.tar.gz{,.sha256sum}
```

Pasting the command as plain text using **Option+Shift+Command+V** doesn't resolve this either. There is new behaviour breaking this command on zsh 5.9 (arm64-apple-darwin25.0) Terminal Version 2.15 (466).

I only noticed this because of a new device and working with the defaults only.

```release-note
Fix Hubble install script failure on macOS caused by automatic curl decompression
```