### PR TITLE
policy: Add allow localhost rule to ingress rules

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -838,14 +838,6 @@ func (l4 *L4Filter) GetRuleLabels(cs CachedSelector) labels.LabelArrayList {
 	return nil
 }
 
-func (l4 *L4Filter) cacheIdentitySelector(sel api.EndpointSelector, selectorCache *SelectorCache) CachedSelector {
-	cs, added := selectorCache.AddIdentitySelectorForTest(l4, sel)
-	if added {
-		l4.PerSelectorPolicies[cs] = nil // no per-selector policy (yet)
-	}
-	return cs
-}
-
 // add L7 rules for all endpoints in the L7DataMap
 func (l7 L7DataMap) addPolicyForSelector(l7Parser L7ParserType, rules *api.L7Rules, terminatingTLS, originatingTLS *TLSContext, auth *api.Authentication, verdict types.Verdict, sni []string, listener string, listenerPriority ListenerPriority, priority types.Priority) {
 	for epsel := range l7 {
@@ -1114,16 +1106,6 @@ func (l4 *L4Filter) attach(ctx PolicyContext, l4Policy *L4Policy) (policyFeature
 
 	for cs, sp := range l4.PerSelectorPolicies {
 		if sp != nil {
-			// Allow localhost if requested and this is a redirect that selects the host
-			if ctx.AllowLocalhost() && l4.Ingress && sp.IsRedirect() && cs.Selects(identity.ReservedIdentityHost) {
-				// Make sure host selector is in the selector cache.
-				host := api.ReservedEndpointSelectors[labels.IDNameHost]
-				// Add the cached host selector to the PerSelectorPolicies, if not
-				// already there. Use empty string labels due to this selector being
-				// added due to agent config rather than any specific rule.
-				l4.cacheIdentitySelector(host, ctx.GetSelectorCache())
-			}
-
 			// collect redirect types (if any)
 			redirectTypes |= sp.redirectType()
 
@@ -1271,6 +1253,7 @@ func (ls L4PolicyMaps) Filters() iter.Seq[*L4Filter] {
 
 // NewL4PolicyMapWithValues creates an new L4PolicMap, with an initial
 // set of values. The initMap argument does not support port ranges.
+// Only used for testing but from multiple packages.
 func NewL4PolicyMapWithValues(initMap map[string]*L4Filter) L4PolicyMaps {
 	l4M := L4PolicyMaps{makeL4PolicyMap()}
 	for k, v := range initMap {

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -397,10 +397,6 @@ type testPolicyContextType struct {
 	logger             *slog.Logger
 }
 
-func (p *testPolicyContextType) AllowLocalhost() bool {
-	return option.Config.AlwaysAllowLocalhost()
-}
-
 func (p *testPolicyContextType) GetNamespace() string {
 	return p.ns
 }
@@ -2321,25 +2317,34 @@ func TestAllowingLocalhostShadowsL7(t *testing.T) {
 		},
 	}
 
-	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
-		Port:     80,
-		Protocol: api.ProtoTCP,
-		U8Proto:  6,
-		wildcard: td.wildcardCachedSelector,
-		PerSelectorPolicies: L7DataMap{
-			td.wildcardCachedSelector: &PerSelectorPolicy{
-				Verdict:          types.Allow,
-				L7Parser:         ParserTypeHTTP,
-				ListenerPriority: ListenerPriorityHTTP,
-				L7Rules: api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{
+		api.PortProtocolAny: {
+			Tier:     types.DefaultPolicy,
+			Protocol: api.ProtoAny,
+			Ingress:  true,
+			PerSelectorPolicies: L7DataMap{
+				td.cachedSelectorHost: &PerSelectorPolicy{Priority: 10},
+			},
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorHost: {LabelsLocalHostIngress}}),
+		},
+		"80/TCP": {
+			Port:     80,
+			Protocol: api.ProtoTCP,
+			U8Proto:  6,
+			wildcard: td.wildcardCachedSelector,
+			PerSelectorPolicies: L7DataMap{
+				td.wildcardCachedSelector: &PerSelectorPolicy{
+					Verdict:          types.Allow,
+					L7Parser:         ParserTypeHTTP,
+					ListenerPriority: ListenerPriorityHTTP,
+					L7Rules: api.L7Rules{
+						HTTP: []api.PortRuleHTTP{{Path: "/", Method: "GET"}},
+					},
 				},
 			},
-			td.cachedSelectorHost: nil, // no proxy redirect
-		},
-		Ingress:    true,
-		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
-	}})
+			Ingress:    true,
+			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
+		}})
 
 	td.policyMapEquals(t, expected, nil, &rule)
 }
@@ -2451,12 +2456,11 @@ func TestDNSWildcardInDefaultAllow(t *testing.T) {
 		},
 		// L3 wildcard rule is also added
 		"0/ANY": {
-			Port:     0,
+			Tier:     types.DefaultPolicy,
 			Protocol: api.ProtoAny,
-			U8Proto:  0,
 			wildcard: td.wildcardCachedSelector,
 			PerSelectorPolicies: L7DataMap{
-				td.wildcardCachedSelector: nil,
+				td.wildcardCachedSelector: &PerSelectorPolicy{Priority: 10},
 			},
 			Ingress:    false,
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {LabelsAllowAnyEgress}}),
@@ -2521,12 +2525,11 @@ func TestHTTPWildcardInDefaultAllow(t *testing.T) {
 		},
 		// L3 wildcard rule is also added
 		"0/ANY": {
-			Port:     0,
+			Tier:     types.DefaultPolicy,
 			Protocol: api.ProtoAny,
-			U8Proto:  0,
 			wildcard: td.wildcardCachedSelector,
 			PerSelectorPolicies: L7DataMap{
-				td.wildcardCachedSelector: nil,
+				td.wildcardCachedSelector: &PerSelectorPolicy{Priority: 10},
 			},
 			Ingress:    true,
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {LabelsAllowAnyIngress}}),
@@ -2590,12 +2593,11 @@ func TestDNSWildcardWithL3FilterInDefaultAllow(t *testing.T) {
 		},
 		// L3 wildcard rule is also added
 		"0/ANY": {
-			Port:     0,
+			Tier:     types.DefaultPolicy,
 			Protocol: api.ProtoAny,
-			U8Proto:  0,
 			wildcard: td.wildcardCachedSelector,
 			PerSelectorPolicies: L7DataMap{
-				td.wildcardCachedSelector: nil,
+				td.wildcardCachedSelector: &PerSelectorPolicy{Priority: 10},
 			},
 			Ingress:    false,
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {LabelsAllowAnyEgress}}),

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
@@ -50,8 +49,6 @@ func KeyForDirection(direction trafficdirection.TrafficDirection) Key {
 }
 
 var (
-	// localHostKey represents an ingress L3 allow from the local host.
-	localHostKey = IngressKey().WithIdentity(identity.ReservedIdentityHost)
 	// allKey represents a key for unknown traffic, i.e., all traffic.
 	// We have one for each traffic direction
 	allKey = [2]Key{
@@ -1578,17 +1575,6 @@ func (changes *ChangeState) insertOldIfNotExists(key Key, entry mapStateEntry) b
 		}
 	}
 	return false
