### PR TITLE
netkit load-time check and associated tests for bpf_redirect/redirect_peer

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2018,7 +2018,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 
 		if (do_redirect)
 			ret = redirect_ep(ctx, CONFIG(interface_ifindex),
-					  should_fast_redirect(ctx, from_host),
+					  should_redirect_peer(ctx, from_host),
 					  from_tunnel);
 		break;
 	default:
@@ -2342,7 +2342,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 
 		if (do_redirect)
 			ret = redirect_ep(ctx, CONFIG(interface_ifindex),
-					  should_fast_redirect(ctx, from_host),
+					  should_redirect_peer(ctx, from_host),
 					  from_tunnel);
 		break;
 	default:

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2018,7 +2018,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 
 		if (do_redirect)
 			ret = redirect_ep(ctx, CONFIG(interface_ifindex),
-					  should_redirect_peer(ctx, from_host),
+					  should_redirect_peer(from_host),
 					  from_tunnel);
 		break;
 	default:
@@ -2342,7 +2342,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 
 		if (do_redirect)
 			ret = redirect_ep(ctx, CONFIG(interface_ifindex),
-					  should_redirect_peer(ctx, from_host),
+					  should_redirect_peer(from_host),
 					  from_tunnel);
 		break;
 	default:

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -55,27 +55,29 @@ tail_call_policy(struct __ctx_buff *ctx, __u16 endpoint_id)
 	return DROP_EP_NOT_READY;
 }
 
