### PR TITLE
gateway-api: fix wildcard HTTP listener with specific HTTPS hostnames

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -323,7 +323,13 @@ func (r *gatewayReconciler) updateStatus(ctx context.Context, original *gatewayv
 
 func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
-	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
+	// Only consider hostnames from HTTP/HTTPS listeners for hostname isolation.
+	// This prevents HTTPS listener hostnames from incorrectly filtering out routes
+	// that should attach to HTTP wildcard listeners.
+	allListenerHostNames := routechecks.GetListenerHostNamesByProtocol(gw.Spec.Listeners, []gatewayv1.ProtocolType{
+		gatewayv1.HTTPProtocolType,
+		gatewayv1.HTTPSProtocolType,
+	})
 	for _, route := range routes {
 		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
@@ -334,7 +340,13 @@ func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *g
 
 func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
-	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
+	// Only consider hostnames from HTTP/HTTPS listeners for hostname isolation.
+	// This prevents HTTPS listener hostnames from incorrectly filtering out routes
+	// that should attach to HTTP wildcard listeners.
+	allListenerHostNames := routechecks.GetListenerHostNamesByProtocol(gw.Spec.Listeners, []gatewayv1.ProtocolType{
+		gatewayv1.HTTPProtocolType,
+		gatewayv1.HTTPSProtocolType,
+	})
 
 	for _, route := range routes {
 		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -26,7 +26,11 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		return false, nil
 	}
 
-	allListenerHostNames := GetAllListenerHostNames(gw.Spec.Listeners)
+	// Only consider hostnames from listeners of protocols this route can attach to.
+	// This prevents hostnames from different protocol types (e.g., HTTPS) from
+	// incorrectly filtering out routes that should attach to wildcard listeners
+	// of another protocol type (e.g., HTTP).
+	allListenerHostNames := GetListenerHostNamesByProtocol(gw.Spec.Listeners, input.GetValidProtocols())
 	hasNamespaceRestriction := false
 	for _, listener := range gw.Spec.Listeners {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
@@ -238,6 +242,24 @@ func GetAllListenerHostNames(listeners []gatewayv1.Listener) []gatewayv1.Hostnam
 	for _, listener := range listeners {
 		if listener.Hostname != nil {
 			hosts = append(hosts, *listener.Hostname)
+		}
+	}
+	return hosts
+}
+
+// GetListenerHostNamesByProtocol returns hostnames from listeners that match any of the specified protocols.
+// This is used to ensure hostname isolation only considers listeners of the same protocol type,
+// preventing HTTPS listener hostnames from incorrectly filtering out routes on HTTP wildcard listeners.
+func GetListenerHostNamesByProtocol(listeners []gatewayv1.Listener, protocols []gatewayv1.ProtocolType) []gatewayv1.Hostname {
+	var hosts []gatewayv1.Hostname
+	for _, listener := range listeners {
+		if listener.Hostname != nil {
+			for _, protocol := range protocols {
+				if listener.Protocol == protocol {
+					hosts = append(hosts, *listener.Hostname)
+					break
+				}
+			}
 		}
 	}
 	return hosts

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -26,11 +26,6 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		return false, nil
 	}
 
-	// Only consider hostnames from listeners of protocols this route can attach to.
-	// This prevents hostnames from different protocol types (e.g., HTTPS) from
-	// incorrectly filtering out routes that should attach to wildcard listeners
-	// of another protocol type (e.g., HTTP).
-	allListenerHostNames := GetListenerHostNamesByProtocol(gw.Spec.Listeners, input.GetValidProtocols())
 	hasNamespaceRestriction := false
 	for _, listener := range gw.Spec.Listeners {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
@@ -40,7 +35,12 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 			continue
 		}
 
-		if listener.Hostname != nil && len(computeHostsForListener(&listener, input.GetHostnames(), allListenerHostNames)) == 0 {
+		// Only consider hostnames from listeners with the same protocol for hostname isolation.
+		// This prevents hostnames from different protocol types (e.g., HTTPS) from
+		// incorrectly filtering out routes that should attach to wildcard listeners
+		// of another protocol type (e.g., HTTP).
+		protocolListenerHostNames := GetListenerHostNamesByProtocol(gw.Spec.Listeners, []gatewayv1.ProtocolType{listener.Protocol})
+		if listener.Hostname != nil && len(computeHostsForListener(&listener, input.GetHostnames(), protocolListenerHostNames)) == 0 {
 			continue
 		}
 

--- a/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
@@ -118,6 +118,42 @@ var gatewayFixtures = []client.Object{
 			},
 		},
 	},
+	// Gateway fixture for testing HTTP wildcard listener with HTTPS specific hostname overlap.
+	// This tests the scenario where an HTTP wildcard listener should still work when
+	// HTTPS listeners have specific hostnames that match the wildcard.
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wildcard-http-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "catchall-http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.example.org"),
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromAll),
+						},
+					},
+				},
+				{
+					Name:     "specific-https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("specific.example.org"),
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromAll),
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 var namespaceFixture = []client.Object{
@@ -538,6 +574,33 @@ func TestCheckGatewayAllowedForNamespace(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			// This test verifies the fix for https://github.com/cilium/cilium/issues/44123
+			// HTTP wildcard listener should allow routes with specific hostnames even when
+			// HTTPS listeners have more specific hostnames that match the wildcard.
+			name: "http wildcard listener allows route with specific hostname matching HTTPS listener",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "another-ns",
+						},
+						Spec: gatewayv1.HTTPRouteSpec{
+							Hostnames: []gatewayv1.Hostname{
+								"specific.example.org",
+							},
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "wildcard-http-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("catchall-http"),
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -548,6 +611,90 @@ func TestCheckGatewayAllowedForNamespace(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("CheckGatewayAllowedForNamespace() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetListenerHostNamesByProtocol(t *testing.T) {
+	tests := []struct {
+		name      string
+		listeners []gatewayv1.Listener
+		protocols []gatewayv1.ProtocolType
+		want      []gatewayv1.Hostname
+	}{
+		{
+			name: "filter by HTTP protocol only",
+			listeners: []gatewayv1.Listener{
+				{
+					Protocol: gatewayv1.HTTPProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.http.example.org"),
+				},
+				{
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.https.example.org"),
+				},
+			},
+			protocols: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType},
+			want:      []gatewayv1.Hostname{"*.http.example.org"},
+		},
+		{
+			name: "filter by HTTP and HTTPS protocols",
+			listeners: []gatewayv1.Listener{
+				{
+					Protocol: gatewayv1.HTTPProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.http.example.org"),
+				},
+				{
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.https.example.org"),
+				},
+				{
+					Protocol: gatewayv1.TLSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.tls.example.org"),
+				},
+			},
+			protocols: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+			want:      []gatewayv1.Hostname{"*.http.example.org", "*.https.example.org"},
+		},
+		{
+			name: "listener with nil hostname is skipped",
+			listeners: []gatewayv1.Listener{
+				{
+					Protocol: gatewayv1.HTTPProtocolType,
+					Hostname: nil,
+				},
+				{
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.https.example.org"),
+				},
+			},
+			protocols: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType},
+			want:      []gatewayv1.Hostname{"*.https.example.org"},
+		},
+		{
+			name: "no matching protocols returns empty",
+			listeners: []gatewayv1.Listener{
+				{
+					Protocol: gatewayv1.TLSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.tls.example.org"),
+				},
+			},
+			protocols: []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType},
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetListenerHostNamesByProtocol(tt.listeners, tt.protocols)
+			if len(got) != len(tt.want) {
+				t.Errorf("GetListenerHostNamesByProtocol() got = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("GetListenerHostNamesByProtocol() got[%d] = %v, want[%d] = %v", i, got[i], i, tt.want[i])
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #44123

## Description

When a Gateway has both an HTTP wildcard listener (e.g., `*.example.org`) and HTTPS listeners with specific hostnames (e.g., `specific.example.org`), routes targeting the HTTP wildcard listener were incorrectly filtered out, causing the `CiliumEnvoyConfig` to not be generated at all.

This broke cert-manager HTTP-01 ACME challenges which require a wildcard HTTP listener to serve challenges for any hostname while also having per-hostname HTTPS listeners for TLS termination.

## Root Cause

The hostname isolation check in `filterHTTPRoutesByGateway` and related functions considered hostnames from ALL listeners regardless of protocol type. When an HTTPS listener had a specific hostname that matched a route's hostname, the route was incorrectly excluded from attaching to the HTTP wildcard listener.

## Changes

- Added `GetListenerHostNamesByProtocol` function in `routechecks/gateway_checks.go` that filters listener hostnames by protocol type
- Updated `filterHTTPRoutesByGateway` to only consider hostnames from HTTP/HTTPS listeners
- Updated `filterGRPCRoutesByGateway` to only consider hostnames from HTTP/HTTPS listeners (gRPC uses same protocols as HTTP)
- Updated `CheckGatewayAllowedForNamespace` to use the route's valid protocols when filtering hostnames
- Added test fixtures and test cases to verify the fix

## Testing

Added two test cases:
1. A test for `GetListenerHostNamesByProtocol` that verifies protocol-based filtering
2. An integration test that verifies an HTTPRoute with a specific hostname can attach to an HTTP wildcard listener even when an HTTPS listener has that specific hostname

```
operator/pkg/gateway-api/gateway_reconcile.go      | 16 ++-
operator/pkg/gateway-api/routechecks/gateway_checks.go  | 24 +++-
operator/pkg/gateway-api/routechecks/gateway_checks_test.go | 147 +++++++++++++++++++++
3 files changed, 184 insertions(+), 3 deletions(-)
```

```release-note
Fixed an issue where HTTP wildcard listeners would not work when HTTPS listeners with more specific hostnames were present on the same Gateway. This fixes cert-manager HTTP-01 ACME challenges with Cilium Gateway API.
```