### PR TITLE
envoy: remove world access to admin socket

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
@@ -312,3 +312,4 @@ admin:
   address:
     pipe:
       path: "/var/run/cilium/envoy/sockets/admin.sock"
+      mode: 0660

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -531,7 +531,7 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 		Admin: &envoy_config_bootstrap.Admin{
 			Address: &envoy_config_core.Address{
 				Address: &envoy_config_core.Address_Pipe{
-					Pipe: &envoy_config_core.Pipe{Path: config.adminPath},
+					Pipe: &envoy_config_core.Pipe{Path: config.adminPath, Mode: 0660},
 				},
 			},
 		},


### PR DESCRIPTION
Explicitly sets mode 0660 on admin.sock for both embedded and standalone envoy. Without this the socket is created world-accessible.

```release-note
Fix envoy admin socket being created as world-accessible
```
