### PR TITLE
operator/ipam: Migrate cloud provider metrics to hive cell pattern

### DIFF
--- a/operator/pkg/ipam/alibabacloud.go
+++ b/operator/pkg/ipam/alibabacloud.go
@@ -15,6 +15,7 @@ import (
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/ipam/allocator/alibabacloud"
+	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -28,6 +29,7 @@ func init() {
 
 		cell.Config(defaultAlibabaCloudConfig),
 		cell.Invoke(startAlibabaAllocator),
+		metrics.Metric(alibabacloud.NewMetrics),
 	))
 }
 
@@ -53,7 +55,8 @@ type alibabaParams struct {
 	Lifecycle          cell.Lifecycle
 	JobGroup           job.Group
 	Clientset          k8sClient.Clientset
-	MetricsRegistry    *metrics.Registry
+	AlibabaMetrics     *alibabacloud.Metrics
+	IPAMMetrics        *ipamMetrics.Metrics
 	DaemonCfg          *option.DaemonConfig
 	NodeWatcherFactory nodeWatcherJobFactory
 
@@ -77,11 +80,11 @@ func startAlibabaAllocator(p alibabaParams) {
 	p.Lifecycle.Append(
 		cell.Hook{
 			OnStart: func(ctx cell.HookContext) error {
-				if err := allocator.Init(ctx, p.Logger, p.MetricsRegistry); err != nil {
+				if err := allocator.Init(ctx, p.Logger, p.AlibabaMetrics); err != nil {
 					return fmt.Errorf("unable to init AlibabaCloud allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.MetricsRegistry)
+				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
 				if err != nil {
 					return fmt.Errorf("unable to start AlibabaCloud allocator: %w", err)
 				}

--- a/operator/pkg/ipam/aws.go
+++ b/operator/pkg/ipam/aws.go
@@ -15,6 +15,7 @@ import (
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/ipam/allocator/aws"
+	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -29,6 +30,7 @@ func init() {
 
 		cell.Config(awsDefaultConfig),
 		cell.Invoke(startAWSAllocator),
+		metrics.Metric(aws.NewMetrics),
 	))
 }
 
@@ -78,7 +80,8 @@ type awsParams struct {
 	Lifecycle          cell.Lifecycle
 	JobGroup           job.Group
 	Clientset          k8sClient.Clientset
-	MetricsRegistry    *metrics.Registry
+	EC2Metrics         *aws.Metrics
+	IPAMMetrics        *ipamMetrics.Metrics
 	DaemonCfg          *option.DaemonConfig
 	NodeWatcherFactory nodeWatcherJobFactory
 
@@ -109,11 +112,11 @@ func startAWSAllocator(p awsParams) {
 	p.Lifecycle.Append(
 		cell.Hook{
 			OnStart: func(ctx cell.HookContext) error {
-				if err := allocator.Init(ctx, p.Logger, p.MetricsRegistry); err != nil {
+				if err := allocator.Init(ctx, p.Logger, p.EC2Metrics); err != nil {
 					return fmt.Errorf("unable to init AWS allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.MetricsRegistry)
+				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
 				if err != nil {
 					return fmt.Errorf("unable to start AWS allocator: %w", err)
 				}

--- a/operator/pkg/ipam/azure.go
+++ b/operator/pkg/ipam/azure.go
@@ -15,6 +15,7 @@ import (
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/ipam/allocator/azure"
+	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -28,6 +29,7 @@ func init() {
 
 		cell.Config(azureDefaultConfig),
 		cell.Invoke(startAzureAllocator),
+		metrics.Metric(azure.NewMetrics),
 	))
 }
 
@@ -59,7 +61,8 @@ type azureParams struct {
 	Lifecycle          cell.Lifecycle
 	JobGroup           job.Group
 	Clientset          k8sClient.Clientset
-	MetricsRegistry    *metrics.Registry
+	AzureMetrics       *azure.Metrics
+	IPAMMetrics        *ipamMetrics.Metrics
 	DaemonCfg          *option.DaemonConfig
 	NodeWatcherFactory nodeWatcherJobFactory
 
@@ -85,13 +88,13 @@ func startAzureAllocator(p azureParams) {
 	p.Lifecycle.Append(
 		cell.Hook{
 			OnStart: func(ctx cell.HookContext) error {
-				if err := allocator.Init(ctx, p.Logger, p.MetricsRegistry); err != nil {
-					return fmt.Errorf("unable to init AWS allocator: %w", err)
+				if err := allocator.Init(ctx, p.Logger); err != nil {
+					return fmt.Errorf("unable to init Azure allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.MetricsRegistry)
+				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.AzureMetrics, p.IPAMMetrics)
 				if err != nil {
-					return fmt.Errorf("unable to start AWS allocator: %w", err)
+					return fmt.Errorf("unable to start Azure allocator: %w", err)
 				}
 
 				p.JobGroup.Add(p.NodeWatcherFactory(nm))

--- a/operator/pkg/ipam/cell.go
+++ b/operator/pkg/ipam/cell.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
+	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var allocators []cell.Cell
@@ -21,6 +23,7 @@ func Cell() cell.Cell {
 
 		cell.Config(defaultConfig),
 		cell.ProvidePrivate(newNodeWatcherJobFactory),
+		metrics.Metric(ipamMetrics.NewMetrics),
 
 		cell.Group(allocators...),
 	)

--- a/operator/pkg/ipam/multipool.go
+++ b/operator/pkg/ipam/multipool.go
@@ -27,7 +27,6 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -62,7 +61,6 @@ type multiPoolParams struct {
 	Lifecycle          cell.Lifecycle
 	JobGroup           job.Group
 	Clientset          k8sClient.Clientset
-	MetricsRegistry    *metrics.Registry
 	DaemonCfg          *option.DaemonConfig
 	CiliumPodIPPools   resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
 	NodeWatcherFactory nodeWatcherJobFactory

--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -6,66 +6,43 @@ package metrics
 import (
 	"time"
 
-	"github.com/cilium/cilium/pkg/metrics"
-
-	"github.com/prometheus/client_golang/prometheus"
+	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
-// PrometheusMetrics is an implementation of Prometheus metrics for external
-// API usage
-type PrometheusMetrics struct {
-	registry    *metrics.Registry
-	APIDuration *prometheus.HistogramVec
-	RateLimit   *prometheus.HistogramVec
+// Metrics holds the Prometheus metrics for external cloud API usage.
+type Metrics struct {
+	APIDuration metric.Vec[metric.Observer]
+	RateLimit   metric.Vec[metric.Observer]
 }
 
-// NewPrometheusMetrics returns a new metrics tracking implementation to cover
-// external API usage.
-func NewPrometheusMetrics(namespace, subsystem string, registry *metrics.Registry) *PrometheusMetrics {
-	m := &PrometheusMetrics{registry: registry}
+// New returns a new Metrics for the given cloud API subsystem (e.g. "ec2", "azure").
+func New(subsystem string) *Metrics {
+	return &Metrics{
+		APIDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: ciliumMetrics.CiliumOperatorNamespace,
+			Subsystem: subsystem,
+			Name:      "api_duration_seconds",
+			Help:      "Duration of interactions with API",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+		}, []string{"operation", "response_code"}),
 
-	m.APIDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Subsystem: subsystem,
-		Name:      "api_duration_seconds",
-		Help:      "Duration of interactions with API",
-		Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
-			4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
-	}, []string{"operation", "response_code"})
-
-	m.RateLimit = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Subsystem: subsystem,
-		Name:      "api_rate_limit_duration_seconds",
-		Help:      "Duration of client-side rate limiter blocking",
-	}, []string{"operation"})
-
-	registry.MustRegister(m.APIDuration)
-	registry.MustRegister(m.RateLimit)
-
-	return m
+		RateLimit: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: ciliumMetrics.CiliumOperatorNamespace,
+			Subsystem: subsystem,
+			Name:      "api_rate_limit_duration_seconds",
+			Help:      "Duration of client-side rate limiter blocking",
+		}, []string{"operation"}),
+	}
 }
 
-// ObserveAPICall must be called on every API call made with the operation
-// performed, the status code received and the duration of the call
-func (p *PrometheusMetrics) ObserveAPICall(operation, status string, duration float64) {
-	p.APIDuration.WithLabelValues(operation, status).Observe(duration)
+// ObserveAPICall records the duration of an API call with the given operation name and response code.
+func (m *Metrics) ObserveAPICall(operation, status string, duration float64) {
+	m.APIDuration.WithLabelValues(operation, status).Observe(duration)
 }
 
-// ObserveRateLimit must be called in case an API call was subject to rate limiting
-func (p *PrometheusMetrics) ObserveRateLimit(operation string, delay time.Duration) {
-	p.RateLimit.WithLabelValues(operation).Observe(delay.Seconds())
+// ObserveRateLimit records a rate-limiter blocking event for the given operation.
+func (m *Metrics) ObserveRateLimit(operation string, delay time.Duration) {
+	m.RateLimit.WithLabelValues(operation).Observe(delay.Seconds())
 }
-
-// NoOpMetrics is a no-op implementation
-type NoOpMetrics struct{}
-
-// ObserveAPICall must be called on every API call made with the operation
-// performed, the status code received and the duration of the call. This No-op
-// implementation will perform no metrics accounting in return.
-func (m *NoOpMetrics) ObserveAPICall(call, status string, duration float64) {}
-
-// ObserveRateLimit must be called in case an API call was subject to rate
-// limiting. This No-op implementation will perform no metrics accounting in
-// return.
-func (m *NoOpMetrics) ObserveRateLimit(operation string, duration time.Duration) {}

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/netip"
 	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -65,8 +64,8 @@ type Client struct {
 
 // MetricsAPI represents the metrics maintained by the Azure API client
 type MetricsAPI interface {
+	helpers.MetricsAPI
 	ObserveAPICall(call, status string, duration float64)
-	ObserveRateLimit(operation string, duration time.Duration)
 }
 
 // net/http Client with a custom cilium user agent

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -12,16 +12,13 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
-	openapi "github.com/cilium/cilium/pkg/alibabacloud/api"
+	alibabacloudAPI "github.com/cilium/cilium/pkg/alibabacloud/api"
 	"github.com/cilium/cilium/pkg/alibabacloud/eni"
 	"github.com/cilium/cilium/pkg/alibabacloud/eni/limits"
 	"github.com/cilium/cilium/pkg/alibabacloud/metadata"
-	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
-	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 )
 
 // Maximum number of tags for exact search of ECS resources.
@@ -40,21 +37,14 @@ type AllocatorAlibabaCloud struct {
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
-	client     *openapi.Client
+	client     *alibabacloudAPI.Client
 }
 
 // Init sets up ENI limits based on given options
 // Credential ref https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/docs/2-Client-EN.md
-func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, reg *metrics.Registry) error {
+func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, aMetrics alibabacloudAPI.MetricsAPI) error {
 	a.rootLogger = logger
 	a.logger = logger.With(subsysLogAttr...)
-	var aMetrics openapi.MetricsAPI
-
-	if operatorOption.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "alibabacloud", reg)
-	} else {
-		aMetrics = &apiMetrics.NoOpMetrics{}
-	}
 
 	if len(operatorOption.Config.IPAMInstanceTags) > MaxInstanceTags {
 		return fmt.Errorf("number of tags in instance-tags-filter exceeds the limit %d", MaxInstanceTags)
@@ -86,7 +76,7 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, r
 	vpcClient.GetConfig().WithScheme("HTTPS")
 	ecsClient.GetConfig().WithScheme("HTTPS")
 
-	a.client = openapi.NewClient(vpcClient, ecsClient, aMetrics, a.LimitIPAMAPIQPS,
+	a.client = alibabacloudAPI.NewClient(vpcClient, ecsClient, aMetrics, a.LimitIPAMAPIQPS,
 		a.LimitIPAMAPIBurst, operatorOption.Config.IPAMInstanceTags)
 
 	if err := limits.UpdateFromAPI(ctx, a.client); err != nil {
@@ -99,16 +89,9 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, r
 // Start kicks off ENI allocation, the initial connection to AlibabaCloud
 // APIs is done in a blocking manner. Provided this is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
-func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, reg *metrics.Registry) (allocator.NodeEventHandler, error) {
-	var iMetrics ipam.MetricsAPI
-
+func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, iMetrics ipam.MetricsAPI) (allocator.NodeEventHandler, error) {
 	a.logger.Info("Starting AlibabaCloud ENI allocator...")
 
-	if operatorOption.Config.EnableMetrics {
-		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, reg)
-	} else {
-		iMetrics = &ipamMetrics.NoOpMetrics{}
-	}
 	instances := eni.NewInstancesManager(a.rootLogger, a.client)
 	nodeManager, err := ipam.NewNodeManager(a.logger, instances, getterUpdater, iMetrics,
 		a.ParallelAllocWorkers, a.AlibabaCloudReleaseExcessIPs, 0, false)

--- a/pkg/ipam/allocator/alibabacloud/metrics.go
+++ b/pkg/ipam/allocator/alibabacloud/metrics.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package alibabacloud
+
+import (
+	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Metrics holds the metrics for the AlibabaCloud API client.
+type Metrics struct {
+	APIDuration metric.Vec[metric.Observer]
+	RateLimit   metric.Vec[metric.Observer]
+}
+
+// NewMetrics returns the metrics for the AlibabaCloud API client.
+func NewMetrics() *Metrics {
+	m := apiMetrics.New("alibabacloud")
+	return &Metrics{
+		APIDuration: m.APIDuration,
+		RateLimit:   m.RateLimit,
+	}
+}
+
+// ObserveAPICall records the duration of an API call.
+func (m *Metrics) ObserveAPICall(operation, status string, duration float64) {
+	m.APIDuration.WithLabelValues(operation, status).Observe(duration)
+}
+
+// ObserveRateLimit records a rate-limiter blocking event.
+func (m *Metrics) ObserveRateLimit(operation string, delay time.Duration) {
+	m.RateLimit.WithLabelValues(operation).Observe(delay.Seconds())
+}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -12,16 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
-	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	ec2shim "github.com/cilium/cilium/pkg/aws/ec2"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	"github.com/cilium/cilium/pkg/aws/metadata"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
-	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -86,10 +83,9 @@ func (a *AllocatorAWS) initENIGarbageCollectionTags(ctx context.Context, cfg aws
 }
 
 // Init sets up ENI limits based on given options
-func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, reg *metrics.Registry) error {
+func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, aMetrics ec2shim.MetricsAPI) error {
 	a.rootLogger = logger
 	a.logger = logger.With(subsysLogAttr...)
-	var aMetrics ec2shim.MetricsAPI
 
 	cfg, err := ec2shim.NewConfig(ctx)
 	if err != nil {
@@ -97,12 +93,6 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, reg *metri
 	}
 	subnetsFilters := ec2shim.NewSubnetsFilters(operatorOption.Config.IPAMSubnetsTags, operatorOption.Config.IPAMSubnetsIDs)
 	instancesFilters := ec2shim.NewTagsFilter(operatorOption.Config.IPAMInstanceTags)
-
-	if operatorOption.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "ec2", reg)
-	} else {
-		aMetrics = &apiMetrics.NoOpMetrics{}
-	}
 
 	eniCreationTags := a.ENITags
 	if a.ENIGarbageCollectionInterval > 0 {
@@ -133,16 +123,9 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, reg *metri
 // Start kicks of ENI allocation, the initial connection to AWS
 // APIs is done in a blocking manner, given that is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
-func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, reg *metrics.Registry) (allocator.NodeEventHandler, error) {
-	var iMetrics ipam.MetricsAPI
-
+func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, iMetrics ipam.MetricsAPI) (allocator.NodeEventHandler, error) {
 	a.logger.Info("Starting ENI allocator...")
 
-	if operatorOption.Config.EnableMetrics {
-		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, reg)
-	} else {
-		iMetrics = &ipamMetrics.NoOpMetrics{}
-	}
 	imds, err := metadata.NewClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize metadata client: %w", err)

--- a/pkg/ipam/allocator/aws/metrics.go
+++ b/pkg/ipam/allocator/aws/metrics.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package aws
+
+import (
+	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Metrics holds the metrics for the AWS EC2 API client.
+type Metrics struct {
+	APIDuration metric.Vec[metric.Observer]
+	RateLimit   metric.Vec[metric.Observer]
+}
+
+// NewMetrics returns the metrics for the AWS EC2 API client.
+func NewMetrics() *Metrics {
+	m := apiMetrics.New("ec2")
+	return &Metrics{
+		APIDuration: m.APIDuration,
+		RateLimit:   m.RateLimit,
+	}
+}
+
+// ObserveAPICall records the duration of an API call.
+func (m *Metrics) ObserveAPICall(operation, status string, duration float64) {
+	m.APIDuration.WithLabelValues(operation, status).Observe(duration)
+}
+
+// ObserveRateLimit records a rate-limiter blocking event.
+func (m *Metrics) ObserveRateLimit(operation string, delay time.Duration) {
+	m.RateLimit.WithLabelValues(operation).Observe(delay.Seconds())
+}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -8,15 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
-	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
 	azureAPI "github.com/cilium/cilium/pkg/azure/api"
 	azureIPAM "github.com/cilium/cilium/pkg/azure/ipam"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
-	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/metrics"
 )
 
 // AllocatorAzure is an implementation of IPAM allocator interface for Azure
@@ -34,20 +30,14 @@ type AllocatorAzure struct {
 }
 
 // Init in Azure implementation doesn't need to do anything
-func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger, reg *metrics.Registry) error {
+func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger) error {
 	a.rootLogger = logger
 	a.logger = a.rootLogger.With(logfields.LogSubsys, "ipam-allocator-azure")
 	return nil
 }
 
 // Start kicks of the Azure IP allocation
-func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, reg *metrics.Registry) (allocator.NodeEventHandler, error) {
-
-	var (
-		azMetrics azureAPI.MetricsAPI
-		iMetrics  ipam.MetricsAPI
-	)
-
+func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeGetterUpdater, azMetrics azureAPI.MetricsAPI, iMetrics ipam.MetricsAPI) (allocator.NodeEventHandler, error) {
 	a.logger.Info("Starting Azure IP allocator...")
 
 	a.logger.Debug("Retrieving Azure cloud name via Azure IMS")
@@ -76,14 +66,6 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNod
 		}
 		resourceGroupName = rgName
 		a.logger.Debug("Detected resource group name via Azure IMS", logfields.Resource, resourceGroupName)
-	}
-
-	if operatorOption.Config.EnableMetrics {
-		azMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "azure", reg)
-		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, reg)
-	} else {
-		azMetrics = &apiMetrics.NoOpMetrics{}
-		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
 	azureClient, err := azureAPI.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, azMetrics, a.LimitIPAMAPIQPS, a.LimitIPAMAPIBurst, a.AzureUsePrimaryAddress)

--- a/pkg/ipam/allocator/azure/metrics.go
+++ b/pkg/ipam/allocator/azure/metrics.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package azure
+
+import (
+	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Metrics holds the metrics for the Azure API client.
+type Metrics struct {
+	APIDuration metric.Vec[metric.Observer]
+	RateLimit   metric.Vec[metric.Observer]
+}
+
+// NewMetrics returns the metrics for the Azure API client.
+func NewMetrics() *Metrics {
+	m := apiMetrics.New("azure")
+	return &Metrics{
+		APIDuration: m.APIDuration,
+		RateLimit:   m.RateLimit,
+	}
+}
+
+// ObserveAPICall records the duration of an API call.
+func (m *Metrics) ObserveAPICall(operation, status string, duration float64) {
+	m.APIDuration.WithLabelValues(operation, status).Observe(duration)
+}
+
+// ObserveRateLimit records a rate-limiter blocking event.
+func (m *Metrics) ObserveRateLimit(operation string, delay time.Duration) {
+	m.RateLimit.WithLabelValues(operation).Observe(delay.Seconds())
+}

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -7,375 +7,381 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	ciliumMetrics "github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
 const ipamSubsystem = "ipam"
 
-type prometheusMetrics struct {
-	registry             *ciliumMetrics.Registry
-	Allocation           *prometheus.HistogramVec
-	Release              *prometheus.HistogramVec
-	AllocateInterfaceOps *prometheus.CounterVec
-	AllocateIpOps        *prometheus.CounterVec
-	ReleaseIpOps         *prometheus.CounterVec
-	AvailableIPs         *prometheus.GaugeVec
-	UsedIPs              *prometheus.GaugeVec
-	NeededIPs            *prometheus.GaugeVec
-	// Deprecated, will be removed in version 1.15.
-	// Use AvailableIPs, UsedIPs and NeededIPs instead.
-	IPsAllocated *prometheus.GaugeVec
-	// Deprecated, will be removed in version 1.14:
-	// Use InterfaceCandidates and EmptyInterfaceSlots instead
-	AvailableInterfaces    prometheus.Gauge
-	InterfaceCandidates    prometheus.Gauge
-	EmptyInterfaceSlots    prometheus.Gauge
-	AvailableIPsPerSubnet  *prometheus.GaugeVec
-	Nodes                  *prometheus.GaugeVec
-	Resync                 prometheus.Counter
-	BackgroundSyncDuration *prometheus.HistogramVec
-	poolMaintainer         *triggerMetrics
-	k8sSync                *triggerMetrics
-	resync                 *triggerMetrics
-}
-
 const LabelTargetNodeName = "target_node"
 
-// NewPrometheusMetrics returns a new interface metrics implementation backed by
-// Prometheus metrics.
-func NewPrometheusMetrics(namespace string, registry *ciliumMetrics.Registry) *prometheusMetrics {
-	m := &prometheusMetrics{
-		registry: registry,
-	}
+// Metrics holds all Prometheus metrics for the IPAM node manager.
+type Metrics struct {
+	// Per-node IP metrics
+	AvailableIPs metric.DeletableVec[metric.Gauge]
+	UsedIPs      metric.DeletableVec[metric.Gauge]
+	NeededIPs    metric.DeletableVec[metric.Gauge]
 
-	m.AvailableIPs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "available_ips",
-		Help:      "Total available IPs on Node for IPAM allocation",
-	}, []string{LabelTargetNodeName})
+	// Deprecated, will be removed in version 1.15.
+	// Use AvailableIPs, UsedIPs and NeededIPs instead.
+	IPsAllocated metric.Vec[metric.Gauge]
 
-	m.UsedIPs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "used_ips",
-		Help:      "Total used IPs on Node for IPAM allocation",
-	}, []string{LabelTargetNodeName})
+	// IP and interface allocation counters
+	AllocateIpOps        metric.Vec[metric.Counter]
+	ReleaseIpOps         metric.Vec[metric.Counter]
+	AllocateInterfaceOps metric.Vec[metric.Counter]
 
-	m.NeededIPs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "needed_ips",
-		Help:      "Number of IPs that are needed on the Node to satisfy IPAM allocation requests",
-	}, []string{LabelTargetNodeName})
+	// Interface availability
+	InterfaceCandidates   metric.Gauge
+	EmptyInterfaceSlots   metric.Gauge
+	AvailableIPsPerSubnet metric.Vec[metric.Gauge]
 
-	m.IPsAllocated = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "ips",
-		Help:      "Number of IPs allocated",
-	}, []string{"type"})
+	// Deprecated, will be removed in version 1.14:
+	// Use InterfaceCandidates and EmptyInterfaceSlots instead
+	AvailableInterfaces metric.Gauge
 
-	m.AllocateIpOps = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "ip_allocation_ops",
-		Help:      "Number of IP allocation operations",
-	}, []string{"subnet_id"})
+	// Node category counts
+	Nodes metric.Vec[metric.Gauge]
 
-	m.ReleaseIpOps = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "ip_release_ops",
-		Help:      "Number of IP release operations",
-	}, []string{"subnet_id"})
+	// Resync counter
+	ResyncTotal metric.Counter
 
-	m.AllocateInterfaceOps = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "interface_creation_ops",
-		Help:      "Number of interfaces allocated",
-	}, []string{"subnet_id"})
+	// Allocation/release latency histograms
+	Allocation             metric.Vec[metric.Observer]
+	Release                metric.Vec[metric.Observer]
+	BackgroundSyncDuration metric.Vec[metric.Observer]
 
-	m.AvailableInterfaces = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "available_interfaces",
-		Help:      "Number of interfaces with addresses available",
-	})
-
-	m.InterfaceCandidates = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "interface_candidates",
-		Help:      "Number of attached interfaces with IPs available for allocation",
-	})
-
-	m.EmptyInterfaceSlots = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "empty_interface_slots",
-		Help:      "Number of empty interface slots available for interfaces to be attached",
-	})
-
-	m.AvailableIPsPerSubnet = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "available_ips_per_subnet",
-		Help:      "Number of available IPs per subnet ID",
-	}, []string{"subnet_id", "availability_zone"})
-
-	m.Nodes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "nodes",
-		Help:      "Number of nodes by category { total | in-deficit | at-capacity }",
-	}, []string{"category"})
-
-	m.Resync = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "resync_total",
-		Help:      "Number of resync operations to synchronize and resolve IP deficit of nodes",
-	})
-
-	m.Allocation = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "allocation_duration_seconds",
-		Help:      "Allocation ip or interface latency in seconds",
-		Buckets: merge(
-			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
-			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
-		),
-	}, []string{"type", "status", "subnet_id"})
-
-	m.Release = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "release_duration_seconds",
-		Help:      "Release ip or interface latency in seconds",
-		Buckets: merge(
-			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
-			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
-		),
-	}, []string{"type", "status", "subnet_id"})
-
-	m.BackgroundSyncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
-		Subsystem: ipamSubsystem,
-		Name:      "background_sync_duration_seconds",
-		Help:      "Duration in seconds of the background API resync",
-		Buckets: merge(
-			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
-			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
-		),
-	}, []string{"status"})
-
+	// Trigger metrics
 	// pool_maintainer is a more generic name, but for backward compatibility
 	// of dashboard, keep the metric name deficit_resolver unchanged
