### PR TITLE
helm: Use bash instead of sh in init containers for Ubuntu 24.04 compatibility

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -559,7 +559,7 @@ spec:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
         {{- end }}
         command:
-        - sh
+        - bash
         - -ec
         # The statically linked Go program binary is invoked to avoid any
         # dependency on utilities like sh and mount that can be missing on certain
@@ -605,7 +605,7 @@ spec:
         - name: BIN_PATH
           value: {{ .Values.cni.binPath }}
         command:
-        - sh
+        - bash
         - -ec
         # The statically linked Go program binary is invoked to avoid any
         # dependency on utilities like sh that can be missing on certain
@@ -673,7 +673,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
         command:
-        - sh
+        - bash
         - -c
         - |
           until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do


### PR DESCRIPTION
Ubuntu 24.04 includes a new AppArmor profile for busybox that restricts nsenter operations on disconnected paths. When init containers run with sh (linked to busybox), they inherit this restrictive profile causing mount-cgroup to fail with Permission denied.

Using bash instead of sh avoids this profile restriction since bash runs as unconfined while busybox runs under the busybox (complain) AppArmor profile.

Signed-off-by: Shiv Deshmukh <shivdesh@cisco.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
