### PR TITLE
datapath/linux/device: add DesiredVLANDeviceSpec

### DIFF
--- a/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/owners.txtar
@@ -27,5 +27,5 @@ eth0.10   dummy    down
 
 -- eth0.10.yaml --
 name: eth0.10
-parentDevice: eth0
+parentName: eth0
 vlanID: 10

--- a/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
@@ -35,18 +35,18 @@ hive/stop
 
 -- eth0.10.yaml --
 name: eth0.10
-parentDevice: eth0
+parentName: eth0
 vlanID: 10
 
 -- eth0.20.yaml --
 name: eth0.20
-parentDevice: eth0
+parentName: eth0
 vlanID: 20
 
 -- desired-device.1.table --
 Owner  Name      Properties
-owner1 eth0.10   Type=vlan, ParentDevice=eth0, VlanID=10
-owner1 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+owner1 eth0.10   Type=vlan, ParentDevice=eth0, VLAN=10
+owner1 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
 
 -- devices.1.table --
 Name      Type     MTU     OperStatus
@@ -57,7 +57,7 @@ eth0.20   vlan     1500    up
 
 -- desired-device.2.table --
 Owner  Name      Properties
-owner1 eth0.10   Type=vlan, ParentDevice=eth0, VlanID=10
+owner1 eth0.10   Type=vlan, ParentDevice=eth0, VLAN=10
 
 -- devices.2.table --
 Name      Type     MTU     OperStatus

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
@@ -30,24 +30,24 @@ hive/stop
 
 -- eth0.10.yaml --
 name: eth0.10
-parentDevice: eth0
+parentName: eth0
 vlanID: 10
 
 -- eth0.20.yaml --
 name: eth0.20
-parentDevice: eth0
+parentName: eth0
 vlanID: 20
 
 -- eth0.20-updated.yaml --
 name: eth0.20
-parentDevice: eth0
+parentName: eth0
 vlanID: 20
 mtu: 1400
 
 -- desired-device.1.table --
 Owner  Name      Properties
-owner1 eth0.10   Type=vlan, ParentDevice=eth0, VlanID=10
-owner2 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+owner1 eth0.10   Type=vlan, ParentDevice=eth0, VLAN=10
+owner2 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
 
 -- devices.1.table --
 Name      Type     MTU     OperStatus
@@ -58,7 +58,7 @@ eth0.20   vlan     1500    up
 
 -- desired-device.2.table --
 Owner  Name      Properties
-owner2 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+owner2 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
 
 -- devices.2.table --
 Name      Type     MTU     OperStatus
@@ -68,7 +68,7 @@ eth0.20   vlan     1500    up
 
 -- desired-device.3.table --
 Owner  Name      Properties
-owner2 eth0.20   Type=vlan, ParentDevice=eth0, VlanID=20
+owner2 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
 
 -- devices.3.table --
 Name      Type     MTU     OperStatus

--- a/pkg/datapath/linux/device/vlan.go
+++ b/pkg/datapath/linux/device/vlan.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package device
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+	"go.yaml.in/yaml/v3"
+)
+
+type DesiredVLANDeviceSpec struct {
+	Name        string `json:"name" yaml:"name"`
+	VLANID      int    `json:"vlanID" yaml:"vlanID"`
+	MTU         int    `json:"mtu" yaml:"mtu"`
+	ParentName  string `json:"parentName" yaml:"parentName"`
+	ParentIndex int
+}
+
+var _ DesiredDeviceSpec = (*DesiredVLANDeviceSpec)(nil)
+
+func (d *DesiredVLANDeviceSpec) ToNetlink() (netlink.Link, error) {
+	return &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        d.Name,
+			MTU:         d.MTU,
+			ParentIndex: d.ParentIndex,
+		},
+		VlanId: d.VLANID,
+	}, nil
+}
+
+func (d *DesiredVLANDeviceSpec) Properties() string {
+	return fmt.Sprintf("Type=vlan, ParentDevice=%s, VLAN=%d", d.ParentName, d.VLANID)
+}
+
+func (d *DesiredVLANDeviceSpec) MarshalYAML() (any, error) {
+	return yaml.Marshal(*d)
+}
+
+func (d *DesiredVLANDeviceSpec) MarshalJSON() ([]byte, error) {
+	return json.Marshal(*d)
+}


### PR DESCRIPTION
Move the already existing type used for tests to a dedicated DesiredVLANDeviceSpec type so it can be used outside of the package. Also implement the JSON/YAML marshalling method in terms of struct tags rather than having to construct a map where all fields have to be repeated.