### PR TITLE
policy: Resolve named ports for egress policies based on destination identities

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -270,7 +270,7 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 
 		// proxyID() returns also the destination port for the policy,
 		// which may be resolved from a named port
-		proxyID, dstPort, dstProto := e.proxyID(l4, listener)
+		proxyID, dstPort, dstProto := e.proxyID(l4, listener, selectorPolicy.GetSelectorSnapshot())
 		if proxyID == "" {
 			// Skip redirects for which a proxyID cannot be created.
 			// This may happen due to the named port mapping not

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -525,7 +525,7 @@ func TestProxyID(t *testing.T) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
 	e.UpdateLogger(nil)
 
-	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "")
+	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
 	require.NotEmpty(t, id)
 	require.Equal(t, uint16(8080), port)
 	require.Equal(t, u8proto.TCP, proto)
@@ -538,7 +538,7 @@ func TestProxyID(t *testing.T) {
 	require.Empty(t, listener)
 	require.NoError(t, err)
 
-	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "test-listener")
+	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "test-listener", policy.SelectorSnapshot{})
 	require.NotEmpty(t, id)
 	require.Equal(t, uint16(8080), port)
 	require.Equal(t, u8proto.TCP, proto)
@@ -551,7 +551,7 @@ func TestProxyID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Undefined named port
-	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "")
+	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
 	require.Empty(t, id)
 	require.Equal(t, uint16(0), port)
 	require.Equal(t, u8proto.ANY, proto)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"log/slog"
 	"net/netip"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -49,13 +51,13 @@ func (e *Endpoint) PreviousMapState() *policy.MapState {
 }
 
 // GetNamedPort returns the port for the given name.
-func (e *Endpoint) GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16 {
+func (e *Endpoint) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, idents iter.Seq[identity.NumericIdentity]) uint16 {
 	if ingress {
 		// Ingress only needs the ports of the POD itself
 		return e.getNamedPortIngress(e.GetK8sPorts(), name, proto)
 	}
-	// egress needs named ports of all the pods
-	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
+	// egress needs named ports of the destination pods
+	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto, idents)
 }
 
 func (e *Endpoint) getNamedPortIngress(npMap types.NamedPortMap, name string, proto u8proto.U8proto) uint16 {
@@ -72,8 +74,8 @@ func (e *Endpoint) getNamedPortIngress(npMap types.NamedPortMap, name string, pr
 	return port
 }
 
-func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string, proto u8proto.U8proto) uint16 {
-	port, err := npMap.GetNamedPort(name, proto)
+func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string, proto u8proto.U8proto, idents iter.Seq[identity.NumericIdentity]) uint16 {
+	port, err := npMap.GetNamedPort(name, proto, idents)
 	// Skip logging for ErrUnknownNamedPort on egress, as the destination POD with the port name
 	// is likely not scheduled yet.
 	if err != nil && !errors.Is(err, types.ErrUnknownNamedPort) && e.logLimiter.Allow() {
@@ -93,7 +95,7 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 // For port ranges the proxy is identified by the first port in
 // the range, as overlapping proxy port ranges are not supported.
 // Must be called with e.mutex held.
-func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16, u8proto.U8proto) {
+func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string, scSnapshot policy.SelectorSnapshot) (string, uint16, u8proto.U8proto) {
 	port := l4.Port
 	protocol := l4.U8Proto
 	// Calculate protocol if it is 0 (default) and
@@ -103,7 +105,7 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string) (string, uint16
 		protocol = proto
 	}
 	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPort(l4.Ingress, l4.PortName, protocol)
+		port = e.GetNamedPort(l4.Ingress, l4.PortName, protocol, l4.Identities(scSnapshot))
 		if port == 0 {
 			return "", 0, 0
 		}

--- a/pkg/envoy/test/updater_mock.go
+++ b/pkg/envoy/test/updater_mock.go
@@ -4,7 +4,10 @@
 package test
 
 import (
+	"iter"
+
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -33,7 +36,9 @@ func (m *ProxyUpdaterMock) GetIPv4Address() string { return m.Ipv4 }
 
 func (m *ProxyUpdaterMock) GetIPv6Address() string { return m.Ipv6 }
 
-func (m *ProxyUpdaterMock) GetNamedPort(bool, string, u8proto.U8proto) uint16 { return 0 }
+func (m *ProxyUpdaterMock) GetNamedPort(bool, string, u8proto.U8proto, iter.Seq[identity.NumericIdentity]) uint16 {
+	return 0
+}
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1526,7 +1526,7 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 
 			port := l4.Port
 			if port == 0 && l4.PortName != "" {
-				port = ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto)
+				port = ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto, l4.Identities(selectors))
 			}
 
 			// Skip if a named port can not be resolved (yet)

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -719,6 +719,10 @@ func (sp *testSelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, poli
 	}
 }
 
