### PR TITLE
bpf: Use global function for `snat_v6_needs_masquerade`

### DIFF
--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -48,6 +48,10 @@
 # define __noinline		__attribute__((noinline))
 #endif
 
+#ifndef __weak
+# define __weak		__attribute__((weak))
+#endif
+
 #ifndef __stringify
 # define __stringify(X)		#X
 #endif

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1684,9 +1684,9 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 }
 
 static __always_inline int
-snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
-			 fraginfo_t fraginfo, int l4_off,
-			 struct ipv6_nat_target *target)
+__snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
+			   fraginfo_t fraginfo, int l4_off,
+			   struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr = CONFIG(nat_ipv6_masquerade);
 	const struct remote_endpoint_info *remote_ep;
@@ -1800,6 +1800,43 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	}
 
 	return NAT_PUNT_TO_STACK;
+}
+
+/* Store struct ipv6_ct_tuple and struct ipv6_nat_target objects in maps to
+ * optimize stack usage.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct ipv6_ct_tuple);
+} ct_tuple_storage __section_maps_btf;
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct ipv6_nat_target);
+} nat_target_storage __section_maps_btf;
+
+static __always_inline int
+snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
+			 fraginfo_t fraginfo __maybe_unused,
+			 int l4_off __maybe_unused)
+{
+	struct ipv6_nat_target *target;
+	struct ipv6_ct_tuple *tuple;
+	int ret, zero = 0;
+
+	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
+	if (!tuple)
+		return DROP_INVALID;
+	target = map_lookup_elem(&nat_target_storage, &zero);
+	if (!target)
+		return DROP_INVALID;
+
+	ret = __snat_v6_needs_masquerade(ctx, tuple, fraginfo, l4_off, target);
+
+	return ret;
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1685,12 +1685,14 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 
 static __always_inline int
 snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
-			 struct ipv6hdr *ip6, fraginfo_t fraginfo, int l4_off,
+			 fraginfo_t fraginfo, int l4_off,
 			 struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr = CONFIG(nat_ipv6_masquerade);
 	const struct remote_endpoint_info *remote_ep;
 	const struct endpoint_info *local_ep;
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
 
 	if (ipv6_addr_equals(&tuple->saddr, &masq_addr)) {
 		ipv6_addr_copy(&target->addr, &masq_addr);
@@ -1698,6 +1700,9 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 		return NAT_NEEDED;
 	}
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
 
 	local_ep = __lookup_ip6_endpoint(&tuple->saddr);
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1669,19 +1669,14 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 }
 
 static __always_inline int
-snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
-			 struct ipv6_ct_tuple *tuple __maybe_unused,
-			 struct ipv6hdr *ip6 __maybe_unused,
-			 fraginfo_t fraginfo __maybe_unused,
-			 int l4_off __maybe_unused,
-			 struct ipv6_nat_target *target __maybe_unused)
+snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
+			 struct ipv6hdr *ip6, fraginfo_t fraginfo, int l4_off,
+			 struct ipv6_nat_target *target)
 {
-	union v6addr masq_addr __maybe_unused = CONFIG(nat_ipv6_masquerade);
-	const struct remote_endpoint_info *remote_ep __maybe_unused;
-	const struct endpoint_info *local_ep __maybe_unused;
+	union v6addr masq_addr = CONFIG(nat_ipv6_masquerade);
+	const struct remote_endpoint_info *remote_ep;
+	const struct endpoint_info *local_ep;
 
-	/* See comments in snat_v4_needs_masquerade(). */
-#if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
 	if (ipv6_addr_equals(&tuple->saddr, &masq_addr)) {
 		ipv6_addr_copy(&target->addr, &masq_addr);
 		target->needs_ct = true;
@@ -1783,7 +1778,6 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 		ipv6_addr_copy(&target->addr, &masq_addr);
 		return NAT_NEEDED;
 	}
-#endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 
 	return NAT_PUNT_TO_STACK;
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1818,7 +1818,7 @@ struct {
 	__type(value, struct ipv6_nat_target);
 } nat_target_storage __section_maps_btf;
 
-static __always_inline int
+__noinline __weak int
 snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 fraginfo_t fraginfo __maybe_unused,
 			 int l4_off __maybe_unused)

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -59,12 +59,12 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
+	int hdrlen, l4_off, ret = NAT_PUNT_TO_STACK;
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
 	struct ipv6_ct_tuple tuple = {};
