### PR TITLE
cilium-cli/connectivity: add --exit-zero-on-failure flag

### DIFF
--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -30,6 +30,7 @@ cilium connectivity test [flags]
   -d, --debug                                                 Show debug messages
       --dns-test-server-image string                          Image path to use for CoreDNS (default "registry.k8s.io/coredns/coredns:v1.14.1@sha256:82b57287b29beb757c740dbbe68f2d4723da94715b563fffad5c13438b71b14a")
       --echo-image string                                     Image path to use for echo server (default "gcr.io/k8s-staging-gateway-api/echo-advanced:v20251204-v1.4.1")
+      --exit-zero-on-failure                                  Exit with zero return code even when test failures are detected
       --external-cidr string                                  IPv4 CIDR to use as external target in connectivity tests (default "1.0.0.0/8")
       --external-cidrv6 string                                IPv6 CIDR to use as external target in connectivity tests (default "2606:4700:4700::/96")
       --external-ip string                                    IPv4 to use as external target in connectivity tests (default "1.1.1.1")

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -192,6 +192,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().BoolVar(&params.CurlInsecure, "curl-insecure", false, "Pass --insecure to curl")
 	cmd.Flags().UintVar(&params.CurlParallel, "curl-parallel", defaults.CurlParallel, "Number of parallel requests in curl commands (0 to disable)")
 
+	cmd.Flags().BoolVar(&params.ExitZeroOnFailure, "exit-zero-on-failure", false, "Exit with zero return code even when test failures are detected")
 	cmd.Flags().BoolVar(&params.CollectSysdumpOnFailure, "collect-sysdump-on-failure", false, "Collect sysdump after a test fails")
 
 	sysdump.InitSysdumpFlags(cmd, &params.SysdumpOptions, "sysdump-", hooks)

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -146,6 +146,7 @@ type Parameters struct {
 	CurlInsecure   bool
 	CurlParallel   uint
 
+	ExitZeroOnFailure       bool
 	CollectSysdumpOnFailure bool
 	SysdumpOptions          sysdump.Options
 

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -574,6 +574,9 @@ func (ct *ConnectivityTest) report() error {
 			ct.LogOwners(allScenarios...)
 		}
 
+		if ct.params.ExitZeroOnFailure {
+			return nil
+		}
 		return fmt.Errorf("[%s] %d tests failed", ct.params.TestNamespace, nf)
 	}
 


### PR DESCRIPTION
Add a new --exit-zero-on-failure flag to the connectivity test command that allows the CLI to exit with a zero return code even when test failures are detected. This is useful in CI pipelines or environments where test failures should be reported but not block the overall process exit status.

