### PR TITLE
workflows/gke: Re-add missing UID in cluster name

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -103,7 +103,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+  clusterName: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 558.0.0


### PR DESCRIPTION
Commit a3b53078eaa1 ("gke: Remove repository_owner and UID from clusterName") removed the UID from the cluster name by mistake, probably while fixing a merge conflict. As a consequence, because Conformance KPR is calling Conformance GKE multiple times, it ends up trying to create multiple clusters with the same name.

cc @YutaroHayakawa 

Fixes: https://github.com/cilium/cilium/pull/44547.