+func (sp *testSelectorPolicy) GetSelectorSnapshot() policy.SelectorSnapshot {
+	return policy.SelectorSnapshot{}
+}
+
 // createSelectorCache creates a common selector cache setup used by both DNS and non-DNS policies
 func (sp *testSelectorPolicy) createSelectorCache() (policy.CachedSelector, *policy.SelectorCache) {
 	dnsServerIdentity := destIdentity

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -471,7 +471,7 @@ func (ipc *IPCache) upsertLocked(
 		}
 		// Update the named ports reference counting, but don't cause policy
 		// updates if no policy uses named ports.
-		namedPortsChanged = ipc.namedPorts.Update(oldK8sMeta.NamedPorts, newNamedPorts)
+		namedPortsChanged = ipc.namedPorts.Update(newIdentity.ID, oldK8sMeta.NamedPorts, newNamedPorts)
 		namedPortsChanged = namedPortsChanged && ipc.needNamedPorts.Load()
 	}
 
@@ -744,7 +744,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	// Update named ports
 	namedPortsChanged = false
 	if oldK8sMeta != nil && len(oldK8sMeta.NamedPorts) > 0 {
-		namedPortsChanged = ipc.namedPorts.Update(oldK8sMeta.NamedPorts, nil)
+		namedPortsChanged = ipc.namedPorts.Update(cachedIdentity.ID, oldK8sMeta.NamedPorts, nil)
 		// Only trigger policy updates if named ports are used in policy.
 		namedPortsChanged = namedPortsChanged && ipc.needNamedPorts.Load()
 	}

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -278,13 +278,14 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	// Named ports have been updated, but no policy uses them, hence don't
 	// trigger policy regen until GetNamedPorts has been called at least once.
 	require.False(t, namedPortsChanged)
+	idents := slices.Values([]identityPkg.NumericIdentity{identity})
 	npm := s.IPIdentityCache.GetNamedPorts()
 	require.NotNil(t, npm)
 	require.Equal(t, 2, npm.Len())