-}
-
-// determineAllowLocalhostIngress determines whether communication should be allowed
-// from the localhost. It inserts the Key corresponding to the localhost in
-// the desiredPolicyKeys if the localhost is allowed to communicate with the
-// endpoint. Authentication for localhost traffic is not required.
-func (ms *mapState) determineAllowLocalhostIngress(features policyFeatures) {
-	if option.Config.AlwaysAllowLocalhost() {
-		entry := newAllowEntryWithLabels(LabelsLocalHostIngress)
-		ms.insertWithChanges(types.Priority(0).ToTierMaxPrecedence(), localHostKey, entry, features, ChangeState{})
-	}
 }
 
 // allowAllIdentities translates all identities in selectorCache to their

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -465,75 +465,68 @@ func (p *Repository) computePolicyEnforcementAndRules(securityIdentity *identity
 	// Insert a wildcard rule if there are any ingress rules
 	if len(rulesIngress) > 0 {
 		if !hasIngressDefaultDeny {
-			defaultRule := rulesIngress.wildcardRule(securityIdentity, LabelsAllowAnyIngress, types.Allow, hasIngressPassVerdict)
+			rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyIngress, types.Allow)
 			p.logger.Debug("Only default-allow policies, synthesizing ingress wildcard-allow rule",
 				logfields.Identity, securityIdentity,
-				logfields.Tier, defaultRule.Tier,
-				logfields.Priority, defaultRule.Priority,
 			)
-			rulesIngress = append(rulesIngress, defaultRule)
-		} else if hasIngressPassVerdict {
-			// Explicit default deny is only needed for PASS verdict compatibility
-			defaultRule := rulesIngress.wildcardRule(securityIdentity, LabelsDenyAnyIngress, types.Deny, hasIngressPassVerdict)
-			p.logger.Debug("Only default-deny policies, synthesizing ingress wildcard-deny rule",
-				logfields.Identity, securityIdentity,
-				logfields.Tier, defaultRule.Tier,
-				logfields.Priority, defaultRule.Priority,
-			)
-			rulesIngress = append(rulesIngress, defaultRule)
+		} else {
+			// insert localhost allow for k8s if the policy subject is not the host
+			if option.Config.AlwaysAllowLocalhost() && securityIdentity.ID != identity.ReservedIdentityHost {
+				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.HostSelectors, LabelsLocalHostIngress, types.Allow)
+				p.logger.Debug("Localhost allowed for k8s, synthesizing ingress host-allow rule",
+					logfields.Identity, securityIdentity,
+				)
+			}
+			if hasIngressPassVerdict {
+				// Explicit default deny is only needed for PASS verdict compatibility
+				rulesIngress = rulesIngress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyIngress, types.Deny)
+				p.logger.Debug("Only default-deny policies, synthesizing ingress wildcard-deny rule",
+					logfields.Identity, securityIdentity,
+				)
+			}
 		}
 	}
 
 	// Same for egress -- synthesize a wildcard rule
 	if len(rulesEgress) > 0 {
 		if !hasEgressDefaultDeny {
-			defaultRule := rulesEgress.wildcardRule(securityIdentity, LabelsAllowAnyEgress, types.Allow, hasEgressPassVerdict)
+			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsAllowAnyEgress, types.Allow)
 			p.logger.Debug("Only default-allow policies, synthesizing egress wildcard-allow rule",
 				logfields.Identity, securityIdentity,
-				logfields.Tier, defaultRule.Tier,
-				logfields.Priority, defaultRule.Priority,
 			)
-			rulesEgress = append(rulesEgress, defaultRule)
 		} else if hasEgressPassVerdict {
 			// Explicit default deny is only needed for PASS verdict compatibility
-			defaultRule := rulesEgress.wildcardRule(securityIdentity, LabelsDenyAnyEgress, types.Deny, hasEgressPassVerdict)
+			rulesEgress = rulesEgress.addDefaultRule(securityIdentity, types.WildcardSelectors, LabelsDenyAnyEgress, types.Deny)
 			p.logger.Debug("Only default-deny policies, synthesizing egress wildcard-deny rule",
 				logfields.Identity, securityIdentity,
-				logfields.Tier, defaultRule.Tier,
-				logfields.Priority, defaultRule.Priority,
 			)
-			rulesEgress = append(rulesEgress, defaultRule)
 		}
 	}
 
 	return
 }
 
