### PR TITLE
datapath: add missing interface MAC configuration for BPFOverlay config

### DIFF
--- a/pkg/datapath/config/overlay.go
+++ b/pkg/datapath/config/overlay.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/byteorder"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -16,6 +17,11 @@ func Overlay(lnc *datapath.LocalNodeConfiguration, link netlink.Link) any {
 	cfg := NewBPFOverlay(NodeConfig(lnc))
 
 	cfg.InterfaceIfIndex = uint32(link.Attrs().Index)
+
+	em := mac.MAC(link.Attrs().HardwareAddr)
+	if len(em) == 6 {
+		cfg.InterfaceMAC = em.As8()
+	}
 
 	cfg.EnableExtendedIPProtocols = option.Config.EnableExtendedIPProtocols
 	cfg.EnableNoServiceEndpointsRoutable = lnc.SvcRouteConfig.EnableNoServiceEndpointsRoutable


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

The InterfaceMAC field is not filled from the tunnel dev's MAC address. Because of this the BPF program for the overlay resolves to 00:00:00:00:00:00, sending this broken response to the VTEP ARP lookup request.

It seems to be that the root cause was https://github.com/cilium/cilium/commit/d296e0d56a76aa2f0ea85e54afe757d96b24d0bf removing the compile time option -DTHIS_INTERFACE_MAC for bpf_overlay.c, but the MAC field was not set in the replacement Go struct.

Fixes: #44453
Fixes: d296e0d56a76aa2f0ea85e54afe757d96b24d0bf

```release-note
Fixed VTEP ARP responses returning 00:00:00:00:00:00 MAC due to interface MAC missing from eBPF Overlay configuration.
```
