### PR TITLE
Refactor double negatives in bgp/clustermesh/ipam testcase

### DIFF
--- a/operator/pkg/bgp/cluster_test.go
+++ b/operator/pkg/bgp/cluster_test.go
@@ -858,7 +858,8 @@ func TestClusterConfigConditions(t *testing.T) {
 			require.EventuallyWithT(t, func(ct *assert.CollectT) {
 				// Check conditions
 				cc, err := f.bgpcClient.Get(ctx, clusterConfigName, meta_v1.GetOptions{})
-				if !assert.NoError(ct, err, "Cannot get cluster config") {
+				if err != nil {
+					ct.Errorf("failed to get cluster config: %v", err)
 					return
 				}
 
@@ -1114,7 +1115,8 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 
 			require.EventuallyWithT(t, func(ct *assert.CollectT) {
 				configs, err := f.bgpcClient.List(ctx, meta_v1.ListOptions{})
-				if !assert.NoError(ct, err, "Cannot list cluster configs") {
+				if err != nil {
+					ct.Errorf("failed to list cluster configs: %v", err)
 					return
 				}
 
@@ -1129,7 +1131,8 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 						config.Status.Conditions,
 						v2.BGPClusterConfigConditionConflictingClusterConfigs,
 					)
-					if !assert.NotNil(ct, cond, "Condition not found") {
+					if cond == nil {
+						ct.Errorf("condition not found")
 						return
 					}
 
@@ -1147,7 +1150,8 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 					expr, err := regexp.Compile(
 						`Selecting the same node\(s\) with ClusterConfig\(s\): \[(.*)\]`,
 					)
-					if !assert.NoError(ct, err, "Error during regexp match") {
+					if err != nil {
+						ct.Errorf("failed to compile regexp: %v", err)
 						return
 					}
 
@@ -1226,7 +1230,8 @@ func TestDisableClusterConfigStatusReport(t *testing.T) {
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Check conditions
 		cc, err := f.bgpcClient.Get(ctx, clusterConfig.Name, meta_v1.GetOptions{})
-		if !assert.NoError(ct, err, "Cannot get cluster config") {
+		if err != nil {
+			ct.Errorf("failed to get cluster config: %v", err)
 			return
 		}
 
@@ -1547,10 +1552,10 @@ func TestRouterIDAllocation(t *testing.T) {
 				// we can't guarantee the order of the router IDs so we use a map to compare
 				InitNodesRouterIDs := make(map[string]struct{})
 				nodeConfigs, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
-				if !assert.NoError(c, err) {
+				if err != nil {
 					return
 				}
-				if !assert.NotNil(c, nodeConfigs) {
+				if nodeConfigs == nil {
 					return
 				}
 
@@ -1575,13 +1580,13 @@ func TestRouterIDAllocation(t *testing.T) {
 				// version even after receiving an event for the new version.
 				if tt.FinalClusterConfigs != nil {
 					for _, clusterConfig := range tt.FinalClusterConfigs {
-						if err := upsertBGPCC(ctx, f, clusterConfig); !assert.NoError(c, err) {
+						if err := upsertBGPCC(ctx, f, clusterConfig); err != nil {
 							return
 						}
 					}
 				}
 				NodeConfigs, err := f.bgpnClient.List(ctx, meta_v1.ListOptions{})
-				if !assert.NoError(c, err) {
+				if err != nil {
 					return
 				}
 				if !assert.Len(c, NodeConfigs.Items, len(tt.FinalExpectedNodeInstances)) {

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -224,7 +224,8 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 				pc, exists, err := peerConfigStore.GetByKey(resource.Key{
 					Name: peerConfigName,
 				})
-				if !assert.NoError(ct, err, "Failed to get peer config") {
+				if err != nil {
+					ct.Errorf("failed to get peer config: %v", err)
 					return
 				}
 				if !assert.True(ct, exists, "Peer config not found") {
@@ -234,7 +235,8 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 					pc.Status.Conditions,
 					v2.BGPPeerConfigConditionMissingAuthSecret,
 				)
-				if !assert.NotNil(ct, cond, "Condition not found") {
+				if cond == nil {
+					ct.Errorf("condition not found")
 					return
 				}
 				assert.Equal(ct, tt.expectedState, cond.Status, "Unexpected condition status")
@@ -291,7 +293,8 @@ func TestDisablePeerConfigStatusReport(t *testing.T) {
 		pc, exists, err := peerConfigStore.GetByKey(resource.Key{
 			Name: peerConfig.Name,
 		})
-		if !assert.NoError(ct, err, "Failed to get peer config") {
+		if err != nil {
+			ct.Errorf("failed to get peer config: %v", err)
 			return
 		}
 		if !assert.True(ct, exists, "Peer config not found") {

--- a/operator/pkg/ipam/podcidroverlap_test.go
+++ b/operator/pkg/ipam/podcidroverlap_test.go
@@ -101,14 +101,16 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		// Get node A from the mock APIServer
 		nodeAInt, err := fakeSet.CiliumFakeClientset.Tracker().Get(ciliumnodesResource, "", "node-a")
-		if !assert.NoError(c, err) {
+		if err != nil {
+			c.Errorf("failed to get node A: %v", err)
 			return
 		}
 		nodeA := nodeAInt.(*cilium_api_v2.CiliumNode)
 
 		// Get node B from the mock APIServer
 		nodeBInt, err := fakeSet.CiliumFakeClientset.Tracker().Get(ciliumnodesResource, "", "node-b")
-		if !assert.NoError(c, err) {
+		if err != nil {
+			c.Errorf("failed to get node B: %v", err)
 			return
 		}
 		nodeB := nodeBInt.(*cilium_api_v2.CiliumNode)

--- a/pkg/bgp/manager/reconciler/crd_status_test.go
+++ b/pkg/bgp/manager/reconciler/crd_status_test.go
@@ -324,7 +324,8 @@ func TestCRDConditions(t *testing.T) {
 			// check eventually the conditions are updated
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				nodeConfig, err := f.bgpnClient.Get(ctx, "node0", metav1.GetOptions{})
-				if !assert.NoError(c, err) {
+				if err != nil {
+					c.Errorf("failed to get node config: %v", err)
 					return
 				}
 				if !assert.Len(c, nodeConfig.Status.Conditions, len(tt.expectedNodeConfig.Status.Conditions)) {
@@ -421,7 +422,8 @@ func TestDisableStatusReport(t *testing.T) {
 	// Wait for status to be cleared
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		nc, err := cs.CiliumV2().CiliumBGPNodeConfigs().Get(ctx, "node0", metav1.GetOptions{})
-		if !assert.NoError(ct, err) {
+		if err != nil {
+			ct.Errorf("failed to get node config: %v", err)
 			return
 		}
 		// The status should be cleared to empty

--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -174,7 +174,8 @@ func TestClusterMesh(t *testing.T) {
 	writeFile(t, path("cluster4"), data)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		sf, _ := statuses.Load("cluster4")
-		if !assert.NotNil(c, sf, "The status function for cluster4 should have been registered") {
+		if sf == nil {
+			c.Errorf("status function for cluster4 is nil")
 			return
 		}
 


### PR DESCRIPTION
see the commit message


```release-note
Refactor double negatives in bgp/clustermesh/ipam testcase
```
