### PR TITLE
clustermesh: fix endpointslicesync cleanup race condition

### DIFF
--- a/pkg/clustermesh/endpointslicesync/endpointslice_meta_controller.go
+++ b/pkg/clustermesh/endpointslicesync/endpointslice_meta_controller.go
@@ -12,10 +12,8 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	discoveryv1 "k8s.io/client-go/kubernetes/typed/discovery/v1"
-	discoverylisters "k8s.io/client-go/listers/discovery/v1"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -29,17 +27,29 @@ import (
 // the service is deleted, but for the clustermesh case the Service could still
 // exist but should no longer sync the remote cluster EndpintSlice, so we need to make
 // sure the existing EndpointSlice from remote clusters are properly deleted.
-func endpointSliceCleanupFactory(ctx context.Context, discoveryClient discoveryv1.DiscoveryV1Interface, endpointSliceLister discoverylisters.EndpointSliceLister) func(namespace, name string) error {
+func endpointSliceCleanupFactory(ctx context.Context, discoveryClient discoveryv1.DiscoveryV1Interface) func(namespace, name string) error {
 	return func(namespace, name string) error {
-		labelSelector := labels.Set(map[string]string{
-			discovery.LabelServiceName: name,
-			discovery.LabelManagedBy:   utils.EndpointSliceMeshControllerName,
-		}).AsSelectorPreValidated()
-		endpointSlices, err := endpointSliceLister.EndpointSlices(namespace).List(labelSelector)
+		labelSelector := metav1.FormatLabelSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				discovery.LabelManagedBy: utils.EndpointSliceMeshControllerName,
+			},
+		})
+		// Note that we have to query the EndpointSlices directly with the client
+		// instead of through the informer cache. The informer cache is asynchronously
+		// updated so even if we are the sole write/owner of those object relying
+		// on the informer cache may result in race conditions.
+		endpointSlices, err := discoveryClient.EndpointSlices(namespace).
+			List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			return err
 		}
-		for _, endpointSlice := range endpointSlices {
+		for _, endpointSlice := range endpointSlices.Items {
+			// Note that this label checks is necessarily client side because
+			// that labels is virtually added through the meshClient
+			// and cannot be queried directly on the the API server.
+			if endpointSlice.Labels[discovery.LabelServiceName] != name {
+				continue
+			}
 			deleteOpt := metav1.DeleteOptions{Preconditions: &metav1.Preconditions{
 				UID: &endpointSlice.UID,
 			}}
@@ -74,7 +84,7 @@ func newEndpointSliceMeshController(
 		int32(cfg.ClusterMeshMaxEndpointsPerSlice),
 		meshClient, cfg.ClusterMeshEndpointUpdatesBatchPeriod,
 		utils.EndpointSliceMeshControllerName, nil,
-		endpointSliceCleanupFactory(ctx, clientset.DiscoveryV1(), endpointSliceInformer.Lister()),
+		endpointSliceCleanupFactory(ctx, meshClient.DiscoveryV1()),
 	)
 
 	return controller, meshServiceInformer, factory


### PR DESCRIPTION
The cleanup logic was relying on the informer to list EndpointSlice to delete which is racy since the informer is updated asynchronously/separately through its own watch rather than acting as a write through cache.

The cleanup logic which is invoked on a cluster removal is modified in this commit to thus directly rely on the client instead. This could was actually reproducible with the existing endpointslicesync test at at small rate (~0.1%).

```release-note
clustermesh: fix a race condition where EndpointSlices created just before a cluster is removed could be left uncleaned
```
