### PR TITLE
modernize: Enable `waitgroup` analyzer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -119,7 +119,6 @@ linters:
     modernize:
       disable: # TODO: remove each disabled rule and fix it
         - omitzero
-        - waitgroup
     govet:
       enable:
         - nilness

--- a/cilium-cli/utils/runner/multierror.go
+++ b/cilium-cli/utils/runner/multierror.go
@@ -21,15 +21,13 @@ type MultiError struct {
 
 // Go runs a function in a separate goroutine.
 func (m *MultiError) Go(fn func() error) {
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
+	m.wg.Go(func() {
 		if err := fn(); err != nil {
 			m.lock.Lock()
 			m.err = errors.Join(m.err, err)
 			m.lock.Unlock()
 		}
-	}()
+	})
 }
 
 // Wait waits for all the goroutines to finish and returns

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -460,11 +460,9 @@ func registerOperatorHooks(log *slog.Logger, lc cell.Lifecycle, llc *LeaderLifec
 	var wg sync.WaitGroup
 	lc.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				runOperator(log, llc, clientset, shutdowner)
-				wg.Done()
-			}()
+			})
 			return nil
 		},
 		OnStop: func(ctx cell.HookContext) error {

--- a/operator/doublewrite/metricreporter.go
+++ b/operator/doublewrite/metricreporter.go
@@ -105,11 +105,9 @@ func (g *DoubleWriteMetricReporter) Start(ctx cell.HookContext) error {
 	cctx, g.crdBackendWatcherStop = context.WithCancel(context.Background())
 	g.crdBackendListDone = make(chan struct{})
 	g.wg = sync.WaitGroup{}
-	g.wg.Add(1)
-	go func() {
+	g.wg.Go(func() {
 		g.crdBackend.ListAndWatch(cctx, NoOpHandlerWithListDone{listDone: g.crdBackendListDone})
-		g.wg.Done()
-	}()
+	})
 
 	g.mgr = controller.NewManager()
 	g.mgr.UpdateController("double-write-metric-reporter",

--- a/operator/unmanagedpods/controller.go
+++ b/operator/unmanagedpods/controller.go
@@ -86,11 +86,9 @@ type unmanagedPodsController struct {
 func (c *unmanagedPodsController) onStart(ctx cell.HookContext) error {
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+	c.wg.Go(func() {
 		c.enableUnmanagedController()
-	}()
+	})
 
 	return nil
 }
@@ -108,12 +106,10 @@ func (c *unmanagedPodsController) enableUnmanagedController() {
 
 	mgr := controller.NewManager()
 
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+	c.wg.Go(func() {
 		<-c.ctx.Done()
 		mgr.RemoveAllAndWait()
-	}()
+	})
 
 	mgr.UpdateController("restart-unmanaged-pods",
 		controller.ControllerParams{

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -68,11 +68,9 @@ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sC
 			CiliumEndpointStore,
 		)
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ciliumEndpointInformer.Run(ctx.Done())
-		}()
+		})
 
 		cache.WaitForCacheSync(ctx.Done(), ciliumEndpointInformer.HasSynced)
 		close(CiliumEndpointsSynced)

--- a/operator/watchers/node.go
+++ b/operator/watchers/node.go
@@ -94,12 +94,10 @@ func nodesInit(wg *sync.WaitGroup, slimClient slimclientset.Interface, stopCh <-
 			},
 			transformToNode,
 		)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer nodeQueue.ShutDown()
 			nodeController.Run(stopCh)
-		}()
+		})
 
 		cache.WaitForCacheSync(stopCh, nodeController.HasSynced)
 		close(slimNodeStoreSynced)

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -170,11 +170,9 @@ func ciliumPodsWatcher(wg *sync.WaitGroup, slimClient slimclientset.Interface, q
 		ciliumPodsStore,
 	)
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ciliumPodInformer.Run(stopCh)
-	}()
+	})
 
 	cache.WaitForCacheSync(stopCh, ciliumPodInformer.HasSynced)
 }
