### PR TITLE
renovate: fix image-tools update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -770,7 +770,8 @@
         "quay.io/cilium/startup-script",
         "quay.io/cilium/image-tester",
       ],
-      "versioning": "regex:^(?<major>\\d+)-[a-f0-9]{7}$"
+      "versioning": "regex:^(?<major>\\d+)-[a-f0-9]{7}$",
+      "maxMajorIncrement": 0
     },
     {
       // Images from the image-tools repository that have a semantic + timestamp-based versioning scheme


### PR DESCRIPTION
This commit fix the image-tools update. Theses images, located in https://github.com/cilium/image-tools are tagged following a unix timestamp format. Since Dec 2025, Renovate has a new option named "maxMajorIncrement", which is set to 500 by default.

Setting the option to 0 allows infinite major increment that will work with our timestamp format.

Renovate associated PR :
https://github.com/renovatebot/renovate/pull/38854 
Renovate associated issue :
https://github.com/renovatebot/renovate/issues/20772