### PR TITLE
release: Reset charts to upstream branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -299,7 +299,7 @@ jobs:
                 # This is a workaround due to left overs made by the generate_helm_release.sh script
                 echo "🧹 Resetting ../charts directory..."
                 cd ../charts
-                git reset --hard HEAD
+                git reset --hard "$(git symbolic-ref refs/remotes/origin/HEAD)"
                 git clean -fdx
                 cd -
 


### PR DESCRIPTION
The reconciler couldn't resolve multiple merges at once because the
reset command was just discarding uncommitted (dirty) changes to the
local tree, and not resetting back to the upstream tree.

What this needs to do is reset back to the tip of the default branch in
the charts directory rather than just reverting back to the existing
(unmergeable) commit.

Fixes: https://github.com/cilium/cilium/pull/43585