### PR TITLE
allocator: handle unlikely goroutine leak

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -355,6 +355,8 @@ func (a *Allocator) start() {
 		go func() {
 			select {
 			case <-a.initialListDone:
+			case <-a.stopGC:
+				return
 			case <-time.After(option.Config.AllocatorListTimeout):
 				logging.Fatal(a.logger, "Timeout while waiting for initial allocator state")
 			}


### PR DESCRIPTION
In the unlikely case that the allocator is stopped before the initial list is complete, don't leak the initial goroutine. This happens occasionaly when running on resource-constrained systems and is detected by goleak.
