### PR TITLE
datapath/linux/device: add desired VLAN device parent index JSON/YAML tags

### DIFF
--- a/pkg/datapath/linux/device/vlan.go
+++ b/pkg/datapath/linux/device/vlan.go
@@ -16,7 +16,7 @@ type DesiredVLANDeviceSpec struct {
 	VLANID      int    `json:"vlanID" yaml:"vlanID"`
 	MTU         int    `json:"mtu" yaml:"mtu"`
 	ParentName  string `json:"parentName" yaml:"parentName"`
-	ParentIndex int
+	ParentIndex int    `json:"parentIndex" yaml:"parentIndex"`
 }
 
 var _ DesiredDeviceSpec = (*DesiredVLANDeviceSpec)(nil)


### PR DESCRIPTION
Make sure the parent index field is also marshaled in the same way as the other field (i.e. with lowercase field name). This was missed in the original change introducing the DesiredVLANDeviceSpec type.

Fixes: 07f78934c9bd ("datapath/linux/device: add DesiredVLANDeviceSpec")