### PR TITLE
python: Add linter and formatter to the codebase

### DIFF
--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -1,0 +1,46 @@
+name: Python Related Checks
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request: {}
+  push:
+    branches:
+    - main
+    - ft/main/**
+  # Add this workflow to be triggered by merge queue events
+  merge_group:
+
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after || github.event.merge_group && github.run_id }}
+  cancel-in-progress: ${{ !github.event.merge_group }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+
+    - name: Run Ruff Check
+      run: |
+        make lint-python || (echo "please run 'make lint-python', adjust code accordingly (manual and/or 'make lint-python-fix') and submit your changes"; exit 1)
+
+    - name: Run Ruff Format
+      run: |
+        make format-python || (echo "please run 'make format-python', adjust code accordingly (manual and/or 'make format-python-fix') and submit your changes"; exit 1)

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,23 @@ bpf/.cache
 # Files used for direnv
 .direnv
 .envrc
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+*.egg-info/
+.pytest_cache/
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# ruff
+.ruff_cache/

--- a/Documentation/_exts/cilium_external_links.py
+++ b/Documentation/_exts/cilium_external_links.py
@@ -1,5 +1,6 @@
 from sphinx.writers.html5 import HTML5Translator
 
+
 # Make all external links open in new tabs
 class PatchedHTMLTranslator(HTML5Translator):
     def starttag(self, node, tagname, *args, **attrs):

--- a/Documentation/_exts/cilium_helm_directive.py
+++ b/Documentation/_exts/cilium_helm_directive.py
@@ -54,21 +54,21 @@ class CiliumHelmInstallDirective(SphinxDirective):
     final_argument_whitespace = False
 
     option_spec = {
-        'namespace': directives.unchanged,
-        'set': directives.unchanged,
-        'command': directives.unchanged,
-        'name': directives.unchanged,
-        'extra-args': directives.unchanged,
-        'post-helm-commands': directives.unchanged,
-        'post-commands': directives.unchanged,
+        "namespace": directives.unchanged,
+        "set": directives.unchanged,
+        "command": directives.unchanged,
+        "name": directives.unchanged,
+        "extra-args": directives.unchanged,
+        "post-helm-commands": directives.unchanged,
+        "post-commands": directives.unchanged,
     }
 
     def _parse_set_options(self):
         """Parse --set options from newlines/spaces."""
-        if 'set' not in self.options:
+        if "set" not in self.options:
             return []
         opts = []
-        for line in self.options['set'].split('\n'):
+        for line in self.options["set"].split("\n"):
             opts.extend(item for item in line.strip().split() if item)
         return opts
 
@@ -76,84 +76,85 @@ class CiliumHelmInstallDirective(SphinxDirective):
         """Build the list of helm command options."""
         opts = []
         if namespace:
-            opts.append(f'--namespace {namespace}')
+            opts.append(f"--namespace {namespace}")
         if extra_args:
             opts.append(extra_args)
-        opts.extend(f'--set {opt}' for opt in set_options)
+        opts.extend(f"--set {opt}" for opt in set_options)
         return opts
 
-    def _format_command(self, base_cmd, opts, indent, post_helm_commands='', post_commands=''):
+    def _format_command(
+        self, base_cmd, opts, indent, post_helm_commands="", post_commands=""
+    ):
         """Format a helm command with proper line continuation."""
         # Parse post_helm_commands (these get line continuation like helm args)
         post_helm_lines = []
         if post_helm_commands:
-            for line in post_helm_commands.split('\n'):
+            for line in post_helm_commands.split("\n"):
                 if line:
                     post_helm_lines.append(line)
 
         # Parse post_commands (these don't get line continuation)
         post_cmd_lines = []
         if post_commands:
-            for line in post_commands.split('\n'):
+            for line in post_commands.split("\n"):
                 if line:
                     post_cmd_lines.append(line)
 
         if not opts and not post_helm_lines and not post_cmd_lines:
-            return f'{indent}{base_cmd}'
+            return f"{indent}{base_cmd}"
 
         has_post_helm = len(post_helm_lines) > 0
         has_post_cmd = len(post_cmd_lines) > 0
 
-        lines = [f'{indent}{base_cmd} \\\\']
+        lines = [f"{indent}{base_cmd} \\\\"]
 
         # Add regular options with line continuation
         for i, opt in enumerate(opts):
             is_last = (i == len(opts) - 1) and not has_post_helm
-            suffix = '' if is_last else ' \\\\'
-            lines.append(f'{indent}   {opt}{suffix}')
+            suffix = "" if is_last else " \\\\"
+            lines.append(f"{indent}   {opt}{suffix}")
 
         # Add post_helm_commands - no line continuation, just aligned with other args
         for line in post_helm_lines:
-            lines.append(f'{indent}   {line}')
+            lines.append(f"{indent}   {line}")
 
         # Add post_commands without line continuation
         for line in post_cmd_lines:
-            lines.append(f'{indent}{line}')
+            lines.append(f"{indent}{line}")
 
-        return '\n'.join(lines)
+        return "\n".join(lines)
 
     def run(self):
-        namespace = self.options.get('namespace', 'kube-system')
-        command = self.options.get('command', 'install')
-        name = self.options.get('name', 'cilium')
-        extra_args = self.options.get('extra-args', '')
-        post_helm_commands = self.options.get('post-helm-commands', '')
-        post_commands = self.options.get('post-commands', '')
+        namespace = self.options.get("namespace", "kube-system")
+        command = self.options.get("command", "install")
+        name = self.options.get("name", "cilium")
+        extra_args = self.options.get("extra-args", "")
+        post_helm_commands = self.options.get("post-helm-commands", "")
+        post_commands = self.options.get("post-commands", "")
 
         set_options = self._parse_set_options()
         opts_list = self._build_opts_list(namespace, extra_args, set_options)
 
         # For template command, format is "helm template |CHART_RELEASE|" (no name)
         # For install/upgrade, format is "helm install name |CHART_RELEASE|"
-        if command == 'template':
-            helm_repo_base = f'helm {command} |CHART_RELEASE|'
-            oci_base = f'helm {command} oci://quay.io/cilium/charts/cilium |CHART_VERSION|'
+        if command == "template":
+            helm_repo_base = f"helm {command} |CHART_RELEASE|"
+            oci_base = (
+                f"helm {command} oci://quay.io/cilium/charts/cilium |CHART_VERSION|"
+            )
         else:
-            helm_repo_base = f'helm {command} {name} |CHART_RELEASE|'
-            oci_base = f'helm {command} {name} oci://quay.io/cilium/charts/cilium |CHART_VERSION|'
+            helm_repo_base = f"helm {command} {name} |CHART_RELEASE|"
+            oci_base = f"helm {command} {name} oci://quay.io/cilium/charts/cilium |CHART_VERSION|"
 
         # Build formatted commands for each section
         helm_repo_cmd = self._format_command(
-            helm_repo_base,
-            opts_list, '            ', post_helm_commands, post_commands
+            helm_repo_base, opts_list, "            ", post_helm_commands, post_commands
         )
         oci_cmd = self._format_command(
-            oci_base,
-            opts_list, '            ', post_helm_commands, post_commands
+            oci_base, opts_list, "            ", post_helm_commands, post_commands
         )
         not_stable_cmd = self._format_command(
-            helm_repo_base,
-            opts_list, '      ', post_helm_commands, post_commands
+            helm_repo_base, opts_list, "      ", post_helm_commands, post_commands
         )
 
         # Generate RST from template
@@ -165,8 +166,7 @@ class CiliumHelmInstallDirective(SphinxDirective):
 
         # Parse and return nodes
         string_list = StringList(
-            rst_content.splitlines(),
-            source=self.state_machine.document['source']
+            rst_content.splitlines(), source=self.state_machine.document["source"]
         )
         node = nodes.container()
         node.document = self.state.document
@@ -178,8 +178,8 @@ class CiliumHelmUpgradeDirective(CiliumHelmInstallDirective):
     """Directive to generate helm upgrade commands with OCI Registry tabs."""
 
     def run(self):
-        if 'command' not in self.options:
-            self.options['command'] = 'upgrade'
+        if "command" not in self.options:
+            self.options["command"] = "upgrade"
         return super().run()
 
 
@@ -187,18 +187,18 @@ class CiliumHelmTemplateDirective(CiliumHelmInstallDirective):
     """Directive to generate helm template commands with OCI Registry tabs."""
 
     def run(self):
-        if 'command' not in self.options:
-            self.options['command'] = 'template'
+        if "command" not in self.options:
+            self.options["command"] = "template"
         return super().run()
 
 
 def setup(app):
-    app.add_directive('cilium-helm-install', CiliumHelmInstallDirective)
-    app.add_directive('cilium-helm-upgrade', CiliumHelmUpgradeDirective)
-    app.add_directive('cilium-helm-template', CiliumHelmTemplateDirective)
+    app.add_directive("cilium-helm-install", CiliumHelmInstallDirective)
+    app.add_directive("cilium-helm-upgrade", CiliumHelmUpgradeDirective)
+    app.add_directive("cilium-helm-template", CiliumHelmTemplateDirective)
 
     return {
-        'version': '1.0',
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }

--- a/Documentation/_exts/cilium_helm_directive.py
+++ b/Documentation/_exts/cilium_helm_directive.py
@@ -18,7 +18,6 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
 from sphinx.util.docutils import SphinxDirective
-from textwrap import dedent
 
 
 RST_TEMPLATE = """\

--- a/Documentation/_exts/cilium_helm_directive.py
+++ b/Documentation/_exts/cilium_helm_directive.py
@@ -144,7 +144,7 @@ class CiliumHelmInstallDirective(SphinxDirective):
             )
         else:
             helm_repo_base = f"helm {command} {name} |CHART_RELEASE|"
-            oci_base = f"helm {command} {name} oci://quay.io/cilium/charts/cilium |CHART_VERSION|"
+            oci_base = f"helm {command} {name} oci://quay.io/cilium/charts/cilium |CHART_VERSION|"  # noqa: E501
 
         # Build formatted commands for each section
         helm_repo_cmd = self._format_command(

--- a/Documentation/_exts/cilium_spellfilters.py
+++ b/Documentation/_exts/cilium_spellfilters.py
@@ -8,4 +8,4 @@ class WireGuardFilter(Filter):
     """
 
     def _skip(self, word):
-        return (word == 'wireguard' or word == 'WireGuard')
+        return word == "wireguard" or word == "WireGuard"

--- a/Documentation/_exts/cilium_spellfilters.py
+++ b/Documentation/_exts/cilium_spellfilters.py
@@ -1,7 +1,9 @@
 from enchant.tokenize import Filter
 
+
 class WireGuardFilter(Filter):
-    """Accept either 'wireguard' (for documenting Helm values) or 'WireGuard',
+    """
+    Accept either 'wireguard' (for documenting Helm values) or 'WireGuard',
     but not 'Wireguard'.
     """
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -18,13 +18,10 @@
 #
 import os
 import sys
-import re
-import subprocess
 import semver
 
 sys.path.insert(0, os.path.abspath('_exts'))
 import cilium_external_links  # noqa: E402
-import cilium_spellfilters  # noqa: E402
 
 # -- General configuration ------------------------------------------------
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -107,12 +107,10 @@ elif branch == "stable":
     archive_name = release
     chart_version = "--version " + release
     chart_release = "cilium/cilium " + chart_version
-    tags.add("stable")
 else:
     archive_name = branch
     chart_version = "--version " + release
     chart_release = "cilium/cilium " + chart_version
-    tags.add("stable")
 relinfo = semver.parse_version_info(release)
 current_release = "%d.%d" % (relinfo.major, relinfo.minor)
 if relinfo.patch == 90:

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -20,7 +20,7 @@ import os
 import sys
 import semver
 
-sys.path.insert(0, os.path.abspath('_exts'))
+sys.path.insert(0, os.path.abspath("_exts"))
 import cilium_external_links  # noqa: E402
 
 # -- General configuration ------------------------------------------------
@@ -33,45 +33,46 @@ import cilium_external_links  # noqa: E402
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 html_logo = "images/logo.svg"
-extensions = ['myst_parser',
-              'sphinx.ext.ifconfig',
-              'sphinx.ext.githubpages',
-              'sphinx.ext.extlinks',
-              'sphinxcontrib.openapi',
-              'sphinx.ext.imgconverter',
-              'sphinx_tabs.tabs',
-              'sphinxcontrib.googleanalytics',
-              'sphinxcontrib.spelling',
-              'versionwarning.extension',
-              "sphinxext.rediraffe",
-              'cilium_helm_directive',
+extensions = [
+    "myst_parser",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.extlinks",
+    "sphinxcontrib.openapi",
+    "sphinx.ext.imgconverter",
+    "sphinx_tabs.tabs",
+    "sphinxcontrib.googleanalytics",
+    "sphinxcontrib.spelling",
+    "versionwarning.extension",
+    "sphinxext.rediraffe",
+    "cilium_helm_directive",
 ]
 
-rediraffe_redirects = 'redirects.txt'
+rediraffe_redirects = "redirects.txt"
 # rediraffe_branch is the base for which rediraffe compares the current HEAD to
 # to detect which Documentation pages have moved or been deleted so it can
 # check for missing redirects and automatically generate new redirect files.
 # The value specified is the commit before we branched v1.16 found using:
 # `git merge-base v1.16 main`
-rediraffe_branch = '5614531067a83e20d24bccc7b12b314330d043c3'
+rediraffe_branch = "5614531067a83e20d24bccc7b12b314330d043c3"
 rediraffe_auto_redirect_perc = 90
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = ['.rst', '.md']
+source_suffix = [".rst", ".md"]
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'Cilium'
-copyright = u'Cilium Authors'
-author = u'Cilium Authors'
+project = "Cilium"
+copyright = "Cilium Authors"
+author = "Cilium Authors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -85,49 +86,53 @@ versionwarning_api_url = "https://docs.cilium.io/"
 
 # The version of Go used to compile Cilium
 go_mod = open("../go.mod", "r").readlines()
-go_release = [line.rstrip()[len("go "):]
-              for line in go_mod if line.startswith("go ")][0]
+go_release = [line.rstrip()[len("go ") :] for line in go_mod if line.startswith("go ")][
+    0
+]
 
 # The image tag for Cilium docker images
-image_tag = 'v' + release
+image_tag = "v" + release
 
 # Fetch the docs version from an environment variable.
 # Map latest -> main.
 # Map stable -> current version number.
-branch = os.environ.get('READTHEDOCS_VERSION')
-if not branch or branch == 'latest':
-    branch = 'HEAD'
-    archive_name = 'main'
-    chart_release = './cilium'
+branch = os.environ.get("READTHEDOCS_VERSION")
+if not branch or branch == "latest":
+    branch = "HEAD"
+    archive_name = "main"
+    chart_release = "./cilium"
     chart_version = "--chart-directory ./install/kubernetes/cilium"
-elif branch == 'stable':
+elif branch == "stable":
     branch = release
     archive_name = release
-    chart_version = '--version ' + release
-    chart_release = 'cilium/cilium ' + chart_version
-    tags.add('stable')
+    chart_version = "--version " + release
+    chart_release = "cilium/cilium " + chart_version
+    tags.add("stable")
 else:
     archive_name = branch
-    chart_version = '--version ' + release
-    chart_release = 'cilium/cilium ' + chart_version
-    tags.add('stable')
+    chart_version = "--version " + release
+    chart_release = "cilium/cilium " + chart_version
+    tags.add("stable")
 relinfo = semver.parse_version_info(release)
-current_release = '%d.%d' % (relinfo.major, relinfo.minor)
+current_release = "%d.%d" % (relinfo.major, relinfo.minor)
 if relinfo.patch == 90:
-    next_release = '%d.%d' % (relinfo.major, relinfo.minor + 1)
+    next_release = "%d.%d" % (relinfo.major, relinfo.minor + 1)
     prev_release = current_release
 else:
     next_release = current_release
-    prev_release = '%d.%d' % (relinfo.major, relinfo.minor - 1)
-githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
+    prev_release = "%d.%d" % (relinfo.major, relinfo.minor - 1)
+githubusercontent = "https://raw.githubusercontent.com/cilium/cilium/"
 scm_web = githubusercontent + branch
-github_repo = 'https://github.com/cilium/cilium/'
-archive_filename = archive_name + '.tar.gz'
-archive_link = github_repo + 'archive/' + archive_filename
-archive_name = 'cilium-' + archive_name.strip('v')
-project_link = github_repo + 'projects?type=classic&query=is:open+' + next_release
-backport_format = github_repo + \
-    'pulls?q=is:open+is:pr+-label:backport/author+label:%s/' + current_release
+github_repo = "https://github.com/cilium/cilium/"
+archive_filename = archive_name + ".tar.gz"
+archive_link = github_repo + "archive/" + archive_filename
+archive_name = "cilium-" + archive_name.strip("v")
+project_link = github_repo + "projects?type=classic&query=is:open+" + next_release
+backport_format = (
+    github_repo
+    + "pulls?q=is:open+is:pr+-label:backport/author+label:%s/"
+    + current_release
+)
 
 # Store variables in the epilogue so they are globally available.
 rst_epilog = """
@@ -142,7 +147,19 @@ rst_epilog = """
 .. |CHART_VERSION| replace:: \\{v}
 .. |GO_RELEASE| replace:: \\{g}
 .. |IMAGE_TAG| replace:: \\{i}
-""".format(s=scm_web, b=branch, a=archive_name, f=archive_filename, l=archive_link, c=current_release, n=next_release, h=chart_release, g=go_release, i=image_tag, v=chart_version)
+""".format(
+    s=scm_web,
+    b=branch,
+    a=archive_name,
+    f=archive_filename,
+    l=archive_link,
+    c=current_release,
+    n=next_release,
+    h=chart_release,
+    g=go_release,
+    i=image_tag,
+    v=chart_version,
+)
 
 # Make Slack link globally available.
 rst_epilog += """
@@ -157,37 +174,40 @@ rst_epilog += """
 language = "en"
 
 extlinks = {
-    'git-tree': (scm_web + "/%s", None),
-    'github-project': (project_link + '%s', None),
-    'github-backport': (backport_format, None),
-    'gh-issue': (github_repo + 'issues/%s', 'GitHub issue %s'),
-    'prev-docs': (versionwarning_api_url + language + '/v' + prev_release + '/%s', None),
+    "git-tree": (scm_web + "/%s", None),
+    "github-project": (project_link + "%s", None),
+    "github-backport": (backport_format, None),
+    "gh-issue": (github_repo + "issues/%s", "GitHub issue %s"),
+    "prev-docs": (
+        versionwarning_api_url + language + "/v" + prev_release + "/%s",
+        None,
+    ),
 }
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # The default language to highlight source code in.
-highlight_language = 'none'
+highlight_language = "none"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
 # Ignore spelling errors in generated files.
-spelling_exclude_patterns = ['_api/v1/*/README.md']
+spelling_exclude_patterns = ["_api/v1/*/README.md"]
 
 # Add custom filters for spell checks.
 spelling_filters = ["cilium_spellfilters.WireGuardFilter"]
 
 # Ignore some warnings from MyST parser
