### PR TITLE
cilium-cli: Disable Helm Server Side Apply

### DIFF
--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -265,6 +265,7 @@ func (k *K8sInstaller) InstallWithHelm(ctx context.Context, k8sClient *k8s.Clien
 		return err
 	}
 	helmClient := action.NewInstall(k8sClient.HelmActionConfig)
+	helmClient.ServerSideApply = false
 	helmClient.ReleaseName = k.params.HelmReleaseName
 	helmClient.Namespace = k.params.Namespace
 	if k.params.Wait {

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -336,6 +336,7 @@ func Upgrade(
 	}
 
 	helmClient := action.NewUpgrade(actionConfig)
+	helmClient.ServerSideApply = "false"
 	helmClient.Namespace = params.Namespace
 	helmClient.ResetThenReuseValues = params.ResetThenReuseValues
 	helmClient.ResetValues = params.ResetValues


### PR DESCRIPTION
In the #44390, we upgraded Helm to v4. In v4, they enable k8s SSA by default. This is not the same behavior as before and may cause  an unexpected field ownership conflict between `cilium install/upgrade` and user's manual intervation. Since this change is unintended and we haven't prepared for this, I believe disabling it for now would be the safer option.

Fixes: #44390 

```release-note
cilium-cli: Disable Helm Server Side Apply
```
