### PR TITLE
pkg/policy: Support more tunnel protocols as extended protocols

### DIFF
--- a/Documentation/security/policy/host.rst
+++ b/Documentation/security/policy/host.rst
@@ -70,9 +70,19 @@ the label ``type=ingress-worker`` on TCP ports 22, 6443 (kube-apiserver), 2379
 To reuse this policy, replace the ``port:`` values with ports used in your
 environment.
 
-In order to allow protocols such as VRRP and IGMP that don't have any transport-layer
-ports, set ``--enable-extended-ip-protocols`` flag to true. By default, such traffic is
-dropped with ``DROP_CT_UNKNOWN_PROTO`` error.
+In order to allow protocols such as VRRP, IGMP, and tunnel/encapsulation protocols
+that don't have any transport-layer ports, set ``--enable-extended-ip-protocols``
+flag to true. By default, such traffic is dropped with ``DROP_CT_UNKNOWN_PROTO`` error.
+
+Supported extended protocols include:
+
+- **VRRP** (protocol 112) - Virtual Router Redundancy Protocol
+- **IGMP** (protocol 2) - Internet Group Management Protocol
+- **GRE** (protocol 47) - Generic Routing Encapsulation
+- **IPIP** (protocol 4) - IP-in-IP Encapsulation (RFC 2003)
+- **IPV6** (protocol 41) - IPv6 Encapsulation / 6in4 (RFC 4213)
+- **ESP** (protocol 50) - Encapsulating Security Payload / IPsec (RFC 4303)
+- **AH** (protocol 51) - Authentication Header / IPsec (RFC 4302)
 
 As an example, the following policy allows egress traffic on any node with
 the label ``type=egress-worker`` on TCP ports 22, 6443/443 (kube-apiserver), 2379

--- a/examples/policies/host/allow-extended-protocols.yaml
+++ b/examples/policies/host/allow-extended-protocols.yaml
@@ -20,4 +20,12 @@ spec:
         protocol: TCP
       - port: "8472"
         protocol: UDP
+      # Extended IP protocols (no transport-layer ports)
       - protocol: VRRP
+      # Tunnel/encapsulation protocols
+      - protocol: GRE
+      - protocol: IPIP
+      - protocol: IPV6
+      # IPsec protocols
+      - protocol: ESP
+      - protocol: AH

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -701,7 +701,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -713,6 +718,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -1624,7 +1634,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -1636,6 +1651,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -2394,7 +2414,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -2406,6 +2431,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -3231,7 +3261,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -3243,6 +3278,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -4009,7 +4049,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -4021,6 +4066,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object
@@ -4933,7 +4983,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -4945,6 +5000,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object
@@ -5704,7 +5764,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -5716,6 +5781,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object
@@ -6542,7 +6612,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -6554,6 +6629,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -704,7 +704,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -716,6 +721,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -1627,7 +1637,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -1639,6 +1654,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -2397,7 +2417,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -2409,6 +2434,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -3234,7 +3264,12 @@ spec:
                                     Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                     with transport ports (TCP, UDP, SCTP) match.
 
-                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                    Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                    "IPV6", "ESP", "AH", "ANY"
+
+                                    Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                    extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                    flag to be set. These protocols do not use transport-layer ports.
 
                                     Matching on ICMP is not supported.
 
@@ -3246,6 +3281,11 @@ spec:
                                   - SCTP
                                   - VRRP
                                   - IGMP
+                                  - GRE
+                                  - IPIP
+                                  - IPV6
+                                  - ESP
+                                  - AH
                                   - ANY
                                   type: string
                               type: object
@@ -4012,7 +4052,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -4024,6 +4069,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object
@@ -4936,7 +4986,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -4948,6 +5003,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object
@@ -5707,7 +5767,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -5719,6 +5784,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object
@@ -6545,7 +6615,12 @@ spec:
                                       Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
                                       with transport ports (TCP, UDP, SCTP) match.
 
-                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+                                      Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+                                      "IPV6", "ESP", "AH", "ANY"
+
+                                      Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+                                      extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+                                      flag to be set. These protocols do not use transport-layer ports.
 
                                       Matching on ICMP is not supported.
 
@@ -6557,6 +6632,11 @@ spec:
                                     - SCTP
                                     - VRRP
                                     - IGMP
+                                    - GRE
+                                    - IPIP
+                                    - IPV6
+                                    - ESP
+                                    - AH
                                     - ANY
                                     type: string
                                 type: object

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -20,7 +20,13 @@ const (
 	ProtoICMPv6 L4Proto = "ICMPV6"
 	ProtoVRRP   L4Proto = "VRRP"
 	ProtoIGMP   L4Proto = "IGMP"
-	ProtoAny    L4Proto = "ANY"
+	// Tunnel/Encapsulation protocols (no transport-layer ports)
+	ProtoGRE  L4Proto = "GRE"  // Generic Routing Encapsulation (protocol 47)
+	ProtoIPIP L4Proto = "IPIP" // IP-in-IP Encapsulation (protocol 4)
+	ProtoIPv6 L4Proto = "IPV6" // IPv6 Encapsulation / 6in4 (protocol 41)
+	ProtoESP  L4Proto = "ESP"  // Encapsulating Security Payload / IPsec (protocol 50)
+	ProtoAH   L4Proto = "AH"   // Authentication Header / IPsec (protocol 51)
+	ProtoAny  L4Proto = "ANY"
 
 	PortProtocolAny = "0/ANY"
 )
