### PR TITLE
Envoy: Cancel completions on proxy listeners removal

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -94,6 +94,12 @@ type AckingResourceMutator interface {
 	// A call to the returned revert function reverts the effects of this
 	// method call.
 	Delete(typeURL string, resourceName string, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc
+
+	// CancelCompletions completes all pending completions on the given TypeURL.
+	// Called only when it is known that the TypeURL client has stopped processing updates.
+	// Completions are completed without an error, as the resource updater can not react in
+	// any way to the resource client going away.
+	CancelCompletions(typeURL string)
 }
 
 // AckingResourceMutatorWrapper is an AckingResourceMutator which wraps a
@@ -259,6 +265,43 @@ func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
 		close(ch)
 	}
 	delete(m.ackedNodes, nodeID)
+}
+
+// CancelCompletions is called after it is known the xDS client has been terminated, so that waiting
+// for any N/ACKs is futile. Full resource sync will happen when the xDS client start again (if it
+// does). Completions are terminated without an error, as there is nothing do, even it an error
+// status was used instead. This mirrors the behavior when it is known the xDS client has not yet
+// been started, when we do not even try to wait for any N/ACKs.
+func (m *AckingResourceMutatorWrapper) CancelCompletions(typeURL string) {
+	scopedLogger := m.logger.With(
+		logfields.XDSTypeURL, typeURL,
+	)
+
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	for comp, pending := range m.pendingCompletions {
+		if comp.Err() != nil {
+			// Completion was canceled or timed out.
+			// Remove from pending list.
+			scopedLogger.Debug(
+				"completion context was canceled",
+				logfields.PendingCompletions, pending,
+			)
+			delete(m.pendingCompletions, comp)
+			continue
+		}
+
+		if pending.typeURL == typeURL {
+			clear(pending.remainingNodesResources)
+			m.metrics.IncreaseCancel(typeURL)
+			scopedLogger.Debug("completing cancel",
+				logfields.WaitVersion, pending.version)
+			comp.Complete(nil)
+			delete(m.pendingCompletions, comp)
+			continue
+		}
+	}
 }
 
 func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc {

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -100,6 +100,7 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Empty(t, acker.ackedVersions)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from another node.
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -108,6 +109,7 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node1])
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for another resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[1].Name}, typeURL, "")
@@ -116,6 +118,7 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
@@ -124,6 +127,7 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
@@ -132,6 +136,7 @@ func TestUpsertSingleNode(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUseCurrent(t *testing.T) {
@@ -155,6 +160,7 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.pendingCompletions, 1)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from another node.
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -164,6 +170,7 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.pendingCompletions, 1)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Use current version, not yet acked
 	acker.UseCurrent(typeURL, []string{node0}, wg)
@@ -178,6 +185,7 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.pendingCompletions, 1)
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
@@ -194,6 +202,7 @@ func TestUseCurrent(t *testing.T) {
 	require.Empty(t, acker.pendingCompletions)
 	require.Equal(t, 2, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUpsertMultipleNodes(t *testing.T) {
@@ -225,6 +234,7 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node2}))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from one of the nodes (node0).
 	// One of the nodes (node1) still needs to ACK.
