### PR TITLE
ci: increase timeout for ci-e2e-upgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -196,7 +196,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
-    timeout-minutes: 55
+    timeout-minutes: 70
     steps:
       - name: Log Matrix Configuration
         run: |


### PR DESCRIPTION
This commit increases the timeout for the `ci-e2e-upgrade` workflow (used by `ci-l3-l4` & `ci-l7`) because we sporadically hit the timeout.

```
E2E Upgrade with L7 Tests / Setup & Test (wireguard-3, minor, 6.12)
The job has exceeded the maximum execution time of 55m0s
```
