### PR TITLE
renovate: Fix `k8s` patch updates on stable branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -278,6 +278,22 @@
       ]
     },
     {
+      // Required so that Renovate creates a separate patch-only PR (staying
+      // within the current minor) even when a newer minor is also available.
+      // Without this, the global separateMinorPatch:false causes Renovate to
+      // produce a single "minor"-typed PR, which is then blocked by the
+      // "k8s major/minor updates disabled" rule and the patch PR never appears.
+      "matchDepNames": [
+        "/^k8s\\.io/",
+        "/^sigs\\.k8s\\.io/"
+      ],
+      "matchBaseBranches": [
+        "!main"
+      ],
+      "separateMajorMinor": true,
+      "separateMinorPatch": true,
+    },
+    {
       // k8s.io dependencies: allow patch updates on stable branches
       "enabled": true,
       "groupName": "k8s.io patch updates stable",


### PR DESCRIPTION
The `"k8s.io patch updates stable"` rule was missing `separateMinorPatch: true`. With the global `separateMinorPatch: false`, Renovate produces a single PR targeting the latest version when a newer minor is available. That PR is classified as "minor", so `matchUpdateTypes: ["patch"]` never matches, `enabled: true` never fires, and the `"k8s major/minor updates disabled"` rule blocks it — no patch PR is ever created.

Add `separateMajorMinor: true` and `separateMinorPatch: true` to the rule, matching the pattern already used for lvh-images and external docker images on stable branches. This forces a separate "patch"-typed PR (staying within the current minor series) which the rule can correctly enable, while the "minor"-typed PR remains blocked as intended.

Followup to #44489