### PR TITLE
gateway-api: Fix hostname bug breaking cert-manager

### DIFF
--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -28,6 +28,7 @@ func TestHTTPGatewayAPI(t *testing.T) {
 		"basic http external traffic policy":                      {},
 		"basic http load balancer":                                {},
 		"multiple parentRefs":                                     {},
+		"cert manager gateway":                                    {},
 		"Conformance/HTTPRouteSimpleSameNamespace":                {},
 		"Conformance/HTTPRouteCrossNamespace":                     {},
 		"Conformance/HTTPExactPathMatching":                       {},

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gateway.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: echo-a
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      hostname: "*.example.com"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: specific.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: specific-example-com
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-httproute.yaml
@@ -1,0 +1,17 @@
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: echo-a
+    namespace: default
+  spec:
+    parentRefs:
+      - name: echo-a
+        sectionName: http
+    hostnames:
+      - specific.example.com
+    rules:
+      - backendRefs:
+          - name: echo-a-internal
+            port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-service.yaml
@@ -1,0 +1,7 @@
+- metadata:
+    creationTimestamp: null
+    name: echo-a-internal
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/output-listeners.yaml
@@ -1,0 +1,32 @@
+- hostname: "*.example.com"
+  name: http
+  port: 80
+  routes:
+    - backends:
+        - TLS: null
+          name: echo-a-internal
+          namespace: default
+          port:
+            port: 8080
+      hostnames:
+        - specific.example.com
+      path_match: {}
+      timeout: {}
+  sources:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: echo-a
+      namespace: default
+      version: v1
+- hostname: "specific.example.com"
+  name: https
+  port: 443
+  sources:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: echo-a
+      namespace: default
+      version: v1
+  tls:
+    - name: specific-example-com
+      namespace: default


### PR DESCRIPTION
This commit fixes a bug that prevented cert-manager from working correctly in the Gateway API reconciler.

When checking hostnames to see if they were isolated from other Listeners on the same Gateway, Cilium did not distinguish between Listeners of different Protocols.

This meant that when a HTTP and HTTPS listener had the same or overlapping hostnames, then the HTTP config would not be generated.

The fix was to keep track of the hostnames by Protocol, and only check the ones of the _same_ protocol, which was the correct behavior the whole time.

This adds a new test to the model ingestion to catch this specific case as well.

Updates #36750
Updates #44123

```release-note
gateway-api: Fix hostname intersection bug that was preventing cert-manager challenges from working correctly.
```
