### PR TITLE
Improve network policy l3/dns documentation

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -18,7 +18,7 @@ default: html
 define build_image
   $(ECHO_DOCKER) $(3)
   # Pre-pull FROM docker image due to Buildkit sometimes failing to pull them.
-  grep -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
+  grep --color=never -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
   $(QUIET)tar c $(REQUIREMENTS) Dockerfile \
     | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) \
                           --build-arg READTHEDOCS_VERSION \
@@ -153,7 +153,7 @@ live-preview: builder-image ## Build and serve the documentation locally.
 	$(QUIET)$(DOCKER_CTR) \
 		--publish $(DOCS_PORT):$(DOCS_PORT) \
 			$(DOCS_BUILDER_IMG) \
-		sphinx-autobuild --open-browser --host 0.0.0.0 --port $(DOCS_PORT) $(SPHINX_OPTS) --ignore *.swp -Q . _preview
+		sphinx-autobuild --open-browser --host 0.0.0.0 --port $(DOCS_PORT) $(SPHINX_OPTS) --ignore "*.swp" -Q . _preview
 
 update-redirects: builder-image ## Build and serve the documentation locally.
 	@echo "$$(tput setaf 2)Writing redirects$$(tput sgr0)"

--- a/Documentation/security/policy/layer3.rst
+++ b/Documentation/security/policy/layer3.rst
@@ -486,7 +486,7 @@ DNS requests themselves, see :ref:`l7_policy`.
 	In order to associate domain names with IP addresses, Cilium intercepts
 	DNS responses per-Endpoint using a `DNS Proxy`. This requires Cilium
 	to be configured with ``--enable-l7-proxy=true`` and an L7 policy allowing
-	DNS requests. For more details, see :ref:`DNS Obtaining Data`.
+	DNS requests (``rules.dns`` YAML block). For more details, see :ref:`DNS Obtaining Data`.
 
 An L3 `CIDR based`_ rule is generated for every ``toFQDNs``
 rule and applies to the same endpoints. The IP information is selected for


### PR DESCRIPTION
<!-- Description of change -->
Fix few lines in Makefile to allow building Documentation on MacOS. Addition of a warning to l3/dns network policy documentation to stress that rules.dns block is strict requirement for toFQDNs policies to work.
Fixes: #44504

```release-note
docs: Add precision about rules DNS section for L3/DNS network policy documentation
```
