### PR TITLE
clustermesh/types: replace remaining uses of `AddrClusterFromIP`

### DIFF
--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -147,24 +147,6 @@ func MustParseAddrCluster(s string) AddrCluster {
 	return addrCluster
 }
 
-// AddrClusterFromIP parses the given net.IP using netipx.FromStdIP and returns
-// AddrCluster with ClusterID = 0.
-func AddrClusterFromIP(ip net.IP) (AddrCluster, bool) {
-	addr, ok := netipx.FromStdIP(ip)
-	if !ok {
-		return AddrCluster{}, false
-	}
-	return AddrCluster{addr: addr, clusterID: 0}, true
-}
-
-func MustAddrClusterFromIP(ip net.IP) AddrCluster {
-	addr, ok := AddrClusterFromIP(ip)
-	if !ok {
-		panic("cannot convert net.IP to AddrCluster")
-	}
-	return addr
-}
-
 // AddrClusterFrom creates AddrCluster from netip.Addr and ClusterID
 func AddrClusterFrom(addr netip.Addr, clusterID uint32) AddrCluster {
 	return AddrCluster{addr: addr, clusterID: clusterID}

--- a/pkg/loadbalancer/writer/benchmark_test.go
+++ b/pkg/loadbalancer/writer/benchmark_test.go
@@ -6,6 +6,7 @@ package writer
 import (
 	"encoding/binary"
 	"fmt"
+	"net/netip"
 	"slices"
 	"testing"
 
@@ -46,7 +47,7 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int, commit bo
 		name := loadbalancer.NewServiceName("test-existing", fmt.Sprintf("svc-%d", i))
 		var addr1 [4]byte
 		binary.BigEndian.PutUint32(addr1[:], 0x02000000+uint32(i))
-		addrCluster, _ := types.AddrClusterFromIP(addr1[:])
+		addrCluster := types.AddrClusterFrom(netip.AddrFrom4(addr1), 0)
 		p.Writer.UpsertServiceAndFrontends(
 			wtxn,
 			&loadbalancer.Service{
@@ -71,7 +72,7 @@ func benchmark_UpsertServiceAndFrontends(b *testing.B, numObjects int, commit bo
 			name := loadbalancer.NewServiceName("test-new", fmt.Sprintf("svc-%d", i))
 			var addr1 [4]byte
 			binary.BigEndian.PutUint32(addr1[:], 0x01000000+uint32(i))
-			addrCluster, _ := types.AddrClusterFromIP(addr1[:])
+			addrCluster := types.AddrClusterFrom(netip.AddrFrom4(addr1), 0)
 			p.Writer.UpsertServiceAndFrontends(
 				wtxn,
 				&loadbalancer.Service{

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"iter"
 	"log/slog"
+	"net/netip"
 	"os"
 	"slices"
 	"testing"
@@ -69,7 +70,7 @@ func fixture(t testing.TB) (p testParams) {
 func intToAddr(i int) cmtypes.AddrCluster {
 	var addr [4]byte
 	binary.BigEndian.PutUint32(addr[:], 0x0100_0000+uint32(i))
-	addrCluster, _ := cmtypes.AddrClusterFromIP(addr[:])
+	addrCluster := cmtypes.AddrClusterFrom(netip.AddrFrom4(addr), 0)
 	return addrCluster
 }
 

--- a/pkg/maglev/maglev_test.go
+++ b/pkg/maglev/maglev_test.go
@@ -6,6 +6,7 @@ package maglev
 import (
 	"encoding/binary"
 	"fmt"
+	"net/netip"
 	"slices"
 	"strings"
 	"testing"
@@ -64,8 +65,7 @@ func mkAddr(i int32) loadbalancer.L3n4Addr {
 	intToAddr := func(i int32) cmtypes.AddrCluster {
 		var addr [4]byte
 		binary.BigEndian.PutUint32(addr[:], uint32(i))
-		addrCluster, _ := cmtypes.AddrClusterFromIP(addr[:])
-		return addrCluster
+		return cmtypes.AddrClusterFrom(netip.AddrFrom4(addr), 0)
 	}
 	a := loadbalancer.NewL3n4Addr(
 		loadbalancer.TCP,


### PR DESCRIPTION
All remaining callers of `AddrClusterFromIP` pass a [4]byte, so `netip.AddrFrom4` can be used to directly construct a `netip.Addr`. Do that inline and remove the `AddrClusterFromIP` helper.

For #24246