-suppress_warnings = ['myst.header', 'myst.xref_missing']
+suppress_warnings = ["myst.header", "myst.xref_missing"]
 
-googleanalytics_id = 'G-V9SYWYG92Y'
+googleanalytics_id = "G-V9SYWYG92Y"
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -197,8 +217,8 @@ googleanalytics_id = 'G-V9SYWYG92Y'
 html_theme = "sphinx_rtd_theme_cilium"
 
 html_context = {
-    'release': release,
-    'current_version': os.environ.get('READTHEDOCS_VERSION')
+    "release": release,
+    "current_version": os.environ.get("READTHEDOCS_VERSION"),
 }
 
 # Set canonical URL from the Read the Docs Domain
@@ -212,30 +232,28 @@ if os.environ.get("READTHEDOCS", "") == "True":
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-    'logo_only': True
-}
+html_theme_options = {"logo_only": True}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['images', '_static']
+html_static_path = ["images", "_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ['robots/robots.txt']
+html_extra_path = ["robots/robots.txt"]
 
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Ciliumdoc'
+htmlhelp_basename = "Ciliumdoc"
 
 # -- Options for Last Page Edit -------------------------------------------
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
 # The empty string is equivalent to '%b %d, %Y'.
-html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%b %d, %Y"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -244,27 +262,23 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
-    'extraclassoptions': 'openany',
+    "extraclassoptions": "openany",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Cilium.tex', u'Cilium Documentation',
-     u'Cilium Authors', 'manual'),
+    (master_doc, "Cilium.tex", "Cilium Documentation", "Cilium Authors", "manual"),
 ]
 
 
@@ -272,10 +286,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'cilium', u'Cilium Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "cilium", "Cilium Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -284,32 +295,36 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Cilium', u'Cilium Documentation',
-     author, 'Cilium', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "Cilium",
+        "Cilium Documentation",
+        author,
+        "Cilium",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 http_strict_mode = False
 
 # Try as hard as possible to find references
-default_role = 'any'
+default_role = "any"
 
 # -- Options for Link Check output ----------------------------------------
 
 linkcheck_ignore = [
     # Local links
-    'http://127.0.0.1',
-    'http://localhost',
-    'http://192.168.60.13',
-    'https://192.168.60.11',
-
+    "http://127.0.0.1",
+    "http://localhost",
+    "http://192.168.60.13",
+    "https://192.168.60.11",
     # URLs that are not reachable(invalid or test links)
-    'https://bookinfo.cilium.rocks',
-    'dns:query',
-
+    "https://bookinfo.cilium.rocks",
+    "dns:query",
     # Needs authentication
-    'https://github.com/cilium/cilium/projects/new',
-    'https://github.com/cilium/cilium/settings/branches',
+    "https://github.com/cilium/cilium/projects/new",
+    "https://github.com/cilium/cilium/settings/branches",
 ]
 
 linkcheck_anchors = False
@@ -319,12 +334,12 @@ tls_verify = False
 
 
 def setup(app):
-    app.add_css_file('parsed-literal.css')
-    app.add_css_file('copybutton.css')
-    app.add_css_file('editbutton.css')
-    app.add_js_file('clipboardjs.min.js')
+    app.add_css_file("parsed-literal.css")
+    app.add_css_file("copybutton.css")
+    app.add_css_file("editbutton.css")
+    app.add_js_file("clipboardjs.min.js")
     app.add_js_file("copybutton.js")
-    app.add_css_file('helm-reference.css')
-    app.add_css_file('wrapped-table.css')
+    app.add_css_file("helm-reference.css")
+    app.add_css_file("wrapped-table.css")
     # Patch HTML translator to open external links in new tabs
     app.set_translator("html", cilium_external_links.PatchedHTMLTranslator)

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,18 @@ lint: golangci-lint custom-lint
 
 lint-fix: golangci-lint-fix
 
+lint-python:
+	ruff check .
+
+lint-python-fix:
+	ruff check --fix .
+
+format-python:
+	ruff format --check .
+
+format-python-fix:
+	ruff format .
+
 check-permissions: ## Check if files are not executable expect for allowlisted files. \
 	# This can happen especially when someone is developing on a Windows machine
 	find ./ -executable -type f | grep -Ev "\.git|\.sh|\.py" > ./executables.txt

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -1,9 +1,16 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.inet import IP, ICMP, TCP
+from scapy.layers.l2 import Ether
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    v4_node_one,
+    v4_pod_one,
+    v4_pod_two,
+)
 
 # outer IPv4 (pod_two -> pod_one), ICMP Destination Unreachable / Fragmentation Needed,
 # embedded original IPv4 + TCP with SNAT'd port

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -8,19 +8,19 @@ from pkt_defs_common import *
 # outer IPv4 (pod_two -> pod_one), ICMP Destination Unreachable / Fragmentation Needed,
 # embedded original IPv4 + TCP with SNAT'd port
 icmp4_err_frag_needed_for_revnat = (
-    Ether(src=mac_one, dst=mac_two) /
-    IP(src=v4_pod_two, dst=v4_pod_one) /
-    ICMP(type=3, code=4, nexthopmtu=1500) /
-    IP(src=v4_pod_one, dst=v4_pod_two, flags="DF") /
-    TCP(sport=32768, dport=80)  # NODEPORT_PORT_MIN_NAT (SNAT'd port)
+    Ether(src=mac_one, dst=mac_two)
+    / IP(src=v4_pod_two, dst=v4_pod_one)
+    / ICMP(type=3, code=4, nexthopmtu=1500)
+    / IP(src=v4_pod_one, dst=v4_pod_two, flags="DF")
+    / TCP(sport=32768, dport=80)  # NODEPORT_PORT_MIN_NAT (SNAT'd port)
 )
 
 
 # After rev-NAT: pod_two -> node_one, with original port restored
 icmp4_err_frag_needed_after_revnat = (
-    Ether(src=mac_one, dst=mac_two) /
-    IP(src=v4_pod_two, dst=v4_node_one) /
-    ICMP(type=3, code=4, nexthopmtu=1500) /
-    IP(src=v4_node_one, dst=v4_pod_two, flags="DF") /
-    TCP(sport=3030, dport=80)  # original port restored
+    Ether(src=mac_one, dst=mac_two)
+    / IP(src=v4_pod_two, dst=v4_node_one)
+    / ICMP(type=3, code=4, nexthopmtu=1500)
+    / IP(src=v4_node_one, dst=v4_pod_two, flags="DF")
+    / TCP(sport=3030, dport=80)  # original port restored
 )

--- a/bpf/tests/scapy/ipv6_ndp_pkt_defs.py
+++ b/bpf/tests/scapy/ipv6_ndp_pkt_defs.py
@@ -1,6 +1,25 @@
-from scapy.all import *
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
 
-from pkt_defs_common import *
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import Ether
+from scapy.layers.inet6 import (
+    ICMPv6ND_NS,
+    ICMPv6ND_NA,
+    ICMPv6NDOptSrcLLAddr,
+    ICMPv6NDOptDstLLAddr,
+)
+
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    v6_node_one,
+    v6_pod_one,
+    v6_pod_three,
+    v6_pod_two,
+    v6_get_ns_addr,
+    v6_get_ns_mac,
+)
 
 ## IPv6 ndp from netdev (ipv6_ndp_from_netdev_test.c)
 

--- a/bpf/tests/scapy/ipv6_ndp_pkt_defs.py
+++ b/bpf/tests/scapy/ipv6_ndp_pkt_defs.py
@@ -6,63 +6,55 @@ from pkt_defs_common import *
 
 ### Pod NS/NA
 v6_ndp_pod_ns = (
-    Ether(dst=mac_two, src=mac_one) /
-    IPv6(dst=v6_pod_two, src=v6_pod_one, hlim=255) /
-    ICMPv6ND_NS(tgt=v6_pod_three)
+    Ether(dst=mac_two, src=mac_one)
+    / IPv6(dst=v6_pod_two, src=v6_pod_one, hlim=255)
+    / ICMPv6ND_NS(tgt=v6_pod_three)
 )
 
