### PR TITLE
fix(policy): Fix CIDR exception validation in CIDR policy

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -724,7 +724,7 @@ func (c *CIDRRule) sanitize() error {
 
 		// Note: this also checks that the allow CIDR prefix and the exception
 		// CIDR prefixes are part of the same address family.
-		if !prefix.Contains(except.Addr()) {
+		if prefix.Bits() > except.Bits() || !prefix.Contains(except.Addr()) {
 			return fmt.Errorf("allow CIDR prefix %s does not contain "+
 				"exclude CIDR prefix %s", c.Cidr, p)
 		}

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -626,6 +626,30 @@ func TestCIDRsanitize(t *testing.T) {
 	cidr = CIDRRule{Cidr: "10.0.0.0/254.0.0.255"}
 	err = cidr.sanitize()
 	require.Error(t, err)
+
+	// Valid ExceptCIDRs
+	cidr = CIDRRule{
+		Cidr:        "10.0.0.0/24",
+		ExceptCIDRs: []CIDR{"10.0.0.1/32", "10.0.0.128/25"},
+	}
+	err = cidr.sanitize()
+	require.NoError(t, err)
+
+	// Invalid ExceptCIDRs: Broader than main CIDR
+	cidr = CIDRRule{
+		Cidr:        "10.0.0.0/24",
+		ExceptCIDRs: []CIDR{"10.0.0.0/16"},
+	}
+	err = cidr.sanitize()
+	require.Error(t, err)
+
+	// Invalid ExceptCIDRs: Outside main CIDR
+	cidr = CIDRRule{
+		Cidr:        "10.0.0.0/24",
+		ExceptCIDRs: []CIDR{"10.1.0.0/24"},
+	}
+	err = cidr.sanitize()
+	require.Error(t, err)
 }
 
 func TestToServicesSanitize(t *testing.T) {


### PR DESCRIPTION
During validation added to consider prefix length too. 
Added unit test cases.

Fixes: #44614

```release-note
Fixes a bug where  toCIDRSet / fromCIDRSet policies permitted CIDR exceptions larger than the given CIDR set.
```