### PR TITLE
fix: nil pointer reference in DNS benchmark test

### DIFF
--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -99,7 +100,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 		DNSMessageHandlerParams{
 			Logger:            logger,
 			NameManager:       nm,
-			ProxyAccessLogger: accesslog.NewProxyAccessLogger(logger, accesslog.ProxyAccessLoggerConfig{}, &noopNotifier{}, &dummyInfoRegistry{}, nil),
+			ProxyAccessLogger: accesslog.NewProxyAccessLogger(logger, accesslog.ProxyAccessLoggerConfig{}, &noopNotifier{}, &dummyInfoRegistry{}, node.NewTestLocalNodeStore(node.LocalNode{})),
 		})
 
 	// Register rules (simulates applied policies).


### PR DESCRIPTION
Fixes the nil pointer dereference in the DNS benchmark test due to `LocalNodeStore` being `nil`.
```
Running tool: /snap/go/current/bin/go test -test.fullpath=true -benchmem -run=^$ -coverprofile=/tmp/vscode-godFwrEL/go-code-cover -bench . github.com/cilium/cilium/pkg/fqdn/messagehandler

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x25ec9f3]

goroutine 93 [running]:
github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Get(_, {_, _})
	/home/singhvipul/ws/cilium/pkg/node/local_node_store.go:170 +0x53
github.com/cilium/cilium/pkg/proxy/accesslog.(*proxyAccessLogger).NewLogRecord(0xc00098c050, {0x38547c8, 0x5acf8a0}, {0x339712e, 0x8}, 0x88?, {0xc0006086c0, 0x4, 0xc0003ec014?})
	/home/singhvipul/ws/cilium/pkg/proxy/accesslog/proxy_access_logger.go:74 +0x254
github.com/cilium/cilium/pkg/fqdn/messagehandler.(*dnsMessageHandler).NotifyOnDNSMsg(0xc0007442c0, {0x35391f8?, 0xc0005a2fb8?, 0x5582260?}, 0xc00025e008, {0x33b4268, 0x10}, 0x0, {{{0x0, 0xffff0a604001}, ...}, ...}, ...)
	/home/singhvipul/ws/cilium/pkg/fqdn/messagehandler/message_handler.go:235 +0xbbe
github.com/cilium/cilium/pkg/fqdn/messagehandler.BenchmarkNotifyOnDNSMsg.func1()
	/home/singhvipul/ws/cilium/pkg/fqdn/messagehandler/message_handler_test.go:143 +0x199
created by github.com/cilium/cilium/pkg/fqdn/messagehandler.BenchmarkNotifyOnDNSMsg in goroutine 66
	/home/singhvipul/ws/cilium/pkg/fqdn/messagehandler/message_handler_test.go:137 +0xd10
exit status 2
FAIL	github.com/cilium/cilium/pkg/fqdn/messagehandler	0.090s
FAIL

```


```release-note
fix: nil pointer reference in DNS benchmark test
```
