### PR TITLE
feat(sdp): Support DNS metrics from Standalone DNS Proxy

### DIFF
--- a/api/v1/standalone-dns-proxy/README.md
+++ b/api/v1/standalone-dns-proxy/README.md
@@ -7,15 +7,19 @@
 
 - [standalone-dns-proxy/standalone-dns-proxy.proto](#standalone-dns-proxy_standalone-dns-proxy-proto)
     - [DNSPolicy](#standalonednsproxy-DNSPolicy)
+    - [DNSResponseData](#standalonednsproxy-DNSResponseData)
     - [DNSServer](#standalonednsproxy-DNSServer)
     - [EndpointInfo](#standalonednsproxy-EndpointInfo)
     - [FQDNMapping](#standalonednsproxy-FQDNMapping)
     - [IdentityToEndpointMapping](#standalonednsproxy-IdentityToEndpointMapping)
     - [IdentityToPrefixMapping](#standalonednsproxy-IdentityToPrefixMapping)
+    - [MetricsData](#standalonednsproxy-MetricsData)
     - [PolicyState](#standalonednsproxy-PolicyState)
     - [PolicyStateResponse](#standalonednsproxy-PolicyStateResponse)
+    - [ProcessingStats](#standalonednsproxy-ProcessingStats)
     - [UpdateMappingResponse](#standalonednsproxy-UpdateMappingResponse)
   
+    - [ProxyErrorType](#standalonednsproxy-ProxyErrorType)
     - [ResponseCode](#standalonednsproxy-ResponseCode)
   
     - [FQDNData](#standalonednsproxy-FQDNData)
@@ -42,6 +46,25 @@ L7 DNS policy specifying which requests are permitted to which DNS server
 | source_endpoint_id | [uint32](#uint32) |  | Endpoint ID of the workload this L7 DNS policy should apply to |
 | dns_pattern | [string](#string) | repeated | Allowed DNS pattern this identity is allowed to resolve. |
 | dns_servers | [DNSServer](#standalonednsproxy-DNSServer) | repeated | List of DNS servers to be allowed to connect. |
+
+
+
+
+
+
+<a name="standalonednsproxy-DNSResponseData"></a>
+
+### DNSResponseData
+DNSResponseData holds the DNS message details extracted from the response
+that are needed for access logging on the agent side.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| is_response | [bool](#bool) |  | Whether this is a DNS response (true) or request (false) |
+| cnames | [string](#string) | repeated | CNAME records from the DNS response |
+| qtypes | [uint32](#uint32) | repeated | DNS question types |
+| answer_types | [uint32](#uint32) | repeated | DNS answer record types |
 
 
 
@@ -95,6 +118,7 @@ FQDN-IP mapping goalstate sent from SDP to agent
 | source_identity | [uint32](#uint32) |  | Identity of the client making the DNS request |
 | source_ip | [bytes](#bytes) |  | IP address of the client making the DNS request |
 | response_code | [uint32](#uint32) |  | DNS Response code as specified in RFC2316 |
+| metrics_data | [MetricsData](#standalonednsproxy-MetricsData) |  | Metrics and access logging data collected by the standalone DNS proxy. |
 
 
 
@@ -127,6 +151,31 @@ Cilium Identity ID to IP prefix mapping
 | ----- | ---- | ----- | ----------- |
 | identity | [uint32](#uint32) |  |  |
 | prefix | [bytes](#bytes) | repeated |  |
+
+
+
+
+
+
+<a name="standalonednsproxy-MetricsData"></a>
+
+### MetricsData
+MetricsData carries the flow context and timing statistics that the agent
+needs to emit proxy metrics and access log records for DNS events
+originating from the standalone DNS proxy.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| processing_stats | [ProcessingStats](#standalonednsproxy-ProcessingStats) |  | Proxy request processing timing statistics |
+| dns_response_data | [DNSResponseData](#standalonednsproxy-DNSResponseData) |  | DNS response metadata extracted from the DNS message |
+| source_port | [uint32](#uint32) |  | Source port of the endpoint making the DNS request |
+| server_addr | [string](#string) |  | IP:port of the destination DNS server as &#34;ip:port&#34; string (e.g., &#34;8.8.8.8:53&#34;) |
+| server_identity | [uint32](#uint32) |  | Security identity of the destination DNS server |
+| protocol | [string](#string) |  | L4 protocol used for the DNS request (e.g., &#34;udp&#34;, &#34;tcp&#34;) |
+| allowed | [bool](#bool) |  | Whether the DNS request was allowed by policy |
+| error_message | [string](#string) |  | Error message if the DNS request encountered an error (empty if no error) |
+| error_type | [ProxyErrorType](#standalonednsproxy-ProxyErrorType) |  | Structured error classification for metrics without relying on string matching. |
 
 
 
@@ -168,6 +217,29 @@ Ack sent from SDP to Agent on processing DNS policy rules
 
 
 
+<a name="standalonednsproxy-ProcessingStats"></a>
+
+### ProcessingStats
+ProcessingStats carries proxy request timing statistics collected by the
+standalone DNS proxy. All durations are in nanoseconds.
+Only fields actually measured by the standalone proxy are included here;
+agent-side timings (policy generation, dataplane, cache updates, etc.)
+are measured directly by the agent after receiving the gRPC message.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| total_time_ns | [int64](#int64) |  |  |
+| processing_time_ns | [int64](#int64) |  |  |
+| upstream_time_ns | [int64](#int64) |  |  |
+| semaphore_acquire_time_ns | [int64](#int64) |  |  |
+| policy_check_time_ns | [int64](#int64) |  |  |
+
+
+
+
+
+
 <a name="standalonednsproxy-UpdateMappingResponse"></a>
 
 ### UpdateMappingResponse
@@ -183,6 +255,25 @@ Ack returned by cilium agent to SDP on receiving FQDN-IP mapping update
 
 
  
+
+
+<a name="standalonednsproxy-ProxyErrorType"></a>
+
+### ProxyErrorType
+ProxyErrorType classifies the error that occurred during DNS proxy
+processing. The agent uses this to reconstruct the correct error type
+for metrics reporting (metric label, semaphore-rejected counter, etc.)
+without relying on Go error-type information that is lost during gRPC
+serialization.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| PROXY_ERROR_TYPE_NONE | 0 | No error occurred. |
+| PROXY_ERROR_TYPE_PROXY | 1 | A generic proxy-side error (e.g. failed to parse, forward, etc.). |
+| PROXY_ERROR_TYPE_TIMEOUT | 2 | An upstream network timeout (e.g. DNS server did not respond). |
+| PROXY_ERROR_TYPE_SEMAPHORE_FAILED | 3 | The DNS proxy concurrency semaphore could not be acquired immediately. |
+| PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT | 4 | The DNS proxy concurrency semaphore timed out during the grace period. |
+
 
 
 <a name="standalonednsproxy-ResponseCode"></a>

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.go
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.go
@@ -89,6 +89,71 @@ func (ResponseCode) EnumDescriptor() ([]byte, []int) {
 	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{0}
 }
 
+// ProxyErrorType classifies the error that occurred during DNS proxy
+// processing. The agent uses this to reconstruct the correct error type
+// for metrics reporting (metric label, semaphore-rejected counter, etc.)
+// without relying on Go error-type information that is lost during gRPC
+// serialization.
+type ProxyErrorType int32
+
+const (
+	// No error occurred.
+	ProxyErrorType_PROXY_ERROR_TYPE_NONE ProxyErrorType = 0
+	// A generic proxy-side error (e.g. failed to parse, forward, etc.).
+	ProxyErrorType_PROXY_ERROR_TYPE_PROXY ProxyErrorType = 1
+	// An upstream network timeout (e.g. DNS server did not respond).
+	ProxyErrorType_PROXY_ERROR_TYPE_TIMEOUT ProxyErrorType = 2
+	// The DNS proxy concurrency semaphore could not be acquired immediately.
+	ProxyErrorType_PROXY_ERROR_TYPE_SEMAPHORE_FAILED ProxyErrorType = 3
+	// The DNS proxy concurrency semaphore timed out during the grace period.
+	ProxyErrorType_PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT ProxyErrorType = 4
+)
+
+// Enum value maps for ProxyErrorType.
+var (
+	ProxyErrorType_name = map[int32]string{
+		0: "PROXY_ERROR_TYPE_NONE",
+		1: "PROXY_ERROR_TYPE_PROXY",
+		2: "PROXY_ERROR_TYPE_TIMEOUT",
+		3: "PROXY_ERROR_TYPE_SEMAPHORE_FAILED",
+		4: "PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT",
+	}
+	ProxyErrorType_value = map[string]int32{
+		"PROXY_ERROR_TYPE_NONE":                0,
+		"PROXY_ERROR_TYPE_PROXY":               1,
+		"PROXY_ERROR_TYPE_TIMEOUT":             2,
+		"PROXY_ERROR_TYPE_SEMAPHORE_FAILED":    3,
+		"PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT": 4,
+	}
+)
+
+func (x ProxyErrorType) Enum() *ProxyErrorType {
+	p := new(ProxyErrorType)
+	*p = x
+	return p
+}
+
+func (x ProxyErrorType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ProxyErrorType) Descriptor() protoreflect.EnumDescriptor {
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_enumTypes[1].Descriptor()
+}
+
+func (ProxyErrorType) Type() protoreflect.EnumType {
+	return &file_standalone_dns_proxy_standalone_dns_proxy_proto_enumTypes[1]
+}
+
+func (x ProxyErrorType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ProxyErrorType.Descriptor instead.
+func (ProxyErrorType) EnumDescriptor() ([]byte, []int) {
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{1}
+}
+
 // Ack sent from SDP to Agent on processing DNS policy rules
 type PolicyStateResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -151,6 +216,7 @@ type FQDNMapping struct {
 	SourceIdentity uint32                 `protobuf:"varint,4,opt,name=source_identity,json=sourceIdentity,proto3" json:"source_identity,omitempty"` // Identity of the client making the DNS request
 	SourceIp       []byte                 `protobuf:"bytes,5,opt,name=source_ip,json=sourceIp,proto3" json:"source_ip,omitempty"`                    // IP address of the client making the DNS request
 	ResponseCode   uint32                 `protobuf:"varint,6,opt,name=response_code,json=responseCode,proto3" json:"response_code,omitempty"`       // DNS Response code as specified in RFC2316
+	MetricsData    *MetricsData           `protobuf:"bytes,7,opt,name=metrics_data,json=metricsData,proto3" json:"metrics_data,omitempty"`           // Metrics and access logging data collected by the standalone DNS proxy.
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -227,6 +293,275 @@ func (x *FQDNMapping) GetResponseCode() uint32 {
 	return 0
 }
 
+func (x *FQDNMapping) GetMetricsData() *MetricsData {
+	if x != nil {
+		return x.MetricsData
+	}
+	return nil
+}
+
+// MetricsData carries the flow context and timing statistics that the agent
+// needs to emit proxy metrics and access log records for DNS events
+// originating from the standalone DNS proxy.
+type MetricsData struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ProcessingStats *ProcessingStats       `protobuf:"bytes,1,opt,name=processing_stats,json=processingStats,proto3" json:"processing_stats,omitempty"`                       // Proxy request processing timing statistics
+	DnsResponseData *DNSResponseData       `protobuf:"bytes,2,opt,name=dns_response_data,json=dnsResponseData,proto3" json:"dns_response_data,omitempty"`                     // DNS response metadata extracted from the DNS message
+	SourcePort      uint32                 `protobuf:"varint,3,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`                                     // Source port of the endpoint making the DNS request
+	ServerAddr      string                 `protobuf:"bytes,4,opt,name=server_addr,json=serverAddr,proto3" json:"server_addr,omitempty"`                                      // IP:port of the destination DNS server as "ip:port" string (e.g., "8.8.8.8:53")
+	ServerIdentity  uint32                 `protobuf:"varint,5,opt,name=server_identity,json=serverIdentity,proto3" json:"server_identity,omitempty"`                         // Security identity of the destination DNS server
+	Protocol        string                 `protobuf:"bytes,6,opt,name=protocol,proto3" json:"protocol,omitempty"`                                                            // L4 protocol used for the DNS request (e.g., "udp", "tcp")
+	Allowed         bool                   `protobuf:"varint,7,opt,name=allowed,proto3" json:"allowed,omitempty"`                                                             // Whether the DNS request was allowed by policy
+	ErrorMessage    string                 `protobuf:"bytes,8,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`                                // Error message if the DNS request encountered an error (empty if no error)
+	ErrorType       ProxyErrorType         `protobuf:"varint,9,opt,name=error_type,json=errorType,proto3,enum=standalonednsproxy.ProxyErrorType" json:"error_type,omitempty"` // Structured error classification for metrics without relying on string matching.
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *MetricsData) Reset() {
+	*x = MetricsData{}
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetricsData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetricsData) ProtoMessage() {}
+
+func (x *MetricsData) ProtoReflect() protoreflect.Message {
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetricsData.ProtoReflect.Descriptor instead.
+func (*MetricsData) Descriptor() ([]byte, []int) {
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *MetricsData) GetProcessingStats() *ProcessingStats {
+	if x != nil {
+		return x.ProcessingStats
+	}
+	return nil
+}
+
+func (x *MetricsData) GetDnsResponseData() *DNSResponseData {
+	if x != nil {
+		return x.DnsResponseData
+	}
+	return nil
+}
+
+func (x *MetricsData) GetSourcePort() uint32 {
+	if x != nil {
+		return x.SourcePort
+	}
+	return 0
+}
+
+func (x *MetricsData) GetServerAddr() string {
+	if x != nil {
+		return x.ServerAddr
+	}
+	return ""
+}
+
+func (x *MetricsData) GetServerIdentity() uint32 {
+	if x != nil {
+		return x.ServerIdentity
+	}
+	return 0
+}
+
+func (x *MetricsData) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
+	}
+	return ""
+}
+
+func (x *MetricsData) GetAllowed() bool {
+	if x != nil {
+		return x.Allowed
+	}
+	return false
+}
+
+func (x *MetricsData) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+func (x *MetricsData) GetErrorType() ProxyErrorType {
+	if x != nil {
+		return x.ErrorType
+	}
+	return ProxyErrorType_PROXY_ERROR_TYPE_NONE
+}
+
+// ProcessingStats carries proxy request timing statistics collected by the
+// standalone DNS proxy. All durations are in nanoseconds.
+// Only fields actually measured by the standalone proxy are included here;
+// agent-side timings (policy generation, dataplane, cache updates, etc.)
+// are measured directly by the agent after receiving the gRPC message.
+type ProcessingStats struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	TotalTimeNs            int64                  `protobuf:"varint,1,opt,name=total_time_ns,json=totalTimeNs,proto3" json:"total_time_ns,omitempty"`
+	ProcessingTimeNs       int64                  `protobuf:"varint,2,opt,name=processing_time_ns,json=processingTimeNs,proto3" json:"processing_time_ns,omitempty"`
+	UpstreamTimeNs         int64                  `protobuf:"varint,3,opt,name=upstream_time_ns,json=upstreamTimeNs,proto3" json:"upstream_time_ns,omitempty"`
+	SemaphoreAcquireTimeNs int64                  `protobuf:"varint,4,opt,name=semaphore_acquire_time_ns,json=semaphoreAcquireTimeNs,proto3" json:"semaphore_acquire_time_ns,omitempty"`
+	PolicyCheckTimeNs      int64                  `protobuf:"varint,5,opt,name=policy_check_time_ns,json=policyCheckTimeNs,proto3" json:"policy_check_time_ns,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ProcessingStats) Reset() {
+	*x = ProcessingStats{}
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProcessingStats) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcessingStats) ProtoMessage() {}
+
+func (x *ProcessingStats) ProtoReflect() protoreflect.Message {
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcessingStats.ProtoReflect.Descriptor instead.
+func (*ProcessingStats) Descriptor() ([]byte, []int) {
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ProcessingStats) GetTotalTimeNs() int64 {
+	if x != nil {
+		return x.TotalTimeNs
+	}
+	return 0
+}
+
+func (x *ProcessingStats) GetProcessingTimeNs() int64 {
+	if x != nil {
+		return x.ProcessingTimeNs
+	}
+	return 0
+}
+
+func (x *ProcessingStats) GetUpstreamTimeNs() int64 {
+	if x != nil {
+		return x.UpstreamTimeNs
+	}
+	return 0
+}
+
+func (x *ProcessingStats) GetSemaphoreAcquireTimeNs() int64 {
+	if x != nil {
+		return x.SemaphoreAcquireTimeNs
+	}
+	return 0
+}
+
+func (x *ProcessingStats) GetPolicyCheckTimeNs() int64 {
+	if x != nil {
+		return x.PolicyCheckTimeNs
+	}
+	return 0
+}
+
+// DNSResponseData holds the DNS message details extracted from the response
+// that are needed for access logging on the agent side.
+type DNSResponseData struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	IsResponse    bool                   `protobuf:"varint,1,opt,name=is_response,json=isResponse,proto3" json:"is_response,omitempty"`           // Whether this is a DNS response (true) or request (false)
+	Cnames        []string               `protobuf:"bytes,2,rep,name=cnames,proto3" json:"cnames,omitempty"`                                      // CNAME records from the DNS response
+	Qtypes        []uint32               `protobuf:"varint,3,rep,packed,name=qtypes,proto3" json:"qtypes,omitempty"`                              // DNS question types
+	AnswerTypes   []uint32               `protobuf:"varint,4,rep,packed,name=answer_types,json=answerTypes,proto3" json:"answer_types,omitempty"` // DNS answer record types
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DNSResponseData) Reset() {
+	*x = DNSResponseData{}
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DNSResponseData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DNSResponseData) ProtoMessage() {}
+
+func (x *DNSResponseData) ProtoReflect() protoreflect.Message {
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DNSResponseData.ProtoReflect.Descriptor instead.
+func (*DNSResponseData) Descriptor() ([]byte, []int) {
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *DNSResponseData) GetIsResponse() bool {
+	if x != nil {
+		return x.IsResponse
+	}
+	return false
+}
+
+func (x *DNSResponseData) GetCnames() []string {
+	if x != nil {
+		return x.Cnames
+	}
+	return nil
+}
+
+func (x *DNSResponseData) GetQtypes() []uint32 {
+	if x != nil {
+		return x.Qtypes
+	}
+	return nil
+}
+
+func (x *DNSResponseData) GetAnswerTypes() []uint32 {
+	if x != nil {
+		return x.AnswerTypes
+	}
+	return nil
+}
+
 // Ack returned by cilium agent to SDP on receiving FQDN-IP mapping update
 type UpdateMappingResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -237,7 +572,7 @@ type UpdateMappingResponse struct {
 
 func (x *UpdateMappingResponse) Reset() {
 	*x = UpdateMappingResponse{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[2]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -249,7 +584,7 @@ func (x *UpdateMappingResponse) String() string {
 func (*UpdateMappingResponse) ProtoMessage() {}
 
 func (x *UpdateMappingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[2]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -262,7 +597,7 @@ func (x *UpdateMappingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateMappingResponse.ProtoReflect.Descriptor instead.
 func (*UpdateMappingResponse) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{2}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *UpdateMappingResponse) GetResponse() ResponseCode {
@@ -284,7 +619,7 @@ type DNSServer struct {
 
 func (x *DNSServer) Reset() {
 	*x = DNSServer{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[3]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -296,7 +631,7 @@ func (x *DNSServer) String() string {
 func (*DNSServer) ProtoMessage() {}
 
 func (x *DNSServer) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[3]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -309,7 +644,7 @@ func (x *DNSServer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSServer.ProtoReflect.Descriptor instead.
 func (*DNSServer) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{3}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *DNSServer) GetDnsServerIdentity() uint32 {
@@ -345,7 +680,7 @@ type DNSPolicy struct {
 
 func (x *DNSPolicy) Reset() {
 	*x = DNSPolicy{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[4]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -357,7 +692,7 @@ func (x *DNSPolicy) String() string {
 func (*DNSPolicy) ProtoMessage() {}
 
 func (x *DNSPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[4]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -370,7 +705,7 @@ func (x *DNSPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DNSPolicy.ProtoReflect.Descriptor instead.
 func (*DNSPolicy) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{4}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DNSPolicy) GetSourceEndpointId() uint32 {
@@ -408,7 +743,7 @@ type PolicyState struct {
 
 func (x *PolicyState) Reset() {
 	*x = PolicyState{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[5]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -420,7 +755,7 @@ func (x *PolicyState) String() string {
 func (*PolicyState) ProtoMessage() {}
 
 func (x *PolicyState) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[5]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -433,7 +768,7 @@ func (x *PolicyState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyState.ProtoReflect.Descriptor instead.
 func (*PolicyState) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{5}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PolicyState) GetEgressL7DnsPolicy() []*DNSPolicy {
@@ -475,7 +810,7 @@ type IdentityToEndpointMapping struct {
 
 func (x *IdentityToEndpointMapping) Reset() {
 	*x = IdentityToEndpointMapping{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[6]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -487,7 +822,7 @@ func (x *IdentityToEndpointMapping) String() string {
 func (*IdentityToEndpointMapping) ProtoMessage() {}
 
 func (x *IdentityToEndpointMapping) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[6]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -500,7 +835,7 @@ func (x *IdentityToEndpointMapping) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentityToEndpointMapping.ProtoReflect.Descriptor instead.
 func (*IdentityToEndpointMapping) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{6}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *IdentityToEndpointMapping) GetIdentity() uint32 {
@@ -528,7 +863,7 @@ type EndpointInfo struct {
 
 func (x *EndpointInfo) Reset() {
 	*x = EndpointInfo{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[7]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -540,7 +875,7 @@ func (x *EndpointInfo) String() string {
 func (*EndpointInfo) ProtoMessage() {}
 
 func (x *EndpointInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[7]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -553,7 +888,7 @@ func (x *EndpointInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EndpointInfo.ProtoReflect.Descriptor instead.
 func (*EndpointInfo) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{7}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *EndpointInfo) GetId() uint64 {
@@ -581,7 +916,7 @@ type IdentityToPrefixMapping struct {
 
 func (x *IdentityToPrefixMapping) Reset() {
 	*x = IdentityToPrefixMapping{}
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[8]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -593,7 +928,7 @@ func (x *IdentityToPrefixMapping) String() string {
 func (*IdentityToPrefixMapping) ProtoMessage() {}
 
 func (x *IdentityToPrefixMapping) ProtoReflect() protoreflect.Message {
-	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[8]
+	mi := &file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -606,7 +941,7 @@ func (x *IdentityToPrefixMapping) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IdentityToPrefixMapping.ProtoReflect.Descriptor instead.
 func (*IdentityToPrefixMapping) Descriptor() ([]byte, []int) {
-	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{8}
+	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *IdentityToPrefixMapping) GetIdentity() uint32 {
@@ -631,14 +966,40 @@ const file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc = "" +
 	"\x13PolicyStateResponse\x12<\n" +
 	"\bresponse\x18\x01 \x01(\x0e2 .standalonednsproxy.ResponseCodeR\bresponse\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x02 \x01(\tR\trequestId\"\xbb\x01\n" +
+	"request_id\x18\x02 \x01(\tR\trequestId\"\xff\x01\n" +
 	"\vFQDNMapping\x12\x12\n" +
 	"\x04fqdn\x18\x01 \x01(\tR\x04fqdn\x12\x1b\n" +
 	"\trecord_ip\x18\x02 \x03(\fR\brecordIp\x12\x10\n" +
 	"\x03ttl\x18\x03 \x01(\rR\x03ttl\x12'\n" +
 	"\x0fsource_identity\x18\x04 \x01(\rR\x0esourceIdentity\x12\x1b\n" +
 	"\tsource_ip\x18\x05 \x01(\fR\bsourceIp\x12#\n" +
-	"\rresponse_code\x18\x06 \x01(\rR\fresponseCode\"U\n" +
+	"\rresponse_code\x18\x06 \x01(\rR\fresponseCode\x12B\n" +
+	"\fmetrics_data\x18\a \x01(\v2\x1f.standalonednsproxy.MetricsDataR\vmetricsData\"\xb7\x03\n" +
+	"\vMetricsData\x12N\n" +
+	"\x10processing_stats\x18\x01 \x01(\v2#.standalonednsproxy.ProcessingStatsR\x0fprocessingStats\x12O\n" +
+	"\x11dns_response_data\x18\x02 \x01(\v2#.standalonednsproxy.DNSResponseDataR\x0fdnsResponseData\x12\x1f\n" +
+	"\vsource_port\x18\x03 \x01(\rR\n" +
+	"sourcePort\x12\x1f\n" +
+	"\vserver_addr\x18\x04 \x01(\tR\n" +
+	"serverAddr\x12'\n" +
+	"\x0fserver_identity\x18\x05 \x01(\rR\x0eserverIdentity\x12\x1a\n" +
+	"\bprotocol\x18\x06 \x01(\tR\bprotocol\x12\x18\n" +
+	"\aallowed\x18\a \x01(\bR\aallowed\x12#\n" +
+	"\rerror_message\x18\b \x01(\tR\ferrorMessage\x12A\n" +
+	"\n" +
+	"error_type\x18\t \x01(\x0e2\".standalonednsproxy.ProxyErrorTypeR\terrorType\"\xf9\x01\n" +
+	"\x0fProcessingStats\x12\"\n" +
+	"\rtotal_time_ns\x18\x01 \x01(\x03R\vtotalTimeNs\x12,\n" +
+	"\x12processing_time_ns\x18\x02 \x01(\x03R\x10processingTimeNs\x12(\n" +
+	"\x10upstream_time_ns\x18\x03 \x01(\x03R\x0eupstreamTimeNs\x129\n" +
+	"\x19semaphore_acquire_time_ns\x18\x04 \x01(\x03R\x16semaphoreAcquireTimeNs\x12/\n" +
+	"\x14policy_check_time_ns\x18\x05 \x01(\x03R\x11policyCheckTimeNs\"\x85\x01\n" +
+	"\x0fDNSResponseData\x12\x1f\n" +
+	"\vis_response\x18\x01 \x01(\bR\n" +
+	"isResponse\x12\x16\n" +
+	"\x06cnames\x18\x02 \x03(\tR\x06cnames\x12\x16\n" +
+	"\x06qtypes\x18\x03 \x03(\rR\x06qtypes\x12!\n" +
+	"\fanswer_types\x18\x04 \x03(\rR\vanswerTypes\"U\n" +
 	"\x15UpdateMappingResponse\x12<\n" +
 	"\bresponse\x18\x01 \x01(\x0e2 .standalonednsproxy.ResponseCodeR\bresponse\"\x8d\x01\n" +
 	"\tDNSServer\x12.\n" +
@@ -674,7 +1035,13 @@ const file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc = "" +
 	"\x1dRESPONSE_CODE_NOT_IMPLEMENTED\x10\x04\x12(\n" +
 	"$RESPONSE_CODE_ERROR_INVALID_ARGUMENT\x10\x06\x12*\n" +
 	"&RESPONSE_CODE_ERROR_ENDPOINT_NOT_FOUND\x10\x05\x12\x19\n" +
-	"\x15RESPONSE_CODE_REFUSED\x10\a2\xd5\x01\n" +
+	"\x15RESPONSE_CODE_REFUSED\x10\a*\xb6\x01\n" +
+	"\x0eProxyErrorType\x12\x19\n" +
+	"\x15PROXY_ERROR_TYPE_NONE\x10\x00\x12\x1a\n" +
+	"\x16PROXY_ERROR_TYPE_PROXY\x10\x01\x12\x1c\n" +
+	"\x18PROXY_ERROR_TYPE_TIMEOUT\x10\x02\x12%\n" +
+	"!PROXY_ERROR_TYPE_SEMAPHORE_FAILED\x10\x03\x12(\n" +
+	"$PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT\x10\x042\xd5\x01\n" +
 	"\bFQDNData\x12c\n" +
 	"\x11StreamPolicyState\x12'.standalonednsproxy.PolicyStateResponse\x1a\x1f.standalonednsproxy.PolicyState\"\x00(\x010\x01\x12d\n" +
 	"\x14UpdateMappingRequest\x12\x1f.standalonednsproxy.FQDNMapping\x1a).standalonednsproxy.UpdateMappingResponse\"\x00B4Z2github.com/cilium/cilium/api/v1/standalonednsproxyb\x06proto3"
@@ -691,37 +1058,45 @@ func file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescGZIP() []byte {
 	return file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDescData
 }
 
-var file_standalone_dns_proxy_standalone_dns_proxy_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_standalone_dns_proxy_standalone_dns_proxy_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_standalone_dns_proxy_standalone_dns_proxy_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_standalone_dns_proxy_standalone_dns_proxy_proto_goTypes = []any{
 	(ResponseCode)(0),                 // 0: standalonednsproxy.ResponseCode
-	(*PolicyStateResponse)(nil),       // 1: standalonednsproxy.PolicyStateResponse
-	(*FQDNMapping)(nil),               // 2: standalonednsproxy.FQDNMapping
-	(*UpdateMappingResponse)(nil),     // 3: standalonednsproxy.UpdateMappingResponse
-	(*DNSServer)(nil),                 // 4: standalonednsproxy.DNSServer
-	(*DNSPolicy)(nil),                 // 5: standalonednsproxy.DNSPolicy
-	(*PolicyState)(nil),               // 6: standalonednsproxy.PolicyState
-	(*IdentityToEndpointMapping)(nil), // 7: standalonednsproxy.IdentityToEndpointMapping
-	(*EndpointInfo)(nil),              // 8: standalonednsproxy.EndpointInfo
-	(*IdentityToPrefixMapping)(nil),   // 9: standalonednsproxy.IdentityToPrefixMapping
+	(ProxyErrorType)(0),               // 1: standalonednsproxy.ProxyErrorType
+	(*PolicyStateResponse)(nil),       // 2: standalonednsproxy.PolicyStateResponse
+	(*FQDNMapping)(nil),               // 3: standalonednsproxy.FQDNMapping
+	(*MetricsData)(nil),               // 4: standalonednsproxy.MetricsData
+	(*ProcessingStats)(nil),           // 5: standalonednsproxy.ProcessingStats
+	(*DNSResponseData)(nil),           // 6: standalonednsproxy.DNSResponseData
+	(*UpdateMappingResponse)(nil),     // 7: standalonednsproxy.UpdateMappingResponse
+	(*DNSServer)(nil),                 // 8: standalonednsproxy.DNSServer
+	(*DNSPolicy)(nil),                 // 9: standalonednsproxy.DNSPolicy
+	(*PolicyState)(nil),               // 10: standalonednsproxy.PolicyState
+	(*IdentityToEndpointMapping)(nil), // 11: standalonednsproxy.IdentityToEndpointMapping
+	(*EndpointInfo)(nil),              // 12: standalonednsproxy.EndpointInfo
+	(*IdentityToPrefixMapping)(nil),   // 13: standalonednsproxy.IdentityToPrefixMapping
 }
 var file_standalone_dns_proxy_standalone_dns_proxy_proto_depIdxs = []int32{
-	0, // 0: standalonednsproxy.PolicyStateResponse.response:type_name -> standalonednsproxy.ResponseCode
-	0, // 1: standalonednsproxy.UpdateMappingResponse.response:type_name -> standalonednsproxy.ResponseCode
-	4, // 2: standalonednsproxy.DNSPolicy.dns_servers:type_name -> standalonednsproxy.DNSServer
-	5, // 3: standalonednsproxy.PolicyState.egress_l7_dns_policy:type_name -> standalonednsproxy.DNSPolicy
-	7, // 4: standalonednsproxy.PolicyState.identity_to_endpoint_mapping:type_name -> standalonednsproxy.IdentityToEndpointMapping
-	9, // 5: standalonednsproxy.PolicyState.identity_to_prefix_mapping:type_name -> standalonednsproxy.IdentityToPrefixMapping
-	8, // 6: standalonednsproxy.IdentityToEndpointMapping.endpoint_info:type_name -> standalonednsproxy.EndpointInfo
-	1, // 7: standalonednsproxy.FQDNData.StreamPolicyState:input_type -> standalonednsproxy.PolicyStateResponse
-	2, // 8: standalonednsproxy.FQDNData.UpdateMappingRequest:input_type -> standalonednsproxy.FQDNMapping
-	6, // 9: standalonednsproxy.FQDNData.StreamPolicyState:output_type -> standalonednsproxy.PolicyState
-	3, // 10: standalonednsproxy.FQDNData.UpdateMappingRequest:output_type -> standalonednsproxy.UpdateMappingResponse
-	9, // [9:11] is the sub-list for method output_type
-	7, // [7:9] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	0,  // 0: standalonednsproxy.PolicyStateResponse.response:type_name -> standalonednsproxy.ResponseCode
+	4,  // 1: standalonednsproxy.FQDNMapping.metrics_data:type_name -> standalonednsproxy.MetricsData
+	5,  // 2: standalonednsproxy.MetricsData.processing_stats:type_name -> standalonednsproxy.ProcessingStats
+	6,  // 3: standalonednsproxy.MetricsData.dns_response_data:type_name -> standalonednsproxy.DNSResponseData
+	1,  // 4: standalonednsproxy.MetricsData.error_type:type_name -> standalonednsproxy.ProxyErrorType
+	0,  // 5: standalonednsproxy.UpdateMappingResponse.response:type_name -> standalonednsproxy.ResponseCode
+	8,  // 6: standalonednsproxy.DNSPolicy.dns_servers:type_name -> standalonednsproxy.DNSServer
+	9,  // 7: standalonednsproxy.PolicyState.egress_l7_dns_policy:type_name -> standalonednsproxy.DNSPolicy
+	11, // 8: standalonednsproxy.PolicyState.identity_to_endpoint_mapping:type_name -> standalonednsproxy.IdentityToEndpointMapping
+	13, // 9: standalonednsproxy.PolicyState.identity_to_prefix_mapping:type_name -> standalonednsproxy.IdentityToPrefixMapping
+	12, // 10: standalonednsproxy.IdentityToEndpointMapping.endpoint_info:type_name -> standalonednsproxy.EndpointInfo
+	2,  // 11: standalonednsproxy.FQDNData.StreamPolicyState:input_type -> standalonednsproxy.PolicyStateResponse
+	3,  // 12: standalonednsproxy.FQDNData.UpdateMappingRequest:input_type -> standalonednsproxy.FQDNMapping
+	10, // 13: standalonednsproxy.FQDNData.StreamPolicyState:output_type -> standalonednsproxy.PolicyState
+	7,  // 14: standalonednsproxy.FQDNData.UpdateMappingRequest:output_type -> standalonednsproxy.UpdateMappingResponse
+	13, // [13:15] is the sub-list for method output_type
+	11, // [11:13] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_standalone_dns_proxy_standalone_dns_proxy_proto_init() }
@@ -734,8 +1109,8 @@ func file_standalone_dns_proxy_standalone_dns_proxy_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc), len(file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   9,
+			NumEnums:      2,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.json.go
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.json.go
@@ -35,6 +35,42 @@ func (msg *FQDNMapping) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler
+func (msg *MetricsData) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseProtoNames: true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *MetricsData) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
+func (msg *ProcessingStats) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseProtoNames: true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *ProcessingStats) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
+func (msg *DNSResponseData) MarshalJSON() ([]byte, error) {
+	return protojson.MarshalOptions{
+		UseProtoNames: true,
+	}.Marshal(msg)
+}
+
+// UnmarshalJSON implements json.Unmarshaler
+func (msg *DNSResponseData) UnmarshalJSON(b []byte) error {
+	return protojson.UnmarshalOptions{}.Unmarshal(b, msg)
+}
+
+// MarshalJSON implements json.Marshaler
 func (msg *UpdateMappingResponse) MarshalJSON() ([]byte, error) {
 	return protojson.MarshalOptions{
 		UseProtoNames: true,

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.proto
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.proto
@@ -51,6 +51,62 @@ message FQDNMapping {
     uint32 source_identity = 4; // Identity of the client making the DNS request
     bytes source_ip = 5; // IP address of the client making the DNS request
     uint32 response_code = 6; // DNS Response code as specified in RFC2316
+    MetricsData metrics_data = 7; // Metrics and access logging data collected by the standalone DNS proxy.
+}
+
+// ProxyErrorType classifies the error that occurred during DNS proxy
+// processing. The agent uses this to reconstruct the correct error type
+// for metrics reporting (metric label, semaphore-rejected counter, etc.)
+// without relying on Go error-type information that is lost during gRPC
+// serialization.
+enum ProxyErrorType {
+    // No error occurred.
+    PROXY_ERROR_TYPE_NONE = 0;
+    // A generic proxy-side error (e.g. failed to parse, forward, etc.).
+    PROXY_ERROR_TYPE_PROXY = 1;
+    // An upstream network timeout (e.g. DNS server did not respond).
+    PROXY_ERROR_TYPE_TIMEOUT = 2;
+    // The DNS proxy concurrency semaphore could not be acquired immediately.
+    PROXY_ERROR_TYPE_SEMAPHORE_FAILED = 3;
+    // The DNS proxy concurrency semaphore timed out during the grace period.
+    PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT = 4;
+}
+
+// MetricsData carries the flow context and timing statistics that the agent
+// needs to emit proxy metrics and access log records for DNS events
+// originating from the standalone DNS proxy.
+message MetricsData {
+    ProcessingStats processing_stats = 1; // Proxy request processing timing statistics
+    DNSResponseData dns_response_data = 2; // DNS response metadata extracted from the DNS message
+    uint32 source_port = 3; // Source port of the endpoint making the DNS request
+    string server_addr = 4; // IP:port of the destination DNS server as "ip:port" string (e.g., "8.8.8.8:53")
+    uint32 server_identity = 5; // Security identity of the destination DNS server
+    string protocol = 6; // L4 protocol used for the DNS request (e.g., "udp", "tcp")
+    bool allowed = 7; // Whether the DNS request was allowed by policy
+    string error_message = 8; // Error message if the DNS request encountered an error (empty if no error)
+    ProxyErrorType error_type = 9; // Structured error classification for metrics without relying on string matching.
+}
+
+// ProcessingStats carries proxy request timing statistics collected by the
+// standalone DNS proxy. All durations are in nanoseconds.
+// Only fields actually measured by the standalone proxy are included here;
+// agent-side timings (policy generation, dataplane, cache updates, etc.)
+// are measured directly by the agent after receiving the gRPC message.
+message ProcessingStats {
+    int64 total_time_ns = 1;
+    int64 processing_time_ns = 2;
+    int64 upstream_time_ns = 3;
+    int64 semaphore_acquire_time_ns = 4;
+    int64 policy_check_time_ns = 5;
+}
+
+// DNSResponseData holds the DNS message details extracted from the response
+// that are needed for access logging on the agent side.
+message DNSResponseData {
+    bool is_response = 1; // Whether this is a DNS response (true) or request (false)
+    repeated string cnames = 2; // CNAME records from the DNS response
+    repeated uint32 qtypes = 3; // DNS question types
+    repeated uint32 answer_types = 4; // DNS answer record types
 }
 
 // Ack returned by cilium agent to SDP on receiving FQDN-IP mapping update

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -12,7 +13,6 @@ import (
 	"net/netip"
 	"strings"
 
-	"github.com/cilium/dns"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/counter"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
@@ -32,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 
 	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
@@ -668,57 +670,157 @@ func (s *FQDNDataServer) deletePolicyRules(writeTxn statedb.WriteTxn, secID iden
 // UpdateMappingRequest updates the FQDN mapping with the given data
 // SDP sends the fqdn mapping to cilium agent
 // Steps to update the mapping:
-// 1. Get the endpoint from the IP
-// 2. If the endpoint is not found, return an error
-// 3. If the IPs are not empty, update the cilium agent with the mapping
-// Note: Not all metrics are reported by the standalone dns proxy yet and will be added in the future.
+// 1. Reconstruct the DNS message details and proxy request context from the gRPC message
+// 2. Best-effort resolve the endpoint from the source IP
+// 3. Call NotifyOnDNSMsg which handles metrics, access logging, and DNS cache updates
+//
+// The endpoint or source IP may be absent for error-path messages (timeouts,
+// semaphore rejections, etc.). We still forward these to NotifyOnDNSMsg so
+// that the agent emits the corresponding proxy metrics.
 func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.FQDNMapping) (*pb.UpdateMappingResponse, error) {
 	now := time.Now()
-	var ips []netip.Addr
 	stat := dnsproxy.ProxyRequestContext{DataSource: accesslog.DNSSourceStandaloneProxy}
+	populateProxyStatContextFromProto(&stat, mappings.GetMetricsData())
 
+	stat.TotalTime.Start()
+
+	var ep *endpoint.Endpoint
 	sourceIP := mappings.GetSourceIp()
-	if sourceIP == nil {
-		s.log.Error("Source IP is nil in FQDN mapping")
+	if sourceIP != nil {
+		endpointAddr, err := netip.ParseAddr(string(sourceIP))
+		if err == nil {
+			ep = s.endpointsLookup.LookupIP(endpointAddr)
+		}
+	}
+
+	msgDetails, serverAddrPort, epIPPort, serverID, protocol, allowed := s.reconstructNotifyArgs(mappings, sourceIP)
+
+	if err := s.updateOnDNSMsg.NotifyOnDNSMsg(now, ep, epIPPort, serverID, serverAddrPort, msgDetails, protocol, allowed, &stat); err != nil {
+		s.log.Error("Failed to process DNS message",
+			logfields.Error, err,
+			logfields.DNSName, mappings.GetFqdn(),
+		)
 		return &pb.UpdateMappingResponse{
-			Response: pb.ResponseCode_RESPONSE_CODE_ERROR_INVALID_ARGUMENT,
-		}, fmt.Errorf("source IP is nil in FQDN mapping")
-	}
-
-	endpointAddr := netip.MustParseAddr(string(sourceIP))
-	ep := s.endpointsLookup.LookupIP(endpointAddr)
-	if ep == nil {
-		s.log.Error("Endpoint not found for IP", logfields.IPAddr, endpointAddr)
-		return &pb.UpdateMappingResponse{
-			Response: pb.ResponseCode_RESPONSE_CODE_ERROR_ENDPOINT_NOT_FOUND,
-		}, fmt.Errorf("endpoint not found for IP: %s", mappings.SourceIp)
-	}
-
-	recordIps := mappings.GetRecordIp()
-	if len(recordIps) == 0 {
-		return &pb.UpdateMappingResponse{
-			Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
-		}, nil
-	}
-
-	for _, ip := range recordIps {
-		ips = append(ips, netip.MustParseAddr(string(ip)))
-	}
-
-	if len(mappings.GetFqdn()) == 0 {
-		s.log.Error("FQDN is nil or empty in FQDN mapping")
-		return &pb.UpdateMappingResponse{
-			Response: pb.ResponseCode_RESPONSE_CODE_ERROR_INVALID_ARGUMENT,
-		}, fmt.Errorf("FQDN is nil or empty in FQDN mapping")
-	}
-
-	if mappings.GetResponseCode() == dns.RcodeSuccess {
-		s.updateOnDNSMsg.UpdateOnDNSMsg(now, ep, mappings.GetFqdn(), ips, int(mappings.GetTtl()), &stat)
+			Response: responseCodeFromError(err),
+		}, fmt.Errorf("failed to process DNS message: %w", err)
 	}
 
 	return &pb.UpdateMappingResponse{
 		Response: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
 	}, nil
+}
+
+func responseCodeFromError(err error) pb.ResponseCode {
+	var noEp dnsproxy.ErrDNSRequestNoEndpoint
+	if errors.As(err, &noEp) {
+		return pb.ResponseCode_RESPONSE_CODE_ERROR_ENDPOINT_NOT_FOUND
+	}
+	return pb.ResponseCode_RESPONSE_CODE_SERVER_FAILURE
+}
+
+func (s *FQDNDataServer) reconstructNotifyArgs(mappings *pb.FQDNMapping, sourceIP []byte) (
+	msgDetails *dnsproxy.MsgDetails,
+	serverAddrPort netip.AddrPort,
+	epIPPort string,
+	serverID identity.NumericIdentity,
+	protocol string,
+	allowed bool,
+) {
+	var responseIPs []netip.Addr
+	for _, ip := range mappings.GetRecordIp() {
+		addr, err := netip.ParseAddr(string(ip))
+		if err != nil {
+			s.log.Warn("Skipping invalid response IP",
+				logfields.IPAddr, string(ip),
+				logfields.Error, err,
+			)
+			continue
+		}
+		responseIPs = append(responseIPs, addr)
+	}
+
+	md := mappings.GetMetricsData()
+
+	if md == nil {
+		s.log.Debug("MetricsData not present in FQDN mapping, using empty defaults", logfields.DNSName, mappings.GetFqdn())
+		md = &pb.MetricsData{}
+	}
+
+	var qtypes []uint16
+	var answerTypes []uint16
+	var isResponse bool
+	var cnames []string
+	if drd := md.GetDnsResponseData(); drd != nil {
+		qtypes = slices.Map(drd.GetQtypes(), func(q uint32) uint16 { return uint16(q) })
+		answerTypes = slices.Map(drd.GetAnswerTypes(), func(a uint32) uint16 { return uint16(a) })
+		isResponse = drd.GetIsResponse()
+		cnames = drd.GetCnames()
+	}
+
+	msgDetails = &dnsproxy.MsgDetails{
+		QName:       mappings.GetFqdn(),
+		ResponseIPs: responseIPs,
+		TTL:         mappings.GetTtl(),
+		CNAMEs:      cnames,
+		RCode:       int(mappings.GetResponseCode()),
+		AnswerTypes: answerTypes,
+		QTypes:      qtypes,
+		Response:    isResponse,
+	}
+
+	if md.GetServerAddr() != "" {
+		var err error
+		if serverAddrPort, err = netip.ParseAddrPort(md.GetServerAddr()); err != nil {
+			s.log.Warn("Failed to parse server address",
+				logfields.IPAddr, md.GetServerAddr(),
+				logfields.Error, err,
+			)
+		}
+	}
+
+	if len(sourceIP) > 0 {
+		epIPPort = fmt.Sprintf("%s:%d", string(sourceIP), md.GetSourcePort())
+	}
+
+	serverID = identity.NumericIdentity(md.GetServerIdentity())
+	protocol = md.GetProtocol()
+	allowed = md.GetAllowed()
+	return
+}
+
+// populateProxyStatContextFromProto populates a ProxyRequestContext with timing
+// and error data from the protobuf MetricsData message.
+func populateProxyStatContextFromProto(stat *dnsproxy.ProxyRequestContext, md *pb.MetricsData) {
+	if md == nil {
+		return
+	}
+	if ps := md.GetProcessingStats(); ps != nil {
+		stat.TotalTime.SetSuccessDuration(time.Duration(ps.GetTotalTimeNs()))
+		stat.ProcessingTime.SetSuccessDuration(time.Duration(ps.GetProcessingTimeNs()))
+		stat.UpstreamTime.SetSuccessDuration(time.Duration(ps.GetUpstreamTimeNs()))
+		stat.SemaphoreAcquireTime.SetSuccessDuration(time.Duration(ps.GetSemaphoreAcquireTimeNs()))
+		stat.PolicyCheckTime.SetSuccessDuration(time.Duration(ps.GetPolicyCheckTimeNs()))
+	}
+	if md.GetErrorMessage() != "" {
+		stat.Err = errorFromProtoType(md.GetErrorType(), md.GetErrorMessage())
+	}
+}
+
+// errorFromProtoType reconstructs a typed Go error from the ProxyErrorType
+// enum received from the standalone DNS proxy. This preserves the error
+// classification across the gRPC boundary so the agent's endMetric() sees
+// the correct error type for metrics labels and counters.
+func errorFromProtoType(et pb.ProxyErrorType, msg string) error {
+	switch et {
+	case pb.ProxyErrorType_PROXY_ERROR_TYPE_SEMAPHORE_FAILED:
+		return dnsproxy.ErrFailedAcquireSemaphore{}
+	case pb.ProxyErrorType_PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT:
+		return dnsproxy.ErrTimedOutAcquireSemaphore{}
+	case pb.ProxyErrorType_PROXY_ERROR_TYPE_TIMEOUT:
+		return fmt.Errorf("%s: %w", msg, context.DeadlineExceeded)
+	default:
+		return fmt.Errorf("%s", msg)
+	}
 }
 
 // ListenAndServe starts the Standalone DNS Proxy gRPC server on the given port

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn"
+	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
 	"github.com/cilium/cilium/pkg/fqdn/namemanager"
 	"github.com/cilium/cilium/pkg/hive"
@@ -32,10 +33,12 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
@@ -106,6 +109,19 @@ func (m *mockUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{
 	return out
 }
 
+type noopNotifier struct{}
+
+func (*noopNotifier) NewProxyLogRecord(_ *accesslog.LogRecord) error { return nil }
+
+type dummyInfoRegistry struct{}
+
+func (*dummyInfoRegistry) FillEndpointInfo(_ context.Context, _ *accesslog.EndpointInfo, _ netip.Addr) {
+}
+
+func newTestProxyAccessLogger(logger *slog.Logger) accesslog.ProxyAccessLogger {
+	return accesslog.NewProxyAccessLogger(logger, accesslog.ProxyAccessLoggerConfig{}, &noopNotifier{}, &dummyInfoRegistry{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+}
+
 func TestFQDNDataServer(t *testing.T) {
 
 	test := map[string]struct {
@@ -165,7 +181,7 @@ func TestFQDNDataServer(t *testing.T) {
 								Lifecycle:         lc,
 								Logger:            logger,
 								NameManager:       nil,
-								ProxyAccessLogger: nil,
+								ProxyAccessLogger: newTestProxyAccessLogger(logger),
 							})
 					},
 					func() *option.DaemonConfig {
@@ -279,7 +295,7 @@ func setupServer(t *testing.T, port int, enableL7Proxy bool, enableStandaloneDNS
 							Lifecycle:         lc,
 							Logger:            logger,
 							NameManager:       nm,
-							ProxyAccessLogger: nil,
+							ProxyAccessLogger: newTestProxyAccessLogger(logger),
 						})
 				},
 				func() *option.DaemonConfig {
@@ -918,50 +934,100 @@ func TestUpdateMappingRequest(t *testing.T) {
 		shouldError      bool
 		errorMessage     string
 	}{
-		"nil source IP should return invalid argument error": {
+		"nil source IP still forwards to NotifyOnDNSMsg for metrics": {
 			mapping: &pb.FQDNMapping{
 				SourceIp:     nil,
 				Fqdn:         "example.com",
 				RecordIp:     [][]byte{[]byte("10.20.30.40")},
 				Ttl:          300,
 				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					Protocol: "udp",
+					Allowed:  true,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: true,
+					},
+				},
 			},
-			expectedResponse: pb.ResponseCode_RESPONSE_CODE_ERROR_INVALID_ARGUMENT,
+			expectedResponse: pb.ResponseCode_RESPONSE_CODE_ERROR_ENDPOINT_NOT_FOUND,
 			shouldError:      true,
-			errorMessage:     "source IP is nil in FQDN mapping",
+			errorMessage:     "DNS request cannot be associated with an existing endpoint",
 		},
 		"empty record IPs should return success": {
 			mapping: &pb.FQDNMapping{
 				SourceIp: []byte("1.2.3.4"),
 				Fqdn:     "example.com",
 				RecordIp: [][]byte{}, // Empty record IPs
+				MetricsData: &pb.MetricsData{
+					SourcePort: 5353,
+					Protocol:   "udp",
+					Allowed:    true,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: false,
+					},
+				},
 			},
 			expectedResponse: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
 			shouldError:      false,
 		},
-		"endpoint not found should return error": {
+		"endpoint not found still forwards to NotifyOnDNSMsg for metrics": {
 			mapping: &pb.FQDNMapping{
 				SourceIp:     []byte("192.168.1.1"), // Non-existent IP
 				Fqdn:         "example.com",
 				RecordIp:     [][]byte{[]byte("1.2.3.4")},
 				Ttl:          300,
 				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					SourcePort: 5353,
+					Protocol:   "udp",
+					Allowed:    true,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: true,
+					},
+				},
 			},
 			expectedResponse: pb.ResponseCode_RESPONSE_CODE_ERROR_ENDPOINT_NOT_FOUND,
 			shouldError:      true,
-			errorMessage:     "endpoint not found for IP",
+			errorMessage:     "DNS request cannot be associated with an existing endpoint",
 		},
-		"fqdn is empty string should return error": {
+		"empty fqdn still forwards to NotifyOnDNSMsg for metrics": {
 			mapping: &pb.FQDNMapping{
 				SourceIp:     []byte("1.2.3.4"),
 				Fqdn:         "",
 				RecordIp:     [][]byte{[]byte("5.6.7.8")},
 				Ttl:          300,
 				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					SourcePort: 5353,
+					Protocol:   "udp",
+					Allowed:    true,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: true,
+					},
+				},
 			},
-			expectedResponse: pb.ResponseCode_RESPONSE_CODE_ERROR_INVALID_ARGUMENT,
-			shouldError:      true,
-			errorMessage:     "FQDN is nil or empty in FQDN mapping",
+			expectedResponse: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+			shouldError:      false,
+		},
+		"empty server_addr and zero source_port should succeed": {
+			mapping: &pb.FQDNMapping{
+				SourceIp:     []byte("1.2.3.4"),
+				Fqdn:         "example.com",
+				RecordIp:     [][]byte{[]byte("5.6.7.8")},
+				Ttl:          300,
+				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					SourcePort: 0,
+					ServerAddr: "",
+					Protocol:   "udp",
+					Allowed:    true,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: true,
+					},
+				},
+			},
+			expectedResponse: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
+			shouldError:      false,
 		},
 		"valid mapping should succeed": {
 			mapping: &pb.FQDNMapping{
@@ -970,6 +1036,26 @@ func TestUpdateMappingRequest(t *testing.T) {
 				RecordIp:     [][]byte{[]byte("5.6.7.8")},
 				Ttl:          300,
 				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					SourcePort:     5353,
+					ServerAddr:     "8.8.8.8:53",
+					ServerIdentity: 42,
+					Protocol:       "udp",
+					Allowed:        true,
+					ProcessingStats: &pb.ProcessingStats{
+						TotalTimeNs:            10000000,
+						ProcessingTimeNs:       1000000,
+						UpstreamTimeNs:         5000000,
+						SemaphoreAcquireTimeNs: 500000,
+						PolicyCheckTimeNs:      200000,
+					},
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse:  true,
+						Cnames:      []string{"alias.example.com."},
+						Qtypes:      []uint32{uint32(dns.TypeA)},
+						AnswerTypes: []uint32{uint32(dns.TypeA)},
+					},
+				},
 			},
 			expectedResponse: pb.ResponseCode_RESPONSE_CODE_NO_ERROR,
 			shouldError:      false,
@@ -992,6 +1078,169 @@ func TestUpdateMappingRequest(t *testing.T) {
 
 			require.NotNil(t, response, "Response should not be nil")
 			require.Equal(t, tc.expectedResponse, response.Response, "Response code mismatch for scenario: %s", scenario)
+		})
+	}
+}
+
+func TestReconstructNotifyArgs(t *testing.T) {
+	testCases := map[string]struct {
+		mapping            *pb.FQDNMapping
+		sourceIP           []byte
+		expectedMsgDetails dnsproxy.MsgDetails
+		expectedServerAddr netip.AddrPort
+		expectedEpIPPort   string
+		expectedServerID   identity.NumericIdentity
+		expectedProtocol   string
+		expectedAllowed    bool
+	}{
+		"response with all fields": {
+			mapping: &pb.FQDNMapping{
+				Fqdn:         "example.com",
+				RecordIp:     [][]byte{[]byte("5.6.7.8"), []byte("9.10.11.12")},
+				Ttl:          300,
+				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					SourcePort:     12345,
+					ServerAddr:     "8.8.8.8:53",
+					ServerIdentity: 42,
+					Protocol:       "udp",
+					Allowed:        true,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse:  true,
+						Cnames:      []string{"alias.example.com."},
+						Qtypes:      []uint32{uint32(dns.TypeA)},
+						AnswerTypes: []uint32{uint32(dns.TypeA), uint32(dns.TypeCNAME)},
+					},
+				},
+			},
+			sourceIP: []byte("1.2.3.4"),
+			expectedMsgDetails: dnsproxy.MsgDetails{
+				QName:       "example.com",
+				ResponseIPs: []netip.Addr{netip.MustParseAddr("5.6.7.8"), netip.MustParseAddr("9.10.11.12")},
+				TTL:         300,
+				CNAMEs:      []string{"alias.example.com."},
+				RCode:       dns.RcodeSuccess,
+				AnswerTypes: []uint16{uint16(dns.TypeA), uint16(dns.TypeCNAME)},
+				QTypes:      []uint16{uint16(dns.TypeA)},
+				Response:    true,
+			},
+			expectedServerAddr: netip.MustParseAddrPort("8.8.8.8:53"),
+			expectedEpIPPort:   "1.2.3.4:12345",
+			expectedServerID:   identity.NumericIdentity(42),
+			expectedProtocol:   "udp",
+			expectedAllowed:    true,
+		},
+		"dns request (non-response) with no record IPs": {
+			mapping: &pb.FQDNMapping{
+				Fqdn:         "request.example.com",
+				Ttl:          0,
+				ResponseCode: dns.RcodeSuccess,
+				MetricsData: &pb.MetricsData{
+					SourcePort:     54321,
+					ServerAddr:     "8.8.4.4:53",
+					ServerIdentity: 10,
+					Protocol:       "tcp",
+					Allowed:        false,
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: false,
+						Qtypes:     []uint32{uint32(dns.TypeAAAA)},
+					},
+				},
+			},
+			sourceIP: []byte("10.0.0.1"),
+			expectedMsgDetails: dnsproxy.MsgDetails{
+				QName:       "request.example.com",
+				ResponseIPs: nil,
+				TTL:         0,
+				CNAMEs:      nil,
+				RCode:       dns.RcodeSuccess,
+				AnswerTypes: nil,
+				QTypes:      []uint16{uint16(dns.TypeAAAA)},
+				Response:    false,
+			},
+			expectedServerAddr: netip.MustParseAddrPort("8.8.4.4:53"),
+			expectedEpIPPort:   "10.0.0.1:54321",
+			expectedServerID:   identity.NumericIdentity(10),
+			expectedProtocol:   "tcp",
+			expectedAllowed:    false,
+		},
+		"empty protocol preserved as empty": {
+			mapping: &pb.FQDNMapping{
+				Fqdn: "default.example.com",
+				MetricsData: &pb.MetricsData{
+					ServerAddr: "1.1.1.1:53",
+					DnsResponseData: &pb.DNSResponseData{
+						IsResponse: true,
+					},
+				},
+			},
+			sourceIP: []byte("10.0.0.2"),
+			expectedMsgDetails: dnsproxy.MsgDetails{
+				QName:    "default.example.com",
+				Response: true,
+			},
+			expectedServerAddr: netip.MustParseAddrPort("1.1.1.1:53"),
+			expectedEpIPPort:   "10.0.0.2:0",
+			expectedProtocol:   "",
+		},
+		"nil MetricsData does not crash": {
+			mapping: &pb.FQDNMapping{
+				Fqdn: "nil-md.example.com",
+			},
+			sourceIP: nil,
+			expectedMsgDetails: dnsproxy.MsgDetails{
+				QName: "nil-md.example.com",
+			},
+			expectedEpIPPort: "",
+		},
+		"empty mapping does not crash": {
+			mapping:          &pb.FQDNMapping{},
+			sourceIP:         nil,
+			expectedEpIPPort: "",
+		},
+		"invalid response IP is skipped": {
+			mapping: &pb.FQDNMapping{
+				Fqdn:     "bad-ip.example.com",
+				RecordIp: [][]byte{[]byte("not-an-ip"), []byte("1.2.3.4")},
+				MetricsData: &pb.MetricsData{
+					ServerAddr: "8.8.8.8:53",
+				},
+			},
+			sourceIP: []byte("10.0.0.1"),
+			expectedMsgDetails: dnsproxy.MsgDetails{
+				QName:       "bad-ip.example.com",
+				ResponseIPs: []netip.Addr{netip.MustParseAddr("1.2.3.4")},
+			},
+			expectedServerAddr: netip.MustParseAddrPort("8.8.8.8:53"),
+			expectedEpIPPort:   "10.0.0.1:0",
+		},
+		"malformed server address does not crash": {
+			mapping: &pb.FQDNMapping{
+				Fqdn: "bad-server.example.com",
+				MetricsData: &pb.MetricsData{
+					ServerAddr: "not-a-valid-addr",
+				},
+			},
+			sourceIP: []byte("10.0.0.1"),
+			expectedMsgDetails: dnsproxy.MsgDetails{
+				QName: "bad-server.example.com",
+			},
+			expectedEpIPPort: "10.0.0.1:0",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			server := &FQDNDataServer{log: hivetest.Logger(t)}
+			msgDetails, serverAddrPort, epIPPort, serverID, protocol, allowed :=
+				server.reconstructNotifyArgs(tc.mapping, tc.sourceIP)
+
+			require.Equal(t, tc.expectedMsgDetails, *msgDetails)
+			require.Equal(t, tc.expectedServerAddr, serverAddrPort)
+			require.Equal(t, tc.expectedEpIPPort, epIPPort)
+			require.Equal(t, tc.expectedServerID, serverID)
+			require.Equal(t, tc.expectedProtocol, protocol)
+			require.Equal(t, tc.expectedAllowed, allowed)
 		})
 	}
 }

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -106,3 +106,12 @@ func (s *SpanStat) Seconds() float64 {
 	total := s.successDuration + s.failureDuration
 	return total.Seconds()
 }
+
+// SetSuccessDuration sets the success duration of the SpanStat directly.
+// This is useful for reconstructing timing data received from an external source
+// (e.g., the standalone DNS proxy sending timing data via gRPC).
+func (s *SpanStat) SetSuccessDuration(d time.Duration) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.successDuration = d
+}

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -206,7 +206,6 @@ type ConnectionHandler interface {
 	// NotifyOnMsg notifies the gRPC client about DNS messages received by the standalone DNS proxy
 	// This method is called by the DNS proxy when it receives a DNS message.
 	// It is responsible for sending the DNS message to the Cilium agent for further processing.
-	// Note: This method is intentionally left empty for now. And will be implemented in future PRs.
 	NotifyOnMsg(msg *pb.FQDNMapping) error
 
 	// IsConnected returns the current connection status

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
@@ -4,14 +4,17 @@
 package messagehandler
 
 import (
+	"errors"
 	"log/slog"
 	"net"
 	"net/netip"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
 
@@ -25,35 +28,108 @@ type messageHandler struct {
 
 // NotifyOnDNSMsg implements messagehandler.DNSMessageHandler.
 // It is used by the standalone DNS proxy to notify the gRPC client about the DNS message.
+// This method always sends the gRPC message to the agent, even in error cases
+// (e.g. ep == nil, timeout, proxy errors), so that the agent can emit the
+// corresponding proxy metrics for every DNS event.
 func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddrPort netip.AddrPort, details *dnsproxy.MsgDetails, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
-	if ep == nil {
-		return dnsproxy.ErrDNSRequestNoEndpoint{}
-	}
 	var ips [][]byte
 	for _, i := range details.ResponseIPs {
 		ips = append(ips, []byte(i.String()))
 	}
 
-	sourceIp, _, err := net.SplitHostPort(epIPPort)
-	if err != nil {
-		m.Logger.Error("Failed to split IP:Port", logfields.Error, err)
-		return err
-	}
+	sourceIP, sourcePort := m.parseSourceAddr(epIPPort)
+	sourceIdentity := m.getSourceIdentity(ep)
 
-	sourceIdentity, err := ep.GetSecurityIdentity()
-	if err != nil {
-		m.Logger.Error("Failed to get security identity", logfields.Error, err)
-		return err
-	}
+	errorType, errorMessage := classifyProxyError(stat)
+
 	message := &pb.FQDNMapping{
 		Fqdn:           details.QName,
 		RecordIp:       ips,
 		Ttl:            details.TTL,
-		SourceIp:       []byte(sourceIp),
-		SourceIdentity: uint32(sourceIdentity.ID),
+		SourceIp:       []byte(sourceIP),
+		SourceIdentity: sourceIdentity,
 		ResponseCode:   uint32(details.RCode),
+		MetricsData: &pb.MetricsData{
+			ProcessingStats: &pb.ProcessingStats{
+				TotalTimeNs:            stat.TotalTime.Total().Nanoseconds(),
+				ProcessingTimeNs:       stat.ProcessingTime.Total().Nanoseconds(),
+				UpstreamTimeNs:         stat.UpstreamTime.Total().Nanoseconds(),
+				SemaphoreAcquireTimeNs: stat.SemaphoreAcquireTime.Total().Nanoseconds(),
+				PolicyCheckTimeNs:      stat.PolicyCheckTime.Total().Nanoseconds(),
+			},
+			DnsResponseData: &pb.DNSResponseData{
+				IsResponse:  details.Response,
+				Cnames:      details.CNAMEs,
+				Qtypes:      slices.Map(details.QTypes, func(q uint16) uint32 { return uint32(q) }),
+				AnswerTypes: slices.Map(details.AnswerTypes, func(a uint16) uint32 { return uint32(a) }),
+			},
+			SourcePort:     sourcePort,
+			ServerAddr:     serverAddrPort.String(),
+			ServerIdentity: serverID.Uint32(),
+			Protocol:       protocol,
+			Allowed:        allowed,
+			ErrorMessage:   errorMessage,
+			ErrorType:      errorType,
+		},
 	}
 	return m.ConnHandler.NotifyOnMsg(message)
+}
+
+// parseSourceAddr extracts the source IP and port from epIPPort (host:port).
+func (m *messageHandler) parseSourceAddr(epIPPort string) (string, uint32) {
+	host, portStr, err := net.SplitHostPort(epIPPort)
+	if err != nil {
+		m.Logger.Warn("Failed to parse source IP:port",
+			logfields.SourceIP, epIPPort,
+			logfields.Error, err,
+		)
+		return "", 0
+	}
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		m.Logger.Warn("Failed to parse source port",
+			logfields.Port, portStr,
+			logfields.Error, err,
+		)
+		return host, 0
+	}
+	return host, uint32(port)
+}
+
+// getSourceIdentity returns the numeric security identity of the endpoint,
+// or 0 if ep is nil or the identity cannot be retrieved.
+func (m *messageHandler) getSourceIdentity(ep *endpoint.Endpoint) uint32 {
+	if ep == nil {
+		return 0
+	}
+	secID, err := ep.GetSecurityIdentity()
+	if err != nil {
+		m.Logger.Warn("Failed to get endpoint security identity", logfields.Error, err)
+		return 0
+	}
+	return secID.ID.Uint32()
+}
+
+// classifyProxyError maps the Go error in stat.Err to a ProxyErrorType enum
+// value and the error message string. This preserves the structured error
+// classification across the gRPC boundary so that the agent can reconstruct
+// the correct error type for metrics (timeout vs semaphore vs generic proxy error).
+func classifyProxyError(stat *dnsproxy.ProxyRequestContext) (pb.ProxyErrorType, string) {
+	if stat.Err == nil {
+		return pb.ProxyErrorType_PROXY_ERROR_TYPE_NONE, ""
+	}
+	msg := stat.Err.Error()
+
+	switch {
+	case errors.As(stat.Err, &dnsproxy.ErrTimedOutAcquireSemaphore{}):
+		return pb.ProxyErrorType_PROXY_ERROR_TYPE_SEMAPHORE_TIMED_OUT, msg
+	case errors.As(stat.Err, &dnsproxy.ErrFailedAcquireSemaphore{}):
+		return pb.ProxyErrorType_PROXY_ERROR_TYPE_SEMAPHORE_FAILED, msg
+	case stat.IsTimeout():
+		return pb.ProxyErrorType_PROXY_ERROR_TYPE_TIMEOUT, msg
+	default:
+		return pb.ProxyErrorType_PROXY_ERROR_TYPE_PROXY, msg
+	}
 }
 
 // SetBindPort is not implemented for standalone DNS proxy yet. The port is set in the config map for the standalone DNS proxy.
@@ -61,7 +137,7 @@ func (m *messageHandler) SetBindPort(uint16) {
 	m.Logger.Warn("SetBindPort is not implemented for standalone DNS proxy")
 }
 
-// UpdateOnDNSMsg is not implemented for standalone DNS proxy. The cilium agent is responsible for update the datapath based on the response from cilium agent.
+// UpdateOnDNSMsg is not implemented for standalone DNS proxy. The cilium agent is responsible for updating the datapath based on the response from cilium agent.
 func (m *messageHandler) UpdateOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, qname string, responseIPs []netip.Addr, TTL int, stat *dnsproxy.ProxyRequestContext) {
 	m.Logger.Warn("UpdateOnDNSMsg is not implemented for standalone DNS proxy")
 }

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
@@ -4,6 +4,8 @@
 package messagehandler
 
 import (
+	"errors"
+	"fmt"
 	"net/netip"
 	"testing"
 
@@ -64,7 +66,29 @@ func buildResponseDetails() *dnsproxy.MsgDetails {
 		AnswerTypes: []uint16{dns.TypeA, dns.TypeAAAA},
 		QTypes:      []uint16{dns.TypeA},
 		Response:    true,
+		CNAMEs:      []string{"alias.example.com."},
 	}
+}
+
+func buildRequestDetails() *dnsproxy.MsgDetails {
+	return &dnsproxy.MsgDetails{
+		QName:    "request.example.com.",
+		TTL:      0,
+		RCode:    dns.RcodeSuccess,
+		QTypes:   []uint16{dns.TypeA},
+		Response: false,
+	}
+}
+
+// buildStatWithTimings returns a ProxyRequestContext with known durations set on each SpanStat.
+func buildStatWithTimings() *dnsproxy.ProxyRequestContext {
+	stat := &dnsproxy.ProxyRequestContext{}
+	stat.TotalTime.SetSuccessDuration(10 * time.Millisecond)
+	stat.ProcessingTime.SetSuccessDuration(1 * time.Millisecond)
+	stat.UpstreamTime.SetSuccessDuration(5 * time.Millisecond)
+	stat.SemaphoreAcquireTime.SetSuccessDuration(500 * time.Microsecond)
+	stat.PolicyCheckTime.SetSuccessDuration(200 * time.Microsecond)
+	return stat
 }
 
 func TestNotifyOnDNSMsg(t *testing.T) {
@@ -73,51 +97,163 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 		details   *dnsproxy.MsgDetails
 		epIPPort  string
 		server    string
+		serverID  identity.NumericIdentity
+		protocol  string
+		allowed   bool
+		stat      *dnsproxy.ProxyRequestContext
 		nilEp     bool
 		expectErr bool
-		expectMsg *pb.FQDNMapping
+		validate  func(t *testing.T, msg *pb.FQDNMapping)
 	}
 
 	tests := []testCase{
 		{
-			name:      "success",
-			details:   buildResponseDetails(),
-			epIPPort:  "10.1.1.10:5353",
-			server:    "8.8.8.8:53",
-			expectErr: false,
-			expectMsg: &pb.FQDNMapping{
-				Fqdn:           "example.com.",
-				RecordIp:       [][]byte{[]byte("1.2.3.4"), []byte("2001:db8::1")},
-				Ttl:            100,
-				SourceIp:       []byte("10.1.1.10"),
-				SourceIdentity: 111,
-				ResponseCode:   0,
+			name:     "response with all fields",
+			details:  buildResponseDetails(),
+			epIPPort: "10.1.1.10:5353",
+			server:   "8.8.8.8:53",
+			serverID: identity.NumericIdentity(42),
+			protocol: "tcp",
+			allowed:  false,
+			stat:     buildStatWithTimings(),
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				// FQDNMapping top-level fields
+				require.Equal(t, "example.com.", msg.Fqdn)
+				require.ElementsMatch(t, [][]byte{[]byte("1.2.3.4"), []byte("2001:db8::1")}, msg.RecordIp)
+				require.Equal(t, uint32(100), msg.Ttl)
+				require.Equal(t, "10.1.1.10", string(msg.SourceIp))
+				require.Equal(t, uint32(111), msg.SourceIdentity)
+				require.Equal(t, uint32(dns.RcodeSuccess), msg.ResponseCode)
+
+				// MetricsData fields
+				md := msg.MetricsData
+				require.NotNil(t, md)
+				require.Equal(t, uint32(5353), md.SourcePort)
+				require.Equal(t, "8.8.8.8:53", md.ServerAddr)
+				require.Equal(t, uint32(42), md.ServerIdentity)
+				require.Equal(t, "tcp", md.Protocol)
+				require.False(t, md.Allowed)
+				require.Empty(t, md.ErrorMessage)
+
+				// DnsResponseData fields
+				drd := md.DnsResponseData
+				require.NotNil(t, drd)
+				require.True(t, drd.IsResponse)
+				require.Equal(t, []string{"alias.example.com."}, drd.Cnames)
+				require.Equal(t, []uint32{uint32(dns.TypeA)}, drd.Qtypes)
+				require.ElementsMatch(t, []uint32{uint32(dns.TypeA), uint32(dns.TypeAAAA)}, drd.AnswerTypes)
+
+				// ProcessingStats timing fields
+				ps := md.ProcessingStats
+				require.NotNil(t, ps)
+				require.Equal(t, int64(10*time.Millisecond), ps.TotalTimeNs)
+				require.Equal(t, int64(1*time.Millisecond), ps.ProcessingTimeNs)
+				require.Equal(t, int64(5*time.Millisecond), ps.UpstreamTimeNs)
+				require.Equal(t, int64(500*time.Microsecond), ps.SemaphoreAcquireTimeNs)
+				require.Equal(t, int64(200*time.Microsecond), ps.PolicyCheckTimeNs)
 			},
 		},
 		{
-			name:      "invalid source ip:port",
-			details:   buildResponseDetails(),
-			epIPPort:  "bad-format",
-			server:    "8.8.4.4:53",
-			expectErr: true,
+			name:     "invalid source ip:port still sends message",
+			details:  buildResponseDetails(),
+			epIPPort: "bad-format",
+			server:   "8.8.4.4:53",
+			protocol: "udp",
+			allowed:  true,
+			stat:     &dnsproxy.ProxyRequestContext{},
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				// Source fields are empty because SplitHostPort failed
+				require.Empty(t, msg.SourceIp)
+				require.Equal(t, uint32(0), msg.MetricsData.SourcePort)
+				// But the DNS details are still present
+				require.Equal(t, "example.com.", msg.Fqdn)
+				require.Equal(t, uint32(100), msg.Ttl)
+			},
 		},
 		{
-			name:      "nil endpoint",
-			details:   buildResponseDetails(),
-			epIPPort:  "10.1.1.10:5353",
-			server:    "8.8.8.8:53",
-			nilEp:     true,
-			expectErr: true,
+			name:     "dns request",
+			details:  buildRequestDetails(),
+			epIPPort: "10.1.1.10:12345",
+			server:   "8.8.8.8:53",
+			protocol: "udp",
+			allowed:  true,
+			stat:     &dnsproxy.ProxyRequestContext{},
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				require.Equal(t, "request.example.com.", msg.Fqdn)
+				require.Nil(t, msg.RecordIp)
+				require.Equal(t, uint32(0), msg.Ttl)
+				require.Equal(t, uint32(12345), msg.MetricsData.SourcePort)
+
+				drd := msg.MetricsData.DnsResponseData
+				require.NotNil(t, drd)
+				require.False(t, drd.IsResponse)
+				require.Nil(t, drd.Cnames)
+				require.Nil(t, drd.AnswerTypes)
+				require.Equal(t, []uint32{uint32(dns.TypeA)}, drd.Qtypes)
+			},
 		},
 		{
-			name:      "empty msg details",
-			details:   &dnsproxy.MsgDetails{},
-			epIPPort:  "10.1.1.10:5353",
-			server:    "1.1.1.1:53",
-			expectErr: false,
-			expectMsg: &pb.FQDNMapping{
-				SourceIp:       []byte("10.1.1.10"),
-				SourceIdentity: 111,
+			name:     "with proxy error",
+			details:  buildResponseDetails(),
+			epIPPort: "10.1.1.10:5353",
+			server:   "8.8.8.8:53",
+			protocol: "udp",
+			allowed:  false,
+			stat: &dnsproxy.ProxyRequestContext{
+				Err: errors.New("upstream failure"),
+			},
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				require.Equal(t, "upstream failure", msg.MetricsData.ErrorMessage)
+				require.Equal(t, pb.ProxyErrorType_PROXY_ERROR_TYPE_PROXY, msg.MetricsData.ErrorType)
+			},
+		},
+		{
+			name:     "nil endpoint still sends metrics",
+			details:  buildResponseDetails(),
+			epIPPort: "10.1.1.10:5353",
+			server:   "8.8.8.8:53",
+			protocol: "udp",
+			allowed:  false,
+			nilEp:    true,
+			stat: &dnsproxy.ProxyRequestContext{
+				Err: fmt.Errorf("cannot extract endpoint IP from DNS request: %w", errors.New("parse error")),
+			},
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				// Source identity is zero because ep was nil
+				require.Equal(t, uint32(0), msg.SourceIdentity)
+				// But metrics data and error are still forwarded
+				require.NotEmpty(t, msg.MetricsData.ErrorMessage)
+				require.Equal(t, "example.com.", msg.Fqdn)
+				require.Equal(t, uint32(5353), msg.MetricsData.SourcePort)
+			},
+		},
+		{
+			name:     "empty msg details",
+			details:  &dnsproxy.MsgDetails{},
+			epIPPort: "10.1.1.10:5353",
+			server:   "1.1.1.1:53",
+			stat:     &dnsproxy.ProxyRequestContext{},
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				require.Equal(t, "10.1.1.10", string(msg.SourceIp))
+				require.Equal(t, uint32(111), msg.SourceIdentity)
+			},
+		},
+		{
+			name:     "empty epIPPort sends zero source port and empty source IP",
+			details:  buildResponseDetails(),
+			epIPPort: "",
+			server:   "8.8.8.8:53",
+			protocol: "udp",
+			allowed:  true,
+			stat:     &dnsproxy.ProxyRequestContext{},
+			validate: func(t *testing.T, msg *pb.FQDNMapping) {
+				require.Empty(t, msg.SourceIp)
+				require.Equal(t, uint32(0), msg.MetricsData.SourcePort)
+				// DNS details are still present
+				require.Equal(t, "example.com.", msg.Fqdn)
+				require.Equal(t, uint32(100), msg.Ttl)
+				// Server addr is still populated
+				require.Equal(t, "8.8.8.8:53", msg.MetricsData.ServerAddr)
 			},
 		},
 	}
@@ -126,18 +262,15 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			h, mc, ep := newTestHandler(t, tc.nilEp)
 			serverAP := netip.MustParseAddrPort(tc.server)
-			err := h.NotifyOnDNSMsg(time.Now(), ep, tc.epIPPort, 0, serverAP, tc.details, "udp", true, &dnsproxy.ProxyRequestContext{})
+			err := h.NotifyOnDNSMsg(time.Now(), ep, tc.epIPPort, tc.serverID, serverAP, tc.details, tc.protocol, tc.allowed, tc.stat)
 			if tc.expectErr {
-				require.Error(t, err, "expected error")
-			} else {
-				require.NoError(t, err, "expected no error")
-				require.NotNil(t, mc.last, "expected mapping")
-				require.Equal(t, tc.expectMsg.Fqdn, mc.last.Fqdn)
-				require.Equal(t, tc.expectMsg.Ttl, mc.last.Ttl)
-				require.Equal(t, string(tc.expectMsg.SourceIp), string(mc.last.SourceIp))
-				require.Equal(t, tc.expectMsg.SourceIdentity, mc.last.SourceIdentity)
-				require.Equal(t, tc.expectMsg.ResponseCode, mc.last.ResponseCode)
-				require.ElementsMatch(t, tc.expectMsg.RecordIp, mc.last.RecordIp)
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, mc.last)
+			if tc.validate != nil {
+				tc.validate(t, mc.last)
 			}
 		})
 	}


### PR DESCRIPTION
This PR adds metrics reporting from the standalone DNS proxy (SDP) to the cilium agent. The SDP now populates proxy request timings, error classification, and flow context into the gRPC `MetricsData` message. On the agent side, these are reconstructed into the `ProxyRequestContext` so that `NotifyOnDNSMsg` emits the same `cilium_proxy_upstream_reply_seconds` histograms, `cilium_policy_l7_total` counters, and access logs as the in-agent DNS proxy.

From the flow logs:
```
Mar 27 22:15:29.413: default/test-pod:35764 (ID:14394) -> kube-system/coredns-6f6b679f8f-llmlv:53 (ID:14801) dns-request standalone-proxy FORWARDED (DNS Query cilium.io. A)
Mar 27 22:15:29.441: default/test-pod:35764 (ID:14394) <- kube-system/coredns-6f6b679f8f-llmlv:53 (ID:14801) dns-response standalone-proxy FORWARDED (DNS Answer "104.198.14.52" TTL: 30 (Query cilium.io. A))
```
Metrics from the agent:
```
singhvipul@CPC-singh-1EMRX:~/ws/cilium$ kubectl -n kube-system exec cilium-hxhqk -c cilium-agent -- cilium-dbg metrics list | grep cilium_proxy_upstream_reply_seconds

cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=dataplaneTime                                    2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=policyCheckTime                                  2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=policyGenerationTime                             2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=processingTime                                   2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=qnameLockTime                                    2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=semaphoreTime                                    2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=totalTime                                        2.593ms / 4.667ms / 20.8ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=updateEpCacheTime                                2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=updateNmCacheTime                                2.5ms / 4.5ms / 4.95ms
cilium_proxy_upstream_reply_seconds                                      error=allow protocol_l7=dns scope=upstreamTime                                     3.333ms / 18.25ms / 43ms

singhvipul@CPC-singh-1EMRX:~/ws/cilium$ kubectl -n kube-system exec cilium-hxhqk -c cilium-agent -- cilium-dbg metrics list | grep "policy_l7_total.*fqdn"

cilium_policy_l7_total                                                   proxy_type=fqdn rule=denied                                                        16.000000
cilium_policy_l7_total                                                   proxy_type=fqdn rule=forwarded                                                     112.000000
cilium_policy_l7_total                                                   proxy_type=fqdn rule=parse_errors                                                  0.000000
cilium_policy_l7_total                                                   proxy_type=fqdn rule=received                                                      128.000000
```

```release-note
feat(sdp): Support DNS metrics from Standalone DNS Proxy
```
