### PR TITLE
Fix performance bug in L7 policy proxy redirect handling

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -741,6 +741,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 
 			Namespace: Namespace,
 			Name:      "endpoint_regeneration_time_stats_seconds",
+			Buckets:   prometheus.ExponentialBuckets(10e-6, 10, 8),
 			Help:      "Endpoint regeneration time stats labeled by the scope",
 		}, []string{LabelScope, LabelStatus}),
 
@@ -784,6 +785,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 
 			Namespace: Namespace,
 			Name:      "policy_implementation_delay",
+			Buckets:   prometheus.ExponentialBuckets(10e-6, 10, 8),
 			Help:      "Time between a policy change and it being fully deployed into the datapath",
 		}, metric.Labels{
 			{

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -50,7 +50,8 @@ type Proxy struct {
 	// redirects is the map of all redirect configurations indexed by
 	// the redirect identifier. Redirects may be implemented by different
 	// proxies.
-	redirects map[string]RedirectImplementation
+	redirects      map[string]RedirectImplementation
+	redirectsCount map[types.ProxyType]int
 
 	envoyIntegration *envoyProxyIntegration
 	dnsIntegration   *dnsProxyIntegration
@@ -86,6 +87,7 @@ func createProxy(
 		logger:           logger,
 		localNodeStore:   localNodeStore,
 		redirects:        make(map[string]RedirectImplementation),
+		redirectsCount:   make(map[types.ProxyType]int),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 		proxyPorts:       proxyPorts,
@@ -258,13 +260,13 @@ func (p *Proxy) createNewRedirect(
 		logfields.Object, redirect,
 		logfields.ProxyPort, pp.ProxyPort)
 
-	p.redirects[id] = impl
+	p.addRedirect(id, impl)
 	p.updateRedirectMetrics()
 
 	revertFunc := func() error {
 		// Undo what we have done above.
 		p.mutex.Lock()
-		delete(p.redirects, id)
+		p.deleteRedirect(id, impl)
 		p.updateRedirectMetrics()
 		p.proxyPorts.ReleaseProxyPort(ppName)
 		p.mutex.Unlock()
@@ -310,7 +312,7 @@ func (p *Proxy) removeRedirect(id string) {
 		return
 	}
 	r := impl.GetRedirect()
-	delete(p.redirects, id)
+	p.deleteRedirect(id, impl)
 
 	impl.Close()
 
@@ -400,12 +402,19 @@ func (p *Proxy) getProxyIP(ctx context.Context) string {
 // updateRedirectMetrics updates the redirect metrics per application protocol
 // in Prometheus. Lock needs to be held to call this function.
 func (p *Proxy) updateRedirectMetrics() {
-	result := map[string]int{}
-	for _, impl := range p.redirects {
-		redirect := impl.GetRedirect()
-		result[string(redirect.proxyPort.ProxyType)]++
+	for proto, count := range p.redirectsCount {
+		metrics.ProxyRedirects.WithLabelValues(string(proto)).Set(float64(count))
 	}
-	for proto, count := range result {
-		metrics.ProxyRedirects.WithLabelValues(proto).Set(float64(count))
-	}
+}
+
+func (p *Proxy) addRedirect(id string, impl RedirectImplementation) {
+	proxyType := impl.GetRedirect().proxyPort.ProxyType
+	p.redirects[id] = impl
+	p.redirectsCount[proxyType]++
+}
+
+func (p *Proxy) deleteRedirect(id string, impl RedirectImplementation) {
+	proxyType := impl.GetRedirect().proxyPort.ProxyType
+	delete(p.redirects, id)
+	p.redirectsCount[proxyType]--
 }


### PR DESCRIPTION
Sample result from testing with(cl2 module coming soon):
* 32 Endpoints
* 512 Policies
* 4000 Redirects per endpoint

Before:
<img width="2166" height="541" alt="image" src="https://github.com/user-attachments/assets/c5944881-564b-4a83-8af4-65c0e46d7c05" />

After:
<img width="1934" height="537" alt="image" src="https://github.com/user-attachments/assets/3ff4498f-00a3-4fc1-b47c-e4edf4b1c7ae" />

See commit message for details.
