### PR TITLE
bgp: Ensure unique job names for BGPCPResourceStore instances

### DIFF
--- a/pkg/bgp/manager/store/resource_store.go
+++ b/pkg/bgp/manager/store/resource_store.go
@@ -65,8 +65,11 @@ func NewBGPCPResourceStore[T k8sRuntime.Object](params bgpCPResourceStoreParams[
 		signaler: params.Signaler,
 	}
 
+	var obj T
+	jobName := fmt.Sprintf("resource-store-events-%T", obj)
+
 	params.JobGroup.Add(
-		job.OneShot("bgpcp-resource-store-events",
+		job.OneShot(jobName,
 			func(ctx context.Context, health cell.Health) (err error) {
 				s.mu.Lock()
 				s.store, err = s.resource.Store(ctx)


### PR DESCRIPTION
Ensure each tracked resource uses unique job name. Duplicate job names are harder to debug, and produce errors upon hive termination, such as:

```
level=ERROR msg="failed to delete reporter status tree" module=health error="reporting for "bgp-control-plane.job-bgpcp-resource-store-events" has been stopped
```

```release-note
bgp: Ensure unique job names for `BGPCPResourceStore` instances to avoid error logs during hive termination
```