@@ -518,14 +516,12 @@ func HandleNodeTolerationAndTaints(wg *sync.WaitGroup, clientset k8sClient.Clien
 	ciliumPodsWatcher(wg, clientset.Slim(), nodeQueue, stopCh, logger)
 
 	for i := 1; i <= option.Config.TaintSyncWorkers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// Do not use the k8sClient provided by the nodesInit function since we
 			// need a k8s client that can update node structures and not simply
 			// watch for node events.
 			for checkTaintForNextNodeItem(clientset, &nodeGetter{}, nodeQueue, logger) {
 			}
-		}()
+		})
 	}
 }

--- a/operator/watchers/pod.go
+++ b/operator/watchers/pod.go
@@ -46,11 +46,9 @@ func UnmanagedPodsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 		cache.ResourceEventHandlerFuncs{},
 		TransformToUnmanagedPod,
 	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		unmanagedPodInformer.Run(ctx.Done())
-	}()
+	})
 
 	cache.WaitForCacheSync(ctx.Done(), unmanagedPodInformer.HasSynced)
 }

--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -531,11 +531,9 @@ func TestWatchRemoteKVStore(t *testing.T) {
 
 	run := func(ctx context.Context, rc RemoteIDCache) context.CancelFunc {
 		ctx, cancel := context.WithCancel(ctx)
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			rc.Watch(ctx, func(context.Context) { synced.Store(true) })
-			wg.Done()
-		}()
+		})
 		return cancel
 	}
 

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -267,12 +267,9 @@ func (c *cache) start() waitChan {
 	c.nextKeyCache = keyMap{}
 	c.mutex.Unlock()
 
-	c.stopWatchWg.Add(1)
-
-	go func() {
+	c.stopWatchWg.Go(func() {
 		c.allocator.backend.ListAndWatch(c.ctx, c)
-		c.stopWatchWg.Done()
-	}()
+	})
 
 	return c.listDone
 }

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -615,12 +615,10 @@ func TestPrivilegedDumpReliablyWithCallbackOverlapping(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	wg := sync.WaitGroup{}
-	wg.Add(1)
 	// This goroutine will continuously delete and reinsert even keys.
 	// Thus, when this is running in parallel with DumpReliablyWithCallback
 	// it is unclear whether any even key will be iterated.
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		for {
 			select {
@@ -635,7 +633,7 @@ func TestPrivilegedDumpReliablyWithCallbackOverlapping(t *testing.T) {
 				require.NoError(t, err)
 			}
 		}
-	}()
+	})
 
 	// We expect that DumpReliablyWithCallback will iterate all odd key/value pairs
 	// even if the even keys are being deleted and reinserted.
@@ -700,9 +698,7 @@ func TestPrivilegedDumpReliablyWithCallback(t *testing.T) {
 	started := make(chan struct{}, 1)
 	done := make(chan struct{}, 1)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		started <- struct{}{}
 		for {
 			for i := range uint32(4) {
@@ -723,11 +719,9 @@ func TestPrivilegedDumpReliablyWithCallback(t *testing.T) {
 			default:
 			}
 		}
-	}()
+	})
 	<-started // wait until the routine has started to start the actual tests
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		expect := map[string]string{}
 		for i := uint32(4); i < maxEntries; i++ {
 			expect[fmt.Sprintf("key=%d", i)] = fmt.Sprintf("custom-value=%d", i+100)
@@ -756,7 +750,7 @@ func TestPrivilegedDumpReliablyWithCallback(t *testing.T) {
 			}
 		}
 		done <- struct{}{}
-	}()
+	})
 	wg.Wait()
 }
 

--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -13,10 +13,8 @@ import (
 // `f` returns from its execution that same waitGroup will signalize function
 // `f` is completed.
 func DeferTerminationCleanupFunction(wg *sync.WaitGroup, ch <-chan struct{}, f func()) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-ch
 		f()
-	}()
+	})
 }

--- a/pkg/datapath/loader/cache_test.go
+++ b/pkg/datapath/loader/cache_test.go
@@ -72,12 +72,10 @@ func TestObjectCacheParallel(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range runtime.GOMAXPROCS(0) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, _, err := cache.fetchOrCompile(ctx, &localNodeConfig, &ep, getDirs(t), nil)
 			assert.NoError(t, err)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -264,11 +264,9 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.Lifecycle.Append(cell.Hook{
 		OnStart: func(hc cell.HookContext) error {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				manager.processEvents(ctx)
-			}()
+			})
 
 			return nil
 		},

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -205,10 +205,9 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 
 	eps := mgr.GetEndpoints()
 	epWG.Add(len(eps))