-	m.poolMaintainer = NewTriggerMetrics(namespace, "deficit_resolver")
-	m.k8sSync = NewTriggerMetrics(namespace, "k8s_sync")
-	m.resync = NewTriggerMetrics(namespace, "resync")
+	PoolMaintainerQueued       metric.Counter
+	PoolMaintainerFolds        metric.Gauge
+	PoolMaintainerCallDuration metric.Histogram
+	PoolMaintainerLatency      metric.Histogram
 
-	registry.MustRegister(m.AvailableIPs)
-	registry.MustRegister(m.UsedIPs)
-	registry.MustRegister(m.NeededIPs)
+	// Trigger metrics – k8s sync
+	K8sSyncQueued       metric.Counter
+	K8sSyncFolds        metric.Gauge
+	K8sSyncCallDuration metric.Histogram
+	K8sSyncLatency      metric.Histogram
 
-	registry.MustRegister(m.IPsAllocated)
-	registry.MustRegister(m.AllocateIpOps)
-	registry.MustRegister(m.ReleaseIpOps)
-	registry.MustRegister(m.AllocateInterfaceOps)
-	registry.MustRegister(m.AvailableInterfaces)
-	registry.MustRegister(m.InterfaceCandidates)
-	registry.MustRegister(m.EmptyInterfaceSlots)
-	registry.MustRegister(m.AvailableIPsPerSubnet)
-	registry.MustRegister(m.Nodes)
-	registry.MustRegister(m.Resync)
-	registry.MustRegister(m.Allocation)
-	registry.MustRegister(m.Release)
-	registry.MustRegister(m.BackgroundSyncDuration)
-	m.poolMaintainer.Register(registry)
-	m.k8sSync.Register(registry)
-	m.resync.Register(registry)
-
-	return m
+	// Trigger metrics – resync
+	ResyncQueued       metric.Counter
+	ResyncFolds        metric.Gauge
+	ResyncCallDuration metric.Histogram
+	ResyncLatency      metric.Histogram
 }
 
