### PR TITLE
IPAM: Add CIDR label to IPAM capacity metric

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -718,7 +718,7 @@ IPAM
 ======================================== ============================================ ========== ========================================================
 Name                                     Labels                                       Default    Description
 ======================================== ============================================ ========== ========================================================
-``ipam_capacity``                        ``family``                                   Enabled    Total number of IPs in the IPAM pool labeled by family
+``ipam_capacity``                        ``family``, ``cidr``                         Enabled    Total number of IPs in the IPAM pool labeled by family
 ``ipam_events_total``                                                                 Enabled    Number of IPAM events received labeled by action and datapath family type
 ``ip_addresses``                         ``family``                                   Enabled    Number of allocated IP addresses
 ======================================== ============================================ ========== ========================================================

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/time"
@@ -90,7 +91,11 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 				return
 			}
 		}
-		metrics.IPAMCapacity.WithLabelValues(string(family)).Set(float64(ipam.ipv4Allocator.Capacity()))
+		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
+			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv4Allocator.Capacity()))
+		} else {
+			metrics.IPAMCapacity.WithLabelValues(string(family), "").Set(float64(ipam.ipv4Allocator.Capacity()))
+		}
 	} else {
 		family = IPv6
 		if ipam.ipv6Allocator == nil {
@@ -107,7 +112,11 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 				return
 			}
 		}
-		metrics.IPAMCapacity.WithLabelValues(string(family)).Set(float64(ipam.ipv6Allocator.Capacity()))
+		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
+			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv6Allocator.Capacity()))
+		} else {
+			metrics.IPAMCapacity.WithLabelValues(string(family), "").Set(float64(ipam.ipv6Allocator.Capacity()))
+		}
 	}
 
 	// If the allocator did not populate the pool, we assume it does not
@@ -133,10 +142,18 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 	switch family {
 	case IPv6:
 		allocator = ipam.ipv6Allocator
-		metrics.IPAMCapacity.WithLabelValues(string(family)).Set(float64(ipam.ipv6Allocator.Capacity()))
+		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
+			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv6Allocator.Capacity()))
+		} else {
+			metrics.IPAMCapacity.WithLabelValues(string(family), "").Set(float64(ipam.ipv6Allocator.Capacity()))
+		}
 	case IPv4:
 		allocator = ipam.ipv4Allocator
-		metrics.IPAMCapacity.WithLabelValues(string(family)).Set(float64(ipam.ipv4Allocator.Capacity()))
+		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
+			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv4Allocator.Capacity()))
+		} else {
+			metrics.IPAMCapacity.WithLabelValues(string(family), "").Set(float64(ipam.ipv4Allocator.Capacity()))
+		}
 
 	default:
 		err = fmt.Errorf("unknown address \"%s\" family requested", family)
@@ -278,7 +295,11 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 		}
 
 		ipam.ipv4Allocator.Release(ip, pool)
-		metrics.IPAMCapacity.WithLabelValues(string(family)).Set(float64(ipam.ipv4Allocator.Capacity()))
+		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
+			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv4Allocator.Capacity()))
+		} else {
+			metrics.IPAMCapacity.WithLabelValues(string(family), "").Set(float64(ipam.ipv4Allocator.Capacity()))
+		}
 	} else {
 		family = IPv6
 		if ipam.ipv6Allocator == nil {
@@ -286,7 +307,11 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 		}
 
 		ipam.ipv6Allocator.Release(ip, pool)
-		metrics.IPAMCapacity.WithLabelValues(string(family)).Set(float64(ipam.ipv6Allocator.Capacity()))
+		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
+			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv6Allocator.Capacity()))
+		} else {
+			metrics.IPAMCapacity.WithLabelValues(string(family), "").Set(float64(ipam.ipv6Allocator.Capacity()))
+		}
 	}
 
 	owner := ipam.releaseIPOwner(ip, pool)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -253,6 +253,9 @@ const (
 
 	LabelValueUpdateOperation = "update"
 	LabelValueDeleteOperation = "delete"
+
+	// LabelCIDR is the label for IPAM CIDR assigned to a node.
+	LabelCIDR = "cidr"
 )
 
 var (
@@ -1078,7 +1081,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Namespace:  Namespace,
 			Name:       "ipam_capacity",
 			Help:       "Total number of IPs in the IPAM pool labeled by family",
-		}, []string{LabelDatapathFamily}),
+		}, []string{LabelDatapathFamily, LabelCIDR}),
 
 		KVStoreOperationsDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds",


### PR DESCRIPTION
This commit adds a new metric label and assigns it to the Cilium agent's IPAM capacity metric. Tracking the capacity of CIDRs used across a cluster will be significantly easier with this label in place.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


```release-note
IPAM: Add CIDR label to IPAM capacity metric
```
