### PR TITLE
ingress: add per-protocol hostNetwork listener ports

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -11,146 +11,149 @@ cilium-operator-alibabacloud [flags]
 ### Options
 
 ```
-      --alibaba-cloud-release-excess-ips                     Enable releasing excess free IP addresses from Alibaba Cloud ENI.
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-selector-labels                          Enable use of node label based identity
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-alibabacloud
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "alibabacloud")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
-      --version                                              Print version information
+      --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
+      --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                   Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                                Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --cluster-pool-ipv4-cidr strings                             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --config string                                              Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                          Configuration directory that contains a file for each option
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                      Enable debugging mode
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-ipv4                                                Enable IPv4 support (default true)
+      --enable-ipv6                                                Enable IPv6 support (default true)
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l7-proxy                                            Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-node-selector-labels                                Enable use of node label based identity
+      --enable-policy string                                       Enable policy enforcement (default "default")
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for cilium-operator-alibabacloud
+      --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                                Backend to use for IPAM (default "alibabacloud")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                         Logging endpoints to use for example syslog
+      --log-opt map                                                Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                                cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
+      --version                                                    Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,108 +11,111 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
-      --alibaba-cloud-release-excess-ips                     Enable releasing excess free IP addresses from Alibaba Cloud ENI.
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
+      --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for hive
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,107 +17,110 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --alibaba-cloud-release-excess-ips                     Enable releasing excess free IP addresses from Alibaba Cloud ENI.
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
+      --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -11,153 +11,156 @@ cilium-operator-aws [flags]
 ### Options
 
 ```
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-selector-labels                          Enable use of node label based identity
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags stringToString                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
-      --eni-tags stringToString                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-aws
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "eni")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
-      --version                                              Print version information
+      --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
+      --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                   Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                                Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --cluster-pool-ipv4-cidr strings                             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --config string                                              Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                          Configuration directory that contains a file for each option
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                      Enable debugging mode
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-ipv4                                                Enable IPv4 support (default true)
+      --enable-ipv6                                                Enable IPv6 support (default true)
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l7-proxy                                            Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-node-selector-labels                                Enable use of node label based identity
+      --enable-policy string                                       Enable policy enforcement (default "default")
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                   Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags stringToString                                 Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
+      --eni-tags stringToString                                    ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
+      --excess-ip-release-delay int                                Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for cilium-operator-aws
+      --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                                Backend to use for IPAM (default "eni")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                         Logging endpoints to use for example syslog
+      --log-opt map                                                Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                                cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
+      --version                                                    Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,115 +11,118 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags stringToString                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
-      --eni-tags stringToString                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
+      --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                   Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags stringToString                                 Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
+      --eni-tags stringToString                                    ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
+      --excess-ip-release-delay int                                Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for hive
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,114 +17,117 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags stringToString                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
-      --eni-tags stringToString                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
+      --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                   Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags stringToString                                 Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
+      --eni-tags stringToString                                    ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
+      --excess-ip-release-delay int                                Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -11,148 +11,151 @@ cilium-operator-azure [flags]
 ### Options
 
 ```
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-selector-labels                          Enable use of node label based identity
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-azure
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "azure")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
-      --version                                              Print version information
+      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-subscription-id string                               Subscription ID to access Azure API
+      --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                   Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                                Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --cluster-pool-ipv4-cidr strings                             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --config string                                              Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                          Configuration directory that contains a file for each option
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                      Enable debugging mode
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-ipv4                                                Enable IPv4 support (default true)
+      --enable-ipv6                                                Enable IPv6 support (default true)
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l7-proxy                                            Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-node-selector-labels                                Enable use of node label based identity
+      --enable-policy string                                       Enable policy enforcement (default "default")
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for cilium-operator-azure
+      --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                                Backend to use for IPAM (default "azure")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                         Logging endpoints to use for example syslog
+      --log-opt map                                                Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                                cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
+      --version                                                    Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,110 +11,113 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-subscription-id string                               Subscription ID to access Azure API
+      --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for hive
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,109 +17,112 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-subscription-id string                               Subscription ID to access Azure API
+      --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -11,145 +11,148 @@ cilium-operator-generic [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools stringToString       Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-selector-labels                          Enable use of node label based identity
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator-generic
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
-      --version                                              Print version information
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                   Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                                Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --cluster-pool-ipv4-cidr strings                             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --config string                                              Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                          Configuration directory that contains a file for each option
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                      Enable debugging mode
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-ipv4                                                Enable IPv4 support (default true)
+      --enable-ipv6                                                Enable IPv6 support (default true)
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l7-proxy                                            Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-node-selector-labels                                Enable use of node label based identity
+      --enable-policy string                                       Enable policy enforcement (default "default")
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for cilium-operator-generic
+      --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                                Backend to use for IPAM (default "cluster-pool")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                         Logging endpoints to use for example syslog
+      --log-opt map                                                Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                                cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
+      --version                                                    Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,107 +11,110 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools stringToString       Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for hive
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,106 +17,109 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --auto-create-cilium-pod-ip-pools stringToString       Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -11,160 +11,163 @@ cilium-operator [flags]
 ### Options
 
 ```
