### PR TITLE
maps: use netip types

### DIFF
--- a/cilium-dbg/cmd/bpf_ipcache_delete.go
+++ b/cilium-dbg/cmd/bpf_ipcache_delete.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 	"os"
 
@@ -44,9 +43,7 @@ var bpfIPCacheDeleteCmd = &cobra.Command{
 			Usagef(cmd, "Invalid prefix address. "+usage)
 		}
 
-		ip := net.IP(prefix.Addr().AsSlice())
-		mask := net.CIDRMask(prefix.Bits(), 32)
-		key := ipcache.NewKey(ip, mask, clusterID)
+		key := ipcache.NewKey(prefix, clusterID)
 		if err := ipcache.IPCacheMap(nil).Delete(&key); err != nil {
 			fmt.Fprintf(os.Stderr, "Error deleting entry %s: %v\n", key, err)
 			os.Exit(1)

--- a/cilium-dbg/cmd/bpf_ipcache_update.go
+++ b/cilium-dbg/cmd/bpf_ipcache_update.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 	"os"
 
@@ -45,8 +44,8 @@ var bpfIPCacheUpdateCmd = &cobra.Command{
 		if err != nil {
 			Usagef(cmd, "Invalid tunnel endpoint. "+usage)
 		}
-		tunnelEndpoint := net.ParseIP(tunnelEndpointString)
-		if tunnelEndpoint == nil {
+		tunnelEndpoint, err := netip.ParseAddr(tunnelEndpointString)
+		if err != nil {
 			Usagef(cmd, "Invalid tunnel endpoint. "+usage)
 		}
 
@@ -73,9 +72,7 @@ var bpfIPCacheUpdateCmd = &cobra.Command{
 			Usagef(cmd, "Invalid cluster ID. "+usage)
 		}
 
-		ip := net.IP(prefix.Addr().AsSlice())
-		mask := net.CIDRMask(prefix.Bits(), 32)
-		key := ipcache.NewKey(ip, mask, clusterID)
+		key := ipcache.NewKey(prefix, clusterID)
 		value := ipcache.NewValue(identity, tunnelEndpoint, encryptKey, flags)
 		if err := ipcache.IPCacheMap(nil).Update(&key, &value); err != nil {
 			fmt.Fprintf(os.Stderr, "Error updating entry %s: %v\n", key, err)

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
-	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -252,14 +251,12 @@ func (k *EgressPolicyKey4) Match(sourceIP netip.Addr, destCIDR netip.Prefix) boo
 
 // GetSourceIP returns the egress policy key's source IP.
 func (k *EgressPolicyKey4) GetSourceIP() netip.Addr {
-	addr, _ := netipx.FromStdIP(k.SourceIP.IP())
-	return addr
+	return k.SourceIP.Addr()
 }
 
 // GetDestCIDR returns the egress policy key's destination CIDR.
 func (k *EgressPolicyKey4) GetDestCIDR() netip.Prefix {
-	addr, _ := netipx.FromStdIP(k.DestCIDR.IP())
-	return netip.PrefixFrom(addr, int(k.PrefixLen-PolicyStaticPrefixBits4))
+	return netip.PrefixFrom(k.DestCIDR.Addr(), int(k.PrefixLen-PolicyStaticPrefixBits4))
 }
 
 // New returns an egress policy value
@@ -373,14 +370,12 @@ func (k *EgressPolicyKey6) Match(sourceIP netip.Addr, destCIDR netip.Prefix) boo
 
 // GetSourceIP returns the egress policy key's source IP.
 func (k *EgressPolicyKey6) GetSourceIP() netip.Addr {
-	addr, _ := netipx.FromStdIP(k.SourceIP.IP())
-	return addr
+	return k.SourceIP.Addr()
 }
 
 // GetDestCIDR returns the egress policy key's destination CIDR.
 func (k *EgressPolicyKey6) GetDestCIDR() netip.Prefix {
-	addr, _ := netipx.FromStdIP(k.DestCIDR.IP())
-	return netip.PrefixFrom(addr, int(k.PrefixLen-PolicyStaticPrefixBits6))
+	return netip.PrefixFrom(k.DestCIDR.Addr(), int(k.PrefixLen-PolicyStaticPrefixBits6))
 }
 
 // New returns an egress policy value

--- a/pkg/maps/l2respondermap/l2_responder_map4.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4.go
@@ -6,7 +6,6 @@ package l2respondermap
 import (
 	"fmt"
 	"log/slog"
-	"net"
 	"net/netip"
 	"unsafe"
 
@@ -121,7 +120,7 @@ type L2ResponderKey struct {
 }
 
 func (k *L2ResponderKey) String() string {
-	return fmt.Sprintf("ip=%s, ifIndex=%d", net.IP(k.IP[:]), k.IfIndex)
+	return fmt.Sprintf("ip=%s, ifIndex=%d", k.IP, k.IfIndex)
 }
 
 func newL2ResponderKey(ip netip.Addr, ifIndex uint32) L2ResponderKey {

--- a/pkg/maps/l2v6respondermap/l2_responder_map6.go
+++ b/pkg/maps/l2v6respondermap/l2_responder_map6.go
@@ -6,7 +6,6 @@ package l2v6respondermap
 import (
 	"fmt"
 	"log/slog"
-	"net"
 	"net/netip"
 	"unsafe"
 
@@ -123,7 +122,7 @@ type L2V6ResponderKey struct {
 }
 
 func (k *L2V6ResponderKey) String() string {
-	return fmt.Sprintf("ip=%s, ifIndex=%d", net.IP(k.IP[:]), k.IfIndex)
+	return fmt.Sprintf("ip=%s, ifIndex=%d", k.IP, k.IfIndex)
 }
 
 func newL2V6ResponderKey(ip netip.Addr, ifIndex uint32) L2V6ResponderKey {

--- a/pkg/maps/multicast/subscribermap.go
+++ b/pkg/maps/multicast/subscribermap.go
@@ -205,11 +205,7 @@ func (m GroupV4OuterMap) ListIterator() ([]netip.Addr, error) {
 
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
-		ip, ok := key.ToNetIPAddr()
-		if !ok {
-			return out, fmt.Errorf("failed to convert key to netip.Addr")
-		}
-		out = append(out, ip)
+		out = append(out, netip.AddrFrom4(key.Group))
 	}
 
 	return out, iter.Err()
@@ -237,11 +233,7 @@ func (m GroupV4OuterMap) ListBatch() ([]netip.Addr, error) {
 	}
 
 	for i := 0; i < len(keys) && i < count; i++ {
-		group, ok := keys[i].ToNetIPAddr()
-		if !ok {
-			return nil, fmt.Errorf("failed to convert GroupV4Key.Group to netip.Addr")
-		}
-		out = append(out, group)
+		out = append(out, netip.AddrFrom4(keys[i].Group))
 	}
 
 	return out, nil
@@ -259,10 +251,6 @@ func NewGroupV4KeyFromNetIPAddr(ip netip.Addr) (out GroupV4Key, err error) {
 	}
 	out.Group = ip.As4()
 	return out, nil
-}
-
-func (k GroupV4Key) ToNetIPAddr() (netip.Addr, bool) {
-	return netip.AddrFromSlice(k.Group[:])
 }
 
 // GroupV4Val is the value of a GroupV4OuterMap.

--- a/pkg/maps/nodemap/node_map_v2.go
+++ b/pkg/maps/nodemap/node_map_v2.go
@@ -6,7 +6,6 @@ package nodemap
 import (
 	"fmt"
 	"log/slog"
-	"net"
 	"net/netip"
 	"unsafe"
 
@@ -79,7 +78,7 @@ type NodeKey struct {
 func (k *NodeKey) String() string {
 	switch k.Family {
 	case bpf.EndpointKeyIPv4:
-		return net.IP(k.IP[:net.IPv4len]).String()
+		return netip.AddrFrom4([4]byte(k.IP[:4])).String()
 	case bpf.EndpointKeyIPv6:
 		return k.IP.String()
 	}

--- a/pkg/maps/nodemap/node_map_v2_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_v2_privileged_test.go
@@ -4,7 +4,6 @@
 package nodemap
 
 import (
-	"net"
 	"net/netip"
 	"testing"
 
@@ -39,7 +38,7 @@ func TestPrivilegedNodeMapV2(t *testing.T) {
 	toMap := func(key *NodeKey, val *NodeValueV2) {
 		address := key.IP.String()
 		if key.Family == bpf.EndpointKeyIPv4 {
-			address = net.IP(key.IP[:net.IPv4len]).String()
+			address = netip.AddrFrom4([4]byte(key.IP[:4])).String()
 		}
 		bpfNodeIDMap[val.NodeID] = address
 		bpfNodeSPI = append(bpfNodeSPI, uint8(val.SPI))

--- a/pkg/maps/subnet/subnet.go
+++ b/pkg/maps/subnet/subnet.go
@@ -5,7 +5,6 @@ package subnet
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 	"unsafe"
 
@@ -51,17 +50,11 @@ func getStaticPrefixBits() uint32 {
 }
 
 func (k SubnetMapKey) String() string {
-	var (
-		addr netip.Addr
-		ok   bool
-	)
+	var addr netip.Addr
 
 	switch k.Family {
 	case SubnetKeyIPv4:
-		addr, ok = netip.AddrFromSlice(k.IP[:net.IPv4len])
-		if !ok {
-			return "<unknown>"
-		}
+		addr = netip.AddrFrom4([4]byte(k.IP[:4]))
 	case SubnetKeyIPv6:
 		addr = netip.AddrFrom16(k.IP)
 	default:

--- a/pkg/types/ipv4.go
+++ b/pkg/types/ipv4.go
@@ -3,10 +3,7 @@
 
 package types
 
-import (
-	"net"
-	"net/netip"
-)
+import "net/netip"
 
 // IPv4 is the binary representation for encoding in binary structs.
 type IPv4 [4]byte
@@ -15,16 +12,12 @@ func (v4 IPv4) IsZero() bool {
 	return v4[0] == 0 && v4[1] == 0 && v4[2] == 0 && v4[3] == 0
 }
 
-func (v4 IPv4) IP() net.IP {
-	return v4[:]
-}
-
 func (v4 IPv4) Addr() netip.Addr {
 	return netip.AddrFrom4(v4)
 }
 
 func (v4 IPv4) String() string {
-	return v4.IP().String()
+	return v4.Addr().String()
 }
 
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.

--- a/pkg/types/ipv4_test.go
+++ b/pkg/types/ipv4_test.go
@@ -4,7 +4,6 @@
 package types
 
 import (
-	"net"
 	"net/netip"
 	"testing"
 
@@ -12,13 +11,6 @@ import (
 )
 
 var testIPv4Address IPv4 = [4]byte{10, 0, 0, 2}
-
-func TestIP(t *testing.T) {
-	var expectedAddress net.IP = []byte{10, 0, 0, 2}
-	result := testIPv4Address.IP()
-
-	require.Equal(t, expectedAddress, result)
-}
 
 func TestAddr(t *testing.T) {
 	expectedAddress := netip.MustParseAddr("10.0.0.2")

--- a/pkg/types/ipv6.go
+++ b/pkg/types/ipv6.go
@@ -3,10 +3,7 @@
 
 package types
 
-import (
-	"net"
-	"net/netip"
-)
+import "net/netip"
 
 // IPv6 is the binary representation for encoding in binary structs.
 type IPv6 [16]byte
@@ -20,16 +17,12 @@ func (v6 IPv6) IsZero() bool {
 	return true
 }
 
-func (v6 IPv6) IP() net.IP {
-	return v6[:]
-}
-
 func (v6 IPv6) Addr() netip.Addr {
 	return netip.AddrFrom16(v6)
 }
 
 func (v6 IPv6) String() string {
-	return v6.IP().String()
+	return v6.Addr().String()
 }
 
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.

--- a/pkg/types/ipv6_test.go
+++ b/pkg/types/ipv6_test.go
@@ -4,7 +4,6 @@
 package types
 
 import (
-	"net"
 	"net/netip"
 	"testing"
 
@@ -12,13 +11,6 @@ import (
 )
 
 var testIPv6Address IPv6 = [16]byte{240, 13, 0, 0, 0, 0, 0, 0, 172, 16, 0, 20, 0, 0, 0, 1}
-
-func TestIPv6(t *testing.T) {
-	var expectedAddress net.IP = []byte{240, 13, 0, 0, 0, 0, 0, 0, 172, 16, 0, 20, 0, 0, 0, 1}
-	result := testIPv6Address.IP()
-
-	require.Equal(t, expectedAddress, result)
-}
 
 func TestAddrV6(t *testing.T) {
 	expectedAddress := netip.AddrFrom16(testIPv6Address)


### PR DESCRIPTION
Use the `netip` types and the appropriate constructors to avoid some unnecessary conversions and return value checks.

See individual commits for details.

For #24246