-	wg.Add(1)
 
 	// This is in a goroutine to allow the caller to proceed with other tasks before waiting for the ACKs to complete
-	go func() {
+	wg.Go(func() {
 		// Wait for all the eps to have applied policy map
 		// changes before waiting for the changes to be ACKed
 		epWG.Wait()
@@ -220,8 +219,7 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 		// This should not block the main flow for Endpoint.
 		mgr.policyUpdateCallback(&sync.WaitGroup{}, nil, true)
 
-		wg.Done()
-	}()
+	})
 
 	// TODO: bound by number of CPUs?
 	for _, ep := range eps {

--- a/pkg/fqdn/dnsproxy/shared_client.go
+++ b/pkg/fqdn/dnsproxy/shared_client.go
@@ -196,9 +196,7 @@ func handler(wg *sync.WaitGroup, client *dns.Client, conn *dns.Conn, requests ch
 	}
 
 	// Receive loop
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer close(responses)
 
 		// Synthesize a dns.Conn for this reading goroutine, so that it is not
@@ -241,7 +239,7 @@ func handler(wg *sync.WaitGroup, client *dns.Client, conn *dns.Conn, requests ch
 				return // exit immediately when the trigger channel is closed
 			}
 		}
-	}()
+	})
 
 	type waiter struct {
 		ch    chan sharedClientResponse

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -134,16 +134,14 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 	// ebpf.io, done by every endpoint.
 	for b.Loop() {
 		for _, ep := range endpoints {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				// Using a hardcoded string representing endpoint IP:port as this
 				// parameter is only used in logging. Not using the endpoint's IP
 				// so we don't spend any time in the benchmark on converting from
 				// net.IP to string.
 				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", 0, srvAddr, ciliumMsg, "udp", true, emptyPRCtx))
 				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, srvAddr, ebpfMsg, "udp", true, emptyPRCtx))
-			}()
+			})
 		}
 		wg.Wait()
 	}

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -741,11 +741,9 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	ch := make(chan *v1.Event, 30)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		r.readFrom(ctx, 0, ch)
-		wg.Done()
-	}()
+	})
 	i := int64(0)
 	for entry := range ch {
 		require.NotNil(t, entry)
@@ -805,11 +803,9 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 	// be able to catch up with the writer.
 	ch := make(chan *v1.Event, 30)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		r.readFrom(ctx, 1, ch)
-	}()
+	})
 	i := int64(1) // ReadFrom
 	for event := range ch {
 		require.NotNil(t, event)
@@ -903,11 +899,9 @@ func TestRing_ReadFrom_Test_3(t *testing.T) {
 	// be able to catch up with the writer.
 	ch := make(chan *v1.Event, 30)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		r.readFrom(ctx, ^uint64(0)-15, ch)
-		wg.Done()
-	}()
+	})
 	i := ^uint64(0) - 15
 	for entry := range ch {
 		require.NotNil(t, entry)

--- a/pkg/hubble/peer/handler_test.go
+++ b/pkg/hubble/peer/handler_test.go
@@ -195,11 +195,9 @@ func TestNodeAdd(t *testing.T) {
 
 			var got *peerpb.ChangeNotification
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				got = <-h.C
-				wg.Done()
-			}()
+			})
 			h.NodeAdd(tt.arg)
 			wg.Wait()
 			assert.Equal(t, tt.want, got)
@@ -477,13 +475,11 @@ func TestNodeUpdate(t *testing.T) {
 
 			var got []*peerpb.ChangeNotification
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				for range tt.want {
 					got = append(got, <-h.C)
 				}
-				wg.Done()
-			}()
+			})
 			h.NodeUpdate(tt.args.old, tt.args.updated)
 			wg.Wait()
 			assert.Equal(t, tt.want, got)
@@ -642,11 +638,9 @@ func TestNodeDelete(t *testing.T) {
 
 			var got *peerpb.ChangeNotification
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				got = <-h.C
-				wg.Done()
-			}()
+			})
 			h.NodeDelete(tt.arg)
 			wg.Wait()
 			assert.Equal(t, tt.want, got)