-v6_ndp_pod_ns_llopt = (
-    v6_ndp_pod_ns /
-    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
-)
+v6_ndp_pod_ns_llopt = v6_ndp_pod_ns / ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
 
 v6_ndp_pod_na_llopt = (
-    Ether(dst=mac_one, src=mac_two) /
-    IPv6(dst=v6_pod_one, src=v6_pod_three, hlim=255) /
-    ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_pod_three) /
-    ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+    Ether(dst=mac_one, src=mac_two)
+    / IPv6(dst=v6_pod_one, src=v6_pod_three, hlim=255)
+    / ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_pod_three)
+    / ICMPv6NDOptDstLLAddr(lladdr=mac_two)
 )
 
 v6_ndp_pod_ns_mmac = v6_get_ns_mac(v6_pod_three)
 v6_ndp_pod_ns_ma = v6_get_ns_addr(v6_pod_three)
-assert(v6_ndp_pod_ns_mmac == '33:33:ff:00:00:03')
-assert(v6_ndp_pod_ns_ma == 'ff02::1:ff00:3')
+assert v6_ndp_pod_ns_mmac == "33:33:ff:00:00:03"
+assert v6_ndp_pod_ns_ma == "ff02::1:ff00:3"
 
 v6_ndp_pod_ns_mcast = (
-    Ether(dst=v6_ndp_pod_ns_mmac, src=mac_one) /
-    IPv6(dst=v6_ndp_pod_ns_ma, src=v6_pod_one, hlim=255) /
-    ICMPv6ND_NS(tgt=v6_pod_three)
+    Ether(dst=v6_ndp_pod_ns_mmac, src=mac_one)
+    / IPv6(dst=v6_ndp_pod_ns_ma, src=v6_pod_one, hlim=255)
+    / ICMPv6ND_NS(tgt=v6_pod_three)
 )
 
-v6_ndp_pod_ns_mcast_llopt = (
-    v6_ndp_pod_ns_mcast /
-    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
+v6_ndp_pod_ns_mcast_llopt = v6_ndp_pod_ns_mcast / ICMPv6NDOptSrcLLAddr(
+    lladdr="01:01:01:01:01:01"
 )
 
 ### Node NS/NA
 v6_ndp_node_ns = (
-    Ether(dst=mac_two, src=mac_one) /
-    IPv6(dst=v6_pod_two, src=v6_pod_one, hlim=255) /
-    ICMPv6ND_NS(tgt=v6_node_one)
+    Ether(dst=mac_two, src=mac_one)
+    / IPv6(dst=v6_pod_two, src=v6_pod_one, hlim=255)
+    / ICMPv6ND_NS(tgt=v6_node_one)
 )
 
-v6_ndp_node_ns_llopt = (
-    v6_ndp_node_ns /
-    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
-)
+v6_ndp_node_ns_llopt = v6_ndp_node_ns / ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
 
 v6_ndp_node_ns_mmac = v6_get_ns_mac(v6_node_one)
 v6_ndp_node_ns_ma = v6_get_ns_addr(v6_node_one)
-assert(v6_ndp_node_ns_mmac == '33:33:ff:00:00:01')
-assert(v6_ndp_node_ns_ma == 'ff02::1:ff00:1')
+assert v6_ndp_node_ns_mmac == "33:33:ff:00:00:01"
+assert v6_ndp_node_ns_ma == "ff02::1:ff00:1"
 
 v6_ndp_node_ns_mcast = (
-    Ether(dst=v6_ndp_node_ns_mmac, src=mac_one) /
-    IPv6(dst=v6_ndp_node_ns_ma, src=v6_pod_one, hlim=255) /
-    ICMPv6ND_NS(tgt=v6_node_one)
+    Ether(dst=v6_ndp_node_ns_mmac, src=mac_one)
+    / IPv6(dst=v6_ndp_node_ns_ma, src=v6_pod_one, hlim=255)
+    / ICMPv6ND_NS(tgt=v6_node_one)
 )
 
-v6_ndp_node_ns_mcast_llopt = (
-    v6_ndp_node_ns_mcast /
-    ICMPv6NDOptSrcLLAddr(lladdr="01:01:01:01:01:01")
+v6_ndp_node_ns_mcast_llopt = v6_ndp_node_ns_mcast / ICMPv6NDOptSrcLLAddr(
+    lladdr="01:01:01:01:01:01"
 )

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -6,15 +6,15 @@ from scapy.all import *
 from pkt_defs_common import *
 
 lb4_clusterip = (
-    Ether(src=mac_one, dst=mac_two) /
-    IP(src=v4_ext_one, dst=v4_svc_one) /
-    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
-    Raw("S"*1)
+    Ether(src=mac_one, dst=mac_two)
+    / IP(src=v4_ext_one, dst=v4_svc_one)
+    / TCP(sport=tcp_src_one, dport=tcp_svc_one)
+    / Raw("S" * 1)
 )
 
 lb6_clusterip = (
-    Ether(src=mac_one, dst=mac_two) /
-    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
-    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
-    Raw("S"*1)
+    Ether(src=mac_one, dst=mac_two)
+    / IPv6(src=v6_ext_node_one, dst=v6_svc_one)
+    / TCP(sport=tcp_src_one, dport=tcp_svc_one)
+    / Raw("S" * 1)
 )

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -1,9 +1,21 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.inet import IP, TCP
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import Ether
+from scapy.packet import Raw
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    v4_ext_one,
+    v4_svc_one,
+    v6_ext_node_one,
+    v6_svc_one,
+    tcp_src_one,
+    tcp_svc_one,
+)
 
 lb4_clusterip = (
     Ether(src=mac_one, dst=mac_two)

--- a/bpf/tests/scapy/parser.py
+++ b/bpf/tests/scapy/parser.py
@@ -17,6 +17,7 @@ PKT_REGEX = re.compile(
     re.DOTALL | re.MULTILINE
 )
 
+
 def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
     """Parse one file and extract BUF_DECL(name, varargs as single string)."""
 
@@ -46,6 +47,7 @@ def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
                 "bytes": [f"0x{b:02x}" for b in list(bytes(buf))]
             }
     return bufs
+
 
 def scan_dir(dir_name: str) -> dict[str, dict]:
     """Recursively scan .h/.c files and return map of name => flat varargs string."""

--- a/bpf/tests/scapy/parser.py
+++ b/bpf/tests/scapy/parser.py
@@ -13,15 +13,14 @@ from pkt_defs import *
 
 # Match BUF_DECL(name, ...)
 PKT_REGEX = re.compile(
-    r'^\s*BUF_DECL\(\s*([A-Za-z0-9_]+)\s*,\s*(.+?)\s*$',
-    re.DOTALL | re.MULTILINE
+    r"^\s*BUF_DECL\(\s*([A-Za-z0-9_]+)\s*,\s*(.+?)\s*$", re.DOTALL | re.MULTILINE
 )
 
 
 def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
     """Parse one file and extract BUF_DECL(name, varargs as single string)."""
 
-    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+    with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
         matches = PKT_REGEX.findall(f.read())
         for match in matches:
             if len(match) != 2:
@@ -31,20 +30,24 @@ def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
             scapy_buf = match[1].strip().replace("\n", "")
 
             # Remove trailing );
-            scapy_buf = re.sub(r'\s*\)\s*;\s*$', '', scapy_buf)
+            scapy_buf = re.sub(r"\s*\)\s*;\s*$", "", scapy_buf)
 
             try:
                 buf = eval(scapy_buf)
             except Exception as e:
-                raise Exception(f"Unknown scapy buffer '{scapy_buf}'. Please make sure it's defined under scapy/*_pkt_defs.py")
+                raise Exception(
+                    f"Unknown scapy buffer '{scapy_buf}'. Please make sure it's defined under scapy/*_pkt_defs.py"
+                )
 
             if name in bufs and buf != bufs[name]["buf"]:
-                raise Exception(f"Mismatching packet definitions with name '{name}'; found '{scapy_buf}' and '{bufs[name]}'.")
+                raise Exception(
+                    f"Mismatching packet definitions with name '{name}'; found '{scapy_buf}' and '{bufs[name]}'."
+                )
 
             bufs[name] = {
                 "str": scapy_buf,
                 "buf": buf,
-                "bytes": [f"0x{b:02x}" for b in list(bytes(buf))]
+                "bytes": [f"0x{b:02x}" for b in list(bytes(buf))],
             }
     return bufs
 
@@ -59,7 +62,7 @@ def scan_dir(dir_name: str) -> dict[str, dict]:
                 # Implement recursion if tests are in subdirs
                 continue
 
-            if not entry.name.endswith(('.h', '.c')) or entry.name == "scapy.h":
+            if not entry.name.endswith((".h", ".c")) or entry.name == "scapy.h":
                 continue
 
             try:
@@ -68,6 +71,7 @@ def scan_dir(dir_name: str) -> dict[str, dict]:
                 print(f"[ERROR] Unable to read {entry.path}: {e}", file=sys.stderr)
                 raise
     return bufs
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/bpf/tests/scapy/parser.py
+++ b/bpf/tests/scapy/parser.py
@@ -36,12 +36,14 @@ def find_buf_refs(filepath: str, bufs: dict[str, dict]) -> dict[str, dict]:
                 buf = eval(scapy_buf)
             except Exception as e:
                 raise Exception(
-                    f"Unknown scapy buffer '{scapy_buf}'. Please make sure it's defined under scapy/*_pkt_defs.py"
+                    f"Unknown scapy buffer '{scapy_buf}'. "
+                    "Please make sure it's defined under scapy/*_pkt_defs.py"
                 )
 
             if name in bufs and buf != bufs[name]["buf"]:
                 raise Exception(
-                    f"Mismatching packet definitions with name '{name}'; found '{scapy_buf}' and '{bufs[name]}'."
+                    f"Mismatching packet definitions with name '{name}'; "
+                    f"found '{scapy_buf}' and '{bufs[name]}'."
                 )
 
             bufs[name] = {
@@ -80,7 +82,7 @@ if __name__ == "__main__":
 
     dir = sys.argv[1]
     if not os.path.isdir(dir):
-        print(f"[ERROR] Invalid directory: {directory_to_scan}")
+        print(f"[ERROR] Invalid directory: {dir}")
         sys.exit(1)
 
     bufs = scan_dir(dir)

--- a/bpf/tests/scapy/pkt_defs_common.py
+++ b/bpf/tests/scapy/pkt_defs_common.py
@@ -1,7 +1,9 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.inet import inet_ntop, inet_pton
+from scapy.layers.inet6 import in6_getnsma, in6_getnsmac
+import socket
 
 # Note: these replicate pktgen.h values
 # TODO: it would be ideal to have a single source of truth for these values

--- a/bpf/tests/scapy/pkt_defs_common.py
+++ b/bpf/tests/scapy/pkt_defs_common.py
@@ -7,40 +7,40 @@ from scapy.all import *
 # TODO: it would be ideal to have a single source of truth for these values
 
 # MAC addresses
-mac_one   = "DE:AD:BE:EF:DE:EF"
-mac_two   = "13:37:13:37:13:37"
+mac_one = "DE:AD:BE:EF:DE:EF"
+mac_two = "13:37:13:37:13:37"
 mac_three = "31:41:59:26:35:89"
-mac_four  = "0D:1D:22:59:A9:C2"
-mac_five  = "15:21:39:45:4D:5D"
-mac_six   = "08:14:1C:32:52:7E"
-mac_zero  = "00:00:00:00:00:00"
+mac_four = "0D:1D:22:59:A9:C2"
+mac_five = "15:21:39:45:4D:5D"
+mac_six = "08:14:1C:32:52:7E"
+mac_zero = "00:00:00:00:00:00"
 mac_bcast = "FF:FF:FF:FF:FF:FF"
 host_mac_addr = "CE:72:A7:03:88:56"
 
 # IPv4 addresses for hosts, external to the cluster
-v4_ext_one   = "110.0.11.1"
-v4_ext_two   = "120.0.12.2"
+v4_ext_one = "110.0.11.1"
+v4_ext_two = "120.0.12.2"
 v4_ext_three = "130.0.13.3"
 
 # IPv4 addresses for nodes in the cluster
-v4_node_one   = "10.0.10.1"
-v4_node_two   = "10.0.10.2"
+v4_node_one = "10.0.10.1"
+v4_node_two = "10.0.10.2"
 v4_node_three = "10.0.10.3"
 
 # IPv4 addresses for services in the cluster
-v4_svc_one   = "172.16.10.1"
-v4_svc_two   = "172.16.10.2"
+v4_svc_one = "172.16.10.1"
+v4_svc_two = "172.16.10.2"
 v4_svc_three = "172.16.10.3"
 
 # IPv4 addresses for pods in the cluster
-v4_pod_one    = "192.168.0.1"
-v4_pod_two    = "192.168.0.2"
-v4_pod_three  = "192.168.0.3"
+v4_pod_one = "192.168.0.1"
+v4_pod_two = "192.168.0.2"
+v4_pod_three = "192.168.0.3"
 
 #Node-specific PodCIDR
-v4_pod_cidr_on_node_two  = "192.168.1.0"
-v4_pod_one_on_node_two   = "192.168.1.1"
-v4_pod_two_on_node_two   = "192.168.1.2"
+v4_pod_cidr_on_node_two = "192.168.1.0"
+v4_pod_one_on_node_two = "192.168.1.1"
+v4_pod_two_on_node_two = "192.168.1.2"
 v4_pod_three_on_node_two = "192.168.1.3"
 
 v4_pod_cidr_size = 24
@@ -50,17 +50,17 @@ v4_svc_loopback = "10.245.255.31"
 v4_all = "0.0.0.0"
 
 # IPv6 addresses for pods in the cluster
-v6_pod_one   = "fd04::1"
-v6_pod_two   = "fd04::2"
+v6_pod_one = "fd04::1"
+v6_pod_two = "fd04::2"
 v6_pod_three = "fd04::3"
 
 # IPv6 addresses for nodes in the cluster
-v6_node_one   = "fd05::1"
-v6_node_two   = "fd05::2"
+v6_node_one = "fd05::1"
+v6_node_two = "fd05::2"
 v6_node_three = "fd05::3"
 
 # IPv6 addresses for services in the cluster
-v6_svc_one    = "fd10::1"
+v6_svc_one = "fd10::1"
 
 # External IPv6 addrs
 v6_ext_node_one = "2001::1"
@@ -68,16 +68,16 @@ v6_ext_node_one = "2001::1"
 v6_all = "::"
 
 # Source port to be used by a client
-tcp_src_one   = 22330
-tcp_src_two   = 33440
+tcp_src_one = 22330
+tcp_src_two = 33440
 tcp_src_three = 44550
 
-tcp_dst_one   = 22331
-tcp_dst_two   = 33441
+tcp_dst_one = 22331
+tcp_dst_two = 33441
 tcp_dst_three = 44551
 
-tcp_svc_one   = 80
-tcp_svc_two   = 443
+tcp_svc_one = 80
+tcp_svc_two = 443
 tcp_svc_three = 53
 
 # Default payload data for tests. Note this includes a trailing
@@ -85,10 +85,12 @@ tcp_svc_three = 53
 # to ensure consistency in things like IP checksum values.
 default_data = b"Should not change!!\x00"
 
+
 # Utility functions
 def v6_get_ns_addr(v6_addr:str) -> str:
     addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_addr))
     return inet_ntop(socket.AF_INET6, addr_bytes)
