### PR TITLE
datapath: read-only to auth, egw_policy, lxc, runtime, affinity_match…

### DIFF
--- a/bpf/lib/auth.h
+++ b/bpf/lib/auth.h
@@ -15,7 +15,7 @@ struct {
 	__type(value, struct auth_info);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 524288);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_auth_map __section_maps_btf;
 
 static __always_inline int

--- a/bpf/lib/config_map.h
+++ b/bpf/lib/config_map.h
@@ -22,6 +22,7 @@ struct {
 	__type(value, __u64);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 256);
+	__uint(map_flags, BPF_F_RDONLY_PROG_COND);
 } cilium_runtime_config __section_maps_btf;
 
 /*

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -41,7 +41,7 @@ struct {
 	__type(value, struct egress_gw_policy_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, EGRESS_POLICY_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_egress_gw_policy_v4 __section_maps_btf;
 
 struct {
@@ -50,7 +50,7 @@ struct {
 	__type(value, struct egress_gw_policy_entry6);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, EGRESS_POLICY_MAP_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_egress_gw_policy_v6 __section_maps_btf;
 
 #ifdef ENABLE_EGRESS_GATEWAY_COMMON

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -56,7 +56,7 @@ struct {
 	__type(value, struct endpoint_info);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, ENDPOINTS_MAP_SIZE);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lxc __section_maps_btf;
 
 static __always_inline __maybe_unused const struct endpoint_info *

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -179,6 +179,10 @@ struct lb6_src_range_key {
 	union v6addr addr;
 };
 
+/* Could be read-only from datapath, but bpf_xdp_store_bytes (unlike
+ * bpf_skb_store_bytes) does not accept MEM_RDONLY pointers, so map values
+ * passed to ctx_store_bytes in XDP programs would be rejected by the verifier.
+ */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u16);
@@ -197,6 +201,10 @@ struct {
 	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb6_services_v2 __section_maps_btf;
 
+/* Could be read-only from datapath, but bpf_xdp_store_bytes (unlike
+ * bpf_skb_store_bytes) does not accept MEM_RDONLY pointers, so map values
+ * passed to ctx_store_bytes in XDP programs would be rejected by the verifier.
+ */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u32);
@@ -251,6 +259,10 @@ struct {
 } cilium_lb6_maglev __section_maps_btf;
 #endif /* OVERWRITE_MAGLEV_MAP_FROM_TEST */
 
+/* Could be read-only from datapath, but bpf_xdp_store_bytes (unlike
+ * bpf_skb_store_bytes) does not accept MEM_RDONLY pointers, so map values
+ * passed to ctx_store_bytes in XDP programs would be rejected by the verifier.
+ */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u16);
@@ -269,6 +281,10 @@ struct {
 	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb4_services_v2 __section_maps_btf;
 
+/* Could be read-only from datapath, but bpf_xdp_store_bytes (unlike
+ * bpf_skb_store_bytes) does not accept MEM_RDONLY pointers, so map values
+ * passed to ctx_store_bytes in XDP programs would be rejected by the verifier.
+ */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u32);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -329,7 +329,7 @@ struct {
 	__type(value, __u8);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CILIUM_LB_AFFINITY_MAP_MAX_ENTRIES);
-	__uint(map_flags, CONDITIONAL_PREALLOC);
+	__uint(map_flags, CONDITIONAL_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb_affinity_match __section_maps_btf;
 
 /* Lookup scope for externalTrafficPolicy=Local */

--- a/bpf/lib/network_device.h
+++ b/bpf/lib/network_device.h
@@ -18,6 +18,11 @@ struct device_state {
 	__u32 pad3;
 };
 
+/* Could be read-only from datapath, but bpf_xdp_store_bytes (unlike
+ * bpf_skb_store_bytes) does not accept MEM_RDONLY pointers, so map values
+ * passed to eth_store_saddr_aligned in XDP programs would be rejected by the
+ * verifier.
+ */
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__type(key, __u32);

--- a/pkg/datapath/maps/maps_generated.go
+++ b/pkg/datapath/maps/maps_generated.go
@@ -132,7 +132,7 @@ func newCiliumAuthMapSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  8,
 		Value:      anyTypeByName(btf, "auth_info"),
 		MaxEntries: 524288,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -298,7 +298,7 @@ func newCiliumEgressGwPolicyV4Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  8,
 		Value:      anyTypeByName(btf, "egress_gw_policy_entry"),
 		MaxEntries: 16384,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -312,7 +312,7 @@ func newCiliumEgressGwPolicyV6Spec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  40,
 		Value:      anyTypeByName(btf, "egress_gw_policy_entry6"),
 		MaxEntries: 16384,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -728,7 +728,7 @@ func newCiliumLBAffinityMatchSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  1,
 		Value:      anyTypeByName(btf, "__u8"),
 		MaxEntries: 65536,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -742,7 +742,7 @@ func newCiliumLXCSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  48,
 		Value:      anyTypeByName(btf, "endpoint_info"),
 		MaxEntries: 65536,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }
@@ -1083,7 +1083,7 @@ func newCiliumRuntimeConfigSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  8,
 		Value:      anyTypeByName(btf, "__u64"),
 		MaxEntries: 256,
-		Flags:      0,
+		Flags:      unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }

--- a/pkg/loadbalancer/maps/lbmaps.go
+++ b/pkg/loadbalancer/maps/lbmaps.go
@@ -223,7 +223,7 @@ func NewAffinityMatchMap(maxEntries int) *bpf.Map {
 		&AffinityMatchKey{},
 		&AffinityMatchValue{},
 		maxEntries,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	)
 }
 

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
 	"github.com/spf13/pflag"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -141,7 +142,7 @@ func createPolicyMap4(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyC
 		&EgressPolicyKey4{},
 		&EgressPolicyVal4{},
 		cfg.EgressGatewayPolicyMapMax,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	).WithPressureMetric(registry)
 
 	lc.Append(cell.Hook{
@@ -169,7 +170,7 @@ func createPolicyMap6(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyC
 		&EgressPolicyKey6{},
 		&EgressPolicyVal6{},
 		cfg.EgressGatewayPolicyMapMax,
-		0,
+		unix.BPF_F_RDONLY_PROG,
 	).WithPressureMetric(registry)
 
 	lc.Append(cell.Hook{

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 
 	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/identity"
@@ -60,7 +61,7 @@ func newMap(registry *metrics.Registry) *lxcMap {
 			&EndpointKey{},
 			&EndpointInfo{},
 			MaxEntries,
-			0,
+			unix.BPF_F_RDONLY_PROG,
 		).
 			WithCache().WithPressureMetric(registry).
 			WithEvents(option.Config.GetEventBufferConfig(mapName)),


### PR DESCRIPTION
Follow up for these prs: [first](https://github.com/cilium/cilium/pull/43076) and [second](https://github.com/cilium/cilium/pull/43554).

Apart from marking the maps read-only, some maps like devices map and backend lb maps cannot be marked read-only now as they pass value pointers directly to BPF helpers. To document such constraint, I have added some comments. For details, please check the second commit.

Relates: #42473 