### PR TITLE
bpf: tests: move v*_svc_loopback boilerplate into bpf_lxc.h

### DIFF
--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -27,7 +27,6 @@ mock_ctx_redirect_peer(const struct __sk_buff *ctx __maybe_unused, int ifindex _
 
 /* Set the LXC source address to be the address of pod one */
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one })
-ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"

--- a/bpf/tests/lib/bpf_lxc.h
+++ b/bpf/tests/lib/bpf_lxc.h
@@ -3,6 +3,14 @@
 
 #include <bpf_lxc.c>
 
+#ifdef ENABLE_IPV4
+ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
+#endif /* ENABLE_IPV6 */
+
 #define FROM_CONTAINER		0
 #define TO_CONTAINER		1
 #define TO_CONTAINER_TAILCALL	2

--- a/bpf/tests/tc_lb_no_backend_nonroutable.c
+++ b/bpf/tests/tc_lb_no_backend_nonroutable.c
@@ -19,7 +19,6 @@
 
 /* Set the LXC source address to be the address of pod one */
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one})
-ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
 ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, false)
 
 #include "lib/endpoint.h"

--- a/bpf/tests/tc_lxc_lb4_nodeport.c
+++ b/bpf/tests/tc_lxc_lb4_nodeport.c
@@ -62,7 +62,6 @@ mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 
 /* Set the LXC source address to be the address of the client pod */
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = CLIENT_IP })
-ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"

--- a/bpf/tests/tc_lxc_lb6_nodeport.c
+++ b/bpf/tests/tc_lxc_lb6_nodeport.c
@@ -62,7 +62,6 @@ mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 
 /* Set the LXC source address to be the address of the client pod */
 ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
-ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
 
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -20,9 +20,7 @@
 
 /* Set the LXC source address to be the address of pod one */
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one})
-ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
 ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
-ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
 
 #define POD_IPV6 v6_pod_one
 #define SERVICE_IPV6 v6_node_three

--- a/bpf/tests/tc_redirect_lxc.h
+++ b/bpf/tests/tc_redirect_lxc.h
@@ -107,11 +107,9 @@ mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 /* Assign necessary load-time configs */
 #ifdef ENABLE_IPV4
 ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one })
-ASSIGN_CONFIG(union v4addr, service_loopback_ipv4, { .be32 = v4_svc_loopback })
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
-ASSIGN_CONFIG(union v6addr, service_loopback_ipv6, { .addr = v6_svc_loopback })
 #endif /* ENABLE_IPV6 */
 
 /* Deal with testing netkit or veth. */


### PR DESCRIPTION
Let's expect that all tests will end up wanting the same loopback IP addresses, and just have the test scaffolding always set them up.