### PR TITLE
v1.18 Backports 2026-02-24

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -103,7 +103,7 @@ jobs:
         id: generate-matrix
         run: |
           cd /tmp/generated/e2e
-          jq '[.[] | del(."key-one", ."key-two") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
+          jq '[.[] | del(."key-two") | . as $entry | [$entry + {mode: "minor"}]] | flatten' configs.json > matrix.json
           echo "Generated matrix:"
           cat /tmp/generated/e2e/matrix.json
           echo "matrix=$(jq -c . < /tmp/generated/e2e/matrix.json)" >> $GITHUB_OUTPUT
@@ -329,7 +329,7 @@ jobs:
           kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
 
           if ${{ matrix.encryption == 'ipsec' }}; then
-            cilium encrypt create-key --auth-algo rfc4106-gcm-aes
+            cilium encrypt create-key --auth-algo ${{ matrix.key-one }}
           fi
 
           if ${{ matrix.skip-upgrade != 'true' }}; then

--- a/cilium-dbg/cmd/ip_get.go
+++ b/cilium-dbg/cmd/ip_get.go
@@ -25,6 +25,8 @@ var (
 	ipQueryLabels []string
 )
 
+const InfoNA = "N/A"
+
 var ipGetCmd = &cobra.Command{
 	Use:   "get ( <cidr> |-l <identity labels> )",
 	Short: "Display IP Cache information",
@@ -99,7 +101,15 @@ func printIPcacheEntriesBrief(entries []*models.IPListEntry) {
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
 	fmt.Fprintf(w, "IP\tHOST\tIDENTITY\tPOD\tNAMESPACE\n")
 	for _, entry := range entries {
-		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", *entry.Cidr, entry.HostIP, *entry.Identity, entry.Metadata.Name, entry.Metadata.Namespace)
+		cidr := InfoNA
+		if entry.Cidr != nil {
+			cidr = *entry.Cidr
+		}
+		identity := InfoNA
+		if entry.Identity != nil {
+			identity = fmt.Sprintf("%d", *entry.Identity)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", cidr, entry.HostIP, identity, entry.Metadata.Name, entry.Metadata.Namespace)
 	}
 	w.Flush()
 }

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -25,6 +25,7 @@ func TestHTTPGatewayAPI(t *testing.T) {
 		"basic http external traffic policy":                     {},
 		"basic http load balancer":                               {},
 		"multiple parentRefs":                                    {},
+		"cert manager gateway":                                   {},
 		"Conformance/HTTPRouteSimpleSameNamespace":               {},
 		"Conformance/HTTPRouteCrossNamespace":                    {},
 		"Conformance/HTTPExactPathMatching":                      {},

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gateway.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: echo-a
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      hostname: "*.example.com"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: specific.example.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: specific-example-com
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-httproute.yaml
@@ -1,0 +1,17 @@
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: echo-a
+    namespace: default
+  spec:
+    parentRefs:
+      - name: echo-a
+        sectionName: http
+    hostnames:
+      - specific.example.com
+    rules:
+      - backendRefs:
+          - name: echo-a-internal
+            port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/input-service.yaml
@@ -1,0 +1,7 @@
+- metadata:
+    creationTimestamp: null
+    name: echo-a-internal
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/cert_manager_gateway/output-listeners.yaml
@@ -1,0 +1,32 @@
+- hostname: "*.example.com"
+  name: http
+  port: 80
+  routes:
+    - backends:
+        - TLS: null
+          name: echo-a-internal
+          namespace: default
+          port:
+            port: 8080
+      hostnames:
+        - specific.example.com
+      path_match: {}
+      timeout: {}
+  sources:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: echo-a
+      namespace: default
+      version: v1
+- hostname: "specific.example.com"
+  name: https
+  port: 443
+  sources:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: echo-a
+      namespace: default
+      version: v1
+  tls:
+    - name: specific-example-com
+      namespace: default

--- a/pkg/loadbalancer/healthserver/testdata/healthserver-proxy-redirect.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-proxy-redirect.txtar
@@ -16,10 +16,8 @@ k8s/add service.yaml
 * http/get http://$HEALTHADDR:$HEALTHPORT healthserver.before
 * cmp healthserver.expected healthserver.before
 
-# Simulate proxy redirection
+# Simulate proxy redirection and verify synthetic endpoint count of 1
 svc/set-proxy-redirect test/echo 1000
-
-# Verify synthetic endpoint count of 1
 * http/get http://$HEALTHADDR:$HEALTHPORT healthserver.after
 * cmp healthserver-proxy.expected healthserver.after
 


### PR DESCRIPTION
 * [x] #44381 (@julianwiedmann) :warning: resolved conflicts
 * [ ] #44323 (@mhofstetter)
 * [x] #44443 (@aanm)
 * [ ] #44462 (@liyihuang) :warning: resolved conflicts
   * Dropped this and marked as `backport/author` since it caused a lot of failure in the CI ([example](https://github.com/cilium/cilium/actions/runs/22585850040/job/65430706577)). We didn't see this in v1.19, so something v1.18-specific logic involved to the failure. Please take a look @liyihuang.
 * [ ] #44492 (@youngnick) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 44381 44323 44443 44462 44492
```
