### PR TITLE
operator: add --leader-election-resource-lock-timeout flag

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -107,6 +107,7 @@ cilium-operator-alibabacloud [flags]
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-resource-lock-timeout duration             Timeout for the HTTP requests to acquire/renew the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2)
       --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -114,6 +114,7 @@ cilium-operator-aws [flags]
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-resource-lock-timeout duration             Timeout for the HTTP requests to acquire/renew the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2)
       --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -109,6 +109,7 @@ cilium-operator-azure [flags]
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-resource-lock-timeout duration             Timeout for the HTTP requests to acquire/renew the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2)
       --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -106,6 +106,7 @@ cilium-operator-generic [flags]
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-resource-lock-timeout duration             Timeout for the HTTP requests to acquire/renew the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2)
       --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -121,6 +121,7 @@ cilium-operator [flags]
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
       --leader-election-lease-duration duration                    Duration that non-leader operator candidates will wait before forcing to acquire leadership (default 15s)
       --leader-election-renew-deadline duration                    Duration that current acting master will retry refreshing leadership in before giving up the lock (default 10s)
+      --leader-election-resource-lock-timeout duration             Timeout for the HTTP requests to acquire/renew the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2)
       --leader-election-retry-period duration                      Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -220,6 +220,10 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 		"Duration that LeaderElector clients should wait between retries of the actions")
 	option.BindEnv(vp, operatorOption.LeaderElectionRetryPeriod)
 
+	flags.Duration(operatorOption.LeaderElectionResourceLockTimeout, 0,
+		"Timeout for the HTTP requests to acquire/renew the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2)")
+	option.BindEnv(vp, operatorOption.LeaderElectionResourceLockTimeout)
+
 	flags.Bool(option.EnableCiliumEndpointSlice, false, "If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.")
 	option.BindEnv(vp, option.EnableCiliumEndpointSlice)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/shell"
@@ -19,6 +20,8 @@ import (
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/workqueue"
@@ -545,16 +548,28 @@ func runOperator(log *slog.Logger, lc *LeaderLifecycle, clientset k8sClient.Clie
 		ns = metav1.NamespaceDefault
 	}
 
-	leResourceLock, err := resourcelock.NewFromKubeconfig(
+	// Create the resource lock for leader election with a configurable HTTP timeout.
+	// By default, the timeout is max(1s, RenewDeadline/2), matching the upstream
+	// NewFromKubeconfig behavior. Users with high-latency control planes can
+	// override this with --leader-election-resource-lock-timeout.
+	rlConfig := *clientset.RestConfig()
+	rlTimeout := operatorOption.Config.LeaderElectionResourceLockTimeout
+	if rlTimeout == 0 {
+		rlTimeout = max(time.Second, operatorOption.Config.LeaderElectionRenewDeadline/2)
+	}
+	rlConfig.Timeout = rlTimeout
+	leaderElectionClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(&rlConfig, "leader-election"))
+	leResourceLock, err := resourcelock.New(
 		resourcelock.LeasesResourceLock,
 		ns,
 		leaderElectionResourceLockName,
+		leaderElectionClient.CoreV1(),
+		leaderElectionClient.CoordinationV1(),
 		resourcelock.ResourceLockConfig{
 			// Identity name of the lock holder
 			Identity: operatorID,
 		},
-		clientset.RestConfig(),
-		operatorOption.Config.LeaderElectionRenewDeadline)
+	)
 	if err != nil {
 		logging.Fatal(log, "Failed to create resource lock for leader election", logfields.Error, err)
 	}

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -160,6 +160,10 @@ const (
 	// tries of the actions in operator HA deployment.
 	LeaderElectionRetryPeriod = "leader-election-retry-period"
 
+	// LeaderElectionResourceLockTimeout is the timeout for the HTTP requests to acquire/renew
+	// the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2).
+	LeaderElectionResourceLockTimeout = "leader-election-resource-lock-timeout"
+
 	// AlibabaCloud options
 
 	// AlibabaCloudVPCID allows user to specific vpc
@@ -243,6 +247,10 @@ type OperatorConfig struct {
 	// LeaderElectionRetryPeriod is the duration that LeaderElector clients should wait between
 	// retries of the actions in operator HA deployment.
 	LeaderElectionRetryPeriod time.Duration
+
+	// LeaderElectionResourceLockTimeout is the timeout for the HTTP requests to acquire/renew
+	// the leader election resource lock. When set to 0, defaults to max(1s, RenewDeadline/2).
+	LeaderElectionResourceLockTimeout time.Duration
 
 	// IPAM options
 
@@ -337,6 +345,7 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.LeaderElectionLeaseDuration = vp.GetDuration(LeaderElectionLeaseDuration)
 	c.LeaderElectionRenewDeadline = vp.GetDuration(LeaderElectionRenewDeadline)
 	c.LeaderElectionRetryPeriod = vp.GetDuration(LeaderElectionRetryPeriod)
+	c.LeaderElectionResourceLockTimeout = vp.GetDuration(LeaderElectionResourceLockTimeout)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)
 	if c.ProxyIdleTimeoutSeconds == 0 {


### PR DESCRIPTION
Add a new configurable flag --leader-election-resource-lock-timeout to
the cilium-operator that controls the HTTP client timeout used when
making API requests to acquire or renew the leader election resource
lock (Lease object in Kubernetes).

Problem:
The HTTP timeout for lease lock API calls is derived from the renew
deadline as max(1s, renewDeadline/2) by the upstream k8s client-go
resourcelock.NewFromKubeconfig() helper. With the default
--leader-election-renew-deadline of 10s, this yields a 5s HTTP timeout.
Users with high-latency control planes (e.g., worker nodes in a
different region than the remote control plane) frequently hit this
timeout, causing the operator to fail leader election with errors like:

  error retrieving resource lock kube-system/cilium-operator-resource-lock:
  net/http: request canceled while waiting for connection
  (Client.Timeout exceeded while awaiting headers)

Previously, the only workaround was to increase
--leader-election-renew-deadline, which also changes the leader election
protocol timing semantics beyond just the HTTP timeout.

Solution:
Introduce --leader-election-resource-lock-timeout (type: duration,
default: 0) that directly controls the HTTP client timeout for lease
lock API requests, independently of the renew deadline.

When set to 0 (default), the existing behavior is preserved exactly:
timeout = max(1s, renewDeadline/2). When set to a positive duration,
that value is used directly as the HTTP client timeout.

Implementation details:
- Added LeaderElectionResourceLockTimeout constant, struct field, and
  viper binding following the same pattern as the existing
  --leader-election-lease-duration, --leader-election-renew-deadline,
  and --leader-election-retry-period flags.
- Replaced the call to resourcelock.NewFromKubeconfig() with a manual
  resource lock construction using resourcelock.New(). This gives us
  control over the rest.Config.Timeout value passed to the Kubernetes
  client used for leader election, while replicating the exact same
  logic from the upstream helper (shallow copy of kubeconfig, user
  agent annotation, NewForConfigOrDie).
- The default behavior (timeout=0) faithfully reproduces the upstream
  formula: timeout = max(1s, renewDeadline/2).

Usage example:
  cilium-operator --leader-election-resource-lock-timeout=15s

Files changed:
- operator/option/config.go: constant, struct field, Populate()
- operator/cmd/flags.go: flag registration with BindEnv
- operator/cmd/root.go: manual resource lock creation with timeout
