### PR TITLE
Policy: space out numeric tiers, compress initial empty tiers

### DIFF
--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -372,8 +372,8 @@ func TestRedirectWithDeny(t *testing.T) {
 
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: policyTypes.AllowEntry(),
-		mapKeyAllL7:     policyTypes.AllowEntry().WithPriority(1000).WithProxyPort(httpPort).WithListenerPriority(policy.ListenerPriorityHTTP),
-		mapKeyFoo:       policyTypes.DenyEntry().WithPriority(1000),
+		mapKeyAllL7:     policyTypes.AllowEntry().WithProxyPort(httpPort).WithListenerPriority(policy.ListenerPriorityHTTP),
+		mapKeyFoo:       policyTypes.DenyEntry(),
 	}
 
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
@@ -501,8 +501,8 @@ func TestRedirectWithPriority(t *testing.T) {
 
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: policyTypes.AllowEntry(),
-		mapKeyFooL7:     policyTypes.AllowEntry().WithPriority(1000).WithProxyPort(crd2Port).WithListenerPriority(1),
-		mapKeyAllL7:     policyTypes.AllowEntry().WithPriority(1000),
+		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd2Port).WithListenerPriority(1),
+		mapKeyAllL7:     policyTypes.AllowEntry(),
 	}
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
 		mapKeyAllowAllE: labels.LabelArrayList{AllowAnyEgressLabels},
