### PR TITLE
gke: Generate clusterName with hashed run identifier

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -103,7 +103,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
+  clusterName: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 557.0.0


### PR DESCRIPTION
The Cilium's cluster name cluster name must be 32 character or less. With the current naming convention, it will exceed 32 characters in certain condition (e.g when the workflow is running in the fork that has a longer name). The change we introduced in #44406 increased the risk further.

To reduce the risk of exceeding 32 characters, use sha256 hash of the run identifier part (trimmed down to the 7 character like Git short hash) for the clusterName.

Fixes: #44406

```release-note
gke: Generate clusterName with hashed run identifier
```
