### PR TITLE
gateway-api: Fixes for TLSRoute conformance

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -801,6 +801,7 @@ func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parent
 
 		// run the Gateway validators
 		for _, fn := range []routechecks.CheckWithParentFunc{
+			routechecks.CheckGatewayMatchingProtocol,
 			routechecks.CheckGatewayRouteKindAllowed,
 			routechecks.CheckGatewayMatchingPorts,
 			routechecks.CheckGatewayMatchingHostnames,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -270,6 +270,12 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-backendtlspolicy-invalid-kind", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "tlsroute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute-referencegrant", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute", Namespace: "gateway-conformance-infra"}}}},
+		{name: "tlsroute-hostname-intersection", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "gw-tlsroute-empty-hostname-x-4", Namespace: "gateway-conformance-infra"}},
+			{FullName: types.NamespacedName{Name: "gw-tlsroute-exact-hostname-x-1", Namespace: "gateway-conformance-infra"}},
+			{FullName: types.NamespacedName{Name: "gw-tlsroute-less-specific-wc-hostname-x-3", Namespace: "gateway-conformance-infra"}},
+			{FullName: types.NamespacedName{Name: "gw-tlsroute-more-specific-wc-hostname-x-2", Namespace: "gateway-conformance-infra"}},
+		}},
 	}
 
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -276,6 +276,11 @@ func Test_Conformance(t *testing.T) {
 			{FullName: types.NamespacedName{Name: "gw-tlsroute-less-specific-wc-hostname-x-3", Namespace: "gateway-conformance-infra"}},
 			{FullName: types.NamespacedName{Name: "gw-tlsroute-more-specific-wc-hostname-x-2", Namespace: "gateway-conformance-infra"}},
 		}},
+		{name: "tlsroute-invalid-no-matching-listener", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "gateway-tlsroute-http-only", Namespace: "gateway-conformance-infra"}, wantErr: false},
+			{FullName: types.NamespacedName{Name: "gateway-tlsroute-https-only", Namespace: "gateway-conformance-infra"}, wantErr: false},
+			{FullName: types.NamespacedName{Name: "gateway-tlsroute-tls-passthrough-only", Namespace: "gateway-conformance-infra"}, wantErr: false},
+		}},
 	}
 
 	for _, tt := range tests {
@@ -338,7 +343,7 @@ func Test_Conformance(t *testing.T) {
 			for _, gwDetail := range tt.gateway {
 				// Reconcile the gateway under test
 				result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: gwDetail.FullName})
-				require.Equal(t, gwDetail.wantErr, err != nil, "Got an unexpected reconciliation error")
+				require.Equal(t, gwDetail.wantErr, err != nil, "Got an unexpected reconciliation error for Gateway %s. want: %t, got: %t", gwDetail.FullName.Name, gwDetail.wantErr, err != nil)
 				require.Equal(t, ctrl.Result{}, result)
 				// Checking the output for Gateway
 				actualGateway := &gatewayv1.Gateway{}

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -170,6 +170,10 @@ func (g *GRPCRouteInput) Log() *slog.Logger {
 	return g.Logger
 }
 
+func (g *GRPCRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType}
+}
+
 func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range g.GRPCRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -165,6 +165,10 @@ func (h *HTTPRouteInput) Log() *slog.Logger {
 	return h.Logger
 }
 
+func (h *HTTPRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType}
+}
+
 // HTTPRouteRule is used to implement the GenericRule interface for TLSRoute
 type HTTPRouteRule struct {
 	Rule gatewayv1.HTTPRouteRule

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -34,6 +34,7 @@ type Input interface {
 	GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error)
 	GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error)
 	GetHostnames() []gatewayv1.Hostname
+	GetValidProtocols() []gatewayv1.ProtocolType
 
 	SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition)
 	Log() *slog.Logger

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -149,3 +149,7 @@ func (t *TLSRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) 
 func (t *TLSRouteInput) Log() *slog.Logger {
 	return t.Logger
 }
+
+func (t *TLSRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.TLSProtocolType}
+}

--- a/operator/pkg/gateway-api/testdata/gateway/base/manifests.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/base/manifests.yaml
@@ -61,6 +61,32 @@ spec:
             kind: Secret
             name: tls-validity-checks-certificate
             namespace: gateway-conformance-infra
