### PR TITLE
ipam: Move IPAM API rate-limit flags into the operator IPAM cell

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -84,6 +84,8 @@ cilium-operator-alibabacloud hive [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -89,6 +89,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -91,6 +91,8 @@ cilium-operator-aws hive [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -96,6 +96,8 @@ cilium-operator-aws hive dot-graph [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -86,6 +86,8 @@ cilium-operator-azure hive [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -91,6 +91,8 @@ cilium-operator-azure hive dot-graph [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -83,6 +83,8 @@ cilium-operator-generic hive [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -88,6 +88,8 @@ cilium-operator-generic hive dot-graph [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -98,6 +98,8 @@ cilium-operator hive [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -103,6 +103,8 @@ cilium-operator hive dot-graph [flags]
       --kvstore-lease-ttl duration                                 Time-to-live for the KVstore lease. (default 15m0s)
       --kvstore-max-consecutive-quorum-errors uint                 Max acceptable kvstore consecutive quorum errors before recreating the etcd connection (default 2)
       --kvstore-opt stringToString                                 Key-value store options e.g. etcd.address=127.0.0.1:4001 (default [])
+      --limit-ipam-api-burst int                                   Upper burst limit when accessing external APIs (default 20)
+      --limit-ipam-api-qps float                                   Queries per second limit when accessing external IPAM APIs (default 4)
       --loadbalancer-l7 string                                     Enable L7 loadbalancer capabilities for services via L7 proxy. Applicable values: envoy
       --loadbalancer-l7-algorithm string                           Default LB algorithm for services that do not specify related annotation (default "round_robin")
       --loadbalancer-l7-ports strings                              List of service ports that will be automatically redirected to backend.

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -23,12 +23,6 @@ import (
 func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags := cmd.Flags()
 
-	flags.Int(operatorOption.IPAMAPIBurst, defaults.IPAMAPIBurst, "Upper burst limit when accessing external APIs")
-	option.BindEnv(vp, operatorOption.IPAMAPIBurst)
-
-	flags.Float64(operatorOption.IPAMAPIQPSLimit, defaults.IPAMAPIQPSLimit, "Queries per second limit when accessing external IPAM APIs")
-	option.BindEnv(vp, operatorOption.IPAMAPIQPSLimit)
-
 	flags.Var(option.NewMapOptions(&operatorOption.Config.IPAMSubnetsTags),
 		operatorOption.IPAMSubnetsTags, "Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag")
 	option.BindEnv(vp, operatorOption.IPAMSubnetsTags)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -54,12 +54,6 @@ const (
 
 	// IPAM options
 
-	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
-	IPAMAPIBurst = "limit-ipam-api-burst"
-
-	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
-	IPAMAPIQPSLimit = "limit-ipam-api-qps"
-
 	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
 	IPAMSubnetsIDs = "subnet-ids-filter"
 
@@ -246,12 +240,6 @@ type OperatorConfig struct {
 
 	// IPAM options
 
-	// IPAMAPIBurst is the burst value allowed when accessing external IPAM APIs
-	IPAMAPIBurst int
-
-	// IPAMAPIQPSLimit is the queries per second limit when accessing external IPAM APIs
-	IPAMAPIQPSLimit float64
-
 	// IPAMSubnetsIDs are optional subnets IDs used to filter subnets and interfaces listing
 	IPAMSubnetsIDs []string
 
@@ -362,11 +350,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 			c.CiliumK8sNamespace = option.Config.K8sNamespace
 		}
 	}
-
-	// IPAM options
-
-	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
-	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
 
 	// Gateways and Ingress
 	c.KubeProxyReplacement = vp.GetBool(KubeProxyReplacement)

--- a/operator/pkg/ipam/alibabacloud.go
+++ b/operator/pkg/ipam/alibabacloud.go
@@ -70,6 +70,8 @@ func startAlibabaAllocator(p alibabaParams) {
 		AlibabaCloudVPCID:            p.AlibabaCfg.AlibabaCloudVPCID,
 		AlibabaCloudReleaseExcessIPs: p.AlibabaCfg.AlibabaCloudReleaseExcessIPs,
 		ParallelAllocWorkers:         p.Cfg.ParallelAllocWorkers,
+		LimitIPAMAPIBurst:            p.Cfg.LimitIPAMAPIBurst,
+		LimitIPAMAPIQPS:              p.Cfg.LimitIPAMAPIQPS,
 	}
 
 	p.Lifecycle.Append(

--- a/operator/pkg/ipam/aws.go
+++ b/operator/pkg/ipam/aws.go
@@ -102,6 +102,8 @@ func startAWSAllocator(p awsParams) {
 		EC2APIEndpoint:               p.AwsCfg.EC2APIEndpoint,
 		AWSMaxResultsPerCall:         p.AwsCfg.AWSMaxResultsPerCall,
 		ParallelAllocWorkers:         p.Cfg.ParallelAllocWorkers,
+		LimitIPAMAPIBurst:            p.Cfg.LimitIPAMAPIBurst,
+		LimitIPAMAPIQPS:              p.Cfg.LimitIPAMAPIQPS,
 	}
 
 	p.Lifecycle.Append(

--- a/operator/pkg/ipam/azure.go
+++ b/operator/pkg/ipam/azure.go
@@ -78,6 +78,8 @@ func startAzureAllocator(p azureParams) {
 		AzureUserAssignedIdentityID: p.AzureCfg.AzureUserAssignedIdentityID,
 		AzureUsePrimaryAddress:      p.AzureCfg.AzureUsePrimaryAddress,
 		ParallelAllocWorkers:        p.Cfg.ParallelAllocWorkers,
+		LimitIPAMAPIBurst:           p.Cfg.LimitIPAMAPIBurst,
+		LimitIPAMAPIQPS:             p.Cfg.LimitIPAMAPIQPS,
 	}
 
 	p.Lifecycle.Append(

--- a/operator/pkg/ipam/cell.go
+++ b/operator/pkg/ipam/cell.go
@@ -28,14 +28,20 @@ func Cell() cell.Cell {
 
 type Config struct {
 	ParallelAllocWorkers int64
+	LimitIPAMAPIBurst    int
+	LimitIPAMAPIQPS      float64
 }
 
 var defaultConfig = Config{
 	ParallelAllocWorkers: 50,
+	LimitIPAMAPIBurst:    20,
+	LimitIPAMAPIQPS:      4.0,
 }
 
 func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.Int64(option.ParallelAllocWorkers, defaultConfig.ParallelAllocWorkers, "Maximum number of parallel IPAM workers")
+	flags.Int("limit-ipam-api-burst", defaultConfig.LimitIPAMAPIBurst, "Upper burst limit when accessing external APIs")
+	flags.Float64("limit-ipam-api-qps", defaultConfig.LimitIPAMAPIQPS, "Queries per second limit when accessing external IPAM APIs")
 }
 
 type nodeWatcherJobFactory func(nm allocator.NodeEventHandler) job.Job

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -367,12 +367,6 @@ const (
 	// AWSResultsPerApiCall is the maximum number of objects to fetch per paginated API call
 	AWSResultsPerApiCall = 1000
 
-	// IPAMAPIBurst is the default burst value when rate limiting access to external APIs
-	IPAMAPIBurst = 20
-
-	// IPAMAPIQPSLimit is the default QPS limit when rate limiting access to external APIs
-	IPAMAPIQPSLimit = 4.0
-
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource = true

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -35,6 +35,8 @@ type AllocatorAlibabaCloud struct {
 	AlibabaCloudVPCID            string
 	AlibabaCloudReleaseExcessIPs bool
 	ParallelAllocWorkers         int64
+	LimitIPAMAPIBurst            int
+	LimitIPAMAPIQPS              float64
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -84,8 +86,8 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, r
 	vpcClient.GetConfig().WithScheme("HTTPS")
 	ecsClient.GetConfig().WithScheme("HTTPS")
 
-	a.client = openapi.NewClient(vpcClient, ecsClient, aMetrics, operatorOption.Config.IPAMAPIQPSLimit,
-		operatorOption.Config.IPAMAPIBurst, operatorOption.Config.IPAMInstanceTags)
+	a.client = openapi.NewClient(vpcClient, ecsClient, aMetrics, a.LimitIPAMAPIQPS,
+		a.LimitIPAMAPIBurst, operatorOption.Config.IPAMInstanceTags)
 
 	if err := limits.UpdateFromAPI(ctx, a.client); err != nil {
 		return fmt.Errorf("unable to update instance type to adapter limits from AlibabaCloud API: %w", err)

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -40,6 +40,8 @@ type AllocatorAWS struct {
 	EC2APIEndpoint               string
 	AWSMaxResultsPerCall         int32
 	ParallelAllocWorkers         int64
+	LimitIPAMAPIBurst            int
+	LimitIPAMAPIQPS              float64
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -121,8 +123,8 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, reg *metri
 		}
 	}
 
-	a.client = ec2shim.NewClient(a.rootLogger, ec2.NewFromConfig(cfg, optionsFunc), aMetrics, operatorOption.Config.IPAMAPIQPSLimit,
-		operatorOption.Config.IPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags,
+	a.client = ec2shim.NewClient(a.rootLogger, ec2.NewFromConfig(cfg, optionsFunc), aMetrics, a.LimitIPAMAPIQPS,
+		a.LimitIPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags,
 		a.AWSUsePrimaryAddress, a.AWSMaxResultsPerCall)
 
 	return nil

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -26,6 +26,8 @@ type AllocatorAzure struct {
 	AzureUserAssignedIdentityID string
 	AzureUsePrimaryAddress      bool
 	ParallelAllocWorkers        int64
+	LimitIPAMAPIBurst           int
+	LimitIPAMAPIQPS             float64
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -84,7 +86,7 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNod
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}
 
-	azureClient, err := azureAPI.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, azMetrics, operatorOption.Config.IPAMAPIQPSLimit, operatorOption.Config.IPAMAPIBurst, a.AzureUsePrimaryAddress)
+	azureClient, err := azureAPI.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, azMetrics, a.LimitIPAMAPIQPS, a.LimitIPAMAPIBurst, a.AzureUsePrimaryAddress)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}


### PR DESCRIPTION
`limit-ipam-api-burst` and `limit-ipam-api-qps` were registered in the global `InitGlobalFlags` and stored in `OperatorConfig`, but they are exclusively consumed by the cloud-provider IPAM allocators. Now that those allocators have proper hive cells, move the flags into the base IPAM cell config so they are owned and registered where they are used.