### PR TITLE
docs: add external blog on Cilium and Hubble pod-to-pod traffic obser…

### DIFF
--- a/FURTHER_READINGS.rst
+++ b/FURTHER_READINGS.rst
@@ -83,5 +83,7 @@ Community blog posts
   <https://blog.scottlowe.org/2017/04/18/black-belt-cilium/>`_
 * `Cilium, BPF and XDP, Google Open Source Blog, Nov 2016
   <https://opensource.googleblog.com/2016/11/cilium-networking-and-security.html>`_
+* `Uncovering Pod-to-Pod Traffic in Kubernetes Using Cilium and Hubble, Jul 2025
+  <https://medium.com/@0.all_existence.0/uncovering-pod-to-pod-traffic-in-kubernetes-using-cilium-and-hubble-0e59a096cce9>`_
 
 .. further-reading-end


### PR DESCRIPTION
## Description of change

This PR adds an external Medium blog to the `FURTHER_READINGS.rst` file.

The blog provides a practical guide on observing and analyzing pod-to-pod traffic in Kubernetes using Cilium and Hubble. It demonstrates how Cilium enables deep network visibility and helps users understand traffic flows between workloads.

This addition may be useful for users looking to learn more about Cilium’s observability and networking capabilities through real-world examples.

Blog link:
https://medium.com/@0.all_existence.0/uncovering-pod-to-pod-traffic-in-kubernetes-using-cilium-and-hubble-0e59a096cce9

```release-note
docs: add external blog on Cilium and Hubble pod-to-pod traffic observability
```
