### PR TITLE
pkg/endpoint: set down the right veth pair interface

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2641,6 +2641,13 @@ func (e *Endpoint) setDown() error {
 	if err != nil {
 		return fmt.Errorf("setting interface %s down: %w", e.HostInterface(), err)
 	}
+	if link.Attrs().Index != e.GetIfIndex() {
+		// Interface with an index different from the one we were expecting.
+		// This can occur if the endpoint was deleted and recreated while the
+		// old endpoint's setDown() was executing. In this case, we should not
+		// set the new interface down.
+		return nil
+	}
 
 	return netlink.LinkSetDown(link)
 }


### PR DESCRIPTION
On certain environments, where StatefulSets are used, the re-usage of a vethpair with the same name can occur. This can cause some concurrency issues and the setDown function is executed for the "new" veth pair, which uses the same name as the "older" veth pair. To prevent this from happening we should also check if the ifindex matches the veth pair fetched by netlink.

Fixes: 6633ca8e766b ("datapath,endpoint: explicitly remove TC filters during endpoint teardown")

```release-note
Fix tearing down wrong pod's veth in aws-cni chaining when using deterministic pod names
```

Fixes https://github.com/cilium/cilium/issues/44463
