### PR TITLE
fix(gateway-api): prevent silent disable on CRD discovery timeout

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -97,6 +97,9 @@ type preconditionParams struct {
 	GatewayApiConfig gatewayApiConfig
 }
 
+// crdDiscoveryTimeout is the maximum duration to retry CRD discovery on transient errors.
+const crdDiscoveryTimeout = 30 * time.Second
+
 // newGatewayAPIPreconditions checks all Gateway API preconditions and returns
 // the result. This includes config checks, kube-proxy-replacement check,
 // external traffic policy validation, and CRD discovery with retry logic.
@@ -114,7 +117,18 @@ func newGatewayAPIPreconditions(params preconditionParams) (*gatewayAPIPrecondit
 		return nil, err
 	}
 
-	params.Logger.Info(
+	ctx, cancel := context.WithTimeout(context.Background(), crdDiscoveryTimeout)
+	defer cancel()
+
+	return discoverCRDsWithRetry(ctx, params.K8sClient, params.Logger, params.Health)
+}
+
+// discoverCRDsWithRetry attempts to discover required Gateway API CRDs, retrying
+// on transient errors until the context expires. Returns a fatal error if the
+// context expires (causing operator restart) or disables Gateway API gracefully
+// if CRDs are permanently missing.
+func discoverCRDsWithRetry(ctx context.Context, client k8sClient.Clientset, logger *slog.Logger, health cell.Health) (*gatewayAPIPreconditions, error) {
+	logger.Info(
 		"Checking for required and optional GatewayAPI resources",
 		logfields.RequiredGVK, requiredGVKs,
 		logfields.OptionalGVK, optionalGVKs,
@@ -123,7 +137,7 @@ func newGatewayAPIPreconditions(params preconditionParams) (*gatewayAPIPrecondit
 	// Configure exponential backoff for CRD discovery.
 	// This allows the operator to recover if API server is temporarily unavailable at startup.
 	bo := backoff.Exponential{
-		Logger: params.Logger,
+		Logger: logger,
 		Min:    200 * time.Millisecond,
 		Max:    5 * time.Second,
 		Factor: 2.0,
@@ -131,36 +145,50 @@ func newGatewayAPIPreconditions(params preconditionParams) (*gatewayAPIPrecondit
 		Name:   "gateway-api-crd-discovery",
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
 	for {
-		installedKinds, err := checkCRDs(ctx, params.K8sClient, params.Logger, requiredGVKs, optionalGVKs)
+		installedKinds, err := checkCRDs(ctx, client, logger, requiredGVKs, optionalGVKs)
 		if err == nil {
-			params.Health.OK("Gateway API CRDs discovered")
+			health.OK("Gateway API CRDs discovered")
 			return &gatewayAPIPreconditions{
 				Enabled:        true,
 				InstalledKinds: installedKinds,
 			}, nil
 		}
 
+		// Context expiry errors from checkCRDs bypass isTransientError, silently
+		// disabling Gateway API. Catch them here to trigger an operator restart.
+		if ctx.Err() != nil {
+			logger.Error(
+				"Gateway API CRD discovery timed out after retrying transient errors, operator will restart",
+				logfields.Error, err,
+			)
+			health.Stopped("Gateway API CRD discovery timed out after transient errors")
+			return nil, fmt.Errorf("gateway API CRD discovery timed out: %w", err)
+		}
+
 		if !isTransientError(err) {
-			params.Logger.Error(
+			logger.Error(
 				"Required GatewayAPI resources are not found, please refer to docs for installation instructions",
 				logfields.Error, err,
 			)
-			params.Health.Degraded("Gateway API CRDs not installed", err)
+			health.Degraded("Gateway API CRDs not installed", err)
 			return &gatewayAPIPreconditions{Enabled: false}, nil
 		}
 
-		params.Logger.Warn(
+		logger.Warn(
 			"Failed to check GatewayAPI CRDs due to transient error, will retry",
 			logfields.Error, err,
 		)
-		params.Health.Degraded("Gateway API initialization pending - API server unreachable", err)
+		health.Degraded("Gateway API initialization pending - API server unreachable", err)
 
 		if err := bo.Wait(ctx); err != nil {
-			return nil, err
+			// Context expired during backoff wait - same handling as above.
+			logger.Error(
+				"Gateway API CRD discovery timed out after retrying transient errors, operator will restart",
+				logfields.Error, err,
+			)
+			health.Stopped("Gateway API CRD discovery timed out after transient errors")
+			return nil, fmt.Errorf("gateway API CRD discovery timed out: %w", err)
 		}
 	}
 }

--- a/operator/pkg/gateway-api/cell_test.go
+++ b/operator/pkg/gateway-api/cell_test.go
@@ -4,13 +4,25 @@
 package gateway_api
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 	"syscall"
 	"testing"
 
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sTesting "k8s.io/client-go/testing"
+
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func TestIsTransientError(t *testing.T) {
@@ -87,4 +99,161 @@ func TestIsTransientError(t *testing.T) {
 			assert.Equal(t, tt.expected, result, "isTransientError(%v) should return %v", tt.err, tt.expected)
 		})
 	}
+}
+
+// makeGatewayCRD creates an apiextensions CRD object matching what checkCRD expects.
+func makeGatewayCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gvk.GroupKind().String(),
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: gvk.Version, Served: true, Storage: true},
+			},
+		},
+	}
+}
+
+// installRequiredCRDs creates the required Gateway API CRDs in the fake apiextensions client.
+func installRequiredCRDs(t *testing.T, fcs *k8sClient.FakeClientset) {
+	t.Helper()
+	for _, gvk := range requiredGVKs {
+		crd := makeGatewayCRD(gvk)
+		_, err := fcs.APIExtFakeClientset.ApiextensionsV1().CustomResourceDefinitions().Create(
+			t.Context(), crd, metav1.CreateOptions{},
+		)
+		require.NoError(t, err)
+	}
+}
+
+func TestDiscoverCRDsWithRetry_Success(t *testing.T) {
+	logger := hivetest.Logger(t)
+	fcs, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	installRequiredCRDs(t, fcs)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	require.NoError(t, err)
+	require.True(t, result.Enabled)
+	assert.Equal(t, cell.StatusOK, simpleHealth.Level)
+	assert.Equal(t, "Gateway API CRDs discovered", simpleHealth.Status)
+}
+
+func TestDiscoverCRDsWithRetry_CRDsNotInstalled(t *testing.T) {
+	logger := hivetest.Logger(t)
+	_, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	require.NoError(t, err)
+	require.False(t, result.Enabled)
+	assert.Equal(t, cell.StatusDegraded, simpleHealth.Level)
+	assert.Equal(t, "Gateway API CRDs not installed", simpleHealth.Status)
+}
+
+func TestDiscoverCRDsWithRetry_TransientErrorThenSuccess(t *testing.T) {
+	logger := hivetest.Logger(t)
+	fcs, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	installRequiredCRDs(t, fcs)
+
+	// Fail the first batch of CRD lookups with a transient error,
+	// then let subsequent calls fall through to the default handler.
+	var callCount atomic.Int32
+	fcs.APIExtFakeClientset.PrependReactor("get", "customresourcedefinitions",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			if callCount.Add(1) <= int32(len(requiredGVKs)) {
+				return true, nil, syscall.ECONNREFUSED
+			}
+			return false, nil, nil
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	require.NoError(t, err)
+	require.True(t, result.Enabled)
+	assert.Equal(t, cell.StatusOK, simpleHealth.Level)
+	assert.Greater(t, int(callCount.Load()), len(requiredGVKs))
+}
+
+func TestDiscoverCRDsWithRetry_TransientErrorUntilTimeout(t *testing.T) {
+	logger := hivetest.Logger(t)
+	fcs, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	// All calls return a transient error.
+	fcs.APIExtFakeClientset.PrependReactor("get", "customresourcedefinitions",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			return true, nil, syscall.ECONNREFUSED
+		},
+	)
+
+	// Short timeout so the test doesn't wait 30s.
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "gateway API CRD discovery timed out")
+	assert.Equal(t, cell.StatusStopped, simpleHealth.Level)
+	assert.Equal(t, "Gateway API CRD discovery timed out after transient errors", simpleHealth.Status)
+}
+
+// TestDiscoverCRDsWithRetry_ContextAlreadyCancelled tests the race condition fix:
+// when the retry context expires and checkCRDs returns an error that isTransientError
+// doesn't recognize, the function must return a fatal error instead of silently
+// disabling Gateway API by treating it as "CRDs not installed".
+func TestDiscoverCRDsWithRetry_ContextAlreadyCancelled(t *testing.T) {
+	logger := hivetest.Logger(t)
+	_, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	// Pre-cancel the context to simulate the race where bo.Wait completes
+	// just before the deadline and checkCRDs is called with an expired context.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	// Must return a fatal error, NOT {Enabled: false}.
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "gateway API CRD discovery timed out")
+	assert.Equal(t, cell.StatusStopped, simpleHealth.Level)
+}
+
+// TestDiscoverCRDsWithRetry_ContextDeadlineExceeded is the same scenario as above
+// using a deadline (DeadlineExceeded) rather than explicit cancellation.
+func TestDiscoverCRDsWithRetry_ContextDeadlineExceeded(t *testing.T) {
+	logger := hivetest.Logger(t)
+	_, cs := k8sClient.NewFakeClientset(logger)
+	health, simpleHealth := cell.NewSimpleHealth()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond) // Ensure the deadline has expired.
+
+	result, err := discoverCRDsWithRetry(ctx, cs, logger, health)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "gateway API CRD discovery timed out")
+	assert.Equal(t, cell.StatusStopped, simpleHealth.Level)
 }