@@ -554,8 +554,8 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 
 	expected := policy.MapStateMap{
 		mapKeyAllowAllE: policyTypes.AllowEntry(),
-		mapKeyFooL7:     policyTypes.AllowEntry().WithPriority(1000).WithProxyPort(crd1Port).WithListenerPriority(1),
-		mapKeyAllL7:     policyTypes.AllowEntry().WithPriority(1000),
+		mapKeyFooL7:     policyTypes.AllowEntry().WithProxyPort(crd1Port).WithListenerPriority(1),
+		mapKeyAllL7:     policyTypes.AllowEntry(),
 	}
 	ep.ValidateRuleLabels(t, LabelArrayListMap{
 		mapKeyAllowAllE: labels.LabelArrayList{AllowAnyEgressLabels},

--- a/pkg/k8s/cluster_network_policy_test.go
+++ b/pkg/k8s/cluster_network_policy_test.go
@@ -106,6 +106,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Subject: subjectAppSubjectSelector,
 			L3:      l3EnvProdSelector,
@@ -140,6 +141,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Subject: types.NewLabelSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{namespaceLabelPrefix + "ns": "subject-ns"},
@@ -169,6 +171,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Subject: subjectAppTestSelector,
 			L3:      l3EnvDevSelector,
@@ -193,6 +196,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Subject: subjectAppTestSelector,
 			L3:      l3EnvDevSelector,
@@ -215,6 +219,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Subject: subjectAppTestSelector,
 			L3:      l3EnvDevSelector,
@@ -235,6 +240,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Verdict: types.Deny,
 			Subject: subjectAppTestSelector,
@@ -252,6 +258,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: false,
 			Subject: subjectAppSubjectSelector,
 			L3:      l3EnvProdSelector,
@@ -273,6 +280,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 		},
 		enableNodeSelectorLabels: true,
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: false,
 			Subject: subjectAppSubjectSelector,
 			L3: types.ToSelectors(
@@ -319,6 +327,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: false,
 			Subject: subjectAppSubjectSelector,
 			L3: types.Selectors{
@@ -342,6 +351,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 		},
 		enableL7Proxy: true,
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: false,
 			Subject: subjectAppSubjectSelector,
 			L3:      types.ToSelectors(api.NewESFromLabels(labels.ParseSelectLabel("k8s-app=kube-dns"))),
@@ -359,6 +369,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			}},
 			Labels: commonPolicyLabels,
 		}, {
+			Tier:    types.Admin,
 			Ingress: false,
 			Subject: subjectAppSubjectSelector,
 			L3: types.Selectors{
@@ -395,6 +406,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: false,
 			Verdict: types.Deny,
 			Subject: subjectAppSubjectSelector,
@@ -424,6 +436,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			},
 		},
 		want: types.PolicyEntries{{
+			Tier:    types.Admin,
 			Ingress: true,
 			Subject: types.NewLabelSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{namespaceLabelPrefix + "app": "main"},
@@ -436,6 +449,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			L4:     portRule("80", api.ProtoTCP),
 			Labels: commonPolicyLabels,
 		}, {
+			Tier:    types.Admin,
 			Ingress: false,
 			Subject: types.NewLabelSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{namespaceLabelPrefix + "app": "main"},

--- a/pkg/policy/distillery_precedence_test.go
+++ b/pkg/policy/distillery_precedence_test.go
@@ -248,6 +248,8 @@ func TestOrderedPolicyValidation(t *testing.T) {
 	DenyEntry := types.DenyEntry()
 	denyEntry := NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil})
 
+	prioNormal := types.Priority(perTierRoundUp)
+
 	identityCache := identity.IdentityMap{
 		identityFoo:       labelsFoo,
 		identityWorld:     labelsWorld,
@@ -334,8 +336,8 @@ func TestOrderedPolicyValidation(t *testing.T) {
 				ingressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyIngress),
 
 				egressKey(0, 6, 80, 0):             denyEntry.withLevel(0),
-				egressKey(identity1111, 6, 81, 15): allowEntry.withLevel(1000),
-				egressKey(0, 0, 0, 0):              allowEntry.withLevel(1001),
+				egressKey(identity1111, 6, 81, 15): allowEntry.withLevel(prioNormal),
+				egressKey(0, 0, 0, 0):              allowEntry.withLevel(prioNormal + 1),
 			},
 			probes: []probe{
 				{key: egressKey(identityWorld, 6, 80, 16), found: true, entry: DenyEntry},
@@ -370,8 +372,8 @@ func TestOrderedPolicyValidation(t *testing.T) {
 				// default allow ingress
 				ingressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyIngress),
 
-				egressKey(0, 0, 0, 0):            denyEntry.withLevel(2001),
-				egressKey(identity1111, 0, 0, 0): allowEntry.withLevel(1).withPassPriority(0, 0, 3000),
+				egressKey(0, 0, 0, 0):            denyEntry.withLevel(2*prioNormal + 1),
+				egressKey(identity1111, 0, 0, 0): allowEntry.withLevel(1).withPassPriority(0, 0, 3*prioNormal),
 			},
 			probes: []probe{
 				{key: egressKey(identityWorld, 6, 80, 16), found: true, entry: DenyEntry},
@@ -418,10 +420,10 @@ func TestOrderedPolicyValidation(t *testing.T) {
 			expected: mapStateMap{
 				// default allow ingress
 				ingressKey(0, 0, 0, 0):           newAllowEntryWithLabels(LabelsAllowAnyIngress),
-				egressKey(0, 6, 80, 0):           denyEntry.withLevel(3001),
-				egressKey(identity1111, 0, 0, 0): allowEntry.withLevel(1).withPassPriority(0, 0, 4000),
-				egressKey(identity1100, 0, 0, 0): denyEntry.withLevel(2).withPassPriority(0, 0, 4000),
-				egressKey(0, 0, 0, 0):            denyEntry.withLevel(5000),
+				egressKey(0, 6, 80, 0):           denyEntry.withLevel(3*prioNormal + 1),
+				egressKey(identity1111, 0, 0, 0): allowEntry.withLevel(1).withPassPriority(0, 0, 4*prioNormal),
+				egressKey(identity1100, 0, 0, 0): denyEntry.withLevel(2).withPassPriority(0, 0, 4*prioNormal),
+				egressKey(0, 0, 0, 0):            denyEntry.withLevel(5 * prioNormal),
 			},
 			probes: []probe{
 				{key: egressKey(identityWorld, 6, 80, 16), found: true, entry: DenyEntry},
@@ -458,9 +460,9 @@ func TestOrderedPolicyValidation(t *testing.T) {
 				ingressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyIngress),
 
 				// default deny egress
-				egressKey(0, 0, 0, 0): newDenyEntryWithLabels(LabelsDenyAnyEgress).withLevel(4000),
+				egressKey(0, 0, 0, 0): newDenyEntryWithLabels(LabelsDenyAnyEgress).withLevel(4 * prioNormal),
 
-				egressKey(identity1111, 0, 0, 0):  newDenyEntryWithLabels(LabelsDenyAnyEgress).withLevel(1001).withPassPriority(0, 0, 3000),
+				egressKey(identity1111, 0, 0, 0):  newDenyEntryWithLabels(LabelsDenyAnyEgress).withLevel(1*prioNormal+1).withPassPriority(0, 0, 3*prioNormal),
 				egressKey(identity1111, 6, 80, 0): allowEntry.withLevel(1),
 			},
 			probes: []probe{},
@@ -491,10 +493,10 @@ func TestOrderedPolicyValidation(t *testing.T) {
 			expected: mapStateMap{
 				// default allow ingress
 				ingressKey(0, 0, 0, 0):            newAllowEntryWithLabels(LabelsAllowAnyIngress),
-				egressKey(identity1111, 0, 0, 0):  newAllowEntryWithLabels(LabelsAllowAnyEgress).withLevel(1001).withPassPriority(0, 0, 3000),
+				egressKey(identity1111, 0, 0, 0):  newAllowEntryWithLabels(LabelsAllowAnyEgress).withLevel(1*prioNormal+1).withPassPriority(0, 0, 3*prioNormal),
 				egressKey(identity1111, 6, 80, 0): allowEntry.withLevel(1),
 				// default allow egress
-				egressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyEgress).withLevel(4000),
+				egressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyEgress).withLevel(4 * prioNormal),
 			},
 			probes: []probe{},
 		}, {
@@ -518,9 +520,9 @@ func TestOrderedPolicyValidation(t *testing.T) {
 				// default allow ingress
 				ingressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyIngress),
 
-				egressKey(identity1111, 0, 0, 0): denyEntry.withLevel(1).withPassPriority(0, 0, 3000),
+				egressKey(identity1111, 0, 0, 0): denyEntry.withLevel(1).withPassPriority(0, 0, 3*prioNormal),
 				// default allow egress
-				egressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyEgress).withLevel(4000),
+				egressKey(0, 0, 0, 0): newAllowEntryWithLabels(LabelsAllowAnyEgress).withLevel(4 * prioNormal),
 			},
 			probes: []probe{},
 		}, {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -1423,11 +1423,11 @@ var (
 	AllowEntry = types.AllowEntry().WithPriority(0)
 	DenyEntry  = types.DenyEntry().WithPriority(0)
 
-	mapEntryDeny  = NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil}).withLevel(1000)
-	mapEntryAllow = NewMapStateEntry(AllowEntry).withLabels(labels.LabelArrayList{nil}).withLevel(1000)
+	mapEntryDeny  = NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil})
+	mapEntryAllow = NewMapStateEntry(AllowEntry).withLabels(labels.LabelArrayList{nil})
 
 	worldLabelArrayList         = labels.LabelArrayList{labels.LabelWorld.LabelArray()}
