### PR TITLE
clustermesh/kvstore: Modernize waitgroup usage

### DIFF
--- a/clustermesh-apiserver/clustermesh/users_mgmt.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt.go
@@ -116,9 +116,7 @@ func (us *usersManager) Start(cell.HookContext) error {
 		DoFunc:  us.sync,
 	})
 
-	us.wg.Add(1)
-	go func() {
-		defer us.wg.Done()
+	us.wg.Go(func() {
 
 		for {
 			select {
@@ -136,7 +134,7 @@ func (us *usersManager) Start(cell.HookContext) error {
 				return
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/clustermesh-apiserver/kvstoremesh/root.go
+++ b/clustermesh-apiserver/kvstoremesh/root.go
@@ -77,11 +77,9 @@ func registerLeaderElectionHooks(lc cell.Lifecycle, llc *LeaderLifecycle, params
 
 	lc.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				runLeaderElection(ctx, llc, params)
-				wg.Done()
-			}()
+			})
 			return nil
 		},
 		OnStop: func(hctx cell.HookContext) error {

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -137,11 +137,9 @@ func TestClusterMesh(t *testing.T) {
 	require.NotNil(t, cm, "Failed to initialize clustermesh")
 	// cluster2 is the cluster which is tested with sync canaries
 	nodesWSS := storeFactory.NewSyncStore("cluster2", client, nodeStore.NodeStorePrefix)
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		nodesWSS.Run(ctx)
-		wg.Done()
-	}()
+	})
 	nodeNames := []string{"foo", "bar", "baz"}
 
 	// wait for the two expected clusters to appear in the list of cm clusters

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -225,9 +225,7 @@ func (cm *clusterMesh) remove(name string) {
 	delete(cm.clusters, name)
 	cm.conf.Metrics.TotalRemoteClusters.Set(float64(len(cm.clusters)))
 
-	cm.wg.Add(1)
-	go func() {
-		defer cm.wg.Done()
+	cm.wg.Go(func() {
 
 		// Run onRemove in a separate go routing as potentially slow, to avoid
 		// blocking the processing of further events in the meanwhile.
@@ -243,7 +241,7 @@ func (cm *clusterMesh) remove(name string) {
 			cm.addLocked(name, path)
 		}
 		cm.mutex.Unlock()
-	}()
+	})
 
 	cm.conf.Logger.Debug("Remote cluster configuration removed", fieldClusterName, name)
 }

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -174,12 +174,10 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				rc.mutex.Unlock()
 
 				ctx, cancel := context.WithCancel(ctx)
-				rc.wg.Add(1)
-				go func() {
+				rc.wg.Go(func() {
 					rc.watchdog(ctx, backend, clusterLock)
 					cancel()
-					rc.wg.Done()
-				}()
+				})
 
 				rc.logger.Info(
 					"Connection to remote cluster established",
@@ -226,12 +224,10 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				// to return early from the controller body, so that the statistics
 				// are updated correctly. Instead, blocking until rc.Run terminates
 				// would prevent a previous failure from being cleared out.
-				rc.wg.Add(1)
-				go func() {
+				rc.wg.Go(func() {
 					rc.Run(ctx, backend, config, ready)
 					cancel()
-					rc.wg.Done()
-				}()
+				})
 
 				if err := <-ready; err != nil {
 					select {

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -143,11 +143,9 @@ func TestRemoteClusterStatus(t *testing.T) {
 				},
 			}
 			ready := make(chan error)
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				rc.Run(ctx, client, cfg, ready)
-				wg.Done()
-			}()
+			})
 
 			require.NoError(t, <-ready, "rc.Run() failed")
 
@@ -215,11 +213,9 @@ func TestRemoteClusterHooks(t *testing.T) {
 		return &models.RemoteCluster{Ready: true, Config: &models.RemoteClusterConfig{}}
 	})
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		rc.Run(ctx, client, cfg, ready)
-		wg.Done()
-	}()
+	})
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.EqualValues(c, 1, clusterAddCalledCount.Load(), "cluster add called once")

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -178,11 +178,9 @@ func TestRemoteClusterRun(t *testing.T) {
 				name:              "foo",
 			}
 
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				rc.Run(ctx, remoteClient, tt.srccfg, ready)
-				wg.Done()
-			}()
+			})
 
 			require.NoError(t, <-ready, "rc.Run() failed")
 
@@ -314,12 +312,10 @@ func TestRemoteClusterClusterIDChange(t *testing.T) {
 			wg.Wait()
 		}()
 
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			cfg := types.CiliumClusterConfig{ID: id, Capabilities: types.CiliumClusterConfigCapabilities{Cached: true}}
 			rc.Run(ctx, remote, cfg, ready)
