### PR TITLE
install: grant Cilium operator to update ServiceImport finalizers

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -419,6 +419,15 @@ rules:
 - apiGroups:
   - multicluster.x-k8s.io
   resources:
+  # The controller needs to be able to set serviceimport finalizers to be able to create a derived Service
+  # resource that is owned by the ServiceImport and sets blockOwnerDeletion=true in its ownerRef.
+  # This is required when the admission plugin OwnerReferencesPermissionEnforcement is activated.
+  - serviceimports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
   - serviceexports
   verbs:
   - get


### PR DESCRIPTION
This is required when the OwnerReferencesPermissionEnforcement admission plugin is set, because the operator creates derived Services resources owned by the corresponding ingress, with the blockOwnerDeletion flag set.

Similar PR as #43949 fixing it for the MCS-API cases (kudos to @fgiloux @giorio94 for the existing work made there, this was spotted when integrating the MCS-API conformance test suite in CI)

```release-note
Grant permissions to the cilium-operator so that it can reconcile ServiceImport when the when the admission plugin OwnerReferencesPermissionEnforcement is activated
```