+    - name: https-with-wildcard-hostname
+      port: 443
+      hostname: "*.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+    - name: https-with-hostname-matching-wildcard
+      port: 443
+      hostname: "fourth-example.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -139,7 +165,7 @@ spec:
       containers:
         - name: infra-backend-v1
           # Originally from https://github.com/kubernetes-sigs/ingress-controller-conformance/tree/master/images/echoserver
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -185,7 +211,7 @@ spec:
     spec:
       containers:
         - name: infra-backend-v2
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -231,7 +257,7 @@ spec:
     spec:
       containers:
         - name: infra-backend-v3
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -277,7 +303,69 @@ spec:
     spec:
       containers:
         - name: tls-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /etc/secret-volume
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TLS_SERVER_CERT
+              value: /etc/secret-volume/crt
+            - name: TLS_SERVER_PRIVKEY
+              value: /etc/secret-volume/key
+          resources:
+            requests:
+              cpu: 10m
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: tls-checks-certificate
+            items:
+              - key: tls.crt
+                path: crt
+              - key: tls.key
+                path: key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-backend-2
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tls-backend-2
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-backend-2
+  namespace: gateway-conformance-infra
+  labels:
+    app: tls-backend-2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls-backend-2
+  template:
+    metadata:
+      labels:
+        app: tls-backend-2
+    spec:
+      containers:
+        - name: tls-backend-2
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/secret-volume
@@ -346,7 +434,7 @@ spec:
     spec:
       containers:
         - name: tls-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           volumeMounts:
             - name: secret-volume
               mountPath: /etc/secret-volume
@@ -408,7 +496,7 @@ spec:
     spec:
       containers:
         - name: app-backend-v1
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -454,7 +542,7 @@ spec:
     spec:
       containers:
         - name: app-backend-v2
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -507,7 +595,7 @@ spec:
     spec:
       containers:
         - name: web-backend
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -554,7 +642,7 @@ spec:
     spec:
       containers:
         - name: grpc-infra-backend-v1
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -603,7 +691,7 @@ spec:
     spec:
       containers:
         - name: grpc-infra-backend-v2
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -652,7 +740,7 @@ spec:
     spec:
       containers:
         - name: grpc-infra-backend-v3
-          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
           env:
             - name: POD_NAME
               valueFrom:
@@ -738,3 +826,75 @@ data:
     foo.bar.com:53 {
       whoami
     }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tcp-backend
+  ports:
+    - name: echo-tcp-plain
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+    - name: echo-tcp-tls
+      protocol: TCP
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-backend
+  namespace: gateway-conformance-infra
+  labels:
+    app: tcp-backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: tcp-backend
+  template:
+    metadata:
+      labels:
+        app: tcp-backend
+    spec:
+      containers:
+        - name: tcp-backend
+          image: gcr.io/k8s-staging-gateway-api/echo-basic:v20260204-monthly-2026.01-60-g28382302
+          resources:
+            requests:
+              cpu: 10m
+          volumeMounts:
+            - name: secret-volume
+              mountPath: /etc/secret-volume
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TLS_SERVER_CERT
+              value: /etc/secret-volume/crt
+            - name: TLS_SERVER_PRIV_KEY
+              value: /etc/secret-volume/key
+            - name: TCP_ECHO_SERVER
+              value: "1"
+      volumes:
+        - name: secret-volume
+          secret:
+            # certificate issued with hostname abc.example.com
+            secretName: tls-passthrough-checks-certificate
+            items:
+              - key: tls.crt
+                path: crt
+              - key: tls.key
+                path: key
+---
+

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/same-namespace-with-https-listener.yaml
@@ -32,6 +32,32 @@ spec:
             kind: Secret
             name: tls-validity-checks-certificate
             namespace: gateway-conformance-infra
+    - name: https-with-wildcard-hostname
+      port: 443
+      hostname: "*.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+    - name: https-with-hostname-matching-wildcard
+      port: 443
+      hostname: "fourth-example.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
 status:
   addresses:
     - type: IPAddress
@@ -89,6 +115,52 @@ status:
           status: "True"
           type: Programmed
       name: https-with-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-with-wildcard-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-with-hostname-matching-wildcard
       supportedKinds:
         - group: gateway.networking.k8s.io
           kind: HTTPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-reencrypt/output/same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-reencrypt/output/same-namespace-with-https-listener.yaml
@@ -32,6 +32,32 @@ spec:
             kind: Secret
             name: tls-validity-checks-certificate
             namespace: gateway-conformance-infra
+    - name: https-with-wildcard-hostname
+      port: 443
+      hostname: "*.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+    - name: https-with-hostname-matching-wildcard
+      port: 443
+      hostname: "fourth-example.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
 status:
   addresses:
     - type: IPAddress
@@ -89,6 +115,52 @@ status:
           status: "True"
           type: Programmed
       name: https-with-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-with-wildcard-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-with-hostname-matching-wildcard
       supportedKinds:
         - group: gateway.networking.k8s.io
           kind: HTTPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/httproute-disallowed-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/httproute-disallowed-kind.yaml
@@ -7,27 +7,26 @@ metadata:
   resourceVersion: "1000"
 spec:
   parentRefs:
-  - name: tlsroutes-only
-    namespace: gateway-conformance-infra
+    - name: tlsroutes-only
+      namespace: gateway-conformance-infra
   rules:
-  - backendRefs:
-    - name: infra-backend-v1
-      port: 8080
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
 status:
   parents:
