### PR TITLE
ci: k8s 1.35 to EKS matrix

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -8,10 +8,12 @@ include:
   - version: "1.32"
     region: ca-central-1
   - version: "1.33"
+    region: eu-central-1
+  - version: "1.34"
     region: us-east-1
     default: true
     kpr: true
-  - version: "1.34"
+  - version: "1.35"
     region: us-west-2
     default: true
     wireguard: true

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -8,9 +8,11 @@ include:
   - version: "1.32"
     region: ca-central-1
   - version: "1.33"
+    region: eu-central-1
+  - version: "1.34"
     region: us-east-1
     default: true
     aws-eni-pd: true
-  - version: "1.34"
+  - version: "1.35"
     region: us-west-2
     default: true


### PR DESCRIPTION
Available in EKS since january 27 https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html  