### PR TITLE
bpf: simplify vtep map lookup check

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -798,15 +798,13 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 #ifdef ENABLE_VTEP
 	{
 		struct remote_endpoint_info fake_info = {0};
-		struct vtep_key vkey = {};
+		struct vtep_key vkey = {
+			.vtep_ip = ip4->daddr & CONFIG(vtep_mask),
+		};
 		const struct vtep_value *vtep;
 
-		vkey.vtep_ip = ip4->daddr & CONFIG(vtep_mask);
 		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
-		if (!vtep)
-			goto skip_vtep;
-
-		if (vtep->vtep_mac && vtep->tunnel_endpoint) {
+		if (vtep && vtep->vtep_mac && vtep->tunnel_endpoint) {
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			fake_info.tunnel_endpoint.ip4 = vtep->tunnel_endpoint;
@@ -817,7 +815,6 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 								bpf_htons(ETH_P_IP));
 		}
 	}
-skip_vtep:
 #endif
 
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1256,15 +1256,13 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 	 */
 #if defined(ENABLE_VTEP)
 	{
-		struct vtep_key vkey = {};
-		struct vtep_value *vtep;
+		struct vtep_key vkey = {
+			.vtep_ip = ip4->daddr & CONFIG(vtep_mask),
+		};
+		const struct vtep_value *vtep;
 
-		vkey.vtep_ip = ip4->daddr & CONFIG(vtep_mask);
 		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
-		if (!vtep)
-			goto skip_vtep;
-
-		if (vtep->vtep_mac && vtep->tunnel_endpoint) {
+		if (vtep && vtep->vtep_mac && vtep->tunnel_endpoint) {
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;
 			fake_info.tunnel_endpoint.ip4 = vtep->tunnel_endpoint;
@@ -1275,7 +1273,6 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 								bpf_htons(ETH_P_IP));
 		}
 	}
-skip_vtep:
 #endif
 
 #if defined(TUNNEL_MODE)

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -306,19 +306,17 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 
 #ifdef ENABLE_VTEP
 	{
-		struct vtep_key vkey = {};
+		struct vtep_key vkey = {
+			.vtep_ip = ip4->saddr & CONFIG(vtep_mask),
+		};
 		const struct vtep_value *vtep;
 
-		vkey.vtep_ip = ip4->saddr & CONFIG(vtep_mask);
 		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
-		if (!vtep)
-			goto skip_vtep;
-		if (vtep->tunnel_endpoint) {
+		if (vtep && vtep->tunnel_endpoint) {
 			if (!identity_is_world_ipv4(*identity))
 				return DROP_INVALID_VNI;
 		}
 	}
-skip_vtep:
 #endif
 
 #if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)


### PR DESCRIPTION
Rather than skipping by using a goto label, just extend the if condition in the block after the map lookup. Also inline setting the vtep_ip field in the key construction.