### PR TITLE
[v1.18] envoy: Cancel Network Policy completions on last proxy listener removal

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -94,6 +94,12 @@ type AckingResourceMutator interface {
 	// A call to the returned revert function reverts the effects of this
 	// method call.
 	Delete(typeURL string, resourceName string, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc
+
+	// CancelCompletions completes all pending completions on the given TypeURL.
+	// Called only when it is known that the TypeURL client has stopped processing updates.
+	// Completions are completed without an error, as the resource updater can not react in
+	// any way to the resource client going away.
+	CancelCompletions(typeURL string)
 }
 
 // AckingResourceMutatorWrapper is an AckingResourceMutator which wraps a
@@ -259,6 +265,43 @@ func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
 		close(ch)
 	}
 	delete(m.ackedNodes, nodeID)
+}
+
+func (m *AckingResourceMutatorWrapper) CancelCompletions(typeURL string) {
+	scopedLogger := m.logger.With(
+		logfields.XDSTypeURL, typeURL,
+	)
+
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	remainingCompletions := make(map[*completion.Completion]*pendingCompletion, len(m.pendingCompletions))
+
+	for comp, pending := range m.pendingCompletions {
+		if comp.Err() != nil {
+			// Completion was canceled or timed out.
+			// Remove from pending list.
+			scopedLogger.Debug(
+				"completion context was canceled",
+				logfields.PendingCompletions, pending,
+			)
+			continue
+		}
+
+		if pending.typeURL == typeURL {
+			clear(pending.remainingNodesResources)
+			m.metrics.IncreaseCancel(typeURL)
+			scopedLogger.Debug("completing cancel",
+				logfields.WaitVersion, pending.version)
+			comp.Complete(nil)
+			continue
+		}
+
+		// Completion didn't match. Keep it in the pending list.
+		remainingCompletions[comp] = pending
+	}
+
+	m.pendingCompletions = remainingCompletions
 }
 
 func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc {

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -98,40 +98,45 @@ func TestUpsertSingleNode(t *testing.T) {
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback)
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Empty(t, acker.ackedVersions)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from another node.
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 1)
 	require.Equal(t, uint64(2), acker.ackedVersions[node1])
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for another resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[1].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUseCurrent(t *testing.T) {
@@ -153,8 +158,9 @@ func TestUseCurrent(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Empty(t, acker.ackedVersions)
 	require.Len(t, acker.pendingCompletions, 1)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from another node.
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -162,8 +168,9 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.ackedVersions, 1)
 	require.Equal(t, uint64(2), acker.ackedVersions[node1])
 	require.Len(t, acker.pendingCompletions, 1)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Use current version, not yet acked
 	acker.UseCurrent(typeURL, []string{node0}, wg)
@@ -176,8 +183,9 @@ func TestUseCurrent(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	// UseCurrent ignores resource names, so an ack of the same or later version from the right node will complete it
 	require.Len(t, acker.pendingCompletions, 1)
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
@@ -192,8 +200,57 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	require.Empty(t, acker.pendingCompletions)
-	require.Equal(t, 2, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
+}
+
+func TestCancelCompletions(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	typeURL1 := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	typeURL2 := "type.googleapis.com/envoy.config.v3.AnotherConfiguration"
+	wg := completion.NewWaitGroup(ctx)
+	metrics := newMockMetrics()
+
+	cache := NewCache(logger)
+	acker := NewAckingResourceMutatorWrapper(logger, cache, metrics)
+	require.Empty(t, acker.ackedVersions)
+
+	// Add one pending completion for each type.
+	callback1, comp1 := newCompCallback(logger)
+	acker.Upsert(typeURL1, resources[0].Name, resources[0], []string{node0}, wg, callback1)
+	require.Condition(t, isNotCompletedComparison(comp1))
+
+	callback2, comp2 := newCompCallback(logger)
+	acker.Upsert(typeURL2, resources[1].Name, resources[1], []string{node0}, wg, callback2)
+	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Len(t, acker.pendingCompletions, 2)
+
+	// Cancel only the first type URL.
+	acker.CancelCompletions(typeURL1)
+	require.Condition(t, completedComparison(comp1))
+	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Len(t, acker.pendingCompletions, 1)
+	require.Equal(t, 0, metrics.ack[typeURL1])
+	require.Equal(t, 0, metrics.nack[typeURL1])
+	require.Equal(t, 1, metrics.cancel[typeURL1])
+	require.Equal(t, 0, metrics.ack[typeURL2])
+	require.Equal(t, 0, metrics.nack[typeURL2])
+	require.Equal(t, 0, metrics.cancel[typeURL2])
+
+	// Verify the other type still completes via ACK.
+	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[1].Name}, typeURL2, "")
+	require.Condition(t, completedComparison(comp2))
+	require.Empty(t, acker.pendingCompletions)
+	require.Equal(t, 0, metrics.ack[typeURL1])
+	require.Equal(t, 0, metrics.nack[typeURL1])
+	require.Equal(t, 1, metrics.cancel[typeURL1])
+	require.Equal(t, 1, metrics.ack[typeURL2])
+	require.Equal(t, 0, metrics.nack[typeURL2])
+	require.Equal(t, 0, metrics.cancel[typeURL2])
 }
 
 func TestUpsertMultipleNodes(t *testing.T) {
@@ -223,8 +280,9 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.False(t, acker.currentVersionAcked([]string{node0}))
 	require.False(t, acker.currentVersionAcked([]string{node1}))
 	require.True(t, acker.currentVersionAcked([]string{node2}))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from one of the nodes (node0).
 	// One of the nodes (node1) still needs to ACK.
@@ -235,8 +293,9 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node2}))
 	require.False(t, acker.currentVersionAcked([]string{node0, node1}))
 	require.True(t, acker.currentVersionAcked([]string{node0, node2}))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from the last remaining node (node1).
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -245,8 +304,9 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node1}))
 	require.True(t, acker.currentVersionAcked([]string{node2}))
 	require.True(t, acker.currentVersionAcked([]string{node0, node1, node2}))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUpsertMoreRecentVersion(t *testing.T) {
@@ -269,14 +329,16 @@ func TestUpsertMoreRecentVersion(t *testing.T) {
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack a more recent version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(123, 123, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUpsertMoreRecentVersionNack(t *testing.T) {
@@ -299,8 +361,9 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// NAck a more recent version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 2, node0, []string{resources[0].Name}, typeURL, "Detail")
@@ -308,8 +371,9 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Error(t, comp.Err())
 	require.EqualValues(t, &ProxyError{Err: ErrNackReceived, Detail: "Detail"}, comp.Err())
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestDeleteSingleNode(t *testing.T) {
@@ -332,8 +396,9 @@ func TestDeleteSingleNode(t *testing.T) {
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with no resources.
 	callback, comp = newCompCallback(logger)
@@ -343,15 +408,17 @@ func TestDeleteSingleNode(t *testing.T) {
 	// Ack the right version, for another resource, from another node.
 	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[2].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for another resource, from the right node.
 	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
 	// The resource name is ignored. For delete, we only consider the version.
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 2, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestDeleteMultipleNodes(t *testing.T) {
@@ -374,8 +441,9 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with no resources.
 	callback, comp = newCompCallback(logger)
@@ -385,15 +453,17 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	// Ack the right version, for another resource, from one of the nodes.
 	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[2].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for another resource, from the remaining node.
 	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
 	// The resource name is ignored. For delete, we only consider the version.
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 2, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestRevertInsert(t *testing.T) {
@@ -434,8 +504,9 @@ func TestRevertInsert(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestRevertUpdate(t *testing.T) {
@@ -483,8 +554,9 @@ func TestRevertUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestRevertDelete(t *testing.T) {
@@ -536,6 +608,7 @@ func TestRevertDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }

--- a/pkg/envoy/xds/metrics.go
+++ b/pkg/envoy/xds/metrics.go
@@ -9,16 +9,18 @@ import (
 )
 
 const (
-	subsystem       = "xds"
-	typeURLLabel    = "type_url"
-	statusLabel     = "status"
-	statusACKValue  = "ack"
-	statusNACKValue = "nack"
+	subsystem         = "xds"
+	typeURLLabel      = "type_url"
+	statusLabel       = "status"
+	statusACKValue    = "ack"
+	statusNACKValue   = "nack"
+	statusCancelValue = "cancel"
 )
 
 type Metrics interface {
 	IncreaseNACK(string)
 	IncreaseACK(string)
+	IncreaseCancel(string)
 }
 
 var _ Metrics = (*XDSMetrics)(nil)
@@ -34,7 +36,7 @@ func NewXDSMetric() *XDSMetrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystem,
 			Name:      "events_count",
-			Help:      "The number of ACK/NACK event responses from Envoy",
+			Help:      "The number of ACK/NACK/Cancel event responses from Envoy",
 		}, []string{typeURLLabel, statusLabel}),
 	}
 }
@@ -45,4 +47,8 @@ func (x *XDSMetrics) IncreaseNACK(typeURL string) {
 
 func (x *XDSMetrics) IncreaseACK(typeURL string) {
 	x.EventCount.WithLabelValues(typeURL, statusACKValue).Inc()
+}
+
+func (x *XDSMetrics) IncreaseCancel(typeURL string) {
+	x.EventCount.WithLabelValues(typeURL, statusCancelValue).Inc()
 }

--- a/pkg/envoy/xds/metrics_mock_test.go
+++ b/pkg/envoy/xds/metrics_mock_test.go
@@ -4,21 +4,27 @@
 package xds
 
 type mockMetrics struct {
-	ack  map[string]int
-	nack map[string]int
-}
-
-func (m *mockMetrics) IncreaseNACK(typeURL string) {
-	m.ack[typeURL]++
+	ack    map[string]int
+	nack   map[string]int
+	cancel map[string]int
 }
 
 func (m *mockMetrics) IncreaseACK(typeURL string) {
+	m.ack[typeURL]++
+}
+
+func (m *mockMetrics) IncreaseNACK(typeURL string) {
 	m.nack[typeURL]++
+}
+
+func (m *mockMetrics) IncreaseCancel(typeURL string) {
+	m.cancel[typeURL]++
 }
 
 func newMockMetrics() *mockMetrics {
 	return &mockMetrics{
-		ack:  map[string]int{},
-		nack: map[string]int{},
+		ack:    map[string]int{},
+		nack:   map[string]int{},
+		cancel: map[string]int{},
 	}
 }

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -127,8 +127,9 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -151,16 +152,18 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
 	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
 	require.Equal(t, uint64(3), v)
 	require.True(t, mod)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -178,8 +181,9 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -202,8 +206,9 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -385,8 +390,9 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -409,8 +415,9 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with resource 0 and 1.
 	// This time, update the cache before sending the request.
@@ -434,8 +441,9 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -458,8 +466,9 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1], resources[2]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -496,8 +505,9 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "6", []proto.Message{resources[2]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Resource 1 has been deleted; Resource 2 exists. Confirm using Lookup().
 	rsrc, err := cache.Lookup(typeURL, resources[1].Name)
@@ -508,8 +518,9 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rsrc)
 	require.Equal(t, resources[2], rsrc.(*envoy_config_route.RouteConfiguration))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -577,8 +588,9 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resource 1.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -614,8 +626,9 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1], resources[2]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -675,8 +688,9 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -699,8 +713,9 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
@@ -725,8 +740,9 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -749,8 +765,9 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -809,8 +826,9 @@ func TestNAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -834,8 +852,9 @@ func TestNAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -869,8 +888,9 @@ func TestNAck(t *testing.T) {
 
 	require.Condition(t, isNotCompletedComparison(comp1))
 	require.Condition(t, isNotCompletedComparison(comp2))
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -885,8 +905,9 @@ func TestNAck(t *testing.T) {
 
 	require.Condition(t, isNotCompletedComparison(comp1))
 	require.Condition(t, completedComparison(comp2))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -945,8 +966,9 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
@@ -969,8 +991,9 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1006,8 +1029,9 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NotEmpty(t, resp.Nonce)
 
 	require.Condition(t, isNotCompletedComparison(comp2))
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 3, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 3, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1022,8 +1046,9 @@ func TestNAckFromTheStart(t *testing.T) {
 
 	// Version 3 was ACKed by the last request.
 	require.Condition(t, completedComparison(comp2))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 3, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 3, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -1089,8 +1114,9 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
 	require.NotEmpty(t, resp.Nonce)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -1181,8 +1207,9 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0]}, false, typeURL))
 	require.NotEmpty(t, resp.Nonce)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1058,12 +1058,24 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 		if count == 0 {
 			if isProxyListener {
 				s.proxyListeners--
+				if s.proxyListeners < 0 {
+					s.logger.Error("Envoy: RemoveListener: negative proxyListener count",
+						logfields.Listener, name,
+						logfields.Count, s.proxyListeners,
+					)
+				}
 			}
 			delete(s.listenerCount, name)
 			s.logger.Info("Envoy: Deleting listener",
 				logfields.Listener, name,
 			)
 			listenerRevertFunc = s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, nil)
+
+			// cancel all pending network policy completions if this was the last
+			// isProxyListener
+			if s.proxyListeners <= 0 {
+				s.NetworkPolicyMutator.CancelCompletions(NetworkPolicyTypeURL)
+			}
 		} else {
 			s.listenerCount[name] = count
 		}


### PR DESCRIPTION
Cancel Network Policy completions when the last proxy listener is removed. This prevents hanging policy update waits in situations where it is known that the NPDS client has been stopped, and that no further ACKs or NACKs are to be received. Any pending completions are cancelled with nil error, as the NPDS cache updaters have no way of reacting to the listeners being removed. NPDS cache is still being updated for the eventual restart of the NPDS client when a new proxy listener is added.

Mock metrics had ACK/NACK reversed, this is now fixed.

Fixes: #44543

```release-note
Fixed ipcache identity update hang when last proxy listener is removed.
```
