### PR TITLE
ci: conformance gke using extended channels

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -4,13 +4,14 @@ k8s:
   - version: "1.30"
     zone: us-west2-c
     vmIndex: 1
+    default: true
   - version: "1.31"
     zone: us-west3-a
     vmIndex: 2
+    default: true
   - version: "1.32"
     zone: us-east4-b
     vmIndex: 3
   - version: "1.33"
     zone: us-west1-c
     vmIndex: 4
-    default: true

--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -63,6 +63,7 @@ runs:
 
         gcloud container clusters create "${{ inputs.cluster-name }}" \
           --zone "${{ inputs.zone }}" \
+          --release-channel "extended" \
           --enable-ip-alias \
           --create-subnetwork="range=/26" \
           --cluster-ipv4-cidr="/21" \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           CHANNEL=$(echo ${{ inputs.extra-args }} | grep "channel" | awk -F'=' '{print $2}' | tr '[:lower:]' '[:upper:]')
           if [ "$CHANNEL" == "" ];then
-            FILTER="channels.channel=REGULAR"
+            FILTER="channels.channel=EXTENDED"
           elif [ "$CHANNEL" == "NONE" ];then
             FILTER=""
           else


### PR DESCRIPTION
GKE version 1.30 & 1.31 aren't in regular channel anymore, but can be
found in extended channel. This commit updates the GKE conformance
workflow to use extended channel instead of regular, covering 1.30
& 1.31.

Also force the gcloud command to seek extended release channel.