### PR TITLE
datapath/loader: Add map count to verifier complexity records

### DIFF
--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -337,6 +337,13 @@ func loadAndRecordComplexity(
 				t.Fatalf("Failed to parse verification time for program %s: %v", n, err)
 			}
 
+			progInfo, err := p.Info()
+			if err != nil {
+				t.Fatalf("Failed to get program info for program %s: %v", n, err)
+			}
+			mapIds, _ := progInfo.MapIDs()
+			r.MapCount = len(mapIds)
+
 			records.Add(r)
 		}
 	}
@@ -358,6 +365,8 @@ type verifierComplexityRecord struct {
 
 	VerificationTimeMicroseconds int `json:"verification_time_microseconds"`
 	StackDepth                   int `json:"stack_depth"`
+
+	MapCount int `json:"map_count"`
 }
 
 type verifierComplexityRecords struct {

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -29,6 +29,8 @@ type verifierComplexityRecord struct {
 
 	VerificationTimeMicroseconds int `json:"verification_time_microseconds"`
 	StackDepth                   int `json:"stack_depth"`
+
+	MapCount int `json:"map_count"`
 }
 
 func main() {
@@ -61,6 +63,11 @@ func main() {
 	})
 	printTop15MinMax("largest differences by stack depth", minMaxStackDepth, percentStackDepth, colorRelativeChange)
 
+	minMaxMapCount := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
+		return r.MapCount
+	})
+	printTop15MinMax("largest differences by map count", minMaxMapCount, percentMapCount, colorRelativeChange)
+
 	var sortedNewRecords []verifierComplexityRecord
 	for _, key := range slices.Sorted(maps.Keys(newRecords)) {
 		sortedNewRecords = append(sortedNewRecords, newRecords[key])
@@ -75,6 +82,11 @@ func main() {
 		return r.StackDepth
 	})
 	printTop15MinMax("largest stack depth", minMaxStackDepth, percentStackDepth, colorAbsoluteValue)
+
+	minMaxMapCount = calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
+		return r.MapCount
+	})
+	printTop15MinMax("largest map count", minMaxMapCount, percentMapCount, colorAbsoluteValue)
 
 	diffRecords = calcDiffRecords(oldRecords, newRecords, false)
 
@@ -139,6 +151,10 @@ func percentInsnsProcessed(i int) float64 {
 
 func percentStackDepth(i int) float64 {
 	return float64(i) / float64(512) * 100
+}
+
+func percentMapCount(i int) float64 {
+	return float64(i) / float64(64) * 100
 }
 
 func colorRelativeChange(program string, i int, p float64) string {
@@ -266,6 +282,8 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 
 			VerificationTimeMicroseconds: newRecord.VerificationTimeMicroseconds - oldRecord.VerificationTimeMicroseconds,
 			StackDepth:                   newRecord.StackDepth - oldRecord.StackDepth,
+
+			MapCount: newRecord.MapCount - oldRecord.MapCount,
 		})
 	}
 
@@ -289,6 +307,8 @@ func calcDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord,
 
 					VerificationTimeMicroseconds: -oldRecord.VerificationTimeMicroseconds,
 					StackDepth:                   -oldRecord.StackDepth,
+
+					MapCount: -oldRecord.MapCount,
 				})
 			}
 		}


### PR DESCRIPTION
We use a lot of maps in Cilium. The kernel limits us to a max of 64 maps per program. We would like to track how many maps are used by our programs, and how close we are to that limit.

So for every permutation of our program we load during the complexity tests, we also query the kernel for the number of maps used by that program, and we add that to the complexity records.

Also updated the complexity diff tool to include map count in its output so its both in the JSON files as well as the human readable output.

Fixes: #44651