### PR TITLE
helm: fix unmanaged-pod-watcher-interval value format

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -360,13 +360,19 @@ Changes to Metrics
 Added Metrics
 #############
 
-* TODO
+* ``cilium_policy_missing_proxy_redirects`` was added and reports the total number of
+  proxy redirects that were missing during endpoint policy calculation.
+* ``cilium_endpoint_component_status`` was added and reports the number of endpoints
+  tagged by the status (``OK``, ``Warning``, ``Failure``) of each component (``BPF``, ``Policy``).
 
 Changed Metrics
 ###############
 
 * The ``cilium_feature_np_other_l7_policies_total`` metric no longer counts
   Kafka policies, as Kafka-aware network policy support has been removed.
+* The metric ``policy_change_total`` now reports additional ``source`` (directory, k8s, custom, generated)
+  and ``operation`` (update, delete) dimensions.
+* The metric ``endpoint_regeneration_total`` now reports additional ``reason`` and ``error`` dimensions.
 
 Deprecated Metrics
 ##################

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1382,7 +1382,7 @@ data:
 
 {{- if .Values.operator.unmanagedPodWatcher.restart }}
   {{- $interval := .Values.operator.unmanagedPodWatcher.intervalSeconds }}
-  unmanaged-pod-watcher-interval: {{ printf "%ds" (int $interval) | quote }}
+  unmanaged-pod-watcher-interval: {{ int $interval | quote }}
 {{- else }}
   unmanaged-pod-watcher-interval: "0"
 {{- end }}


### PR DESCRIPTION
Fixes: #44268

The unmanaged-pod-watcher-interval config option was being rendered with a "s" suffix (e.g., "15s") in the Helm-generated ConfigMap, but the operator code expects an integer value. This caused the operator to crash with a parsing error when the unmanaged pod watcher was enabled.

The issue was in the Helm template `cilium-configmap.yaml` which used `printf "%ds"` to add a duration suffix, but the Go code reads this value using `viper.GetInt()` which cannot parse duration strings.

## Changes
- Fixed `install/kubernetes/cilium/templates/cilium-configmap.yaml` to output just the integer value without the "s" suffix

## Testing
- Verified the change produces `"15"` instead of `"15s"` when `intervalSeconds: 15` is set
- The operator code in `operator/option/config.go` uses `vp.GetInt(UnmanagedPodWatcherInterval)` which correctly parses integer values

```release-note
Fix unmanaged-pod-watcher-interval Helm template to output integer value instead of duration string
```