-	port, err := npm.GetNamedPort("http", u8proto.TCP)
+	port, err := npm.GetNamedPort("http", u8proto.TCP, idents)
 	require.NoError(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("dns", u8proto.ANY)
+	port, err = npm.GetNamedPort("dns", u8proto.ANY, idents)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
 
@@ -334,13 +335,14 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	npm = s.IPIdentityCache.GetNamedPorts()
 	require.NotNil(t, npm)
 	require.Equal(t, 3, npm.Len())
-	port, err = npm.GetNamedPort("http", u8proto.TCP)
+	port, err = npm.GetNamedPort("http", u8proto.TCP, idents)
 	require.NoError(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("dns", u8proto.ANY)
+	port, err = npm.GetNamedPort("dns", u8proto.ANY, idents)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
-	port, err = npm.GetNamedPort("https", u8proto.TCP)
+	idents2 := slices.Values([]identityPkg.NumericIdentity{identity2})
+	port, err = npm.GetNamedPort("https", u8proto.TCP, idents2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(443), port)
 
@@ -350,10 +352,10 @@ func TestIPCacheNamedPorts(t *testing.T) {
 	require.NotNil(t, npm)
 	require.Equal(t, 2, npm.Len())
 
-	port, err = npm.GetNamedPort("dns", u8proto.ANY)
+	port, err = npm.GetNamedPort("dns", u8proto.ANY, idents2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
-	port, err = npm.GetNamedPort("https", u8proto.TCP)
+	port, err = npm.GetNamedPort("https", u8proto.TCP, idents2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(443), port)
 
@@ -441,11 +443,11 @@ func TestIPCacheNamedPorts(t *testing.T) {
 		require.NoError(t, err)
 		npm = s.IPIdentityCache.GetNamedPorts()
 		require.NotNil(t, npm)
-		port, err := npm.GetNamedPort("http2", u8proto.TCP)
+		port, err := npm.GetNamedPort("http2", u8proto.TCP, slices.Values(identities))
 		require.NoError(t, err)
 		require.Equal(t, uint16(8080), port)
-		// only the first changes named ports, as they are all the same
-		require.Equal(t, index == 0, namedPortsChanged)
+		// last two don't changed named ports as they are for the same identity
+		require.Equal(t, index == 0 || index == 1 || index == 2, namedPortsChanged)
 		cachedIdentity, _ := s.IPIdentityCache.LookupByIP(endpointIPs[index])
 		require.Equal(t, identities[index], cachedIdentity.ID)
 	}
@@ -486,8 +488,8 @@ func TestIPCacheNamedPorts(t *testing.T) {
 		npm = s.IPIdentityCache.GetNamedPorts()
 		require.NotNil(t, npm)
 		t.Logf("Named ports after Delete %d: %v", index, npm)
-		// 2nd delete removes named port mapping, as remaining IPs have an already deleted ID (29)
-		require.Equal(t, index == 1, namedPortsChanged)
+		// 1st and 2nd delete removes named port mapping, as remaining IPs have an already deleted ID (29)
+		require.Equal(t, index == 0 || index == 1, namedPortsChanged)
 
 		_, exists = s.IPIdentityCache.LookupByIP(endpointIPs[index])
 		require.False(t, exists)

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -74,7 +74,7 @@ type IPMetadata any
 // is otherwise read-only.
 type namedPortMultiMapUpdater interface {
 	types.NamedPortMultiMap
-	Update(old, new types.NamedPortMap) (namedPortChanged bool)
+	Update(epID identity.NumericIdentity, old, new types.NamedPortMap) (namedPortChanged bool)
 }
 
 // merge overwrites the field in 'resourceInfo' corresponding to 'info'. This

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -10,6 +10,7 @@ import (
 	"iter"
 	"log/slog"
 	"math/bits"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -674,6 +675,22 @@ func (l4 *L4Filter) makeMapStateEntry(logger *slog.Logger, p *EndpointPolicy, po
 	)
 }
 
+// Identities extracts the set of identities corresponding to selectors.
+func (l4 *L4Filter) Identities(txn SelectorSnapshot) iter.Seq[identity.NumericIdentity] {
+	return func(yield func(identity.NumericIdentity) bool) {
+		for cs := range l4.PerSelectorPolicies {
+			if cs == nil {
+				continue
+			}
+			for _, id := range cs.GetSelectionsAt(txn) {
+				if !yield(id) {
+					return
+				}
+			}
+		}
+	}
+}
+
 // toMapState converts a single filter into a MapState entries added to 'p.PolicyMapState'.
 //
 // Note: It is possible for two selectors to select the same security ID.  To give priority to deny,
@@ -703,7 +720,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, tierPriority, nextTierPriori
 
 	// resolve named port
 	if port == 0 && l4.PortName != "" {
-		port = p.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
+		port = p.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto, l4.Identities(p.selectors))
 		if port == 0 {
 			return // nothing to be done for undefined named port
 		}
@@ -1592,10 +1609,11 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 	l4Policy.mutex.RLock()
 	defer l4Policy.mutex.RUnlock()
 
+	idents := slices.Values(append(adds, deletes...))
 	for epPolicy := range l4Policy.users {
 		// resolve named port
 		if port == 0 && l4.PortName != "" {
-			port = epPolicy.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
+			port = epPolicy.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto, idents)
 			if port == 0 {
 				continue
 			}

--- a/pkg/policy/lookup.go
+++ b/pkg/policy/lookup.go
@@ -9,9 +9,11 @@ package policy
 
 import (
 	"fmt"
+	"iter"
 	"log/slog"
 
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/spanstat"
@@ -119,9 +121,9 @@ func (ei *endpointInfo) GetID() uint64 {
 
 // GetNamedPort determines the named port of the *destination*. So, if ingress
 // is false, then this looks up the peer.
-func (ei *endpointInfo) GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16 {
+func (ei *endpointInfo) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16 {
 	if !ingress && ei.remoteEndpoint != nil {
-		return ei.remoteEndpoint.GetNamedPort(true, name, proto)
+		return ei.remoteEndpoint.GetNamedPort(true, name, proto, destIdentities)
 	}
 	switch {
 	case proto == u8proto.TCP && ei.TCPNamedPorts != nil:

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -15,6 +15,7 @@ import (
 	cilium "github.com/cilium/proxy/go/cilium/api"
 
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
@@ -159,6 +160,9 @@ type SelectorPolicy interface {
 	// DistillPolicy returns the policy in terms of connectivity to peer
 	// Identities.
 	DistillPolicy(logger *slog.Logger, owner PolicyOwner, redirects map[string]uint16) *EndpointPolicy
+
+	// GetSelectorSnapshot returns a selector snapshot if available and valid
+	GetSelectorSnapshot() SelectorSnapshot
 }
 
 // selectorPolicy is a structure which contains the resolved policy for a
@@ -182,6 +186,10 @@ type selectorPolicy struct {
 	// EgressPolicyEnabled specifies whether this policy contains any policy
 	// at egress.
 	EgressPolicyEnabled bool
+}
+
+func (p *selectorPolicy) GetSelectorSnapshot() SelectorSnapshot {
+	return p.SelectorCache.GetSelectorSnapshot()
 }
 
 func (p *selectorPolicy) Attach(ctx PolicyContext) {
@@ -261,7 +269,7 @@ func (p *EndpointPolicy) CopyMapStateFrom(m MapStateMap) {
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64
-	GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16
+	GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16
 	PolicyDebug(msg string, attrs ...any)
 	IsHost() bool
 	PreviousMapState() *MapState

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"fmt"
+	"iter"
 	"log/slog"
 	"net/netip"
 	"strconv"
@@ -180,11 +181,7 @@ type DummyOwner struct {
 func (d DummyOwner) CreateRedirects(*L4Filter) {
 }
 
-func (d DummyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16 {
-	return 80
-}
-
-func (d DummyOwner) GetNamedPortLocked(ingress bool, name string, proto u8proto.U8proto) uint16 {
+func (d DummyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16 {
 	return 80
 }
 

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -275,10 +275,13 @@ type SelectorCache struct {
 	userHandlerDone chan struct{}
 }
 
-// GetReadTxn returns a read-only state of the current selectors in the selector cache.
-// The returned SelectorReadTxn should be Close()d as soon as possible to limit memory use.
+// GetSelectorSnapshot returns a read-only state of the current selectors in the selector cache.
+// The returned SelectorSnapshot should be Invalidate()d if stored on the heap and not needed any more.
 func (sc *SelectorCache) GetSelectorSnapshot() SelectorSnapshot {
-	return *sc.readTxn.Load()
+	if sc != nil {
+		return *sc.readTxn.Load()
+	}
+	return SelectorSnapshot{}
 }
 
 // WithRLock calls the given function with the selector cache locked for reading, so that the caller

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -4,6 +4,9 @@
 package endpoint
 
 import (
+	"iter"
+
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -15,7 +18,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16
+	GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/types/portmap.go
+++ b/pkg/types/portmap.go
@@ -6,10 +6,12 @@ package types
 import (
 	"errors"
 	"fmt"
+	"iter"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/iana"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -32,8 +34,8 @@ type PortProto struct {
 // NamedPortMap maps port names to port numbers and protocols.
 type NamedPortMap map[string]PortProto
 
-// PortProtoSet is a reference-counted set of unique PortProto values.
-type PortProtoSet counter.Counter[PortProto]
+// PortProtoSet maps PortProto to a map of endpoint IDs to their reference counts.
+type PortProtoSet map[PortProto]map[identity.NumericIdentity]int
 
 // Equal returns true if the PortProtoSets are equal.
 func (pps PortProtoSet) Equal(other PortProtoSet) bool {
@@ -41,29 +43,52 @@ func (pps PortProtoSet) Equal(other PortProtoSet) bool {
 		return false
 	}
 
-	for port := range pps {
-		if _, exists := other[port]; !exists {
+	for pp, epCounts := range pps {
+		otherEpCounts, exists := other[pp]
+		if !exists || len(epCounts) != len(otherEpCounts) {
 			return false
+		}
+		for epID, count := range epCounts {
+			otherCount, epExists := otherEpCounts[epID]
+			if !epExists || count != otherCount {
+				return false
+			}
 		}
 	}
 	return true
 }
 
-// Add increments the reference count for the specified key.
-func (pps PortProtoSet) Add(pp PortProto) bool {
-	return counter.Counter[PortProto](pps).Add(pp)
+// Add increments the reference count for the epID associated with the PortProto.
+// Returns true if the epID was not previously in the map (count was 0).
+func (pps PortProtoSet) Add(pp PortProto, epID identity.NumericIdentity) bool {
+	epCounts, ok := pps[pp]
+	if !ok {
+		epCounts = make(map[identity.NumericIdentity]int)
+		pps[pp] = epCounts
+	}
+	return counter.Counter[identity.NumericIdentity](epCounts).Add(epID)
 }
 
-// Delete decrements the reference count for the specified key.
-func (pps PortProtoSet) Delete(pp PortProto) bool {
-	return counter.Counter[PortProto](pps).Delete(pp)
+// Delete decrements the reference count for the epID associated with the PortProto.
+// It returns true if the epID was deleted.
+func (pps PortProtoSet) Delete(pp PortProto, epID identity.NumericIdentity) bool {
+	epCounts, ok := pps[pp]
+	if !ok {
+		return false
+	}
+	deleted := counter.Counter[identity.NumericIdentity](epCounts).Delete(epID)
+	if deleted && len(epCounts) == 0 {
+		delete(pps, pp)
+	}
+	return deleted
 }
 
 // NamedPortMultiMap may have multiple entries for a name if multiple PODs
 // define the same name with different values.
 type NamedPortMultiMap interface {
 	// GetNamedPort returns the port number for the named port, if any.
-	GetNamedPort(name string, proto u8proto.U8proto) (uint16, error)
+	GetNamedPort(name string, proto u8proto.U8proto, epIDs iter.Seq[identity.NumericIdentity]) (uint16, error)
+
 	// Len returns the number of Name->PortProtoSet mappings known.
 	Len() int
 }
@@ -88,27 +113,40 @@ func (npm *namedPortMultiMap) Len() int {
 }
 
 // Update applies potential changes in named ports, and returns whether there were any.
-func (npm *namedPortMultiMap) Update(old, new NamedPortMap) (namedPortsChanged bool) {
+func (npm *namedPortMultiMap) Update(epID identity.NumericIdentity, old, new NamedPortMap) (namedPortsChanged bool) {
 	npm.Lock()
 	defer npm.Unlock()
-	// The order is important here. Increment the refcount first, and then
-	// decrement it again for old ports, so that we don't hit zero if there are
-	// no changes.
-	for name, port := range new {
-		c, ok := npm.m[name]
-		if !ok {
-			c = make(PortProtoSet)
-			npm.m[name] = c
-		}
-		if c.Add(port) {
-			namedPortsChanged = true
+
+	// Handle removals: Ports in old but not in new, or changed.
+	for name, oldPP := range old {
+		newPP, exists := new[name]
+		if !exists || oldPP != newPP {
+			if pps, ok := npm.m[name]; ok {
+				if deleted := pps.Delete(oldPP, epID); deleted {
+					namedPortsChanged = true
+				}
+			}
 		}
 	}
-	for name, port := range old {
-		if npm.m[name].Delete(port) {
-			namedPortsChanged = true
-			if len(npm.m[name]) == 0 {
-				delete(npm.m, name)
+
+	// Clean up empty PortProtoSets from the main map
+	for name, pps := range npm.m {
+		if len(pps) == 0 {
+			delete(npm.m, name)
+		}
+	}
+
+	// Handle additions: Ports in new but not in old, or changed.
+	for name, newPP := range new {
+		oldPP, exists := old[name]
+		if !exists || newPP != oldPP {
+			pps, ok := npm.m[name]
+			if !ok {
+				pps = make(PortProtoSet)
+				npm.m[name] = pps
+			}
+			if pps.Add(newPP, epID) {
+				namedPortsChanged = true
 			}
 		}
 	}
@@ -180,7 +218,7 @@ func (npm NamedPortMap) GetNamedPort(name string, proto u8proto.U8proto) (uint16
 }
 
 // GetNamedPort returns the port number for the named port, if any.
-func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto) (uint16, error) {
+func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto, epIDs iter.Seq[identity.NumericIdentity]) (uint16, error) {
 	if npm == nil {
 		return 0, ErrNilMap
 	}
@@ -198,7 +236,19 @@ func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto) (
 	// Find if there is a single port that has no proto conflict and no zero port value
 	port := uint16(0)
 	err := ErrUnknownNamedPort
-	for pp := range pps {
+	for pp, epSet := range pps {
+		// Check if this PortProto is defined by any of the target endpoint IDs
+		validEp := false
+		for epID := range epIDs {
+			if _, exists := epSet[epID]; exists {
+				validEp = true
+				break
+			}
+		}
+		if !validEp {
+			continue // Skip if PortProto is not from the target endpoints
+		}
+
 		if pp.Proto != 0 && proto != pp.Proto {
 			err = ErrIncompatibleProtocol
 			continue // conflicting proto

--- a/pkg/types/portmap_test.go
+++ b/pkg/types/portmap_test.go
@@ -4,10 +4,12 @@
 package types
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -86,107 +88,160 @@ func TestPolicyNamedPortMap(t *testing.T) {
 
 func TestPolicyPortProtoSet(t *testing.T) {
 	a := PortProtoSet{
-		PortProto{Port: 80, Proto: 6}:  1,
-		PortProto{Port: 443, Proto: 6}: 1,
-		PortProto{Port: 53, Proto: 17}: 1,
+		PortProto{Port: 80, Proto: u8proto.TCP}:  {identity.NumericIdentity(0): 1},
+		PortProto{Port: 443, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
+		PortProto{Port: 53, Proto: u8proto.UDP}:  {identity.NumericIdentity(0): 1},
 	}
 	b := PortProtoSet{
-		PortProto{Port: 80, Proto: 6}:  1,
-		PortProto{Port: 443, Proto: 6}: 1,
-		PortProto{Port: 53, Proto: 6}:  1,
+		PortProto{Port: 80, Proto: u8proto.TCP}:  {identity.NumericIdentity(0): 1},
+		PortProto{Port: 443, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
+		PortProto{Port: 53, Proto: u8proto.TCP}:  {identity.NumericIdentity(0): 1},
 	}
 	require.True(t, a.Equal(a))
 	require.False(t, a.Equal(b))
 	require.True(t, b.Equal(b))
+
+	// Test reference counting
+	pps := make(PortProtoSet)
+	pp := PortProto{Port: 80, Proto: u8proto.TCP}
+	id1 := identity.NumericIdentity(1)
+	id2 := identity.NumericIdentity(2)
+
+	// Add id1
+	require.True(t, pps.Add(pp, id1))
+	require.Equal(t, 1, pps[pp][id1])
+	require.Len(t, pps[pp], 1)
+
+	// Add id1 again (should increment ref count for the same id)
+	require.False(t, pps.Add(pp, id1))
+	require.Equal(t, 2, pps[pp][id1])
+	require.Len(t, pps[pp], 1)
+
+	// Add id2
+	require.True(t, pps.Add(pp, id2))
+	require.Equal(t, 2, pps[pp][id1])
+	require.Equal(t, 1, pps[pp][id2])
+	require.Len(t, pps[pp], 2)
+
+	// Remove id1
+	require.False(t, pps.Delete(pp, id1))
+	require.Equal(t, 1, pps[pp][id1])
+	require.Equal(t, 1, pps[pp][id2])
+	require.Len(t, pps[pp], 2)
+
+	// Remove id2
+	require.True(t, pps.Delete(pp, id2))
+	require.Equal(t, 1, pps[pp][id1])
+	require.Equal(t, 0, pps[pp][id2])
+	require.Len(t, pps[pp], 1)
+
+	// Remove id1 again — last identity, so the PortProto entry is cleaned up
+	require.True(t, pps.Delete(pp, id1))
+	require.Nil(t, pps[pp]) // entire PortProto entry removed
+	require.Empty(t, pps)
+
+	// Test removing non-existent id from existing PortProto
+	require.True(t, pps.Add(pp, id1))
+	require.True(t, pps.Delete(pp, id2))
+	require.Equal(t, 1, pps[pp][id1])
+	require.Len(t, pps[pp], 1)
+
+	// Test removing from non-existent PortProto
+	pp2 := PortProto{Port: 443, Proto: u8proto.TCP}
+	require.False(t, pps.Delete(pp2, id1))
 }
 
 func TestPolicyNamedPortMultiMap(t *testing.T) {
+	id0 := slices.Values([]identity.NumericIdentity{0})
+	id1 := slices.Values([]identity.NumericIdentity{1})
 	a := &namedPortMultiMap{
 		m: map[string]PortProtoSet{
 			"http": {
-				PortProto{Port: 80, Proto: 6}:   1,
-				PortProto{Port: 8080, Proto: 6}: 1,
+				PortProto{Port: 80, Proto: u8proto.TCP}:   {identity.NumericIdentity(0): 1},
+				PortProto{Port: 8080, Proto: u8proto.TCP}: {identity.NumericIdentity(1): 1},
 			},
 			"https": {
-				PortProto{Port: 443, Proto: 6}: 1,
+				PortProto{Port: 443, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
 			},
 			"zero": {
-				PortProto{Port: 0, Proto: 6}: 1,
+				PortProto{Port: 0, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
 			},
 			"none": {},
 			"dns": {
-				PortProto{Port: 53, Proto: 17}: 1,
-				PortProto{Port: 53, Proto: 6}:  1,
+				PortProto{Port: 53, Proto: u8proto.UDP}: {identity.NumericIdentity(0): 1},
+				PortProto{Port: 53, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
 			},
 		},
 	}
 	b := &namedPortMultiMap{
 		m: map[string]PortProtoSet{
 			"http": {
-				PortProto{Port: 80, Proto: 6}:   1,
-				PortProto{Port: 8080, Proto: 6}: 1,
+				PortProto{Port: 80, Proto: u8proto.TCP}:   {identity.NumericIdentity(0): 1},
+				PortProto{Port: 8080, Proto: u8proto.TCP}: {identity.NumericIdentity(1): 1},
 			},
 			"https": {
-				PortProto{Port: 443, Proto: 6}: 1,
+				PortProto{Port: 443, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
 			},
 			"zero": {
-				PortProto{Port: 0, Proto: 6}: 1,
+				PortProto{Port: 0, Proto: u8proto.TCP}: {identity.NumericIdentity(0): 1},
 			},
 			"none": {},
 			"dns": {
-				PortProto{Port: 53, Proto: 0}: 1,
+				PortProto{Port: 53, Proto: 0}: {identity.NumericIdentity(0): 1},
 			},
 		},
 	}
 
-	port, err := a.GetNamedPort("http", 6)
+	port, err := a.GetNamedPort("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{0, 1}))
 	require.Equal(t, ErrDuplicateNamedPorts, err)
 	require.Equal(t, uint16(0), port)
 
-	port, err = a.GetNamedPort("http", 17)
+	port, err = a.GetNamedPort("http", u8proto.UDP, id1)
 	require.Equal(t, ErrIncompatibleProtocol, err)
 	require.Equal(t, uint16(0), port)
 
-	port, err = a.GetNamedPort("zero", 6)
+	port, err = a.GetNamedPort("zero", u8proto.TCP, id0)
 	require.Equal(t, ErrNamedPortIsZero, err)
 	require.Equal(t, uint16(0), port)
 
-	port, err = a.GetNamedPort("none", 6)
+	port, err = a.GetNamedPort("none", u8proto.TCP, id0)
 	require.Equal(t, ErrUnknownNamedPort, err)
 	require.Equal(t, uint16(0), port)
 
-	port, err = a.GetNamedPort("unknown", 6)
+	port, err = a.GetNamedPort("unknown", u8proto.TCP, id0)
 	require.Equal(t, ErrUnknownNamedPort, err)
 	require.Equal(t, uint16(0), port)
 
 	var nilvalued *namedPortMultiMap
-	port, err = NamedPortMultiMap(nilvalued).GetNamedPort("unknown", 6)
+	port, err = NamedPortMultiMap(nilvalued).GetNamedPort("unknown", u8proto.TCP, id0)
 	require.Equal(t, ErrNilMap, err)
 	require.Equal(t, uint16(0), port)
 
-	port, err = a.GetNamedPort("https", 6)
+	port, err = a.GetNamedPort("https", u8proto.TCP, id0)
 	require.NoError(t, err)
 	require.Equal(t, uint16(443), port)
 
-	port, err = a.GetNamedPort("dns", 6)
+	port, err = a.GetNamedPort("dns", u8proto.TCP, id0)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
 
-	port, err = b.GetNamedPort("dns", 6)
+	port, err = b.GetNamedPort("dns", u8proto.TCP, id0)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
 
-	port, err = a.GetNamedPort("dns", 17)
+	port, err = a.GetNamedPort("dns", u8proto.UDP, id0)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
 
-	port, err = b.GetNamedPort("dns", 17)
+	port, err = b.GetNamedPort("dns", u8proto.UDP, id0)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
 }
 
 func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	npm := NewNamedPortMultiMap()
+	id1 := slices.Values([]identity.NumericIdentity{1})
+	id2 := slices.Values([]identity.NumericIdentity{2})
 
 	pod1PortsOld := map[string]PortProto{}
 	pod1PortsNew := map[string]PortProto{
@@ -194,15 +249,15 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	}
 
 	// Insert http=80/TCP from pod1
-	changed := npm.Update(pod1PortsOld, pod1PortsNew)
+	changed := npm.Update(identity.NumericIdentity(1), pod1PortsOld, pod1PortsNew)
 	require.True(t, changed)
 
 	// No changes
-	changed = npm.Update(pod1PortsNew, pod1PortsNew)
+	changed = npm.Update(identity.NumericIdentity(1), pod1PortsNew, pod1PortsNew)
 	require.False(t, changed)
 
 	// Assert http=80/TCP
-	port, err := npm.GetNamedPort("http", u8proto.TCP)
+	port, err := npm.GetNamedPort("http", u8proto.TCP, id1)
 	require.NoError(t, err)
 	require.Equal(t, uint16(80), port)
 
@@ -212,13 +267,13 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	}
 
 	// Insert http=8080/UDP from pod2, retain http=80/TCP from pod1
-	changed = npm.Update(pod2PortsOld, pod2PortsNew)
+	changed = npm.Update(identity.NumericIdentity(2), pod2PortsOld, pod2PortsNew)
 	require.True(t, changed)
 
-	port, err = npm.GetNamedPort("http", u8proto.TCP)
+	port, err = npm.GetNamedPort("http", u8proto.TCP, id1)
 	require.NoError(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("http", u8proto.UDP)
+	port, err = npm.GetNamedPort("http", u8proto.UDP, id2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(8080), port)
 
@@ -227,10 +282,10 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	pod1PortsNew = map[string]PortProto{}
 
 	// Delete http=80/TCP from pod1
-	changed = npm.Update(pod1PortsOld, pod1PortsNew)
+	changed = npm.Update(identity.NumericIdentity(1), pod1PortsOld, pod1PortsNew)
 	require.True(t, changed)
 
-	port, err = npm.GetNamedPort("http", u8proto.UDP)
+	port, err = npm.GetNamedPort("http", u8proto.UDP, id2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(8080), port)
 }


### PR DESCRIPTION
Previously, egress policies using named ports would consider all named port definitions across the cluster. This could lead to 'ErrDuplicateNamedPorts' errors if different pods, not targeted by the policy, used the same port name with different port numbers.

This commit enhances the named port resolution mechanism for egress policies by filtering the available named port mappings based on the destination identities selected by the policy. The set of potential destination identities is now passed to the `GetNamedPort` function.

The underlying `NamedPortMultiMap` and `PortProtoSet` data structures have been updated to store the association between named port definitions and the endpoint identities that own them. This allows `GetNamedPort` to accurately resolve the port number by only considering the definitions from the endpoints matching the policy's selectors.

Fixes: #30003

```release-note
Egress policies with named ports now only consider ports from selected endpoints, preventing duplicate port errors.
```
