### PR TITLE
Documentation: fix CI to catch untracked generated files

### DIFF
--- a/Documentation/check-cmdref.sh
+++ b/Documentation/check-cmdref.sh
@@ -7,6 +7,9 @@ set -o pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cmdref_dir="${script_dir}/cmdref"
 
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "${cmdref_dir}"
+
 if ! git diff --quiet -- "${cmdref_dir}" ; then
     git --no-pager diff "${cmdref_dir}"
     echo "HINT: to fix this, run 'make -C Documentation update-cmdref'"

--- a/Documentation/check-codeowners.sh
+++ b/Documentation/check-codeowners.sh
@@ -8,6 +8,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source_dir="$(cd "${script_dir}/.." && pwd)"
 target_file="${script_dir}/codeowners.rst"
 
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "$target_file"
+
 if ! git diff --quiet -- "$target_file" ; then
     git --no-pager diff -- "$target_file"
     echo "HINT: to fix this, run 'make -C Documentation update-codeowners'"

--- a/Documentation/check-crdlist.sh
+++ b/Documentation/check-crdlist.sh
@@ -7,6 +7,9 @@ set -o pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 target_file="${script_dir}/crdlist.rst"
 
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "$target_file"
+
 if ! git diff --quiet -- "$target_file" ; then
     git --no-pager diff -- "$target_file"
     echo "HINT: to fix this, run 'make -C Documentation update-crdlist'"

--- a/Documentation/check-flaggen.sh
+++ b/Documentation/check-flaggen.sh
@@ -7,6 +7,9 @@ set -o pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 config_dir="${script_dir}/configuration"
 
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "${config_dir}"
+
 if ! git diff --quiet -- "${config_dir}" ; then
     git --no-pager diff "${config_dir}"
     echo "HINT: to fix this, run 'make -C Documentation api-flaggen'"

--- a/Documentation/check-helmvalues.sh
+++ b/Documentation/check-helmvalues.sh
@@ -7,6 +7,9 @@ set -o pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 helm_values="${script_dir}/helm-values.rst"
 
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "${helm_values}"
+
 if ! git diff --quiet -- "${helm_values}" ; then
     git --no-pager diff "${helm_values}"
     echo "HINT: to fix this, run 'make -C Documentation update-helm-values'"

--- a/Documentation/check-redirects.sh
+++ b/Documentation/check-redirects.sh
@@ -7,6 +7,9 @@ set -o pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 redirect_txt="${script_dir}/redirects.txt"
 
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "${redirect_txt}"
+
 if ! git diff --quiet -- "${redirect_txt}" ; then
     git --no-pager diff "${redirect_txt}"
     echo "HINT: to fix this, run 'make -C Documentation update-redirects'"


### PR DESCRIPTION
When new commands are added or new documentation is generated, the scripts in Documentation/ check for diffs using 'git diff --quiet'. However, this does not catch new, untracked files. This can lead to CI passing even if required documentation files are missing from the PR (but generated during the CI run).

This PR adds 'git add --intent-to-add' before the diff check to ensure new files are also considered.

Fixes https://github.com/cilium/cilium/issues/44636