### PR TITLE
bugtool: add JSON output for endpoint list command

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -390,6 +390,7 @@ func ciliumDbgCommands(cmdDir string) []string {
 		"cilium-dbg config -a",
 		"cilium-dbg encrypt status",
 		"cilium-dbg endpoint list",
+		"cilium-dbg endpoint list -o json",
 		"cilium-dbg bpf auth list",
 		"cilium-dbg bpf bandwidth list",
 		"cilium-dbg bpf config list",


### PR DESCRIPTION
This change adds `cilium-dbg endpoint list -o json` to the bugtool commands since it will have more data in details for the endpoint.

That's especially hopeful when there are  a lot of cilium network polices with different selectors.

```release-note
add JSON output for cilium-dbg endpoint list for bugtool commands
```