-	mapEntryWorldDenyWithLabels = NewMapStateEntry(DenyEntry).withLabels(worldLabelArrayList).withLevel(1000)
+	mapEntryWorldDenyWithLabels = NewMapStateEntry(DenyEntry).withLabels(worldLabelArrayList)
 
 	worldIPIdentity = localIdentity(16324)
 	worldIPCIDR     = api.CIDR("192.0.2.3/32")
@@ -2056,12 +2056,12 @@ func Test_IncrementalFQDNDeletion(t *testing.T) {
 		},
 		expected: MapStateMap{
 			mapKeyAllowAll__:     AllowEntry,
-			egressL3OnlyKey(id2): AllowEntry.WithPriority(1000),
-			egressL3OnlyKey(id3): AllowEntry.WithPriority(1000),
+			egressL3OnlyKey(id2): AllowEntry,
+			egressL3OnlyKey(id3): AllowEntry,
 		},
 		fqdnIds: maps.Clone(fqdnIdentities),
 		adds: MapStateMap{
-			egressL3OnlyKey(idExample): AllowEntry.WithPriority(1000),
+			egressL3OnlyKey(idExample): AllowEntry,
 		},
 	}}
 

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
-var denyPerSelectorPolicy = &PerSelectorPolicy{Verdict: types.Deny, Priority: 1000}
+var denyPerSelectorPolicy = &PerSelectorPolicy{Verdict: types.Deny}
 
 // Tests in this file:
 //

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -181,11 +181,33 @@ func (td *testData) addIdentitySelector(sel api.EndpointSelector) bool {
 	return added
 }
 