@@ -54,14 +60,19 @@ type PortProtocol struct {
 	// Protocol is the L4 protocol. If "ANY", omitted or empty, any protocols
 	// with transport ports (TCP, UDP, SCTP) match.
 	//
-	// Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "ANY"
+	// Accepted values: "TCP", "UDP", "SCTP", "VRRP", "IGMP", "GRE", "IPIP",
+	// "IPV6", "ESP", "AH", "ANY"
+	//
+	// Tunnel/encapsulation protocols (GRE, IPIP, IPV6, ESP, AH) and other
+	// extended IP protocols (VRRP, IGMP) require the --enable-extended-ip-protocols
+	// flag to be set. These protocols do not use transport-layer ports.
 	//
 	// Matching on ICMP is not supported.
 	//
 	// Named port specified for a container may narrow this down, but may not
 	// contradict this.
 	//
-	// +kubebuilder:validation:Enum=TCP;UDP;SCTP;VRRP;IGMP;ANY
+	// +kubebuilder:validation:Enum=TCP;UDP;SCTP;VRRP;IGMP;GRE;IPIP;IPV6;ESP;AH;ANY
 	// +kubebuilder:validation:Optional
 	Protocol L4Proto `json:"protocol,omitempty"`
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -604,6 +604,18 @@ func (pr *PortDenyRule) sanitize() error {
 	return nil
 }
 
+// isExtendedIPProtocol returns true if the protocol is an extended IP protocol
+// that does not use transport-layer ports (e.g., VRRP, IGMP, GRE, IPIP, ESP, AH).
+func isExtendedIPProtocol(proto L4Proto) bool {
+	switch proto {
+	case ProtoVRRP, ProtoIGMP,
+		ProtoGRE, ProtoIPIP, ProtoIPv6, ProtoESP, ProtoAH:
+		return true
+	default:
+		return false
+	}
+}
+
 func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
 	if pp.Port == "" {
 		if !option.Config.EnableExtendedIPProtocols {
@@ -617,7 +629,9 @@ func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
 	if iana.IsSvcName(pp.Port) {
 		pp.Port = strings.ToLower(pp.Port) // Normalize for case insensitive comparison
 	} else if pp.Port != "" {
-		if pp.Port != "0" && (pp.Protocol == ProtoVRRP || pp.Protocol == ProtoIGMP) {
+		// Extended IP protocols and tunnel/encapsulation protocols do not have
+		// transport-layer ports. Require port to be empty or 0 for these protocols.
+		if pp.Port != "0" && isExtendedIPProtocol(pp.Protocol) {
 			return isZero, errors.New("port must be empty or 0")
 		}
 		p, err := strconv.ParseUint(pp.Port, 0, 16)

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -86,9 +86,11 @@ func (h *PortRuleL7) Equal(o PortRuleL7) bool {
 // Validate returns an error if the layer 4 protocol is not valid
 func (l4 L4Proto) Validate() error {
 	switch l4 {
-	case ProtoAny, ProtoTCP, ProtoUDP, ProtoSCTP, ProtoVRRP, ProtoIGMP:
+	case ProtoAny, ProtoTCP, ProtoUDP, ProtoSCTP,
+		ProtoVRRP, ProtoIGMP,
+		ProtoGRE, ProtoIPIP, ProtoIPv6, ProtoESP, ProtoAH:
 	default:
-		return fmt.Errorf("invalid protocol %q, must be { tcp | udp | sctp | vrrp | igmp | any }", l4)
+		return fmt.Errorf("invalid protocol %q, must be { tcp | udp | sctp | vrrp | igmp | gre | ipip | ipv6 | esp | ah | any }", l4)
 	}
 
 	return nil

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -810,6 +810,130 @@ func TestIPProtocolsWithNoTransportPorts(t *testing.T) {
 	td.policyMapEquals(t, expectedIn, expectedOut, &rule1)
 }
 
+func TestTunnelProtocolsWithNoTransportPorts(t *testing.T) {
+	old := option.Config.EnableExtendedIPProtocols
+	option.Config.EnableExtendedIPProtocols = true
+	t.Cleanup(func() {
+		option.Config.EnableExtendedIPProtocols = old
+	})
+	td := newTestData(t, hivetest.Logger(t))
+
+	// Test tunnel/encapsulation protocols: GRE, IPIP, IPV6, ESP, AH
+	rule1 := api.Rule{
+		EndpointSelector: endpointSelectorA,
+		Ingress: []api.IngressRule{
+			{
+				ToPorts: []api.PortRule{
+					{
+						Ports: []api.PortProtocol{
+							{Protocol: api.ProtoGRE},
+							{Protocol: api.ProtoIPIP},
+							{Protocol: api.ProtoIPv6},
+							{Protocol: api.ProtoESP},
+							{Protocol: api.ProtoAH},
+						},
+					},
+				},
+			},
+		},
+		Egress: []api.EgressRule{
+			{
+				ToPorts: []api.PortRule{
+					{
+						Ports: []api.PortProtocol{
+							{Protocol: api.ProtoGRE},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedIn := NewL4PolicyMapWithValues(map[string]*L4Filter{
+		"0/gre": {
+			Port:     0,
+			Protocol: api.ProtoGRE,
+			U8Proto:  u8proto.ProtoIDs["gre"],
+			Ingress:  true,
+			wildcard: td.wildcardCachedSelector,
+			PerSelectorPolicies: L7DataMap{
+				td.wildcardCachedSelector: nil,
+			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
+		},
+		"0/ipip": {
+			Port:     0,
+			Protocol: api.ProtoIPIP,
+			U8Proto:  u8proto.ProtoIDs["ipip"],
+			Ingress:  true,
+			wildcard: td.wildcardCachedSelector,
+			PerSelectorPolicies: L7DataMap{
+				td.wildcardCachedSelector: nil,
+			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
+		},
+		"0/ipv6": {
+			Port:     0,
+			Protocol: api.ProtoIPv6,
+			U8Proto:  u8proto.ProtoIDs["ipv6"],
+			Ingress:  true,
+			wildcard: td.wildcardCachedSelector,
+			PerSelectorPolicies: L7DataMap{
+				td.wildcardCachedSelector: nil,
+			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
+		},
+		"0/esp": {
+			Port:     0,
+			Protocol: api.ProtoESP,
+			U8Proto:  u8proto.ProtoIDs["esp"],
+			Ingress:  true,
+			wildcard: td.wildcardCachedSelector,
+			PerSelectorPolicies: L7DataMap{
+				td.wildcardCachedSelector: nil,
+			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
+		},
+		"0/ah": {
+			Port:     0,
+			Protocol: api.ProtoAH,
+			U8Proto:  u8proto.ProtoIDs["ah"],
+			Ingress:  true,
+			wildcard: td.wildcardCachedSelector,
+			PerSelectorPolicies: L7DataMap{
+				td.wildcardCachedSelector: nil,
+			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+				td.wildcardCachedSelector: {nil},
+			}),
+		},
+	})
+
+	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"0/gre": {
+		Port:     0,
+		Protocol: api.ProtoGRE,
+		U8Proto:  u8proto.ProtoIDs["gre"],
+		Ingress:  false,
+		wildcard: td.wildcardCachedSelector,
+		PerSelectorPolicies: L7DataMap{
+			td.wildcardCachedSelector: nil,
+		},
+		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{
+			td.wildcardCachedSelector: {nil},
+		}),
+	}})
+
+	td.policyMapEquals(t, expectedIn, expectedOut, &rule1)
+}
+
 // Tests the restrictions of combining certain label-based L3 and L4 policies.
 // This ensures that the user is informed of policy combinations that are not
 // implemented in the datapath.

--- a/pkg/u8proto/u8proto.go
+++ b/pkg/u8proto/u8proto.go
@@ -17,8 +17,13 @@ const (
 	ANY    U8proto = 0
 	ICMP   U8proto = 1
 	IGMP   U8proto = 2
+	IPIP   U8proto = 4 // IP-in-IP Encapsulation (RFC 2003)
 	TCP    U8proto = 6
 	UDP    U8proto = 17
+	IPv6   U8proto = 41 // IPv6 Encapsulation (6in4, RFC 4213)
+	GRE    U8proto = 47 // Generic Routing Encapsulation (RFC 2784)
+	ESP    U8proto = 50 // Encapsulating Security Payload (RFC 4303)
+	AH     U8proto = 51 // Authentication Header (RFC 4302)
 	ICMPv6 U8proto = 58
 	VRRP   U8proto = 112
 	SCTP   U8proto = 132
@@ -28,8 +33,13 @@ var protoNames = map[U8proto]string{
 	0:   "ANY",
 	1:   "ICMP",
 	2:   "IGMP",
+	4:   "IPIP",
 	6:   "TCP",
 	17:  "UDP",
+	41:  "IPv6",
+	47:  "GRE",
+	50:  "ESP",
+	51:  "AH",
 	58:  "ICMPv6",
 	112: "VRRP",
 	132: "SCTP",
@@ -41,8 +51,13 @@ var ProtoIDs = map[string]U8proto{
 	"none":   0,
 	"icmp":   1,
 	"igmp":   2,
+	"ipip":   4,
 	"tcp":    6,
 	"udp":    17,
+	"ipv6":   41,
+	"gre":    47,
+	"esp":    50,
+	"ah":     51,
 	"icmpv6": 58,
 	"vrrp":   112,
 	"sctp":   132,


### PR DESCRIPTION
Add support to other extended protocols IPIP, IPV6, GRE, ESP and AH.

Host firewall currently breaks ipsec for us as well as the tunnels we are using. Only workaround is to disable host-firewall alltogether. This PR bases on #39872 by extended the list of protocols.

This also fixes #44386