-func (p *prometheusMetrics) PoolMaintainerTrigger() trigger.MetricsObserver {
-	return p.poolMaintainer
-}
-
-func (p *prometheusMetrics) K8sSyncTrigger() trigger.MetricsObserver {
-	return p.k8sSync
-}
-
-func (p *prometheusMetrics) ResyncTrigger() trigger.MetricsObserver {
-	return p.resync
-}
-
-func (p *prometheusMetrics) IncInterfaceAllocation(subnetID string) {
-	p.AllocateInterfaceOps.WithLabelValues(subnetID).Inc()
-}
-
-func (p *prometheusMetrics) AddIPAllocation(subnetID string, allocated int64) {
-	p.AllocateIpOps.WithLabelValues(subnetID).Add(float64(allocated))
-}
-
-func (p *prometheusMetrics) AddIPRelease(subnetID string, released int64) {
-	p.ReleaseIpOps.WithLabelValues(subnetID).Add(float64(released))
-}
-
-func (p *prometheusMetrics) SetAllocatedIPs(typ string, allocated int) {
-	p.IPsAllocated.WithLabelValues(typ).Set(float64(allocated))
-}
-
-func (p *prometheusMetrics) SetAvailableInterfaces(available int) {
-	p.AvailableInterfaces.Set(float64(available))
-}
-
-func (p *prometheusMetrics) SetInterfaceCandidates(interfaceCandidates int) {
-	p.InterfaceCandidates.Set(float64(interfaceCandidates))
-}
-
-func (p *prometheusMetrics) SetEmptyInterfaceSlots(emptyInterfaceSlots int) {
-	p.EmptyInterfaceSlots.Set(float64(emptyInterfaceSlots))
-}
-
-func (p *prometheusMetrics) SetAvailableIPsPerSubnet(subnetID string, availabilityZone string, available int) {
-	p.AvailableIPsPerSubnet.WithLabelValues(subnetID, availabilityZone).Set(float64(available))
-}
-
-func (p *prometheusMetrics) SetNodes(label string, nodes int) {
-	p.Nodes.WithLabelValues(label).Set(float64(nodes))
-}
-
-func (p *prometheusMetrics) IncResyncCount() {
-	p.Resync.Inc()
-}
-
-func (p *prometheusMetrics) AllocationAttempt(typ, status, subnetID string, observe float64) {
-	p.Allocation.WithLabelValues(typ, status, subnetID).Observe(observe)
-}
-
-func (p *prometheusMetrics) ReleaseAttempt(typ, status, subnetID string, observe float64) {
-	p.Release.WithLabelValues(typ, status, subnetID).Observe(observe)
-}
-
-// Per Node metrics.
-func (p *prometheusMetrics) SetIPAvailable(node string, cap int) {
-	p.AvailableIPs.WithLabelValues(node).Set(float64(cap))
-}
-
-func (p *prometheusMetrics) SetIPUsed(node string, usage int) {
-	p.UsedIPs.WithLabelValues(node).Set(float64(usage))
-}
-
-func (p *prometheusMetrics) SetIPNeeded(node string, usage int) {
-	p.NeededIPs.WithLabelValues(node).Set(float64(usage))
-}
-
-// DeleteNode removes all per-node metrics for a particular node (i.e. those labeled with "target_node").
-// This is to ensure that when a Node/CiliumNode delete event happens that the operator will no longer report
-// metrics for that node.
-func (p *prometheusMetrics) DeleteNode(node string) {
-	p.AvailableIPs.DeleteLabelValues(node)
-	p.UsedIPs.DeleteLabelValues(node)
-	p.NeededIPs.DeleteLabelValues(node)
-}
-
-func (p *prometheusMetrics) ObserveBackgroundSync(status string, duration time.Duration) {
-	p.BackgroundSyncDuration.WithLabelValues(status).Observe(duration.Seconds())
-}
-
-type triggerMetrics struct {
-	total        prometheus.Counter
-	folds        prometheus.Gauge
-	callDuration prometheus.Histogram
-	latency      prometheus.Histogram
-}
-
-func NewTriggerMetrics(namespace, name string) *triggerMetrics {
-	return &triggerMetrics{
-		total: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
+// NewMetrics returns a new interface metrics implementation.
+func NewMetrics() *Metrics {
+	ns := ciliumMetrics.CiliumOperatorNamespace
+	return &Metrics{
+		AvailableIPs: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: ns,
 			Subsystem: ipamSubsystem,
-			Name:      name + "_queued_total",
-			Help:      "Number of queued triggers",
-		}),
-		folds: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
+			Name:      "available_ips",
+			Help:      "Total available IPs on Node for IPAM allocation",
+		}, []string{LabelTargetNodeName}),
+
+		UsedIPs: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: ns,
 			Subsystem: ipamSubsystem,
