### PR TITLE
workflows: Cover v6.18 kernel instead of v5.10

### DIFF
--- a/.github/actions/e2e/ipsec.yaml
+++ b/.github/actions/e2e/ipsec.yaml
@@ -10,7 +10,7 @@
   # must be decrypted before L7 processing and re-encrypted for upstream connections
   test-l7: 'true'
 - name: 'ipsec-2'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'disabled'
@@ -20,7 +20,7 @@
   # L7 testing: IPsec encryption has complex interaction with L7 proxy
   test-l7: 'true'
 - name: 'ipsec-3'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'disabled'

--- a/.github/actions/e2e/kernel-versions.yml
+++ b/.github/actions/e2e/kernel-versions.yml
@@ -2,8 +2,6 @@ kernels:
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   rhel8.10: 'rhel8.10-20260211.084719'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  5.10: '5.10-20260211.084719'
-  # renovate: datasource=docker depName=quay.io/lvh-images/kind
   5.15: '5.15-20260211.084719'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   6.1: '6.1-20260211.084719'

--- a/.github/actions/e2e/kube-proxy.yaml
+++ b/.github/actions/e2e/kube-proxy.yaml
@@ -8,7 +8,7 @@
   # L7 testing: Basic VXLAN + host firewall - moderate interaction, test on schedule only
   test-l7: 'false'
 - name: 'kube-proxy-2'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'disabled'
@@ -17,7 +17,7 @@
   # L7 testing: Disabled tunnel + host firewall - moderate interaction, test on schedule only
   test-l7: 'false'
 - name: 'kube-proxy-3'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'false'
   tunnel: 'disabled'

--- a/.github/actions/e2e/misc.yaml
+++ b/.github/actions/e2e/misc.yaml
@@ -1,5 +1,5 @@
 - name: 'misc-1'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'true'
   devices: '{eth0,eth1}'

--- a/.github/actions/e2e/wireguard.yaml
+++ b/.github/actions/e2e/wireguard.yaml
@@ -1,5 +1,5 @@
 - name: 'wireguard-1'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'true'
   devices: '{eth0,eth1}'
@@ -75,7 +75,7 @@
   # L7 testing: WireGuard encryption + Ingress controller requires L7 proxy for HTTP routing
   test-l7: 'true'
 - name: 'wireguard-6'
-  kernel: '5.10'
+  kernel: '6.18'
   kube-proxy: 'iptables'
   kpr: 'true'
   devices: '{eth0,eth1}'

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -14,7 +14,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.10-20260211.084719"
+    kernel: "6.12-20260211.084719"
     kernel-type: "oldstable"
 
   - k8s-version: "1.33"
@@ -22,7 +22,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.10-20260211.084719"
+    kernel: "6.6-20260211.084719"
     kernel-type: "oldstable"
 
   - k8s-version: "1.32"
@@ -30,5 +30,5 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.10-20260211.084719"
+    kernel: "6.1-20260211.084719"
     kernel-type: "stable"

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -85,9 +85,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - kernel: '5.10'
-            kernel-name: '510'
-            ci-kernel: '510'
           - kernel: '5.15'
             kernel-name: '515'
             ci-kernel: '510'
@@ -136,8 +133,6 @@ jobs:
         run: |
           KERNEL="${{ matrix.kernel }}"
           case "$KERNEL" in
-            # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "5.10") FULL_KERNEL="5.10-20260211.084719" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "5.15") FULL_KERNEL="5.15-20260211.084719" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test


### PR DESCRIPTION
We're preparing to deprecate v5.10 support in Cilium v1.20. In parallel, LTS v6.18 is now out and starting to reach distros and we still have very little coverage for it. This commit therefore trades the v5.10 end-to-end test cases for v6.18.

Updates: https://github.com/cilium/cilium/issues/44201.
Fixes: https://github.com/cilium/cilium/issues/43636.