+
 
 def v6_get_ns_mac(v6_addr:str) -> str:
     addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_addr))

--- a/bpf/tests/scapy/pkt_defs_common.py
+++ b/bpf/tests/scapy/pkt_defs_common.py
@@ -37,7 +37,7 @@ v4_pod_one = "192.168.0.1"
 v4_pod_two = "192.168.0.2"
 v4_pod_three = "192.168.0.3"
 
-#Node-specific PodCIDR
+# Node-specific PodCIDR
 v4_pod_cidr_on_node_two = "192.168.1.0"
 v4_pod_one_on_node_two = "192.168.1.1"
 v4_pod_two_on_node_two = "192.168.1.2"
@@ -87,11 +87,11 @@ default_data = b"Should not change!!\x00"
 
 
 # Utility functions
-def v6_get_ns_addr(v6_addr:str) -> str:
+def v6_get_ns_addr(v6_addr: str) -> str:
     addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_addr))
     return inet_ntop(socket.AF_INET6, addr_bytes)
 
 
-def v6_get_ns_mac(v6_addr:str) -> str:
+def v6_get_ns_mac(v6_addr: str) -> str:
     addr_bytes = in6_getnsma(inet_pton(socket.AF_INET6, v6_addr))
     return in6_getnsmac(addr_bytes)

--- a/bpf/tests/scapy/selftest_pkt_defs.py
+++ b/bpf/tests/scapy/selftest_pkt_defs.py
@@ -1,9 +1,17 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.inet import IP, TCP
+from scapy.layers.l2 import ARP, Ether
+from scapy.packet import Raw
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_bcast,
+    mac_one,
+    mac_two,
+    v4_ext_one,
+    v4_svc_one,
+)
 
 ## Scapy self tests (_scapy_selftest.c)
 sst_req = Ether(dst=mac_bcast, src=mac_one) / ARP(

--- a/bpf/tests/scapy/selftest_pkt_defs.py
+++ b/bpf/tests/scapy/selftest_pkt_defs.py
@@ -6,40 +6,25 @@ from scapy.all import *
 from pkt_defs_common import *
 
 ## Scapy self tests (_scapy_selftest.c)
-sst_req = (
-    Ether(dst=mac_bcast, src=mac_one) /
-    ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, \
-        hwsrc=mac_one, hwdst=mac_bcast)
+sst_req = Ether(dst=mac_bcast, src=mac_one) / ARP(
+    op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, hwsrc=mac_one, hwdst=mac_bcast
 )
 
-sst_rep = (
-    Ether(dst=mac_one, src=mac_two) /
-    ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
-        hwsrc=mac_two, hwdst=mac_one)
+sst_rep = Ether(dst=mac_one, src=mac_two) / ARP(
+    op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, hwsrc=mac_two, hwdst=mac_one
 )
 
 # Padded reply to test
 sst_rep_pad = (
-    Ether(dst=mac_one, src=mac_two) /
-    ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
-        hwsrc=mac_two, hwdst=mac_one) /
-    Raw("A"*8)
+    Ether(dst=mac_one, src=mac_two)
+    / ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, hwsrc=mac_two, hwdst=mac_one)
+    / Raw("A" * 8)
 )
 assert len(bytes(sst_rep_pad)) == (len(bytes(sst_rep)) + 8)
 
 # Testing large packets
-sst_lpkt = (
-    Ether(dst=mac_one, src=mac_two) /
-    IP() /
-    TCP() /
-    Raw(load='S'*970)
-)
+sst_lpkt = Ether(dst=mac_one, src=mac_two) / IP() / TCP() / Raw(load="S" * 970)
 assert len(bytes(sst_lpkt)) == 1024
 
-sst_xlpkt = (
-    Ether(dst=mac_one, src=mac_two) /
-    IP() /
-    TCP() /
-    Raw(load='S'*1464)
-)
+sst_xlpkt = Ether(dst=mac_one, src=mac_two) / IP() / TCP() / Raw(load="S" * 1464)
 assert len(bytes(sst_xlpkt)) == 1518

--- a/bpf/tests/scapy/tc_l2_announce6_pkt_defs.py
+++ b/bpf/tests/scapy/tc_l2_announce6_pkt_defs.py
@@ -1,9 +1,23 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.l2 import Ether
+from scapy.layers.inet6 import IPv6
+from scapy.layers.inet6 import (
+    ICMPv6ND_NS,
+    ICMPv6NDOptSrcLLAddr,
+    ICMPv6NDOptDstLLAddr,
+    ICMPv6ND_NA,
+)
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    v6_ext_node_one,
+    v6_svc_one,
+    v6_get_ns_mac,
+    v6_get_ns_addr,
+)
 
 ## IPv6 L2 announce (tc_l2_announcement6.c)
 

--- a/bpf/tests/scapy/tc_l2_announce6_pkt_defs.py
+++ b/bpf/tests/scapy/tc_l2_announce6_pkt_defs.py
@@ -10,26 +10,26 @@ from pkt_defs_common import *
 ### Calculate the IPv6 NS solicitation address
 l2_announce6_ns_mmac = v6_get_ns_mac(v6_svc_one)
 l2_announce6_ns_ma = v6_get_ns_addr(v6_svc_one)
-assert(l2_announce6_ns_mmac == '33:33:ff:00:00:01')
-assert(l2_announce6_ns_ma == 'ff02::1:ff00:1')
+assert l2_announce6_ns_mmac == "33:33:ff:00:00:01"
+assert l2_announce6_ns_ma == "ff02::1:ff00:1"
 
 l2_announce6_ns = (
-    Ether(dst=l2_announce6_ns_mmac, src=mac_one) /
-    IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255) /
-    ICMPv6ND_NS(tgt=v6_svc_one) /
-    ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+    Ether(dst=l2_announce6_ns_mmac, src=mac_one)
+    / IPv6(src=v6_ext_node_one, dst=l2_announce6_ns_ma, hlim=255)
+    / ICMPv6ND_NS(tgt=v6_svc_one)
+    / ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
 )
 
 l2_announce6_targeted_ns = (
-    Ether(dst=mac_two, src=mac_one) /
-    IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255) /
-    ICMPv6ND_NS(tgt=v6_svc_one) /
-    ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
+    Ether(dst=mac_two, src=mac_one)
+    / IPv6(src=v6_ext_node_one, dst=v6_svc_one, hlim=255)
+    / ICMPv6ND_NS(tgt=v6_svc_one)
+    / ICMPv6NDOptSrcLLAddr(lladdr=mac_one)
 )
 
 l2_announce6_na = (
-    Ether(dst=mac_one, src=mac_two) /
-    IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255) /
-    ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one) /
-    ICMPv6NDOptDstLLAddr(lladdr=mac_two)
+    Ether(dst=mac_one, src=mac_two)
+    / IPv6(src=v6_svc_one, dst=v6_ext_node_one, hlim=255)
+    / ICMPv6ND_NA(R=0, S=1, O=1, tgt=v6_svc_one)
+    / ICMPv6NDOptDstLLAddr(lladdr=mac_two)
 )