-      --alibaba-cloud-release-excess-ips                     Enable releasing excess free IP addresses from Alibaba Cloud ENI.
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools stringToString       Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
-      --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
-      --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --cluster-pool-ipv4-cidr strings                       IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
-      --cluster-pool-ipv4-mask-size int                      Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
-      --cluster-pool-ipv6-cidr strings                       IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
-      --cluster-pool-ipv6-mask-size int                      Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --config string                                        Configuration file (default "$HOME/ciliumd.yaml")
-      --config-dir string                                    Configuration directory that contains a file for each option
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-  -D, --debug                                                Enable debugging mode
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-ipv4                                          Enable IPv4 support (default true)
-      --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-l7-proxy                                      Enable L7 proxy for L7 policy enforcement (default true)
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-metrics                                       Enable Prometheus metrics
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-node-selector-labels                          Enable use of node label based identity
-      --enable-policy string                                 Enable policy enforcement (default "default")
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags stringToString                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
-      --eni-tags stringToString                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for cilium-operator
-      --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --ipam string                                          Backend to use for IPAM (default "cluster-pool")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-namespace string                                 Name of the Kubernetes namespace in which Cilium Operator is deployed in
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --leader-election-lease-duration duration              Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
-      --leader-election-renew-deadline duration              Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
-      --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
-      --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
-      --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --log-driver strings                                   Logging endpoints to use for example syslog
-      --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --pod-restart-selector string                          cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --remove-cilium-node-taints                            Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
-      --set-cilium-is-up-condition                           Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                               Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --subnet-ids-filter strings                            Subnets IDs (separated by commas)
-      --subnet-tags-filter map                               Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                               Number of workers used to synchronize node tains and conditions (default 10)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
-      --version                                              Print version information
+      --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
+      --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
+      --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
+      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-subscription-id string                               Subscription ID to access Azure API
+      --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)
+      --cilium-pod-labels string                                   Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
+      --cilium-pod-namespace string                                Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --cluster-pool-ipv4-cidr strings                             IPv4 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv4=true'
+      --cluster-pool-ipv4-mask-size int                            Mask size for each IPv4 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv4=true' (default 24)
+      --cluster-pool-ipv6-cidr strings                             IPv6 CIDR Range for Pods in cluster. Requires 'ipam=cluster-pool' and 'enable-ipv6=true'
+      --cluster-pool-ipv6-mask-size int                            Mask size for each IPv6 podCIDR per node. Requires 'ipam=cluster-pool' and 'enable-ipv6=true' (default 112)
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --config string                                              Configuration file (default "$HOME/ciliumd.yaml")
+      --config-dir string                                          Configuration directory that contains a file for each option
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+  -D, --debug                                                      Enable debugging mode
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-ipv4                                                Enable IPv4 support (default true)
+      --enable-ipv6                                                Enable IPv6 support (default true)
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l7-proxy                                            Enable L7 proxy for L7 policy enforcement (default true)
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-node-selector-labels                                Enable use of node label based identity
+      --enable-policy string                                       Enable policy enforcement (default "default")
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                   Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags stringToString                                 Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
+      --eni-tags stringToString                                    ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
+      --excess-ip-release-delay int                                Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for cilium-operator
+      --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --ipam string                                                Backend to use for IPAM (default "cluster-pool")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-namespace string                                       Name of the Kubernetes namespace in which Cilium Operator is deployed in
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
+      --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --log-driver strings                                         Logging endpoints to use for example syslog
+      --log-opt map                                                Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --pod-restart-selector string                                cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
+      --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
+      --version                                                    Print version information
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,122 +11,125 @@ cilium-operator hive [flags]
 ### Options
 
 ```
-      --alibaba-cloud-release-excess-ips                     Enable releasing excess free IP addresses from Alibaba Cloud ENI.
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools stringToString       Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags stringToString                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
-      --eni-tags stringToString                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-  -h, --help                                                 help for hive
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
+      --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
+      --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
+      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-subscription-id string                               Subscription ID to access Azure API
+      --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                   Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags stringToString                                 Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
+      --eni-tags stringToString                                    ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
+      --excess-ip-release-delay int                                Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+  -h, --help                                                       help for hive
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,121 +17,124 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --alibaba-cloud-release-excess-ips                     Enable releasing excess free IP addresses from Alibaba Cloud ENI.
-      --alibaba-cloud-vpc-id string                          Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools stringToString       Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
-      --aws-enable-prefix-delegation                         Allows operator to allocate prefixes to ENIs instead of individual IP addresses
-      --aws-max-results-per-call int32                       Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
-      --aws-release-excess-ips                               Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                          Resource group to use for Azure IPAM
-      --azure-subscription-id string                         Subscription ID to access Azure API
-      --azure-use-primary-address                            Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
-      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
-      --ces-rate-limits string                               Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
-      --cluster-id uint32                                    Unique identifier of the cluster
-      --cluster-name string                                  Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
-      --clustermesh-cache-ttl duration                       The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
-      --clustermesh-concurrent-service-endpoint-syncs int    The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
-      --clustermesh-config string                            Path to the ClusterMesh configuration directory
-      --clustermesh-default-global-namespace                 Mark all namespaces as global by default unless overridden by annotation (default true)
-      --clustermesh-enable-endpoint-sync                     Whether or not the endpoint slice cluster mesh synchronization is enabled.
-      --clustermesh-enable-mcs-api                           Enable Cluster Mesh MCS-API support
-      --clustermesh-endpoint-updates-batch-period duration   The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
-      --clustermesh-endpoints-per-slice int                  The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
-      --clustermesh-mcs-api-install-crds                     Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
-      --clustermesh-sync-timeout duration                    Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
-      --controller-group-metrics strings                     List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
-      --default-lb-service-ipam string                       Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
-      --double-write-metric-reporter-interval duration       Refresh interval for the Double Write Metric Reporter (default 1m0s)
-      --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
-      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-gateway-api-alpn                              Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
-      --enable-gateway-api-app-protocol                      Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
-      --enable-gateway-api-proxy-protocol                    Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
-      --enable-gops                                          Enable gops server (default true)
-      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
-      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
-      --enable-ipsec                                         Enable IPsec
-      --enable-k8s                                           Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
-      --enable-lb-ipam                                       Enable LB IPAM (default true)
-      --enable-node-ipam                                     Enable Node IPAM
-      --enable-policy-secrets-sync                           Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
-      --enable-wireguard                                     Enable WireGuard
-      --enable-ztunnel                                       Use zTunnel as Cilium's encryption infrastructure
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
-      --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
-      --eni-gc-tags stringToString                           Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
-      --eni-tags stringToString                              ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
-      --excess-ip-release-delay int                          Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
-      --gateway-api-hostnetwork-enabled                      Exposes Gateway listeners on the host network.
-      --gateway-api-hostnetwork-nodelabelselector string     Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
-      --gateway-api-service-externaltrafficpolicy string     Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
-      --gateway-api-xff-num-trusted-hops uint32              The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --gops-port uint16                                     Port for gops server to listen on (default 9891)
-      --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
-      --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
-      --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
-      --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
-      --identity-management-mode string                      Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
-      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
-      --ingress-default-request-timeout duration             Default request timeout for Ingress.
-      --ingress-default-secret-name string                   Default secret name for Ingress.
-      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
-      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-hostnetwork-enabled                          Exposes ingress listeners on the host network.
-      --ingress-hostnetwork-nodelabelselector string         Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
-      --ingress-hostnetwork-shared-listener-port uint32      Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
-      --ingress-lb-annotation-prefixes strings               Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
-      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
-      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
-      --k8s-api-server-urls strings                          Kubernetes API server URLs
-      --k8s-client-connection-keep-alive duration            Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
-      --k8s-client-connection-timeout duration               Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
-      --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
-      --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
-      --kvstore string                                       Key-value store type
-      --kvstore-lease-ttl duration                           Time-to-live for the KVstore lease. (default 15m0s)
-      --kvstore-max-consecutive-quorum-errors uint           Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
-      --kvstore-opt stringToString                           Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
-      --loadbalancer-l7 string                               Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
-      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
-      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
-      --max-connected-clusters uint32                        Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
-      --mesh-auth-enabled                                    Enable authentication processing & garbage collection (beta)
-      --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
-      --metrics-sampling-interval duration                   Set the internal metrics sampling interval (default 5m0s)
-      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
-      --operator-k8s-client-burst int                        Burst value allowed for the K8s client (default 200)
-      --operator-k8s-client-qps float32                      Queries per second limit for the K8s client (default 100)
-      --operator-pprof                                       Enable serving pprof debugging API
-      --operator-pprof-address string                        Address that pprof listens on (default "localhost")
-      --operator-pprof-block-profile-rate int                Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
-      --operator-pprof-mutex-profile-fraction int            Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
-      --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
-      --operator-prometheus-enable-tls                       Enable TLS for prometheus server
-      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
-      --operator-prometheus-tls-cert-file string             Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
-      --operator-prometheus-tls-client-ca-files strings      Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
-      --operator-prometheus-tls-key-file string              Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
-      --parallel-alloc-workers int                           Maximum number of parallel IPAM workers (default 50)
-      --policy-default-local-cluster                         Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
-      --policy-secrets-namespace string                      Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
-      --shell-sock-path string                               Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
-      --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
-      --synchronize-k8s-nodes                                Perform GC of stale node entries from the KVStore (default true)
-      --unmanaged-pod-watcher-interval duration              Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
-      --validate-network-policy                              Whether to enable or disable the informational network policy validator (default true)
+      --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
+      --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
+      --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
+      --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
+      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
+      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-subscription-id string                               Subscription ID to access Azure API
+      --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
+      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
+      --cluster-id uint32                                          Unique identifier of the cluster
+      --cluster-name string                                        Name of the cluster. It must consist of at most 32 lower case alphanumeric characters and '-', start and end with an alphanumeric character. (default "default")
+      --clustermesh-cache-ttl duration                             The time to live for the cache of a remote cluster after connectivity is lost. If the connection is not re-established within this duration, the cached data is revoked to prevent stale state. If not specified or set to 0s, the cache is never revoked.
+      --clustermesh-concurrent-service-endpoint-syncs int          The number of remote cluster service syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. (default 5)
+      --clustermesh-config string                                  Path to the ClusterMesh configuration directory
+      --clustermesh-default-global-namespace                       Mark all namespaces as global by default unless overridden by annotation (default true)
+      --clustermesh-enable-endpoint-sync                           Whether or not the endpoint slice cluster mesh synchronization is enabled.
+      --clustermesh-enable-mcs-api                                 Enable Cluster Mesh MCS-API support
+      --clustermesh-endpoint-updates-batch-period duration         The length of endpoint slice updates batching period for remote cluster services. Processing of pod changes will be delayed by this duration to join them with potential upcoming updates and reduce the overall number of endpoints updates. Larger number = higher endpoint programming latency, but lower number of endpoints revision generated. (default 500ms)
+      --clustermesh-endpoints-per-slice int                        The maximum number of endpoints that will be added to a remote cluster's EndpointSlice . More endpoints per slice will result in less endpoint slices, but larger resources. (default 100)
+      --clustermesh-mcs-api-install-crds                           Install and manage the MCS API CRDs. Only applicable if MCS API support is enabled. (default true)
+      --clustermesh-sync-timeout duration                          Timeout waiting for the initial synchronization of information from remote clusters (default 1m0s)
+      --controller-group-metrics strings                           List of controller group names for which to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
+      --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
+      --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
+      --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
+      --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
+      --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-gateway-api-secrets-sync                            Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-gops                                                Enable gops server (default true)
+      --enable-ingress-controller                                  Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                              Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                                Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+      --enable-ipsec                                               Enable IPsec
+      --enable-k8s                                                 Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-node-ipam                                           Enable Node IPAM
+      --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
+      --enable-wireguard                                           Enable WireGuard
+      --enable-ztunnel                                             Use zTunnel as Cilium's encryption infrastructure
+      --enforce-ingress-https                                      Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+      --eni-gc-interval duration                                   Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
+      --eni-gc-tags stringToString                                 Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected (default [])
+      --eni-tags stringToString                                    ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag) (default [])
+      --excess-ip-release-delay int                                Number of seconds operator would wait before it releases an IP previously marked as excess (default 180)
+      --gateway-api-hostnetwork-enabled                            Exposes Gateway listeners on the host network.
+      --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+      --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
+      --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
+      --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
+      --identity-heartbeat-timeout duration                        Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --identity-management-mode string                            Configure whether Cilium Identities are managed by cilium-agent, cilium-operator, or both (default "agent")
+      --ingress-default-lb-mode string                             Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-request-timeout duration                   Default request timeout for Ingress.
+      --ingress-default-secret-name string                         Default secret name for Ingress.
+      --ingress-default-secret-namespace string                    Default secret namespace for Ingress.
+      --ingress-default-xff-num-trusted-hops uint32                The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+      --ingress-hostnetwork-enabled                                Exposes ingress listeners on the host network.
+      --ingress-hostnetwork-http-listener-port uint32              Port on the host network that gets used for the shared HTTP listener
+      --ingress-hostnetwork-https-listener-port uint32             Port on the host network that gets used for the shared HTTPS listener
+      --ingress-hostnetwork-nodelabelselector string               Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
+      --ingress-hostnetwork-shared-listener-port uint32            Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)
+      --ingress-hostnetwork-tls-passthrough-listener-port uint32   Port on the host network that gets used for the shared TLS passthrough listener
+      --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --k8s-api-server-urls strings                                Kubernetes API server URLs
+      --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
+      --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
+      --k8s-heartbeat-timeout duration                             Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                                 Absolute path of the kubernetes kubeconfig file
+      --k8s-service-proxy-name string                              Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --kvstore string                                             Key-value store type
+      --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
+      --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
+      --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
+      --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.
+      --max-connected-clusters uint32                              Maximum number of clusters to be connected in a clustermesh. Increasing this value will reduce the maximum number of identities available. Valid configurations are [255, 511]. (default 255)
+      --mesh-auth-enabled                                          Enable authentication processing & garbage collection (beta)
+      --mesh-auth-mutual-enabled                                   The flag to enable mutual authentication for the SPIRE server (beta).
+      --mesh-auth-spiffe-trust-domain string                       The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-agent-socket string                        The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
+      --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
+      --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
+      --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
+      --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)
+      --operator-pprof                                             Enable serving pprof debugging API
+      --operator-pprof-address string                              Address that pprof listens on (default "localhost")
+      --operator-pprof-block-profile-rate int                      Enable goroutine blocking profiling and set the rate of sampled events in nanoseconds (set to 1 to sample all events [warning: performance overhead])
+      --operator-pprof-mutex-profile-fraction int                  Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
+      --operator-pprof-port uint16                                 Port that pprof listens on (default 6061)
+      --operator-prometheus-enable-tls                             Enable TLS for prometheus server
+      --operator-prometheus-serve-addr string                      Address to serve Prometheus metrics (default ":9963")
+      --operator-prometheus-tls-cert-file string                   Path to TLS certificate file for prometheus server. The file must contain PEM encoded data
+      --operator-prometheus-tls-client-ca-files strings            Path to one or more TLS client CA certificates files to use for TLS with mutual authentication (mTLS) for prometheus server. The files must contain PEM encoded data. When provided, this option effectively enables mTLS.
+      --operator-prometheus-tls-key-file string                    Path to TLS private key file for prometheus server. The file must contain PEM encoded data.
+      --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
+      --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
+      --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
+      --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
+      --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
+      --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```
 
 ### SEE ALSO

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2744,6 +2744,14 @@
      - Configure whether the Envoy listeners should be exposed on the host network.
      - bool
      - ``false``
