### PR TITLE
[v1.18] endpoint/bpf: remove change empty condition for updateEnvoy

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1142,9 +1142,6 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext, hasNewPolicy bool) error {
 	e.PolicyDebug("applyPolicyMapChanges")
 
-	// Always update Envoy if policy has changed
-	updateEnvoy := hasNewPolicy
-
 	// Note that after successful endpoint regeneration the desired and realized policies are
 	// the same pointer. During the bpf regeneration possible incremental updates are collected
 	// on the newly computed desired policy, which is not fully realized yet. This is why we get
@@ -1164,20 +1161,17 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	}
 
 	hasEnvoyRedirect := e.desiredPolicy.L4Policy.HasEnvoyRedirect()
-	if !changes.Empty() {
-		// updateEnvoy if there were any mapChanges, but only if the endpoint has Envoy
-		// redirects, or is an Ingress endpoint, which needs to enforce also the full L3/4
-		// policy.
-		//
-		// Even if there are no changes, we update the proxyWaitGroup for any in-progress
-		// NetworkPolicy update to be done if the endpoint has envoy redirects, so that the
-		// the expected policy is in place.
-		//
-		// 'updateEnvoy' is already set to 'true' if policy changed. In that case there can
-		// be new redirects and a full policy map update even if there were no incremental
-		// updates.
-		updateEnvoy = updateEnvoy || hasEnvoyRedirect || e.isIngress
-	}
+	// updateEnvoy when policy has changed, if the endpoint has Envoy redirects,
+	// or is an Ingress endpoint, which needs to enforce also the full L3/4 policy.
+	//
+	// Even if there are no changes, we update the proxyWaitGroup for any in-progress
+	// NetworkPolicy update to be done if the endpoint has envoy redirects, so that the
+	// the expected policy is in place.
+	//
+	// 'updateEnvoy' is already set to 'true' if policy changed. In that case there can
+	// be new redirects and a full policy map update even if there were no incremental
+	// updates.
+	updateEnvoy := hasNewPolicy || hasEnvoyRedirect || e.isIngress
 
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
@@ -1205,7 +1199,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	// NOTE: unlike regeneratePolicy, UpdateNetworkPolicy requires the endpoint read lock for
 	// 'e.desiredPolicy' access.
 	if !e.IsProxyDisabled() {
-		if updateEnvoy {
+		if updateEnvoy && e.desiredPolicy.VersionHandle.IsValid() {
 			e.getLogger().Debug(
 				"applyPolicyMapChanges: Updating Envoy NetworkPolicy",
 				logfields.SelectorCacheVersion, e.desiredPolicy.VersionHandle,


### PR DESCRIPTION
This is the follow up for https://github.com/cilium/cilium/pull/44519. The backport causes a lot of failure. It looks like that's because 1.18 implementation is a bit different from 1.19 where we need extra condition check to get it working.

I leave the current CI failure for review so people can see it's not from this commit.