### PR TITLE
endpoint: remove unused NewEndpointFromChangeModel context parameter

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -206,7 +206,7 @@ func (ds *DaemonSuite) prepareEndpoint(t *testing.T, identity *identity.Identity
 		ID:    int64(testEndpointID),
 		State: ptr.To(models.EndpointState(endpoint.StateWaitingForIdentity)),
 	}
-	e, err := ds.endpointCreator.NewEndpointFromChangeModel(t.Context(), model)
+	e, err := ds.endpointCreator.NewEndpointFromChangeModel(model)
 	require.NoError(t, err)
 
 	e.Start(testEndpointID)

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -7,7 +7,6 @@
 package endpoint
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"maps"
@@ -56,7 +55,7 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 }
 
 // NewEndpointFromChangeModel creates a new endpoint from a request
-func NewEndpointFromChangeModel(ctx context.Context, p EndpointParams, dnsRulesAPI DNSRulesAPI, proxy EndpointProxy, model *models.EndpointChangeRequest, policyDebugLog io.Writer) (*Endpoint, error) {
+func NewEndpointFromChangeModel(p EndpointParams, dnsRulesAPI DNSRulesAPI, proxy EndpointProxy, model *models.EndpointChangeRequest, policyDebugLog io.Writer) (*Endpoint, error) {
 	if model == nil {
 		return nil, nil
 	}

--- a/pkg/endpoint/api/endpoint_api_handler.go
+++ b/pkg/endpoint/api/endpoint_api_handler.go
@@ -268,7 +268,7 @@ func (h *EndpointPatchEndpointIDHandler) Handle(params endpointapi.PatchEndpoint
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := h.endpointCreator.NewEndpointFromChangeModel(params.HTTPRequest.Context(), epTemplate)
+	newEp, err2 := h.endpointCreator.NewEndpointFromChangeModel(epTemplate)
 	if err2 != nil {
 		r.Error(err2, endpointapi.PutEndpointIDInvalidCode)
 		return api.Error(endpointapi.PutEndpointIDInvalidCode, err2)

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -139,7 +139,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 	apiLabels := labels.NewLabelsFromModel(epTemplate.Labels)
 	epTemplate.Labels = nil
 
-	ep, err := m.endpointCreator.NewEndpointFromChangeModel(ctx, epTemplate)
+	ep, err := m.endpointCreator.NewEndpointFromChangeModel(epTemplate)
 	if err != nil {
 		return invalidDataError(ep, fmt.Errorf("unable to parse endpoint parameters: %w", err))
 	}

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -39,7 +39,7 @@ func TestWriteInformationalComments(t *testing.T) {
 		CTMapGC:          ctmap.NewFakeGCRunner(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
 	}
-	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -71,7 +71,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 		CTMapGC:          ctmap.NewFakeGCRunner(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
 	}
-	e, err := NewEndpointFromChangeModel(b.Context(), p, nil, nil, model, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))

--- a/pkg/endpoint/creator/creator.go
+++ b/pkg/endpoint/creator/creator.go
@@ -31,7 +31,7 @@ var launchTime = 30 * time.Second
 
 type EndpointCreator interface {
 	// NewEndpointFromChangeModel creates a new endpoint from a request
-	NewEndpointFromChangeModel(ctx context.Context, base *models.EndpointChangeRequest) (*endpoint.Endpoint, error)
+	NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*endpoint.Endpoint, error)
 
 	ParseEndpoint(epJSON []byte) (*endpoint.Endpoint, error)
 
@@ -92,9 +92,8 @@ func policyDebugLogger() *lumberjack.Logger {
 	}
 }
 
-func (c *endpointCreator) NewEndpointFromChangeModel(ctx context.Context, base *models.EndpointChangeRequest) (*endpoint.Endpoint, error) {
+func (c *endpointCreator) NewEndpointFromChangeModel(base *models.EndpointChangeRequest) (*endpoint.Endpoint, error) {
 	return endpoint.NewEndpointFromChangeModel(
-		ctx,
 		c.epParams,
 		c.params.DNSRulesService,
 		c.params.Proxy,

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -34,7 +34,7 @@ func TestGetCiliumEndpointStatus(t *testing.T) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	}
-	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
 	require.NoError(t, err)
 
 	status := e.GetCiliumEndpointStatus()
@@ -78,7 +78,7 @@ func TestGetCiliumEndpointStatusWithServiceAccount(t *testing.T) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	}
-	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
 	require.NoError(t, err)
 
 	// Create a mock pod with ServiceAccount

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -213,7 +213,7 @@ func TestEndpointDatapathOptions(t *testing.T) {
 	}
 
 	p := createTestEndpointParams(t)
-	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
 	require.NoError(t, err)
 	require.Equal(t, option.OptionDisabled, e.Options.GetValue(option.SourceIPVerification))
 }
@@ -222,7 +222,7 @@ func TestEndpointUpdateLabels(t *testing.T) {
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
 	p := createTestEndpointParams(t)
 
-	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -267,7 +267,7 @@ func TestEndpointUpdateLabels(t *testing.T) {
 func TestEndpointState(t *testing.T) {
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
 	p := createTestEndpointParams(t)
-	e, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 	require.NoError(t, err)
 	e.Start(uint16(model.ID))
 	t.Cleanup(e.Stop)
@@ -652,7 +652,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 
 	model := newTestEndpointModel(12345, StateReady)
 	p := createTestEndpointParams(t)
-	ep, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, nil)
+	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -732,7 +732,7 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 func BenchmarkEndpointGetModel(b *testing.B) {
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
 	p := createTestEndpointParams(b)
-	e, err := NewEndpointFromChangeModel(b.Context(), p, nil, nil, model, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))
@@ -812,7 +812,7 @@ func TestMetadataResolver(t *testing.T) {
 				model := newTestEndpointModel(100, StateWaitingForIdentity)
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
 				p.KVStoreSynchronizer = kvstoreSync
-				ep, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, nil)
+				ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
 				require.NoError(t, err)
 
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -29,7 +29,7 @@ func TestPolicyLog(t *testing.T) {
 	model := newTestEndpointModel(12345, StateReady)
 	p := createTestEndpointParams(t)
 	p.PolicyRepo = do.repo
-	ep, err := NewEndpointFromChangeModel(t.Context(), p, nil, nil, model, f)
+	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, f)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -188,7 +188,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
 	p := s.createTestEndpointParams(t)
 	p.KVStoreSynchronizer = kvstoreSync
-	ep, err := NewEndpointFromChangeModel(t.Context(), p, nil, s.rsp, model, nil)
+	ep, err := NewEndpointFromChangeModel(p, nil, s.rsp, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -65,7 +65,7 @@ func (s *EndpointSuite) endpointCreator(t testing.TB, id uint16, secID identity.
 	identity.Sanitize()
 
 	model := newTestEndpointModel(int(id), StateReady)
-	ep, err := NewEndpointFromChangeModel(t.Context(), p, nil, &FakeEndpointProxy{}, model, nil)
+	ep, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -47,7 +47,7 @@ func TestMarkAndSweep(t *testing.T) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		model := newTestEndpointModel(int(id), endpoint.StateReady)
-		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 			NamedPortsGetter: testipcache.NewMockIPCache(),
 			Allocator:        testidentity.NewMockIdentityAllocator(nil),

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -4,7 +4,6 @@
 package endpointmanager
 
 import (
-	"context"
 	"net/netip"
 	"sync"
 	"testing"
@@ -391,7 +390,7 @@ func TestLookup(t *testing.T) {
 			logger := hivetest.Logger(t)
 			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+				ep, err = endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 					EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 					NamedPortsGetter: testipcache.NewMockIPCache(),
 					Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -426,7 +425,7 @@ func TestLookupCiliumID(t *testing.T) {
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
 		PolicyRepo:       s.repo,
@@ -511,7 +510,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -544,7 +543,7 @@ func TestLookupIPv4(t *testing.T) {
 
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(4, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -707,7 +706,7 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 			NamedPortsGetter: testipcache.NewMockIPCache(),
 			Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -761,7 +760,7 @@ func TestUpdateReferences(t *testing.T) {
 	for _, tt := range tests {
 		var err error
 		logger := hivetest.Logger(t)
-		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+		ep, err = endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 			EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 			NamedPortsGetter: testipcache.NewMockIPCache(),
 			Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -807,7 +806,7 @@ func TestRemove(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(7, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -877,7 +876,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter:    testipcache.NewMockIPCache(),
 		Allocator:           testidentity.NewMockIdentityAllocator(nil),
@@ -940,7 +939,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Add labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
 					NamedPortsGetter:    testipcache.NewMockIPCache(),
 					Allocator:           testidentity.NewMockIdentityAllocator(nil),
@@ -982,7 +981,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
 					NamedPortsGetter:    testipcache.NewMockIPCache(),
 					Allocator:           testidentity.NewMockIdentityAllocator(nil),
@@ -1027,7 +1026,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
 
-				ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
 					NamedPortsGetter:    testipcache.NewMockIPCache(),
 					Allocator:           testidentity.NewMockIdentityAllocator(nil),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -170,7 +170,7 @@ func (s *DNSProxyTestSuite) LookupRegisteredEndpoint(ip netip.Addr) (*endpoint.E
 		return nil, false, fmt.Errorf("No EPs available when restoring")
 	}
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -905,7 +905,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep1, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -967,7 +967,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules for epID3
 	modelEP3 := newTestEndpointModel(int(epID3), endpoint.StateReady)
-	ep3, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep3, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),
@@ -1189,7 +1189,7 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 	// restore rules, set the mock to restoring state
 	s.restoring = true
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(context.Background(), endpoint.EndpointParams{
+	ep1, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
 		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
 		NamedPortsGetter: testipcache.NewMockIPCache(),
 		Allocator:        testidentity.NewMockIdentityAllocator(nil),

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -345,7 +345,7 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 	}()
 
 	// Create the endpoint
-	ep, err := endpointCreator.NewEndpointFromChangeModel(baseCtx, info)
+	ep, err := endpointCreator.NewEndpointFromChangeModel(info)
 	if err != nil {
 		return nil, fmt.Errorf("Error while creating endpoint model: %w", err)
 	}


### PR DESCRIPTION
The context is unused, remove it.