### PR TITLE
verifier_diff: Reduce number of subdirs

### DIFF
--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -150,9 +150,9 @@ def plot_comparison(file1: str, file2: str, key: str, outdir: str):
                      f"{width}", va="center", ha="left", fontsize=8)
 
         plt.tight_layout()
-        build_dir = os.path.join(outdir, collection, f"build{build}")
-        os.makedirs(build_dir, exist_ok=True)
-        outfile = os.path.join(build_dir, f"states-load{load}.png")
+        collect_dir = os.path.join(outdir, collection)
+        os.makedirs(collect_dir, exist_ok=True)
+        outfile = os.path.join(collect_dir, f"states-build{build}-load{load}.png")
         plt.savefig(outfile)
         plt.close()
         logging.info(f"Saved plot: {outfile}")


### PR DESCRIPTION
This commit moves all the different build configuration to the same directory. It's probably a matter of opinion, but I find that more convenient because I can then just use the image viewer to navigate between all images for a given collection (ex., bpf_host) instead of having to switch directory 8 times.

Checking all build configurations for a given collection is usually my first task, before diving into those that look unexpected.