@@ -237,6 +247,7 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node0, node2}))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for the right resource, from the last remaining node (node1).
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -247,6 +258,7 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node0, node1, node2}))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUpsertMoreRecentVersion(t *testing.T) {
@@ -271,12 +283,14 @@ func TestUpsertMoreRecentVersion(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack a more recent version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(123, 123, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUpsertMoreRecentVersionNack(t *testing.T) {
@@ -301,6 +315,7 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// NAck a more recent version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 2, node0, []string{resources[0].Name}, typeURL, "Detail")
@@ -310,6 +325,7 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	require.EqualValues(t, &ProxyError{Err: ErrNackReceived, Detail: "Detail"}, comp.Err())
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 1, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestDeleteSingleNode(t *testing.T) {
@@ -334,6 +350,7 @@ func TestDeleteSingleNode(t *testing.T) {
 	require.Condition(t, completedComparison(comp))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with no resources.
 	callback, comp = newCompCallback(logger)
@@ -345,6 +362,7 @@ func TestDeleteSingleNode(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for another resource, from the right node.
 	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
@@ -352,6 +370,7 @@ func TestDeleteSingleNode(t *testing.T) {
 	require.Condition(t, completedComparison(comp))
 	require.Equal(t, 2, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestUpsertCompletionAfterDeletedResource(t *testing.T) {
@@ -418,6 +437,7 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	require.Condition(t, completedComparison(comp))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with no resources.
 	callback, comp = newCompCallback(logger)
@@ -429,6 +449,7 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Ack the right version, for another resource, from the remaining node.
 	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
@@ -436,6 +457,7 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	require.Condition(t, completedComparison(comp))
 	require.Equal(t, 2, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestRevertInsert(t *testing.T) {
@@ -478,6 +500,7 @@ func TestRevertInsert(t *testing.T) {
 
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestRevertUpdate(t *testing.T) {
@@ -527,6 +550,7 @@ func TestRevertUpdate(t *testing.T) {
 
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
 func TestRevertDelete(t *testing.T) {
@@ -580,4 +604,5 @@ func TestRevertDelete(t *testing.T) {
 
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 }

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -205,6 +205,54 @@ func TestUseCurrent(t *testing.T) {
 	require.Equal(t, 0, metrics.cancel[typeURL])
 }
 
+func TestCancelCompletions(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	typeURL1 := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	typeURL2 := "type.googleapis.com/envoy.config.v3.AnotherConfiguration"
+	wg := completion.NewWaitGroup(ctx)
+	metrics := newMockMetrics()
+
+	cache := NewCache(logger)
+	acker := NewAckingResourceMutatorWrapper(logger, cache, metrics)
+	require.Empty(t, acker.ackedVersions)
+
+	// Add one pending completion for each type.
+	callback1, comp1 := newCompCallback(logger)
+	acker.Upsert(typeURL1, resources[0].Name, resources[0], []string{node0}, wg, callback1)
+	require.Condition(t, isNotCompletedComparison(comp1))
+
+	callback2, comp2 := newCompCallback(logger)
+	acker.Upsert(typeURL2, resources[1].Name, resources[1], []string{node0}, wg, callback2)
+	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Len(t, acker.pendingCompletions, 2)
+
+	// Cancel only the first type URL.
+	acker.CancelCompletions(typeURL1)
+	require.Condition(t, completedComparison(comp1))
+	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Len(t, acker.pendingCompletions, 1)
+	require.Equal(t, 0, metrics.ack[typeURL1])
+	require.Equal(t, 0, metrics.nack[typeURL1])
+	require.Equal(t, 1, metrics.cancel[typeURL1])
+	require.Equal(t, 0, metrics.ack[typeURL2])
+	require.Equal(t, 0, metrics.nack[typeURL2])
+	require.Equal(t, 0, metrics.cancel[typeURL2])
+
+	// Verify the other type still completes via ACK.
+	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[1].Name}, typeURL2, "")
+	require.Condition(t, completedComparison(comp2))
+	require.Empty(t, acker.pendingCompletions)
+	require.Equal(t, 0, metrics.ack[typeURL1])
+	require.Equal(t, 0, metrics.nack[typeURL1])
+	require.Equal(t, 1, metrics.cancel[typeURL1])
+	require.Equal(t, 1, metrics.ack[typeURL2])
+	require.Equal(t, 0, metrics.nack[typeURL2])
+	require.Equal(t, 0, metrics.cancel[typeURL2])
+}
+
 func TestUpsertMultipleNodes(t *testing.T) {
 	logger := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/envoy/xds/metrics.go
+++ b/pkg/envoy/xds/metrics.go
@@ -9,16 +9,18 @@ import (
 )
 
 const (
-	subsystem       = "xds"
-	typeURLLabel    = "type_url"
-	statusLabel     = "status"
-	statusACKValue  = "ack"
-	statusNACKValue = "nack"
+	subsystem         = "xds"
+	typeURLLabel      = "type_url"
+	statusLabel       = "status"
+	statusACKValue    = "ack"
+	statusNACKValue   = "nack"
+	statusCancelValue = "cancel"
 )
 
 type Metrics interface {
 	IncreaseNACK(string)
 	IncreaseACK(string)
+	IncreaseCancel(string)
 }
 
 var _ Metrics = (*XDSMetrics)(nil)
@@ -34,7 +36,7 @@ func NewXDSMetric() *XDSMetrics {
 			Namespace: metrics.Namespace,
 			Subsystem: subsystem,
 			Name:      "events_count",
-			Help:      "The number of ACK/NACK event responses from Envoy",
+			Help:      "The number of ACK/NACK/Cancel event responses from Envoy",
 		}, []string{typeURLLabel, statusLabel}),
 	}
 }
@@ -45,4 +47,8 @@ func (x *XDSMetrics) IncreaseNACK(typeURL string) {
 
 func (x *XDSMetrics) IncreaseACK(typeURL string) {
 	x.EventCount.WithLabelValues(typeURL, statusACKValue).Inc()
+}
+
+func (x *XDSMetrics) IncreaseCancel(typeURL string) {
+	x.EventCount.WithLabelValues(typeURL, statusCancelValue).Inc()
 }

--- a/pkg/envoy/xds/metrics_mock_test.go
+++ b/pkg/envoy/xds/metrics_mock_test.go
@@ -4,8 +4,9 @@
 package xds
 
 type mockMetrics struct {
-	ack  map[string]int
-	nack map[string]int
+	ack    map[string]int
+	nack   map[string]int
+	cancel map[string]int
 }
 
 func (m *mockMetrics) IncreaseACK(typeURL string) {
@@ -16,9 +17,14 @@ func (m *mockMetrics) IncreaseNACK(typeURL string) {
 	m.nack[typeURL]++
 }
 
+func (m *mockMetrics) IncreaseCancel(typeURL string) {
+	m.cancel[typeURL]++
+}
+
 func newMockMetrics() *mockMetrics {
 	return &mockMetrics{
-		ack:  map[string]int{},
-		nack: map[string]int{},
+		ack:    map[string]int{},
+		nack:   map[string]int{},
+		cancel: map[string]int{},
 	}
 }

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -129,6 +129,7 @@ func TestRequestAllResources(t *testing.T) {
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -153,6 +154,7 @@ func TestRequestAllResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
@@ -161,6 +163,7 @@ func TestRequestAllResources(t *testing.T) {
 	require.True(t, mod)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -180,6 +183,7 @@ func TestRequestAllResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -204,6 +208,7 @@ func TestRequestAllResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -387,6 +392,7 @@ func TestRequestSomeResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -411,6 +417,7 @@ func TestRequestSomeResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "2", nil, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with resource 0 and 1.
 	// This time, update the cache before sending the request.
@@ -436,6 +443,7 @@ func TestRequestSomeResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -460,6 +468,7 @@ func TestRequestSomeResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1], resources[2]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -498,6 +507,7 @@ func TestRequestSomeResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "6", []proto.Message{resources[2]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Resource 1 has been deleted; Resource 2 exists. Confirm using Lookup().
 	rsrc, err := cache.Lookup(typeURL, resources[1].Name)
@@ -510,6 +520,7 @@ func TestRequestSomeResources(t *testing.T) {
 	require.Equal(t, resources[2], rsrc.(*envoy_config_route.RouteConfiguration))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -579,6 +590,7 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[1]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resource 1.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -616,6 +628,7 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1], resources[2]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -677,6 +690,7 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -701,6 +715,7 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
@@ -727,6 +742,7 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -751,6 +767,7 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -811,6 +828,7 @@ func TestNAck(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -836,6 +854,7 @@ func TestNAck(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -871,6 +890,7 @@ func TestNAck(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp2))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 2, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -887,6 +907,7 @@ func TestNAck(t *testing.T) {
 	require.Condition(t, completedComparison(comp2))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 2, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -947,6 +968,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
@@ -971,6 +993,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 1, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1008,6 +1031,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp2))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 3, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1024,6 +1048,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.Condition(t, completedComparison(comp2))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 3, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -1091,6 +1116,7 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	require.NotEmpty(t, resp.Nonce)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -1183,6 +1209,7 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	require.NotEmpty(t, resp.Nonce)
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Close the stream.
 	closeStream()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1029,12 +1029,24 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 		if count == 0 {
 			if isProxyListener {
 				s.proxyListeners--
+				if s.proxyListeners < 0 {
+					s.logger.Error("Envoy: RemoveListener: negative proxyListener count",
+						logfields.Listener, name,
+						logfields.Count, s.proxyListeners,
+					)
+				}
 			}
 			delete(s.listenerCount, name)
 			s.logger.Info("Envoy: Deleting listener",
 				logfields.Listener, name,
 			)
 			listenerRevertFunc = s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, nil)
+
+			// cancel all pending network policy completions if this was the last
+			// listener with bpf metadata listener filter with bpf path configured.
+			if s.proxyListeners <= 0 {
+				s.networkPolicyMutator.CancelCompletions(NetworkPolicyTypeURL)
+			}
 		} else {
 			s.listenerCount[name] = count
 		}


### PR DESCRIPTION
Cancel Network Policy completions when the last proxy listener is removed. This prevents hanging policy update waits in situations where it is known that the NPDS client has been stopped, and that no further ACKs or NACKs are to be received. Any pending completions are cancelled with nil error, as the NPDS cache updaters have no way of reacting to the listeners being removed. NPDS cache is still being updated for the eventual restart of the NPDS client when a new proxy listener is added.

Mock metrics had ACK/NACK reversed, this is now fixed.

Fixes: #44543

```release-note
Fixed ipcache identity update hang when last proxy listener is removed. 
```