-  - conditions:
-    - lastTransitionTime: "2025-07-01T14:19:43Z"
-      message: HTTPRoute is not allowed to attach to this Gateway due to route kind
-        restrictions
-      reason: NotAllowedByListeners
-      status: "False"
-      type: Accepted
-    - lastTransitionTime: "2025-07-01T14:19:43Z"
-      message: Service reference is valid
-      reason: ResolvedRefs
-      status: "True"
-      type: ResolvedRefs
-    controllerName: io.cilium/gateway-controller
-    parentRef:
-      name: tlsroutes-only
-      namespace: gateway-conformance-infra
+    - conditions:
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: "No Listener with matching Protocol. Allowed protocols: [HTTP HTTPS]"
+          reason: NotAllowedByListeners
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: tlsroutes-only
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/same-namespace-with-https-listener.yaml
@@ -1,32 +1,56 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  creationTimestamp: null
   name: same-namespace-with-https-listener
   namespace: gateway-conformance-infra
-  resourceVersion: "1000"
 spec:
   gatewayClassName: cilium
   listeners:
-    - allowedRoutes:
-        namespaces:
-          from: Same
-      name: https
+    - name: https
       port: 443
       protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
       tls:
         certificateRefs:
           - group: ""
             kind: Secret
             name: tls-validity-checks-certificate
             namespace: gateway-conformance-infra
-    - allowedRoutes:
+    - name: https-with-hostname
+      port: 443
+      hostname: second-example.org
+      protocol: HTTPS
+      allowedRoutes:
         namespaces:
           from: Same
-      hostname: second-example.org
-      name: https-with-hostname
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+    - name: https-with-wildcard-hostname
       port: 443
+      hostname: "*.wildcard.org"
       protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+    - name: https-with-hostname-matching-wildcard
+      port: 443
+      hostname: "fourth-example.wildcard.org"
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
       tls:
         certificateRefs:
           - group: ""
@@ -87,6 +111,52 @@ status:
           status: "False"
           type: Programmed
       name: https-with-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: https-with-wildcard-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: https-with-hostname-matching-wildcard
       supportedKinds:
         - group: gateway.networking.k8s.io
           kind: HTTPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/input/tlsroute-hostname-intersection.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/input/tlsroute-hostname-intersection.yaml