-			Name:      name + "_folds",
-			Help:      "Current level of folding",
-		}),
-		callDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: namespace,
+			Name:      "used_ips",
+			Help:      "Total used IPs on Node for IPAM allocation",
+		}, []string{LabelTargetNodeName}),
+
+		NeededIPs: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: ns,
 			Subsystem: ipamSubsystem,
-			Name:      name + "_duration_seconds",
-			Help:      "Duration of trigger runs",
-			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
-				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
-		}),
-		latency: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: namespace,
+			Name:      "needed_ips",
+			Help:      "Number of IPs that are needed on the Node to satisfy IPAM allocation requests",
+		}, []string{LabelTargetNodeName}),
+
+		IPsAllocated: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: ns,
 			Subsystem: ipamSubsystem,
-			Name:      name + "_latency_seconds",
-			Help:      "Latency between queue and trigger run",
-			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
-				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+			Name:      "ips",
+			Help:      "Number of IPs allocated",
+		}, []string{"type"}),
+
+		AllocateIpOps: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "ip_allocation_ops",
+			Help:      "Number of IP allocation operations",
+		}, []string{"subnet_id"}),
+
+		ReleaseIpOps: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "ip_release_ops",
+			Help:      "Number of IP release operations",
+		}, []string{"subnet_id"}),
+
+		AllocateInterfaceOps: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "interface_creation_ops",
+			Help:      "Number of interfaces allocated",
+		}, []string{"subnet_id"}),
+
+		AvailableInterfaces: metric.NewGauge(metric.GaugeOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "available_interfaces",
+			Help:      "Number of interfaces with addresses available",
 		}),
