### PR TITLE
Auto-generate feature metrics documentation for agent and operator

### DIFF
--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -272,8 +272,9 @@ jobs:
              --metrics-prefix cilium_operator_feature \
              --metrics-separators adv_connect_and_lb \
              > Documentation/observability/feature-metrics-operator.txt
-          if ! git diff --quiet; then
+          if ! git diff --exit-code; then
             echo "Feature metrics documentation out-of-sync"
+            echo "HINT: to fix this, install via 'make kind-install-cilium-metrics' and run 'make -C Documentation update-metrics'."
             exit 1
           fi
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -65,7 +65,49 @@ DOCKER_CTR := $(DOCKER_CTR_BASE) \
 		--env INCREMENTAL=$(INCREMENTAL)
 DOCKER_RUN := $(DOCKER_CTR) $(DOCS_BUILDER_IMG)
 
+PROMTOOL_IMG ?= quay.io/prometheus/prometheus:latest
+PROMTOOL := $(DOCKER_CTR) --entrypoint /bin/promtool $(PROMTOOL_IMG)
+
 ##@ Auto-generated Contents Updates and Validation
+
+.PHONY: update-metrics
+update-metrics: AGENT_METRICS_PROM := agent-metrics.prom
+update-metrics: AGENT_METRICS_DOC := ./observability/feature-metrics-agent.txt
+update-metrics: AGENT_METRICS_PREFIX := cilium_feature
+update-metrics: AGENT_METRICS_SEPARATORS := adv_connect_and_lb,controlplane,datapath,network_policies
+update-metrics: OPERATOR_METRICS_PROM := operator-metrics.prom
+update-metrics: OPERATOR_METRICS_DOC := ./observability/feature-metrics-operator.txt
+update-metrics: OPERATOR_METRICS_PREFIX := cilium_operator_feature
+update-metrics: OPERATOR_METRICS_SEPARATORS := adv_connect_and_lb
+update-metrics:
+	@$(ECHO_GEN)metrics
+	$(QUIET)set -eu; \
+		AGENT_IP="$$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].status.podIP}')"; \
+		OPERATOR_IP="$$(kubectl get pods -n kube-system -l io.cilium/app=operator -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}')"; \
+		echo "Fetching agent metrics from http://$${AGENT_IP}:9962/metrics"; \
+		curl -fsS --connect-timeout 5 --max-time 20 "http://$${AGENT_IP}:9962/metrics" -o $(AGENT_METRICS_PROM).tmp; \
+		echo "Fetching operator metrics from http://$${OPERATOR_IP}:9963/metrics"; \
+		curl -fsS --connect-timeout 5 --max-time 20 "http://$${OPERATOR_IP}:9963/metrics" -o $(OPERATOR_METRICS_PROM).tmp
+	@$(ECHO_CHECK) $(AGENT_METRICS_PROM).tmp
+	$(QUIET)$(PROMTOOL) check metrics < $(AGENT_METRICS_PROM).tmp
+	@$(ECHO_CHECK) $(OPERATOR_METRICS_PROM).tmp
+	$(QUIET)$(PROMTOOL) check metrics < $(OPERATOR_METRICS_PROM).tmp
+	$(QUIET)grep '$(AGENT_METRICS_PREFIX)' $(AGENT_METRICS_PROM).tmp > $(AGENT_METRICS_PROM)
+	$(QUIET)grep '$(OPERATOR_METRICS_PREFIX)' $(OPERATOR_METRICS_PROM).tmp > $(OPERATOR_METRICS_PROM)
+	@$(ECHO_GEN) $(AGENT_METRICS_DOC)
+	$(QUIET)$(GO) run $(ROOT_DIR)/tools/feature-helm-generator \
+		--prom-file $(AGENT_METRICS_PROM) \
+		--metrics-prefix $(AGENT_METRICS_PREFIX) \
+		--metrics-separators $(AGENT_METRICS_SEPARATORS) \
+		> $(AGENT_METRICS_DOC)
+	@$(ECHO_GEN) $(OPERATOR_METRICS_DOC)
+	$(QUIET)$(GO) run $(ROOT_DIR)/tools/feature-helm-generator \
+		--prom-file $(OPERATOR_METRICS_PROM) \
+		--metrics-prefix $(OPERATOR_METRICS_PREFIX) \
+		--metrics-separators $(OPERATOR_METRICS_SEPARATORS) \
+		> $(OPERATOR_METRICS_DOC)
+	$(QUIET)$(RM) -- $(AGENT_METRICS_PROM).tmp $(OPERATOR_METRICS_PROM).tmp \
+		$(AGENT_METRICS_PROM) $(OPERATOR_METRICS_PROM)
 
 .PHONY: api-flaggen
 api-flaggen: ## Update the table of API flags restrictions.
