### PR TITLE
contrib: Minor cleanups for check-source-info.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=
 
 TEST_UNITTEST_LDFLAGS=
 
+BPF_SOURCE_INFO ?= "bpf/lib/source_info.h"
+GO_SOURCE_INFO ?= "pkg/monitor/api/files.go"
+
 build: $(SUBDIRS) ## Builds all the components for Cilium by executing make in the respective sub directories.
 
 build-container: ## Builds components required for cilium-agent container.
@@ -507,7 +510,7 @@ endif
 	@$(ECHO_CHECK) contrib/scripts/check-go-testdata.sh
 	$(QUIET) contrib/scripts/check-go-testdata.sh
 	@$(ECHO_CHECK) contrib/scripts/check-source-info.sh
-	$(QUIET) contrib/scripts/check-source-info.sh
+	$(QUIET) BPF_SOURCE_INFO=$(BPF_SOURCE_INFO) GO_SOURCE_INFO=$(GO_SOURCE_INFO) contrib/scripts/check-source-info.sh
 	@$(ECHO_CHECK) contrib/scripts/check-xfrmstate.sh
 	$(QUIET) contrib/scripts/check-xfrmstate.sh
 	@$(ECHO_CHECK) contrib/scripts/check-legacy-header-guard.sh

--- a/contrib/scripts/check-source-info.sh
+++ b/contrib/scripts/check-source-info.sh
@@ -2,35 +2,34 @@
 
 set -euo pipefail
 
-source_info_h="bpf/lib/source_info.h"
-api_files_go="pkg/monitor/api/files.go"
-
 #
 # This simple awk command extracts file names from the definition of the
 # __id_for_file function. This is the list of file names which
 # are currently assigned a numerical ID.
 #
 defined_files=$(
-	awk -F: '/@@ source files list begin/{found=1; next}
+	echo ${BPF_SOURCE_INFO} |
+	xargs -n1 awk -F: '/@@ source files list begin/{found=1; next}
 	/@@ source files list end/{exit}
 	{if (!found || !/_strcase_/) next}
-	{gsub(/.* |"|\)|;/, "", $1); print $1}
-	' "$source_info_h" | sort -u
+	{gsub(/.* |"|\)|;/, "", $1); print $1}' |
+	sort -u
 )
 
 #
 # Now let's find all the names defined inside the go source file
 #
 defined_files_go=$(
-	awk '/@@ source files list begin/{found=1; next}
+	echo ${GO_SOURCE_INFO} |
+	xargs -n1 awk '/@@ source files list begin/{found=1; next}
 	{if (!found) next}
 	/@@ source files list end/{exit}
 	{if (!/: /) next}
-	{gsub(/"|,/, "", $2); print $2}
-	' "$api_files_go" | sort -u
+	{gsub(/"|,/, "", $2); print $2}' |
+	sort -u
 )
 if [ "$defined_files" != "$defined_files_go" ]; then
-	echo "File lists in ${source_info_h} and ${api_files_go} aren't same, please sync" >&2
+	echo "File lists in ${BPF_SOURCE_INFO} and ${GO_SOURCE_INFO} aren't same, please sync" >&2
 	exit 1
 fi
 
@@ -44,7 +43,7 @@ fi
 # functions.
 #
 required_files=$(
-	grep -E 'send_drop_notify(|_error|_ext|_error_ext)?|update_(trace_)?metrics|send_trace_notify' bpf/*.c bpf/lib/*.h |
+	grep -E 'send_drop_notify(|_error|_ext|_error_ext)?|update_(trace_)?metrics|send_trace_notify' bpf/*.c bpf/*.h bpf/lib/*.h |
 	cut -f1 -d: |
 	sort -u |
 	grep -v "metrics.h" |
@@ -57,7 +56,7 @@ required_files=$(
 retval=0
 for f in $required_files; do
 	if ! grep --silent -w "$f" <<<"$defined_files"; then
-		echo "$0: $f is not defined, please add its mapping to ${source_info_h}" >&2
+		echo "$0: $f is not defined, please add its mapping to ${BPF_SOURCE_INFO}" >&2
 		retval=1
 	fi
 done
@@ -67,7 +66,7 @@ done
 #
 for f in $defined_files; do
 	if ! grep --silent -w "$f" <<<"$required_files"; then
-		echo "$0: $f is not using send_drop_notify*, update_(trace_)metrics or send_trace_notify, please remove it from ${source_info_h}" >&2
+		echo "$0: $f is not using send_drop_notify*, update_(trace_)metrics or send_trace_notify, please remove it from ${BPF_SOURCE_INFO}" >&2
 		retval=1
 	fi
 done


### PR DESCRIPTION
- Don't hard-code input files. Make them injectable via variable.
- Matching patterns for required_files doesn't include bpf/*.h. Since nothing prevents us from having header file at the bpf top directory, we should include them.

```release-note
contrib: Minor cleanups for check-source-info.sh
```