-// wildcardRule generates a wildcard rule that only selects the given subject identity.
-func (rules ruleSlice) wildcardRule(subject *identity.Identity, lbls labels.LabelArray, verdict types.Verdict, hasPassVerdict bool) *rule {
-	// User the lowest tier and priority
+// addDefaultRule appends a default policy tier wildcard rule that only selects the given subject
+// identity.
+func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Selectors, lbls labels.LabelArray, verdict types.Verdict) ruleSlice {
+	var priority float64
 	lastRule := rules[len(rules)-1]
-	ingress := lastRule.Ingress
-	tier, priority := lastRule.Tier, lastRule.Priority
-
-	// Keep the tier and priority as zeroes for backwards compatibility if the last rule
-	// is at tier and priority 0.
-	if hasPassVerdict || tier > 0 || priority > 0 {
-		tier++
-		priority = 0
+	if lastRule.Tier == types.DefaultPolicy {
+		priority = lastRule.Priority + 1
 	}
+	ingress := lastRule.Ingress
 
-	return &rule{
+	return append(rules, &rule{
 		PolicyEntry: types.PolicyEntry{
-			Tier:     tier,
+			Tier:     types.DefaultPolicy,
 			Priority: priority,
 			Verdict:  verdict,
 			Ingress:  ingress,
 			Subject:  types.NewLabelSelectorFromLabels(subject.LabelArray...),
-			L3:       types.WildcardSelectors,
+			L3:       peers,
 			Labels:   lbls,
 		},
-	}
+	})
 }
 
 // GetSelectorPolicy computes the SelectorPolicy for a given identity.

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/time"
@@ -26,10 +25,6 @@ import (
 // PolicyContext is an interface policy resolution functions use to access the Repository.
 // This way testing code can run without mocking a full Repository.
 type PolicyContext interface {
-	// AllowLocalhost returns true if policy should allow ingress from local host.
-	// Always returns false for egress.
-	AllowLocalhost() bool
-
 	// return the namespace in which the policy rule is being resolved
 	GetNamespace() string
 
@@ -89,10 +84,6 @@ type policyContext struct {
 }
 
 var _ PolicyContext = &policyContext{}
-
-func (p *policyContext) AllowLocalhost() bool {
-	return option.Config.AlwaysAllowLocalhost()
-}
 
 // GetNamespace() returns the namespace for the policy rule being resolved
 func (p *policyContext) GetNamespace() string {
@@ -360,10 +351,6 @@ func (p *selectorPolicy) DistillPolicy(logger *slog.Logger, policyOwner PolicyOw
 	// after the computation of PolicyMapState has started.
 	p.L4Policy.Ingress.toMapState(logger, calculatedPolicy)
 	p.L4Policy.Egress.toMapState(logger, calculatedPolicy)
-
-	if !policyOwner.IsHost() {
-		calculatedPolicy.policyMapState.determineAllowLocalhostIngress(p.L4Policy.Ingress.features)
-	}
 
 	return calculatedPolicy
 }

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -321,9 +321,6 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 	policy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
 	policy.Ready()
 
-	cachedSelectorHost := td.sc.findCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
-	require.NotNil(t, cachedSelectorHost)
-
 	expectedEndpointPolicy := EndpointPolicy{
 		SelectorPolicy: &selectorPolicy{
 			Revision:      repo.GetRevision(),
@@ -331,6 +328,18 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
+					api.PortProtocolAny: {
+						Tier:     types.DefaultPolicy,
+						Protocol: api.ProtoAny,
+						Ingress:  true,
+						PerSelectorPolicies: L7DataMap{
+							td.cachedSelectorHost: &PerSelectorPolicy{
+								Verdict:  types.Allow,
+								Priority: 10,
+							},
+						},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorHost: {nil}}),
+					},
 					"80/TCP": {
 						Tier:     types.Normal,
 						Port:     80,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -594,9 +594,6 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, testRedirects)
 	policy.Ready()
 
-	cachedSelectorHost := td.sc.findCachedIdentitySelector(api.ReservedEndpointSelectors[labels.IDNameHost])
-	require.NotNil(t, cachedSelectorHost)
-
 	expectedEndpointPolicy := EndpointPolicy{
 		Redirects: testRedirects,
 		SelectorPolicy: &selectorPolicy{
@@ -605,6 +602,18 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 			L4Policy: L4Policy{
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
+					api.PortProtocolAny: {
+						Tier:     types.DefaultPolicy,
+						Protocol: api.ProtoAny,
+						Ingress:  true,
+						PerSelectorPolicies: L7DataMap{
+							td.cachedSelectorHost: &PerSelectorPolicy{
+								Verdict:  types.Allow,
+								Priority: 10,
+							},
+						},
+						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorHost: {nil}}),
+					},
 					"80/TCP": {
 						Tier:     types.Normal,
 						Port:     80,
@@ -612,7 +621,6 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 						U8Proto:  0x6,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
-							cachedSelectorHost: nil,
 							td.wildcardCachedSelector: &PerSelectorPolicy{
 								Verdict:          types.Allow,
 								L7Parser:         ParserTypeHTTP,

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -18,6 +18,7 @@ var ErrTooManyPriorityLevels = errors.New("endpoint policy direction has more th
 // ErrUnorderedTiers is returned if tiers of policy entries are unordered when they are expected to
 // be ordered.
 var ErrUnorderedTiers = errors.New("Unordered policy entry tiers")
+var ErrInvalidTier = errors.New("Too high tier value")
 
 // ErrUnorderedRules is returned if prioritites of policy entries are unordered when they are
 // expected to be ordered.
@@ -53,8 +54,11 @@ func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) 
 
 	for _, r := range rules {
 		if r.Tier != lastTier {
-			if r.Tier < lastTier || r.Tier >= types.Tier(nTiers) {
+			if r.Tier < lastTier {
 				return nil, nil, ErrUnorderedTiers
+			}
+			if int(r.Tier) >= nTiers {
+				return nil, nil, ErrInvalidTier
 			}
 			// Keep the needed priority levels for the previous tier,
 			// rounding up to next 10 to reduce policy map churn.

--- a/pkg/policy/types/policyentry.go
+++ b/pkg/policy/types/policyentry.go
@@ -11,10 +11,11 @@ import (
 type Tier uint8
 
 const (
-	TierUnspec Tier = 0
-	Admin      Tier = 100
-	Normal     Tier = 200
-	Baseline   Tier = 250
+	TierUnspec    Tier = 0
+	Admin         Tier = 100
+	Normal        Tier = 200
+	Baseline      Tier = 250
+	DefaultPolicy Tier = 255 // reserved for Cilium internal use
 )
 
 type Verdict uint8

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -33,6 +33,8 @@ type APISelector interface {
 var (
 	WildcardSelector  = NewLabelSelectorFromLabels()
 	WildcardSelectors = Selectors{WildcardSelector}
+	HostSelector      = NewLabelSelector(api.ReservedEndpointSelectors[labels.IDNameHost])
+	HostSelectors     = Selectors{HostSelector}
 )
 
 // Selectors is a slice of Selectors.


### PR DESCRIPTION
Add a new predefined Tier "DefaultPolicy" (255), only to be used for Cilium internal default allow or default deny rules.

Add allow local host rule to the ingress rules right before the possible default deny rule, on the same tier, but previous priority. This way the allow localhost rule gets the correct tier and priority.

Remove patching localhost allow to the L4Filter or mapstate directly.

This fixes the problem where the allow localhost rule was patched into L4Filter with a redirect with a priority outside of the range for the tier. Now that the localhost allow rule is at the lowest priority, just before default deny, higher priority rules can add e.g., HTTP ingress policies for traffic from the host without being overridden by the previously highest-priority allow rule.

Note that before the introduction of tier and rule priorities, both the localhost allow entry and possible HTTP allow rules were on the same priority (0) where the plain allow does not override HTTP allow rules. Thus this commit fixes a regression introduced by the addition of rule priorities and tiers. This regression only became apparent after the normal rules were changed to non-zero tier by default.

Higher precedence deny rules can still override the default allow localhost rule like before, as deny on the same priority level takes precedence over allow rules.

Fixes: #42896
