### PR TITLE
dpgen: relax validation of kind flag of dpgen config

### DIFF
--- a/tools/dpgen/main.go
+++ b/tools/dpgen/main.go
@@ -59,8 +59,8 @@ func configCmd() *cobra.Command {
 				return fmt.Errorf("out cannot be empty")
 			}
 
-			if kind != "object" && kind != "node" {
-				return fmt.Errorf("kind needs to be 'object' or 'node'")
+			if kind == "" {
+				return fmt.Errorf("kind cannot be empty")
 			}
 			return nil
 		},


### PR DESCRIPTION
Historically, dpgen used to support any value for the kind flag. The blamed commit introduced stricter validation, only allowing explicitly defined kinds. However, this introduces an unnecessary limitation in overall flexibility, preventing downstream projects from leveraging different kinds for specific purposes (e.g., separation). Hence, let's relax the validation again, to allow different kinds as well.

Fixes: e9ede604490b ("bpf: implement 'dpgen maps' command and MapSpec registry")