### PR TITLE
egressgateway: support CiliumEndpointSlice (CES) as endpoint source

### DIFF
--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"net/netip"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 )
@@ -26,15 +24,21 @@ type endpointMetadata struct {
 	nodeIP string
 }
 
-// endpointID is based on endpoint's UID
-type endpointID = types.UID
+// endpointID uniquely identifies an endpoint. For CEP-sourced endpoints this
+// is the Kubernetes UID; for CES-sourced endpoints it is namespace/name.
+type endpointID = string
 
 func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
 	var addrs []netip.Addr
 
-	if endpoint.UID == "" {
-		// this can happen when CiliumEndpointSlices are in use - which is not supported in the EGW yet
-		return nil, fmt.Errorf("endpoint has empty UID")
+	id := endpointID(endpoint.UID)
+	if id == "" {
+		// CES-sourced endpoints don't carry a Kubernetes UID.
+		// Fall back to namespace/name which is unique per endpoint.
+		if endpoint.Name == "" {
+			return nil, fmt.Errorf("endpoint has neither UID nor Name")
+		}
+		id = endpointID(endpoint.Namespace + "/" + endpoint.Name)
 	}
 
 	if endpoint.Networking == nil {
@@ -65,7 +69,7 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 	data := &endpointMetadata{
 		ips:    addrs,
 		labels: identityLabels.K8sStringMap(),
-		id:     endpoint.UID,
+		id:     id,
 		nodeIP: endpoint.Networking.NodeIP,
 	}
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -25,7 +25,9 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/identity"
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -124,6 +126,19 @@ type Manager struct {
 	// endpoints allows reading endpoint CRD from k8s.
 	endpoints resource.Resource[*k8sTypes.CiliumEndpoint]
 
+	// enableCES indicates whether CiliumEndpointSlice mode is active.
+	// Derived from DaemonConfig.EnableCiliumEndpointSlice at startup.
+	enableCES bool
+
+	// endpointSlices allows reading CiliumEndpointSlice CRD from k8s.
+	// nil when CES feature is disabled.
+	endpointSlices resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
+
+	// cesTrackedEndpoints maps CES name -> set of endpointIDs that were last
+	// seen in that slice. Used to compute diffs on CES update events.
+	// Only non-nil when CES mode is active.
+	cesTrackedEndpoints map[string]sets.Set[endpointID]
+
 	// policyConfigs stores policy configs indexed by policyID
 	policyConfigs map[policyID]*PolicyConfig
 
@@ -174,6 +189,7 @@ type Params struct {
 	Policies          resource.Resource[*Policy]
 	Nodes             resource.Resource[*cilium_api_v2.CiliumNode]
 	Endpoints         resource.Resource[*k8sTypes.CiliumEndpoint]
+	EndpointSlices    resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice] `optional:"true"`
 	Sysctl            sysctl.Sysctl
 
 	Lifecycle cell.Lifecycle
@@ -193,10 +209,6 @@ func NewEgressGatewayManager(p Params) (out struct {
 
 	if dcfg.IdentityAllocationMode != option.IdentityAllocationModeCRD {
 		return out, fmt.Errorf("egress gateway is not supported in %s identity allocation mode", dcfg.IdentityAllocationMode)
-	}
-
-	if dcfg.EnableCiliumEndpointSlice {
-		return out, errors.New("egress gateway is not supported in combination with the CiliumEndpointSlice feature")
 	}
 
 	// TODO: refactor config checks for both ipv4 and ipv6, and derive whether the environment supports egress gateway policies for either protocol
@@ -237,8 +249,14 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 		policies:                      p.Policies,
 		ciliumNodes:                   p.Nodes,
 		endpoints:                     p.Endpoints,
+		endpointSlices:                p.EndpointSlices,
 		sysctl:                        p.Sysctl,
 		nodesAddresses2Labels:         make(map[string]map[string]string),
+	}
+
+	if p.DaemonConfig.EnableCiliumEndpointSlice {
+		manager.enableCES = true
+		manager.cesTrackedEndpoints = make(map[string]sets.Set[endpointID])
 	}
 
 	t, err := trigger.NewTrigger(trigger.Parameters{
@@ -343,7 +361,18 @@ func (manager *Manager) processEvents(ctx context.Context) {
 
 	policyEvents := manager.policies.Events(ctx)
 	nodeEvents := manager.ciliumNodes.Events(ctx)
-	endpointEvents := manager.endpoints.Events(ctx, resource.WithRateLimiter(endpointsRateLimit))
+
+	// Decide which endpoint source to listen to based on whether CES is enabled.
+	// When one channel is nil, Go's select correctly ignores that case (reading
+	// from a nil channel blocks forever and is never selected).
+	var endpointEvents <-chan resource.Event[*k8sTypes.CiliumEndpoint]
+	var cesEvents <-chan resource.Event[*cilium_api_v2alpha1.CiliumEndpointSlice]
+
+	if manager.enableCES {
+		cesEvents = manager.endpointSlices.Events(ctx, resource.WithRateLimiter(endpointsRateLimit))
+	} else {
+		endpointEvents = manager.endpoints.Events(ctx, resource.WithRateLimiter(endpointsRateLimit))
+	}
 
 	for {
 		select {
@@ -375,6 +404,15 @@ func (manager *Manager) processEvents(ctx context.Context) {
 				event.Done(nil)
 			} else {
 				manager.handleEndpointEvent(event)
+			}
+
+		case event := <-cesEvents:
+			if event.Kind == resource.Sync {
+				endpointSync = true
+				maybeTriggerReconcile()
+				event.Done(nil)
+			} else {
+				manager.handleCESEvent(event)
 			}
 		}
 	}
@@ -458,12 +496,23 @@ func (manager *Manager) onDeleteEgressPolicy(policy *Policy) {
 }
 
 func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
+	manager.Lock()
+	defer manager.Unlock()
+
+	if err := manager.addEndpointLocked(endpoint); err != nil {
+		return err
+	}
+
+	manager.reconciliationTrigger.TriggerWithReason("endpoint updated")
+	return nil
+}
+
+// addEndpointLocked is the lock-free core of addEndpoint. The caller MUST hold
+// manager.Mutex.
+func (manager *Manager) addEndpointLocked(endpoint *k8sTypes.CiliumEndpoint) error {
 	var epData *endpointMetadata
 	var err error
 	var identityLabels labels.Labels
-
-	manager.Lock()
-	defer manager.Unlock()
 
 	logger := manager.logger.With(
 		logfields.K8sEndpointName, endpoint.Name,
@@ -507,9 +556,7 @@ func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
 	}
 
 	manager.epDataStore[epData.id] = epData
-
 	manager.setEventBitmap(eventUpdateEndpoint)
-	manager.reconciliationTrigger.TriggerWithReason("endpoint updated")
 
 	return nil
 }
@@ -518,13 +565,19 @@ func (manager *Manager) deleteEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 	manager.Lock()
 	defer manager.Unlock()
 
+	id := endpointID(endpoint.UID)
+	if id == "" {
+		// CES-sourced endpoints use namespace/name as their ID.
+		id = endpointID(endpoint.Namespace + "/" + endpoint.Name)
+	}
+
 	manager.logger.Debug(
 		"Deleted CiliumEndpoint",
 		logfields.K8sEndpointName, endpoint.Name,
 		logfields.K8sNamespace, endpoint.Namespace,
-		logfields.K8sUID, endpoint.UID,
+		logfields.K8sUID, id,
 	)
-	delete(manager.epDataStore, endpoint.UID)
+	delete(manager.epDataStore, id)
 
 	manager.setEventBitmap(eventDeleteEndpoint)
 	manager.reconciliationTrigger.TriggerWithReason("endpoint deleted")
@@ -539,6 +592,93 @@ func (manager *Manager) handleEndpointEvent(event resource.Event[*k8sTypes.Ciliu
 		manager.deleteEndpoint(endpoint)
 		event.Done(nil)
 	}
+}
+
+// handleCESEvent expands a CiliumEndpointSlice into individual endpoint
+// add/delete calls. On upsert, it diffs against the previous state to detect
+// which endpoints were removed from the slice.
+func (manager *Manager) handleCESEvent(event resource.Event[*cilium_api_v2alpha1.CiliumEndpointSlice]) {
+	ces := event.Object
+
+	switch event.Kind {
+	case resource.Upsert:
+		event.Done(manager.onUpsertCES(ces))
+	case resource.Delete:
+		manager.onDeleteCES(ces)
+		event.Done(nil)
+	}
+}
+
+// onUpsertCES processes a CiliumEndpointSlice upsert event. It converts each
+// CoreCiliumEndpoint in the slice to a types.CiliumEndpoint and adds it to the
+// epDataStore. It also diffs against the previous snapshot of the slice to
+// remove endpoints that are no longer present.
+//
+// The entire operation runs under a single lock acquisition to avoid
+// intermediate states visible to the reconciliation goroutine and to avoid
+// per-endpoint lock/unlock overhead.
+func (manager *Manager) onUpsertCES(ces *cilium_api_v2alpha1.CiliumEndpointSlice) error {
+	manager.Lock()
+	defer manager.Unlock()
+
+	currentIDs := sets.New[endpointID]()
+
+	var firstErr error
+	for i := range ces.Endpoints {
+		ccep := &ces.Endpoints[i]
+		if ccep.Name == "" {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("CES %s contains endpoint with empty name at index %d", ces.Name, i)
+			}
+			continue
+		}
+		ep := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(ccep, ces.Namespace)
+		id := endpointID(ces.Namespace + "/" + ccep.Name)
+		currentIDs.Insert(id)
+
+		if err := manager.addEndpointLocked(ep); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// Diff: remove endpoints that were in the previous version of this slice
+	// but are no longer present.
+	if prev, ok := manager.cesTrackedEndpoints[ces.Name]; ok {
+		for id := range prev {
+			if !currentIDs.Has(id) {
+				manager.logger.Debug(
+					"Deleted CiliumEndpoint (removed from CES)",
+					logfields.K8sUID, id,
+				)
+				delete(manager.epDataStore, id)
+				manager.setEventBitmap(eventDeleteEndpoint)
+			}
+		}
+	}
+	manager.cesTrackedEndpoints[ces.Name] = currentIDs
+
+	// Trigger reconciliation once for the entire slice update, rather than
+	// per-endpoint.
+	manager.reconciliationTrigger.TriggerWithReason("CES updated")
+
+	return firstErr
+}
+
+// onDeleteCES processes a CiliumEndpointSlice delete event. It removes all
+// endpoints that belonged to the deleted slice from the epDataStore.
+func (manager *Manager) onDeleteCES(ces *cilium_api_v2alpha1.CiliumEndpointSlice) {
+	manager.Lock()
+	defer manager.Unlock()
+
+	if tracked, ok := manager.cesTrackedEndpoints[ces.Name]; ok {
+		for id := range tracked {
+			delete(manager.epDataStore, id)
+		}
+		delete(manager.cesTrackedEndpoints, ces.Name)
+	}
+
+	manager.setEventBitmap(eventDeleteEndpoint)
+	manager.reconciliationTrigger.TriggerWithReason("CES deleted")
 }
 
 // handleNodeEvent takes care of node upserts and removals.

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -634,24 +634,31 @@ func (manager *Manager) onUpsertCES(ces *cilium_api_v2alpha1.CiliumEndpointSlice
 		}
 		ep := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(ccep, ces.Namespace)
 		id := endpointID(ces.Namespace + "/" + ccep.Name)
-		currentIDs.Insert(id)
 
-		if err := manager.addEndpointLocked(ep); err != nil && firstErr == nil {
-			firstErr = err
+		if err := manager.addEndpointLocked(ep); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
+		currentIDs.Insert(id)
 	}
 
 	// Diff: remove endpoints that were in the previous version of this slice
-	// but are no longer present.
+	// but are no longer present. Before removing from epDataStore, verify no
+	// other slice still tracks the endpoint (guards against out-of-order
+	// events when an endpoint moves between slices).
 	if prev, ok := manager.cesTrackedEndpoints[ces.Name]; ok {
 		for id := range prev {
 			if !currentIDs.Has(id) {
-				manager.logger.Debug(
-					"Deleted CiliumEndpoint (removed from CES)",
-					logfields.K8sUID, id,
-				)
-				delete(manager.epDataStore, id)
-				manager.setEventBitmap(eventDeleteEndpoint)
+				if !manager.endpointTrackedByOtherCES(id, ces.Name) {
+					manager.logger.Debug(
+						"Deleted CiliumEndpoint (removed from CES)",
+						logfields.K8sUID, id,
+					)
+					delete(manager.epDataStore, id)
+					manager.setEventBitmap(eventDeleteEndpoint)
+				}
 			}
 		}
 	}
@@ -664,18 +671,35 @@ func (manager *Manager) onUpsertCES(ces *cilium_api_v2alpha1.CiliumEndpointSlice
 	return firstErr
 }
 
+// endpointTrackedByOtherCES returns true if the given endpoint ID is tracked by
+// any CES other than the one identified by exclude. The caller MUST hold
+// manager.Mutex.
+func (manager *Manager) endpointTrackedByOtherCES(id endpointID, exclude string) bool {
+	for name, tracked := range manager.cesTrackedEndpoints {
+		if name != exclude && tracked.Has(id) {
+			return true
+		}
+	}
+	return false
+}
+
 // onDeleteCES processes a CiliumEndpointSlice delete event. It removes all
 // endpoints that belonged to the deleted slice from the epDataStore.
 func (manager *Manager) onDeleteCES(ces *cilium_api_v2alpha1.CiliumEndpointSlice) {
 	manager.Lock()
 	defer manager.Unlock()
 
-	if tracked, ok := manager.cesTrackedEndpoints[ces.Name]; ok {
-		for id := range tracked {
+	tracked, ok := manager.cesTrackedEndpoints[ces.Name]
+	if !ok {
+		return
+	}
+
+	for id := range tracked {
+		if !manager.endpointTrackedByOtherCES(id, ces.Name) {
 			delete(manager.epDataStore, id)
 		}
-		delete(manager.cesTrackedEndpoints, ces.Name)
 	}
+	delete(manager.cesTrackedEndpoints, ces.Name)
 
 	manager.setEventBitmap(eventDeleteEndpoint)
 	manager.reconciliationTrigger.TriggerWithReason("CES deleted")

--- a/pkg/egressgateway/manager_ces_test.go
+++ b/pkg/egressgateway/manager_ces_test.go
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package egressgateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/identity"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/maps/egressmap"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// newCESEndpoint creates a CiliumEndpoint that looks like what
+// ConvertCoreCiliumEndpointToTypesCiliumEndpoint produces: it has Name and
+// Namespace but NO UID (because CoreCiliumEndpoint doesn't carry one).
+func newCESEndpoint(name, namespace, ipv4, ipv6, nodeIP string, identityID int64) *k8sTypes.CiliumEndpoint {
+	ep := &k8sTypes.CiliumEndpoint{
+		ObjectMeta: slimv1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			// UID intentionally left empty — CES endpoints have no UID
+		},
+		Identity: &cilium_api_v2.EndpointIdentity{
+			ID: identityID,
+		},
+		Networking: &cilium_api_v2.EndpointNetworking{
+			Addressing: cilium_api_v2.AddressPairList{
+				&cilium_api_v2.AddressPair{
+					IPV4: ipv4,
+					IPV6: ipv6,
+				},
+			},
+			NodeIP: nodeIP,
+		},
+	}
+	return ep
+}
+
+// TestGetEndpointMetadata_CESEndpointRejected verifies that getEndpointMetadata
+// accepts CES-sourced endpoints (empty UID) by falling back to namespace/name
+// as the endpoint ID. This was the root cause of issue #24833.
+func TestGetEndpointMetadata_CESEndpointRejected(t *testing.T) {
+	ep := newCESEndpoint("pod-1", "default", ep1IP, "", node1IP, 1000)
+
+	identityLabels := labels.Map2Labels(ep1Labels, labels.LabelSourceK8s)
+
+	epData, err := getEndpointMetadata(ep, identityLabels)
+
+	// After the fix: should succeed with namespace/name as ID
+	require.NoError(t, err, "getEndpointMetadata should accept CES endpoints with empty UID")
+	require.NotNil(t, epData)
+	require.Equal(t, endpointID("default/pod-1"), epData.id,
+		"CES endpoint ID should be namespace/name")
+}
+
+// TestGetEndpointMetadata_CESEndpointNamespaceNameKey verifies that for
+// CES-sourced endpoints (empty UID), the endpoint ID is correctly derived
+// from namespace + "/" + name.
+func TestGetEndpointMetadata_CESEndpointNamespaceNameKey(t *testing.T) {
+	ep := newCESEndpoint("my-pod", "production", "10.0.1.5", "", node1IP, 2000)
+
+	identityLabels := labels.Map2Labels(ep1Labels, labels.LabelSourceK8s)
+
+	epData, err := getEndpointMetadata(ep, identityLabels)
+	require.NoError(t, err)
+	require.NotNil(t, epData)
+
+	require.Equal(t, endpointID("production/my-pod"), epData.id,
+		"endpoint ID should use namespace/name format for CES endpoints")
+	require.Equal(t, "10.0.1.5", epData.ips[0].String())
+}
+
+// TestGetEndpointMetadata_CEPEndpointStillUsesUID verifies that the existing
+// behavior for CEP-sourced endpoints (with a real UID) is preserved — the
+// endpoint ID should still be the UID.
+func TestGetEndpointMetadata_CEPEndpointStillUsesUID(t *testing.T) {
+	ep := &k8sTypes.CiliumEndpoint{
+		ObjectMeta: slimv1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+			UID:       "abcd-1234-efgh",
+		},
+		Networking: &cilium_api_v2.EndpointNetworking{
+			Addressing: cilium_api_v2.AddressPairList{
+				&cilium_api_v2.AddressPair{IPV4: ep1IP},
+			},
+		},
+	}
+
+	identityLabels := labels.Map2Labels(ep1Labels, labels.LabelSourceK8s)
+
+	epData, err := getEndpointMetadata(ep, identityLabels)
+	require.NoError(t, err)
+	require.NotNil(t, epData)
+	require.Equal(t, endpointID("abcd-1234-efgh"), epData.id,
+		"CEP endpoint ID should still use UID when available")
+}
+
+// TestGetEndpointMetadata_CESEndpointNoNameOrUID verifies that endpoints with
+// neither UID nor Name are rejected (defensive case).
+func TestGetEndpointMetadata_CESEndpointNoNameOrUID(t *testing.T) {
+	ep := &k8sTypes.CiliumEndpoint{
+		ObjectMeta: slimv1.ObjectMeta{
+			// No UID, no Name
+		},
+		Networking: &cilium_api_v2.EndpointNetworking{
+			Addressing: cilium_api_v2.AddressPairList{
+				&cilium_api_v2.AddressPair{IPV4: ep1IP},
+			},
+		},
+	}
+
+	identityLabels := labels.Map2Labels(ep1Labels, labels.LabelSourceK8s)
+
+	_, err := getEndpointMetadata(ep, identityLabels)
+	require.Error(t, err, "should reject endpoint with neither UID nor Name")
+}
+
+// TestPrivilegedCESEndpoint_AddAndDelete is an integration test that verifies
+// CES-shaped endpoints (no UID) can be added to and deleted from the egress
+// gateway manager's epDataStore, and that reconciliation creates correct BPF
+// map entries. This validates the fix for issue #24833.
+func TestPrivilegedCESEndpoint_AddAndDelete(t *testing.T) {
+	k := setupEgressGatewayTestSuite(t)
+
+	egressGatewayManager := k.manager
+	policyMap4 := egressGatewayManager.policyMap4
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	// Sync all resources to allow reconciliation
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpoints.sync(t)
+
+	// Add a node
+	node1Obj := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	addNodeAndReconcile(t, k, egressGatewayManager, &node1Obj)
+
+	// Add a policy that selects ep1Labels
+	policy1 := &policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+	}
+	addPolicyAndReconcile(t, egressGatewayManager, k.policies, policy1)
+
+	// Allocate an identity for the endpoint labels
+	id1, _, _ := identityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep1Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+
+	// Create a CES-shaped endpoint (no UID, has Name+Namespace)
+	cesEp := newCESEndpoint("ep-1", "default", ep1IP, "", node1IP, int64(id1.ID))
+
+	// --- Test: addEndpoint should accept a CES endpoint ---
+	err := egressGatewayManager.addEndpoint(cesEp)
+	require.NoError(t, err, "addEndpoint should not error on CES endpoint")
+
+	expectedID := endpointID("default/ep-1")
+
+	egressGatewayManager.Lock()
+	_, found := egressGatewayManager.epDataStore[expectedID]
+	egressGatewayManager.Unlock()
+	require.True(t, found, "CES endpoint should be present in epDataStore with key %q", expectedID)
+
+	// Trigger reconciliation and verify BPF map entry
+	egressGatewayManager.Lock()
+	egressGatewayManager.reconcileLocked()
+	egressGatewayManager.Unlock()
+
+	assertEgressRules4(t, policyMap4, []egressRule{
+		{ep1IP, destCIDR, egressIP1, node1IP, 0},
+	})
+
+	// --- Test: deleteEndpoint should remove the CES endpoint ---
+	egressGatewayManager.deleteEndpoint(cesEp)
+
+	egressGatewayManager.Lock()
+	_, found = egressGatewayManager.epDataStore[expectedID]
+	egressGatewayManager.Unlock()
+	require.False(t, found, "CES endpoint should be removed from epDataStore after delete")
+
+	// Trigger reconciliation and verify BPF map is empty
+	egressGatewayManager.Lock()
+	egressGatewayManager.reconcileLocked()
+	egressGatewayManager.Unlock()
+
+	assertEgressRules4(t, policyMap4, []egressRule{})
+}
+
+// TestPrivilegedCESEndpoint_MultipleEndpointsSameNamespace verifies that
+// multiple CES-sourced endpoints from the same namespace can coexist in the
+// manager's epDataStore and independently match different policies.
+func TestPrivilegedCESEndpoint_MultipleEndpointsSameNamespace(t *testing.T) {
+	k := setupEgressGatewayTestSuite(t)
+
+	egressGatewayManager := k.manager
+	policyMap4 := egressGatewayManager.policyMap4
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpoints.sync(t)
+
+	node1Obj := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	addNodeAndReconcile(t, k, egressGatewayManager, &node1Obj)
+
+	// Policy matching ep1Labels
+	addPolicyAndReconcile(t, egressGatewayManager, k.policies, &policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+	})
+
+	// Allocate identities
+	id1, _, _ := identityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep1Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+	id2, _, _ := identityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep2Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+
+	// Two CES endpoints, same namespace, different names and labels
+	cesEp1 := newCESEndpoint("ep-1", "default", ep1IP, "", node1IP, int64(id1.ID))
+	cesEp2 := newCESEndpoint("ep-2", "default", ep2IP, "", node1IP, int64(id2.ID))
+
+	// Add both
+	require.NoError(t, egressGatewayManager.addEndpoint(cesEp1))
+	require.NoError(t, egressGatewayManager.addEndpoint(cesEp2))
+
+	egressGatewayManager.Lock()
+	_, found1 := egressGatewayManager.epDataStore[endpointID("default/ep-1")]
+	_, found2 := egressGatewayManager.epDataStore[endpointID("default/ep-2")]
+	egressGatewayManager.Unlock()
+
+	require.True(t, found1, "ep-1 should be in epDataStore")
+	require.True(t, found2, "ep-2 should be in epDataStore")
+
+	// Reconcile — only ep-1 matches policy-1
+	egressGatewayManager.Lock()
+	egressGatewayManager.reconcileLocked()
+	egressGatewayManager.Unlock()
+
+	assertEgressRules4(t, policyMap4, []egressRule{
+		{ep1IP, destCIDR, egressIP1, node1IP, 0},
+	})
+
+	// Delete ep-1, verify BPF map is cleaned up
+	egressGatewayManager.deleteEndpoint(cesEp1)
+
+	egressGatewayManager.Lock()
+	egressGatewayManager.reconcileLocked()
+	egressGatewayManager.Unlock()
+
+	assertEgressRules4(t, policyMap4, []egressRule{})
+}
+
+// ---------------------------------------------------------------------------
+// CES Event Flow Integration Tests
+//
+// These tests exercise the full CES event path: CiliumEndpointSlice events
+// are fed through handleCESEvent -> onUpsertCES/onDeleteCES -> addEndpoint,
+// exercising the per-slice diff tracking in cesTrackedEndpoints.
+// ---------------------------------------------------------------------------
+
+// EgressGatewayCESTestSuite is a test suite for CES-mode egress gateway tests.
+// It mirrors EgressGatewayTestSuite but uses CES events instead of CEP events.
+type EgressGatewayCESTestSuite struct {
+	manager        *Manager
+	policies       fakeResource[*Policy]
+	nodes          fakeResource[*cilium_api_v2.CiliumNode]
+	endpointSlices fakeResource[*cilium_api_v2alpha1.CiliumEndpointSlice]
+	sysctl         sysctl.Sysctl
+}
+
+func setupEgressGatewayCESTestSuite(t *testing.T) *EgressGatewayCESTestSuite {
+	testutils.PrivilegedTest(t)
+	logger := hivetest.Logger(t)
+
+	bpf.CheckOrMountFS(logger, "")
+
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err)
+
+	nodeTypes.SetName(node1)
+
+	k := &EgressGatewayCESTestSuite{}
+	k.policies = make(fakeResource[*Policy])
+	k.nodes = make(fakeResource[*cilium_api_v2.CiliumNode])
+	k.endpointSlices = make(fakeResource[*cilium_api_v2alpha1.CiliumEndpointSlice])
+	k.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+
+	lc := hivetest.Lifecycle(t)
+	policyMap4 := egressmap.CreatePrivatePolicyMap4(lc, nil, egressmap.DefaultPolicyConfig)
+	policyMap6 := egressmap.CreatePrivatePolicyMap6(lc, nil, egressmap.DefaultPolicyConfig)
+
+	// Note: Endpoints is nil (no CEP resource), EndpointSlices is set.
+	// This simulates CES-enabled mode.
+	k.manager, err = newEgressGatewayManager(Params{
+		Logger:    logger,
+		Lifecycle: lc,
+		Config:    Config{1 * time.Millisecond},
+		DaemonConfig: &option.DaemonConfig{
+			EnableCiliumEndpointSlice: true,
+		},
+		IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+		PolicyMap4:        policyMap4,
+		PolicyMap6:        policyMap6,
+		Policies:          k.policies,
+		Nodes:             k.nodes,
+		EndpointSlices:    k.endpointSlices,
+		Sysctl:            k.sysctl,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, k.manager)
+
+	return k
+}
+
+// cesAddNodeAndReconcile adds a CiliumNode and waits for reconciliation.
+func cesAddNodeAndReconcile(tb testing.TB, k *EgressGatewayCESTestSuite, manager *Manager, node *nodeTypes.Node) {
+	currentRun := manager.reconciliationEventsCount.Load()
+	k.nodes.process(tb, resource.Event[*cilium_api_v2.CiliumNode]{
+		Kind:   resource.Upsert,
+		Object: node.ToCiliumNode(),
+	})
+	waitForReconciliationRun(tb, manager, currentRun)
+}
+
+// upsertCESAndReconcile sends a CES upsert event and waits for reconciliation.
+func upsertCESAndReconcile(tb testing.TB, manager *Manager, endpointSlices fakeResource[*cilium_api_v2alpha1.CiliumEndpointSlice], ces *cilium_api_v2alpha1.CiliumEndpointSlice) {
+	currentRun := manager.reconciliationEventsCount.Load()
+	endpointSlices.process(tb, resource.Event[*cilium_api_v2alpha1.CiliumEndpointSlice]{
+		Kind:   resource.Upsert,
+		Object: ces,
+	})
+	waitForReconciliationRun(tb, manager, currentRun)
+}
+
+// deleteCESAndReconcile sends a CES delete event and waits for reconciliation.
+func deleteCESAndReconcile(tb testing.TB, manager *Manager, endpointSlices fakeResource[*cilium_api_v2alpha1.CiliumEndpointSlice], ces *cilium_api_v2alpha1.CiliumEndpointSlice) {
+	currentRun := manager.reconciliationEventsCount.Load()
+	endpointSlices.process(tb, resource.Event[*cilium_api_v2alpha1.CiliumEndpointSlice]{
+		Kind:   resource.Delete,
+		Object: ces,
+	})
+	waitForReconciliationRun(tb, manager, currentRun)
+}
+
+// newTestCES creates a CiliumEndpointSlice for testing.
+func newTestCES(name, namespace string, endpoints ...cilium_api_v2alpha1.CoreCiliumEndpoint) *cilium_api_v2alpha1.CiliumEndpointSlice {
+	return &cilium_api_v2alpha1.CiliumEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Namespace: namespace,
+		Endpoints: endpoints,
+	}
+}
+
+// newTestCoreCEP creates a CoreCiliumEndpoint for testing.
+func newTestCoreCEP(name string, identityID int64, ipv4, nodeIP string) cilium_api_v2alpha1.CoreCiliumEndpoint {
+	return cilium_api_v2alpha1.CoreCiliumEndpoint{
+		Name:       name,
+		IdentityID: identityID,
+		Networking: &cilium_api_v2.EndpointNetworking{
+			Addressing: cilium_api_v2.AddressPairList{
+				&cilium_api_v2.AddressPair{
+					IPV4: ipv4,
+				},
+			},
+			NodeIP: nodeIP,
+		},
+	}
+}
+
+// TestPrivilegedCESEventFlow_BasicUpsert verifies the full CES event path:
+// a CiliumEndpointSlice upsert event creates BPF map entries for matching
+// endpoints.
+func TestPrivilegedCESEventFlow_BasicUpsert(t *testing.T) {
+	k := setupEgressGatewayCESTestSuite(t)
+
+	manager := k.manager
+	policyMap4 := manager.policyMap4
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	// Sync all resources
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpointSlices.sync(t)
+
+	// Add a node
+	node1Obj := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	cesAddNodeAndReconcile(t, k, manager, &node1Obj)
+
+	// Add a policy matching ep1Labels
+	addPolicyAndReconcile(t, manager, k.policies, &policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+	})
+
+	// No endpoints yet — BPF map should be empty
+	assertEgressRules4(t, policyMap4, []egressRule{})
+
+	// Allocate an identity matching ep1Labels
+	cesIdentityAllocator := manager.identityAllocator.(*testidentity.MockIdentityAllocator)
+	id1, _, _ := cesIdentityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep1Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+
+	// Create a CES with one endpoint matching the policy
+	ces := newTestCES("slice-1", "default",
+		newTestCoreCEP("ep-1", int64(id1.ID), ep1IP, node1IP),
+	)
+	upsertCESAndReconcile(t, manager, k.endpointSlices, ces)
+
+	// BPF map should have the entry
+	assertEgressRules4(t, policyMap4, []egressRule{
+		{ep1IP, destCIDR, egressIP1, node1IP, 0},
+	})
+}
+
+// TestPrivilegedCESEventFlow_UpsertDiff verifies that when a CES is updated
+// (endpoints added/removed), the manager correctly diffs and creates/deletes
+// the appropriate BPF map entries.
+func TestPrivilegedCESEventFlow_UpsertDiff(t *testing.T) {
+	k := setupEgressGatewayCESTestSuite(t)
+
+	manager := k.manager
+	policyMap4 := manager.policyMap4
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpointSlices.sync(t)
+
+	node1Obj := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	cesAddNodeAndReconcile(t, k, manager, &node1Obj)
+
+	addPolicyAndReconcile(t, manager, k.policies, &policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+	})
+
+	cesIdentityAllocator := manager.identityAllocator.(*testidentity.MockIdentityAllocator)
+	id1, _, _ := cesIdentityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep1Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+	id2, _, _ := cesIdentityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep2Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+
+	// Initial CES with ep-1 (matches policy) and ep-2 (doesn't match)
+	ces := newTestCES("slice-1", "default",
+		newTestCoreCEP("ep-1", int64(id1.ID), ep1IP, node1IP),
+		newTestCoreCEP("ep-2", int64(id2.ID), ep2IP, node1IP),
+	)
+	upsertCESAndReconcile(t, manager, k.endpointSlices, ces)
+
+	// Only ep-1 matches
+	assertEgressRules4(t, policyMap4, []egressRule{
+		{ep1IP, destCIDR, egressIP1, node1IP, 0},
+	})
+
+	// Update CES: remove ep-1, keep ep-2 (which doesn't match policy)
+	cesUpdated := newTestCES("slice-1", "default",
+		newTestCoreCEP("ep-2", int64(id2.ID), ep2IP, node1IP),
+	)
+	upsertCESAndReconcile(t, manager, k.endpointSlices, cesUpdated)
+
+	// ep-1 was removed from the slice → should be deleted from epDataStore
+	// ep-2 doesn't match policy → BPF map should be empty
+	assertEgressRules4(t, policyMap4, []egressRule{})
+
+	// Verify ep-1 is actually gone from epDataStore
+	manager.Lock()
+	_, found := manager.epDataStore[endpointID("default/ep-1")]
+	manager.Unlock()
+	require.False(t, found, "ep-1 should be removed from epDataStore after CES diff")
+}
+
+// TestPrivilegedCESEventFlow_DeleteSlice verifies that deleting an entire
+// CiliumEndpointSlice removes all its tracked endpoints from the manager.
+func TestPrivilegedCESEventFlow_DeleteSlice(t *testing.T) {
+	k := setupEgressGatewayCESTestSuite(t)
+
+	manager := k.manager
+	policyMap4 := manager.policyMap4
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpointSlices.sync(t)
+
+	node1Obj := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	cesAddNodeAndReconcile(t, k, manager, &node1Obj)
+
+	addPolicyAndReconcile(t, manager, k.policies, &policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+	})
+
+	cesIdentityAllocator := manager.identityAllocator.(*testidentity.MockIdentityAllocator)
+	id1, _, _ := cesIdentityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep1Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+
+	// Create and upsert a CES
+	ces := newTestCES("slice-1", "default",
+		newTestCoreCEP("ep-1", int64(id1.ID), ep1IP, node1IP),
+	)
+	upsertCESAndReconcile(t, manager, k.endpointSlices, ces)
+
+	assertEgressRules4(t, policyMap4, []egressRule{
+		{ep1IP, destCIDR, egressIP1, node1IP, 0},
+	})
+
+	// Delete the entire CES
+	deleteCESAndReconcile(t, manager, k.endpointSlices, ces)
+
+	// All endpoints from that slice should be removed
+	assertEgressRules4(t, policyMap4, []egressRule{})
+
+	manager.Lock()
+	_, found := manager.epDataStore[endpointID("default/ep-1")]
+	_, tracked := manager.cesTrackedEndpoints["slice-1"]
+	manager.Unlock()
+	require.False(t, found, "ep-1 should be removed from epDataStore after CES delete")
+	require.False(t, tracked, "slice-1 should be removed from cesTrackedEndpoints after CES delete")
+}
+
+// TestPrivilegedCESEventFlow_DeleteUnknownSlice verifies that deleting a
+// CES the manager never saw is a safe no-op.
+func TestPrivilegedCESEventFlow_DeleteUnknownSlice(t *testing.T) {
+	k := setupEgressGatewayCESTestSuite(t)
+
+	manager := k.manager
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpointSlices.sync(t)
+
+	// Delete a CES we never upserted — should be a no-op
+	ces := newTestCES("unknown-slice", "default",
+		newTestCoreCEP("ep-1", 12345, ep1IP, node1IP),
+	)
+	deleteCESAndReconcile(t, manager, k.endpointSlices, ces)
+
+	// Manager should still be healthy with empty stores
+	manager.Lock()
+	require.Empty(t, manager.epDataStore)
+	manager.Unlock()
+}
+
+// TestPrivilegedCESEventFlow_NodeSelector verifies that CES-sourced endpoints
+// correctly carry NodeIP so that policies with nodeSelectors can match (or
+// reject) endpoints based on which node they run on.
+func TestPrivilegedCESEventFlow_NodeSelector(t *testing.T) {
+	k := setupEgressGatewayCESTestSuite(t)
+
+	manager := k.manager
+	policyMap4 := manager.policyMap4
+
+	createTestInterface(t, k.sysctl, testInterface1, []string{egressCIDR1})
+
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpointSlices.sync(t)
+
+	// Add two nodes with different labels
+	node1Obj := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	cesAddNodeAndReconcile(t, k, manager, &node1Obj)
+
+	node2Obj := newCiliumNode(node2, node2IP, nodeGroup2Labels)
+	cesAddNodeAndReconcile(t, k, manager, &node2Obj)
+
+	// Create a policy that matches ep1Labels AND requires nodeGroup2Labels
+	// (i.e. only endpoints on node2 should match)
+	addPolicyAndReconcile(t, manager, k.policies, &policyParams{
+		name:             "policy-with-node-selector",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		nodeSelectors:    nodeGroup2Labels,
+		policyGwParams: []policyGatewayParams{
+			{
+				nodeLabels: nodeGroup1Labels,
+				iface:      testInterface1,
+			},
+		},
+	})
+
+	cesIdentityAllocator := manager.identityAllocator.(*testidentity.MockIdentityAllocator)
+	id1, _, _ := cesIdentityAllocator.AllocateIdentity(
+		context.Background(),
+		labels.Map2Labels(ep1Labels, labels.LabelSourceK8s),
+		true, identity.InvalidIdentity,
+	)
+
+	// Endpoint on node1 — should NOT match (wrong node labels)
+	cesOnNode1 := newTestCES("slice-node1", "default",
+		newTestCoreCEP("ep-on-node1", int64(id1.ID), ep1IP, node1IP),
+	)
+	upsertCESAndReconcile(t, manager, k.endpointSlices, cesOnNode1)
+
+	assertEgressRules4(t, policyMap4, []egressRule{})
+
+	// Endpoint on node2 — should match (correct node labels)
+	cesOnNode2 := newTestCES("slice-node2", "default",
+		newTestCoreCEP("ep-on-node2", int64(id1.ID), ep2IP, node2IP),
+	)
+	upsertCESAndReconcile(t, manager, k.endpointSlices, cesOnNode2)
+
+	assertEgressRules4(t, policyMap4, []egressRule{
+		{ep2IP, destCIDR, egressIP1, node1IP, 0},
+	})
+
+	// Delete the matching CES — BPF map should be empty again
+	deleteCESAndReconcile(t, manager, k.endpointSlices, cesOnNode2)
+
+	assertEgressRules4(t, policyMap4, []egressRule{})
+}

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -816,7 +816,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 		var rules []egressRule
 
 		for _, endpoint := range endpoints {
-			h := computeEndpointHash(endpoint.ep.UID)
+			h := computeEndpointHash(endpointID(endpoint.ep.UID))
 			gw := gateways[h%uint32(len(gateways))]
 			ifindex := egressIfindex
 

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -252,7 +252,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc 
 	return nil
 }
 
-func computeEndpointHash(endpointUID types.UID) uint32 {
+func computeEndpointHash(endpointUID endpointID) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(endpointUID))
 	return h.Sum32()


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) (CoreWeave is already listed)
- [x] Thanks for contributing!

