### PR TITLE
operator: Refactor legacy hive cell, extract CiliumNode GC to dedicated cell

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -43,6 +43,7 @@ cilium-operator-alibabacloud hive [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -98,6 +98,7 @@ cilium-operator-alibabacloud hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -103,6 +103,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -49,6 +49,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -46,6 +46,7 @@ cilium-operator-aws hive [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -105,6 +105,7 @@ cilium-operator-aws hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -110,6 +110,7 @@ cilium-operator-aws hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -52,6 +52,7 @@ cilium-operator-aws hive dot-graph [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -100,6 +100,7 @@ cilium-operator-azure hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -45,6 +45,7 @@ cilium-operator-azure hive [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -51,6 +51,7 @@ cilium-operator-azure hive dot-graph [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -105,6 +105,7 @@ cilium-operator-azure hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -97,6 +97,7 @@ cilium-operator-generic hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -42,6 +42,7 @@ cilium-operator-generic hive [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -48,6 +48,7 @@ cilium-operator-generic hive dot-graph [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -102,6 +102,7 @@ cilium-operator-generic hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -53,6 +53,7 @@ cilium-operator hive [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -112,6 +112,7 @@ cilium-operator hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -59,6 +59,7 @@ cilium-operator hive dot-graph [flags]
       --enable-k8s                                                 Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                   Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-lb-ipam                                             Enable LB IPAM (default true)
+      --enable-metrics                                             Enable Prometheus metrics
       --enable-node-ipam                                           Enable Node IPAM
       --enable-policy-secrets-sync                                 Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by policy-secrets-namespace flag)
       --enable-wireguard                                           Enable WireGuard

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -117,6 +117,7 @@ cilium-operator hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)
       --operator-k8s-client-qps float32                            Queries per second limit for the K8s client (default 100)

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -57,11 +57,6 @@ func TestMetricsHandlerWithoutMetrics(t *testing.T) {
 		cell.Provide(func() (*option.DaemonConfig, ciliumMetrics.RegistryConfig) {
 			return option.Config, ciliumMetrics.RegistryConfig{}
 		}),
-		cell.Provide(func() operatorMetrics.SharedConfig {
-			return operatorMetrics.SharedConfig{
-				EnableMetrics: false,
-			}
-		}),
 
 		MetricsHandlerCell,
 
@@ -120,11 +115,6 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 
 	hive := hive.New(
 		operatorMetrics.Cell,
-		cell.Provide(func() operatorMetrics.SharedConfig {
-			return operatorMetrics.SharedConfig{
-				EnableMetrics: true,
-			}
-		}),
 		cell.Provide(func() *option.DaemonConfig {
 			return option.Config
 		}),
@@ -215,11 +205,6 @@ func TestMetricsHandlermTLS(t *testing.T) {
 
 	hive := hive.New(
 		operatorMetrics.Cell,
-		cell.Provide(func() operatorMetrics.SharedConfig {
-			return operatorMetrics.SharedConfig{
-				EnableMetrics: true,
-			}
-		}),
 		cell.Provide(func() *option.DaemonConfig {
 			return option.Config
 		}),

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -67,9 +67,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(operatorOption.EndpointGCInterval, operatorOption.EndpointGCIntervalDefault, "GC interval for cilium endpoints")
 	option.BindEnv(vp, operatorOption.EndpointGCInterval)
 
-	flags.Bool(operatorOption.EnableMetrics, false, "Enable Prometheus metrics")
-	option.BindEnv(vp, operatorOption.EnableMetrics)
-
 	// Logging flags
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
 	option.BindEnv(vp, option.LogDriver)

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -186,9 +186,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium Operator is deployed in")
 	option.BindEnv(vp, option.K8sNamespaceName)
 
-	flags.Duration(operatorOption.NodesGCInterval, 5*time.Minute, "GC interval for CiliumNodes")
-	option.BindEnv(vp, operatorOption.NodesGCInterval)
-
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(vp, operatorOption.SyncK8sServices)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -602,9 +602,6 @@ type params struct {
 	Lifecycle                cell.Lifecycle
 	Clientset                k8sClient.Clientset
 	Resources                operatorK8s.Resources
-	SvcResolver              dial.Resolver
-	CfgClusterMeshPolicy     cmtypes.PolicyConfig
-	MetricsRegistry          *metrics.Registry
 	Logger                   *slog.Logger
 	WorkQueueMetricsProvider workqueue.MetricsProvider
 }
@@ -616,9 +613,7 @@ func registerLegacyOnLeader(p params) {
 		cancel:                   cancel,
 		clientset:                p.Clientset,
 		resources:                p.Resources,
-		cfgClusterMeshPolicy:     p.CfgClusterMeshPolicy,
 		workqueueMetricsProvider: p.WorkQueueMetricsProvider,
-		metricsRegistry:          p.MetricsRegistry,
 		logger:                   p.Logger,
 	}
 	p.Lifecycle.Append(cell.Hook{
@@ -633,8 +628,6 @@ type legacyOnLeader struct {
 	clientset                k8sClient.Clientset
 	wg                       sync.WaitGroup
 	resources                operatorK8s.Resources
-	cfgClusterMeshPolicy     cmtypes.PolicyConfig
-	metricsRegistry          *metrics.Registry
 	workqueueMetricsProvider workqueue.MetricsProvider
 	logger                   *slog.Logger
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -121,17 +121,6 @@ var (
 
 		// Provides the modular metrics registry, metric HTTP server and legacy metrics cell.
 		operatorMetrics.Cell,
-		cell.Provide(func(
-			operatorCfg *operatorOption.OperatorConfig,
-		) operatorMetrics.SharedConfig {
-			return operatorMetrics.SharedConfig{
-				// Cloud provider specific allocators needs to read operatorCfg.EnableMetrics
-				// to add their metrics when it's set to true. Therefore, we leave the flag as global
-				// instead of declaring it as part of the metrics cell.
-				// This should be changed once the IPAM allocator is modularized.
-				EnableMetrics: operatorCfg.EnableMetrics,
-			}
-		}),
 
 		// Shell for inspecting the operator. Listens on the 'shell.sock' UNIX socket.
 		shell.ServerCell(defaults.ShellSockPath),

--- a/operator/metrics/cell.go
+++ b/operator/metrics/cell.go
@@ -40,20 +40,16 @@ var Cell = cell.Module(
 // Config contains the configuration for the operator-metrics cell.
 type Config struct {
 	OperatorPrometheusServeAddr string
+	EnableMetrics               bool
 }
 
 var defaultConfig = Config{
 	// default server address for operator metrics
 	OperatorPrometheusServeAddr: ":9963",
+	EnableMetrics:               false,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.String(OperatorPrometheusServeAddr, def.OperatorPrometheusServeAddr, "Address to serve Prometheus metrics")
-}
-
-// SharedConfig contains the configuration that is shared between
-// this module and others.
-type SharedConfig struct {
-	// EnableMetrics is set to true if operator metrics are enabled
-	EnableMetrics bool
+	flags.Bool("enable-metrics", def.EnableMetrics, "Enable Prometheus metrics")
 }

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -27,8 +27,7 @@ type params struct {
 	Lifecycle  cell.Lifecycle
 	Shutdowner hive.Shutdowner
 
-	Cfg       Config
-	SharedCfg SharedConfig
+	Cfg Config
 
 	Metrics []metric.WithMetadata `group:"hive-metrics"`
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -40,9 +40,6 @@ const (
 	// will simply return.
 	EndpointGCInterval = "cilium-endpoint-gc-interval"
 
-	// NodesGCInterval is the duration for which the cilium nodes are GC.
-	NodesGCInterval = "nodes-gc-interval"
-
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
 
@@ -205,9 +202,6 @@ const (
 
 // OperatorConfig is the configuration used by the operator.
 type OperatorConfig struct {
-	// NodesGCInterval is the GC interval for CiliumNodes
-	NodesGCInterval time.Duration
-
 	// EndpointGCInterval is the interval between attempts of the CEP GC
 	// controller.
 	// Note that only one node per cluster should run this, and most iterations
@@ -307,7 +301,6 @@ type OperatorConfig struct {
 
 // Populate sets all options with the values from viper.
 func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
-	c.NodesGCInterval = vp.GetDuration(NodesGCInterval)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
 	c.UnmanagedPodWatcherInterval = vp.GetInt(UnmanagedPodWatcherInterval)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -34,9 +34,6 @@ const (
 )
 
 const (
-	// EnableMetrics enables prometheus metrics.
-	EnableMetrics = "enable-metrics"
-
 	// EndpointGCInterval is the interval between attempts of the CEP GC
 	// controller.
 	// Note that only one node per cluster should run this, and most iterations
@@ -211,9 +208,6 @@ type OperatorConfig struct {
 	// NodesGCInterval is the GC interval for CiliumNodes
 	NodesGCInterval time.Duration
 
-	// EnableMetrics enables prometheus metrics.
-	EnableMetrics bool
-
 	// EndpointGCInterval is the interval between attempts of the CEP GC
 	// controller.
 	// Note that only one node per cluster should run this, and most iterations
@@ -314,7 +308,6 @@ type OperatorConfig struct {
 // Populate sets all options with the values from viper.
 func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.NodesGCInterval = vp.GetDuration(NodesGCInterval)
-	c.EnableMetrics = vp.GetBool(EnableMetrics)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
 	c.UnmanagedPodWatcherInterval = vp.GetInt(UnmanagedPodWatcherInterval)

--- a/operator/watchers/cilium_node_gc_cell.go
+++ b/operator/watchers/cilium_node_gc_cell.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/controller"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// CiliumNodeGCCell periodically garbage collects stale CiliumNode custom
+// resources that no longer have a corresponding Kubernetes Node object.
+// When CiliumNode CRD support is disabled it performs a one-off deletion of
+// all existing CiliumNode objects.
+var CiliumNodeGCCell = cell.Module(
+	"cilium-node-gc",
+	"CiliumNode garbage collector",
+
+	cell.Config(ciliumNodeGCDefaultConfig),
+	cell.Invoke(registerCiliumNodeGC),
+)
+
+// CiliumNodeGCConfig holds the configuration for the CiliumNode GC cell.
+type CiliumNodeGCConfig struct {
+	NodesGCInterval time.Duration
+}
+
+var ciliumNodeGCDefaultConfig = CiliumNodeGCConfig{
+	NodesGCInterval: 5 * time.Minute,
+}
+
+func (def CiliumNodeGCConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("nodes-gc-interval", def.NodesGCInterval, "GC interval for CiliumNodes")
+}
+
+type ciliumNodeGCParams struct {
+	cell.In
+
+	Logger                   *slog.Logger
+	Lifecycle                cell.Lifecycle
+	Clientset                k8sClient.Clientset
+	CiliumNodes              resource.Resource[*cilium_v2.CiliumNode]
+	WorkQueueMetricsProvider workqueue.MetricsProvider
+	DaemonConfig             *option.DaemonConfig
+
+	Cfg CiliumNodeGCConfig
+}
+
+func registerCiliumNodeGC(p ciliumNodeGCParams) {
+	if !p.Clientset.IsEnabled() {
+		return
+	}
+	if p.Cfg.NodesGCInterval == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	gc := &ciliumNodeGC{
+		ctx:                      ctx,
+		cancel:                   cancel,
+		clientset:                p.Clientset,
+		ciliumNodes:              p.CiliumNodes,
+		interval:                 p.Cfg.NodesGCInterval,
+		enableCiliumNodeCRD:      p.DaemonConfig.EnableCiliumNodeCRD,
+		workqueueMetricsProvider: p.WorkQueueMetricsProvider,
+		logger:                   p.Logger,
+		ctrlMgr:                  controller.NewManager(),
+	}
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: gc.start,
+		OnStop:  gc.stop,
+	})
+}
+
+type ciliumNodeGC struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	clientset                k8sClient.Clientset
+	ciliumNodes              resource.Resource[*cilium_v2.CiliumNode]
+	interval                 time.Duration
+	enableCiliumNodeCRD      bool
+	workqueueMetricsProvider workqueue.MetricsProvider
+	logger                   *slog.Logger
+	ctrlMgr                  *controller.Manager
+}
+
+func (g *ciliumNodeGC) start(startCtx cell.HookContext) error {
+	var candidateStore *ciliumNodeGCCandidate
+	var shouldGCPred func(
+		ctx context.Context,
+		nodeName string,
+		ciliumNodeStore resource.Store[*cilium_v2.CiliumNode],
+		nodeGetter slimNodeGetter,
+		interval time.Duration,
+		candidateStore *ciliumNodeGCCandidate,
+		scopedLog *slog.Logger,
+	) (bool, error)
+
+	interval := g.interval
+
+	if !g.enableCiliumNodeCRD {
+		g.logger.InfoContext(startCtx, "Running one-off GC of CiliumNode CRD when disabled")
+		interval = 0
+		shouldGCPred = shouldGCNodeCRDDisabled
+	} else {
+		nodesInit(&g.wg, g.clientset.Slim(), g.ctx.Done(), g.workqueueMetricsProvider)
+
+		// Wait for the node store to be synced before starting the GC loop
+		// so that shouldGCNode can reliably determine whether a node exists.
+		select {
+		case <-slimNodeStoreSynced:
+		case <-g.ctx.Done():
+			return nil
+		}
+
+		g.logger.InfoContext(startCtx, "Starting to garbage collect stale CiliumNode custom resources")
+		candidateStore = newCiliumNodeGCCandidate()
+		shouldGCPred = shouldGCNode
+	}
+
+	ciliumNodeStore, err := g.ciliumNodes.Store(g.ctx)
+	if err != nil {
+		return err
+	}
+
+	g.ctrlMgr.UpdateController("cilium-node-gc",
+		controller.ControllerParams{
+			Group:   controller.NewGroup("cilium-node-gc"),
+			Context: g.ctx,
+			DoFunc: func(ctx context.Context) error {
+				return performCiliumNodeGC(
+					ctx,
+					g.clientset.CiliumV2().CiliumNodes(),
+					ciliumNodeStore,
+					nodeGetter{},
+					interval,
+					candidateStore,
+					g.logger,
+					shouldGCPred,
+				)
+			},
+			RunInterval: interval,
+		},
+	)
+
+	return nil
+}
+
+func (g *ciliumNodeGC) stop(_ cell.HookContext) error {
+	g.cancel()
+	g.ctrlMgr.RemoveControllerAndWait("cilium-node-gc")
+	g.wg.Wait()
+	return nil
+}


### PR DESCRIPTION
See individual commits for details:
* Move `enable-metrics` flag to metrics cell
* Remove unused fields from `legacyOnLeader`
* Extract CiliumNode GC into a dedicated Hive cell