-			wg.Done()
-		}()
+		})
 
 		run(t, ready)
 	}

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -583,11 +583,9 @@ func TestRemoteCache(t *testing.T) {
 		wg.Wait()
 	}()
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		rc.Watch(ctx, func(ctx context.Context) {})
-		wg.Done()
-	}()
+	})
 
 	// wait for remote cache to be populated
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -440,11 +440,9 @@ func (s *SharedStore) deleteSharedKey(name string) {
 func (s *SharedStore) listAndStartWatcher() error {
 	listDone := make(chan struct{})
 
-	s.wg.Add(1)
-	go func() {
+	s.wg.Go(func() {
 		s.watcher(listDone)
-		s.wg.Done()
-	}()
+	})
 
 	select {
 	case <-listDone:

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -126,11 +126,9 @@ func TestWorkqueueSyncStore(t *testing.T) {
 	store := st.NewSyncStore("qux", backend, "/foo/bar")
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		store.Run(ctx)
-	}()
+	})
 
 	defer func() {
 		cancel()
@@ -184,11 +182,9 @@ func TestWorkqueueSyncStoreWithoutLease(t *testing.T) {
 	store := st.NewSyncStore("qux", backend, "/foo/bar", WSSWithoutLease())
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		store.Run(ctx)
-	}()
+	})
 
 	defer func() {
 		cancel()
@@ -209,11 +205,9 @@ func TestWorkqueueSyncStoreWithRateLimiter(t *testing.T) {
 	store := st.NewSyncStore("qux", backend, "/foo/bar", WSSWithRateLimiter(limiter))
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		store.Run(ctx)
-	}()
+	})
 
 	defer func() {
 		cancel()
@@ -237,11 +231,9 @@ func TestWorkqueueSyncStoreWithWorkers(t *testing.T) {
 	store := st.NewSyncStore("qux", backend, "/foo/bar", WSSWithWorkers(2))
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		store.Run(ctx)
-	}()
+	})
 
 	defer func() {
 		cancel()
@@ -269,11 +261,9 @@ func TestWorkqueueSyncStoreSynced(t *testing.T) {
 			store := st.NewSyncStore("qux", backend, "foo/bar", opts...)
 
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				store.Run(ctx)
-			}()
+			})
 
 			defer func() {
 				cancel()
@@ -403,11 +393,9 @@ func TestWorkqueueSyncStoreMetrics(t *testing.T) {
 
 	// Start the store
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		store.Run(ctx)
-	}()
+	})
 
 	defer func() {
 		cancel()

--- a/pkg/kvstore/store/watchstore_test.go
+++ b/pkg/kvstore/store/watchstore_test.go
@@ -87,11 +87,9 @@ func rwsRun(store WatchStore, prefix string, body func(), backend WatchStoreBack
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		store.Watch(ctx, backend, prefix)
-	}()
+	})
 
 	defer func() {
 		cancel()
@@ -265,11 +263,9 @@ func TestRestartableWatchStoreConcurrent(t *testing.T) {
 	f, _ := GetFactory(t)
 	store := f.NewWatchStore("qux", KVPairCreator, observer)
 
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		store.Watch(ctx, backend, "foo/bar/")
-		wg.Done()
-	}()
+	})
 
 	// Ensure that the Watch operation running in the goroutine has started
 	require.Equal(t, NewKVPair("key1", "value1"), eventually(observer.updated))

--- a/pkg/kvstore/store/watchstoremgr.go
+++ b/pkg/kvstore/store/watchstoremgr.go
@@ -61,12 +61,10 @@ func (mgr *wsmCommon) ready(ctx context.Context, prefix string) {
 		mgr.log.Debug("Starting function for kvstore prefix", logfields.Prefix, prefix)
 		delete(mgr.functions, prefix)
 
-		mgr.wg.Add(1)
-		go func() {
-			defer mgr.wg.Done()
+		mgr.wg.Go(func() {
 			fn(ctx)
 			mgr.log.Debug("Function terminated for kvstore prefix", logfields.Prefix, prefix)
-		}()
+		})
 	} else {
 		mgr.log.Debug("Received sync event for unregistered prefix", logfields.Prefix, prefix)
 	}


### PR DESCRIPTION
Apply go 1.25 [waitgroup modernization](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_waitgroup) in `clustermesh` and `kvstore` related packages.

> The waitgroup analyzer simplifies goroutine management with `sync.WaitGroup`. It replaces the common pattern
>
> ```go
> wg.Add(1)
> go func() {
> 	defer wg.Done()
> 	...
> }()
> ```
> with a single call to
>
> ```go
> wg.Go(func(){ ... })
> ```