### PR TITLE
connectivity: treat VLAN filter drops as expected

### DIFF
--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -151,6 +151,7 @@ var (
 		"Unknown ICMPv6 code",
 		"Forbidden ICMPv6 message",
 		"No egress gateway found",
+		"VLAN traffic disallowed by VLAN filter",
 	}
 
 	ExpectedXFRMErrors = []string{


### PR DESCRIPTION
Fixes #36830

The `no-unexpected-packet-drops` connectivity test fails in virtualized environments (Proxmox,
Talos, Debian VMs) because VLAN-tagged packets arrive on bridge interfaces and Cilium correctly
drops them with reason "VLAN traffic disallowed by VLAN filter" (drop code 182). These aren't
connectivity failures.

The suggested workaround (`--vlan-bpf-bypass=0`) doesn't help because drops still show up in
metrics. Users can work around it with the hidden `--expected-drop-reasons` flag but shouldn't
have to.

Added the VLAN drop reason to the default `ExpectedDropReasons` list.