## Description

When `ciliumEndpointSlice.enabled: true`, the Cilium operator stops creating individual `CiliumEndpoint` (CEP) resources and instead batches endpoint data into `CiliumEndpointSlice` (CES) resources. The egress gateway manager only subscribed to CEP events, so it never received endpoint data and the BPF egress policy map stayed empty.

Two problems are fixed:

**Event delivery** (`manager.go`): `processEvents` now subscribes to CES events when the CES resource is available (via `optional:"true"` hive dependency), falling back to CEP events otherwise. The nil-channel select idiom ensures only
one source is active at a time. CES upsert handling converts each `CoreCiliumEndpoint` via the existing `ConvertCoreCiliumEndpointToTypesCiliumEndpoint` helper and uses a per-slice diff tracker (`cesTrackedEndpoints`) to detect endpoints removed between snapshots. The entire slice update runs under a single lock acquisition and triggers reconciliation once rather than per-endpoint.

**Endpoint identity keying** (`endpoint.go`, `manager.go`): `CoreCiliumEndpoint` (inside CES) has no UID field. `getEndpointMetadata` and `deleteEndpoint` now fall back to `namespace/name` as the endpoint ID when UID is empty. Endpoints with neither UID nor Name are rejected as a defensive measure.

The CES incompatibility guard in `NewEgressGatewayManager` is removed.

### Testing

- **18 unit/privileged tests pass** (11 new CES + 7 existing, zero regressions)
  - Unit tests for `namespace/name` ID fallback (`TestGetEndpointMetadata_CESEndpoint*`)
  - Privileged integration tests for CES endpoint add/delete lifecycle with BPF map verification
  - Full CES event flow tests: upsert, snapshot diffing, slice deletion, unknown slice no-op
  - Node-selector policy matching with CES-sourced endpoints carrying NodeIP
- **E2E verified** on Kind cluster with `ciliumEndpointSlice.enabled: true`:
  - `seq-egress-gateway`: PASS (51 actions)
  - `seq-egress-gateway-with-l7-policy`: PASS (51 actions)

Fixes: #24833

```release-note
Allow egress gateway to work when CiliumEndpointSlice (CES) is enabled
```