### PR DESCRIPTION

## Summary

Fixes a race condition in Gateway API CRD discovery where the operator silently disables Gateway API instead of restarting when the API server is unreachable for longer than 30 seconds.

When the retry context expires during a `checkCRDs` call (as opposed to during `bo.Wait`), the returned error is a context deadline error that `isTransientError` does not recognize. The code falls through to the "permanent error" branch, returning `{Enabled: false}` with no error, silently disabling Gateway API and TLS secret synchronization while the operator continues running. HTTPS traffic through Gateway API fails permanently with no self-healing until manual restart.

### Changes

- Add `ctx.Err()` check before `isTransientError` in the retry loop to catch context expiry regardless of where it occurs
- Improve `bo.Wait` timeout path with explicit logging and `Health.Stopped()` instead of a bare error return
- Extract `discoverCRDsWithRetry` for testability (accepts a context parameter instead of hardcoding a 30s timeout)
- Add 6 tests covering: success, CRDs not installed, transient retry then success, transient timeout, and the two race condition variants (context cancelled / deadline exceeded)

### How it was validated

The new tests for the race condition (`_ContextAlreadyCancelled`, `_ContextDeadlineExceeded`) simulate calling `discoverCRDsWithRetry` with an already-expired context, which is the exact scenario that triggers the bug. Without the `ctx.Err()` guard, these tests fail because the function returns `{Enabled: false}` with a nil error instead of a fatal error. The `_TransientErrorUntilTimeout` test validates that the `bo.Wait` path also reports the correct health status and wraps the error message. Full `go test ./operator/pkg/gateway-api/` suite passes.

### AI usage

[AIL-3](https://danielmiessler.com/blog/ai-influence-level-ail): AI wrote code, structure/design is mine. The bug analysis, fix design, and approach are mine, from a production incident. AI helped write some of the implementation and tests based on that design. Everything was reviewed and validated manually.

## Test plan

- [x] `TestDiscoverCRDsWithRetry_Success` - CRDs found on first try
- [x] `TestDiscoverCRDsWithRetry_CRDsNotInstalled` - permanent error, graceful disable
- [x] `TestDiscoverCRDsWithRetry_TransientErrorThenSuccess` - retry recovers
- [x] `TestDiscoverCRDsWithRetry_TransientErrorUntilTimeout` - timeout via bo.Wait returns fatal error with proper health status
- [x] `TestDiscoverCRDsWithRetry_ContextAlreadyCancelled` - race condition: pre-cancelled context returns fatal error, not silent disable
- [x] `TestDiscoverCRDsWithRetry_ContextDeadlineExceeded` - race condition: expired deadline returns fatal error, not silent disable

Fixes: https://github.com/cilium/cilium/issues/43130
Relates: https://github.com/cilium/cilium/pull/43452