### PR TITLE
plugins/cilium-cni: generalize OnConfigReady CNI ADD hook

### DIFF
--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -568,7 +568,7 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 	}
 
 	for _, hook := range cmd.onConfigReady {
-		if err := hook.OnConfigReady(n, cniArgs, conf); err != nil {
+		if err := hook.OnConfigReady(args, cniArgs, conf); err != nil {
 			return err
 		}
 	}

--- a/plugins/cilium-cni/cmd/hooks.go
+++ b/plugins/cilium-cni/cmd/hooks.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"github.com/containernetworking/cni/pkg/skel"
 	cniTypesV1 "github.com/containernetworking/cni/pkg/types/100"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -15,7 +16,7 @@ import (
 // configuration, CNI arguments and the Cilium agent configuration were loaded. It may be used to
 // sets up internal state of the hook.
 type OnConfigReady interface {
-	OnConfigReady(netConf *types.NetConf, cniArgs *types.ArgsSpec, conf *models.DaemonConfigurationStatus) error
+	OnConfigReady(args *skel.CmdArgs, cniArgs *types.ArgsSpec, conf *models.DaemonConfigurationStatus) error
 }
 
 // OnIPAMReady is invoked after IPAM configuration was validated. It may be used to derive further


### PR DESCRIPTION
Amend the OnConfigReady hook so that it takes the entire [skel.CmdArgs] object as first parameter, rather than the parsed [types.NetConf] data only. This allows downstream implementations to potentially configure the internal state of the hook based on a more complete view.