### PR TITLE
helm: Add validation to explicitly require eni.enabled=true when ipam.mode=eni is configured

### DIFF
--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -61,7 +61,10 @@ Configuration
 
 * The Cilium agent and operator must be run with the option ``--ipam=eni`` or
   the option ``ipam: eni``  must be set in the ConfigMap. This will enable ENI
-  allocation in both the node agent and operator.
+  allocation in both the node agent and operator. When installing via Helm, the 
+  flag ``eni.enabled=true`` must also be set. This flag configures all
+  requirements for AWS ENI environments, such as operator image selection,
+  enabling endpoint routes, CiliumNode management, and IPv4 masquerade defaults.
 
 * In most scenarios, it makes sense to automatically create the
   ``ciliumnodes.cilium.io`` custom resource when the agent starts up on a node

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -239,3 +239,8 @@
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/* validate IPAM ENI */}}
+{{- if and (eq .Values.ipam.mode "eni") (not .Values.eni.enabled) }}
+  {{ fail "ipam.mode=eni requires eni.enabled=true" }}
+{{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
### Summary
This PR adds Helm validation to fail early when `ipam.mode=eni` is defined without `eni.enabled=true`, and updates the ENI concepts' documentation to clarify this requirement. 

*(Note: Initially, this PR attempted to update the operator image selection logic to respect `ipam.mode=eni`. However, after maintainer feedback, it was clarified that `eni.enabled` acts as a mandatory wrapper that configures multiple settings required for an AWS ENI environment, such as endpoint routes, CiliumNode management, and masquerade defaults. Attempting to deploy with only `ipam.mode=eni` results in an incorrect and incomplete cluster state.)*

### Root Cause
Presently, users following the ambiguous documentation might configure `ipam.mode=eni` without `eni.enabled=true`. Because `eni.enabled` gates so much AWS-specific functionality, the cluster ends up missing mandatory configuration. The first noticeable failure is a `CrashLoopBackOff` in the operator pod:

```text
exec: "cilium-operator-generic": executable file not found in $PATH
```

This error masks the broader issue, that the cluster has not enabled the mandatory Agent and ConfigMap settings to function successfully on AWS using `ipam.mode=eni`.

### Symptoms
Deployments fail at runtime instead of being rejected proactively at exactly the point of misconfiguration during `helm install` / `helm template`. 

### Fix
Instead of trying to implicitly inherit or patch individual checks across the chart based on `ipam.mode=eni`, this PR addresses the problem through explicit rejection and documentation and has taken the following actions:
- Added a fail rule to validate.yaml rejecting Helm installations where `ipam.mode=eni` is provided without `eni.enabled=true`.
- Improved the `Configuration` section of eni.rst to explicitly define `eni.enabled=true` as a mandatory flag that configures all requirements for AWS ENI environments.
- Discarded previous additive logic in `_helpers.tpl` to align with maintainer guidance.

```release-note
helm: Add validation to explicitly require `eni.enabled=true` when `ipam.mode=eni` is configured
```