### PR TITLE
operator: Refactor legacy hive cell, extract node taint sync to dedicated cell

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -144,14 +144,14 @@ cilium-operator-alibabacloud [flags]
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
       --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
       --version                                                    Print version information

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -115,9 +115,13 @@ cilium-operator-alibabacloud hive [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -120,9 +120,13 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -151,14 +151,14 @@ cilium-operator-aws [flags]
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
       --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
       --version                                                    Print version information

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -122,9 +122,13 @@ cilium-operator-aws hive [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -127,9 +127,13 @@ cilium-operator-aws hive dot-graph [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -146,14 +146,14 @@ cilium-operator-azure [flags]
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
       --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
       --version                                                    Print version information

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -117,9 +117,13 @@ cilium-operator-azure hive [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -122,9 +122,13 @@ cilium-operator-azure hive dot-graph [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -143,14 +143,14 @@ cilium-operator-generic [flags]
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
       --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
       --version                                                    Print version information

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -114,9 +114,13 @@ cilium-operator-generic hive [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -119,9 +119,13 @@ cilium-operator-generic hive dot-graph [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -158,14 +158,14 @@ cilium-operator [flags]
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
-      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes if Cilium is scheduled but not up and running
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --subnet-ids-filter strings                                  Subnets IDs (separated by commas)
       --subnet-tags-filter map                                     Subnets tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
       --synchronize-k8s-services                                   Synchronize Kubernetes services to kvstore (default true)
-      --taint-sync-workers int                                     Number of workers used to synchronize node tains and conditions (default 10)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
       --version                                                    Print version information

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -129,9 +129,13 @@ cilium-operator hive [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -134,9 +134,13 @@ cilium-operator hive dot-graph [flags]
       --parallel-alloc-workers int                                 Maximum number of parallel IPAM workers (default 50)
       --policy-default-local-cluster                               Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
+      --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
+      --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)
+      --set-cilium-node-taints                                     Set node taint "node.cilium.io/agent-not-ready" on Kubernetes nodes if Cilium is scheduled but not up and running
       --shell-sock-path string                                     Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --skip-crd-creation                                          When true, Kubernetes Custom Resource Definitions will not be created
       --synchronize-k8s-nodes                                      Perform GC of stale node entries from the KVStore (default true)
+      --taint-sync-workers int                                     Number of workers used to synchronize node taints and conditions (default 10)
       --unmanaged-pod-watcher-interval duration                    Interval to check for unmanaged kube-dns pods (0 to disable) (default 15s)
       --validate-network-policy                                    Whether to enable or disable the informational network policy validator (default true)
 ```

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -221,18 +221,6 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(operatorOption.CiliumPodLabels, "k8s-app=cilium", "Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false")
 	option.BindEnv(vp, operatorOption.CiliumPodLabels)
 
-	flags.Int(operatorOption.TaintSyncWorkers, 10, "Number of workers used to synchronize node tains and conditions")
-	option.BindEnv(vp, operatorOption.TaintSyncWorkers)
-
-	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", option.Config.AgentNotReadyNodeTaintValue()))
-	option.BindEnv(vp, operatorOption.RemoveCiliumNodeTaints)
-
-	flags.Bool(operatorOption.SetCiliumNodeTaints, false, fmt.Sprintf("Set node taint %q from Kubernetes nodes if Cilium is scheduled but not up and running", option.Config.AgentNotReadyNodeTaintValue()))
-	option.BindEnv(vp, operatorOption.SetCiliumNodeTaints)
-
-	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
-	option.BindEnv(vp, operatorOption.SetCiliumIsUpCondition)
-
 	flags.String(operatorOption.PodRestartSelector, "k8s-app=kube-dns", "cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted")
 	option.BindEnv(vp, operatorOption.PodRestartSelector)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -75,7 +75,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/heartbeat"
 	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -662,12 +661,6 @@ func (legacy *legacyOnLeader) onStart(ctx cell.HookContext) error {
 		}
 		if operatorOption.Config.EndpointGCInterval == 0 {
 			logging.Fatal(legacy.logger, "Cilium Identity garbage collector requires the CiliumEndpoint garbage collector to be enabled")
-		}
-	}
-
-	if legacy.clientset.IsEnabled() {
-		if err := labelsfilter.ParseLabelPrefixCfg(legacy.logger, option.Config.Labels, option.Config.NodeLabels, option.Config.LabelPrefixFile); err != nil {
-			logging.Fatal(legacy.logger, "Unable to parse Label prefix configuration", logfields.Error, err)
 		}
 	}
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -242,6 +242,29 @@ var (
 		// Manages node taints and conditions based on Cilium pod readiness.
 		operatorWatchers.NodeTaintSyncCell,
 
+		// Validates that identity allocation mode is consistent with the
+		// Kubernetes client and endpoint GC configuration.
+		cell.Invoke(func(in struct {
+			cell.In
+			IdentityGCCfg identitygc.SharedConfig
+			EndpointGCCfg endpointgc.SharedConfig
+			Clientset     k8sClient.Clientset
+			Logger        *slog.Logger
+		}) error {
+			mode := in.IdentityGCCfg.IdentityAllocationMode
+			if mode == option.IdentityAllocationModeCRD ||
+				mode == option.IdentityAllocationModeDoubleWriteReadKVstore ||
+				mode == option.IdentityAllocationModeDoubleWriteReadCRD {
+				if !in.Clientset.IsEnabled() {
+					return fmt.Errorf("%s identity allocation mode requires k8s to be configured", mode)
+				}
+				if in.EndpointGCCfg.Interval == 0 {
+					return fmt.Errorf("cilium identity garbage collector requires the CiliumEndpoint garbage collector to be enabled")
+				}
+			}
+			return nil
+		}),
+
 		legacyCell,
 
 		// When running in kvstore mode, the start hook of the identity GC
@@ -612,61 +635,16 @@ var legacyCell = cell.Module(
 	"legacy-cell",
 	"Cilium operator legacy cell",
 
-	cell.Invoke(registerLegacyOnLeader),
+	cell.Invoke(func(lc cell.Lifecycle, logger *slog.Logger) {
+		lc.Append(cell.Hook{
+			OnStart: func(_ cell.HookContext) error {
+				isLeader.Store(true)
+				logger.Info("Initialization complete")
+				return nil
+			},
+		})
+	}),
 )
-
-type params struct {
-	cell.In
-	Lifecycle cell.Lifecycle
-	Clientset k8sClient.Clientset
-	Logger    *slog.Logger
-}
-
-func registerLegacyOnLeader(p params) {
-	ctx, cancel := context.WithCancel(context.Background())
-	legacy := &legacyOnLeader{
-		ctx:       ctx,
-		cancel:    cancel,
-		clientset: p.Clientset,
-		logger:    p.Logger,
-	}
-	p.Lifecycle.Append(cell.Hook{
-		OnStart: legacy.onStart,
-		OnStop:  legacy.onStop,
-	})
-}
-
-type legacyOnLeader struct {
-	ctx       context.Context
-	cancel    context.CancelFunc
-	clientset k8sClient.Clientset
-	logger    *slog.Logger
-}
-
-func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
-	legacy.cancel()
-	return nil
-}
-
-// onStart is the function called once the operator starts leading
-// in HA mode.
-func (legacy *legacyOnLeader) onStart(ctx cell.HookContext) error {
-	isLeader.Store(true)
-
-	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD ||
-		option.Config.IdentityAllocationMode == option.IdentityAllocationModeDoubleWriteReadKVstore ||
-		option.Config.IdentityAllocationMode == option.IdentityAllocationModeDoubleWriteReadCRD {
-		if !legacy.clientset.IsEnabled() {
-			logging.Fatal(legacy.logger, fmt.Sprintf("%s Identity allocation mode requires k8s to be configured.", option.Config.IdentityAllocationMode))
-		}
-		if operatorOption.Config.EndpointGCInterval == 0 {
-			logging.Fatal(legacy.logger, "Cilium Identity garbage collector requires the CiliumEndpoint garbage collector to be enabled")
-		}
-	}
-
-	legacy.logger.InfoContext(ctx, "Initialization complete")
-	return nil
-}
 
 // kvstoreExtraOptions provides the extra options to initialize the kvstore client.
 func kvstoreExtraOptions(in struct {

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -240,6 +240,9 @@ var (
 		// Garbage collects stale CiliumNode custom resources.
 		operatorWatchers.CiliumNodeGCCell,
 
+		// Manages node taints and conditions based on Cilium pod readiness.
+		operatorWatchers.NodeTaintSyncCell,
+
 		legacyCell,
 
 		// When running in kvstore mode, the start hook of the identity GC
@@ -638,16 +641,11 @@ type legacyOnLeader struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	clientset k8sClient.Clientset
-	wg        sync.WaitGroup
 	logger    *slog.Logger
 }
 
 func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
 	legacy.cancel()
-
-	// Wait for background goroutines to finish.
-	legacy.wg.Wait()
-
 	return nil
 }
 
@@ -655,23 +653,6 @@ func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
 // in HA mode.
 func (legacy *legacyOnLeader) onStart(ctx cell.HookContext) error {
 	isLeader.Store(true)
-
-	watcherLogger := legacy.logger.With(logfields.LogSubsys, "watchers")
-
-	if legacy.clientset.IsEnabled() &&
-		(operatorOption.Config.RemoveCiliumNodeTaints || operatorOption.Config.SetCiliumIsUpCondition) {
-		legacy.logger.InfoContext(ctx,
-			"Managing Cilium Node Taints or Setting Cilium Is Up Condition for Kubernetes Nodes",
-			logfields.K8sNamespace, operatorOption.Config.CiliumK8sNamespace,
-			logfields.LabelSelectorFlagOption, operatorOption.Config.CiliumPodLabels,
-			logfields.RemoveCiliumNodeTaintsFlagOption, operatorOption.Config.RemoveCiliumNodeTaints,
-			logfields.SetCiliumNodeTaintsFlagOption, operatorOption.Config.SetCiliumNodeTaints,
-			logfields.SetCiliumIsUpConditionFlagOption, operatorOption.Config.SetCiliumIsUpCondition,
-		)
-
-		operatorWatchers.HandleNodeTolerationAndTaints(&legacy.wg, legacy.clientset, legacy.ctx.Done(),
-			watcherLogger)
-	}
 
 	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD ||
 		option.Config.IdentityAllocationMode == option.IdentityAllocationModeDoubleWriteReadKVstore ||

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -183,22 +183,6 @@ const (
 	// with.
 	CiliumPodLabels = "cilium-pod-labels"
 
-	// TaintSyncWorkers is the number of workers used to synchronize
-	// taints and conditions in Kubernetes nodes.
-	TaintSyncWorkers = "taint-sync-workers"
-
-	// RemoveCiliumNodeTaints is the flag to define if the Cilium node taint
-	// should be removed in Kubernetes nodes.
-	RemoveCiliumNodeTaints = "remove-cilium-node-taints"
-
-	// SetCiliumNodeTaints is whether or not to taint nodes that do not have
-	// a running Cilium instance.
-	SetCiliumNodeTaints = "set-cilium-node-taints"
-
-	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
-	// nodes.
-	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
-
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	// default values: k8s-app=kube-dns
 	PodRestartSelector = "pod-restart-selector"
@@ -287,22 +271,6 @@ type OperatorConfig struct {
 	// with.
 	CiliumPodLabels string
 
-	// TaintSyncWorkers is the number of workers used to synchronize
-	// taints and conditions in Kubernetes nodes.
-	TaintSyncWorkers int
-
-	// RemoveCiliumNodeTaints is the flag to define if the Cilium node taint
-	// should be removed in Kubernetes nodes.
-	RemoveCiliumNodeTaints bool
-
-	// SetCiliumNodeTaints is whether or not to set taints on nodes that do not
-	// have a running Cilium pod.
-	SetCiliumNodeTaints bool
-
-	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
-	// nodes.
-	SetCiliumIsUpCondition bool
-
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	PodRestartSelector string
 }
@@ -330,10 +298,6 @@ func (c *OperatorConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 		c.ProxyStreamIdleTimeoutSeconds = DefaultProxyStreamIdleTimeoutSeconds
 	}
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
-	c.TaintSyncWorkers = vp.GetInt(TaintSyncWorkers)
-	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
-	c.SetCiliumNodeTaints = vp.GetBool(SetCiliumNodeTaints)
-	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)
 	c.PodRestartSelector = vp.GetString(PodRestartSelector)
 
 	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)

--- a/operator/policyderivative/cell.go
+++ b/operator/policyderivative/cell.go
@@ -14,6 +14,7 @@ var Cell = cell.Module(
 	"policy-derivative",
 	"CNP and CCNP derivative policy watcher",
 
+	cell.Invoke(registerLabelPrefixConfig),
 	cell.Invoke(registerWatchers),
 )
 

--- a/operator/policyderivative/controller.go
+++ b/operator/policyderivative/controller.go
@@ -5,6 +5,7 @@ package policyderivative
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -13,7 +14,27 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/option"
 )
+
+type labelPrefixParams struct {
+	cell.In
+
+	SharedCfg SharedConfig
+	DaemonCfg *option.DaemonConfig
+	Logger    *slog.Logger
+}
+
+func registerLabelPrefixConfig(p labelPrefixParams) error {
+	if !p.SharedCfg.K8sEnabled {
+		return nil
+	}
+	if err := labelsfilter.ParseLabelPrefixCfg(p.Logger, p.DaemonCfg.Labels, p.DaemonCfg.NodeLabels, p.DaemonCfg.LabelPrefixFile); err != nil {
+		return fmt.Errorf("unable to parse label prefix configuration: %w", err)
+	}
+	return nil
+}
 
 type params struct {
 	cell.In

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -147,14 +146,14 @@ func ciliumPodHandler(obj any, queue workqueue.TypedRateLimitingInterface[string
 }
 
 // ciliumPodsWatcher starts up a pod watcher to handle pod events.
-func ciliumPodsWatcher(wg *sync.WaitGroup, slimClient slimclientset.Interface, queue workqueue.TypedRateLimitingInterface[string], stopCh <-chan struct{}, logger *slog.Logger) {
+func ciliumPodsWatcher(wg *sync.WaitGroup, slimClient slimclientset.Interface, queue workqueue.TypedRateLimitingInterface[string], stopCh <-chan struct{}, logger *slog.Logger, namespace, labelSelector string) {
 	ciliumPodInformer := informer.NewInformerWithStore(
 		k8sUtils.ListerWatcherWithModifier(
 			k8sUtils.ListerWatcherFromTyped[*slim_corev1.PodList](
-				slimClient.CoreV1().Pods(option.Config.CiliumK8sNamespace),
+				slimClient.CoreV1().Pods(namespace),
 			),
 			func(options *metav1.ListOptions) {
-				options.LabelSelector = option.Config.CiliumPodLabels
+				options.LabelSelector = labelSelector
 			}),
 		&slim_corev1.Pod{},
 		0,
@@ -500,11 +499,11 @@ func markNode(ctx context.Context, c kubernetes.Interface, nodeGetter slimNodeGe
 }
 
 // HandleNodeTolerationAndTaints remove node
-func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clientset, stopCh <-chan struct{}, logger *slog.Logger) {
+func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clientset, stopCh <-chan struct{}, logger *slog.Logger, cfg NodeTaintSyncConfig, ciliumNamespace, ciliumPodLabels string) {
 	mno = markNodeOptions{
-		RemoveNodeTaint:        option.Config.RemoveCiliumNodeTaints,
-		SetNodeTaint:           option.Config.SetCiliumNodeTaints,
-		SetCiliumIsUpCondition: option.Config.SetCiliumIsUpCondition,
+		RemoveNodeTaint:        cfg.RemoveCiliumNodeTaints,
+		SetNodeTaint:           cfg.SetCiliumNodeTaints,
+		SetCiliumIsUpCondition: cfg.SetCiliumIsUpCondition,
 	}
 
 	nodesInit(wg, clientset.Slim(), stopCh, nil)
@@ -513,9 +512,9 @@ func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clien
 	// so checkAndMarkNode has cilium-pod information.
 	// Additionally, we pass nodeQueue to ciliumPodWatcher.
 	// that was initialized in nodesInit.
-	ciliumPodsWatcher(wg, clientset.Slim(), nodeQueue, stopCh, logger)
+	ciliumPodsWatcher(wg, clientset.Slim(), nodeQueue, stopCh, logger, ciliumNamespace, ciliumPodLabels)
 
-	for i := 1; i <= option.Config.TaintSyncWorkers; i++ {
+	for range cfg.TaintSyncWorkers {
 		wg.Go(func() {
 			// Do not use the k8sClient provided by the nodesInit function since we
 			// need a k8s client that can update node structures and not simply

--- a/operator/watchers/node_taint_cell.go
+++ b/operator/watchers/node_taint_cell.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/defaults"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// NodeTaintSyncCell manages node taints and conditions based on Cilium pod
+// readiness. It removes the agent-not-ready taint once Cilium is running on
+// a node, and optionally sets it when Cilium is scheduled but not yet ready.
+var NodeTaintSyncCell = cell.Module(
+	"node-taint-sync",
+	"Manages node taints and conditions based on Cilium pod readiness",
+
+	cell.Config(nodeTaintSyncDefaultConfig),
+	cell.Invoke(registerNodeTaintSync),
+)
+
+// NodeTaintSyncConfig holds the configuration owned by the node taint sync cell.
+// CiliumK8sNamespace and CiliumPodLabels are shared with other cells and
+// therefore remain in OperatorConfig.
+type NodeTaintSyncConfig struct {
+	TaintSyncWorkers       int
+	RemoveCiliumNodeTaints bool
+	SetCiliumNodeTaints    bool
+	SetCiliumIsUpCondition bool
+}
+
+var nodeTaintSyncDefaultConfig = NodeTaintSyncConfig{
+	TaintSyncWorkers:       10,
+	RemoveCiliumNodeTaints: true,
+	SetCiliumNodeTaints:    false,
+	SetCiliumIsUpCondition: true,
+}
+
+func (def NodeTaintSyncConfig) Flags(flags *pflag.FlagSet) {
+	flags.Int("taint-sync-workers", def.TaintSyncWorkers,
+		"Number of workers used to synchronize node taints and conditions")
+	flags.Bool("remove-cilium-node-taints", def.RemoveCiliumNodeTaints,
+		fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", defaults.AgentNotReadyNodeTaint))
+	flags.Bool("set-cilium-node-taints", def.SetCiliumNodeTaints,
+		fmt.Sprintf("Set node taint %q on Kubernetes nodes if Cilium is scheduled but not up and running", defaults.AgentNotReadyNodeTaint))
+	flags.Bool("set-cilium-is-up-condition", def.SetCiliumIsUpCondition,
+		"Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
+}
+
+type nodeTaintSyncParams struct {
+	cell.In
+
+	Logger      *slog.Logger
+	Lifecycle   cell.Lifecycle
+	Clientset   k8sClient.Clientset
+	OperatorCfg *operatorOption.OperatorConfig
+
+	Cfg NodeTaintSyncConfig
+}
+
+func registerNodeTaintSync(p nodeTaintSyncParams) {
+	if !p.Clientset.IsEnabled() {
+		return
+	}
+	if !p.Cfg.RemoveCiliumNodeTaints && !p.Cfg.SetCiliumIsUpCondition {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &nodeTaintSync{
+		ctx:         ctx,
+		cancel:      cancel,
+		clientset:   p.Clientset,
+		operatorCfg: p.OperatorCfg,
+		cfg:         p.Cfg,
+		logger:      p.Logger,
+	}
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: s.start,
+		OnStop:  s.stop,
+	})
+}
+
+type nodeTaintSync struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	clientset   k8sClient.Clientset
+	operatorCfg *operatorOption.OperatorConfig
+	cfg         NodeTaintSyncConfig
+	logger      *slog.Logger
+}
+
+func (s *nodeTaintSync) start(ctx cell.HookContext) error {
+	s.logger.InfoContext(ctx,
+		"Managing Cilium Node Taints or Setting Cilium Is Up Condition for Kubernetes Nodes",
+		logfields.K8sNamespace, s.operatorCfg.CiliumK8sNamespace,
+		logfields.LabelSelectorFlagOption, s.operatorCfg.CiliumPodLabels,
+		logfields.RemoveCiliumNodeTaintsFlagOption, s.cfg.RemoveCiliumNodeTaints,
+		logfields.SetCiliumNodeTaintsFlagOption, s.cfg.SetCiliumNodeTaints,
+		logfields.SetCiliumIsUpConditionFlagOption, s.cfg.SetCiliumIsUpCondition,
+	)
+	HandleNodeTolerationAndTaints(&s.wg, s.clientset, s.ctx.Done(), s.logger, s.cfg,
+		s.operatorCfg.CiliumK8sNamespace, s.operatorCfg.CiliumPodLabels)
+	return nil
+}
+
+func (s *nodeTaintSync) stop(_ cell.HookContext) error {
+	s.cancel()
+	s.wg.Wait()
+	return nil
+}


### PR DESCRIPTION
See individual commits for details:
* Extract node taint sync into a dedicated Hive cell
* Move label prefix config parsing into the policy derivative cell
* Move identity allocation mode validation out of legacy cell

This is in continuation of #44528 with the ultimate goal of removing the legacy operator cell