+
+		InterfaceCandidates: metric.NewGauge(metric.GaugeOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "interface_candidates",
+			Help:      "Number of attached interfaces with IPs available for allocation",
+		}),
+
+		EmptyInterfaceSlots: metric.NewGauge(metric.GaugeOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "empty_interface_slots",
+			Help:      "Number of empty interface slots available for interfaces to be attached",
+		}),
+
+		AvailableIPsPerSubnet: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "available_ips_per_subnet",
+			Help:      "Number of available IPs per subnet ID",
+		}, []string{"subnet_id", "availability_zone"}),
+
+		Nodes: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "nodes",
+			Help:      "Number of nodes by category { total | in-deficit | at-capacity }",
+		}, []string{"category"}),
+
+		ResyncTotal: metric.NewCounter(metric.CounterOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "resync_total",
+			Help:      "Number of resync operations to synchronize and resolve IP deficit of nodes",
+		}),
+
+		Allocation: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "allocation_duration_seconds",
+			Help:      "Allocation ip or interface latency in seconds",
+			Buckets: merge(
+				prometheus.LinearBuckets(0.25, 0.25, 2),
+				prometheus.LinearBuckets(1, 1, 60),
+			),
+		}, []string{"type", "status", "subnet_id"}),
+
+		Release: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "release_duration_seconds",
+			Help:      "Release ip or interface latency in seconds",
+			Buckets: merge(
+				prometheus.LinearBuckets(0.25, 0.25, 2),
+				prometheus.LinearBuckets(1, 1, 60),
+			),
+		}, []string{"type", "status", "subnet_id"}),
+
+		BackgroundSyncDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: ns,
+			Subsystem: ipamSubsystem,
+			Name:      "background_sync_duration_seconds",
+			Help:      "Duration in seconds of the background API resync",
+			Buckets: merge(
+				prometheus.LinearBuckets(0.25, 0.25, 2),
+				prometheus.LinearBuckets(1, 1, 60),
+			),
+		}, []string{"status"}),
+
+		PoolMaintainerQueued:       newTriggerCounter(ns, "deficit_resolver"),
+		PoolMaintainerFolds:        newTriggerFolds(ns, "deficit_resolver"),
+		PoolMaintainerCallDuration: newTriggerDuration(ns, "deficit_resolver"),
+		PoolMaintainerLatency:      newTriggerLatency(ns, "deficit_resolver"),
+
+		K8sSyncQueued:       newTriggerCounter(ns, "k8s_sync"),
+		K8sSyncFolds:        newTriggerFolds(ns, "k8s_sync"),
+		K8sSyncCallDuration: newTriggerDuration(ns, "k8s_sync"),
+		K8sSyncLatency:      newTriggerLatency(ns, "k8s_sync"),
+
+		ResyncQueued:       newTriggerCounter(ns, "resync"),
+		ResyncFolds:        newTriggerFolds(ns, "resync"),
+		ResyncCallDuration: newTriggerDuration(ns, "resync"),
+		ResyncLatency:      newTriggerLatency(ns, "resync"),
 	}
 }
 