+   * - :spelling:ignore:`ingressController.hostNetwork.httpPort`
+     - Configure a specific port on the host network that gets used for the shared HTTP listener. If unset or 0, sharedListenerPort is used.
+     - int
+     - ``0``
+   * - :spelling:ignore:`ingressController.hostNetwork.httpsPort`
+     - Configure a specific port on the host network that gets used for the shared HTTPS listener. If unset or 0, sharedListenerPort is used.
+     - int
+     - ``0``
    * - :spelling:ignore:`ingressController.hostNetwork.nodes.matchLabels`
      - Specify the labels of the nodes where the Ingress listeners should be exposed  matchLabels:   kubernetes.io/os: linux   kubernetes.io/hostname: kind-worker
      - object
@@ -2752,6 +2760,10 @@
      - Configure a specific port on the host network that gets used for the shared listener.
      - int
      - ``8080``
+   * - :spelling:ignore:`ingressController.hostNetwork.tlsPassthroughPort`
+     - Configure a specific port on the host network that gets used for the shared TLS passthrough listener. If unset or 0, sharedListenerPort is used.
+     - int
+     - ``0``
    * - :spelling:ignore:`ingressController.ingressLBAnnotationPrefixes`
      - IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service
      - list

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -246,6 +246,9 @@ Once enabled, host network ports can be specified with the following methods:
 
 * Shared Ingress: Globally via Helm flags
     * ``ingressController.hostNetwork.sharedListenerPort``: Host network port to expose the Cilium ingress controller Envoy listener. The default port is ``8080``. If you change it, you should choose a port number higher than ``1023`` (see `Bind to privileged port`_).