@@ -131,6 +173,8 @@ check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values
 	$(QUIET) ./check-crdlist.sh
 	@$(ECHO_CHECK) redirects.txt
 	$(QUIET) ./check-redirects.sh
+	@$(ECHO_CHECK) metrics
+	$(QUIET) ./check-metrics.sh
 
 ##@ Build
 

--- a/Documentation/check-metrics.sh
+++ b/Documentation/check-metrics.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+metrics_dir="${script_dir}/observability"
+
+if ! git diff --quiet -- "${metrics_dir}" ; then
+    git --no-pager diff "${metrics_dir}"
+    echo "HINT: to fix this, install via 'make kind-install-cilium-metrics' and run 'make -C Documentation update-metrics'"
+    exit 1
+fi

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -364,6 +364,19 @@ kind-install-cilium: check_deps kind-ready ## Install a local Cilium version int
 		--set=k8sClusterNetworkPolicy.enabled=$(ENABLE_CLUSTERNETWORKPOLICY) \
 		--version=
 
+.PHONY: kind-install-cilium-metrics
+kind-install-cilium-metrics: check_deps kind-ready
+	@echo "  INSTALL cilium"
+	# cilium-cli doesn't support idempotent installs, so we uninstall and
+	# reinstall here. https://github.com/cilium/cilium-cli/issues/205
+	-@$(CILIUM_CLI) uninstall >/dev/null 2>&1 || true
+	$(CILIUM_CLI) install \
+		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
+		$(KIND_VALUES_FILES) \
+		--helm-values=$(ROOT_DIR)/contrib/testing/kind-metrics.yaml \
+		--set=k8sClusterNetworkPolicy.enabled=$(ENABLE_CLUSTERNETWORKPOLICY) \
+		--version=
+
 GW_VERSION ?= $(shell grep "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}' | awk -F'-' '{print (NF>2)?$$NF:$$0}')
 # Set this to "standard" to use the standard CRDs instead
 GW_CHANNEL ?= experimental

--- a/contrib/testing/kind-metrics.yaml
+++ b/contrib/testing/kind-metrics.yaml
@@ -1,0 +1,38 @@
+nodeinit:
+  enabled: true
+kubeProxyReplacement: true
+ipam:
+  mode: kubernetes
+prometheus:
+  enabled: true
+hubble:
+  enabled: true
+  metrics:
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - flow
+      - port-distribution
+      - icmp
+      - http
+ingressController:
+  enabled: true
+extraEnv:
+  - name: CILIUM_FEATURE_METRICS_WITH_DEFAULTS
+    value: "true"
+  - name: CILIUM_INVALID_METRIC_VALUE_DETECTOR
+    value: "true"
+  - name: CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION
+    value: "true"
+
+operator:
+  prometheus:
+    enabled: true
+  extraEnv:
+    - name: CILIUM_FEATURE_METRICS_WITH_DEFAULTS
+      value: "true"
+    - name: CILIUM_INVALID_METRIC_VALUE_DETECTOR
+      value: "true"
+    - name: CILIUM_FEATURE_METRICS_WITHOUT_ENV_VERSION
+      value: "true"


### PR DESCRIPTION
Following #44114 CI will now fail if feature metric documentation is out of sync. However, [as noted](https://github.com/cilium/cilium/pull/44114#discussion_r2856236665), the developer U/X for this is poor.

This PR:
1. Introduces a new kind install target: `make kind-install-cilium-metrics`.
   This can be run to install Cilium with the necessary config to express default metrics. This is required to auto-generate the documentation.
   
2. Introduces a new docs target: `make -C Documentation update-metrics`.
   This queries the installed kind cluster and auto-generates the feature metric files in Documentation/observability.
   
3. Updates the `tests-smoke.yaml` file to better express any detected sync issues for these files, and also mentions the new build targets that can be used to re-generate them from command line.

4. The standard `make -C Documentation check` is also updated to check the metrics files.

**Note**: the smoke test workflow is now duplicating some logic, but thought it best to leave this alone for now until these changes are accepted. I envisage a follow-up PR in due course that could split the testing out into its own workflow and refactoring to reducing duplication.

---

**CI Test example**

Screenshot below from [test CI run](https://github.com/cilium/cilium/actions/runs/22494316198/job/65164688375?pr=44555) with a commit that modifies one of the documents.

<img width="1009" height="419" alt="image" src="https://github.com/user-attachments/assets/4aed746b-683b-429e-88ee-b398c85a837a" />

---

```release-note
Introduce build targets to resynchronise feature metric documentation files for the agent and operator.
```