@@ -698,11 +692,9 @@ func TestHubblePort(t *testing.T) {
 
 			var got *peerpb.ChangeNotification
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				got = <-h.C
-				wg.Done()
-			}()
+			})
 			h.NodeAdd(tt.arg)
 
 			want := &peerpb.ChangeNotification{

--- a/pkg/idpool/idpool_test.go
+++ b/pkg/idpool/idpool_test.go
@@ -309,8 +309,7 @@ func testAllocatedID(t *testing.T, nGoRoutines int) {
 	var allocators sync.WaitGroup
 
 	for range nGoRoutines {
-		allocators.Add(1)
-		go func() {
+		allocators.Go(func() {
 			for i := 1; i <= maxID; i++ {
 				id := p.AllocateID()
 				if id == NoID {
@@ -318,8 +317,7 @@ func testAllocatedID(t *testing.T, nGoRoutines int) {
 				}
 				allocated <- id
 			}
-			allocators.Done()
-		}()
+		})
 	}
 
 	go func() {

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -113,12 +113,10 @@ func TestIPIdentityWatcher(t *testing.T) {
 				wg.Wait()
 			}()
 
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				watcher.Watch(ctx, backend, opts...)
 				close(ipcache.events)
-				wg.Done()
-			}()
+			})
 
 			body(t, ipcache)
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -821,12 +821,10 @@ func TestMetadataWaitForRevision(t *testing.T) {
 	_, wantRev := m.dequeuePrefixUpdates()
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err := m.waitForRevision(t.Context(), wantRev)
 		require.NoError(t, err)
-		wg.Done()
-	}()
+	})
 
 	m.setInjectedRevision(wantRev)
 	wg.Wait()

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -425,9 +425,7 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 	}
 
 	// Fork a goroutine to process the queued keys and pass them to the subscriber.
-	r.wg.Add(1)
-	go func() {
-		defer r.wg.Done()
+	r.wg.Go(func() {
 		defer close(out)
 
 		// Grab a handle to the store. Asynchronous as informer is started in the background.
@@ -464,20 +462,18 @@ func (r *resource[T]) Events(ctx context.Context, opts ...EventsOpt) <-chan Even
 		r.mu.Lock()
 		delete(r.subscribers, subId)
 		r.mu.Unlock()
-	}()
+	})
 
 	// Fork a goroutine to wait for either the subscriber cancelling or the resource
 	// shutting down.
-	r.wg.Add(1)
-	go func() {
-		defer r.wg.Done()
+	r.wg.Go(func() {
 		select {
 		case <-r.ctx.Done():
 		case <-ctx.Done():
 		}
 		subCancel()
 		sub.wq.ShutDownWithDrain()
-	}()
+	})
 
 	return out
 }

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -999,8 +999,7 @@ func BenchmarkResource(b *testing.B) {
 	var wg sync.WaitGroup
 
 	// Feed in b.N nodes as watcher events
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		for i := 0; b.Loop(); i++ {
 			name := fmt.Sprintf("node-%d", i)
 			lw.events <- watch.Event{Type: watch.Added, Object: &corev1.Node{
@@ -1010,8 +1009,7 @@ func BenchmarkResource(b *testing.B) {
 				},
 			}}
 		}
-		wg.Done()
-	}()
+	})
 
 	// Consume the events via the resource
 	for b.Loop() {

--- a/pkg/ztunnel/zds/server.go
+++ b/pkg/ztunnel/zds/server.go
@@ -224,11 +224,9 @@ func newZDSServer(p serverParams) serverOut {
 				return fmt.Errorf("failed to listen on ztunnel unix addr: %w", err)
 			}
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				server.Serve(ctx)
-			}()
+			})
 
 			return nil
 		},
@@ -282,13 +280,11 @@ func (s *Server) Serve(ctx context.Context) {
 		connCtx, cancel := context.WithCancel(ctx)
 		cancelPrevConn = cancel
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if err := s.handleConn(connCtx, zc); err != nil {
 				s.logger.Error("failed to handle connection", logfields.Error, err)
 			}
-		}()
+		})
 	}
 }
 


### PR DESCRIPTION
Enable the [`waitgroup`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_waitgroup) modernize analyzer globally and address the last remaining failures.

Patch generated with `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -waitgroup ./...`

Followup to #42642