+    * ``ingressController.hostNetwork.httpPort``: Host network port to expose the shared HTTP listener. If unset or ``0``, ``sharedListenerPort`` is used.
+    * ``ingressController.hostNetwork.httpsPort``: Host network port to expose the shared HTTPS listener. If unset or ``0``, ``sharedListenerPort`` is used.
+    * ``ingressController.hostNetwork.tlsPassthroughPort``: Host network port to expose the shared TLS passthrough listener. If unset or ``0``, ``sharedListenerPort`` is used.
 * Dedicated Ingress: Per ``Ingress`` resource via annotations
     * ``ingress.cilium.io/host-listener-port``:  Host network port to expose the Cilium ingress controller Envoy listener. The default port is ``8080`` but it can only be used for a single ``Ingress`` resource as it needs to be unique per ``Ingress`` resource. You should choose a port higher than ``1023`` (see `Bind to privileged port`_). This annotation is mandatory if the global Cilium ingress controller mode is configured to ``dedicated`` (``ingressController.loadbalancerMode``) or the ingress resource sets the ``ingress.cilium.io/loadbalancer-mode`` annotation to ``dedicated`` and multiple ``Ingress`` resources are deployed.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -753,6 +753,7 @@ setrlimit
 sfc
 sg
 sha
+sharedListenerPort
 sid
 sig
 skb

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -736,8 +736,11 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
 | ingressController.hostNetwork.enabled | bool | `false` | Configure whether the Envoy listeners should be exposed on the host network. |