--- a/bpf/tests/scapy/tc_l2_announce_pkt_defs.py
+++ b/bpf/tests/scapy/tc_l2_announce_pkt_defs.py
@@ -1,9 +1,15 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.l2 import Ether, ARP
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    mac_bcast,
+    v4_ext_one,
+    v4_svc_one,
+)
 
 ## IPv4 L2 announce (tc_l2_announcement.c)
 l2_announce_arp_req = Ether(dst=mac_bcast, src=mac_one) / ARP(

--- a/bpf/tests/scapy/tc_l2_announce_pkt_defs.py
+++ b/bpf/tests/scapy/tc_l2_announce_pkt_defs.py
@@ -6,14 +6,10 @@ from scapy.all import *
 from pkt_defs_common import *
 
 ## IPv4 L2 announce (tc_l2_announcement.c)
-l2_announce_arp_req = (
-    Ether(dst=mac_bcast, src=mac_one) /
-    ARP(op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, \
-        hwsrc=mac_one, hwdst=mac_bcast)
+l2_announce_arp_req = Ether(dst=mac_bcast, src=mac_one) / ARP(
+    op="who-has", psrc=v4_ext_one, pdst=v4_svc_one, hwsrc=mac_one, hwdst=mac_bcast
 )
 
-l2_announce_arp_reply = (
-    Ether(dst=mac_one, src=mac_two) /
-    ARP(op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, \
-        hwsrc=mac_two, hwdst=mac_one)
+l2_announce_arp_reply = Ether(dst=mac_one, src=mac_two) / ARP(
+    op="is-at", psrc=v4_svc_one, pdst=v4_ext_one, hwsrc=mac_two, hwdst=mac_one
 )

--- a/bpf/tests/scapy/tc_wireguard_from_overlay_pkt_defs.py
+++ b/bpf/tests/scapy/tc_wireguard_from_overlay_pkt_defs.py
@@ -1,9 +1,19 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.inet import IP, TCP
+from scapy.layers.l2 import Ether
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    mac_three,
+    mac_four,
+    tcp_dst_one,
+    tcp_src_one,
+    v4_pod_one,
+    v4_pod_two,
+)
 
 ## Wireguard from overlay (tc_wireguard_from_overlay.c)
 

--- a/bpf/tests/scapy/tc_wireguard_from_overlay_pkt_defs.py
+++ b/bpf/tests/scapy/tc_wireguard_from_overlay_pkt_defs.py
@@ -9,9 +9,9 @@ from pkt_defs_common import *
 
 # TCP packet from pod to pod through overlay network (input packet)
 v4_overlay_tcp_packet = (
-    Ether(dst=mac_two, src=mac_one) /
-    IP(src=v4_pod_one, dst=v4_pod_two) /
-    TCP(sport=tcp_src_one, dport=tcp_dst_one)
+    Ether(dst=mac_two, src=mac_one)
+    / IP(src=v4_pod_one, dst=v4_pod_two)
+    / TCP(sport=tcp_src_one, dport=tcp_dst_one)
 )
 
 # Expected packet after MAC rewriting for local delivery
@@ -19,7 +19,7 @@ v4_overlay_tcp_packet = (
 # TTL is decremented by 1 during forwarding (64 -> 63)
 # IP checksum is recalculated to reflect TTL change
 v4_overlay_tcp_packet_rewritten = (
-    Ether(dst=mac_three, src=mac_four) /
-    IP(src=v4_pod_one, dst=v4_pod_two, ttl=63) /
-    TCP(sport=tcp_src_one, dport=tcp_dst_one)
+    Ether(dst=mac_three, src=mac_four)
+    / IP(src=v4_pod_one, dst=v4_pod_two, ttl=63)
+    / TCP(sport=tcp_src_one, dport=tcp_dst_one)
 )

--- a/bpf/tests/scapy/trace_diff_pkts.py
+++ b/bpf/tests/scapy/trace_diff_pkts.py
@@ -8,6 +8,8 @@ import sys
 
 from scapy.all import *
 
+from scapy.all import Packet
+
 
 def parse_asserts():
     try:
@@ -27,8 +29,8 @@ def bytes_to_scapy_pkt(first_layer, hex_str):
         raise e
 
 
-def pkt_to_dict(pkt: Packet) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
+def pkt_to_dict(pkt: Packet) -> dict[str, any]:
+    result: dict[str, any] = {}
     current_layer = pkt
 
     current_layer_str = ""

--- a/bpf/tests/scapy/trace_diff_pkts.py
+++ b/bpf/tests/scapy/trace_diff_pkts.py
@@ -73,7 +73,7 @@ def diff_pkts(expected: Packet, got: Packet) -> None:
             print(f"  + {key}: {str(add[key])}")
             add.pop(key)
     for key in add:
-            print(f"  + {key}: {str(add[key])}")
+        print(f"  + {key}: {str(add[key])}")
 
 
 def main():
@@ -96,6 +96,7 @@ def main():
         diff_pkts(exp, got)
 
         print(f"\n=== END {elem['file']}:{elem['linenum']} '{elem['name']}' ===")
+
 
 if __name__ == "__main__":
     main()

--- a/bpf/tests/scapy/trace_diff_pkts.py
+++ b/bpf/tests/scapy/trace_diff_pkts.py
@@ -3,12 +3,11 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
 import json
-import re
 import sys
 
 from scapy.all import *
+
 
 def parse_asserts():
     try:
@@ -18,6 +17,7 @@ def parse_asserts():
         raise e
     return asserts
 
+
 def bytes_to_scapy_pkt(first_layer, hex_str):
     try:
         s = f"{first_layer}({bytes.fromhex(hex_str)})"
@@ -25,6 +25,7 @@ def bytes_to_scapy_pkt(first_layer, hex_str):
     except Exception as e:
         print(f"ERROR: unable generate scapy Packet from '{hex_str}': {e}")
         raise e
+
 
 def pkt_to_dict(pkt: Packet) -> Dict[str, Any]:
     result: Dict[str, Any] = {}
@@ -42,6 +43,7 @@ def pkt_to_dict(pkt: Packet) -> Dict[str, Any]:
             break
 
     return result
+
 
 def diff_pkts(expected: Packet, got: Packet) -> None:
     pkt1 = pkt_to_dict(expected)
@@ -73,6 +75,7 @@ def diff_pkts(expected: Packet, got: Packet) -> None:
     for key in add:
             print(f"  + {key}: {str(add[key])}")
 
+
 def main():
     asserts = parse_asserts()
 
@@ -87,9 +90,9 @@ def main():
         got.show()
 
         # Show pseudo-diff
-        print(f">>> Diff <<<")
-        print(f"  --- a/pkt (Expected)")
-        print(f"  +++ b/pkt (Got)\n")
+        print(">>> Diff <<<")
+        print("  --- a/pkt (Expected)")
+        print("  +++ b/pkt (Got)\n")
         diff_pkts(exp, got)
 
         print(f"\n=== END {elem['file']}:{elem['linenum']} '{elem['name']}' ===")

--- a/bpf/tests/scapy/wg_from_netdev_pkt_defs.py
+++ b/bpf/tests/scapy/wg_from_netdev_pkt_defs.py
@@ -1,9 +1,18 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-from scapy.all import *
+from scapy.layers.inet import IP, TCP, UDP
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import Ether
 
-from pkt_defs_common import *
+from pkt_defs_common import (
+    mac_one,
+    mac_two,
+    v4_node_one,
+    v4_node_two,
+    v6_node_one,
+    v6_node_two,
+)
 
 ## Wireguard from netdev (wireguard_from_netdev.c)
 

--- a/bpf/tests/scapy/wg_from_netdev_pkt_defs.py
+++ b/bpf/tests/scapy/wg_from_netdev_pkt_defs.py
@@ -10,37 +10,37 @@ from pkt_defs_common import *
 wireguard_port = 51871
 
 v4_wireguard = (
-    Ether(dst=mac_two, src=mac_one) /
-    IP(src=v4_node_one, dst=v4_node_two) /
-    UDP(sport=wireguard_port, dport=wireguard_port)
+    Ether(dst=mac_two, src=mac_one)
+    / IP(src=v4_node_one, dst=v4_node_two)
+    / UDP(sport=wireguard_port, dport=wireguard_port)
 )
 
 v4_wireguard_sport_mismatch = (
-    Ether(dst=mac_two, src=mac_one) /
-    IP(src=v4_node_one, dst=v4_node_two) /
-    UDP(sport=wireguard_port+1, dport=wireguard_port)
+    Ether(dst=mac_two, src=mac_one)
+    / IP(src=v4_node_one, dst=v4_node_two)
+    / UDP(sport=wireguard_port + 1, dport=wireguard_port)
 )
 
 v4_wireguard_proto_mismatch = (
-    Ether(dst=mac_two, src=mac_one) /
-    IP(src=v4_node_one, dst=v4_node_two) /
-    TCP(sport=wireguard_port, dport=wireguard_port)
+    Ether(dst=mac_two, src=mac_one)
+    / IP(src=v4_node_one, dst=v4_node_two)
+    / TCP(sport=wireguard_port, dport=wireguard_port)
 )
 
 v6_wireguard = (
-    Ether(dst=mac_two, src=mac_one) /
-    IPv6(src=v6_node_one, dst=v6_node_two) /
-    UDP(sport=wireguard_port, dport=wireguard_port)
+    Ether(dst=mac_two, src=mac_one)
+    / IPv6(src=v6_node_one, dst=v6_node_two)
+    / UDP(sport=wireguard_port, dport=wireguard_port)
 )
 
 v6_wireguard_sport_mismatch = (
-    Ether(dst=mac_two, src=mac_one) /
-    IPv6(src=v6_node_one, dst=v6_node_two) /
-    UDP(sport=wireguard_port+1, dport=wireguard_port)
+    Ether(dst=mac_two, src=mac_one)
+    / IPv6(src=v6_node_one, dst=v6_node_two)
+    / UDP(sport=wireguard_port + 1, dport=wireguard_port)
 )
 
 v6_wireguard_proto_mismatch = (
-    Ether(dst=mac_two, src=mac_one) /
-    IPv6(src=v6_node_one, dst=v6_node_two) /
-    TCP(sport=wireguard_port, dport=wireguard_port)
+    Ether(dst=mac_two, src=mac_one)
+    / IPv6(src=v6_node_one, dst=v6_node_two)
+    / TCP(sport=wireguard_port, dport=wireguard_port)
 )

--- a/bpf/tools/log2scapy.py
+++ b/bpf/tools/log2scapy.py
@@ -3,10 +3,10 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 import re
 import argparse
 from scapy.all import *
+
 
 def parse_pkts(filename: str) -> List[Dict]:
     """
@@ -45,11 +45,13 @@ def parse_pkts(filename: str) -> List[Dict]:
             pkts.append(pkt)
     return pkts
 
+
 def dump_pkts(pkts) -> None:
     for pkt in pkts:
         print(f"{pkt['context']}")
         pkt["scapy"].show()
-        print(f"")
+        print("")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Parse packets from a trace_pipe log.")

--- a/bpf/tools/log2scapy.py
+++ b/bpf/tools/log2scapy.py
@@ -5,10 +5,12 @@
 
 import re
 import argparse
+
 from scapy.all import *
+from scapy.all import wrpcap
 
 
-def parse_pkts(filename: str) -> List[Dict]:
+def parse_pkts(filename: str) -> list[dict]:
     """
     Parses packet hexdump log entries in the trace_pipe log.
 
@@ -20,7 +22,7 @@ def parse_pkts(filename: str) -> List[Dict]:
         context: bpftest.test-1515316 [001] b..11 102260.946440: bpf_trace_printk: tc_l2_announcement.c:93 no_entry:
         first_layer: Ether
         bytes: ffffffffffffdeadbeefdeef08060001080006040001deadbeefdeef6e000b01ffffffffffffac100a01
-    """
+    """  # noqa: E501
     # TODO attempt to parse FILENAME:LINENUM if possible (HEXDUMP())
     # TODO parse timestamp
     pattern = re.compile(r"\s*(.*)\s*pkt_hex\s*(\w+)\[(.*?)\]")

--- a/bpf/tools/log2scapy.py
+++ b/bpf/tools/log2scapy.py
@@ -21,19 +21,19 @@ def parse_pkts(filename: str) -> List[Dict]:
         first_layer: Ether
         bytes: ffffffffffffdeadbeefdeef08060001080006040001deadbeefdeef6e000b01ffffffffffffac100a01
     """
-    #TODO attempt to parse FILENAME:LINENUM if possible (HEXDUMP())
-    #TODO parse timestamp
+    # TODO attempt to parse FILENAME:LINENUM if possible (HEXDUMP())
+    # TODO parse timestamp
     pattern = re.compile(r"\s*(.*)\s*pkt_hex\s*(\w+)\[(.*?)\]")
 
     pkts = []
-    with open(filename, 'r') as f:
+    with open(filename, "r") as f:
         for line in f:
             match = pattern.match(line)
             if not match:
                 continue
             pkt = {}
 
-            #TODO Improve context by further parsing filenum etc
+            # TODO Improve context by further parsing filenum etc
             pkt["context"] = match.group(1)
 
             try:
@@ -55,9 +55,16 @@ def dump_pkts(pkts) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Parse packets from a trace_pipe log.")
-    parser.add_argument('filename', help="Log file to parse")
-    parser.add_argument('-i', '--interactive', action='store_true', help="Open interactive Scapy shell with parsed packets.")
-    parser.add_argument('-p', '--pcap', metavar='FILE', help="Write parsed packets to a pcap file")
+    parser.add_argument("filename", help="Log file to parse")
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Open interactive Scapy shell with parsed packets.",
+    )
+    parser.add_argument(
+        "-p", "--pcap", metavar="FILE", help="Write parsed packets to a pcap file"
+    )
     args = parser.parse_args()
 
     pkts = parse_pkts(args.filename)
@@ -71,12 +78,14 @@ def main():
 
     if args.interactive:
         import code
+
         local_vars = globals().copy()
-        local_vars['pkts'] = pkts
+        local_vars["pkts"] = pkts
         print("Opening Scapy shell. Inspect 'pkts'...")
         code.interact(local=local_vars)
     else:
         dump_pkts(pkts)
+
 
 if __name__ == "__main__":
     main()

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -15,7 +15,8 @@ try:
     from github import Github
 except ImportError:
     print(
-        "pygithub not found you can install it by running 'pip3 install --user PyGithub'"
+        "pygithub not found you can install it by running "
+        "'pip3 install --user PyGithub'"
     )
     sys.exit(-1)
 

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -14,14 +14,16 @@ import sys
 try:
     from github import Github
 except ImportError:
-    print("pygithub not found you can install it by running 'pip3 install --user PyGithub'")
+    print(
+        "pygithub not found you can install it by running 'pip3 install --user PyGithub'"
+    )
     sys.exit(-1)
 
 parser = argparse.ArgumentParser()
-parser.add_argument('pr_number', type=int)
+parser.add_argument("pr_number", type=int)
 actions = ["pending", "done"]
-parser.add_argument('action', type=str, choices=actions)
-parser.add_argument('version', type=str, default="1.0", nargs='?')
+parser.add_argument("action", type=str, choices=actions)
+parser.add_argument("version", type=str, default="1.0", nargs="?")
 
 args = parser.parse_args()
 
@@ -52,32 +54,32 @@ cilium_labels = cilium.get_labels()
 
 print("Setting labels for PR {}... ".format(pr_number), end="")
 if action == "pending":
-    pr_labels = [l for l in pr_labels
-                 if l.name != "needs-backport/"+version]
+    pr_labels = [l for l in pr_labels if l.name != "needs-backport/" + version]
     if old_label_len - 1 != len(pr_labels):
-        print("needs-backport/"+version+" label not found in PR, exiting")
+        print("needs-backport/" + version + " label not found in PR, exiting")
         sys.exit(1)
 
     pr_labels.append(
-        [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
+        [l for l in cilium_labels if l.name == "backport-pending/" + version][0]
+    )
 
     if old_label_len != len(pr_labels):
-        print("error adding backport-pending/"+version+" label to PR, exiting")
+        print("error adding backport-pending/" + version + " label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
 
 if action == "done":
-    pr_labels = [l for l in pr_labels
-                 if l.name != "backport-pending/"+version]
+    pr_labels = [l for l in pr_labels if l.name != "backport-pending/" + version]
     if old_label_len - 1 != len(pr_labels):
-        print("backport-pending/"+version+" label not found in PR, exiting")
+        print("backport-pending/" + version + " label not found in PR, exiting")
         sys.exit(1)
 
     pr_labels.append(
-        [l for l in cilium_labels if l.name == "backport-done/"+version][0])
+        [l for l in cilium_labels if l.name == "backport-done/" + version][0]
+    )
 
     if old_label_len != len(pr_labels):
-        print("error adding backport-done/"+version+" label to PR, exiting")
+        print("error adding backport-done/" + version + " label to PR, exiting")
         sys.exit(2)
     pr.set_labels(*pr_labels)
 

--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -84,7 +84,7 @@ def first_target_pkg(stack):
             continue
 
         # Convert the following:
-        #         /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1886 +0x28ee
+        # /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1886 +0x28ee
         # =>
         # daemon/cm
         result = re.sub(r".*{}(.*)/[^.]*\.go.*".format(cilium_source), r"\1", s)
@@ -176,9 +176,8 @@ if __name__ == "__main__":
 
     if len(skipped) > 0:
         print(
-            "Stacktraces from the following packages were skipped as they do not match {}:".format(
-                keywords
-            ),
+            "Stacktraces from the following packages were skipped "
+            f"as they do not match {keywords}:",
             file=sys.stderr,
         )
         for s in sorted(skipped.keys()):

--- a/contrib/scripts/consolidate_go_stacktrace.py
+++ b/contrib/scripts/consolidate_go_stacktrace.py
@@ -11,8 +11,8 @@ from functools import cmp_to_key
 import argparse
 
 
-cilium_source = '/go/src/github.com/cilium/cilium/'
-filters = {'lock': ["lock", "Lock(", "RLock(", "Semacquire("]}
+cilium_source = "/go/src/github.com/cilium/cilium/"
+filters = {"lock": ["lock", "Lock(", "RLock(", "Semacquire("]}
 
 
 def get_stacks(f):
@@ -73,51 +73,52 @@ def skip_paths(line, must_exist, must_not_exist):
             return True
     return False
 
+
 # For stack : list[str], find the first line matching the source
 # repository and return the go pkg path for that stack.
 
 
 def first_target_pkg(stack):
     for s in stack:
-        if skip_paths(s, [cilium_source], ['vendor', 'lock']):
+        if skip_paths(s, [cilium_source], ["vendor", "lock"]):
             continue
 
         # Convert the following:
         #         /go/src/github.com/cilium/cilium/daemon/cmd/daemon_main.go:1886 +0x28ee
         # =>
         # daemon/cm
-        result = re.sub(
-            r'.*{}(.*)/[^.]*\.go.*'.format(cilium_source),
-            r'\1',
-            s)
+        result = re.sub(r".*{}(.*)/[^.]*\.go.*".format(cilium_source), r"\1", s)
         # print('  > found {}'.format(result))
         return result
     fallback = stack[-2].lstrip()
     # print('  > found {}'.format(fallback))
-    return 'goroutine initiated from {}'.format(fallback)
+    return "goroutine initiated from {}".format(fallback)
 
 
 if __name__ == "__main__":
     # Handle arguments. We only support a file path, or stdin on "-" or no
     # parameter
     parser = argparse.ArgumentParser(
-        description='Consolidate stacktraces to remove duplicate stacks.')
+        description="Consolidate stacktraces to remove duplicate stacks."
+    )
     parser.add_argument(
-        'infile',
-        metavar='PATH',
-        nargs='?',
-        help='Read and parse this file. Specify \'-\' or omit this option for stdin.')
+        "infile",
+        metavar="PATH",
+        nargs="?",
+        help="Read and parse this file. Specify '-' or omit this option for stdin.",
+    )
     parser.add_argument(
-        '-s',
-        '--source-dir',
+        "-s",
+        "--source-dir",
         default="",
-        help='Rewrite Cilium source paths to refer to this directory')
+        help="Rewrite Cilium source paths to refer to this directory",
+    )
     parser.add_argument(
-        '-f',
-        '--filter',
-        nargs='?',
-        help='Filter by known categories ({})'.format(
-            ','.join(filters.keys())))
+        "-f",
+        "--filter",
+        nargs="?",
+        help="Filter by known categories ({})".format(",".join(filters.keys())),
+    )
     args = parser.parse_args()
 
     if args.infile in ["-", "", None]:
@@ -139,22 +140,21 @@ if __name__ == "__main__":
     source_dir = args.source_dir
     if source_dir == "":
         source_dir = "./"
-    elif source_dir != "" and source_dir[-1] != '/':
+    elif source_dir != "" and source_dir[-1] != "/":
         source_dir += "/"
 
     # print count of each unique stack, and a sample, sorted by frequency
-    print('{} unique stack traces'.format(len(consolidated)))
+    print("{} unique stack traces".format(len(consolidated)))
     skipped = dict()
     blocked = dict()
     keywords = None
     if args.filter in filters:
         keywords = filters[args.filter]
     for stack in sorted(
-            consolidated.values(),
-            key=cmp_to_key(
-                lambda a,
-                b: len(a) - len(b)),
-            reverse=True):
+        consolidated.values(),
+        key=cmp_to_key(lambda a, b: len(a) - len(b)),
+        reverse=True,
+    ):
         if keywords is not None:
             if len(stack[0]) == 0:
                 continue
@@ -175,19 +175,22 @@ if __name__ == "__main__":
         print("\n".join(stack[0]).replace(cilium_source, source_dir))
 
     if len(skipped) > 0:
-        print('Stacktraces from the following packages were skipped as they do not match {}:'.format(
-            keywords), file=sys.stderr)
+        print(
+            "Stacktraces from the following packages were skipped as they do not match {}:".format(
+                keywords
+            ),
+            file=sys.stderr,
+        )
         for s in sorted(skipped.keys()):
             print(
-                '{} ({} goroutines)'.format(
-                    s.replace(
-                        cilium_source,
-                        args.source_dir),
-                    skipped[s]),
-                file=sys.stderr)
+                "{} ({} goroutines)".format(
+                    s.replace(cilium_source, args.source_dir), skipped[s]
+                ),
+                file=sys.stderr,
+            )
         print(file=sys.stderr)
     if len(blocked) > 0:
-        print('The following packages are blocked:')
+        print("The following packages are blocked:")
         for s in blocked:
             print(s.replace(cilium_source, args.source_dir))
 

--- a/contrib/scripts/portgen.py
+++ b/contrib/scripts/portgen.py
@@ -5,8 +5,8 @@
 # connections already opened on the host.
 #
 # Suggested usage to form a C array suitable for the BPF unit tests:
-# contrib/scripts/portgen.py | awk 'NR%10 {printf("%s, ", $0); next} {printf("%s,\n", $0)}' | sed -e 's/^/\t/' -e '$s/ $//' > bpf/tests/tcp_ports0.txt
-# contrib/scripts/portgen.py -u | awk 'NR%10 {printf("%s, ", $0); next} {printf("%s,\n", $0)}' | sed -e 's/^/\t/' -e '$s/ $//' > bpf/tests/udp_ports0.txt
+# contrib/scripts/portgen.py | awk 'NR%10 {printf("%s, ", $0); next} {printf("%s,\n", $0)}' | sed -e 's/^/\t/' -e '$s/ $//' > bpf/tests/tcp_ports0.txt # noqa: E501
+# contrib/scripts/portgen.py -u | awk 'NR%10 {printf("%s, ", $0); next} {printf("%s,\n", $0)}' | sed -e 's/^/\t/' -e '$s/ $//' > bpf/tests/udp_ports0.txt # noqa: E501
 
 from contextlib import contextmanager
 import argparse

--- a/contrib/scripts/portgen.py
+++ b/contrib/scripts/portgen.py
@@ -22,19 +22,19 @@ class NetNamespace:
         self.name = name
 
     def __enter__(self):
-        subprocess.check_call(['ip', 'netns', 'add', self.name])
+        subprocess.check_call(["ip", "netns", "add", self.name])
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        subprocess.check_call(['ip', 'netns', 'del', self.name])
+        subprocess.check_call(["ip", "netns", "del", self.name])
 
     def check_call(self, args, **kwargs):
-        subprocess.check_call(['ip', 'netns', 'exec', self.name, *args], **kwargs)
+        subprocess.check_call(["ip", "netns", "exec", self.name, *args], **kwargs)
 
     @contextmanager
     def enter(self):
-        with open(f'/proc/{os.getpid()}/ns/net', 'r') as old:
-            with open(f'/run/netns/{self.name}', 'r') as new:
+        with open(f"/proc/{os.getpid()}/ns/net", "r") as old:
+            with open(f"/run/netns/{self.name}", "r") as new:
                 os.setns(new.fileno(), os.CLONE_NEWNET)
             try:
                 yield
@@ -48,11 +48,23 @@ class VethPair:
         self.name2 = name2
 
     def __enter__(self):
-        subprocess.check_call(['ip', 'link', 'add', self.name1, 'type', 'veth', 'peer', 'name', self.name2])
+        subprocess.check_call(
+            [
+                "ip",
+                "link",
+                "add",
+                self.name1,
+                "type",
+                "veth",
+                "peer",
+                "name",
+                self.name2,
+            ]
+        )
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        subprocess.check_call(['ip', 'link', 'del', self.name1])
+        subprocess.check_call(["ip", "link", "del", self.name1])
 
 
 def port_generator(server_addr, server_port, udp):
@@ -62,7 +74,7 @@ def port_generator(server_addr, server_port, udp):
         client = socket.socket(socket.AF_INET, socket_type)
         try:
             if udp:
-                client.sendto(bytes('hello', 'ascii'), (server_addr, server_port))
+                client.sendto(bytes("hello", "ascii"), (server_addr, server_port))
             else:
                 client.connect((server_addr, server_port))
         except OSError as e:
@@ -73,36 +85,43 @@ def port_generator(server_addr, server_port, udp):
         yield client.getsockname()[1]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('-u', '--udp', action='store_true',
-                        help='open UDP connections instead of TCP')
+    parser.add_argument(
+        "-u", "--udp", action="store_true", help="open UDP connections instead of TCP"
+    )
     args = parser.parse_args()
 
     nofile_hard = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
     resource.setrlimit(resource.RLIMIT_NOFILE, (nofile_hard, nofile_hard))
 
-    with NetNamespace('portgen1') as ns1, NetNamespace('portgen2') as ns2:
-        ns1.check_call(['ip', 'link', 'set', 'lo', 'up'])
-        ns2.check_call(['ip', 'link', 'set', 'lo', 'up'])
-        with VethPair('pgen0', 'pgen1') as veth:
-            subprocess.check_call(['ip', 'link', 'set', veth.name1, 'netns', ns1.name])
+    with NetNamespace("portgen1") as ns1, NetNamespace("portgen2") as ns2:
+        ns1.check_call(["ip", "link", "set", "lo", "up"])
+        ns2.check_call(["ip", "link", "set", "lo", "up"])
+        with VethPair("pgen0", "pgen1") as veth:
+            subprocess.check_call(["ip", "link", "set", veth.name1, "netns", ns1.name])
             try:
-                subprocess.check_call(['ip', 'link', 'set', veth.name2, 'netns', ns2.name])
-                ns1.check_call(['ip', 'addr', 'replace', '10.38.73.1/24', 'dev', veth.name1])
-                ns1.check_call(['ip', 'link', 'set', veth.name1, 'up'])
-                ns2.check_call(['ip', 'addr', 'replace', '10.38.73.2/24', 'dev', veth.name2])
-                ns2.check_call(['ip', 'link', 'set', veth.name2, 'up'])
+                subprocess.check_call(
+                    ["ip", "link", "set", veth.name2, "netns", ns2.name]
+                )
+                ns1.check_call(
+                    ["ip", "addr", "replace", "10.38.73.1/24", "dev", veth.name1]
+                )
+                ns1.check_call(["ip", "link", "set", veth.name1, "up"])
+                ns2.check_call(
+                    ["ip", "addr", "replace", "10.38.73.2/24", "dev", veth.name2]
+                )
+                ns2.check_call(["ip", "link", "set", veth.name2, "up"])
                 with ns2.enter():
                     socket_type = socket.SOCK_DGRAM if args.udp else socket.SOCK_STREAM
                     server = socket.socket(socket.AF_INET, socket_type)
-                    server.bind(('', 8080))
+                    server.bind(("", 8080))
                     if not args.udp:
                         server.listen()
                 with ns1.enter():
                     clients = []
                     try:
-                        for port in port_generator('10.38.73.2', 8080, args.udp):
+                        for port in port_generator("10.38.73.2", 8080, args.udp):
                             if args.udp:
                                 server.recvfrom(8)
                             else:
@@ -113,4 +132,6 @@ if __name__ == '__main__':
                             c.close()
                         clients = []
             finally:
-                ns1.check_call(['ip', 'link', 'set', veth.name1, 'netns', str(os.getpid())])
+                ns1.check_call(
+                    ["ip", "link", "set", veth.name1, "netns", str(os.getpid())]
+                )

--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -60,8 +60,7 @@ def organize_data(data, key: str) -> dict:
         if not isinstance(entry[key], (int, float)) or not str(entry[key]).isnumeric():
             logging.error(f"Key '{key}' doesn't have a numeric value.")
             break
-        k = (entry["collection"], entry["build"],
-             entry["load"], entry["program"])
+        k = (entry["collection"], entry["build"], entry["load"], entry["program"])
         organized[k] = int(entry[key])
     return organized
 
@@ -80,21 +79,31 @@ def plot_comparison(file1: str, file2: str, key: str, outdir: str):
 
     # Collect all unique (collection, build, load) triples
     groups = set((c, b, l) for c, b, l, _ in data1.keys()) | set(
-        (c, b, l) for c, b, l, _ in data2.keys())
+        (c, b, l) for c, b, l, _ in data2.keys()
+    )
 
     for collection, build, load in groups:
         # Collect all programs for this collection/build/load
-        programs = sorted(set(
-            [p for c, b, l, p in data1.keys()
-             if c == collection and b == build and l == load] +
-            [p for c, b, l, p in data2.keys()
-             if c == collection and b == build and l == load]
-        ))
+        programs = sorted(
+            set(
+                [
+                    p
+                    for c, b, l, p in data1.keys()
+                    if c == collection and b == build and l == load
+                ]
+                + [
+                    p
+                    for c, b, l, p in data2.keys()
+                    if c == collection and b == build and l == load
+                ]
+            )
+        )
 
         if not programs:
             logging.debug(
                 f"No programs found for collection {collection}, "
-                f"build {build}, load {load}, skipping.")
+                f"build {build}, load {load}, skipping."
+            )
             continue
 
         before_vals = []
@@ -108,7 +117,8 @@ def plot_comparison(file1: str, file2: str, key: str, outdir: str):
                 logging.debug(
                     f"Program {prog} unchanged ({v1}) for "
                     f"collection {collection}, build {build}, "
-                    f"load {load}, skipping.")
+                    f"load {load}, skipping."
+                )
                 continue  # skip unchanged values
             filtered_programs.append(prog)
             before_vals.append(v1)
@@ -117,21 +127,25 @@ def plot_comparison(file1: str, file2: str, key: str, outdir: str):
         if not filtered_programs:  # skip if all values unchanged
             logging.info(
                 f"All programs unchanged for collection {collection} "
-                f"build {build} load {load}, skipping.")
+                f"build {build} load {load}, skipping."
+            )
             continue
 
         # Plot
         y_pos = np.arange(len(filtered_programs))
         bar_height = 0.35
         fig_width = 10
-        fig_height = min(fig_width, max(fig_width//2,
-                                        bar_height * len(filtered_programs)))
+        fig_height = min(
+            fig_width, max(fig_width // 2, bar_height * len(filtered_programs))
+        )
 
         plt.figure(figsize=(fig_width, fig_height))
-        bars_before = plt.barh(y_pos + bar_height/2, before_vals,
-                               bar_height, label="Before", alpha=0.7)
-        bars_after = plt.barh(y_pos - bar_height/2, after_vals,
-                              bar_height, label="After", alpha=0.7)
+        bars_before = plt.barh(
+            y_pos + bar_height / 2, before_vals, bar_height, label="Before", alpha=0.7
+        )
+        bars_after = plt.barh(
+            y_pos - bar_height / 2, after_vals, bar_height, label="After", alpha=0.7
+        )
 
         plt.yticks(y_pos, filtered_programs)
         plt.xlabel(key)
@@ -142,13 +156,25 @@ def plot_comparison(file1: str, file2: str, key: str, outdir: str):
         max_val = max(before_vals + after_vals)
         for bar in bars_before:
             width = bar.get_width()
-            plt.text(width + max_val * 0.01, bar.get_y() + bar.get_height()/2,
-                     f"{width}", va="center", ha="left", fontsize=8)
+            plt.text(
+                width + max_val * 0.01,
+                bar.get_y() + bar.get_height() / 2,
+                f"{width}",
+                va="center",
+                ha="left",
+                fontsize=8,
+            )
 
         for bar in bars_after:
             width = bar.get_width()
-            plt.text(width + max_val * 0.01, bar.get_y() + bar.get_height()/2,
-                     f"{width}", va="center", ha="left", fontsize=8)
+            plt.text(
+                width + max_val * 0.01,
+                bar.get_y() + bar.get_height() / 2,
+                f"{width}",
+                va="center",
+                ha="left",
+                fontsize=8,
+            )
 
         plt.tight_layout()
         build_dir = os.path.join(outdir, collection, f"build{build}")
@@ -171,8 +197,8 @@ def setup_output_dir(file_after: str, file_before: str) -> str:
     Returns:
         str: Name of the new output directory.
     """
-    base_after = os.path.basename(file_after).replace('.', '_')
-    base_before = os.path.basename(file_before).replace('.', '_')
+    base_after = os.path.basename(file_after).replace(".", "_")
+    base_before = os.path.basename(file_before).replace(".", "_")
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     output_dir = f"insn-diff-{base_after}-wrt-{base_before}-{timestamp}"
 
@@ -191,20 +217,28 @@ def main():
     and runs comparison and visualization.
     """
     parser = argparse.ArgumentParser(
-        description="Compare number of verified instructions " +
-        "from eBPF verifier logs.")
+        description="Compare number of verified instructions "
+        + "from eBPF verifier logs."
+    )
     parser.add_argument("file_before", help="Path to the log before patch")
     parser.add_argument("file_after", help="Path to the log after patch")
-    parser.add_argument('-v', '--verbose', action='store_true', help="Print debug logs.")
-    parser.add_argument('--key', default="insns_processed", help="Verifier statistic to compare (ex., peak_states, verification_time_microseconds).")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Print debug logs."
+    )
+    parser.add_argument(
+        "--key",
+        default="insns_processed",
+        help="Verifier statistic to compare (ex., peak_states, verification_time_microseconds).",
+    )
 
     args = parser.parse_args()
 
     log_level = logging.INFO
     if args.verbose:
         log_level = logging.DEBUG
-    logging.basicConfig(level=log_level,
-                        format="%(asctime)s [%(levelname)s] %(message)s")
+    logging.basicConfig(
+        level=log_level, format="%(asctime)s [%(levelname)s] %(message)s"
+    )
 
     output_dir = setup_output_dir(args.file_after, args.file_before)
 

--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -228,7 +228,17 @@ def main():
     parser.add_argument(
         "--key",
         default="insns_processed",
-        help="Verifier statistic to compare (ex., peak_states, verification_time_microseconds).",
+        choices=[
+            "insns_processed",
+            "insns_limit",
+            "max_states_per_insn",
+            "total_states",
+            "peak_states",
+            "mark_read",
+            "verification_time_microseconds",
+            "stack_depth",
+        ],
+        help="Verifier statistic to compare.",
     )
 
     args = parser.parse_args()

--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -54,7 +54,7 @@ def organize_data(data, key: str) -> dict:
     """
     organized = {}
     for entry in data:
-        if not key in entry:
+        if key not in entry:
             logging.error(f"Key '{key}' not found in data.")
             break
         if not isinstance(entry[key], (int, float)) or not str(entry[key]).isnumeric():
@@ -67,7 +67,8 @@ def organize_data(data, key: str) -> dict:
 
 
 def plot_comparison(file1: str, file2: str, key: str, outdir: str):
-    """Plot comparison of eBPF verifier logs.
+    """
+    Plot comparison of eBPF verifier logs.
 
     Args:
         file1 (str): Path to the first JSON file.

--- a/examples/kubernetes-grpc/cc_door_client.py
+++ b/examples/kubernetes-grpc/cc_door_client.py
@@ -22,51 +22,56 @@ import cloudcity_pb2
 import cloudcity_pb2_grpc
 import sys
 
-arg1 = 'GetName'
-arg2 = '1'
-arg3 = '99'
+arg1 = "GetName"
+arg2 = "1"
+arg3 = "99"
 
 
 def run():
-  channel = grpc.insecure_channel('cc-door-server:50051')
-  stub = cloudcity_pb2_grpc.DoorManagerStub(channel)
-  if arg1 == 'GetName':
-    response = stub.GetName(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
-    print("Door name is: " + response.name)
-  elif arg1 == 'GetLocation':
-    response = stub.GetLocation(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
-    print("Door location is lat = %s long = %s" % (response.lat, response.long))
-  elif arg1 == 'GetStatus':
-    response = stub.GetStatus(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
-    if response.state == cloudcity_pb2.OPEN:
-        print("Door is open")
-    else:
-        print("Door is closed")
-  elif arg1 == 'RequestMaintenance':
-    response = stub.RequestMaintenance(cloudcity_pb2.DoorMaintRequest(
-            door_id=int(arg2), maint_description=arg3))
-    if response.success:
-        print("Successfully submitted maintenance request")
-    else:
-        print("Failed to submit maintenaince request")
-  elif arg1 == 'SetAccessCode':
-    response = stub.SetAccessCode(cloudcity_pb2.DoorAccessCodeRequest(
-            door_id=int(arg2), access_code=int(arg3)))
-    if response.success:
-        print("Successfully set AccessCode to " + arg3)
-    else:
-        print("Failed to set AccessCode")
+    channel = grpc.insecure_channel("cc-door-server:50051")
+    stub = cloudcity_pb2_grpc.DoorManagerStub(channel)
+    if arg1 == "GetName":
+        response = stub.GetName(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
+        print("Door name is: " + response.name)
+    elif arg1 == "GetLocation":
+        response = stub.GetLocation(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
+        print("Door location is lat = %s long = %s" % (response.lat, response.long))
+    elif arg1 == "GetStatus":
+        response = stub.GetStatus(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
+        if response.state == cloudcity_pb2.OPEN:
+            print("Door is open")
+        else:
+            print("Door is closed")
+    elif arg1 == "RequestMaintenance":
+        response = stub.RequestMaintenance(
+            cloudcity_pb2.DoorMaintRequest(door_id=int(arg2), maint_description=arg3)
+        )
+        if response.success:
+            print("Successfully submitted maintenance request")
+        else:
+            print("Failed to submit maintenaince request")
+    elif arg1 == "SetAccessCode":
+        response = stub.SetAccessCode(
+            cloudcity_pb2.DoorAccessCodeRequest(
+                door_id=int(arg2), access_code=int(arg3)
+            )
+        )
+        if response.success:
+            print("Successfully set AccessCode to " + arg3)
+        else:
+            print("Failed to set AccessCode")
 
-  else:
-    print("Invalid call " + arg1)
-    return
+    else:
+        print("Invalid call " + arg1)
+        return
 
-if __name__ == '__main__':
-  if len(sys.argv) > 1:
-    arg1 = sys.argv[1]
-  if len(sys.argv) > 2:
-    arg2 = sys.argv[2]
-  if len(sys.argv) > 3:
-    arg3 = sys.argv[3]
 
-  run()
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        arg1 = sys.argv[1]
+    if len(sys.argv) > 2:
+        arg2 = sys.argv[2]
+    if len(sys.argv) > 3:
+        arg3 = sys.argv[3]
+
+    run()

--- a/examples/kubernetes-grpc/cc_door_client.py
+++ b/examples/kubernetes-grpc/cc_door_client.py
@@ -24,7 +24,8 @@ import sys
 
 arg1 = 'GetName'
 arg2 = '1'
-arg3 = '99' 
+arg3 = '99'
+
 
 def run():
   channel = grpc.insecure_channel('cc-door-server:50051')
@@ -37,24 +38,24 @@ def run():
     print("Door location is lat = %s long = %s" % (response.lat, response.long))
   elif arg1 == 'GetStatus':
     response = stub.GetStatus(cloudcity_pb2.DoorRequest(door_id=int(arg2)))
-    if response.state == cloudcity_pb2.OPEN: 
+    if response.state == cloudcity_pb2.OPEN:
         print("Door is open")
-    else: 
+    else:
         print("Door is closed")
   elif arg1 == 'RequestMaintenance':
     response = stub.RequestMaintenance(cloudcity_pb2.DoorMaintRequest(
             door_id=int(arg2), maint_description=arg3))
-    if response.success: 
+    if response.success:
         print("Successfully submitted maintenance request")
-    else: 
-        print("Failed to submit maintenaince request") 
+    else:
+        print("Failed to submit maintenaince request")
   elif arg1 == 'SetAccessCode':
     response = stub.SetAccessCode(cloudcity_pb2.DoorAccessCodeRequest(
             door_id=int(arg2), access_code=int(arg3)))
-    if response.success: 
+    if response.success:
         print("Successfully set AccessCode to " + arg3)
-    else: 
-        print("Failed to set AccessCode") 
+    else:
+        print("Failed to set AccessCode")
 
   else:
     print("Invalid call " + arg1)

--- a/examples/kubernetes-grpc/cc_door_server.py
+++ b/examples/kubernetes-grpc/cc_door_server.py
@@ -26,33 +26,33 @@ _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
 
 class DoorManager(cloudcity_pb2_grpc.DoorManagerServicer):
+    def GetName(self, request, context):
+        return cloudcity_pb2.DoorNameReply(name="Spaceport Door #%s" % request.door_id)
 
-  def GetName(self, request, context):
-    return cloudcity_pb2.DoorNameReply(name='Spaceport Door #%s' % request.door_id)
+    def GetLocation(self, request, context):
+        return cloudcity_pb2.DoorLocationReply(lat=10.2222, long=68.8788)
 
-  def GetLocation(self, request, context):
-    return cloudcity_pb2.DoorLocationReply(lat=10.2222, long=68.8788)
+    def GetStatus(self, request, context):
+        return cloudcity_pb2.DoorStatusReply(state=cloudcity_pb2.CLOSED)
 
-  def GetStatus(self, request, context):
-    return cloudcity_pb2.DoorStatusReply(state=cloudcity_pb2.CLOSED)
+    def RequestMaintenance(self, request, context):
+        return cloudcity_pb2.DoorActionReply(success=True)
 
-  def RequestMaintenance(self, request, context):
-    return cloudcity_pb2.DoorActionReply(success=True)
-
-  def SetAccessCode(self, request, context):
-    return cloudcity_pb2.DoorActionReply(success=True)
+    def SetAccessCode(self, request, context):
+        return cloudcity_pb2.DoorActionReply(success=True)
 
 
 def serve():
-  server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-  cloudcity_pb2_grpc.add_DoorManagerServicer_to_server(DoorManager(), server)
-  server.add_insecure_port('[::]:50051')
-  server.start()
-  try:
-    while True:
-      time.sleep(_ONE_DAY_IN_SECONDS)
-  except KeyboardInterrupt:
-    server.stop(0)
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    cloudcity_pb2_grpc.add_DoorManagerServicer_to_server(DoorManager(), server)
+    server.add_insecure_port("[::]:50051")
+    server.start()
+    try:
+        while True:
+            time.sleep(_ONE_DAY_IN_SECONDS)
+    except KeyboardInterrupt:
+        server.stop(0)
 
-if __name__ == '__main__':
-  serve()
+
+if __name__ == "__main__":
+    serve()

--- a/examples/kubernetes-grpc/cc_door_server.py
+++ b/examples/kubernetes-grpc/cc_door_server.py
@@ -30,17 +30,17 @@ class DoorManager(cloudcity_pb2_grpc.DoorManagerServicer):
   def GetName(self, request, context):
     return cloudcity_pb2.DoorNameReply(name='Spaceport Door #%s' % request.door_id)
 
-  def GetLocation(self, request, context): 
+  def GetLocation(self, request, context):
     return cloudcity_pb2.DoorLocationReply(lat=10.2222, long=68.8788)
 
-  def GetStatus(self, request, context): 
+  def GetStatus(self, request, context):
     return cloudcity_pb2.DoorStatusReply(state=cloudcity_pb2.CLOSED)
 
-  def RequestMaintenance(self, request, context): 
-    return cloudcity_pb2.DoorActionReply(success=True) 
+  def RequestMaintenance(self, request, context):
+    return cloudcity_pb2.DoorActionReply(success=True)
 
-  def SetAccessCode(self, request, context): 
-    return cloudcity_pb2.DoorActionReply(success=True) 
+  def SetAccessCode(self, request, context):
+    return cloudcity_pb2.DoorActionReply(success=True)
 
 
 def serve():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,74 @@
 name = "cilium-tooling"
 version = "0.1.0"
 description = "Python dependencies required for building tools around Cilium"
-dependencies = ["pygithub>=2.8.1", "scapy>=2.7.0"]
+dependencies = ["pygithub>=2.8.1", "scapy>=2.7.0", "ruff>=0.15.0"]
 requires-python = ">=3.10"
 
 [tool.setuptools]
 packages = []
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+indent-width = 4
+extend-exclude = ["vendor/**"]
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+select = [
+    "D",
+    "E",
+    "F",
+    "W",
+    "UP035",
+    "E201",
+    "E202",
+    "E203",
+    "E221",
+    "E251",
+    "E261",
+    "E272",
+    "E302",
+    "E703",
+]
+ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D202",
+    "D203",
+    "D204",
+    "D205",
+    "D212",
+    "D301",
+    "D400",
+    "D401",
+    "D402",
+    "D403",
+    "D404",
+    "D413",
+    "D415",
+    "D417",
+    "E266",
+    "E305",
+    "E306",
+    "E721",
+    "E741",
+    "F841",
+]
+external = ["E122"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.ruff.format]
+docstring-code-format = true
+quote-style = "double"
+indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ external = ["E122"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"bpf/tools/log2scapy.py" = ["F403"]
+"bpf/tests/scapy/parser.py" = ["F403"]
+"bpf/tests/scapy/pkt_defs.py" = ["F403"]
+"bpf/tests/scapy/trace_diff_pkts.py" = ["F403"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "cilium-tooling"
+version = "0.1.0"
+description = "Python dependencies required for building tools around Cilium"
+dependencies = ["pygithub>=2.8.1", "scapy>=2.7.0"]
+requires-python = ">=3.10"
+
+[tool.setuptools]
+packages = []

--- a/test/vtep/vxlan-responder.py
+++ b/test/vtep/vxlan-responder.py
@@ -21,47 +21,48 @@ import argparse
 from scapy.layers.inet import IP, ICMP, UDP
 from scapy.sendrecv import sniff, send
 from scapy.all import *
-PAYLOAD='zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+PAYLOAD = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 
 
 def udp_monitor_callback(pkt):
     inLayer3 = pkt.payload.payload.payload.payload.payload
 
-    if(pkt.haslayer(IP) and inLayer3.dst == INNERIP):
-        print("incoming IP packet matches",  INNERIP)
+    if pkt.haslayer(IP) and inLayer3.dst == INNERIP:
+        print("incoming IP packet matches", INNERIP)
         outLayer3 = pkt.payload
         udpLayer = pkt.payload.payload
         vxlanLayer = pkt.payload.payload.payload
         inLayer2 = pkt.payload.payload.payload.payload
         inLayer4 = pkt.payload.payload.payload.payload.payload.payload
 
-        outerIP=IP(src=outLayer3.dst, dst=outLayer3.src)
+        outerIP = IP(src=outLayer3.dst, dst=outLayer3.src)
 
-        udpinfo=UDP(sport=SRCPORT, dport=UDPPORT)
+        udpinfo = UDP(sport=SRCPORT, dport=UDPPORT)
 
-        vxlan=VXLAN(flags=vxlanLayer.flags, vni=VNI)
+        vxlan = VXLAN(flags=vxlanLayer.flags, vni=VNI)
 
-        innerETH=Ether(dst=inLayer2.src, src=inLayer2.dst, type=0x800)
+        innerETH = Ether(dst=inLayer2.src, src=inLayer2.dst, type=0x800)
 
-        innerIP=IP(src=inLayer3.dst,dst=inLayer3.src)
+        innerIP = IP(src=inLayer3.dst, dst=inLayer3.src)
 
-        innerICMP=ICMP(type=0, code=0, id=inLayer4.id, seq=inLayer4.seq)
+        innerICMP = ICMP(type=0, code=0, id=inLayer4.id, seq=inLayer4.seq)
 
-        send(outerIP/udpinfo/vxlan/innerETH/innerIP/innerICMP/PAYLOAD)
+        send(outerIP / udpinfo / vxlan / innerETH / innerIP / innerICMP / PAYLOAD)
 
-    if(pkt.haslayer(ARP)):
+    if pkt.haslayer(ARP):
         print("incoming ARP packet")
 
 
 def dispatcher_callback(pkt):
-    if(pkt.haslayer(UDP) and (pkt[UDP].dport == UDPPORT) and (pkt[IP].dst == DSTHOST)):
+    if pkt.haslayer(UDP) and (pkt[UDP].dport == UDPPORT) and (pkt[IP].dst == DSTHOST):
         print("incoming VXLAN packet")
         udp_monitor_callback(pkt)
     else:
         return
 
-if __name__ == '__main__':
 
+if __name__ == "__main__":
     global UDPPORT
     global SRCPORT
     global DSTHOST
@@ -70,38 +71,49 @@ if __name__ == '__main__':
     global BRIDGE
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dport", action="store", dest="udpport", type=int, help="VXLAN UDP port")
-    parser.add_argument("--sport", action="store", dest="srcport", type=int, help="UDP source port")
-    parser.add_argument("--vni", action="store", dest="vxlanvni", type=int, help="VXLAN VNI value")
-    parser.add_argument("--outerip", action="store", dest="dsthost", help="Outer dst IP")
-    parser.add_argument("--innerip", action="store", dest="innerhost", help="Inner dst IP")
-    parser.add_argument("--bridge", action="store", dest="bridge", help="Bridge interface to sniff")
+    parser.add_argument(
+        "--dport", action="store", dest="udpport", type=int, help="VXLAN UDP port"
+    )
+    parser.add_argument(
+        "--sport", action="store", dest="srcport", type=int, help="UDP source port"
+    )
+    parser.add_argument(
+        "--vni", action="store", dest="vxlanvni", type=int, help="VXLAN VNI value"
+    )
+    parser.add_argument(
+        "--outerip", action="store", dest="dsthost", help="Outer dst IP"
+    )
+    parser.add_argument(
+        "--innerip", action="store", dest="innerhost", help="Inner dst IP"
+    )
+    parser.add_argument(
+        "--bridge", action="store", dest="bridge", help="Bridge interface to sniff"
+    )
     args = parser.parse_args()
 
     if args.udpport:
         print("Destination port: % d" % args.udpport)
-        UDPPORT=args.udpport
+        UDPPORT = args.udpport
 
     if args.srcport:
         print("Source port: % d" % args.srcport)
-        SRCPORT=args.srcport
+        SRCPORT = args.srcport
 
     if args.vxlanvni:
         print("VXLAN VNI: % d" % args.vxlanvni)
-        VNI=args.vxlanvni
+        VNI = args.vxlanvni
 
     if args.dsthost:
         print("Destination IP: % s" % args.dsthost)
-        DSTHOST=args.dsthost
+        DSTHOST = args.dsthost
 
     if args.innerhost:
         print("Inner destination IP as: % s" % args.innerhost)
-        INNERIP=args.innerhost
+        INNERIP = args.innerhost
 
     if args.bridge:
         print("Bridge interface: % s" % args.bridge)
-        BRIDGE=args.bridge
-
+        BRIDGE = args.bridge
 
     print("Scapy vxlan responder")
     scapy.all.conf.iface = BRIDGE

--- a/test/vtep/vxlan-responder.py
+++ b/test/vtep/vxlan-responder.py
@@ -18,10 +18,7 @@ optional arguments:
 """
 
 import argparse
-from scapy import all
-from scapy.layers import all
 from scapy.layers.inet import IP, ICMP, UDP
-from scapy.packet import ls, Raw
 from scapy.sendrecv import sniff, send
 from scapy.all import *
 PAYLOAD='zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
@@ -54,6 +51,7 @@ def udp_monitor_callback(pkt):
 
     if(pkt.haslayer(ARP)):
         print("incoming ARP packet")
+
 
 def dispatcher_callback(pkt):
     if(pkt.haslayer(UDP) and (pkt[UDP].dport == UDPPORT) and (pkt[IP].dst == DSTHOST)):

--- a/test/vtep/vxlan-responder.py
+++ b/test/vtep/vxlan-responder.py
@@ -4,8 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 Copyright Authors of Cilium
 
 # vxlan-responder.py -h
-usage: vxlan-responder.py [-h] [--dport UDPPORT] [--sport SRCPORT] [--vni VXLANVNI] [--outerip DSTHOST]
-                          [--innerip INNERHOST] [--bridge BRIDGE]
+usage: vxlan-responder.py [-h] [--dport UDPPORT] [--sport SRCPORT] [--vni VXLANVNI]
+                          [--outerip DSTHOST] [--innerip INNERHOST] [--bridge BRIDGE]
 
 optional arguments:
   -h, --help           show this help message and exit
@@ -18,9 +18,12 @@ optional arguments:
 """
 
 import argparse
-from scapy.layers.inet import IP, ICMP, UDP
+import scapy
+
+from scapy.layers.inet import IP, ICMP, UDP, Ether
+from scapy.all import VXLAN
+from scapy.layers.l2 import ARP
 from scapy.sendrecv import sniff, send
-from scapy.all import *
 
 PAYLOAD = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 
@@ -31,7 +34,6 @@ def udp_monitor_callback(pkt):
     if pkt.haslayer(IP) and inLayer3.dst == INNERIP:
         print("incoming IP packet matches", INNERIP)
         outLayer3 = pkt.payload
-        udpLayer = pkt.payload.payload
         vxlanLayer = pkt.payload.payload.payload
         inLayer2 = pkt.payload.payload.payload.payload
         inLayer4 = pkt.payload.payload.payload.payload.payload.payload

--- a/tools/dev-doctor/pythondepscheck.go
+++ b/tools/dev-doctor/pythondepscheck.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const name = "cilium-tooling"
+
+var pythonScript = fmt.Sprintf(`
+import importlib.metadata as m
+import sys
+
+try:
+    dist = m.distribution("%s")
+    deps = dist.requires or []
+except m.PackageNotFoundError:
+    print("ERR_NOT_INSTALLED")
+    sys.exit(0)
+
+missing = []
+for dep in deps:
+    pkg_name = dep.split(";")[0].split(">=")[0].split("==")[0].split("[")[0].strip()
+    try:
+        m.distribution(pkg_name)
+    except m.PackageNotFoundError:
+        missing.append(pkg_name)
+
+if missing:
+    print("MISSING:" + ",".join(missing))
+else:
+    print("OK")
+`, name)
+
+// A pythonDepsCheck checks that Python dependencies are installed.
+type pythonDepsCheck struct{}
+
+func (pythonDepsCheck) Name() string {
+	return "python3-deps"
+}
+
+func (pythonDepsCheck) Run() (checkResult, string) {
+	cmd := exec.Command("python3", "-c", pythonScript)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return checkWarning, fmt.Sprintf("failed to run Python: %v", err)
+	}
+
+	result := strings.TrimSpace(string(output))
+
+	switch {
+	case result == "ERR_NOT_INSTALLED":
+		return checkWarning, fmt.Sprintf("project '%s' not found", name)
+
+	case strings.HasPrefix(result, "MISSING:"):
+		pkgs := strings.TrimPrefix(result, "MISSING:")
+		return checkWarning, fmt.Sprintf("the following dependencies are missing: %s", pkgs)
+
+	case result == "OK":
+		return checkOK, "found all python3 dependencies"
+
+	default:
+		return checkWarning, fmt.Sprintf("unexpected output: %s", result)
+	}
+}
+
+func (pythonDepsCheck) Hint() string {
+	return `Run "pip3 install ." (see pyproject.toml).`
+}

--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -161,6 +161,14 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			versionRegexp: regexp.MustCompile(`pip ` + versionRegex),
 		},
 		&binaryCheck{
+			name:          "python3",
+			ifNotFound:    checkError,
+			versionArgs:   []string{"--version"},
+			versionRegexp: regexp.MustCompile(`Python\s+` + versionRegex),
+			minVersion:    &semver.Version{Major: 3, Minor: 10, Patch: 0},
+		},
+		&pythonDepsCheck{},
+		&binaryCheck{
 			name:          "kind",
 			ifNotFound:    checkWarning,
 			versionArgs:   []string{"--version"},
@@ -191,21 +199,6 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			&binaryCheck{
 				name:       "jq",
 				ifNotFound: checkError,
-			},
-			&binaryCheck{
-				name:          "python3",
-				ifNotFound:    checkError,
-				versionArgs:   []string{"--version"},
-				versionRegexp: regexp.MustCompile(`Python\s+` + versionRegex),
-				minVersion:    &semver.Version{Major: 3, Minor: 6, Patch: 0},
-			},
-			&commandCheck{
-				name:             "pygithub",
-				command:          "python3",
-				args:             []string{"-c", "from github import Github"},
-				ifFailure:        checkWarning,
-				ifSuccessMessage: "pygithub installed",
-				hint:             `Run "pip3 install --user PyGithub".`,
 			},
 			&binaryCheck{
 				name:          "gh",


### PR DESCRIPTION
Dear friends,
I think the time for this has come.

We (at least me) are constantly seeing more Python-based contribs, especially given the last introduction of Scapy-based BPF unit test (packet definition and assertion). Python is not the main language of the codebase, nor it will, but I honestly think we should start putting guidelines so that there's a common sense, and we all keep writing quality and readable code.

For this reason, this PR:

1. defines `pyproject.toml`: Cilium is not built as a Python project of course, but this is useful to define dev/tooling dependencies for Python tools. For instance, at the current time there's nothing that is telling a developer "Hey, you need Scapy to run BPF unit tests even though you're using only Go".
2. introduces `Ruff` as linter (PEP8) and formatter (similar to Blake). After trials-and-errors, the config is very similar to the one used in one of the most used Python projects: `matplotlib`. Enabling a too strict config would've led to too many changes in the codebase, and too specific subtleties. Ruff is not mandatory for developers in their own editors, but PR will be rejected if Ruff formatter complains in CI. On this, I'm open to discuss its adoption only as linter and not as formatter, though I truly believe given Python is not the core of Cilium it is a good moment to use it for both.
3. adds Ruff to GitHub CI, to reject PRs going against the style/format
4. applies automatic Ruff fixes run locally
5. applies manual fixes: I went Messiah mode and adjusted all the remaining complaints.
6. Python dependencies are now checked within the `make dev-doctor` command.

Doubts:

* need Dev doc changes?
* @joestringer I'd love your feedback on this, and if you could guide me throughout what is missing
* I'm not aware of previous discussion on this topic, please refresh my mind if there were any

This is a best-effort tentative, any kind feedback is appreciated.
