### PR TITLE
bpf: lxc: de-magic a CTX_ACT_OK

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2550,7 +2550,7 @@ out:
 
 	return ret;
 #else
-	return 0;
+	return CTX_ACT_OK;
 #endif
 }
 


### PR DESCRIPTION
When the special cil_lxc_policy_egress() tailcall program returns 0, make it clear that this goes back to the kernel and handled as CTX_ACT_OK. And is different from simple "return 0 for success" semantics.