+| ingressController.hostNetwork.httpPort | int | `0` | Configure a specific port on the host network that gets used for the shared HTTP listener. If unset or 0, sharedListenerPort is used. |
+| ingressController.hostNetwork.httpsPort | int | `0` | Configure a specific port on the host network that gets used for the shared HTTPS listener. If unset or 0, sharedListenerPort is used. |
 | ingressController.hostNetwork.nodes.matchLabels | object | `{}` | Specify the labels of the nodes where the Ingress listeners should be exposed  matchLabels:   kubernetes.io/os: linux   kubernetes.io/hostname: kind-worker |
 | ingressController.hostNetwork.sharedListenerPort | int | `8080` | Configure a specific port on the host network that gets used for the shared listener. |
+| ingressController.hostNetwork.tlsPassthroughPort | int | `0` | Configure a specific port on the host network that gets used for the shared TLS passthrough listener. If unset or 0, sharedListenerPort is used. |
 | ingressController.ingressLBAnnotationPrefixes | list | `["lbipam.cilium.io","nodeipam.cilium.io","service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service |
 | ingressController.loadbalancerMode | string | `"dedicated"` | Default ingress load balancer mode Supported values: shared, dedicated For granular control, use the following annotations on the ingress resource: "ingress.cilium.io/loadbalancer-mode: dedicated" (or "shared"). |
 | ingressController.secretsNamespace | object | `{"create":true,"name":"cilium-secrets","sync":true}` | SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -291,6 +291,9 @@ data:
   {{- end }}
   ingress-hostnetwork-enabled: {{ .Values.ingressController.hostNetwork.enabled | quote }}
   ingress-hostnetwork-shared-listener-port: {{ .Values.ingressController.hostNetwork.sharedListenerPort | quote }}
+  ingress-hostnetwork-http-listener-port: {{ .Values.ingressController.hostNetwork.httpPort | quote }}
+  ingress-hostnetwork-https-listener-port: {{ .Values.ingressController.hostNetwork.httpsPort | quote }}
+  ingress-hostnetwork-tls-passthrough-listener-port: {{ .Values.ingressController.hostNetwork.tlsPassthroughPort | quote }}
   ingress-hostnetwork-nodelabelselector: {{ include "mapToString" .Values.ingressController.hostNetwork.nodes.matchLabels | quote }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4263,6 +4263,12 @@
             "enabled": {
               "type": "boolean"
             },
+            "httpPort": {
+              "type": "integer"
+            },
+            "httpsPort": {
+              "type": "integer"
+            },
             "nodes": {
               "properties": {
                 "matchLabels": {
@@ -4272,6 +4278,9 @@
               "type": "object"
             },
             "sharedListenerPort": {
+              "type": "integer"
+            },
+            "tlsPassthroughPort": {
               "type": "integer"
             }
           },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1037,6 +1037,15 @@ ingressController:
     enabled: false
     # -- Configure a specific port on the host network that gets used for the shared listener.
     sharedListenerPort: 8080
+    # -- Configure a specific port on the host network that gets used for the shared HTTP listener.
+    # If unset or 0, sharedListenerPort is used.
+    httpPort: 0
+    # -- Configure a specific port on the host network that gets used for the shared HTTPS listener.
+    # If unset or 0, sharedListenerPort is used.
+    httpsPort: 0
+    # -- Configure a specific port on the host network that gets used for the shared TLS passthrough listener.
+    # If unset or 0, sharedListenerPort is used.
+    tlsPassthroughPort: 0
     # Specify the nodes where the Ingress listeners should be exposed
     nodes:
       # -- Specify the labels of the nodes where the Ingress listeners should be exposed

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1045,6 +1045,15 @@ ingressController:
     enabled: false
     # -- Configure a specific port on the host network that gets used for the shared listener.
     sharedListenerPort: 8080
+    # -- Configure a specific port on the host network that gets used for the shared HTTP listener.
+    # If unset or 0, sharedListenerPort is used.
+    httpPort: 0
+    # -- Configure a specific port on the host network that gets used for the shared HTTPS listener.
+    # If unset or 0, sharedListenerPort is used.
+    httpsPort: 0
+    # -- Configure a specific port on the host network that gets used for the shared TLS passthrough listener.
+    # If unset or 0, sharedListenerPort is used.
+    tlsPassthroughPort: 0
     # Specify the nodes where the Ingress listeners should be exposed
     nodes:
       # -- Specify the labels of the nodes where the Ingress listeners should be exposed

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -38,30 +38,36 @@ var Cell = cell.Module(
 		IngressSharedLBServiceName:   "cilium-ingress",
 		IngressDefaultLBMode:         "dedicated",
 
-		IngressHostnetworkEnabled:            false,
-		IngressHostnetworkSharedListenerPort: 0,
-		IngressHostnetworkNodelabelselector:  "",
+		IngressHostnetworkEnabled:                    false,
+		IngressHostnetworkSharedListenerPort:         0,
+		IngressHostnetworkHTTPListenerPort:           0,
+		IngressHostnetworkHTTPSListenerPort:          0,
+		IngressHostnetworkTLSPassthroughListenerPort: 0,
+		IngressHostnetworkNodelabelselector:          "",
 	}),
 	cell.Invoke(registerReconciler),
 	cell.Provide(registerSecretSync),
 )
 
 type IngressConfig struct {
-	EnableIngressController              bool
-	EnforceIngressHTTPS                  bool
-	EnableIngressProxyProtocol           bool
-	EnableIngressSecretsSync             bool
-	IngressSecretsNamespace              string
-	IngressLBAnnotationPrefixes          []string
-	IngressSharedLBServiceName           string
-	IngressDefaultLBMode                 string
-	IngressDefaultSecretNamespace        string
-	IngressDefaultSecretName             string
-	IngressDefaultRequestTimeout         time.Duration
-	IngressHostnetworkEnabled            bool
-	IngressHostnetworkSharedListenerPort uint32
-	IngressHostnetworkNodelabelselector  string
-	IngressDefaultXffNumTrustedHops      uint32
+	EnableIngressController                      bool
+	EnforceIngressHTTPS                          bool
+	EnableIngressProxyProtocol                   bool
+	EnableIngressSecretsSync                     bool
+	IngressSecretsNamespace                      string
+	IngressLBAnnotationPrefixes                  []string
+	IngressSharedLBServiceName                   string
+	IngressDefaultLBMode                         string
+	IngressDefaultSecretNamespace                string
+	IngressDefaultSecretName                     string
+	IngressDefaultRequestTimeout                 time.Duration
+	IngressHostnetworkEnabled                    bool
+	IngressHostnetworkSharedListenerPort         uint32
+	IngressHostnetworkHTTPListenerPort           uint32
+	IngressHostnetworkHTTPSListenerPort          uint32
+	IngressHostnetworkTLSPassthroughListenerPort uint32
+	IngressHostnetworkNodelabelselector          string
+	IngressDefaultXffNumTrustedHops              uint32
 }
 
 func (r IngressConfig) Flags(flags *pflag.FlagSet) {
@@ -78,6 +84,9 @@ func (r IngressConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration("ingress-default-request-timeout", r.IngressDefaultRequestTimeout, "Default request timeout for Ingress.")
 	flags.Bool("ingress-hostnetwork-enabled", r.IngressHostnetworkEnabled, "Exposes ingress listeners on the host network.")
 	flags.Uint32("ingress-hostnetwork-shared-listener-port", r.IngressHostnetworkSharedListenerPort, "Port on the host network that gets used for the shared listener (HTTP, HTTPS & TLS passthrough)")
+	flags.Uint32("ingress-hostnetwork-http-listener-port", r.IngressHostnetworkHTTPListenerPort, "Port on the host network that gets used for the shared HTTP listener")
+	flags.Uint32("ingress-hostnetwork-https-listener-port", r.IngressHostnetworkHTTPSListenerPort, "Port on the host network that gets used for the shared HTTPS listener")
+	flags.Uint32("ingress-hostnetwork-tls-passthrough-listener-port", r.IngressHostnetworkTLSPassthroughListenerPort, "Port on the host network that gets used for the shared TLS passthrough listener")
 	flags.String("ingress-hostnetwork-nodelabelselector", r.IngressHostnetworkNodelabelselector, "Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
 	flags.Uint32("ingress-default-xff-num-trusted-hops", r.IngressDefaultXffNumTrustedHops, "The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
 }
@@ -153,6 +162,9 @@ func registerReconciler(params ingressParams) error {
 
 		params.IngressConfig.IngressHostnetworkEnabled,
 		params.IngressConfig.IngressHostnetworkSharedListenerPort,
+		params.IngressConfig.IngressHostnetworkHTTPListenerPort,
+		params.IngressConfig.IngressHostnetworkHTTPSListenerPort,
+		params.IngressConfig.IngressHostnetworkTLSPassthroughListenerPort,
 	)
 
 	if err := reconciler.SetupWithManager(params.CtrlRuntimeManager); err != nil {

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -43,8 +43,11 @@ type ingressReconciler struct {
 	enforcedHTTPS           bool
 	defaultRequestTimeout   time.Duration
 
-	hostNetworkEnabled    bool
-	hostNetworkSharedPort uint32
+	hostNetworkEnabled            bool
+	hostNetworkSharedPort         uint32
+	hostNetworkHTTPPort           uint32
+	hostNetworkHTTPSPort          uint32
+	hostNetworkTLSPassthroughPort uint32
 
 	cecTranslator       translation.CECTranslator
 	dedicatedTranslator translation.Translator
@@ -65,6 +68,9 @@ func newIngressReconciler(
 	defaultRequestTimeout time.Duration,
 	hostNetworkEnabled bool,
 	hostNetworkSharedPort uint32,
+	hostNetworkHTTPPort uint32,
+	hostNetworkHTTPSPort uint32,
+	hostNetworkTLSPassthroughPort uint32,
 ) *ingressReconciler {
 	return &ingressReconciler{
 		logger: logger,
@@ -82,8 +88,11 @@ func newIngressReconciler(
 		enforcedHTTPS:           enforcedHTTPS,
 		defaultRequestTimeout:   defaultRequestTimeout,
 
-		hostNetworkEnabled:    hostNetworkEnabled,
-		hostNetworkSharedPort: hostNetworkSharedPort,
+		hostNetworkEnabled:            hostNetworkEnabled,
+		hostNetworkSharedPort:         hostNetworkSharedPort,
+		hostNetworkHTTPPort:           hostNetworkHTTPPort,
+		hostNetworkHTTPSPort:          hostNetworkHTTPSPort,
+		hostNetworkTLSPassthroughPort: hostNetworkTLSPassthroughPort,
 	}
 }
 

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -237,11 +237,17 @@ func (r *ingressReconciler) getSharedListenerPorts() (uint32, uint32, uint32) {
 		return defaultPassthroughPort, defaultInsecureHTTPPort, defaultSecureHTTPPort
 	}
 
-	if r.hostNetworkSharedPort > 0 {
-		return r.hostNetworkSharedPort, r.hostNetworkSharedPort, r.hostNetworkSharedPort
-	}
+	return r.effectiveHostNetworkPort(r.hostNetworkTLSPassthroughPort), r.effectiveHostNetworkPort(r.hostNetworkHTTPPort), r.effectiveHostNetworkPort(r.hostNetworkHTTPSPort)
+}
 
-	return defaultHostNetworkListenerPort, defaultHostNetworkListenerPort, defaultHostNetworkListenerPort
+func (r *ingressReconciler) effectiveHostNetworkPort(port uint32) uint32 {
+	if port > 0 {
+		return port
+	}
+	if r.hostNetworkSharedPort > 0 {
+		return r.hostNetworkSharedPort
+	}
+	return defaultHostNetworkListenerPort
 }
 
 func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress *networkingv1.Ingress, scopedLog *slog.Logger) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -77,7 +77,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -129,7 +129,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -181,7 +181,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -225,7 +225,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -295,7 +295,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -362,7 +362,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -416,7 +416,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -498,7 +498,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -556,7 +556,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -597,7 +597,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -656,7 +656,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -712,7 +712,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -752,7 +752,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -793,7 +793,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{"test.acme.io/"}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -866,7 +866,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -924,7 +924,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -966,7 +966,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -1024,7 +1024,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := translation.NewCECTranslator(cfg)
 		dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -1066,7 +1066,7 @@ func TestReconcile(t *testing.T) {
 
 		cecTranslator := &fakeCECTranslator{}
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, nil, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 55555)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, nil, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 55555, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -1106,7 +1106,7 @@ func TestReconcile(t *testing.T) {
 		cecTranslator := &fakeCECTranslator{}
 		dedicatedIngressTranslator := &fakeDedicatedIngressTranslator{}
 
-		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 0)
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, true, 0, 0, 0, 0)
 
 		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 			NamespacedName: types.NamespacedName{
@@ -1168,6 +1168,9 @@ func TestGetSharedListenerPorts(t *testing.T) {
 		desc                     string
 		hostNetworkEnabled       bool
 		hostNetworkSharedPort    uint32
+		hostNetworkHTTPPort      uint32
+		hostNetworkHTTPSPort     uint32
+		hostNetworkTLSPort       uint32
 		expectedPassthroughPort  uint32
 		expectedInsecureHTTPPort uint32
 		expectedSecureHTTPPort   uint32
@@ -1195,12 +1198,26 @@ func TestGetSharedListenerPorts(t *testing.T) {
 			expectedInsecureHTTPPort: 55555,
 			expectedSecureHTTPPort:   55555,
 		},
+		{
+			desc:                     "external loadbalancer with per-protocol ports",
+			hostNetworkEnabled:       true,
+			hostNetworkSharedPort:    55555,
+			hostNetworkHTTPPort:      80,
+			hostNetworkHTTPSPort:     443,
+			hostNetworkTLSPort:       8443,
+			expectedPassthroughPort:  8443,
+			expectedInsecureHTTPPort: 80,
+			expectedSecureHTTPPort:   443,
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			ir := ingressReconciler{
-				hostNetworkEnabled:    tC.hostNetworkEnabled,
-				hostNetworkSharedPort: tC.hostNetworkSharedPort,
+				hostNetworkEnabled:            tC.hostNetworkEnabled,
+				hostNetworkSharedPort:         tC.hostNetworkSharedPort,
+				hostNetworkHTTPPort:           tC.hostNetworkHTTPPort,
+				hostNetworkHTTPSPort:          tC.hostNetworkHTTPSPort,
+				hostNetworkTLSPassthroughPort: tC.hostNetworkTLSPort,
 			}
 
 			passthrough, insecureHTTP, secureHTTP := ir.getSharedListenerPorts()


### PR DESCRIPTION
HostNetwork mode previously forced HTTP/HTTPS/TLS passthrough to share a single listener port. Introduce per-protocol overrides so users can configure distinct ports while keeping the shared port as the fallback.

Fixes: #39422

```release-note
ingress: allow per-protocol port overrides for HTTP, HTTPS and TLS passthrough in the HostNetwork mode.
```
