### PR TITLE
[CFP-39876]: Add connectivity test for non-global namespace isolation

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -288,6 +288,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientEgressToCidrgroupDenyByLabel{},
 		clientEgressToCidrDenyDefault{},
 		clusterMeshEndpointSliceSync{},
+		clusterMeshNSNotGlobal{},
 		health{},
 		northSouthLoadbalancing{},
 		podToPodEncryption{},

--- a/cilium-cli/connectivity/builder/clustermesh_ns_not_global.go
+++ b/cilium-cli/connectivity/builder/clustermesh_ns_not_global.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clusterMeshNSNotGlobal struct{}
+
+func (t clusterMeshNSNotGlobal) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("clustermesh-ns-not-global", ct).
+		WithCondition(func() bool { return ct.Params().MultiCluster != "" }).
+		WithFeatureRequirements(features.RequireDisabled(features.DefaultGlobalNamespace)).
+		WithSetupFunc(func(ctx context.Context, t *check.Test, testCtx *check.ConnectivityTest) error {
+			return check.DeployNonGlobalNSTestEnv(ctx, t, testCtx)
+		}).
+		WithScenarios(tests.ClusterMeshNSNotGlobal()).
+		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
+			return check.ResultDropCurlTimeout, check.ResultNone
+		}).
+		WithFinalizer(func(ctx context.Context) error {
+			return check.CleanupNonGlobalNSTestEnv(ctx, ct)
+		})
+}

--- a/cilium-cli/connectivity/tests/clustermesh-ns-not-global.go
+++ b/cilium-cli/connectivity/tests/clustermesh-ns-not-global.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+func ClusterMeshNSNotGlobal() check.Scenario {
+	return &clusterMeshNSNotGlobal{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+type clusterMeshNSNotGlobal struct {
+	check.ScenarioBase
+}
+
+func (s *clusterMeshNSNotGlobal) Name() string {
+	return "clustermesh-ns-not-global"
+}
+
+func (s *clusterMeshNSNotGlobal) Run(ctx context.Context, t *check.Test) {
+	ct := t.Context()
+	client := ct.RandomClientPod()
+	if client == nil {
+		t.Fatalf("No client pod available")
+	}
+
+	ep := check.HTTPEndpoint(
+		"echo-non-global",
+		fmt.Sprintf("http://echo-non-global.%s.svc.cluster.local:8080/", check.NonGlobalNSName),
+	)
+
+	t.ForEachIPFamily(func(ipFam features.IPFamily) {
+		t.NewAction(s, fmt.Sprintf("curl-%s", ipFam), client, ep, ipFam).Run(func(a *check.Action) {
+			a.ExecInPod(ctx, a.CurlCommand(ep))
+		})
+	})
+}


### PR DESCRIPTION
Add a connectivity test that verifies services in a non-global namespace are not synced across clusters when defaultGlobalNamespace is disabled as defined in [CFP-39876](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-39876-clustermesh-filtered-export.md#mcs-support).
The test deploys an echo server in a namespace without the global annotation and expects cross-cluster connectivity to fail.

Follow-up of:
-  #42905
- #43385
- #43918

Specifically addresses the comment from this pr. https://github.com/cilium/cilium/pull/43918#discussion_r2775527385

