### PR TITLE
renovate: Disable major/minor k8s upgrades on stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -690,7 +690,8 @@
       ]
     },
     {
-      // k8s dependencies will be updated manually along with tests on main branch.
+      // k8s major/minor updates are disabled on all branches.
+      // On main, they will be updated manually along with tests.
       // On stable branches, patch updates are allowed via the "k8s.io patch updates stable" rule.
       "enabled": false,
       "matchUpdateTypes": [
@@ -700,9 +701,6 @@
       "matchDepNames": [
         "/^k8s\\.io/",
         "/^sigs\\.k8s\\.io/"
-      ],
-      "matchBaseBranches": [
-        "main"
       ]
     },
     {


### PR DESCRIPTION
PR #44389 introduced the `"matchBaseBranches": ["main"]` constraint to the `"disable major/minor k8s updates"` rule. The intent was to scope that rule to main since stable branches would have their own logic, but the new `"k8s.io patch updates stable"` rule only covers patch/digest — it never disables major/minor on stable. So major/minor k8s update fell through with nothing blocking them on v1.17/v1.18/v1.19.

That's how we got #44481 attempting to bump those from `v0.32.0` to `v0.35.1` on 1.17 and #44476 from `v0.33.3` to `v0.35.1` on 1.18.

This PR removes the `matchBaseBranches: ["main"]` from the disable rule so it applies to all branches. The `"k8s.io patch updates stable"` rule (which explicitly enables patch+digest on stable) will still take precedence for those update types, giving the correct behavior:
* All branches: major/minor k8s updates disabled
* Stable branches only: patch/digest k8s updates enabled
