### PR TITLE
loader: run XDP tests against 'lo' interface

### DIFF
--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -103,7 +103,7 @@ func xdpAttachedModeToFlag(mode uint32) link.XDPAttachFlags {
 //
 // bpffsBase is typically set to /sys/fs/bpf/cilium, but can be a temp directory
 // during tests.
-func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, xdpDevs []string, xdpMode xdp.Mode, bpffsBase string) {
+func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, keep []string, xdpMode xdp.Mode, bpffsBase string) {
 	links, err := safenetlink.LinkList()
 	if err != nil {
 		logger.Warn("Failed to list links for XDP unload",
@@ -123,8 +123,8 @@ func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, xdpDevs []string, xdpMo
 		}
 
 		used := false
-		for _, xdpDev := range xdpDevs {
-			if link.Attrs().Name == xdpDev &&
+		for _, dev := range keep {
+			if link.Attrs().Name == dev &&
 				xdpAttachedModeToFlag(linkxdp.AttachMode) == xdpConfigModeToFlag(xdpMode) {
 				// XDP mode matches; don't unload, otherwise we might introduce
 				// intermittent connectivity problems

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
@@ -29,68 +28,43 @@ func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
+	basePath := testutils.TempBPFFS(t)
+	prog := mustXDPProgram(t, symbolFromHostNetdevXDP)
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: "veth"},
+		PeerName:  "peer",
+	}
+
 	ns := netns.NewNetNS(t)
-
 	ns.Do(func() error {
-		h, err := safenetlink.NewHandle(nil)
-		require.NoError(t, err)
+		require.NoError(t, netlink.LinkAdd(veth))
 
-		veth0 := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
-			PeerName:  "veth2",
-		}
-		err = h.LinkAdd(veth0)
-		require.NoError(t, err)
+		loLinkPath := bpffsDeviceLinksDir(basePath, lo)
+		require.NoError(t, bpf.MkdirBPF(loLinkPath))
+		vethLinkPath := bpffsDeviceLinksDir(basePath, veth)
+		require.NoError(t, bpf.MkdirBPF(vethLinkPath))
 
-		veth1 := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: "veth1"},
-			PeerName:  "veth3",
-		}
-		err = h.LinkAdd(veth1)
-		require.NoError(t, err)
-
-		prog := mustXDPProgram(t, symbolFromHostNetdevXDP)
-		basePath := testutils.TempBPFFS(t)
-		veth0LinkPath := bpffsDeviceLinksDir(basePath, veth0)
-		require.NoError(t, bpf.MkdirBPF(veth0LinkPath))
-		veth1LinkPath := bpffsDeviceLinksDir(basePath, veth1)
-		require.NoError(t, bpf.MkdirBPF(veth1LinkPath))
 		// need to use symbolFromHostNetdevXDP as progName here as maybeUnloadObsoleteXDPPrograms explicitly uses that name.
-		err = attachXDPProgram(logger, veth0, prog, symbolFromHostNetdevXDP, veth0LinkPath, link.XDPDriverMode)
-		require.NoError(t, err)
+		require.NoError(t, attachXDPProgram(logger, lo, prog, symbolFromHostNetdevXDP, loLinkPath, link.XDPGenericMode))
+		require.NoError(t, attachXDPProgram(logger, veth, prog, symbolFromHostNetdevXDP, vethLinkPath, link.XDPGenericMode))
 
-		err = attachXDPProgram(logger, veth1, prog, symbolFromHostNetdevXDP, veth1LinkPath, link.XDPDriverMode)
-		require.NoError(t, err)
+		// Clean up all interfaces except lo.
+		maybeUnloadObsoleteXDPPrograms(logger, []string{lo.Attrs().Name}, option.XDPModeLinkGeneric, basePath)
 
-		maybeUnloadObsoleteXDPPrograms(logger,
-			[]string{"veth0"}, option.XDPModeLinkDriver, basePath,
-		)
-
+		// Wait for veth to be detached.
 		require.NoError(t, testutils.WaitUntil(func() bool {
-			v1, err := safenetlink.WithRetryResult(func() (netlink.Link, error) {
-				//nolint:forbidigo
-				return h.LinkByName("veth1")
-			})
-			require.NoError(t, err)
-			if v1.Attrs().Xdp != nil {
-				return v1.Attrs().Xdp.Attached == false
+			obsolete := getLink(t, veth)
+			if obsolete.Attrs().Xdp == nil {
+				return false
 			}
-			return true
+
+			return !obsolete.Attrs().Xdp.Attached
 		}, time.Second))
 
-		v0, err := safenetlink.WithRetryResult(func() (netlink.Link, error) {
-			//nolint:forbidigo
-			return h.LinkByName("veth0")
-		})
-		require.NoError(t, err)
-		require.NotNil(t, v0.Attrs().Xdp)
-		require.True(t, v0.Attrs().Xdp.Attached)
-
-		err = netlink.LinkDel(veth0)
-		require.NoError(t, err)
-
-		err = netlink.LinkDel(veth1)
-		require.NoError(t, err)
+		// Wait for lo to be attached.
+		attached := getLink(t, lo)
+		require.NotNil(t, attached.Attrs().Xdp)
+		require.True(t, attached.Attrs().Xdp.Attached)
 
 		return nil
 	})
@@ -102,23 +76,11 @@ func TestPrivilegedAttachXDP(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	ns := netns.NewNetNS(t)
-
 	ns.Do(func() error {
-		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
-			PeerName:  "veth1",
-		}
-		err := netlink.LinkAdd(veth)
-		require.NoError(t, err)
-
 		prog := mustXDPProgram(t, "test")
 		basePath := testutils.TempBPFFS(t)
 
-		err = attachXDPProgram(logger, veth, prog, "test", basePath, link.XDPGenericMode)
-		require.NoError(t, err)
-
-		err = netlink.LinkDel(veth)
-		require.NoError(t, err)
+		require.NoError(t, attachXDPProgram(logger, lo, prog, "test", basePath, link.XDPGenericMode))
 
 		return nil
 	})
@@ -130,26 +92,12 @@ func TestPrivilegedAttachXDPWithPreviousAttach(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	ns := netns.NewNetNS(t)
-
 	ns.Do(func() error {
-		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
-			PeerName:  "veth1",
-		}
-		err := netlink.LinkAdd(veth)
-		require.NoError(t, err)
-
 		prog := mustXDPProgram(t, "test")
 		basePath := testutils.TempBPFFS(t)
 
-		err = netlink.LinkSetXdpFdWithFlags(veth, prog.FD(), int(link.XDPGenericMode))
-		require.NoError(t, err)
-
-		err = attachXDPProgram(logger, veth, prog, "test", basePath, link.XDPGenericMode)
-		require.NoError(t, err)
-
-		err = netlink.LinkDel(veth)
-		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetXdpFdWithFlags(lo, prog.FD(), int(link.XDPGenericMode)))
+		require.NoError(t, attachXDPProgram(logger, lo, prog, "test", basePath, link.XDPGenericMode))
 
 		return nil
 	})
