### PR TITLE
cilium-cli/connectivity: remove allowlist entry for deleting no longer present service

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -57,7 +57,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 
 	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
 	envoyExternalOtherTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalOtherTarget))}
-	warningLogExceptions := []logMatcher{cantEnableJIT, delMissingService, podCIDRUnavailable,
+	warningLogExceptions := []logMatcher{cantEnableJIT, podCIDRUnavailable,
 		unableGetNode, sessionAffinitySocketLB, objectHasBeenModified, noBackendResponse,
 		legacyBGPFeature, etcdTimeout, endpointRestoreFailed, unableRestoreRouterIP,
 		routerIPReallocated, cantFindIdentityInCache, keyAllocFailedFoundMaster,
@@ -427,7 +427,6 @@ const (
 
 	// warnings
 	cantEnableJIT                    stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.
-	delMissingService                stringMatcher = "Deleting no longer present service"                                     // cf. https://github.com/cilium/cilium/issues/29679
 	podCIDRUnavailable               stringMatcher = " PodCIDR not available"                                                 // cf. https://github.com/cilium/cilium/issues/29680
 	unableGetNode                    stringMatcher = "Unable to get node resource"                                            // cf. https://github.com/cilium/cilium/issues/29710
 	sessionAffinitySocketLB          stringMatcher = "Session affinity for host reachable services needs kernel"              // cf. https://github.com/cilium/cilium/issues/29736


### PR DESCRIPTION
Commit dbeffa843028 ("tests: remove allowlist entry for deleting no longer present service") removed the warning log from the Ginkgo test matcher. The same message can now also be removed from the cilium-cli connectivity test allowlist.

See commit message of the referenced commit for more details.

For #29679