-static __always_inline bool should_redirect_peer(struct __ctx_buff *ctx, bool from_host)
+static __always_inline bool
+should_redirect_peer(bool from_host)
 {
-	/* Going via CPU backlog queue (aka needs_backlog) is required
-	 * whenever we cannot do a fast ingress -> ingress switch but
-	 * instead need an ingress -> egress netns traversal or vice
-	 * versa.
+	/* We should only do a redirect_peer() if BPF Host Routing is enabled,
+	 * otherwise we do a standard redirect().
 	 *
-	 * This is also the case if BPF host routing is disabled, or if
-	 * we are currently on egress which is indicated by ingress_ifindex
-	 * being 0. The latter is cleared upon skb scrubbing.
+	 * Also, if we're from_host, we cannot do an ingress -> ingress switch
+	 * via redirect_peer() and instead need an ingress -> egress netns
+	 * traversal (or vice versa.)
 	 *
-	 * In case of netkit, we're on the egress side and need a regular
-	 * redirect to the peer device's ifindex. In case of veth we're
-	 * on ingress and need a redirect peer to get to the target. Both
-	 * only traverse the CPU backlog queue once. In case of phys ->
-	 * Pod, the ingress_ifindex is > 0 and in both device types we
-	 * do want a redirect peer into the target Pod's netns.
+	 * Finally, in case of Pod -> Pod:
+	 * - on veth, we're on TC ingress and need a redirect_peer() to get
+	 *   to the target namespace.
+	 * - on netkit, we're on TC egress and need a regular redirect() to
+	 *   the peer device's ifindex. Netkit takes care of the namespace
+	 *   switch for us.
+	 *
+	 * Note: both redirect() and redirect_peer() only traverse the CPU
+	 * backlog queue once.
 	 */
 	return is_defined(ENABLE_HOST_ROUTING) &&
 	       !from_host &&
-	       ctx_get_ingress_ifindex(ctx) > 0;
+	       !CONFIG(enable_netkit);
 }
 
 static __always_inline int redirect_ep(struct __ctx_buff *ctx,
@@ -141,18 +143,17 @@ local_delivery(struct __ctx_buff *ctx, __u32 seclabel, __u32 magic,
 			return ret;
 	}
 
-/*
- * When BPF host routing is enabled we need to check policies at source, as in
- * this case the skb is delivered directly to pod's namespace and the ingress
- * policy (the cil_to_container BPF program) is bypassed.
- */
-	use_redirect_peer = should_redirect_peer(ctx, from_host);
+	/* When BPF host routing is enabled we need to check policies at source, as in
+	 * this case the skb is delivered directly to pod's namespace and the ingress
+	 * policy (the cil_to_container BPF program) is bypassed.
+	 */
+	use_redirect_peer = should_redirect_peer(from_host);
 	if (is_defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && !use_redirect_peer &&
 	    /* We need to enforce policies at the source in case of netkit
 	     * devices because we can't redirect to proxy from bpf_lxc. That
 	     * needs a fix upstream.
 	     */
-	    (!CONFIG(enable_netkit) || ctx_get_ingress_ifindex(ctx) > 0)) {
+	    !CONFIG(enable_netkit)) {
 		set_identity_mark(ctx, seclabel, magic);
 
 # if !defined(ENABLE_NODEPORT)

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -14,3 +14,4 @@ from wg_from_netdev_pkt_defs import *
 from tc_wireguard_from_overlay_pkt_defs import *
 from icmp_err_revnat_pkt_defs import *
 from lb_pkt_defs import *
+from tc_redirect_pkt_defs import *

--- a/bpf/tests/scapy/pkt_defs_common.py
+++ b/bpf/tests/scapy/pkt_defs_common.py
@@ -45,6 +45,7 @@ v4_pod_three_on_node_two = "192.168.1.3"
 
 v4_pod_cidr_size = 24
 
+# IPv4 service loopback
 v4_svc_loopback = "10.245.255.31"
 
 v4_all = "0.0.0.0"
@@ -65,6 +66,9 @@ v6_svc_one    = "fd10::1"
 # External IPv6 addrs
 v6_ext_node_one = "2001::1"
 
+# IPv6 service loopback
+v6_svc_loopback = "fd05::1"
+
 v6_all = "::"
 
 # Source port to be used by a client
@@ -79,6 +83,10 @@ tcp_dst_three = 44551
 tcp_svc_one   = 80
 tcp_svc_two   = 443
 tcp_svc_three = 53
+
+# Other default properties for TCP
+tcp_default_seq = 123456
+tcp_default_win = 65535
 
 # Default payload data for tests. Note this includes a trailing
 # NUL-terminating byte for consistency with the C macro. This is

--- a/bpf/tests/scapy/tc_redirect_pkt_defs.py
+++ b/bpf/tests/scapy/tc_redirect_pkt_defs.py
@@ -1,0 +1,34 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+
+from pkt_defs_common import *
+
+# tc_redirect_lxc IPv4
+tc_redirect_lxc_ipv4_pre = (
+	Ether(src=mac_one, dst=mac_two) /
+	IP(src=v4_pod_one, dst=v4_svc_one, id=0, ttl=64) /
+	TCP(sport=tcp_src_one, dport=tcp_svc_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)
+tc_redirect_lxc_ipv4_post = (
+	Ether(src=mac_three, dst=mac_four) /
+	IP(src=v4_svc_loopback, dst=v4_pod_one, id=0, ttl=63) /
+	TCP(sport=tcp_src_one, dport=tcp_dst_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)
+
+# tc_redirect_lxc IPv6
+tc_redirect_lxc_ipv6_pre = (
+	Ether(src=mac_one, dst=mac_two) /
+	IPv6(src=v6_pod_one, dst=v6_svc_one, hlim=64) /
+	TCP(sport=tcp_src_one, dport=tcp_svc_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)
+tc_redirect_lxc_ipv6_post = (
+	Ether(src=mac_three, dst=mac_four) /
+	IPv6(src=v6_svc_loopback, dst=v6_pod_one, hlim=63) /
+	TCP(sport=tcp_src_one, dport=tcp_dst_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)

--- a/bpf/tests/scapy/tc_redirect_pkt_defs.py
+++ b/bpf/tests/scapy/tc_redirect_pkt_defs.py
@@ -32,3 +32,31 @@ tc_redirect_lxc_ipv6_post = (
 	TCP(sport=tcp_src_one, dport=tcp_dst_one, seq=tcp_default_seq, window=tcp_default_win) /
 	Raw(default_data)
 )
+
+# tc_redirect_host IPv4
+tc_redirect_host_ipv4_pre = (
+	Ether(src=mac_one, dst=mac_two) /
+	IP(src=v4_ext_one, dst=v4_pod_one, id=0, ttl=64) /
+	TCP(sport=tcp_src_one, dport=tcp_svc_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)
+tc_redirect_host_ipv4_post = (
+	Ether(src=mac_three, dst=mac_four) /
+	IP(src=v4_ext_one, dst=v4_pod_one, id=0, ttl=63) /
+	TCP(sport=tcp_src_one, dport=tcp_svc_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)
+
+# tc_redirect_host IPv6
+tc_redirect_host_ipv6_pre = (
+	Ether(src=mac_one, dst=mac_two) /
+	IPv6(src=v6_ext_node_one, dst=v6_pod_one, hlim=64) /
+	TCP(sport=tcp_src_one, dport=tcp_svc_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)
+tc_redirect_host_ipv6_post = (
+	Ether(src=mac_three, dst=mac_four) /
+	IPv6(src=v6_ext_node_one, dst=v6_pod_one, hlim=63) /
+	TCP(sport=tcp_src_one, dport=tcp_svc_one, seq=tcp_default_seq, window=tcp_default_win) /
+	Raw(default_data)
+)

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -1,0 +1,332 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+#include "scapy.h"
+
+/* We always assume we have BPF Host Routing enabled */
+#define ENABLE_HOST_ROUTING 1
+
+/* Define an endpoint ID that we'll use as index into policy maps. */
+#define TEST_LXC_ID_LOCAL 233
+
+/* Define host and LXC interface index */
+#define TEST_HOST_IFACE 24
+#define TEST_LXC_IFACE 25
+
+/* Define mac addresses we expect to see on redirected packet */
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *ep_mac = mac_four;
+
+/* Counters to record helper usage across tests */
+enum {
+	RECORD_TAILCALL = 0,
+	RECORD_REDIRECT,
+	RECORD_REDIRECT_PEER,
+	RECORD__MAX
+};
+
+static unsigned int num_calls[RECORD__MAX] = {};
+
+/* Mocked out BPF helpers that we're intending to test usage of. */
+int mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused,
+		      int ifindex __maybe_unused,
+		      __u32 flags __maybe_unused)
+{
+	num_calls[RECORD_REDIRECT]++;
+	return CTX_ACT_REDIRECT;
+}
+
+int mock_ctx_redirect_peer(const struct __ctx_buff *ctx __maybe_unused,
+			   int ifindex __maybe_unused,
+			   __u32 flags __maybe_unused)
+{
+	num_calls[RECORD_REDIRECT_PEER]++;
+	return CTX_ACT_REDIRECT;
+}
+
+int mock_tail_policy(struct __ctx_buff *ctx); /* Defined below bpf_host inclusion */
+
+__section_entry
+int mock_handle_policy(struct __ctx_buff *ctx)
+{
+	num_calls[RECORD_TAILCALL]++;
+
+	/* If we've invoked a policy tailcall exactly once, we can proceed to
+	 * a redirect. In the case of bpf_host, we need to call our mock
+	 * policy handling, which will call redirect_ep().
+	 */
+	if (num_calls[RECORD_TAILCALL] == 1)
+		return mock_tail_policy(ctx);
+
+	return CTX_ACT_DROP;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[TEST_LXC_ID_LOCAL] = &mock_handle_policy,
+	},
+};
+
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused,
+		       __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+#define tail_call_dynamic mock_tail_call_dynamic
+#define ctx_redirect mock_ctx_redirect
+#define ctx_redirect_peer mock_ctx_redirect_peer
+
+/* Load the appropriate BPF programs. */
+#include "lib/bpf_host.h"
+
+/* Mocked out policy function so we can test redirect_ep(). This is needed
+ * because the policy logic is in bpf_lxc and we can't include that here.
+ * But, the aim of this test is to exercise the redirect_ep() logic so this
+ * seems OK.
+ */
+int mock_tail_policy(struct __ctx_buff *ctx)
+{
+	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
+	bool from_tunnel = false;
+
+	/* We should always be from_host here. */
+	if (do_redirect && from_host)
+		return redirect_ep(ctx, CONFIG(interface_ifindex),
+				   should_redirect_peer(from_host),
+				   from_tunnel);
+
+	/* Failure path */
+	return CTX_ACT_DROP;
+}
+
+/* Set our host interface index */
+ASSIGN_CONFIG(__u32, interface_ifindex, TEST_HOST_IFACE)
+
+/* Deal with testing netkit or veth. */
+#ifdef __CONFIG_ENABLE_NETKIT
+#define TEST_DRIVER_NAME "netkit"
+ASSIGN_CONFIG(bool, enable_netkit, true)
+#else
+#define TEST_DRIVER_NAME "veth"
+ASSIGN_CONFIG(bool, enable_netkit, false)
+#endif
+
+/* Source identity so we can validate skb mark. */
+#define TEST_SRC_IDENTITY 0xCAFE
+#if !defined(__CONFIG_ENABLE_NETKIT) && defined(USE_BPF_PROG_FOR_INGRESS_POLICY)
+#define TEST_SKB_MARK (__u32)((TEST_SRC_IDENTITY << 16) | MARK_MAGIC_IDENTITY)
+#else
+#define TEST_SKB_MARK (__u32)0x0
+#endif
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+
+#ifdef ENABLE_IPV4
+
+/* Setup for this test:
+ * +--------External--------+    +----------Pod 1---------+
+ * | v4_ext_one:high-port   | -> | v4_pod_one:tcp_svc_one |
+ * +------------------------+    +------------------------+
+ */
+PKTGEN("tc", "tc_redirect_host_ipv4")
+int tc_redirect_host_ipv4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(REDIRECT_HOST_IPV4_PRE, tc_redirect_host_ipv4_pre);
+	BUILDER_PUSH_BUF(builder, REDIRECT_HOST_IPV4_PRE);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Test that sending a packet from the host into a Pod is correctly forwarded via
+ * the appropriate bpf redirect helper.
+ */
+SETUP("tc", "tc_redirect_host_ipv4")
+int tc_redirect_host_ipv4_setup(struct __ctx_buff *ctx)
+{
+	/* Add an IPCache entry for pod 1 */
+	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
+
+	/* Add endpoint for local LXC */
+	endpoint_v4_add_entry(v4_pod_one, TEST_LXC_IFACE, TEST_LXC_ID_LOCAL, 0, 0, 0,
+			      (const __u8 *)ep_mac, (const __u8 *)node_mac);
+
+	/* Add source identity to test mark */
+	ipcache_v4_add_entry(v4_ext_one, 0, TEST_SRC_IDENTITY, 0, 0);
+
+	return host_send_packet(ctx);
+}
+
+CHECK("tc", "tc_redirect_host_ipv4")
+int tc_redirect_host_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+#ifdef __CONFIG_ENABLE_NETKIT
+	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
+#elif !defined(__CONFIG_ENABLE_NETKIT) && defined(USE_BPF_PROG_FOR_INGRESS_POLICY)
+	const unsigned int expected[RECORD__MAX] = {0, 1, 0};
+#else
+	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
+#endif
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	/* Should trigger CTX_ACT_REDIRECT */
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Test redirect calls */
+	test_log(TEST_DRIVER_NAME ": mark 0x%lx", ctx->mark);
+	test_log(TEST_DRIVER_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
+		 num_calls[RECORD_TAILCALL],
+		 num_calls[RECORD_REDIRECT],
+		 num_calls[RECORD_REDIRECT_PEER]);
+
+	if (ctx->mark != TEST_SKB_MARK)
+		test_fatal(TEST_DRIVER_NAME ": Incorrect skb mark: 0x%lx != 0x%lx",
+			   ctx->mark, TEST_SKB_MARK);
+	if (num_calls[RECORD_TAILCALL] != expected[RECORD_TAILCALL])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of tail calls");
+	if (num_calls[RECORD_REDIRECT] != expected[RECORD_REDIRECT])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of bpf_redirect() calls")
+	if (num_calls[RECORD_REDIRECT_PEER] != expected[RECORD_REDIRECT_PEER])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
+
+	/* Check the packet. */
+	BUF_DECL(REDIRECT_HOST_IPV4_POST, tc_redirect_host_ipv4_post);
+	ASSERT_CTX_BUF_OFF("tc_redirect_host_ipv4_post",
+			   "Ether", ctx, sizeof(__u32),
+			   REDIRECT_HOST_IPV4_POST,
+			   sizeof(BUF(REDIRECT_HOST_IPV4_POST)));
+
+	test_finish();
+}
+
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+
+/* Setup for this test:
+ * +--------External--------+    +----------Pod 1---------+
+ * | v6_ext_one:high-port   | -> | v6_pod_one:tcp_svc_one |
+ * +------------------------+    +------------------------+
+ */
+PKTGEN("tc", "tc_redirect_host_ipv6")
+int tc_redirect_host_ipv6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(REDIRECT_HOST_IPV6_PRE, tc_redirect_host_ipv6_pre);
+	BUILDER_PUSH_BUF(builder, REDIRECT_HOST_IPV6_PRE);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Test that sending a packet from the host into a Pod is correctly forwarded via
+ * the appropriate bpf redirect helper.
+ */
+SETUP("tc", "tc_redirect_host_ipv6")
+int tc_redirect_host_ipv6_setup(struct __ctx_buff *ctx)
+{
+	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
+	const union v6addr ext_ip = { .addr = v6_ext_node_one_addr };
+
+	/* Add an IPCache entry for pod 1 */
+	ipcache_v6_add_entry(&pod_ip, 0, 112233, 0, 0);
+
+	/* Add endpoint for local LXC */
+	endpoint_v6_add_entry(&pod_ip, TEST_LXC_IFACE, TEST_LXC_ID_LOCAL, 0, 0,
+			      (const __u8 *)ep_mac, (const __u8 *)node_mac);
+
+	/* Add source identity to test mark */
+	ipcache_v6_add_entry(&ext_ip, 0, TEST_SRC_IDENTITY, 0, 0);
+
+	return host_send_packet(ctx);
+}
+
+CHECK("tc", "tc_redirect_host_ipv6")
+int tc_redirect_host_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+#ifdef __CONFIG_ENABLE_NETKIT
+	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
+#elif defined(USE_BPF_PROG_FOR_INGRESS_POLICY)
+	const unsigned int expected[RECORD__MAX] = {0, 1, 0};
+#else
+	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
+#endif
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	/* Should trigger CTX_ACT_REDIRECT */
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Test redirect calls */
+	test_log(TEST_DRIVER_NAME ": mark 0x%lx", ctx->mark);
+	test_log(TEST_DRIVER_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
+		 num_calls[RECORD_TAILCALL],
+		 num_calls[RECORD_REDIRECT],
+		 num_calls[RECORD_REDIRECT_PEER]);
+
+	if (ctx->mark != TEST_SKB_MARK)
+		test_fatal(TEST_DRIVER_NAME ": Incorrect skb mark: 0x%lx != 0x%lx",
+			   ctx->mark, TEST_SKB_MARK);
+	if (num_calls[RECORD_TAILCALL] != expected[RECORD_TAILCALL])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of tail calls");
+	if (num_calls[RECORD_REDIRECT] != expected[RECORD_REDIRECT])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of bpf_redirect() calls")
+	if (num_calls[RECORD_REDIRECT_PEER] != expected[RECORD_REDIRECT_PEER])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
+
+	/* Check the packet. */
+	BUF_DECL(REDIRECT_HOST_IPV6_POST, tc_redirect_host_ipv6_post);
+	ASSERT_CTX_BUF_OFF("tc_redirect_host_ipv6_post",
+			   "Ether", ctx, sizeof(__u32),
+			   REDIRECT_HOST_IPV6_POST,
+			   sizeof(BUF(REDIRECT_HOST_IPV6_POST)));
+
+	test_finish();
+}
+
+#endif /* ENABLE_IPV6 */

--- a/bpf/tests/tc_redirect_host_netkit_ipv4.c
+++ b/bpf/tests/tc_redirect_host_netkit_ipv4.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV4 1
+#undef USE_BPF_PROG_FOR_INGRESS_POLICY
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_netkit_ipv4_policy.c
+++ b/bpf/tests/tc_redirect_host_netkit_ipv4_policy.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV4 1
+#define USE_BPF_PROG_FOR_INGRESS_POLICY 1
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_netkit_ipv6.c
+++ b/bpf/tests/tc_redirect_host_netkit_ipv6.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV6 1
+#undef USE_BPF_PROG_FOR_INGRESS_POLICY
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_netkit_ipv6_policy.c
+++ b/bpf/tests/tc_redirect_host_netkit_ipv6_policy.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV6 1
+#define USE_BPF_PROG_FOR_INGRESS_POLICY 1
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_veth_ipv4.c
+++ b/bpf/tests/tc_redirect_host_veth_ipv4.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV4 1
+#undef USE_BPF_PROG_FOR_INGRESS_POLICY
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_veth_ipv4_policy.c
+++ b/bpf/tests/tc_redirect_host_veth_ipv4_policy.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV4 1
+#define USE_BPF_PROG_FOR_INGRESS_POLICY 1
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_veth_ipv6.c
+++ b/bpf/tests/tc_redirect_host_veth_ipv6.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV6 1
+#undef USE_BPF_PROG_FOR_INGRESS_POLICY
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_host_veth_ipv6_policy.c
+++ b/bpf/tests/tc_redirect_host_veth_ipv6_policy.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV6 1
+#define USE_BPF_PROG_FOR_INGRESS_POLICY 1
+#include "tc_redirect_host.h"

--- a/bpf/tests/tc_redirect_lxc.h
+++ b/bpf/tests/tc_redirect_lxc.h
@@ -1,0 +1,323 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+
+/* Enable CT debug output */
+#undef QUIET_CT
+
+#include "pktgen.h"
+#include "scapy.h"
+
+/* We always assume we have BPF Host Routing enabled */
+#define ENABLE_HOST_ROUTING 1
+
+/* Forward declaration for tailcall routines because they're not provided
+ * until we pull in bpf_lxc.
+ *
+ * Note: we only allow one address family to be enabled per test so the
+ * test mock policy tailcall doesn't need to switch by address family.
+ */
+#if defined(ENABLE_IPV4) && !defined(ENABLE_IPV6)
+static inline int tail_ipv4_ct_ingress_policy_only(struct __ctx_buff *ctx);
+#define test_ct_ingress_policy_only tail_ipv4_ct_ingress_policy_only
+#elif !defined(ENABLE_IPV4) && defined(ENABLE_IPV6)
+static inline int tail_ipv6_ct_ingress_policy_only(struct __ctx_buff *ctx);
+#define test_ct_ingress_policy_only tail_ipv6_ct_ingress_policy_only
+#else
+#error This test must set either ENABLE_IPV4 or ENABLE_IPV6, but not both.
+#endif
+
+/* Define an endpoint ID that we'll use as index into policy maps. */
+#define TEST_LXC_ID_LOCAL 233
+
+/* Define mac addresses we expect to see on redirected packet */
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *ep_mac = mac_four;
+
+/* Counters to record helper usage across tests */
+enum {
+	RECORD_TAILCALL = 0,
+	RECORD_REDIRECT,
+	RECORD_REDIRECT_PEER,
+	RECORD__MAX
+};
+
+static unsigned int num_calls[RECORD__MAX] = {};
+
+/* Mocked out BPF helpers that we're intending to test usage of. */
+int mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused,
+		      int ifindex __maybe_unused,
+		      __u32 flags __maybe_unused)
+{
+	num_calls[RECORD_REDIRECT]++;
+	return CTX_ACT_REDIRECT;
+}
+
+int mock_ctx_redirect_peer(const struct __ctx_buff *ctx __maybe_unused,
+			   int ifindex __maybe_unused,
+			   __u32 flags __maybe_unused)
+{
+	num_calls[RECORD_REDIRECT_PEER]++;
+	return CTX_ACT_REDIRECT;
+}
+
+__section_entry
+int mock_handle_policy(struct __ctx_buff *ctx)
+{
+	num_calls[RECORD_TAILCALL]++;
+
+	/* If we've invoked a policy tailcall exactly once, we can proceed to
+	 * a redirect. In the case of bpf_lxc, we need to call the subsequent
+	 * policy function manually to get to the final redirect_ep() call.
+	 */
+	if (num_calls[RECORD_TAILCALL] == 1)
+		return test_ct_ingress_policy_only(ctx);
+
+	return CTX_ACT_DROP;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[TEST_LXC_ID_LOCAL] = &mock_handle_policy,
+	},
+};
+
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused,
+		       __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+#define tail_call_dynamic mock_tail_call_dynamic
+#define ctx_redirect mock_ctx_redirect
+#define ctx_redirect_peer mock_ctx_redirect_peer
+
+/* Load the appropriate BPF programs. */
+#include "lib/bpf_lxc.h"
+
+/* Assign necessary load-time configs */
+#ifdef ENABLE_IPV4
+ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one })
+ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
+#endif /* ENABLE_IPV4 */
+#ifdef ENABLE_IPV6
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
+ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
+#endif /* ENABLE_IPV6 */
+
+/* Deal with testing netkit or veth. */
+#ifdef __CONFIG_ENABLE_NETKIT
+#define TEST_DRIVER_NAME "netkit"
+ASSIGN_CONFIG(bool, enable_netkit, true)
+#else
+#define TEST_DRIVER_NAME "veth"
+ASSIGN_CONFIG(bool, enable_netkit, false)
+#endif
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+#include "lib/policy.h"
+
+#ifdef ENABLE_IPV4
+
+/* Setup for this test:
+ * +-------ClusterIP--------+    +----------Pod 1---------+
+ * | v4_svc_one:tcp_svc_one | -> | v4_pod_one:tcp_svc_one |
+ * +------------------------+    +------------------------+
+ *            ^                            |
+ *            \---------------------------/
+ */
+PKTGEN("tc", "tc_redirect_lxc_ipv4")
+int tc_redirect_lxc_ipv4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(REDIRECT_LXC_IPV4_PRE, tc_redirect_lxc_ipv4_pre);
+	BUILDER_PUSH_BUF(builder, REDIRECT_LXC_IPV4_PRE);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Test that sending a packet from a pod to its own service gets source nat-ed
+ * and that it is forwarded via the correct BPF redirect helper.
+ */
+SETUP("tc", "tc_redirect_lxc_ipv4")
+int tc_redirect_lxc_ipv4_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* Add ClusterIP */
+	lb_v4_add_service(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
+			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
+
+	/* Add an IPCache entry for pod 1 */
+	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
+
+	/* Add endpoint for local LXC */
+	endpoint_v4_add_entry(v4_pod_one, 0, TEST_LXC_ID_LOCAL, 0, 0, 0,
+			      (const __u8 *)ep_mac, (const __u8 *)node_mac);
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_redirect_lxc_ipv4")
+int tc_redirect_lxc_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+#ifdef __CONFIG_ENABLE_NETKIT
+	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
+#else
+	const unsigned int expected[RECORD__MAX] = {1, 0, 1};
+#endif
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	/* Should trigger CTX_ACT_REDIRECT */
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Test redirect usage */
+	test_log(TEST_DRIVER_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
+		 num_calls[RECORD_TAILCALL],
+		 num_calls[RECORD_REDIRECT],
+		 num_calls[RECORD_REDIRECT_PEER]);
+
+	if (num_calls[RECORD_TAILCALL] != expected[RECORD_TAILCALL])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of tail calls");
+	if (num_calls[RECORD_REDIRECT] != expected[RECORD_REDIRECT])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of bpf_redirect() calls")
+	if (num_calls[RECORD_REDIRECT_PEER] != expected[RECORD_REDIRECT_PEER])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
+
+	/* Check the packet. */
+	BUF_DECL(REDIRECT_LXC_IPV4_POST, tc_redirect_lxc_ipv4_post);
+	ASSERT_CTX_BUF_OFF("tc_redirect_lxc_ipv4_post",
+			   "Ether", ctx, sizeof(__u32),
+			   REDIRECT_LXC_IPV4_POST,
+			   sizeof(BUF(REDIRECT_LXC_IPV4_POST)));
+
+	test_finish();
+}
+
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+
+/* Setup for this test:
+ * +-------ClusterIP--------+    +----------Pod 1---------+
+ * | v6_svc_one:tcp_svc_one | -> | v6_pod_one:tcp_svc_one |
+ * +------------------------+    +------------------------+
+ *            ^                            |
+ *            \---------------------------/
+ */
+PKTGEN("tc", "tc_redirect_lxc_ipv6")
+int tc_redirect_lxc_ipv6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	BUF_DECL(REDIRECT_LXC_IPV6_PRE, tc_redirect_lxc_ipv6_pre);
+	BUILDER_PUSH_BUF(builder, REDIRECT_LXC_IPV6_PRE);
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Test that sending a packet from a pod to its own service gets source nat-ed
+ * and that it is forwarded via the correct BPF redirect helper.
+ */
+SETUP("tc", "tc_redirect_lxc_ipv6")
+int tc_redirect_lxc_ipv6_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+	const union v6addr service_ip = { .addr = v6_svc_one_addr };
+	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
+
+	/* Add ClusterIP */
+	lb_v6_add_service(&service_ip, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&service_ip, tcp_svc_one, 1, 124,
+			  &pod_ip, tcp_dst_one, IPPROTO_TCP, 0);
+
+	/* Add an IPCache entry for pod 1 */
+	ipcache_v6_add_entry(&pod_ip, 0, 112233, 0, 0);
+
+	/* Add endpoint for local LXC */
+	endpoint_v6_add_entry(&pod_ip, 0, TEST_LXC_ID_LOCAL, 0, 0,
+			      (const __u8 *)ep_mac, (const __u8 *)node_mac);
+
+	return pod_send_packet(ctx);
+}
+
+CHECK("tc", "tc_redirect_lxc_ipv6")
+int tc_redirect_lxc_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+#ifdef __CONFIG_ENABLE_NETKIT
+	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
+#else
+	const unsigned int expected[RECORD__MAX] = {1, 0, 1};
+#endif
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	/* Should trigger CTX_ACT_REDIRECT */
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Test redirect usage */
+	test_log(TEST_DRIVER_NAME ": num_calls %u/%u/%u (tailcall/redirect/redirect_peer)",
+		 num_calls[RECORD_TAILCALL],
+		 num_calls[RECORD_REDIRECT],
+		 num_calls[RECORD_REDIRECT_PEER]);
+
+	if (num_calls[RECORD_TAILCALL] != expected[RECORD_TAILCALL])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of tail calls");
+	if (num_calls[RECORD_REDIRECT] != expected[RECORD_REDIRECT])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect number of bpf_redirect() calls")
+	if (num_calls[RECORD_REDIRECT_PEER] != expected[RECORD_REDIRECT_PEER])
+		test_fatal(TEST_DRIVER_NAME ": Incorrect nunmber of bpf_redirect_peer() calls")
+
+	/* Check the packet. */
+	BUF_DECL(REDIRECT_LXC_IPV6_POST, tc_redirect_lxc_ipv6_post);
+	ASSERT_CTX_BUF_OFF("tc_redirect_lxc_ipv6_post",
+			   "Ether", ctx, sizeof(__u32),
+			   REDIRECT_LXC_IPV6_POST,
+			   sizeof(BUF(REDIRECT_LXC_IPV6_POST)));
+
+	test_finish();
+}
+
+#endif /* ENABLE_IPV6 */

--- a/bpf/tests/tc_redirect_lxc_netkit_ipv4.c
+++ b/bpf/tests/tc_redirect_lxc_netkit_ipv4.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV4 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_netkit_ipv6.c
+++ b/bpf/tests/tc_redirect_lxc_netkit_ipv6.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_veth_ipv4.c
+++ b/bpf/tests/tc_redirect_lxc_veth_ipv4.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV4 1
+#include "tc_redirect_lxc.h"

--- a/bpf/tests/tc_redirect_lxc_veth_ipv6.c
+++ b/bpf/tests/tc_redirect_lxc_veth_ipv6.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#undef __CONFIG_ENABLE_NETKIT
+#define ENABLE_IPV6 1
+#include "tc_redirect_lxc.h"


### PR DESCRIPTION
This PR:

* Migrates BPF run-time checks for netkit, via `ctx->ingress_ifindex > 0`, to use the new `enable_netkit` load-time variable introduced in a prior PR.

* Introduces BPF tests that exercise the associated code paths up to `bpf_redirect()` and `bpf_redirect_peer()` usage.

Fixes: #41961

```release-note
Update netkit-specific logic in the data path to use a load-time variable, and add additional testing to verify this.
```