@@ -1,0 +1,190 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-exact-hostname-x-1
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-exact-hostname
+      protocol: TLS
+      port: 443
+      hostname: abc.example.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-more-specific-wc-hostname-x-2
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-more-specific-wc-hostname
+      protocol: TLS
+      port: 443
+      hostname: "*.example.com"
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-less-specific-wc-hostname-x-3
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-less-specific-wc-hostname
+      protocol: TLS
+      port: 443
+      hostname: "*.com"
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-empty-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-empty-hostname
+      protocol: TLS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-more-specific-wc-hostname-x-1
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-exact-hostname-x-1
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.example.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-exact-hostname-x-2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-more-specific-wc-hostname-x-2
+      namespace: gateway-conformance-infra
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-less-specific-wc-hostname-x-2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-more-specific-wc-hostname-x-2
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-exact-hostname-x-3
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-less-specific-wc-hostname-x-3
+      namespace: gateway-conformance-infra
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-more-specific-wc-hostname-x-3
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-less-specific-wc-hostname-x-3
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.example.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-exact-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-less-specific-wc-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
@@ -1,0 +1,120 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gw-tlsroute-empty-hostname-x-4
+  name: cilium-gateway-gw-tlsroute-empty-hostname-x-4
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gw-tlsroute-empty-hostname-x-4
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+    - name: tls-backend-2
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: gateway-conformance-infra:tls-backend:443
+        - filterChainMatch:
+            serverNames:
+              - "*.com"
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: gateway-conformance-infra:tls-backend-2:443
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend-2:443
+      name: gateway-conformance-infra:tls-backend-2:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: ""
+      name: cilium-gateway-gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
@@ -1,0 +1,99 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gw-tlsroute-exact-hostname-x-1
+  name: cilium-gateway-gw-tlsroute-exact-hostname-x-1
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gw-tlsroute-exact-hostname-x-1
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: gateway-conformance-infra:tls-backend:443
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: ""
+      name: cilium-gateway-gw-tlsroute-exact-hostname-x-1
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
@@ -1,0 +1,120 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gw-tlsroute-less-specific-wc-hostname-x-3
+  name: cilium-gateway-gw-tlsroute-less-specific-wc-hostname-x-3
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gw-tlsroute-less-specific-wc-hostname-x-3
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+    - name: tls-backend-2
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: gateway-conformance-infra:tls-backend:443
+        - filterChainMatch:
+            serverNames:
+              - "*.example.com"
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: gateway-conformance-infra:tls-backend-2:443
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend-2:443
+      name: gateway-conformance-infra:tls-backend-2:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: ""
+      name: cilium-gateway-gw-tlsroute-less-specific-wc-hostname-x-3
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
@@ -1,0 +1,120 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gw-tlsroute-more-specific-wc-hostname-x-2
+  name: cilium-gateway-gw-tlsroute-more-specific-wc-hostname-x-2
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gw-tlsroute-more-specific-wc-hostname-x-2
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+    - name: tls-backend-2
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: gateway-conformance-infra:tls-backend:443
+        - filterChainMatch:
+            serverNames:
+              - "*.example.com"
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: gateway-conformance-infra:tls-backend-2:443
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend-2:443
+      name: gateway-conformance-infra:tls-backend-2:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: ""
+      name: cilium-gateway-gw-tlsroute-more-specific-wc-hostname-x-2
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-empty-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-empty-hostname-x-4.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-empty-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-empty-hostname
+      protocol: TLS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - type: "Accepted"
+      status: "True"
+      reason: "Accepted"
+      message: "Gateway successfully scheduled"
+    - type: "Programmed"
+      status: "False"
+      reason: "AddressNotAssigned"
+      message: "Gateway waiting for address"
+  listeners:
+    - attachedRoutes: 2
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: listener-empty-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-exact-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-exact-hostname-x-1.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-exact-hostname-x-1
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-exact-hostname
+      protocol: TLS
+      port: 443
+      hostname: abc.example.com
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - type: "Accepted"
+      status: "True"
+      reason: "Accepted"
+      message: "Gateway successfully scheduled"
+    - type: "Programmed"
+      status: "False"
+      reason: "AddressNotAssigned"
+      message: "Gateway waiting for address"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: listener-exact-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-less-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-less-specific-wc-hostname-x-3.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-less-specific-wc-hostname-x-3
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-less-specific-wc-hostname
+      protocol: TLS
+      port: 443
+      hostname: "*.com"
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - type: "Accepted"
+      status: "True"
+      reason: "Accepted"
+      message: "Gateway successfully scheduled"
+    - type: "Programmed"
+      status: "False"
+      reason: "AddressNotAssigned"
+      message: "Gateway waiting for address"
+  listeners:
+    - attachedRoutes: 2
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: listener-less-specific-wc-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-more-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/gw-tlsroute-more-specific-wc-hostname-x-2.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-more-specific-wc-hostname-x-2
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-more-specific-wc-hostname
+      protocol: TLS
+      port: 443
+      hostname: "*.example.com"
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - type: "Accepted"
+      status: "True"
+      reason: "Accepted"
+      message: "Gateway successfully scheduled"
+    - type: "Programmed"
+      status: "False"
+      reason: "AddressNotAssigned"
+      message: "Gateway waiting for address"
+  listeners:
+    - attachedRoutes: 2
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: listener-more-specific-wc-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-2.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-exact-hostname-x-2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-more-specific-wc-hostname-x-2
+      namespace: gateway-conformance-infra
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-more-specific-wc-hostname-x-2
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-3.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-exact-hostname-x-3
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-less-specific-wc-hostname-x-3
+      namespace: gateway-conformance-infra
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-less-specific-wc-hostname-x-3
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-4.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-exact-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+  hostnames:
+    - abc.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-empty-hostname-x-4
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-2.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-less-specific-wc-hostname-x-2
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-more-specific-wc-hostname-x-2
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-more-specific-wc-hostname-x-2
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-4.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-less-specific-wc-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-empty-hostname-x-4
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-1.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-more-specific-wc-hostname-x-1
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-exact-hostname-x-1
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.example.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-exact-hostname-x-1
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-3.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-more-specific-wc-hostname-x-3
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gw-tlsroute-less-specific-wc-hostname-x-3
+      namespace: gateway-conformance-infra
+  hostnames:
+    - "*.example.com"
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gw-tlsroute-less-specific-wc-hostname-x-3
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/input/tlsroute-invalid-no-matching-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/input/tlsroute-invalid-no-matching-listener.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVORENDQXB5Z0F3SUJBZ0lSQUtEL0JMRkJmd0tJWjBXR3JIdFRINmd3RFFZSktvWklodmNOQVFFTEJRQXcKZHpFZU1Cd0dBMVVFQ2hNVmJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElFTkJNU1l3SkFZRFZRUUxEQjEwWVcxdApZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tURXRNQ3NHQTFVRUF3d2tiV3RqWlhKMElIUmhiVzFoClkyaEFabVZrYjNKaExteGhiaUFvVkdGdElFMWhZMmdwTUI0WERUSXpNREl5TVRFeE1EZzBNMW9YRFRJMU1EVXkKTVRFeU1EZzBNMW93VVRFbk1DVUdBMVVFQ2hNZWJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElHTmxjblJwWm1sagpZWFJsTVNZd0pBWURWUVFMREIxMFlXMXRZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFNSVp5KzBKUlZqcXBXZ2VxMmRQKzFvbGlPNEEKQ2Nabk1nNHRTcVBhbGhEUUw2TWY2OEhZTGZpenlKSXBSek1KOTA1cllkMEFjbVhtdS9nMEVvOHlrSHhGRHo1VApzZVBzMlhRbmc4TU40YXpzUm1tMWw0Zjc0b3Zhd1F6UWNiODIyUVAxQ1M2SUxaM1Z0d05qUmgybkF3dGhZQk1vCkNrbmdER2VROEdsMHRqSExGbkJkVGRTd1FSbUUyanREQmNBZ3lFR3BxKzZSZVl0Ky80N25ObjdkQ2Z0c1ZxaEUKQllyOVhIM2l0ZWZIbXNiZmo3eldGYnB0ZGtvN3E5bE1Id25CZCswaGQ0ME1tSklYTVpyT0dHRlpqYXdKREJxUwpzQnEyUTNsNlhRejhYN1AvR0E4RG44aDR3M3JwcG1pYU43TE9tR1hla2kzeFgyd3FuTSswczZhWllac0NBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUI4R0ExVWQKSXdRWU1CYUFGR1EyREIwNkNkUUZRQnNZUHllME5Cd0VyVU5FTUJjR0ExVWRFUVFRTUE2Q0RIVnVhWFIwWlhOMApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVlFQXJ0SGRLV1hSNmFFTHBmYWwxN2JpYWJDUHZJRjlqNm53CnVEemNkTVlRTHJYbThNK05IZTh4M2RwSTd1M2xsdE8rZHpMbmcrblZLUU9SM2FsUUFDU21SRDljN2llOGVUNWQKN3pLT1RrNmtlWTE5NUkxd1ZWNGpiTkxiTldhOXk0UkpRUlR2QkxBdkFQOU5WdFV3MlEvdy9FclVUcVN5eitvYgpkd250NGdZQ3c2ZEdubHVMeGxmRjM0REI5S2ZsdlZOU25reU1CL2dzQjRBM3IxR1BPSW8wR3lmNzRpZzNGV3JTCndIWUtuQmJ0WmZZTzBKVjBMQ29QeUhlOGcwWGFqWmU4RENiUC9FNlNtbFROQW1KRVNWamlnVFRjSUJBa0ZJK24KdG9CQWR4ZmhqS1VHYUNsT0hTMjljcGFpeW5qU2F5R200UmtIa3g3bWNBdWE5bFdQZjdwU2EzbUNjRmIrd0ZyMwpBQmtIRFBKSDJhY2ZhVUsxdmdLVGdPd2NHLzZLQTgyMC9QcmFvU2loTGFQSy9BN2VnNzdyMUVlWXB0ME5lcHBiClhqdlVwM1ltVmxJTVpYUHpyak9zYXN0b0RTcnN5Z2o1amRWdG00UHNsdjluUGh6RHJCamxacEVKU2NXNEpsYisKNnd0ZDdwMDNVREJTS2ZUYlZST1ZBZTVtdkp2QTBob1MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRENHY3Z0Q1VWWTZxVm8KSHF0blQvdGFKWWp1QUFuR1p6SU9MVXFqMnBZUTBDK2pIK3ZCMkMzNHM4aVNLVWN6Q2ZkT2EySGRBSEpsNXJ2NApOQktQTXBCOFJROCtVN0hqN05sMEo0UEREZUdzN0VacHRaZUgrK0tMMnNFTTBIRy9OdGtEOVFrdWlDMmQxYmNEClkwWWRwd01MWVdBVEtBcEo0QXhua1BCcGRMWXh5eFp3WFUzVXNFRVpoTm83UXdYQUlNaEJxYXZ1a1htTGZ2K08KNXpaKzNRbjdiRmFvUkFXSy9WeDk0clhueDVyRzM0KzgxaFc2YlhaS082dlpUQjhKd1hmdElYZU5ESmlTRnpHYQp6aGhoV1kyc0NRd2FrckFhdGtONWVsME0vRit6L3hnUEE1L0llTU42NmFab21qZXl6cGhsM3BJdDhWOXNLcHpQCnRMT21tV0diQWdNQkFBRUNnZ0VBRWpBU29NSjJvZzlTc24vMU5iZ1Q2RzJOK0NjK3d6MldQaWZXVDZaQzI0NTIKZUVXY2RNeUoranoyZFdPeXpVQ0kwT3RVL3oxMGVzSDFLUnZRQldVS2p1cDF0RFJwZmQ4S3ZVeWFseU5zMnlSRQpzTkVZUXVEQ2FMSjExbnFOdmdvb3FhdERVZjNtc0Z4L1NxejV1L3VUV0hTbWFRVWVlYStwMmVhRjhJdkVLc1FmCjZRTmtsa2VIc3YrR1ZQditpaWJmYlhYbmU2STVhVjM1UmM0UTA4elJDZ1lYL0JOMUFZWFY2aG80UkM5ZFpWR1AKSlVrU0x6UmFkZWdvay9FT05La3JxTFpPRkpWYjJ3dEZxODVnSjAxbE9ETS9najdHcU01OU0vd2s1NUNhUUlSRAo5eDVINFg0cnBNMnJobWlOTGtJTjB0R0xLTzhYMzF1cDdoVHg5YnZKY1FLQmdRRDUxTUxXWVlVUHovdW12U3JOClFPVDlVaEVISS9ieHRDYldRdGhXM0wxcXJWVDdEQjhKa28vNi94WWxYaGw3bndWd0p6MjRqSmY5dnV4V2JCcEwKSFpSZjBRc0RPMi9PNHJxaEtEb3YvR01VQ3gyc2h6YytKN2srVDkzS05WQU5ZYTA1Z3VxTWVCOG4zMEhQcm9rRgpMZ2loVkZGMjBrOVo2U2liVXZnVE1wRjFFd0tCZ1FERzVNQmdjOG9GWG1sci83cEhLaXpDNEYzZURBWFV4VkhNCldDSWJTd015ek9YS3FEY2RYTkR6OGNRcmpoS2EyckQxZktoRTBvUlIrUXZIejhJUEMrME1zVDdRNlFzSUhZajUKQ1h1YkhyMHM1azhQSkFwK0xrMkVkSGVQWlFNL0kvdmovZ1N3eG5KOVFzNjRGV1oyNUs5elluTk5zaW9qUWVsNwpXVm1JOUlWYVdRS0JnRDNCWWdnc1F3QU5vVjh1RTQ1NUpDR2FUNnM4TUthK3FYcjlPd3o5czdUUzg5YTZ3RkZWCmNWSFNERjlnUzF4TGlzU1dicU5YM1pwVHY0ZjlZT0tBaFZUS0Q3YlUwbWFKbFNpUkVSRWJpa0pDSFN1d29PODAKVW80Y24rNkVEeTIvbjFwQUNrcCt4dlRNTXpCckxHT2paVzY3c1FkMkpUZE1jMFV4MVRDcHAxc1JBb0dBYUVWSQpyY2hHWXlZcDhwcXcxOW8rZVRRVFFmUGZvcnFIdGErR3dmUkRpd0JzZ0NCTU5MS1NRVEhBZkcwUlIrbmExL2d3CloxUk9Wb05RTDhLMXBCbkdmdDcxWmFTblNldmlBVjE5VmNkNXVlNU1DRTRHeWp3UUc1N0xoM3VYaGlTaFM5ZkMKTWNMNEJyOWRqSmg3alYwNnRpMG84ZFN6enFRaGVhOVFCMExhSHBFQ2dZQXBjOG9Cb2lLNjlzMHdYeUk0K1BoeApTY0JKMFhxREJZRmt4eVhyOFk1cEVhckVhcUN0bDFPUFBNT2lRUkRXb3hSUitGd0EvMGxhU2ZoNXh3MFUzYitxCmlaMlhwa3JiUXAwMzRyQzBVUjZwK0ttMVN2OUFWQ0FDQWpyY1EzTlphZjhiRE9XcXZwbGE3QXVxMG9HOGk2VVgKaEVLQ0tmL04zZ0Uxb01yVHhWelVEUT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: tls-validity-checks-certificate
+  namespace: gateway-conformance-infra
+type: kubernetes.io/tls
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-tls-passthrough-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tls-passthrough
+      protocol: TLS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-http-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-https-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: tlsroute-not-allowed-protocol-http
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-http-only
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: tlsroute-not-allowed-protocol-https
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-https-only
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: tlsroute-no-matching-section-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-tls-passthrough-only
+      sectionName: nonexistent-listener
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-http-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-http-only.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-tlsroute-http-only
+  name: cilium-gateway-gateway-tlsroute-http-only
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gateway-tlsroute-http-only
+      uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+  services:
+    - listener: ""
+      name: cilium-gateway-gateway-tlsroute-http-only
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-https-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-https-only.yaml
@@ -1,0 +1,114 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-tlsroute-https-only
+  name: cilium-gateway-gateway-tlsroute-https-only
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gateway-tlsroute-https-only
+      uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-secure
+                statPrefix: listener-secure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: /gateway-conformance-infra-tls-validity-checks-certificate
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-secure
+  services:
+    - listener: ""
+      name: cilium-gateway-gateway-tlsroute-https-only
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-tls-passthrough-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-tls-passthrough-only.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-tlsroute-tls-passthrough-only
+  name: cilium-gateway-gateway-tlsroute-tls-passthrough-only
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gateway-tlsroute-tls-passthrough-only
+      uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+  services:
+    - listener: ""
+      name: cilium-gateway-gateway-tlsroute-tls-passthrough-only
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/gateway-tlsroute-http-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/gateway-tlsroute-http-only.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-http-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/gateway-tlsroute-https-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/gateway-tlsroute-https-only.yaml
@@ -1,0 +1,55 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-https-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-validity-checks-certificate
+            namespace: gateway-conformance-infra
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/gateway-tlsroute-tls-passthrough-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/gateway-tlsroute-tls-passthrough-only.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-tls-passthrough-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tls-passthrough
+      protocol: TLS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: tls-passthrough
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-no-matching-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-no-matching-section-name.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-no-matching-section-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-tls-passthrough-only
+      sectionName: nonexistent-listener
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: No matching listener with sectionName nonexistent-listener
+          reason: NoMatchingParent
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tlsroute-tls-passthrough-only
+        sectionName: nonexistent-listener

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-http.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-http.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-not-allowed-protocol-http
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-http-only
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: "No Listener with matching Protocol. Allowed protocols: [TLS]"
+          reason: NotAllowedByListeners
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tlsroute-http-only

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-https.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-not-allowed-protocol-https
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-https-only
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: "No Listener with matching Protocol. Allowed protocols: [TLS]"
+          reason: NotAllowedByListeners
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-08-15T00:36:04Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tlsroute-https-only

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -69,7 +69,8 @@ func TestHTTPGatewayAPI(t *testing.T) {
 func TestTLSGatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
 		"basic tls http": {},
-		"Conformance/TLSRouteSimpleSameNamespace": {},
+		"Conformance/TLSRouteSimpleSameNamespace":  {},
+		"Conformance/TLSRouteHostnameIntersection": {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteHostnameIntersection/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteHostnameIntersection/output-listeners.yaml
@@ -38,8 +38,8 @@
           port:
             port: 8080
       hostnames:
-        - bar.wildcard.io
         - foo.bar.wildcard.io
+        - bar.wildcard.io
         - foo.wildcard.io
       path_match:
         prefix: /s2

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-gateway.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gw-tlsroute-empty-hostname-x-4
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: listener-empty-hostname
+      protocol: TLS
+      port: 443
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - type: "Accepted"
+      status: "True"
+      reason: "Accepted"
+      message: "Gateway successfully scheduled"
+    - type: "Programmed"
+      status: "False"
+      reason: "AddressNotAssigned"
+      message: "Gateway waiting for address"
+  listeners:
+    - attachedRoutes: 2
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: listener-empty-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-service.yaml
@@ -1,0 +1,104 @@
+- metadata:
+    creationTimestamp: null
+    name: infra-backend-v1
+    namespace: gateway-conformance-infra
+  spec:
+    ports:
+      - port: 8080
+        protocol: tcp
+        targetPort: 3000
+    selector:
+      app: infra-backend-v1
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: infra-backend-v2
+    namespace: gateway-conformance-infra
+  spec:
+    ports:
+      - port: 8080
+        protocol: tcp
+        targetPort: 3000
+    selector:
+      app: infra-backend-v2
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: infra-backend-v3
+    namespace: gateway-conformance-infra
+  spec:
+    ports:
+      - port: 8080
+        protocol: tcp
+        targetPort: 3000
+    selector:
+      app: infra-backend-v3
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: app-backend-v1
+    namespace: gateway-conformance-app-backend
+  spec:
+    ports:
+      - port: 8080
+        protocol: tcp
+        targetPort: 3000
+    selector:
+      app: app-backend-v1
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: app-backend-v2
+    namespace: gateway-conformance-app-backend
+  spec:
+    ports:
+      - port: 8080
+        protocol: tcp
+        targetPort: 3000
+    selector:
+      app: app-backend-v2
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: web-backend
+    namespace: gateway-conformance-web-backend
+  spec:
+    ports:
+      - port: 8080
+        protocol: tcp
+        targetPort: 3000
+    selector:
+      app: web-backend
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: tls-backend
+    namespace: gateway-conformance-infra
+  spec:
+    ports:
+      - port: 443
+        protocol: tcp
+        targetPort: 8443
+    selector:
+      app: tls-backend
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: tls-backend-2
+    namespace: gateway-conformance-infra
+  spec:
+    ports:
+      - port: 443
+        protocol: tcp
+        targetPort: 8443
+    selector:
+      app: tls-backend-2
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-tlsroute.yaml
@@ -1,0 +1,64 @@
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    name: tlsroute-exact-hostname-x-4
+    namespace: gateway-conformance-infra
+  spec:
+    parentRefs:
+      - name: gw-tlsroute-empty-hostname-x-4
+        namespace: gateway-conformance-infra
+    hostnames:
+      - abc.example.com
+    rules:
+      - backendRefs:
+          - name: tls-backend
+            port: 443
+  status:
+    parents:
+      - conditions:
+          - lastTransitionTime: "2025-08-15T00:36:04Z"
+            message: Accepted TLSRoute
+            reason: Accepted
+            status: "True"
+            type: Accepted
+          - lastTransitionTime: "2025-08-15T00:36:04Z"
+            message: Service reference is valid
+            reason: ResolvedRefs
+            status: "True"
+            type: ResolvedRefs
+        controllerName: io.cilium/gateway-controller
+        parentRef:
+          name: gw-tlsroute-empty-hostname-x-4
+          namespace: gateway-conformance-infra
+- apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    name: tlsroute-less-specific-wc-hostname-x-4
+    namespace: gateway-conformance-infra
+  spec:
+    parentRefs:
+      - name: gw-tlsroute-empty-hostname-x-4
+        namespace: gateway-conformance-infra
+    hostnames:
+      - "*.com"
+    rules:
+      - backendRefs:
+          - name: tls-backend-2
+            port: 443
+  status:
+    parents:
+      - conditions:
+          - lastTransitionTime: "2025-08-15T00:36:04Z"
+            message: Accepted TLSRoute
+            reason: Accepted
+            status: "True"
+            type: Accepted
+          - lastTransitionTime: "2025-08-15T00:36:04Z"
+            message: Service reference is valid
+            reason: ResolvedRefs
+            status: "True"
+            type: ResolvedRefs
+        controllerName: io.cilium/gateway-controller
+        parentRef:
+          name: gw-tlsroute-empty-hostname-x-4
+          namespace: gateway-conformance-infra

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/output-listeners.yaml
@@ -1,0 +1,24 @@
+- hostname: "*"
+  name: listener-empty-hostname
+  port: 443
+  routes:
+    - backends:
+        - name: tls-backend
+          namespace: gateway-conformance-infra
+          port:
+            port: 443
+      hostnames:
+        - abc.example.com
+    - backends:
+        - name: tls-backend-2
+          namespace: gateway-conformance-infra
+          port:
+            port: 443
+      hostnames:
+        - "*.com"
+  sources:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+      version: v1

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -564,15 +564,31 @@ func (m *Model) AllPorts() []uint32 {
 	return slices.SortedUnique(ports)
 }
 
-// TLSBackendsToHostnames returns a map of TLS backends to hostnames.
-// This is only for TLS Passthrough listeners.
-func (m *Model) TLSBackendsToHostnames() map[string][]string {
-	res := make(map[string][]string)
+type TLSBackendDetails struct {
+	BackendKey string
+	Hostnames  []string
+}
+
+// TLSBackends returns a slice of TLSBackendDetails.
+// This is only used for TLS Passthrough listeners.
+//
+// The slice keeps the ordering of the model Listeners,
+// as the model Listeners are correctly sorted by hostname,
+// in decreasing order of specificity.
+//
+// This ensures that the rules that end up generated in the translation
+// process are in the correct most-specific to least-specific order.
+func (m *Model) TLSBackends() []TLSBackendDetails {
+	res := []TLSBackendDetails{}
+
 	for _, h := range m.TLSPassthrough {
 		for _, route := range h.Routes {
 			for _, backend := range route.Backends {
 				key := fmt.Sprintf("%s:%s:%s", backend.Namespace, backend.Name, backend.Port.GetPort())
-				res[key] = append(res[key], route.Hostnames...)
+				res = append(res, TLSBackendDetails{
+					BackendKey: key,
+					Hostnames:  route.Hostnames,
+				})
 			}
 		}
 	}

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/cec-output.yaml
@@ -1,0 +1,89 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gw-tlsroute-empty-hostname-x-4
+  name: cilium-gateway-gw-tlsroute-empty-hostname-x-4
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gw-tlsroute-empty-hostname-x-4
+      uid: ""
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+    - name: tls-backend-2
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: gateway-conformance-infra:tls-backend:443
+        - filterChainMatch:
+            serverNames:
+              - "*.com"
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: gateway-conformance-infra:tls-backend-2:443
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend-2:443
+      name: gateway-conformance-infra:tls-backend-2:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: ""
+      name: cilium-gateway-gw-tlsroute-empty-hostname-x-4
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/config-input.yaml
@@ -1,0 +1,12 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config:
+  ipv4_enabled: true
+  ipv6_enabled: true
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config: {}
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/input.yaml
@@ -1,0 +1,25 @@
+tls_passthrough:
+  - hostname: "*"
+    name: listener-empty-hostname
+    port: 443
+    routes:
+      - backends:
+          - name: tls-backend
+            namespace: gateway-conformance-infra
+            port:
+              port: 443
+        hostnames:
+          - abc.example.com
+      - backends:
+          - name: tls-backend-2
+            namespace: gateway-conformance-infra
+            port:
+              port: 443
+        hostnames:
+          - "*.com"
+    sources:
+      - group: gateway.networking.k8s.io
+        kind: Gateway
+        name: gw-tlsroute-empty-hostname-x-4
+        namespace: gateway-conformance-infra
+        version: v1

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: gw-tlsroute-empty-hostname-x-4
+    io.cilium.gateway/owning-gateway: gw-tlsroute-empty-hostname-x-4
+  name: cilium-gateway-gw-tlsroute-empty-hostname-x-4
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gw-tlsroute-empty-hostname-x-4
+      uid: ""
+spec:
+  ports:
+    - name: port-443
+      port: 443
+      protocol: TCP
+      targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -59,6 +59,10 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "conformance/httproute_request_redirect_with_multi_httplisteners"},
 		{name: "conformance/httproute_backend_protocol_h_2_c_app_protocol"},
 
+		// TLSRoute related tests
+
+		{name: "conformance/tlsroute_hostname_intersection"},
+
 		// GAMMA related tests
 		{name: "conformance/gamma/mesh_frontend"},
 		{name: "conformance/gamma/mesh_ports"},


### PR DESCRIPTION
This PR fixes some issues that will be a problem when we perform the upgrade to Gateway API v1.5, which includes new conformance tests for TLSRoute behavior.

The new conformance tests are testing behavior that we _should_ always have been doing, so this should be backportable back to v1.18, where we upgraded to Gateway API v1.4.0.

There are two separate changes, each in their own commit. Please review by commits.

```release-note
gateway-api: Fixed some issues with TLSRoute attachment that will be covered by new conformance tests soon.
```
