### PR TITLE
nodediscovery: retry CiliumNode updates on transient errors

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -244,7 +244,6 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 			var err error
 			nodeResource, err = n.k8sGetters.GetCiliumNode(ctx, nodeTypes.GetName())
 			if err != nil {
-				lastErr = err
 				n.logger.Info(
 					"Unable to get CiliumNode resource",
 					logfields.Error, err,

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -237,12 +237,14 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 
 	performGet := true
 	var nodeResource *ciliumv2.CiliumNode
+	var lastErr error
 	for retryCount := range maxRetryCount {
 		performUpdate := true
 		if performGet {
 			var err error
 			nodeResource, err = n.k8sGetters.GetCiliumNode(ctx, nodeTypes.GetName())
 			if err != nil {
+				lastErr = err
 				n.logger.Info(
 					"Unable to get CiliumNode resource",
 					logfields.Error, err,
@@ -260,6 +262,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 		}
 
 		if err := n.mutateNodeResource(ctx, nodeResource, ln); err != nil {
+			lastErr = err
 			n.logger.Warn(
 				"Unable to mutate nodeResource",
 				logfields.Error, err,
@@ -274,6 +277,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 		performGet = true
 		if performUpdate {
 			if _, err := n.clientset.CiliumV2().CiliumNodes().Update(ctx, nodeResource, metav1.UpdateOptions{}); err != nil {
+				lastErr = err
 				n.logger.Info("Unable to update CiliumNode resource, will retry", logfields.Error, err)
 				// Backoff before retrying
 				time.Sleep(backoffDuration)
@@ -283,6 +287,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 			}
 		} else {
 			if _, err := n.clientset.CiliumV2().CiliumNodes().Create(ctx, nodeResource, metav1.CreateOptions{}); err != nil {
+				lastErr = err
 				n.logger.Info("Unable to create CiliumNode resource, will retry", logfields.Error, err)
 				// Backoff before retrying
 				time.Sleep(backoffDuration)
@@ -293,7 +298,7 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 			}
 		}
 	}
-	logging.Fatal(n.logger, fmt.Sprintf("Could not create or update CiliumNode resource, despite %d retries", maxRetryCount))
+	logging.Fatal(n.logger, "Could not create or update CiliumNode resource", logfields.Error, lastErr, logfields.Retries, maxRetryCount)
 }
 
 func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ciliumv2.CiliumNode, ln *node.LocalNode) error {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/cilium/stream"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
 
@@ -275,25 +274,19 @@ func (n *NodeDiscovery) updateCiliumNodeResource(ctx context.Context, ln *node.L
 		performGet = true
 		if performUpdate {
 			if _, err := n.clientset.CiliumV2().CiliumNodes().Update(ctx, nodeResource, metav1.UpdateOptions{}); err != nil {
-				if k8serrors.IsConflict(err) {
-					n.logger.Info("Unable to update CiliumNode resource, will retry", logfields.Error, err)
-					// Backoff before retrying
-					time.Sleep(backoffDuration)
-					continue
-				}
-				logging.Fatal(n.logger, "Unable to update CiliumNode resource", logfields.Error, err)
+				n.logger.Info("Unable to update CiliumNode resource, will retry", logfields.Error, err)
+				// Backoff before retrying
+				time.Sleep(backoffDuration)
+				continue
 			} else {
 				return
 			}
 		} else {
 			if _, err := n.clientset.CiliumV2().CiliumNodes().Create(ctx, nodeResource, metav1.CreateOptions{}); err != nil {
-				if k8serrors.IsConflict(err) || k8serrors.IsAlreadyExists(err) {
-					n.logger.Info("Unable to create CiliumNode resource, will retry", logfields.Error, err)
-					// Backoff before retrying
-					time.Sleep(backoffDuration)
-					continue
-				}
-				logging.Fatal(n.logger, "Unable to create CiliumNode resource", logfields.Error, err)
+				n.logger.Info("Unable to create CiliumNode resource, will retry", logfields.Error, err)
+				// Backoff before retrying
+				time.Sleep(backoffDuration)
+				continue
 			} else {
 				n.logger.Info("Successfully created CiliumNode resource")
 				return

--- a/pkg/nodediscovery/nodediscovery_test.go
+++ b/pkg/nodediscovery/nodediscovery_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodediscovery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+
+	apimodels "github.com/cilium/cilium/api/v1/models"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	clienttestutils "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/node"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
+)
+
+// mockK8sGetters implements k8sGetters returning a pre-existing CiliumNode,
+// so updateCiliumNodeResource takes the Update path (not Create).
+type mockK8sGetters struct {
+	ciliumNode *ciliumv2.CiliumNode
+}
+
+func (m *mockK8sGetters) GetCiliumNode(_ context.Context, _ string) (*ciliumv2.CiliumNode, error) {
+	return m.ciliumNode, nil
+}
+
+// mockCNIConfigManager implements cni.CNIConfigManager with no-op methods.
+type mockCNIConfigManager struct{}
+
+func (m *mockCNIConfigManager) GetMTU() int                         { return 0 }
+func (m *mockCNIConfigManager) GetChainingMode() string             { return "" }
+func (m *mockCNIConfigManager) Status() *apimodels.Status           { return nil }
+func (m *mockCNIConfigManager) GetCustomNetConf() *cnitypes.NetConf { return nil }
+func (m *mockCNIConfigManager) ExternalRoutingEnabled() bool        { return false }
+
+// TestUpdateCiliumNodeResourceTransientErrorCausesFatal reproduces
+// https://github.com/cilium/cilium/issues/44388: a transient error from the
+// API server during a CiliumNode Update caused logging.Fatal instead of being
+// retried.
+func TestUpdateCiliumNodeResourceTransientErrorCausesFatal(t *testing.T) {
+	logging.RegisterExitHandler(func() { panic("fatal called") })
+	t.Cleanup(func() { logging.RegisterExitHandler(func() {}) })
+
+	option.Config.AutoCreateCiliumNodeResource = true
+	option.Config.IPAM = ""
+	t.Cleanup(func() {
+		option.Config.AutoCreateCiliumNodeResource = false
+	})
+
+	const nodeName = "test-node"
+	nodeTypes.SetName(nodeName)
+
+	fakeClient, _ := clienttestutils.NewFakeClientset(hivetest.Logger(t))
+
+	existingNode := &ciliumv2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	}
+	require.NoError(t, fakeClient.CiliumFakeClientset.Tracker().Add(existingNode))
+
+	updateCalls := 0
+	// PrependReactor is required: the tracker's ObjectReaction (added at
+	// clientset creation via AddReactor) would otherwise intercept Update
+	// first and return a Conflict error due to the missing resource version.
+	fakeClient.CiliumFakeClientset.PrependReactor("update", "ciliumnodes",
+		func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			updateCalls++
+			return true, nil, fmt.Errorf("connection reset by peer")
+		},
+	)
+
+	nd := &NodeDiscovery{
+		logger:           hivetest.Logger(t),
+		clientset:        fakeClient,
+		k8sGetters:       &mockK8sGetters{ciliumNode: existingNode},
+		cniConfigManager: &mockCNIConfigManager{},
+	}
+
+	ln := &node.LocalNode{
+		Node:  nodeTypes.Node{Name: nodeName},
+		Local: &node.LocalNodeInfo{},
+	}
+
+	require.Panics(t, func() {
+		nd.updateCiliumNodeResource(context.Background(), ln)
+	})
+
+	require.Equal(t, maxRetryCount, updateCalls,
+		"transient errors should be retried %d times, not fataled immediately", maxRetryCount)
+}


### PR DESCRIPTION
Fixes: #44388

`updateCiliumNodeResource` retried only on conflict errors, calling `logging.Fatal` immediately on any other error. This caused the agent to crash on transient network failures such as a connection reset or HTTP/2 ping timeout, which would resolve themselves on a simple retry.   
                                                                                                                                                                 
Fix by retrying on all errors uniformly. The existing exhaustion-Fatal after `maxRetryCount` attempts still fires if the problem persists.  
                                                                                                                                              
A unit test is added that injects a permanent "connection reset by peer" error via a fake clientset reactor and asserts that all  `maxRetryCount` retries are attempted before giving up.

```release-note
Fix cilium-agent crash when a transient network error occurs during CiliumNode update. The agent now retries instead of calling Fatal.