@@ -161,22 +109,14 @@ func TestPrivilegedAttachXDPWithExistingLink(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	ns := netns.NewNetNS(t)
-
 	ns.Do(func() error {
-		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
-			PeerName:  "veth1",
-		}
-		err := netlink.LinkAdd(veth)
-		require.NoError(t, err)
-
 		prog := mustXDPProgram(t, "test")
 
 		// Probe XDP bpf_link support by manually attaching a Program and
 		// immediately closing the link when it succeeds.
 		l, err := link.AttachXDP(link.XDPOptions{
 			Program:   prog,
-			Interface: veth.Attrs().Index,
+			Interface: lo.Attrs().Index,
 			Flags:     link.XDPGenericMode,
 		})
 		if errors.Is(err, ebpf.ErrNotSupported) {
@@ -186,24 +126,18 @@ func TestPrivilegedAttachXDPWithExistingLink(t *testing.T) {
 		require.NoError(t, l.Close())
 
 		basePath := testutils.TempBPFFS(t)
-		pinDir := bpffsDeviceLinksDir(basePath, veth)
+		pinDir := bpffsDeviceLinksDir(basePath, lo)
 		require.NoError(t, bpf.MkdirBPF(pinDir))
 
 		// At this point, we know bpf_link is supported, so attachXDPProgram should
 		// use it.
-		err = attachXDPProgram(logger, veth, prog, "test", pinDir, link.XDPGenericMode)
-		require.NoError(t, err)
+		require.NoError(t, attachXDPProgram(logger, lo, prog, "test", pinDir, link.XDPGenericMode))
 
 		// Attach the same program again. This should update the existing link.
-		err = attachXDPProgram(logger, veth, prog, "test", pinDir, link.XDPGenericMode)
-		require.NoError(t, err)
+		require.NoError(t, attachXDPProgram(logger, lo, prog, "test", pinDir, link.XDPGenericMode))
 
 		// Detach the program.
-		err = DetachXDP(veth.Attrs().Name, basePath, "test")
-		require.NoError(t, err)
-
-		err = netlink.LinkDel(veth)
-		require.NoError(t, err)
+		require.NoError(t, DetachXDP(lo.Attrs().Name, basePath, "test"))
 
 		return nil
 	})
@@ -215,30 +149,18 @@ func TestPrivilegedDetachXDPWithPreviousAttach(t *testing.T) {
 
 	ns := netns.NewNetNS(t)
 	ns.Do(func() error {
-		var veth netlink.Link = &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
-			PeerName:  "veth1",
-		}
-		err := netlink.LinkAdd(veth)
-		require.NoError(t, err)
-
 		prog := mustXDPProgram(t, "test")
 		basePath := testutils.TempBPFFS(t)
 
-		err = netlink.LinkSetXdpFdWithFlags(veth, prog.FD(), int(link.XDPGenericMode))
-		require.NoError(t, err)
-		require.True(t, getLink(t, veth).Attrs().Xdp.Attached)
+		require.NoError(t, netlink.LinkSetXdpFdWithFlags(lo, prog.FD(), int(link.XDPGenericMode)))
+		require.True(t, getLink(t, lo).Attrs().Xdp.Attached)
 
 		// Detach with the wrong name, leaving the program attached.
-		err = DetachXDP(veth.Attrs().Name, basePath, "foo")
-		require.NoError(t, err)
-		require.True(t, getLink(t, veth).Attrs().Xdp.Attached)
+		require.NoError(t, DetachXDP(lo.Attrs().Name, basePath, "foo"))
+		require.True(t, getLink(t, lo).Attrs().Xdp.Attached)
 
-		err = DetachXDP(veth.Attrs().Name, basePath, "test")
-		require.NoError(t, err)
-		require.False(t, getLink(t, veth).Attrs().Xdp.Attached)
-
-		require.NoError(t, netlink.LinkDel(veth))
+		require.NoError(t, DetachXDP(lo.Attrs().Name, basePath, "test"))
+		require.False(t, getLink(t, lo).Attrs().Xdp.Attached)
 
 		return nil
 	})


### PR DESCRIPTION
This removes quite a bit of boilerplate and complexity from the XDP tests.

Also renamed xdpDevs in maybeUnloadObsoleteXDPPrograms to clarify it's a list of interfaces to keep.