### PR TITLE
modernize: Enable `rangeint` analyzer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -119,7 +119,6 @@ linters:
     modernize:
       disable: # TODO: remove each disabled rule and fix it
         - omitzero
-        - rangeint
         - waitgroup
     govet:
       enable:

--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -390,7 +390,7 @@ func scapyParseAsserts(t *testing.T, scapyAssertMap *ebpf.Map) {
 
 	asserts := []map[string]any{}
 
-	for i := uint32(0); i < info.MaxEntries; i++ {
+	for i := range info.MaxEntries {
 		err = scapyAssertMap.Lookup(&i, &aval)
 		if err != nil {
 			t.Fatalf("error while getting iterating over the assert map: %s", err)

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -86,7 +86,7 @@ func (c *k8sStatusMockClient) setDaemonSet(namespace, name, filter string, desir
 
 	c.status = map[string]*models.StatusResponse{}
 
-	for i := int32(0); i < available; i++ {
+	for i := range available {
 		podName := fmt.Sprintf("%s-%d", name, i)
 		c.addPod(namespace, podName, filter, []corev1.Container{{Image: "cilium:1.8"}}, corev1.PodStatus{Phase: corev1.PodRunning})
 
@@ -103,7 +103,7 @@ func (c *k8sStatusMockClient) setDaemonSet(namespace, name, filter string, desir
 		}
 	}
 
-	for i := int32(0); i < unavailable; i++ {
+	for i := range unavailable {
 		podName := fmt.Sprintf("%s-%d", name, i+available)
 		c.addPod(namespace, podName, filter, []corev1.Container{{Image: "cilium:1.9"}}, corev1.PodStatus{Phase: corev1.PodFailed})
 		c.status[podName] = &models.StatusResponse{

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -2782,7 +2782,7 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 
 	// Create N services
 	N := 16
-	for i := 0; i < N; i++ {
+	for i := range N {
 		_, err = fakeK8s.Services("default").Create(t.Context(), &slim_core_v1.Service{
 			ObjectMeta: slim_meta_v1.ObjectMeta{
 				Name: "service" + strconv.Itoa(i),
@@ -2804,7 +2804,7 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	previousIPs := []string{}
-	for i := 0; i < N; i++ {
+	for i := range N {
 		svc, err := fakeK8s.Services("default").Get(t.Context(), "service"+strconv.Itoa(i), meta_v1.GetOptions{})
 		require.NoError(t, err)
 		t.Log("service", i, "ingress", svc.Status.LoadBalancer.Ingress)
@@ -2860,14 +2860,14 @@ func TestLBIPAMRestartOnFullPool(t *testing.T) {
 		assert.Equal(collect, int64(N), counters.serviceEvents.Load())
 	}, 5*time.Second, 100*time.Millisecond)
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		svc, err := fakeK8s.Services("default").Get(t.Context(), "service"+strconv.Itoa(i), meta_v1.GetOptions{})
 		require.NoError(t, err)
 		t.Log("service", i, "ingress", svc.Status.LoadBalancer.Ingress)
 	}
 
 	// The same services should still have IPs
-	for i := 0; i < N; i++ {
+	for i := range N {
 		svc, err := fakeK8s.Services("default").Get(t.Context(), "service"+strconv.Itoa(i), meta_v1.GetOptions{})
 		require.NoError(t, err)
 		if i < N/2 {

--- a/operator/pkg/model/helpers.go
+++ b/operator/pkg/model/helpers.go
@@ -239,7 +239,7 @@ func wildcardHostnamesIntersect(routeHostname, listenerHostname string) bool {
 
 	matchingLabels := 0
 
-	for i := 0; i < maxLength; i++ {
+	for i := range maxLength {
 		if routeSlice[i] == "*" || listenerSlice[i] == "*" {
 			break
 		}

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -328,7 +328,7 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 			return "", nil, err
 		}
 	} else {
-		for i := int32(0); i < toAllocate; i++ {
+		for range toAllocate {
 			ip, err := e.allocator.AllocateNext()
 			if err != nil {
 				panic("Unable to allocate IP from allocator")
@@ -462,7 +462,7 @@ func (e *API) AssignPrivateIpAddresses(ctx context.Context, eniID string, addres
 				return nil, fmt.Errorf("subnet %s has not enough addresses available", eni.Subnet.ID)
 			}
 
-			for i := int32(0); i < addresses; i++ {
+			for range addresses {
 				ip, err := e.allocator.AllocateNext()
 				if err != nil {
 					panic("Unable to allocate IP from allocator")
@@ -538,7 +538,7 @@ func assignPrefixToENI(e *API, eni *eniTypes.ENI, prefixes int32) error {
 		}
 	}
 
-	for i := int32(0); i < prefixes; i++ {
+	for range prefixes {
 		// Get a new /28 prefix
 		pfx, err := e.pdAllocator.AllocateNext()
 		if err != nil {

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -202,7 +202,7 @@ func TestExtractSubnetIDs(t *testing.T) {
 	// Create 100 instances across only 2 different subnets to test deduplication
 	instances := ipamTypes.NewInstanceMap()
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		instanceID := fmt.Sprintf("vm-%d", i)
 		interfaceID := fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/%s/networkInterfaces/eth0", instanceID)
 

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -640,7 +640,7 @@ func TestPrivilegedDumpReliablyWithCallbackOverlapping(t *testing.T) {
 	// We expect that DumpReliablyWithCallback will iterate all odd key/value pairs
 	// even if the even keys are being deleted and reinserted.
 	expect := map[string]string{}
-	for i := uint32(0); i < maxEntries; i++ {
+	for i := range maxEntries {
 		if i%2 != 0 {
 			expect[fmt.Sprintf("key=%d", i)] = fmt.Sprintf("value=%d", i+200)
 		}
@@ -705,7 +705,7 @@ func TestPrivilegedDumpReliablyWithCallback(t *testing.T) {
 		defer wg.Done()
 		started <- struct{}{}
 		for {
-			for i := uint32(0); i < 4; i++ {
+			for i := range uint32(4) {
 				if i < 3 {
 					err := m.Update(&TestKey{Key: i}, &TestValue{Value: i + 100})
 					// avoid assert to ensure we call wg.Done

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -481,7 +481,7 @@ func TestUnsignedAncestors(t *testing.T) {
 	// Create a uint Trie that contains overlapping ranges
 	// from 0-65535.
 	tu := NewUintTrie[uint16, string]()
-	for i := uint(0); i < 16; i++ {
+	for i := range uint(16) {
 		rng := uint16RangeMap[i]
 		entry := fmt.Sprintf("%d-%d", 0, rng)
 		tu.Upsert(i, rng, entry)
@@ -489,7 +489,7 @@ func TestUnsignedAncestors(t *testing.T) {
 	// Check to see that each range
 	// lookup returns all ranges that contain
 	// it.
-	for i := uint(0); i < 16; i++ {
+	for i := range uint(16) {
 		rng := uint16RangeMap[i]
 		entry := fmt.Sprintf("%d-%d", 0, rng)
 		t.Run(entry, func(t *testing.T) {
@@ -521,7 +521,7 @@ func TestUnsignedDescendants(t *testing.T) {
 	}
 	// Check to see that each range lookup returns
 	// all ranges that contain it.
-	for i := uint(0); i < 16; i++ {
+	for i := range uint(16) {
 		rng := uint16RangeMap[i]
 		entry := fmt.Sprintf("%d-%d", 0, rng)
 		t.Run(entry, func(t *testing.T) {
@@ -656,11 +656,11 @@ func BenchmarkTrieUpsert(b *testing.B) {
 	// mimic adding 2 octets worth of addresses
 	tri.Upsert(16, 0xffff_0000, emptyS)
 	count++
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperThree := 0xffff_0000 | i<<8
 		tri.Upsert(24, upperThree, emptyS)
 		count++
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			tri.Upsert(32, upperThree|t, emptyS)
 			count++
 		}
@@ -678,9 +678,9 @@ func BenchmarkMapUpdate(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	// mimic adding 2 octets worth of addresses
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			map32[0xffff_0000|upperOct|t] = emptyS
 			count++
 		}
@@ -698,11 +698,11 @@ func BenchmarkTrieAncestorsRange(b *testing.B) {
 	// mimic adding 2 octets worth of addresses
 	tri.Upsert(16, 0xffff_0000, emptyS)
 	count++
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
 		tri.Upsert(24, 0xffff_0000|upperOct, emptyS)
 		count++
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			tri.Upsert(32, 0xffff_0000|upperOct|t, emptyS)
 			count++
 		}
@@ -721,7 +721,7 @@ func BenchmarkTrieAncestorsRange(b *testing.B) {
 	if st == nil {
 		b.Fatal("expected valid lookup, but got nil")
 	}
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
 		var st *struct{}
 		tri.Ancestors(24, 0xffff_0000|upperOct, func(_ uint, _ uint32, v *struct{}) bool {
@@ -731,7 +731,7 @@ func BenchmarkTrieAncestorsRange(b *testing.B) {
 		if st == nil {
 			b.Fatal("expected valid lookup, but got nil")
 		}
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			var st *struct{}
 			tri.Ancestors(32, 0xffff_0000|upperOct|t, func(_ uint, _ uint32, v *struct{}) bool {
 				st = v
@@ -749,11 +749,11 @@ func BenchmarkTrieLongestPrefixMatch(b *testing.B) {
 	emptyS := &struct{}{}
 	count := uint(0)
 	// mimic adding 2 octets worth of addresses
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
 		tri.Upsert(24, 0xffff_0000|upperOct, emptyS)
 		count++
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			tri.Upsert(32, 0xffff_0000|upperOct|t, emptyS)
 			count++
 		}
@@ -764,9 +764,9 @@ func BenchmarkTrieLongestPrefixMatch(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			_, _, ok := tri.LongestPrefixMatch(0xffff_0000 | upperOct | t)
 			if !ok {
 				b.Fatal("expected valid lookup, but got nil")
@@ -780,9 +780,9 @@ func BenchmarkMapLookup(b *testing.B) {
 	emptyS := &struct{}{}
 	count := 0
 	// mimic adding 2 octets worth of addresses
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			map32[0xffff_0000|upperOct|t] = emptyS
 			count++
 		}
@@ -793,9 +793,9 @@ func BenchmarkMapLookup(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			v, ok := map32[0xffff_0000|upperOct|t]
 			if !ok || v == nil {
 				b.Fatalf("expected to get value from map lookup, got nil")
@@ -809,11 +809,11 @@ func BenchmarkTrieDelete(b *testing.B) {
 	emptyS := &struct{}{}
 	count := uint(0)
 	// mimic adding 2 octets worth of addresses
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
 		tri.Upsert(24, 0xffff_0000|upperOct, emptyS)
 		count++
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			tri.Upsert(32, 0xffff_0000|upperOct|t, emptyS)
 			count++
 		}
@@ -824,12 +824,12 @@ func BenchmarkTrieDelete(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
 		if !tri.Delete(24, 0xffff_0000|upperOct) {
 			b.Fatal("expected valid delete, but got nil")
 		}
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			if !tri.Delete(32, 0xffff_0000|upperOct|t) {
 				b.Fatal("expected valid lookup, but got nil")
 			}
@@ -846,9 +846,9 @@ func BenchmarkMapDelete(b *testing.B) {
 	emptyS := &struct{}{}
 	count := 0
 	// mimic adding 2 octets worth of addresses
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			map32[0xffff_0000|upperOct|t] = emptyS
 			count++
 		}
@@ -859,9 +859,9 @@ func BenchmarkMapDelete(b *testing.B) {
 
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := uint32(0); i < 255; i++ {
+	for i := range uint32(255) {
 		upperOct := i << 8
-		for t := uint32(0); t < 255; t++ {
+		for t := range uint32(255) {
 			delete(map32, 0xffff_0000|upperOct|t)
 		}
 	}

--- a/pkg/datapath/prefilter/prefilter.go
+++ b/pkg/datapath/prefilter/prefilter.go
@@ -80,7 +80,7 @@ func (p *PreFilter) Dump(to []string) ([]string, int64) {
 
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
-	for i := prefixesV4Dyn; i < mapCount; i++ {
+	for i := range mapCount {
 		to = p.dumpOneMap(i, to)
 	}
 	return to, p.revision
@@ -229,7 +229,7 @@ func (p *PreFilter) initOneMap(which preFilterMapType) error {
 }
 
 func (p *PreFilter) init() error {
-	for i := prefixesV4Dyn; i < mapCount; i++ {
+	for i := range mapCount {
 		if err := p.initOneMap(i); err != nil {
 			return err
 		}

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1566,7 +1566,7 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	// ensure we also count things like the strings "borrowed" from rulesPerEP
 	b.ReportMetric(float64(getMemStats().HeapInuse-initialHeap), "B(HeapInUse)/op")
 
-	for epID := uint64(0); epID < nEPs; epID++ {
+	for epID := range uint64(nEPs) {
 		pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 	}
 	if len(pea) > 0 {
@@ -1574,7 +1574,7 @@ func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	}
 	b.StopTimer()
 	// Remove all the inserted rules to ensure the cache goes down to zero entries
-	for epID := uint64(0); epID < 20; epID++ {
+	for epID := range uint64(20) {
 		pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 	}
 	if len(pea) > 0 || len(c) > 0 {
@@ -1666,7 +1666,7 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		for epID := uint64(0); epID < numEPs; epID++ {
+		for epID := range numEPs {
 			pea.setPortRulesForID(c, epID, udpProtoPort8053, rules)
 		}
 	}
@@ -1688,7 +1688,7 @@ func Benchmark_perEPAllow_setPortRulesForID_large(b *testing.B) {
 	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
 	fmt.Printf("\tNumGC = %v\n", m.NumGC)
 	// Remove all the inserted rules to ensure both indexes go to zero entries
-	for epID := uint64(0); epID < numEPs; epID++ {
+	for epID := range numEPs {
 		pea.setPortRulesForID(c, epID, udpProtoPort8053, nil)
 	}
 	if len(pea) > 0 || len(c) > 0 {

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -730,7 +730,7 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 	}
 
 	// Add 5 events
-	for i := uint64(0); i < 5; i++ {
+	for i := range uint64(5) {
 		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 		lastWrite = r.LastWrite()
 		if lastWrite != i {
@@ -792,7 +792,7 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 	}
 
 	// Add 20 events
-	for i := uint64(0); i < 20; i++ {
+	for i := range uint64(20) {
 		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 		lastWrite = r.LastWrite()
 		if lastWrite != i {
@@ -851,7 +851,7 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 	}
 
 	// Add 20 more events that we read back immediately
-	for i := uint64(0); i < 20; i++ {
+	for i := range uint64(20) {
 		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(20 + i)}})
 
 		want := &timestamppb.Timestamp{Seconds: int64(20 + (i - 1))}
@@ -890,7 +890,7 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 	}
 
 	// Add 20 events
-	for i := uint64(0); i < 20; i++ {
+	for i := range uint64(20) {
 		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(i)}})
 		lastWrite = r.LastWrite()
 		if lastWrite != i {
@@ -949,7 +949,7 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 	}
 
 	// Add 20 more events that we read back immediately
-	for i := uint64(0); i < 20; i++ {
+	for i := range uint64(20) {
 		r.Write(&v1.Event{Timestamp: &timestamppb.Timestamp{Seconds: int64(20 + i)}})
 
 		want := &timestamppb.Timestamp{Seconds: int64(20 + (i - 1))}

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -512,7 +512,7 @@ func TestExporterAggregationDisabledWhenIntervalZero(t *testing.T) {
 	assert.Nil(t, exporter.aggregator, "aggregator should be disabled when interval <= 0")
 
 	// Send two flow events that would otherwise aggregate.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		err := exporter.Export(t.Context(), &v1.Event{Event: &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}})
 		assert.NoError(t, err)
 	}

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -607,7 +607,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 	v4Cidrs := make([]*cidr.CIDR, 10)
 	v6Cidrs := make([]*cidr.CIDR, 10)
 	cidrPodCIDRs := make([]types.IPAMCIDR, 0, 20)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		c4 := cidr.MustParseCIDR(fmt.Sprintf("10.0.100.%d/32", i))
 		v4Cidrs[i] = c4
 		cidrPodCIDRs = append(cidrPodCIDRs, types.IPAMCIDR(c4.String()))
@@ -663,7 +663,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 	<-events // first upsert (initial node)
 
 	// Allocate 5 IPv4 and 5 IPv6 IPs
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		ip4 := net.ParseIP(fmt.Sprintf("10.0.100.%d", i))
 		_, err := mgr.allocateIP(ip4, fmt.Sprintf("pod4-%d", i), "default", IPv4, false)
 		assert.NoError(t, err)
@@ -691,7 +691,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 	for _, c := range alloc[0].CIDRs {
 		remaining[string(c)] = struct{}{}
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		assert.Contains(t, remaining, v4Cidrs[i].String(), "in-use CIDR %s should not be released", v4Cidrs[i].String())
 		assert.Contains(t, remaining, v6Cidrs[i].String(), "in-use CIDR %s should not be released", v6Cidrs[i].String())
 	}

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1514,7 +1514,7 @@ func (e *etcdClient) ListPrefixIfLocked(ctx context.Context, prefix string, lock
 	getR := txnReply.Responses[0].GetResponseRange()
 
 	pairs := KeyValuePairs(make(map[string]Value, getR.Count))
-	for i := int64(0); i < getR.Count; i++ {
+	for i := range getR.Count {
 		pairs[string(getR.Kvs[i].Key)] = Value{
 			Data:        getR.Kvs[i].Value,
 			ModRevision: uint64(getR.Kvs[i].ModRevision),
@@ -1552,7 +1552,7 @@ func (e *etcdClient) ListPrefix(ctx context.Context, prefix string) (v KeyValueP
 	lr.Done()
 
 	pairs := KeyValuePairs(make(map[string]Value, getR.Count))
-	for i := int64(0); i < getR.Count; i++ {
+	for i := range getR.Count {
 		pairs[string(getR.Kvs[i].Key)] = Value{
 			Data:        getR.Kvs[i].Value,
 			ModRevision: uint64(getR.Kvs[i].ModRevision),

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -156,7 +156,7 @@ func (wss *wqSyncStore) Run(ctx context.Context) {
 
 	wss.log.Info("Starting workqueue-based sync store", logfields.Workers, wss.workers)
 	wg.Add(int(wss.workers))
-	for i := uint(0); i < wss.workers; i++ {
+	for range wss.workers {
 		go func() {
 			defer wg.Done()
 			for wss.processNextItem(ctx) {

--- a/pkg/maps/ctmap/types_test.go
+++ b/pkg/maps/ctmap/types_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMapKey(t *testing.T) {
-	for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
+	for mapType := range mapTypeMax {
 		assert.NotNil(t, mapType.key())
 	}
 
@@ -45,7 +45,7 @@ func TestMaxEntries(t *testing.T) {
 			option.Config.CTMapEntriesGlobalTCP = tt.tcp
 			option.Config.CTMapEntriesGlobalAny = tt.any
 
-			for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
+			for mapType := range mapTypeMax {
 				if mapType.isTCP() {
 					assert.Equal(t, tt.etcp, mapType.maxEntries())
 				} else {

--- a/pkg/maps/nat/stats/stats_test.go
+++ b/pkg/maps/nat/stats/stats_test.go
@@ -24,7 +24,7 @@ import (
 
 func Test_topk(t *testing.T) {
 	top5 := newTopK(5)
-	for i := byte(0); i < 10; i++ {
+	for i := range byte(10) {
 		ip := types.IPv4{10, 0, 0, i}
 		k := SNATTuple4{
 			DestAddr: ip,
@@ -50,8 +50,8 @@ func TestPrivilegedCountNat(t *testing.T) {
 		ip6Map.UnpinIfExists()
 	})
 
-	for addr := byte(0); addr < 20; addr++ {
-		for i := uint16(0); i < uint16(addr); i++ {
+	for addr := range byte(20) {
+		for i := range uint16(addr) {
 			ip := types.IPv4{10, 0, 0, addr}
 			mapKey := &nat.NatKey4{}
 			mapKey.TupleKey4.SourceAddr = ip

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -3374,7 +3374,7 @@ func permutations(arr []int) [][]int {
 		if n == 1 {
 			res = append(res, slices.Clone(arr))
 		} else {
-			for i := 0; i < n; i++ {
+			for i := range n {
 				helper(arr, n-1)
 				if n%2 == 1 {
 					tmp := arr[i]

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -137,7 +137,7 @@ func TestMeanProcessingDuration(t *testing.T) {
 		ParallelRequests:            2,
 	}, nil)
 
-	for i := int64(0); i < iterations; i++ {
+	for range iterations {
 		req, err := a.Wait(context.Background())
 		require.NoError(t, err)
 		require.NotNil(t, req)

--- a/tools/slogloggercheck/main.go
+++ b/tools/slogloggercheck/main.go
@@ -152,7 +152,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 
 // checkLoggingCallArgs examines the arguments of a logging call for String() method invocations
 func (v *visitor) checkLoggingCallArgs(methodName string, args []ast.Expr) {
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		arg := args[i]
 
 		// Look for direct String() calls in the argument


### PR DESCRIPTION
Followup to #43248

Enable the [`rangeint`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_rangeint) modernize analyzer globally and address the last remaining failures.


Patch generated with `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -rangeint ./...`

Summary of the main patterns in the diff:
* `for i := 0; i < 2; i++` becomes `for range 2` when the `i` iterator variable was unused in the scope of the loop
* `for i := uint64(0); i < 20; i++` becomes `for i := range uint64(20)` when the iterator variable needs to be of a specific type (not just `int`)
* `for epID := uint64(0); epID < numEPs; epID++` becomes `for epID := range numEPs` when the iterator needs to be of a specific type and the range bound variable is already of that type