### PR TITLE
ci: reduce number of k8s versions tested on EKS

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -1,14 +1,10 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.30"
-    region: us-west-1
-  - version: "1.31"
-    region: us-east-2
   - version: "1.32"
     region: ca-central-1
   - version: "1.33"
-    region: eu-central-1
+    region: us-east-2
   - version: "1.34"
     region: us-east-1
     default: true

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,14 +1,10 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.30"
-    region: us-west-1
-  - version: "1.31"
-    region: us-east-2
   - version: "1.32"
     region: ca-central-1
   - version: "1.33"
-    region: eu-central-1
+    region: us-east-2
   - version: "1.34"
     region: us-east-1
     default: true


### PR DESCRIPTION
Following discussion in https://github.com/cilium/cilium/pull/44403 Reduction of the number of k8s versions tested on EKS.

cc @joestringer @julianwiedmann 