### PR TITLE
ztunnel/ces: add PodUID field to CoreCiliumEndpoint

### DIFF
--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -355,6 +355,7 @@ func (r *slimReconciler) convertPodToCoreCEP(pod *slim_corev1.Pod) *cilium_v2a1.
 	return &cilium_v2a1.CoreCiliumEndpoint{
 		Name:       pod.GetName(),
 		IdentityID: identityId,
+		PodUID:     string(pod.UID),
 		Networking: networking,
 		Encryption: cilium_v2.EncryptionSpec{
 			Key: encryptionKey,

--- a/operator/pkg/ciliumendpointslice/testutils/test_utils.go
+++ b/operator/pkg/ciliumendpointslice/testutils/test_utils.go
@@ -40,6 +40,7 @@ func CreateManagerEndpoint(name string, identity int64, node string) capi_v2a1.C
 	return capi_v2a1.CoreCiliumEndpoint{
 		Name:       name,
 		IdentityID: identity,
+		PodUID:     name + "-uid",
 		Networking: &v2.EndpointNetworking{
 			NodeIP: NodeIPs[node],
 		},

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
@@ -100,6 +100,9 @@ spec:
                   required:
                   - addressing
                   type: object
+                pod-uid:
+                  description: PodUID is the UID of the Pod that owns this endpoint.
+                  type: string
                 service-account:
                   description: ServiceAccount is the service account of the endpoint.
                   type: string

--- a/pkg/k8s/apis/cilium.io/v2alpha1/types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/types.go
@@ -36,6 +36,9 @@ type CoreCiliumEndpoint struct {
 	// IdentityID is the numeric identity of the endpoint
 	// +kubebuilder:validation:Optional
 	IdentityID int64 `json:"id,omitempty"`
+	// PodUID is the UID of the Pod that owns this endpoint.
+	// +kubebuilder:validation:Optional
+	PodUID string `json:"pod-uid,omitempty"`
 	// Networking is the networking properties of the endpoint.
 
 	// +kubebuilder:validation:Optional

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1296,6 +1296,9 @@ func (in *CoreCiliumEndpoint) DeepEqual(other *CoreCiliumEndpoint) bool {
 	if in.IdentityID != other.IdentityID {
 		return false
 	}
+	if in.PodUID != other.PodUID {
+		return false
+	}
 	if (in.Networking == nil) != (other.Networking == nil) {
 		return false
 	} else if in.Networking != nil {

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	core_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -1283,6 +1284,12 @@ func Test_ConvertCEPToCoreCEP(t *testing.T) {
 	cep := &v2.CiliumEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-endpoint",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind: "Pod",
+					UID:  "test-pod-uid-1234",
+				},
+			},
 		},
 		Status: v2.EndpointStatus{
 			Identity: &v2.EndpointIdentity{
@@ -1315,6 +1322,7 @@ func Test_ConvertCEPToCoreCEP(t *testing.T) {
 
 	require.Equal(t, "test-endpoint", coreCEP.Name)
 	require.Equal(t, int64(1234), coreCEP.IdentityID)
+	require.Equal(t, "test-pod-uid-1234", coreCEP.PodUID)
 	require.Equal(t, "test-service-account", coreCEP.ServiceAccount)
 	require.Equal(t, v2.EncryptionSpec{Key: 42}, coreCEP.Encryption)
 	require.NotNil(t, coreCEP.Networking)
@@ -1323,10 +1331,29 @@ func Test_ConvertCEPToCoreCEP(t *testing.T) {
 	require.Equal(t, "http", coreCEP.NamedPorts[0].Name)
 }
 
+func Test_ConvertCEPToCoreCEP_NoPodOwner(t *testing.T) {
+	cep := &v2.CiliumEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-endpoint",
+		},
+		Status: v2.EndpointStatus{
+			Identity: &v2.EndpointIdentity{
+				ID: 1234,
+			},
+		},
+	}
+
+	coreCEP := ConvertCEPToCoreCEP(cep)
+
+	require.Equal(t, "test-endpoint", coreCEP.Name)
+	require.Empty(t, coreCEP.PodUID, "PodUID should be empty when there is no Pod owner reference")
+}
+
 func Test_ConvertCoreCiliumEndpointToTypesCiliumEndpoint(t *testing.T) {
 	coreCEP := &cilium_v2a1.CoreCiliumEndpoint{
 		Name:       "test-endpoint",
 		IdentityID: 5678,
+		PodUID:     "test-pod-uid-5678",
 		Networking: &v2.EndpointNetworking{
 			Addressing: []*v2.AddressPair{
 				{
@@ -1360,6 +1387,22 @@ func Test_ConvertCoreCiliumEndpointToTypesCiliumEndpoint(t *testing.T) {
 	require.Equal(t, "192.168.1.2", typesCEP.Networking.NodeIP)
 	require.Len(t, typesCEP.NamedPorts, 1)
 	require.Equal(t, "grpc", typesCEP.NamedPorts[0].Name)
+	// Verify OwnerReferences reconstructed from PodUID
+	require.Len(t, typesCEP.OwnerReferences, 1)
+	require.Equal(t, "Pod", typesCEP.OwnerReferences[0].Kind)
+	require.Equal(t, k8sTypes.UID("test-pod-uid-5678"), typesCEP.OwnerReferences[0].UID)
+}
+
+func Test_ConvertCoreCiliumEndpointToTypesCiliumEndpoint_NoPodUID(t *testing.T) {
+	coreCEP := &cilium_v2a1.CoreCiliumEndpoint{
+		Name:       "test-endpoint",
+		IdentityID: 5678,
+	}
+
+	typesCEP := ConvertCoreCiliumEndpointToTypesCiliumEndpoint(coreCEP, "test-namespace")
+
+	require.Equal(t, "test-endpoint", typesCEP.Name)
+	require.Nil(t, typesCEP.OwnerReferences)
 }
 
 func Test_AnnotationsEqual(t *testing.T) {


### PR DESCRIPTION
The CEP path preserves Pod UID through OwnerReferences, but the CES path loses it because `CoreCiliumEndpoint` has no UID field. This causes ztunnel to treat all CES-derived workloads as the same endpoint, retaining only the last one received.

Relates to #43128

```release-note
Add PodUID field to CoreCiliumEndpoint so CES-derived endpoints carry the Pod UID for ztunnel workload identification.
```