-func (t *triggerMetrics) Register(registry *ciliumMetrics.Registry) {
-	registry.MustRegister(t.total)
-	registry.MustRegister(t.folds)
-	registry.MustRegister(t.callDuration)
-	registry.MustRegister(t.latency)
+// ipam.MetricsAPI implementation
+
+func (m *Metrics) SetIPAvailable(node string, cap int) {
+	m.AvailableIPs.WithLabelValues(node).Set(float64(cap))
 }
 
-func (t *triggerMetrics) QueueEvent(reason string) {
-	t.total.Inc()
+func (m *Metrics) SetIPUsed(node string, usage int) {
+	m.UsedIPs.WithLabelValues(node).Set(float64(usage))
 }
 
-func (t *triggerMetrics) PostRun(duration, latency time.Duration, folds int) {
-	t.callDuration.Observe(duration.Seconds())
+func (m *Metrics) SetIPNeeded(node string, usage int) {
+	m.NeededIPs.WithLabelValues(node).Set(float64(usage))
+}
+
+// DeleteNode removes all per-node metrics for the given node.
+func (m *Metrics) DeleteNode(node string) {
+	m.AvailableIPs.DeleteLabelValues(node)
+	m.UsedIPs.DeleteLabelValues(node)
+	m.NeededIPs.DeleteLabelValues(node)
+}
+
+func (m *Metrics) AllocationAttempt(typ, status, subnetID string, observe float64) {
+	m.Allocation.WithLabelValues(typ, status, subnetID).Observe(observe)
+}
+
+func (m *Metrics) ReleaseAttempt(typ, status, subnetID string, observe float64) {
+	m.Release.WithLabelValues(typ, status, subnetID).Observe(observe)
+}
+
+func (m *Metrics) IncInterfaceAllocation(subnetID string) {
+	m.AllocateInterfaceOps.WithLabelValues(subnetID).Inc()
+}
+
+func (m *Metrics) AddIPAllocation(subnetID string, allocated int64) {
+	m.AllocateIpOps.WithLabelValues(subnetID).Add(float64(allocated))
+}
+
+func (m *Metrics) AddIPRelease(subnetID string, released int64) {
+	m.ReleaseIpOps.WithLabelValues(subnetID).Add(float64(released))
+}
+
+func (m *Metrics) SetAllocatedIPs(typ string, allocated int) {
+	m.IPsAllocated.WithLabelValues(typ).Set(float64(allocated))
+}
+
+func (m *Metrics) SetAvailableInterfaces(available int) {
+	m.AvailableInterfaces.Set(float64(available))
+}
+
+func (m *Metrics) SetInterfaceCandidates(interfaceCandidates int) {
+	m.InterfaceCandidates.Set(float64(interfaceCandidates))
+}
+
+func (m *Metrics) SetEmptyInterfaceSlots(emptyInterfaceSlots int) {
+	m.EmptyInterfaceSlots.Set(float64(emptyInterfaceSlots))
+}
+
+func (m *Metrics) SetAvailableIPsPerSubnet(subnetID string, availabilityZone string, available int) {
+	m.AvailableIPsPerSubnet.WithLabelValues(subnetID, availabilityZone).Set(float64(available))
+}
+
+func (m *Metrics) SetNodes(label string, nodes int) {
+	m.Nodes.WithLabelValues(label).Set(float64(nodes))
+}
+
+func (m *Metrics) IncResyncCount() {
+	m.ResyncTotal.Inc()
+}
+
+func (m *Metrics) ObserveBackgroundSync(status string, duration time.Duration) {
+	m.BackgroundSyncDuration.WithLabelValues(status).Observe(duration.Seconds())
+}
+
+func (m *Metrics) PoolMaintainerTrigger() trigger.MetricsObserver {
+	return &triggerObserver{
+		queued:       m.PoolMaintainerQueued,
+		folds:        m.PoolMaintainerFolds,
+		callDuration: m.PoolMaintainerCallDuration,
+		latency:      m.PoolMaintainerLatency,
+	}
+}
+
+func (m *Metrics) K8sSyncTrigger() trigger.MetricsObserver {
+	return &triggerObserver{
+		queued:       m.K8sSyncQueued,
+		folds:        m.K8sSyncFolds,
+		callDuration: m.K8sSyncCallDuration,
+		latency:      m.K8sSyncLatency,
+	}
+}
+
+func (m *Metrics) ResyncTrigger() trigger.MetricsObserver {
+	return &triggerObserver{
+		queued:       m.ResyncQueued,
+		folds:        m.ResyncFolds,
+		callDuration: m.ResyncCallDuration,
+		latency:      m.ResyncLatency,
+	}
+}
+
+// triggerObserver implements trigger.MetricsObserver using metric.* types.
+type triggerObserver struct {
+	queued       metric.Counter
+	folds        metric.Gauge
+	callDuration metric.Histogram
+	latency      metric.Histogram
+}
+
+func (t *triggerObserver) QueueEvent(reason string) {
+	t.queued.Inc()
+}
+
+func (t *triggerObserver) PostRun(callDuration, latency time.Duration, folds int) {
+	t.callDuration.Observe(callDuration.Seconds())
 	t.latency.Observe(latency.Seconds())
 	t.folds.Set(float64(folds))
 }
 
-// NoOpMetricsObserver is a no-operation implementation of the metrics observer
-type NoOpMetricsObserver struct{}
+// Helpers for creating trigger metric fields.
 
-// MetricsObserver implementation
-func (m *NoOpMetricsObserver) PostRun(callDuration, latency time.Duration, folds int) {}
-func (m *NoOpMetricsObserver) QueueEvent(reason string)                               {}
+func newTriggerCounter(ns, name string) metric.Counter {
+	return metric.NewCounter(metric.CounterOpts{
+		Namespace: ns,
+		Subsystem: ipamSubsystem,
+		Name:      name + "_queued_total",
+		Help:      "Number of queued triggers",
+	})
+}
 
-// NoOpMetrics is a no-operation implementation of the metrics
-type NoOpMetrics struct{}
+func newTriggerFolds(ns, name string) metric.Gauge {
+	return metric.NewGauge(metric.GaugeOpts{
+		Namespace: ns,
+		Subsystem: ipamSubsystem,
+		Name:      name + "_folds",
+		Help:      "Current level of folding",
+	})
+}
 
-func (m *NoOpMetrics) AllocationAttempt(typ, status, subnetID string, observe float64)           {}
-func (m *NoOpMetrics) ReleaseAttempt(typ, status, subnetID string, observe float64)              {}
-func (m *NoOpMetrics) IncInterfaceAllocation(subnetID string)                                    {}
-func (m *NoOpMetrics) AddIPAllocation(subnetID string, allocated int64)                          {}
-func (m *NoOpMetrics) AddIPRelease(subnetID string, released int64)                              {}
-func (m *NoOpMetrics) SetAllocatedIPs(typ string, allocated int)                                 {}
-func (m *NoOpMetrics) SetAvailableInterfaces(available int)                                      {}
-func (m *NoOpMetrics) SetInterfaceCandidates(interfaceCandidates int)                            {}
-func (m *NoOpMetrics) SetEmptyInterfaceSlots(emptyInterfaceSlots int)                            {}
-func (m *NoOpMetrics) SetAvailableIPsPerSubnet(subnetID, availabilityZone string, available int) {}
-func (m *NoOpMetrics) SetNodes(category string, nodes int)                                       {}
-func (m *NoOpMetrics) IncResyncCount()                                                           {}
-func (m *NoOpMetrics) SetIPAvailable(node string, n int)                                         {}
-func (m *NoOpMetrics) SetIPUsed(node string, n int)                                              {}
-func (m *NoOpMetrics) SetIPNeeded(node string, n int)                                            {}
-func (m *NoOpMetrics) ObserveBackgroundSync(status string, duration time.Duration)               {}
-func (m *NoOpMetrics) PoolMaintainerTrigger() trigger.MetricsObserver                            { return &NoOpMetricsObserver{} }
-func (m *NoOpMetrics) K8sSyncTrigger() trigger.MetricsObserver                                   { return &NoOpMetricsObserver{} }
-func (m *NoOpMetrics) ResyncTrigger() trigger.MetricsObserver                                    { return &NoOpMetricsObserver{} }
-func (m *NoOpMetrics) DeleteNode(n string)                                                       {}
+func newTriggerDuration(ns, name string) metric.Histogram {
+	return metric.NewHistogram(metric.HistogramOpts{
+		Namespace: ns,
+		Subsystem: ipamSubsystem,
+		Name:      name + "_duration_seconds",
+		Help:      "Duration of trigger runs",
+		Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+			4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+	})
+}
+
+func newTriggerLatency(ns, name string) metric.Histogram {
+	return metric.NewHistogram(metric.HistogramOpts{
+		Namespace: ns,
+		Subsystem: ipamSubsystem,
+		Name:      name + "_latency_seconds",
+		Help:      "Latency between queue and trigger run",
+		Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+			4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+	})
+}
+
+// SinceInSeconds returns the time elapsed since start in seconds.
+func SinceInSeconds(start time.Time) float64 {
+	return time.Since(start).Seconds()
+}
 
 func merge(slices ...[]float64) []float64 {
 	result := make([]float64, 1)
@@ -383,9 +389,4 @@ func merge(slices ...[]float64) []float64 {
 		result = append(result, s...)
 	}
 	return result
-}
-
-// SinceInSeconds gets the time since the specified start in seconds.
-func SinceInSeconds(start time.Time) float64 {
-	return time.Since(start).Seconds()
 }


### PR DESCRIPTION
Replace legacy prometheus metric registration (manual `MustRegister`, `NoOpMetrics` structs, `EnableMetrics` conditionals, `*metrics.Registry` threading) with the modern hive `metrics.Metric()` cell pattern across all cloud-provider IPAM allocators.

Now each cloud provider's IPAM cell's `init()` function gets a `metrics.Metric(...)` instead of a `*metrics.Registry`. This means we no longer need to manually check in each allocator the global `EnableMetrics` flag to know whether we should use a `NoOpMetrics` or not.

Some notes:
* In `pkg/azure/api`: updated `MetricsAPI` to embed `helpers.MetricsAPI` instead of duplicating the `ObserveRateLimit` signature, becoming consistent with AWS and AlibabaCloud's `MetricsAPI`.
* In `pkg/ipam/allocator/alibabacloud`: renamed the `pkg/alibabacloud/api` package import from `openapi` to `alibabacloudAPI` to be more consistent with the equivalent AWS and Azure allocator packages.
* We have to duplicate the `Metrics` struct from `pkg/api/metrics` in each cloud-provider's IPAM allocator package (`pkg/ipam/allocator/<provider>/metrics.go`) because otherwise, building the omnibus operator with all IPAM modes included fails as each IPAM mode implementation tries to provide a `*apiMetrics.Metrics` to the hive dependency injection system. By using separate concrete types, we prevent that conflict.


### Testing

I deployed this in a test AWS cluster with ENI IPAM mode and the expected metrics are still there:

<details>
<summary>On the prometheus metrics endpoint:</summary>

```
...
# HELP cilium_operator_ec2_api_duration_seconds Duration of interactions with API
# TYPE cilium_operator_ec2_api_duration_seconds histogram
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.005"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.025"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.05"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.1"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.2"} 11
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.4"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.6"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="0.8"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="1"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="1.25"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="1.5"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="2"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="3"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="4"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="5"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="6"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="8"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="10"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="15"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="20"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="30"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="45"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="60"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeInstanceTypes",response_code="OK",le="+Inf"} 12
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeInstanceTypes",response_code="OK"} 1.6726459550000001
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeInstanceTypes",response_code="OK"} 12
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.005"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.025"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.05"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.1"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.2"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.4"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.6"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="0.8"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="1"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="1.25"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="1.5"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="2"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="3"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="4"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="5"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="6"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="8"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="10"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="15"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="20"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="30"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="45"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="60"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="Failed",le="+Inf"} 1
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeNetworkInterfaces",response_code="Failed"} 0.00011698
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeNetworkInterfaces",response_code="Failed"} 1
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.005"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.025"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.05"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.1"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.2"} 4
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="0.8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="1"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="1.25"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="1.5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="3"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="10"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="15"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="20"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="30"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="45"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="60"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeNetworkInterfaces",response_code="OK",le="+Inf"} 5
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeNetworkInterfaces",response_code="OK"} 0.9820052340000001
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeNetworkInterfaces",response_code="OK"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.005"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.025"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.05"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.1"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.2"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.4"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.6"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="0.8"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="1"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="1.25"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="1.5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="3"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="10"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="15"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="20"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="30"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="45"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="60"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeRouteTables",response_code="OK",le="+Inf"} 5
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeRouteTables",response_code="OK"} 4.736689149
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeRouteTables",response_code="OK"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.005"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.025"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.05"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.1"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.2"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="0.8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="1"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="1.25"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="1.5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="3"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="10"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="15"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="20"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="30"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="45"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="60"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSecurityGroups",response_code="OK",le="+Inf"} 5
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeSecurityGroups",response_code="OK"} 1.264111481
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeSecurityGroups",response_code="OK"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.005"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.025"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.05"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.1"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="0.8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="1"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="1.25"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="1.5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="3"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="10"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="15"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="20"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="30"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="45"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="60"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeSubnets",response_code="OK",le="+Inf"} 5
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeSubnets",response_code="OK"} 0.7726829980000001
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeSubnets",response_code="OK"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.005"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.025"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.05"} 0
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.1"} 4
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="0.8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="1"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="1.25"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="1.5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="2"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="3"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="4"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="5"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="6"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="8"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="10"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="15"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="20"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="30"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="45"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="60"} 5
cilium_operator_ec2_api_duration_seconds_bucket{operation="DescribeVpcs",response_code="OK",le="+Inf"} 5
cilium_operator_ec2_api_duration_seconds_sum{operation="DescribeVpcs",response_code="OK"} 0.463449864
cilium_operator_ec2_api_duration_seconds_count{operation="DescribeVpcs",response_code="OK"} 5
...
```

</details>

And through the `metrics` shell command:
```
k exec -it deploy/cilium-operator -- /usr/bin/cilium-operator-aws shell metrics | grep ec2_api
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeInstanceTypes response_code=OK                  154.5ms / 198.2ms / 376ms
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeNetworkInterfaces response_code=Failed          2.5ms / 4.5ms / 4.95ms
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeNetworkInterfaces response_code=OK              150ms / 190ms / 199ms
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeRouteTables response_code=OK                    900ms / 980ms / 998ms
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeSecurityGroups response_code=OK                 300ms / 380ms / 398ms
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeSubnets response_code=OK                        150ms / 190ms / 199ms
cilium_operator_ec2_api_duration_seconds                                         operation=DescribeVpcs response_code=OK                           75ms / 95ms / 99.5ms
```