### PR TITLE
iptables: skip intra-CILIUM_ rule removal in removeCiliumRules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -245,6 +245,14 @@ func (m *Manager) removeCiliumRules(table string, prog runnable, match string) e
 			continue
 		}
 
+		// Skip rules that live inside a CILIUM_ chain — they will be cleared when
+		// the chain is flushed in doRemove. Only feeder rules (those in built-in
+		// chains that jump to a CILIUM_ chain) need explicit removal here, because
+		// iptables -X fails if the chain is still referenced by another chain.
+		if parts := strings.Fields(rule); len(parts) >= 2 && strings.HasPrefix(parts[1], match) {
+			continue
+		}
+
 		// do not remove feeder for chains that are set to be disabled
 		// ie catch the beginning of the rule like -A POSTROUTING to match it against
 		// disabled chains

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -632,12 +632,6 @@ func TestRemoveCiliumRulesv4(t *testing.T) {
 			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
 		}, {
 			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
-		}, {
-			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
-		}, {
-			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff",
-		}, {
-			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 
@@ -681,12 +675,6 @@ func TestRemoveCiliumRulesv6(t *testing.T) {
 			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
 		}, {
 			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
-		}, {
-			args: "-t mangle -D OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment cilium: any->pod redirect proxied traffic to host proxy -j MARK --set-xmark 0x200/0xffffffff",
-		}, {
-			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff",
-		}, {
-			args: "-t mangle -D OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment cilium: TPROXY to host cilium-dns-egress proxy -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff",
 		},
 	}
 


### PR DESCRIPTION
`removeCiliumRules` iterates over every iptables rules and deletes any that reference a `CILIUM_` chain. This covers two categories:
* Rules inside custom chains (e.g. `-A CILIUM_FORWARD ... -j ACCEPT`)
* Feeder rules in built-in chains (e.g. `-A POSTROUTING ... -j CILIUM_POST`)

The first category is redundant: `removeRules` subsequently calls `doRemove` on each custom chain, which flushes them with `-F` before deleting them with `-X`. The per-rule `-D` calls are not necessary.

The second category is required: iptables `-X` fails if any other chain still references the chain being deleted. Feeder rules in built-in chains (`PREROUTING`, `POSTROUTING`, etc.) are never flushed, so they must be removed explicitly before `-X` can succeed.

This PR skips the deletion of rules that are in a chain that will get flushed and deleted right after. This reduces the number of iptables calls proportionally to the number of rules installed across all `CILIUM_` chains.
