### PR TITLE
fix: escape $ character in regex to prevent injection

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -35,7 +35,7 @@
                 return body.replace(/\'/g, '')
                   .replace(/"/g, '')
                   .replace(/`/g, '')
-                  .replace(/$/g, '')
+                  .replace(/\$/g, '')
               result-encoding: string
 
           - name: Update labels


### PR DESCRIPTION
Corrected the regular expression by properly escaping the $ character to ensure literal matching:

This PR fixes a vulnerability in the regular expression where the `$` character was not properly escaped, causing it to match end-of-string positions instead of literal `$` characters.
Before: .replace(/$g, '')
After:  .replace(/\$/g, '')

Reported-By: Vikram <vikram@cure53.de>
Reported-By: Youssef Abdullah Al-Otaibi <u4@hotmail.com>

Signed-off-by: Peter Oyekunle <poyekunl@cisco.com>