### PR TITLE
renovate: Add support to manage `echo-advanced` image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -795,6 +795,13 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>\\d+)-[a-f0-9]{7}$",
     },
     {
+      // echo-advanced uses a date + semver versioning scheme: v20251204-v1.4.1
+      "matchDepNames": [
+        "gcr.io/k8s-staging-gateway-api/echo-advanced"
+      ],
+      "versioning": "regex:^v(?<major>\\d+)-v(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
+    },
+    {
       // Avoid updating minor or major version for github.com/envoyproxy/go-control-plane/envoy
       // as we need to update cilium-envoy accordingly.
       "matchPackageNames": [

--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -29,7 +29,7 @@ cilium connectivity test [flags]
       --curl-parallel uint                                    Number of parallel requests in curl commands (0 to disable)
   -d, --debug                                                 Show debug messages
       --dns-test-server-image string                          Image path to use for CoreDNS (default "registry.k8s.io/coredns/coredns:v1.14.1@sha256:82b57287b29beb757c740dbbe68f2d4723da94715b563fffad5c13438b71b14a")
-      --echo-image string                                     Image path to use for echo server (default "gcr.io/k8s-staging-gateway-api/echo-advanced:v20240412-v1.0.0-394-g40c666fd")
+      --echo-image string                                     Image path to use for echo server (default "gcr.io/k8s-staging-gateway-api/echo-advanced:v20251204-v1.4.1")
       --external-cidr string                                  IPv4 CIDR to use as external target in connectivity tests (default "1.0.0.0/8")
       --external-cidrv6 string                                IPv6 CIDR to use as external target in connectivity tests (default "2606:4700:4700::/96")
       --external-ip string                                    IPv4 to use as external target in connectivity tests (default "1.1.1.1")

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -182,7 +182,7 @@ var (
 
 	ConnectivityCheckOptionalImagesTest = map[string]string{
 		// renovate: datasource=docker
-		"ConnectivityTestEchoImage": "gcr.io/k8s-staging-gateway-api/echo-advanced:v20240412-v1.0.0-394-g40c666fd",
+		"ConnectivityTestEchoImage": "gcr.io/k8s-staging-gateway-api/echo-advanced:v20251204-v1.4.1",
 	}
 
 	ConnectivityCheckImagesPerf = map[string]string{


### PR DESCRIPTION
This image uses a non standard versioning scheme. I updated the image to its current second to last version: `v20251204-v1.4.1` (latest is `v20260227-v1.5.0`). The goal is to validate that the newly updated renovate configuration will cause it to open a PR for the 1.4.1 -> 1.5.0 bump.