-	int hdrlen, l4_off, ret;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	fraginfo_t fraginfo;
@@ -84,7 +84,9 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	    nodeport_has_nat_conflict_ipv6(ctx, ip6, &target))
 		goto apply_snat;
 
+#if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
 	ret = snat_v6_needs_masquerade(ctx, &tuple, ip6, fraginfo, l4_off, &target);
+#endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -60,45 +60,54 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  __s8 *ext_err)
 {
 	int hdrlen, l4_off, ret = NAT_PUNT_TO_STACK;
-	struct ipv6_nat_target target = {
-		.min_port = NODEPORT_PORT_MIN_NAT,
-		.max_port = NODEPORT_PORT_MAX_NAT,
-	};
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_nat_target *target;
+	struct ipv6_ct_tuple *tuple;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	fraginfo_t fraginfo;
+	int zero = 0;
+
+	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
+	if (!tuple)
+		return DROP_INVALID;
+	target = map_lookup_elem(&nat_target_storage, &zero);
+	if (!target)
+		return DROP_INVALID;
+
+	memset(target, 0, sizeof(*target));
+	target->min_port = NODEPORT_PORT_MIN_NAT;
+	target->max_port = NODEPORT_PORT_MAX_NAT;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	tuple.nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
+	tuple->nexthdr = ip6->nexthdr;
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);
 	if (hdrlen < 0)
 		return hdrlen;
 
-	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, &tuple);
+	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, tuple);
 	l4_off = ETH_HLEN + hdrlen;
 
-	if (lb_is_svc_proto(tuple.nexthdr) &&
-	    nodeport_has_nat_conflict_ipv6(ctx, ip6, &target))
+	if (lb_is_svc_proto(tuple->nexthdr) &&
+	    nodeport_has_nat_conflict_ipv6(ctx, ip6, target))
 		goto apply_snat;
 
 #if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
-	ret = snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	ret = snat_v6_needs_masquerade(ctx, fraginfo, l4_off);
 #endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
-	if (target.egress_gateway) {
+	if (target->egress_gateway) {
 		/* Stay on the desired egress interface: */
-		if (target.ifindex && target.ifindex == CONFIG(interface_ifindex))
+		if (target->ifindex && target->ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
 
 		/* Send packet to the correct egress interface, and SNAT it there. */
-		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &target.addr,
-							   &tuple.daddr, target.ifindex,
+		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &target->addr,
+							   &tuple->daddr, target->ifindex,
 							   ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
@@ -109,9 +118,9 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 #endif
 
 apply_snat:
-	ipv6_addr_copy(saddr, &tuple.saddr);
-	ret = snat_v6_nat(ctx, &tuple, ip6, fraginfo, l4_off,
-			  &target, trace, ext_err);
+	ipv6_addr_copy(saddr, &tuple->saddr);
+	ret = snat_v6_nat(ctx, tuple, ip6, fraginfo, l4_off,
+			  target, trace, ext_err);
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -85,7 +85,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		goto apply_snat;
 
 #if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
-	ret = snat_v6_needs_masquerade(ctx, &tuple, ip6, fraginfo, l4_off, &target);
+	ret = snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
 #endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;


### PR DESCRIPTION
We're having complexity issues with the `nodeport_snat_fwd_ipv6` BPF program: on some kernels & configurations, the verifier rejects the program because it's too complex to verify in the one million instruction budget.

This pull request fixes it by relying on function-by-function verification. For this BPF program, a large amount of code leaves in function `snat_v6_needs_masquerade` which is currently inlined. By making it a non-inlined, global function, the kernel will verify it separately from the rest of the BPF program, thus reducing complexity significantly.

The first three commits are preparatory. The fourth one makes the switch to a global function. The last one avoids calls to the global function when unnecessary.

This pull request sometimes causes smaller programs that use `snat_v6_needs_masquerade` to increase in complexity. That's because inlining this function used to allow for some simplification in the caller. The compiler cannot make those simplifications anymore. For larger programs, which are the main focus for complexity issues, the impact is quite clear and we see the divide-and-conqueer gains of the function-by-function verification. Below is an example for a configuration of the bpf_host program.

<img width="1000" height="500" alt="states-build9-load14" src="https://github.com/user-attachments/assets/45eab9a9-5309-4964-acfe-e2fa8ff46768" />

Checkpatch is failing because I introduced the `#define __weak __attribute__(...)` macro and it's saying I should use `__weak` instead of `__attribute__(...)` :sweat_smile: 