+// tiersWithRules returns the list of non-empty tiers in a given
+// PolicyMaps. This is used for comparing equality, as a missing
+// and an empty policy map are equivalent
+func tiersWithRules(l4pms L4PolicyMaps) []int {
+	out := make([]int, 0, len(l4pms))
+	for tier, l4pm := range l4pms {
+		if l4pm.Len() > 0 {
+			out = append(out, tier)
+		}
+	}
+	return out
+}
+
 func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4PolicyMaps, availableIDs ...identity.NumericIdentity) {
 	t.Helper()
 
-	require.Len(t, actual, len(expected))
+	// Validate that the set of tiers with rules is identical.
+	// This makes it more ergonomic to write policy map literals by omitting empty tiers
+	require.Equal(t, tiersWithRules(expected), tiersWithRules(actual), "set of non-empty tiers must be the same")
+
+	// Compare policy maps
 	for i := range expected {
+		// it is OK if expected[i] is empty and actual[i] doesn't exist.
+		if i >= len(actual) && expected[i].Len() == 0 {
+			continue
+		}
+
 		require.Equal(t, expected[i].Len(), actual[i].Len())
 		expected[i].ForEach(func(l4 *L4Filter) bool {
 			port := l4.PortName

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1036,7 +1036,7 @@ func TestMapState_insertWithChanges(t *testing.T) {
 			return true
 		})
 
-		entry := NewMapStateEntry(tt.args.entry).withLabels(labels.LabelArrayList{nil}).withLevel(1000)
+		entry := NewMapStateEntry(tt.args.entry).withLabels(labels.LabelArrayList{nil})
 		ms.insertWithChanges(types.Priority(0).ToTierMaxPrecedence(), tt.args.key, entry, denyRules, changes)
 		ms.validatePortProto(t)
 		require.Truef(t, ms.Equal(&tt.want), "%s: MapState mismatch:\n%s", tt.name, ms.diff(&tt.want))
@@ -1083,7 +1083,7 @@ func TcpEgressKey(id identity.NumericIdentity) Key {
 }
 
 func allowEntry() mapStateEntry {
-	return NewMapStateEntry(AllowEntry.WithPriority(1000)).withLabels(labels.LabelArrayList{nil})
+	return NewMapStateEntry(AllowEntry).withLabels(labels.LabelArrayList{nil})
 }
 
 func passEntry(priority, tierPriority, nextTierPriority types.Priority) mapStateEntry {
@@ -1091,19 +1091,19 @@ func passEntry(priority, tierPriority, nextTierPriority types.Priority) mapState
 }
 
 func proxyEntryHTTP(proxyPort uint16) mapStateEntry {
-	return NewMapStateEntry(AllowEntry.WithPriority(1000).WithProxyPort(proxyPort).WithListenerPriority(ListenerPriorityHTTP)).withLabels(labels.LabelArrayList{nil})
+	return NewMapStateEntry(AllowEntry.WithProxyPort(proxyPort).WithListenerPriority(ListenerPriorityHTTP)).withLabels(labels.LabelArrayList{nil})
 }
 
 func proxyEntryDNS(proxyPort uint16) mapStateEntry {
-	return NewMapStateEntry(AllowEntry.WithPriority(1000).WithProxyPort(proxyPort).WithListenerPriority(ListenerPriorityDNS)).withLabels(labels.LabelArrayList{nil})
+	return NewMapStateEntry(AllowEntry.WithProxyPort(proxyPort).WithListenerPriority(ListenerPriorityDNS)).withLabels(labels.LabelArrayList{nil})
 }
 
 func proxyEntryCRD(proxyPort uint16) mapStateEntry {
-	return NewMapStateEntry(AllowEntry.WithPriority(1000).WithProxyPort(proxyPort).WithListenerPriority(ListenerPriorityCRD)).withLabels(labels.LabelArrayList{nil})
+	return NewMapStateEntry(AllowEntry.WithProxyPort(proxyPort).WithListenerPriority(ListenerPriorityCRD)).withLabels(labels.LabelArrayList{nil})
 }
 
 func denyEntry() mapStateEntry {
-	return NewMapStateEntry(DenyEntry.WithPriority(1000)).withLabels(labels.LabelArrayList{nil})
+	return NewMapStateEntry(DenyEntry).withLabels(labels.LabelArrayList{nil})
 }
 
 func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
@@ -1433,7 +1433,7 @@ func TestMapState_AccumulateMapChangesDeny(t *testing.T) {
 			if x.deny {
 				verdict = types.Deny
 			}
-			value := newMapStateEntry(1000, types.HighestPriority, types.LowestPriority, NilRuleOrigin, proxyPort, priority, verdict, NoAuthRequirement)
+			value := newMapStateEntry(0, types.HighestPriority, types.LowestPriority, NilRuleOrigin, proxyPort, priority, verdict, NoAuthRequirement)
 			policyMaps.AccumulateMapChanges(0, 0, adds, deletes, []Key{key}, value)
 		}
 		policyMaps.SyncMapChanges(types.MockSelectorSnapshot())
@@ -1602,7 +1602,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{level: 2, cs: nil, adds: []int{0}, deletes: []int{}, ingress: false, deny: true},
 		},
 		state: testMapState(t, mapStateMap{
-			AnyEgressKey():    denyEntry().withLevel(1002),
+			AnyEgressKey():    denyEntry().withLevel(2),
 			HttpEgressKey(44): proxyEntryHTTP(1),
 		}),
 		adds: Keys{
@@ -1616,8 +1616,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{level: 1, cs: csFoo, adds: []int{44}, deletes: []int{}, port: 0, proto: 6, ingress: false, deny: true},
 		},
 		state: testMapState(t, mapStateMap{
-			AnyEgressKey():    denyEntry().withLevel(1002),
-			TcpEgressKey(44):  denyEntry().withLevel(1001),
+			AnyEgressKey():    denyEntry().withLevel(2),
+			TcpEgressKey(44):  denyEntry().withLevel(1),
 			HttpEgressKey(44): proxyEntryHTTP(1),
 		}),
 		adds: Keys{
@@ -1632,9 +1632,9 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{level: 1, cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, deny: true},
 		},
 		state: testMapState(t, mapStateMap{
-			AnyEgressKey():    denyEntry().withLevel(1002),
-			TcpEgressKey(44):  denyEntry().withLevel(1001),
-			HttpEgressKey(43): denyEntry().withLevel(1001),
+			AnyEgressKey():    denyEntry().withLevel(2),
+			TcpEgressKey(44):  denyEntry().withLevel(1),
+			HttpEgressKey(43): denyEntry().withLevel(1),
 		}),
 		adds: Keys{
 			HttpEgressKey(43): {},
@@ -1649,8 +1649,8 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			{level: 0, cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: ListenerPriorityHTTP},
 		},
 		state: testMapState(t, mapStateMap{
-			AnyEgressKey():    denyEntry().withLevel(1002),
-			TcpEgressKey(44):  denyEntry().withLevel(1001),
+			AnyEgressKey():    denyEntry().withLevel(2),
+			TcpEgressKey(44):  denyEntry().withLevel(1),
 			HttpEgressKey(43): proxyEntryHTTP(1),
 		}),
 		adds: Keys{
@@ -1981,7 +1981,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			if x.deny {
 				verdict = types.Deny
 			}
-			value := newMapStateEntry(1000+x.level, types.HighestPriority, types.LowestPriority, NilRuleOrigin, proxyPort, priority, verdict, x.authReq)
+			value := newMapStateEntry(x.level, types.HighestPriority, types.LowestPriority, NilRuleOrigin, proxyPort, priority, verdict, x.authReq)
 			policyMaps.AccumulateMapChanges(0, 0, adds, deletes, []Key{key}, value)
 		}
 		policyMaps.SyncMapChanges(types.MockSelectorSnapshot())
@@ -2024,7 +2024,7 @@ func TestMapState_AccumulateMapChanges(t *testing.T) {
 			if x.deny {
 				verdict = types.Deny
 			}
-			value := newMapStateEntry(1000+x.level, types.HighestPriority, types.LowestPriority, NilRuleOrigin, proxyPort, priority, verdict, x.authReq)
+			value := newMapStateEntry(x.level, types.HighestPriority, types.LowestPriority, NilRuleOrigin, proxyPort, priority, verdict, x.authReq)
 			policyMaps.AccumulateMapChanges(0, 0, adds, deletes, []Key{key}, value)
 		}
 		policyMaps.SyncMapChanges(types.MockSelectorSnapshot())

--- a/pkg/policy/origin_test.go
+++ b/pkg/policy/origin_test.go
@@ -101,7 +101,7 @@ func TestOriginMerge(t *testing.T) {
 		Tier: 1, Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		Ingress: false,
 		PerSelectorPolicies: L7DataMap{
-			td.cachedSelectorB: &PerSelectorPolicy{Priority: 1000},
+			td.cachedSelectorB: nil,
 		},
 		RuleOrigin: OriginLogsForTest(map[CachedSelector]string{
 			td.cachedSelectorB: "rule2",

--- a/pkg/policy/origin_test.go
+++ b/pkg/policy/origin_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/policy/utils"
 )
 
@@ -98,7 +99,7 @@ func TestOriginMerge(t *testing.T) {
 
 	// Expected incorrectly has rule origin from both rules!
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
-		Tier: 1, Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		Tier: types.Normal, Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		Ingress: false,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: nil,

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/types"
 )
 
 func GenerateL3IngressDenyRules(numRules int) (api.Rules, identity.IdentityMap) {
@@ -256,7 +257,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -331,7 +332,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -408,7 +409,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -553,7 +554,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -355,7 +355,7 @@ func TestEgressCIDRTCPPort(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Egress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -432,7 +432,7 @@ func TestEgressWildcardCIDRMatchesWorld(t *testing.T) {
 			Revision: repo.GetRevision(),
 			Egress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 				"80/TCP": {
-					Tier:     1,
+					Tier:     types.Normal,
 					Port:     80,
 					Protocol: api.ProtoTCP,
 					U8Proto:  0x6,
@@ -517,7 +517,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -606,7 +606,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -691,7 +691,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,
@@ -836,7 +836,7 @@ func TestMapStateWithIngress(t *testing.T) {
 				Revision: repo.GetRevision(),
 				Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 					"80/TCP": {
-						Tier:     1,
+						Tier:     types.Normal,
 						Port:     80,
 						Protocol: api.ProtoTCP,
 						U8Proto:  0x6,

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -361,7 +361,7 @@ func TestEgressCIDRTCPPort(t *testing.T) {
 						U8Proto:  0x6,
 						Ingress:  false,
 						PerSelectorPolicies: L7DataMap{
-							td.cachedSelectorCIDR: &PerSelectorPolicy{Priority: 1000},
+							td.cachedSelectorCIDR: nil,
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorCIDR: {nil}}),
 					},
@@ -438,7 +438,7 @@ func TestEgressWildcardCIDRMatchesWorld(t *testing.T) {
 					U8Proto:  0x6,
 					Ingress:  false,
 					PerSelectorPolicies: L7DataMap{
-						td.cachedSelectorCIDR0: &PerSelectorPolicy{Priority: 1000},
+						td.cachedSelectorCIDR0: nil,
 					},
 					RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.cachedSelectorCIDR0: {nil}}),
 				},
@@ -526,7 +526,6 @@ func TestL7WithIngressWildcard(t *testing.T) {
 							td.wildcardCachedSelector: &PerSelectorPolicy{
 								Verdict:          types.Allow,
 								L7Parser:         ParserTypeHTTP,
-								Priority:         1000,
 								ListenerPriority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
@@ -617,7 +616,6 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 							td.wildcardCachedSelector: &PerSelectorPolicy{
 								Verdict:          types.Allow,
 								L7Parser:         ParserTypeHTTP,
-								Priority:         1000,
 								ListenerPriority: ListenerPriorityHTTP,
 								L7Rules: api.L7Rules{
 									HTTP: []api.PortRuleHTTP{{Method: "GET", Path: "/good"}},
@@ -681,7 +679,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	policy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, testRedirects)
 	policy.Ready()
 
-	rule1MapStateEntry := newAllowEntryWithLabels(ruleLabel).withLevel(1000)
+	rule1MapStateEntry := newAllowEntryWithLabels(ruleLabel)
 	allowEgressMapStateEntry := newAllowEntryWithLabels(ruleLabelAllowAnyEgress)
 
 	expectedEndpointPolicy := EndpointPolicy{
@@ -699,9 +697,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 						U8Proto:  0x6,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
-							td.wildcardCachedSelector: &PerSelectorPolicy{
-								Priority: 1000,
-							},
+							td.wildcardCachedSelector: nil,
 						},
 						RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {ruleLabel}}),
 					},
@@ -828,7 +824,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	cachedSelectorTest := td.sc.findCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.NotNil(t, cachedSelectorTest)
 
-	rule1MapStateEntry := newAllowEntryWithLabels(ruleLabel).withLevel(1000)
+	rule1MapStateEntry := newAllowEntryWithLabels(ruleLabel)
 	allowEgressMapStateEntry := newAllowEntryWithLabels(ruleLabelAllowAnyEgress)
 
 	expectedEndpointPolicy := EndpointPolicy{
@@ -846,12 +842,11 @@ func TestMapStateWithIngress(t *testing.T) {
 						U8Proto:  0x6,
 						Ingress:  true,
 						PerSelectorPolicies: L7DataMap{
-							cachedSelectorWorld:   &PerSelectorPolicy{Priority: 1000},
-							cachedSelectorWorldV4: &PerSelectorPolicy{Priority: 1000},
-							cachedSelectorWorldV6: &PerSelectorPolicy{Priority: 1000},
+							cachedSelectorWorld:   nil,
+							cachedSelectorWorldV4: nil,
+							cachedSelectorWorldV6: nil,
 							cachedSelectorTest: &PerSelectorPolicy{
-								Priority: 1000,
-								Verdict:  types.Allow,
+								Verdict: types.Allow,
 								Authentication: &api.Authentication{
 									Mode: api.AuthenticationModeDisabled,
 								},

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -31,20 +31,6 @@ func roundUp(n int, to int) int {
 	return ((n + (to - 1)) / to) * to
 }
 
-// ensureSlice makes sure slice 's' can be indexed at 'index'.
-//
-// We avoid cloning and append in a loop since:
-// - 's' may have unused capacity, and
-// - 'index' is typically the same between invocations, and
-// - 'index' usually grows by one when not the same as before.
-// This way we avoid unnecessary allocations in typical cases.
-func ensureSlice[E any, S ~[]E, I ~uint | ~uint8](s *S, index I) {
-	for len(*s) <= int(index) {
-		var e E
-		*s = append(*s, e)
-	}
-}
-
 var perTierRoundUp = 1000
 
 // computeTierPriorities determines the base priority for each tier, and the number of priority
@@ -56,14 +42,14 @@ var perTierRoundUp = 1000
 // compressed, but used 1:1, i.e., tier 3 in policy is at index 3, even if tier 2 had no rules int
 // it.
 func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) {
-	lastTier := types.Tier(0)
 	nTiers := int(rules[len(rules)-1].Tier) + 1
 	tierPriorityLevels := make([]int, nTiers)
-	numPassVerdicts := make([]int, 1)
+	numPassVerdicts := make([]int, nTiers)
 
 	lastPrio := rules[0].Priority
 	levels := 1 // each tier with any rules occupies at least one priority level
 	lastPassLevel := 0
+	lastTier := types.Tier(0)
 
 	for _, r := range rules {
 		if r.Tier != lastTier {
@@ -73,8 +59,6 @@ func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) 
 			// Keep the needed priority levels for the previous tier,
 			// rounding up to next 10 to reduce policy map churn.
 			tierPriorityLevels[lastTier] = roundUp(levels, 10)
-
-			ensureSlice(&numPassVerdicts, r.Tier)
 
 			// reset counting priority levels for the next tier
 			lastTier = r.Tier
@@ -96,7 +80,6 @@ func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) 
 		}
 	}
 	// for the last tier
-	ensureSlice(&tierPriorityLevels, lastTier)
 	tierPriorityLevels[lastTier] = roundUp(levels, perTierRoundUp)
 
 	// Compute the whole priority range needed for each tier by adding the lower tier priorities

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -47,28 +47,15 @@ func ensureSlice[E any, S ~[]E, I ~uint | ~uint8](s *S, index I) {
 
 var perTierRoundUp = 1000
 
-// computeTierPriorities determines how many priority levels are needed for each tier, considering
-// that PASS verdicts require priority space after them for all the rules in the lower tiers. Two
-// slices are returned: one with the number of priority levels needed for the tier, and other with
-// the base priority for each tier.
+// computeTierPriorities determines the base priority for each tier, and the number of priority
+// levels to reserve after each pass verdict on each tier. Two slices are returned: one with the
+// base priority for each tier, and other with the number of priority levels to reserve after each
+// pass verdict on each tier.
 //
-// The returned slices has the needed priority range for each tier (0, 1, ...), including the full
-// range for all the remaining tiers in the policy.  Policy tiers are not compressed, but used 1:1,
-// i.e., tier 3 in policy is at index 3, even if tier 2 had no rules int it.
-//
-// Full range of the remaining tiers must be included so that we know to leave sufficient space
-// after each pass verdict for the rules promoted from the remaining tiers.
-//
-// Note that since the the full range of remaining tiers is included, the returned range for
-// tiers without any rules is the same as the next tier.
-//
-// Since the full range of the remaining tiers is included, the base priority of each tier can be
-// calculated as follows (range is the returned slice):
-//
-//	basePriority[tier] = range[0] - range[tier]
-//
-// 'rules' is already sorted by tier/priority
-func (rules ruleSlice) computeTierPriorities() ([]int, []types.Priority, error) {
+// The returned slices have the values for each tier (0, 1, ...) in the policy. Policy tiers are not
+// compressed, but used 1:1, i.e., tier 3 in policy is at index 3, even if tier 2 had no rules int
+// it.
+func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) {
 	lastTier := types.Tier(0)
 	nTiers := int(rules[len(rules)-1].Tier) + 1
 	tierPriorityLevels := make([]int, nTiers)
@@ -131,7 +118,10 @@ func (rules ruleSlice) computeTierPriorities() ([]int, []types.Priority, error) 
 		tierBasePriorities[tier] = basePriority
 	}
 
-	return tierPriorityLevels, tierBasePriorities, nil
+	// transform tierPriority levels to the number of priority levels needed after each pass
+	// verdict on any given tier by shifting up by one.
+	tierPriorityLevels = append(tierPriorityLevels[1:], 0)
+	return tierBasePriorities, tierPriorityLevels, nil
 }
 
 func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPolicy, error) {
@@ -146,14 +136,14 @@ func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPoli
 		return result, nil
 	}
 
-	// compute how many priotity levels are needed for each tier.
-	tierPriorityLevels, tierBasePriorities, err := rules.computeTierPriorities()
+	// compute how many priority levels are needed for each tier.
+	tierBasePriorities, tierPassPriorities, err := rules.computeTierPriorities()
 	if err != nil {
 		return result, err
 	}
 
 	result.tierBasePriority = tierBasePriorities
-	lastTier := types.Tier(len(tierPriorityLevels) - 1)
+	lastTier := types.Tier(len(tierBasePriorities) - 1)
 
 	// add rules, computing the absolute priority for each rule,
 	// making sufficient gaps after each pass verdict, but keeping entries with the same
@@ -191,7 +181,7 @@ func (rules ruleSlice) resolveL4Policy(policyCtx PolicyContext) (L4DirectionPoli
 		// + 1 for the pass verdict itself so that there is space for all passed to entries
 		// after the pass entry itself.
 		if r.Verdict == types.Pass && tier < lastTier {
-			increment = types.Priority(tierPriorityLevels[tier+1]) + 1
+			increment = types.Priority(tierPassPriorities[tier]) + 1
 		}
 	}
 

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -49,7 +49,7 @@ func (rules ruleSlice) computeTierPriorities() ([]types.Priority, []int, error) 
 	lastPrio := rules[0].Priority
 	levels := 1 // each tier with any rules occupies at least one priority level
 	lastPassLevel := 0
-	lastTier := types.Tier(0)
+	lastTier := rules[0].Tier
 
 	for _, r := range rules {
 		if r.Tier != lastTier {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -31,7 +31,7 @@ func roundUp(n int, to int) int {
 	return ((n + (to - 1)) / to) * to
 }
 
-var perTierRoundUp = 1000
+var perTierRoundUp = 10
 
 // computeTierPriorities determines the base priority for each tier, and the number of priority
 // levels to reserve after each pass verdict on each tier. Two slices are returned: one with the

--- a/pkg/policy/rules_test.go
+++ b/pkg/policy/rules_test.go
@@ -40,7 +40,7 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			basePriorities: []types.Priority{0, 1},
+			basePriorities: []types.Priority{0, 0},
 			priorityLevels: []int{1, 0},
 		},
 		{
@@ -205,7 +205,7 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			basePriorities: []types.Priority{0, 1, 1},
+			basePriorities: []types.Priority{0, 0, 0},
 			priorityLevels: []int{1, 1, 0},
 		},
 	} {

--- a/pkg/policy/rules_test.go
+++ b/pkg/policy/rules_test.go
@@ -31,7 +31,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0},
-			expectedPriorities: []int{1},
+			expectedPriorities: []int{0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -41,7 +41,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 1},
-			expectedPriorities: []int{2, 1},
+			expectedPriorities: []int{1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -96,7 +96,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 3},
-			expectedPriorities: []int{5, 2},
+			expectedPriorities: []int{2, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -111,7 +111,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 2},
-			expectedPriorities: []int{3, 1},
+			expectedPriorities: []int{1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -129,7 +129,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 1},
-			expectedPriorities: []int{2, 1},
+			expectedPriorities: []int{1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -147,7 +147,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 1, 2},
-			expectedPriorities: []int{3, 2, 1},
+			expectedPriorities: []int{2, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -167,7 +167,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 4, 6},
-			expectedPriorities: []int{7, 3, 1},
+			expectedPriorities: []int{3, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -182,7 +182,7 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 2, 2},
-			expectedPriorities: []int{3, 1, 1},
+			expectedPriorities: []int{1, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -196,7 +196,17 @@ func TestComputeTierPriorities(t *testing.T) {
 				},
 			},
 			expectedTiers:      []types.Priority{0, 1, 1},
-			expectedPriorities: []int{2, 1, 1},
+			expectedPriorities: []int{1, 1, 0},
+		},
+		{
+			rules: []types.PolicyEntry{
+				{
+					Tier:     2,
+					Priority: 0,
+				},
+			},
+			expectedTiers:      []types.Priority{0, 1, 1},
+			expectedPriorities: []int{1, 1, 0},
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -213,10 +223,10 @@ func TestComputeTierPriorities(t *testing.T) {
 				tc.expectedPriorities[i] *= perTierRoundUp
 			}
 
-			actualPriorities, actualTiers, err := rs.computeTierPriorities()
+			actualBasePriorities, actualPassPriorities, err := rs.computeTierPriorities()
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedTiers, actualTiers)
-			require.Equal(t, tc.expectedPriorities, actualPriorities)
+			require.Equal(t, tc.expectedTiers, actualBasePriorities)
+			require.Equal(t, tc.expectedPriorities, actualPassPriorities)
 		})
 	}
 }

--- a/pkg/policy/rules_test.go
+++ b/pkg/policy/rules_test.go
@@ -19,9 +19,9 @@ func TestComputeTierPriorities(t *testing.T) {
 
 	// note that expected priorities are multiplied by perTierRoundUp
 	for i, tc := range []struct {
-		rules              []types.PolicyEntry
-		expectedTiers      []types.Priority
-		expectedPriorities []int
+		rules          []types.PolicyEntry
+		basePriorities []types.Priority
+		priorityLevels []int
 	}{
 		{
 			rules: []types.PolicyEntry{
@@ -30,8 +30,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0},
-			expectedPriorities: []int{0},
+			basePriorities: []types.Priority{0},
+			priorityLevels: []int{0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -40,8 +40,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 1},
-			expectedPriorities: []int{1, 0},
+			basePriorities: []types.Priority{0, 1},
+			priorityLevels: []int{1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -95,8 +95,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 10,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 3},
-			expectedPriorities: []int{2, 0},
+			basePriorities: []types.Priority{0, 3},
+			priorityLevels: []int{2, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -110,8 +110,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 2},
-			expectedPriorities: []int{1, 0},
+			basePriorities: []types.Priority{0, 2},
+			priorityLevels: []int{1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -128,8 +128,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 1},
-			expectedPriorities: []int{1, 0},
+			basePriorities: []types.Priority{0, 1},
+			priorityLevels: []int{1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -146,8 +146,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 1, 2},
-			expectedPriorities: []int{2, 1, 0},
+			basePriorities: []types.Priority{0, 1, 2},
+			priorityLevels: []int{2, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -166,8 +166,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 4, 6},
-			expectedPriorities: []int{3, 1, 0},
+			basePriorities: []types.Priority{0, 4, 6},
+			priorityLevels: []int{3, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -181,8 +181,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 2, 2},
-			expectedPriorities: []int{1, 1, 0},
+			basePriorities: []types.Priority{0, 2, 2},
+			priorityLevels: []int{1, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -195,8 +195,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 1, 1},
-			expectedPriorities: []int{1, 1, 0},
+			basePriorities: []types.Priority{0, 1, 1},
+			priorityLevels: []int{1, 1, 0},
 		},
 		{
 			rules: []types.PolicyEntry{
@@ -205,8 +205,8 @@ func TestComputeTierPriorities(t *testing.T) {
 					Priority: 0,
 				},
 			},
-			expectedTiers:      []types.Priority{0, 1, 1},
-			expectedPriorities: []int{1, 1, 0},
+			basePriorities: []types.Priority{0, 1, 1},
+			priorityLevels: []int{1, 1, 0},
 		},
 	} {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -218,15 +218,15 @@ func TestComputeTierPriorities(t *testing.T) {
 			}
 			rs.sort()
 
-			for i := range tc.expectedPriorities {
-				tc.expectedTiers[i] *= types.Priority(perTierRoundUp)
-				tc.expectedPriorities[i] *= perTierRoundUp
+			for i := range tc.priorityLevels {
+				tc.basePriorities[i] *= types.Priority(perTierRoundUp)
+				tc.priorityLevels[i] *= perTierRoundUp
 			}
 
-			actualBasePriorities, actualPassPriorities, err := rs.computeTierPriorities()
+			actualBasePriorities, actualPriorityLevels, err := rs.computeTierPriorities()
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedTiers, actualBasePriorities)
-			require.Equal(t, tc.expectedPriorities, actualPassPriorities)
+			require.Equal(t, tc.basePriorities, actualBasePriorities, "tierBasePriorities mismatch")
+			require.Equal(t, tc.priorityLevels, actualPriorityLevels, "tierPriorityLevels mismatch")
 		})
 	}
 }

--- a/pkg/policy/simulate_fuzz_test.go
+++ b/pkg/policy/simulate_fuzz_test.go
@@ -141,9 +141,14 @@ func makeFuzzEntries(input []byte) types.PolicyEntries {
 		prio := input[i*2+1]
 
 		// Take bottom two bits of prio for tier
-		tier := types.Tier(prio & 0b0000_0011)
-		if tier >= types.Baseline {
+		tier := types.TierUnspec
+		switch prio & 0b0000_0011 {
+		case 0:
+			tier = types.Admin
+		case 1, 3:
 			tier = types.Normal
+		case 2:
+			tier = types.Baseline
 		}
 		prio = prio >> 2
 

--- a/pkg/policy/types/policyentry.go
+++ b/pkg/policy/types/policyentry.go
@@ -11,10 +11,10 @@ import (
 type Tier uint8
 
 const (
-	Admin Tier = iota
-	Normal
-	Baseline
-	numTiers // one past the lowest tier
+	TierUnspec Tier = 0
+	Admin      Tier = 100
+	Normal     Tier = 200
+	Baseline   Tier = 250
 )
 
 type Verdict uint8


### PR DESCRIPTION
This PR changes the values of Admin, Normal, and Baseline tiers to 100, 200, and 255 respectively. The reason for this is to allow for future expansion if necessary.

Most of the changes are mechanical, such as changing expected test literals. The functional changes are isolated to separate commits.

The largest functional change is that, previously, priority headroom was allocated for each tier, regardless of whether or not it was in use. In other words, if you had rules with tiers 2, 3, and 6, then headroom would be allocated for 0, 1, 2, 3, 4, 5, 6. After this change, we allocate headroom for 2, 3, 4, 5, 6.

This means that the base case, i.e. all rules in Normal, is now once again indistinguishable from the policy engine pre-Tier. This matches v1.19, which is an added benefit.