### PR TITLE
Add support for multi-path routing of tunnel traffic

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -138,6 +138,7 @@ cilium-agent [flags]
       --enable-endpoint-routes                                    Use per endpoint routes instead of routing via cilium_host
       --enable-envoy-config                                       Enable Envoy Config CRDs
       --enable-extended-ip-protocols                              Enable traffic with extended IP protocols in datapath
+      --enable-floating-tunnel-endpoint                           Enable floating tunnel endpoints
       --enable-gateway-api                                        Enables Envoy secret sync for Gateway API related TLS secrets
       --enable-gops                                               Enable gops server (default true)
       --enable-health-check-loadbalancer-ip                       Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs --enable-health-check-nodeport to be enabled
@@ -441,6 +442,7 @@ cilium-agent [flags]
       --trace-sock                                                Enable tracing for socket-based LB (default true)
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")
       --tunnel-protocol string                                    Encapsulation protocol to use for the overlay ("vxlan" or "geneve") (default "vxlan")
+      --tunnel-routing-devices strings                            A list of devices used to route tunnel traffic when floating tunnel endpoints are enabled
       --tunnel-source-port-range string                           Tunnel source port range hint (default 0-0) (default "0-0")
       --underlay-protocol string                                  IP family for the underlay ("ipv4", "ipv6", or "auto") (default "auto")
       --use-full-tls-context                                      If enabled, persist ca.crt keys into the Envoy config even in a terminatingTLS block on an L7 Cilium Policy. This is to enable compatibility with previously buggy behaviour. This flag is deprecated and will be removed in a future release.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1300,6 +1300,10 @@
      - Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in ``helm template`` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance.
      - bool
      - ``true``
+   * - :spelling:ignore:`enableFloatingTunnelEndpoint`
+     - Make Cilium use floating tunnel endpoints. When enabled, Cilium will use the router IPs of remote nodes     as the tunnel endpoint instead of the node IP, which allows that traffic to be routed over multiple interfaces.
+     - bool
+     - ``false``
    * - :spelling:ignore:`enableIPv4BIGTCP`
      - Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods
      - bool
@@ -4008,6 +4012,10 @@
      - Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve
      - string
      - ``"vxlan"``
+   * - :spelling:ignore:`tunnelRoutingDevices`
+     - List of devices to be used for routing tunnel traffic when not empty, Cilium will create multipath routes for the    router IPs via the specified devices.
+     - list
+     - ``[]``
    * - :spelling:ignore:`tunnelSourcePortRange`
      - Configure VXLAN and Geneve tunnel source port range hint.
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -590,6 +590,7 @@ multicast
 multicluster
 multicore
 multihoming
+multipath
 musl
 mutex
 mutexes

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -824,6 +824,12 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableCiliumNodeCRDName)
 	option.BindEnv(vp, option.EnableCiliumNodeCRDName)
 
+	flags.Bool(option.EnableFloatingTunnelEndpoint, defaults.EnableFloatingTunnelEndpoint, "Enable floating tunnel endpoints")
+	option.BindEnv(vp, option.EnableFloatingTunnelEndpoint)
+
+	flags.StringSlice(option.TunnelRoutingDevices, nil, "A list of devices used to route tunnel traffic when floating tunnel endpoints are enabled")
+	option.BindEnv(vp, option.TunnelRoutingDevices)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		logging.Fatal(logger, "BindPFlags failed", logfields.Error, err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -375,6 +375,7 @@ contributors across the globe, there is almost always someone available to help.
 | egressGateway.enabled | bool | `false` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
+| enableFloatingTunnelEndpoint | bool | `false` | Make Cilium use floating tunnel endpoints. When enabled, Cilium will use the router IPs of remote nodes     as the tunnel endpoint instead of the node IP, which allows that traffic to be routed over multiple interfaces. |
 | enableIPv4BIGTCP | bool | `false` | Enables IPv4 BIG TCP support which increases maximum IPv4 GSO/GRO limits for nodes and pods |
 | enableIPv4Masquerade | bool | `true` unless ipam eni mode is active | Enables masquerading of IPv4 traffic leaving the node from endpoints. |
 | enableIPv6BIGTCP | bool | `false` | Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods |
@@ -1052,6 +1053,7 @@ contributors across the globe, there is almost always someone available to help.
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
 | tunnelProtocol | string | `"vxlan"` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve |
+| tunnelRoutingDevices | list | `[]` | List of devices to be used for routing tunnel traffic when not empty, Cilium will create multipath routes for the    router IPs via the specified devices. |
 | tunnelSourcePortRange | string | 0-0 to let the kernel driver decide the range | Configure VXLAN and Geneve tunnel source port range hint. |
 | underlayProtocol | string | `"auto"` | IP family for the underlay. Possible values:   - "ipv4"   - "ipv6"   - "auto" |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -568,6 +568,13 @@ data:
   underlay-protocol: {{ .Values.underlayProtocol | quote }}
 {{- end }}
 
+{{- if .Values.enableFloatingTunnelEndpoint }}
+  enable-floating-tunnel-endpoint: "true"
+{{- end }}
+{{- if .Values.tunnelRoutingDevices }}
+  tunnel-routing-devices: {{ join " " .Values.tunnelRoutingDevices | quote }}
+{{- end }}
+
 {{- if .Values.serviceNoBackendResponse }}
   service-no-backend-response: "{{ .Values.serviceNoBackendResponse }}"
 {{- end}}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1883,6 +1883,9 @@
     "enableCriticalPriorityClass": {
       "type": "boolean"
     },
+    "enableFloatingTunnelEndpoint": {
+      "type": "boolean"
+    },
     "enableIPv4BIGTCP": {
       "type": "boolean"
     },
@@ -6506,6 +6509,10 @@
     },
     "tunnelProtocol": {
       "type": "string"
+    },
+    "tunnelRoutingDevices": {
+      "items": {},
+      "type": "array"
     },
     "tunnelSourcePortRange": {
       "type": "string"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2427,6 +2427,12 @@ enableMasqueradeRouteSource: false
 enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
+# -- Make Cilium use floating tunnel endpoints. When enabled, Cilium will use the router IPs of remote nodes 
+#    as the tunnel endpoint instead of the node IP, which allows that traffic to be routed over multiple interfaces.
+enableFloatingTunnelEndpoint: false
+# -- List of devices to be used for routing tunnel traffic when not empty, Cilium will create multipath routes for the
+#    router IPs via the specified devices.
+tunnelRoutingDevices: []
 nat:
   # -- Number of the top-k SNAT map connections to track in Cilium statedb.
   mapStatsEntries: 32

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2452,6 +2452,13 @@ enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
 
+# -- Make Cilium use floating tunnel endpoints. When enabled, Cilium will use the router IPs of remote nodes 
+#    as the tunnel endpoint instead of the node IP, which allows that traffic to be routed over multiple interfaces.
+enableFloatingTunnelEndpoint: false
+# -- List of devices to be used for routing tunnel traffic when not empty, Cilium will create multipath routes for the
+#    router IPs via the specified devices.
+tunnelRoutingDevices: []
+
 nat:
   # -- Number of the top-k SNAT map connections to track in Cilium statedb.
   mapStatsEntries: 32

--- a/pkg/datapath/ipcache/cell.go
+++ b/pkg/datapath/ipcache/cell.go
@@ -24,5 +24,8 @@ var Cell = cell.Module(
 		func(agent monitorAgent.Agent) monitorNotify { return agent },
 	),
 
-	cell.Invoke(func(listener *BPFListener, ipc *ipcache.IPCache) { ipc.AddListener(listener) }),
+	cell.Invoke(func(listener *BPFListener, ipc *ipcache.IPCache) {
+		ipc.AddListener(listener)
+		ipc.AddTunnelEndpointMappingListener(listener)
+	}),
 )

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -15,11 +15,13 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // monitorNotify is an interface to notify the monitor about ipcache changes.
@@ -47,17 +49,38 @@ type BPFListener struct {
 	tunnelConf tunnel.Config
 
 	localNodeStore *node.LocalNodeStore
+
+	mu                 lock.Mutex
+	tunnelEndpoints    map[string]net.IP
+	pendingByHostIP    map[string]map[string]pendingEntry
+	programmedByHostIP map[string]map[string]pendingEntry
+	prefixToHostIP     map[string]string
 }
 
 // NewListener returns a new listener to push IPCache entries into BPF maps.
 func NewListener(m Map, mn monitorNotify, tunnelConf tunnel.Config, logger *slog.Logger, localNodeStore *node.LocalNodeStore) *BPFListener {
 	return &BPFListener{
-		logger:         logger,
-		bpfMap:         m,
-		monitorNotify:  mn,
-		tunnelConf:     tunnelConf,
-		localNodeStore: localNodeStore,
+		logger:             logger,
+		bpfMap:             m,
+		monitorNotify:      mn,
+		tunnelConf:         tunnelConf,
+		localNodeStore:     localNodeStore,
+		tunnelEndpoints:    make(map[string]net.IP),
+		pendingByHostIP:    make(map[string]map[string]pendingEntry),
+		programmedByHostIP: make(map[string]map[string]pendingEntry),
+		prefixToHostIP:     make(map[string]string),
 	}
+}
+
+type pendingEntry struct {
+	cidrCluster   cmtypes.PrefixCluster
+	oldHostIP     net.IP
+	newHostIP     net.IP
+	oldID         *ipcache.Identity
+	newID         ipcache.Identity
+	encryptKey    uint8
+	k8sMeta       *ipcache.K8sMetadata
+	endpointFlags uint8
 }
 
 func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
@@ -123,47 +146,38 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	// logically located.
 
 	// Update BPF Maps.
-
-	key := ipcacheMap.NewKey(prefix, uint16(cidrCluster.ClusterID()))
+	entry := pendingEntry{
+		cidrCluster:   cidrCluster,
+		oldHostIP:     oldHostIP,
+		newHostIP:     newHostIP,
+		oldID:         oldID,
+		newID:         newID,
+		encryptKey:    encryptKey,
+		k8sMeta:       k8sMeta,
+		endpointFlags: endpointFlags,
+	}
 
 	switch modType {
 	case ipcache.Upsert:
-		var tunnelEndpoint netip.Addr
-		if newHostIP != nil {
-			ln, err := l.localNodeStore.Get(context.Background())
-			if err != nil {
-				logging.Fatal(l.logger, "Failed to retrieve local node")
-			}
-
-			// If the hostIP is specified and it doesn't point to
-			// the local host, then the ipcache should be populated
-			// with the hostIP so that this traffic can be guided
-			// to a tunnel endpoint destination.
-			switch l.tunnelConf.UnderlayProtocol() {
-			case tunnel.IPv4:
-				nodeIPv4 := ln.GetNodeIP(false)
-				if ip4 := newHostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
-					tunnelEndpoint, _ = netipx.FromStdIP(ip4)
-				}
-			case tunnel.IPv6:
-				nodeIPv6 := ln.GetNodeIP(true)
-				if !newHostIP.Equal(nodeIPv6) {
-					tunnelEndpoint, _ = netipx.FromStdIP(newHostIP)
-				}
-			}
+		originalHostIP, effectiveHostIP, shouldDelay := l.prepareUpsert(entry)
+		if shouldDelay {
+			scopedLog.Debug("Delaying ipcache map update until tunnel endpoint mapping is known",
+				logfields.TunnelPeer, originalHostIP,
+			)
+			return
 		}
-		value := ipcacheMap.NewValue(uint32(newID.ID), tunnelEndpoint, encryptKey,
-			ipcacheMap.RemoteEndpointInfoFlags(endpointFlags))
-		err := l.bpfMap.Update(&key, &value)
+		err := l.applyUpsert(entry, effectiveHostIP)
 		if err != nil {
 			scopedLog.Warn(
 				"unable to update bpf map",
 				logfields.Error, err,
-				logfields.Key, key,
-				logfields.Value, value,
 			)
 		}
 	case ipcache.Delete:
+		if l.dropPendingOrProgrammed(cidrCluster) {
+			return
+		}
+		key := ipcacheMap.NewKey(prefix, uint16(cidrCluster.ClusterID()))
 		err := l.bpfMap.Delete(&key)
 		if err != nil {
 			scopedLog.Warn(
@@ -174,4 +188,200 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	default:
 		scopedLog.Warn("cache modification type not supported")
 	}
+}
+
+func (l *BPFListener) OnTunnelEndpointMappingUpsert(from, to net.IP) {
+	l.mu.Lock()
+	l.tunnelEndpoints[from.String()] = to
+	l.mu.Unlock()
+
+	entries := l.takeEntries(l.pendingByHostIP, from.String())
+	if len(entries) == 0 {
+		return
+	}
+
+	for _, entry := range entries {
+		_, effectiveHostIP, shouldDelay := l.resolveHostIP(entry.newHostIP)
+		if shouldDelay {
+			l.storeEntry(l.pendingByHostIP, from.String(), entry)
+			continue
+		}
+		_ = l.applyUpsert(entry, effectiveHostIP)
+	}
+}
+
+func (l *BPFListener) OnTunnelEndpointMappingDelete(from net.IP) {
+	l.mu.Lock()
+	delete(l.tunnelEndpoints, from.String())
+	l.mu.Unlock()
+
+	entries := l.takeEntries(l.programmedByHostIP, from.String())
+	if len(entries) == 0 {
+		return
+	}
+
+	for _, entry := range entries {
+		key := ipcacheMap.NewKey(entry.cidrCluster.AsPrefix(), uint16(entry.cidrCluster.ClusterID()))
+		_ = l.bpfMap.Delete(&key)
+		l.storeEntry(l.pendingByHostIP, from.String(), entry)
+	}
+}
+
+func (l *BPFListener) prepareUpsert(entry pendingEntry) (originalHostIP, effectiveHostIP net.IP, shouldDelay bool) {
+	originalHostIP, effectiveHostIP, shouldDelay = l.resolveHostIP(entry.newHostIP)
+	prefixKey := entry.cidrCluster.String()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.removeTrackedEntryLocked(prefixKey)
+	if shouldDelay {
+		l.storeEntryLocked(l.pendingByHostIP, originalHostIP.String(), entry)
+		return originalHostIP, nil, true
+	}
+	if originalHostIP != nil && !originalHostIP.IsUnspecified() {
+		l.storeEntryLocked(l.programmedByHostIP, originalHostIP.String(), entry)
+	}
+
+	return originalHostIP, effectiveHostIP, false
+}
+
+func (l *BPFListener) resolveHostIP(hostIP net.IP) (originalHostIP, effectiveHostIP net.IP, shouldDelay bool) {
+	if hostIP == nil || hostIP.IsUnspecified() {
+		return nil, nil, false
+	}
+
+	originalHostIP = hostIP
+	effectiveHostIP = hostIP
+
+	if !option.Config.EnableFloatingTunnelEndpoint {
+		return originalHostIP, effectiveHostIP, false
+	}
+
+	l.mu.Lock()
+	mappedIP, ok := l.tunnelEndpoints[hostIP.String()]
+	l.mu.Unlock()
+	if ok {
+		return originalHostIP, mappedIP, false
+	}
+
+	ln, err := l.localNodeStore.Get(context.Background())
+	if err != nil {
+		logging.Fatal(l.logger, "Failed to retrieve local node")
+	}
+
+	switch l.underlayProtocol(hostIP) {
+	case tunnel.IPv4:
+		nodeIPv4 := ln.GetNodeIP(false)
+		if ip4 := hostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
+			return originalHostIP, nil, true
+		}
+	case tunnel.IPv6:
+		nodeIPv6 := ln.GetNodeIP(true)
+		if !hostIP.Equal(nodeIPv6) {
+			return originalHostIP, nil, true
+		}
+	}
+
+	return originalHostIP, effectiveHostIP, false
+}
+
+func (l *BPFListener) applyUpsert(entry pendingEntry, hostIP net.IP) error {
+	key := ipcacheMap.NewKey(entry.cidrCluster.AsPrefix(), uint16(entry.cidrCluster.ClusterID()))
+
+	var tunnelEndpoint netip.Addr
+	if hostIP != nil {
+		ln, err := l.localNodeStore.Get(context.Background())
+		if err != nil {
+			logging.Fatal(l.logger, "Failed to retrieve local node")
+		}
+
+		switch l.underlayProtocol(hostIP) {
+		case tunnel.IPv4:
+			nodeIPv4 := ln.GetNodeIP(false)
+			if ip4 := hostIP.To4(); ip4 != nil && !ip4.Equal(nodeIPv4) {
+				tunnelEndpoint, _ = netipx.FromStdIP(ip4)
+			}
+		case tunnel.IPv6:
+			nodeIPv6 := ln.GetNodeIP(true)
+			if !hostIP.Equal(nodeIPv6) {
+				tunnelEndpoint, _ = netipx.FromStdIP(hostIP)
+			}
+		}
+	}
+
+	value := ipcacheMap.NewValue(uint32(entry.newID.ID), tunnelEndpoint, entry.encryptKey,
+		ipcacheMap.RemoteEndpointInfoFlags(entry.endpointFlags))
+	return l.bpfMap.Update(&key, &value)
+}
+
+func (l *BPFListener) underlayProtocol(hostIP net.IP) tunnel.UnderlayProtocol {
+	switch proto := l.tunnelConf.UnderlayProtocol(); proto {
+	case tunnel.IPv4, tunnel.IPv6:
+		return proto
+	default:
+		if hostIP.To4() != nil {
+			return tunnel.IPv4
+		}
+		return tunnel.IPv6
+	}
+}
+
+func (l *BPFListener) dropPendingOrProgrammed(cidrCluster cmtypes.PrefixCluster) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.removeTrackedEntryLocked(cidrCluster.String())
+}
+
+func (l *BPFListener) takeEntries(source map[string]map[string]pendingEntry, hostIP string) []pendingEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	prefixes, ok := source[hostIP]
+	if !ok {
+		return nil
+	}
+	delete(source, hostIP)
+
+	entries := make([]pendingEntry, 0, len(prefixes))
+	for prefixKey, entry := range prefixes {
+		delete(l.prefixToHostIP, prefixKey)
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func (l *BPFListener) storeEntry(target map[string]map[string]pendingEntry, hostIP string, entry pendingEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.storeEntryLocked(target, hostIP, entry)
+}
+
+func (l *BPFListener) storeEntryLocked(target map[string]map[string]pendingEntry, hostIP string, entry pendingEntry) {
+	prefixKey := entry.cidrCluster.String()
+	if target[hostIP] == nil {
+		target[hostIP] = make(map[string]pendingEntry)
+	}
+	target[hostIP][prefixKey] = entry
+	l.prefixToHostIP[prefixKey] = hostIP
+}
+
+func (l *BPFListener) removeTrackedEntryLocked(prefixKey string) bool {
+	hostIP, ok := l.prefixToHostIP[prefixKey]
+	if !ok {
+		return false
+	}
+	delete(l.prefixToHostIP, prefixKey)
+
+	for _, tracked := range []map[string]map[string]pendingEntry{l.pendingByHostIP, l.programmedByHostIP} {
+		if entries, ok := tracked[hostIP]; ok {
+			delete(entries, prefixKey)
+			if len(entries) == 0 {
+				delete(tracked, hostIP)
+			}
+		}
+	}
+
+	return true
 }

--- a/pkg/datapath/ipcache/listener_test.go
+++ b/pkg/datapath/ipcache/listener_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	pkgipcache "github.com/cilium/cilium/pkg/ipcache"
+	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+type mapRecorder struct {
+	updates map[string]ipcacheMap.RemoteEndpointInfo
+	deletes []string
+}
+
+func newMapRecorder() *mapRecorder {
+	return &mapRecorder{updates: make(map[string]ipcacheMap.RemoteEndpointInfo)}
+}
+
+func (m *mapRecorder) Update(key bpf.MapKey, value bpf.MapValue) error {
+	k := key.(*ipcacheMap.Key)
+	v := value.(*ipcacheMap.RemoteEndpointInfo)
+	m.updates[k.String()] = *v
+	return nil
+}
+
+func (m *mapRecorder) Delete(key bpf.MapKey) error {
+	k := key.(*ipcacheMap.Key)
+	m.deletes = append(m.deletes, k.String())
+	delete(m.updates, k.String())
+	return nil
+}
+
+func TestBPFListenerBuffersFloatingTunnelEndpointMapWrites(t *testing.T) {
+	logger := hivetest.Logger(t)
+	oldFloating := option.Config.EnableFloatingTunnelEndpoint
+	t.Cleanup(func() {
+		option.Config.EnableFloatingTunnelEndpoint = oldFloating
+	})
+	option.Config.EnableFloatingTunnelEndpoint = true
+
+	ipc := pkgipcache.NewIPCache(&pkgipcache.Configuration{
+		Context:                      t.Context(),
+		Logger:                       logger,
+		EnableFloatingTunnelEndpoint: true,
+	})
+	lns := node.NewTestLocalNodeStore(node.LocalNode{
+		Node: nodeTypes.Node{
+			IPAddresses: []nodeTypes.Address{{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.1")}},
+		},
+		Local: &node.LocalNodeInfo{UnderlayProtocol: tunnel.IPv4},
+	})
+	recorder := newMapRecorder()
+	listener := NewListener(recorder, nil, tunnel.Config{}, logger, lns)
+	ipc.AddTunnelEndpointMappingListener(listener)
+
+	cidrCluster := cmtypes.MustParsePrefixCluster("10.1.0.10/32")
+	hostIP := net.ParseIP("10.0.1.2")
+	mappedIP := net.ParseIP("192.0.2.2")
+
+	listener.OnIPIdentityCacheChange(
+		pkgipcache.Upsert,
+		cidrCluster,
+		nil,
+		hostIP,
+		nil,
+		pkgipcache.Identity{ID: 1234, Source: source.CustomResource},
+		7,
+		nil,
+		0,
+	)
+	require.Empty(t, recorder.updates)
+
+	ipc.UpsertTunnelEndpointMapping(hostIP, mappedIP)
+	key := ipcacheMap.NewKey(cidrCluster.AsPrefix(), uint16(cidrCluster.ClusterID())).String()
+	value, ok := recorder.updates[key]
+	require.True(t, ok)
+	require.Equal(t, netip.MustParseAddr("192.0.2.2"), value.GetTunnelEndpoint())
+}
+
+func TestBPFListenerRemovesMappedEntryWhenTunnelMappingDisappears(t *testing.T) {
+	logger := hivetest.Logger(t)
+	oldFloating := option.Config.EnableFloatingTunnelEndpoint
+	t.Cleanup(func() {
+		option.Config.EnableFloatingTunnelEndpoint = oldFloating
+	})
+	option.Config.EnableFloatingTunnelEndpoint = true
+
+	ipc := pkgipcache.NewIPCache(&pkgipcache.Configuration{
+		Context:                      t.Context(),
+		Logger:                       logger,
+		EnableFloatingTunnelEndpoint: true,
+	})
+	lns := node.NewTestLocalNodeStore(node.LocalNode{
+		Node: nodeTypes.Node{
+			IPAddresses: []nodeTypes.Address{{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.1")}},
+		},
+		Local: &node.LocalNodeInfo{UnderlayProtocol: tunnel.IPv4},
+	})
+	recorder := newMapRecorder()
+	listener := NewListener(recorder, nil, tunnel.Config{}, logger, lns)
+	ipc.AddTunnelEndpointMappingListener(listener)
+
+	cidrCluster := cmtypes.MustParsePrefixCluster("10.1.0.10/32")
+	hostIP := net.ParseIP("10.0.1.2")
+	mappedIP := net.ParseIP("192.0.2.2")
+	key := ipcacheMap.NewKey(cidrCluster.AsPrefix(), uint16(cidrCluster.ClusterID())).String()
+
+	ipc.UpsertTunnelEndpointMapping(hostIP, mappedIP)
+	listener.OnIPIdentityCacheChange(
+		pkgipcache.Upsert,
+		cidrCluster,
+		nil,
+		hostIP,
+		nil,
+		pkgipcache.Identity{ID: 1234, Source: source.CustomResource},
+		7,
+		nil,
+		0,
+	)
+	require.Contains(t, recorder.updates, key)
+
+	ipc.DeleteTunnelEndpointMapping(hostIP)
+	require.NotContains(t, recorder.updates, key)
+	require.Contains(t, recorder.deletes, key)
+}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"regexp"
 	"sync"
 	"syscall"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -25,10 +27,13 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	dpTunnel "github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/idpool"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -77,7 +82,11 @@ type linuxNodeHandler struct {
 
 	kprCfg kpr.KPRConfig
 
-	ipsecCfg ipsecTypes.Config
+	ipsecCfg                         ipsecTypes.Config
+	db                               *statedb.DB
+	deviceTable                      statedb.Table[*tables.Device]
+	tunnelRoutingDeviceRegexes       []*regexp.Regexp
+	tunnelEndpointMappingInitialized ipcache.TEPMappingInitializer
 }
 
 var (
@@ -98,13 +107,17 @@ func NewNodeHandler(
 	kprCfg kpr.KPRConfig,
 	ipsecAgent ipsecTypes.Agent,
 	localNodeStore *node.LocalNodeStore,
+	db *statedb.DB,
+	deviceTable statedb.Table[*tables.Device],
+	tunnelEndpointMappingInitialized ipcache.TEPMappingInitializer,
+	sysctl sysctl.Sysctl,
 ) (node.Handler, node.IDHandler) {
 	datapathConfig := DatapathConfiguration{
 		HostDevice:   defaults.HostDevice,
 		TunnelDevice: tunnelConfig.DeviceName(),
 	}
 
-	handler := newNodeHandler(log, datapathConfig, nodeMap, kprCfg, ipsecAgent, fakeipsec.Config{}, localNodeStore)
+	handler := newNodeHandler(log, datapathConfig, nodeMap, kprCfg, ipsecAgent, fakeipsec.Config{}, localNodeStore, db, deviceTable, tunnelEndpointMappingInitialized)
 
 	nodeManager.Subscribe(handler)
 	nodeConfigNotifier.Subscribe(handler)
@@ -112,6 +125,7 @@ func NewNodeHandler(
 	lifecycle.Append(cell.Hook{
 		OnStart: func(_ cell.HookContext) error {
 			handler.RestoreNodeIDs()
+			handler.setMultipathDeviceRPFilter(sysctl)
 			return nil
 		},
 	})
@@ -129,22 +143,43 @@ func newNodeHandler(
 	ipsecAgent ipsecTypes.Agent,
 	ipsecCfg ipsecTypes.Config,
 	localNodeStore *node.LocalNodeStore,
+	db *statedb.DB,
+	deviceTable statedb.Table[*tables.Device],
+	tunnelEndpointMappingInitialized ipcache.TEPMappingInitializer,
 ) *linuxNodeHandler {
+	var patterns []*regexp.Regexp
+	for _, device := range option.Config.TunnelMultipathDevices {
+		pattern, err := regexp.Compile(fmt.Sprintf("^%s$", device))
+		if err != nil {
+			log.Error("failed to compile regex pattern for tunnel multipath device",
+				logfields.Device, device,
+				logfields.Error, err,
+			)
+			continue
+		}
+
+		patterns = append(patterns, pattern)
+	}
+
 	return &linuxNodeHandler{
-		log:                  log,
-		datapathConfig:       datapathConfig,
-		nodeConfig:           config.Config{},
-		nodes:                map[nodeTypes.Identity]*nodeTypes.Node{},
-		localNodeStore:       localNodeStore,
-		nodeMap:              nodeMap,
-		nodeIDs:              idpool.NewIDPool(minNodeID, maxNodeID),
-		nodeIDsByIPs:         map[string]uint16{},
-		nodeIPsByIDs:         map[uint16]sets.Set[string]{},
-		ipsecMetricCollector: ipsec.NewXFRMCollector(log),
-		ipsecUpdateNeeded:    map[nodeTypes.Identity]bool{},
-		kprCfg:               kprCfg,
-		ipsecAgent:           ipsecAgent,
-		ipsecCfg:             ipsecCfg,
+		log:                              log,
+		datapathConfig:                   datapathConfig,
+		nodeConfig:                       config.Config{},
+		nodes:                            map[nodeTypes.Identity]*nodeTypes.Node{},
+		localNodeStore:                   localNodeStore,
+		nodeMap:                          nodeMap,
+		nodeIDs:                          idpool.NewIDPool(minNodeID, maxNodeID),
+		nodeIDsByIPs:                     map[string]uint16{},
+		nodeIPsByIDs:                     map[uint16]sets.Set[string]{},
+		ipsecMetricCollector:             ipsec.NewXFRMCollector(log),
+		ipsecUpdateNeeded:                map[nodeTypes.Identity]bool{},
+		kprCfg:                           kprCfg,
+		ipsecAgent:                       ipsecAgent,
+		ipsecCfg:                         ipsecCfg,
+		deviceTable:                      deviceTable,
+		db:                               db,
+		tunnelRoutingDeviceRegexes:       patterns,
+		tunnelEndpointMappingInitialized: tunnelEndpointMappingInitialized,
 	}
 }
 
@@ -459,6 +494,65 @@ func (n *linuxNodeHandler) updateOrRemoveNodeRoutes(old, new []*cidr.CIDR, isLoc
 	return errs
 }
 
+func (n *linuxNodeHandler) updateMultipathTunnelRoute(newNode *nodeTypes.Node) error {
+	rxn := n.db.ReadTxn()
+	for _, ipv6 := range []bool{false, true} {
+		bits := 32
+		if ipv6 {
+			bits = 128
+		}
+
+		dst := newNode.GetCiliumInternalIP(ipv6)
+		if dst == nil {
+			continue
+		}
+
+		r := netlink.Route{
+			Dst:      &net.IPNet{IP: dst, Mask: net.CIDRMask(bits, bits)},
+			Protocol: linux_defaults.RTProto,
+		}
+
+		for link := range n.deviceTable.All(rxn) {
+			for _, pattern := range n.tunnelRoutingDeviceRegexes {
+				if pattern.MatchString(link.Name) {
+					r.MultiPath = append(r.MultiPath, &netlink.NexthopInfo{
+						LinkIndex: link.Index,
+					})
+					break
+				}
+			}
+		}
+		if len(r.MultiPath) > 0 {
+			if err := netlink.RouteReplace(&r); err != nil {
+				return fmt.Errorf("failed to replace multipath route for node %s: %w", newNode.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (n *linuxNodeHandler) deleteMultipathTunnelRoute(oldNode *nodeTypes.Node) error {
+	for _, ipv6 := range []bool{false, true} {
+		dst := oldNode.GetCiliumInternalIP(ipv6)
+		if dst == nil {
+			continue
+		}
+
+		bits := 32
+		if ipv6 {
+			bits = 128
+		}
+
+		if err := netlink.RouteDel(&netlink.Route{
+			Dst:      &net.IPNet{IP: dst, Mask: net.CIDRMask(bits, bits)},
+			Protocol: linux_defaults.RTProto,
+		}); err != nil {
+			return fmt.Errorf("failed to delete multipath route for node %s: %w", oldNode.Name, err)
+		}
+	}
+	return nil
+}
+
 func (n *linuxNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
@@ -539,6 +633,12 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 			n.registerIpsecMetricOnce()
 		}
 		return errs
+	}
+
+	if option.Config.EnableFloatingTunnelEndpoint && len(option.Config.TunnelMultipathDevices) > 0 {
+		if err := n.updateMultipathTunnelRoute(newNode); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to update multipath tunnel route: %w", err))
+		}
 	}
 
 	if n.nodeConfig.EnableAutoDirectRouting && !n.enableEncapsulation(newNode) {
@@ -655,6 +755,12 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 
 	if err := n.deallocateIDForNode(oldNode); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to deallocate old node ID: %w", err))
+	}
+
+	if option.Config.EnableFloatingTunnelEndpoint && len(option.Config.TunnelMultipathDevices) > 0 {
+		if err := n.deleteMultipathTunnelRoute(oldNode); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to update multipath tunnel route: %w", err))
+		}
 	}
 
 	return errs
@@ -851,4 +957,25 @@ func deleteDefaultLocalRule(family int) error {
 
 func (n *linuxNodeHandler) OverrideEnableEncapsulation(fn func(*nodeTypes.Node) bool) {
 	n.enableEncapsulation = fn
+}
+
+func (n *linuxNodeHandler) setMultipathDeviceRPFilter(sysctl sysctl.Sysctl) {
+	// Set rp_filter=0 on each of the multipath devices. This is needed as otherwise
+	// packets are dropped as martians since we might not have an IP address on the
+	// devices that would match the incoming traffic.
+
+	settings := []tables.Sysctl{}
+	for link := range n.deviceTable.All(n.db.ReadTxn()) {
+		for _, pattern := range n.tunnelRoutingDeviceRegexes {
+			if pattern.MatchString(link.Name) {
+				settings = append(settings, tables.Sysctl{
+					Name:      []string{"net", "ipv4", "conf", link.Name, "rp_filter"},
+					Val:       "0",
+					IgnoreErr: true,
+				})
+				break
+			}
+		}
+	}
+	sysctl.ApplySettings(settings)
 }

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -252,7 +252,7 @@ func testUpdateNodeRoute(t *testing.T, family string) {
 	log := hivetest.Logger(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
 
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns, nil, nil, nil)
 	mustConfigureNode(t, s.ns, lnh, s.nodeConfigTemplate)
 
 	if s.enableIPv4 {
@@ -294,7 +294,7 @@ func testAuxiliaryPrefixes(t *testing.T, family string) {
 	log := hivetest.Logger(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
 
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns, nil, nil, nil)
 	nodeConfig := s.nodeConfigTemplate
 	nodeConfig.AuxiliaryPrefixes = []*cidr.CIDR{net1, net2}
 	mustConfigureNode(t, s.ns, lnh, nodeConfig)
@@ -371,7 +371,7 @@ func commonNodeUpdateEncapsulation(t *testing.T, family string, encap bool, over
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	log := hivetest.Logger(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns, nil, nil, nil)
 
 	lnh.OverrideEnableEncapsulation(override)
 
@@ -533,7 +533,7 @@ func testNodeUpdateIDs(t *testing.T, family string) {
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	log := hivetest.Logger(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	lnh := newNodeHandler(log, dpConfig, nodeMap, kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodeMap, kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns, nil, nil, nil)
 
 	mustConfigureNode(t, s.ns, lnh, s.nodeConfigTemplate)
 
@@ -696,7 +696,7 @@ func testNodeChurnXFRMLeaksWithConfig(t *testing.T, s *nodeSuite, config config.
 
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, a, fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, a, fakeipsec.Config{}, lns, nil, nil, nil)
 
 	mustConfigureNode(t, s.ns, lnh, config)
 
@@ -787,7 +787,7 @@ func testNodeUpdateDirectRouting(t *testing.T, family string) {
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	log := hivetest.Logger(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns, nil, nil, nil)
 
 	nodeConfig := s.nodeConfigTemplate
 	nodeConfig.Devices = append(slices.Clone(nodeConfig.Devices), dev1, dev2)
@@ -1020,7 +1020,7 @@ func testNodeValidationDirectRouting(t *testing.T, family string) {
 	dpConfig := DatapathConfiguration{HostDevice: hostDevice}
 	log := hivetest.Logger(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, ipsec.NewTestIPsecAgent(t), fakeipsec.Config{}, lns, nil, nil, nil)
 
 	nodeConfig := s.nodeConfigTemplate
 	nodeConfig.EnableEncapsulation = false
@@ -1164,7 +1164,7 @@ func testNodePodCIDRsChurnIPSec(t *testing.T, family string) {
 	log := hivetest.Logger(t)
 	a := ipsec.NewTestIPsecAgent(t)
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, a, fakeipsec.Config{}, lns)
+	lnh := newNodeHandler(log, dpConfig, nodemapfake.NewFakeNodeMapV2(), kpr.KPRConfig{}, a, fakeipsec.Config{}, lns, nil, nil, nil)
 
 	nodeConfig := s.nodeConfigTemplate
 	nodeConfig.Devices = append(slices.Clone(nodeConfig.Devices), dev1, dev2)

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -56,7 +56,7 @@ func TestCreateNodeRoute(t *testing.T) {
 	log := hivetest.Logger(t)
 
 	lns := node.NewTestLocalNodeStore(node.LocalNode{})
-	nodeHandler := newNodeHandler(log, dpConfig, nil, kpr.KPRConfig{}, &fakeipsec.Agent{}, fakeipsec.Config{}, lns)
+	nodeHandler := newNodeHandler(log, dpConfig, nil, kpr.KPRConfig{}, &fakeipsec.Agent{}, fakeipsec.Config{}, lns, nil, nil, nil)
 	nodeHandler.NodeConfigurationChanged(nodeConfig)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -539,6 +539,9 @@ const (
 
 	// PolicyAccouting is the default value for option.PolicyAccounting
 	PolicyAccounting = true
+
+	// EnableFloatingTunnelEndpoint is the default value for option.EnableFloatingTunnelEndpoint
+	EnableFloatingTunnelEndpoint = false
 )
 
 var (

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
@@ -134,7 +135,12 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 				continue
 			}
 
-			addr, ok := netipx.FromStdIP(node.GetNodeIP(false))
+			nodeIP := node.GetNodeIP(false)
+			if option.Config.EnableFloatingTunnelEndpoint {
+				nodeIP = node.GetCiliumInternalIP(false)
+			}
+
+			addr, ok := netipx.FromStdIP(nodeIP)
 			if !ok {
 				continue
 			}

--- a/pkg/ipcache/cell/apiserver_watcher.go
+++ b/pkg/ipcache/cell/apiserver_watcher.go
@@ -16,6 +16,7 @@ import (
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -26,12 +27,18 @@ import (
 //
 // The actual implementation of this logic down to the datapath is handled
 // asynchronously by IPCache.
-func registerAPIServerBackendWatcher(jobs job.Group, db *statedb.DB, backends statedb.Table[*loadbalancer.Backend], ipc *ipcache.IPCache) {
+func registerAPIServerBackendWatcher(jobs job.Group, db *statedb.DB, backends statedb.Table[*loadbalancer.Backend], ipc *ipcache.IPCache, conf *option.DaemonConfig, TEPMappingInitializer ipcache.TEPMappingInitializer) {
 	jobs.Add(
 		job.OneShot(
 			"api-server-backend-watcher",
 			func(ctx context.Context, health cell.Health) error {
 				for {
+					// If floating tunnel endpoints are enabled, then we need to wait for the mappings in the ipcache
+					// to be initialized before we start inserting endpoints.
+					if conf.EnableFloatingTunnelEndpoint {
+						TEPMappingInitializer.Wait()
+					}
+
 					// Get all backend IPs associated to the api-server
 					bes, watch := loadbalancer.ListBackendsByServiceName(
 						db.ReadTxn(),

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -40,6 +40,7 @@ var Cell = cell.Module(
 		ipcache.NewLocalIPIdentityWatcher,
 		ipcache.NewIPIdentitySynchronizer,
 		newIPCacheAPIHandler,
+		ipcache.NewTEPMappingInitializer,
 	),
 
 	// LocalIdentityRestorer restores the identities at startup
@@ -56,6 +57,10 @@ var Cell = cell.Module(
 		// Register a job to associate default/kubernetes backend IPs with the
 		// 'reserved:kube-apiserver' label.
 		registerAPIServerBackendWatcher,
+
+		// Register a job to reconcile IPCache entries on tunnel endpoint mapping
+		// changes.
+		ipcache.RegisterReconcileTunnelEndpointsJob,
 	),
 )
 
@@ -82,11 +87,12 @@ func newIPCache(params ipCacheParams) *ipcache.IPCache {
 	// local identities. Generates incremental updates, pushes
 	// to endpoints.
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{
-		Context:           ctx,
-		Logger:            params.Logger,
-		IdentityAllocator: params.CacheIdentityAllocator,
-		IdentityUpdater:   params.IdentityUpdater,
-		CacheStatus:       params.CacheStatus,
+		Context:                      ctx,
+		Logger:                       params.Logger,
+		IdentityAllocator:            params.CacheIdentityAllocator,
+		IdentityUpdater:              params.IdentityUpdater,
+		CacheStatus:                  params.CacheStatus,
+		EnableFloatingTunnelEndpoint: params.DaemonConfig.EnableFloatingTunnelEndpoint,
 	})
 
 	params.Lifecycle.Append(cell.Hook{

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -10,6 +10,9 @@ import (
 	"net/netip"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/cilium/hive/job"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
@@ -108,6 +111,8 @@ type Configuration struct {
 	cache.IdentityAllocator
 	ipcacheTypes.IdentityUpdater
 	synced.CacheStatus
+	EnableFloatingTunnelEndpoint bool
+	TEPMappingInitializer        TEPMappingInitializer
 }
 
 // IPCache is a collection of mappings:
@@ -115,15 +120,17 @@ type Configuration struct {
 //     which are part of the same cluster, and vice-versa
 //   - mapping of endpoint IP or CIDR to host IP (maybe nil)
 type IPCache struct {
-	logger            *slog.Logger
-	mutex             lock.SemaphoredMutex
-	ipToIdentityCache map[string]Identity
-	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
-	ipToHostIPCache   map[string]IPKeyPair
-	ipToK8sMetadata   map[string]K8sMetadata
-	ipToEndpointFlags map[string]uint8
+	logger             *slog.Logger
+	mutex              lock.SemaphoredMutex
+	ipToIdentityCache  map[string]Identity
+	identityToIPCache  map[identity.NumericIdentity]map[string]struct{}
+	ipToHostIPCache    map[string]IPKeyPair
+	ipToK8sMetadata    map[string]K8sMetadata
+	ipToEndpointFlags  map[string]uint8
+	ipToTunnelEndpoint map[string]net.IP
 
-	listeners []IPIdentityMappingListener
+	listeners               []IPIdentityMappingListener
+	tunnelEndpointListeners []TunnelEndpointMappingListener
 
 	// controllers manages the async controllers for this IPCache
 	controllers *controller.Manager
@@ -155,24 +162,33 @@ type IPCache struct {
 	// injectionStarted is a sync.Once so we can lazily start the prefix injection controller,
 	// but only once
 	injectionStarted sync.Once
+
+	// tunnelMappingsTrigger for reconciling changed tunnel mappings
+	tunnelMappingsTrigger job.Trigger
 }
+
+const (
+	tunnelMappingsMinInterval = 5 * time.Second
+)
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
 // identity (and vice-versa) initialized.
 func NewIPCache(c *Configuration) *IPCache {
 	ipc := &IPCache{
-		logger:            c.Logger,
-		mutex:             lock.NewSemaphoredMutex(),
-		ipToIdentityCache: map[string]Identity{},
-		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
-		ipToHostIPCache:   map[string]IPKeyPair{},
-		ipToK8sMetadata:   map[string]K8sMetadata{},
-		ipToEndpointFlags: map[string]uint8{},
-		controllers:       controller.NewManager(),
-		namedPorts:        types.NewNamedPortMultiMap(),
-		metadata:          newMetadata(c.Logger),
-		prefixLengths:     counter.DefaultPrefixLengthCounter(),
-		Configuration:     c,
+		logger:                c.Logger,
+		mutex:                 lock.NewSemaphoredMutex(),
+		ipToIdentityCache:     map[string]Identity{},
+		identityToIPCache:     map[identity.NumericIdentity]map[string]struct{}{},
+		ipToHostIPCache:       map[string]IPKeyPair{},
+		ipToK8sMetadata:       map[string]K8sMetadata{},
+		ipToEndpointFlags:     map[string]uint8{},
+		ipToTunnelEndpoint:    map[string]net.IP{},
+		controllers:           controller.NewManager(),
+		namedPorts:            types.NewNamedPortMultiMap(),
+		metadata:              newMetadata(c.Logger),
+		prefixLengths:         counter.DefaultPrefixLengthCounter(),
+		Configuration:         c,
+		tunnelMappingsTrigger: job.NewTrigger(job.WithDebounce(tunnelMappingsMinInterval)),
 	}
 	return ipc
 }
@@ -333,6 +349,14 @@ func (ipc *IPCache) upsertLocked(
 	oldEndpointFlags := ipc.getEndpointFlagsRLocked(ip)
 	oldK8sMeta := ipc.ipToK8sMetadata[ip]
 	metaEqual := oldK8sMeta.Equal(k8sMeta)
+
+	if ipc.Configuration.EnableFloatingTunnelEndpoint {
+		if hostIP != nil {
+			if tunnelIP, found := ipc.ipToTunnelEndpoint[hostIP.String()]; found {
+				hostIP = tunnelIP
+			}
+		}
+	}
 
 	cachedIdentity, found := ipc.ipToIdentityCache[ip]
 	if found {
@@ -635,6 +659,11 @@ func (ipc *IPCache) dumpToListenerLocked(listener IPIdentityMappingListener) {
 			continue
 		}
 		hostIP, encryptKey := ipc.getHostIPCacheRLocked(ip)
+		if option.Config.EnableFloatingTunnelEndpoint && hostIP != nil {
+			if mappedIP, ok := ipc.ipToTunnelEndpoint[hostIP.String()]; ok {
+				hostIP = mappedIP
+			}
+		}
 		k8sMeta := ipc.getK8sMetadata(ip)
 		endpointFlags := ipc.getEndpointFlagsRLocked(ip)
 		cidrCluster, err := cmtypes.ParsePrefixCluster(ip)
@@ -911,6 +940,127 @@ func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.
 		}
 	}
 	return cidrs
+}
+
+type TEPMappingInitializer chan struct{}
+
+// TunnelEndpointMappingListener represents a component that is interested in
+// floating tunnel endpoint mapping changes.
+type TunnelEndpointMappingListener interface {
+	OnTunnelEndpointMappingUpsert(from, to net.IP)
+	OnTunnelEndpointMappingDelete(from net.IP)
+}
+
+func NewTEPMappingInitializer() TEPMappingInitializer {
+	return make(chan struct{})
+}
+
+func (tepm TEPMappingInitializer) Initialize() {
+	close(tepm)
+}
+
+func (tepm TEPMappingInitializer) Wait() {
+	<-tepm
+}
+
+// AddTunnelEndpointMappingListener adds a listener for tunnel endpoint mapping changes.
+func (ipc *IPCache) AddTunnelEndpointMappingListener(listener TunnelEndpointMappingListener) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.RUnlock()
+	ipc.tunnelEndpointListeners = append(ipc.tunnelEndpointListeners, listener)
+	ipc.mutex.UnlockToRLock()
+
+	for from, to := range ipc.ipToTunnelEndpoint {
+		listener.OnTunnelEndpointMappingUpsert(net.ParseIP(from), to)
+	}
+}
+
+func (ipc *IPCache) UpsertTunnelEndpointMapping(from, to net.IP) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.RUnlock()
+	ipc.ipToTunnelEndpoint[from.String()] = to
+	ipc.mutex.UnlockToRLock()
+
+	for _, listener := range ipc.tunnelEndpointListeners {
+		listener.OnTunnelEndpointMappingUpsert(from, to)
+	}
+}
+
+func (ipc *IPCache) GetTunnelEndpointMapping(from net.IP) (to net.IP, ok bool) {
+	ipc.mutex.RLock()
+	to, ok = ipc.ipToTunnelEndpoint[from.String()]
+	ipc.mutex.RUnlock()
+	return
+}
+
+func (ipc *IPCache) DeleteTunnelEndpointMapping(from net.IP) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+	delete(ipc.ipToTunnelEndpoint, from.String())
+
+	for _, listener := range ipc.tunnelEndpointListeners {
+		listener.OnTunnelEndpointMappingDelete(from)
+	}
+}
+
+func RegisterReconcileTunnelEndpointsJob(jg job.Group, ipc *IPCache) {
+	jg.Add(
+		job.Timer(
+			"reconcile-tunnel-endpoints",
+			ipc.reconcileTunnelEndpoints,
+			0, // only runs when triggered
+			job.WithTrigger(ipc.tunnelMappingsTrigger),
+		),
+	)
+}
+
+// reconcileTunnelEndpoints is triggered when tunnel mappings are updated to fix entries
+// that point to the old endpoint.
+func (ipc *IPCache) reconcileTunnelEndpoints(_ context.Context) error {
+	// Find entries that need to be re-upserted in order to pick up the new tunnel
+	// endpoint. As we don't expect in steady state for there to be anything to
+	// update we find the entries first with RLock() and then promote to Lock()
+	// when needed.
+	var outOfDate []string
+	ipc.mutex.RLock()
+	for ip, host := range ipc.ipToHostIPCache {
+		tunnelIP, found := ipc.ipToTunnelEndpoint[host.IP.String()]
+		if !found || host.IP.Equal(tunnelIP) {
+			continue
+		}
+		outOfDate = append(outOfDate, ip)
+	}
+	ipc.mutex.RUnlock()
+
+	if len(outOfDate) == 0 {
+		return nil
+	}
+
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+	for _, ip := range outOfDate {
+		// As the entry might've changed after acquiring the write lock, recheck
+		// it.
+		host, found := ipc.ipToHostIPCache[ip]
+		if !found {
+			continue
+		}
+		tunnelIP, found := ipc.ipToTunnelEndpoint[host.IP.String()]
+		if !found || host.IP.Equal(tunnelIP) {
+			continue
+		}
+		_, _ = ipc.upsertLocked(
+			ip,
+			host.IP,
+			host.Key,
+			ipc.getK8sMetadata(ip),
+			ipc.ipToIdentityCache[ip],
+			ipc.ipToEndpointFlags[ip],
+			false,
+			false,
+		)
+	}
+	return nil
 }
 
 // Equal returns true if two K8sMetadata pointers contain the same data or are

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -656,3 +656,32 @@ func TestIPCacheShadowing(t *testing.T) {
 	_, exists := ipc.LookupByPrefix(cidrOverlap)
 	require.False(t, exists)
 }
+
+func TestIPCacheTunnelEndpointMapping(t *testing.T) {
+	t.Parallel()
+	s := setupIPCacheTestSuite(t)
+	s.IPIdentityCache.Configuration.EnableFloatingTunnelEndpoint = true
+
+	endpointIP := "10.0.0.15"
+	hostIP := net.ParseIP("20.0.1.2")
+	mappedIP := net.ParseIP("30.0.1.2")
+	identity := (identityPkg.NumericIdentity(68))
+
+	// Assure sane state at start.
+	require.Empty(t, s.IPIdentityCache.ipToIdentityCache)
+	require.Empty(t, s.IPIdentityCache.identityToIPCache)
+
+	// Deletion of key that doesn't exist doesn't cause panic.
+	s.IPIdentityCache.Delete(endpointIP, source.KVStore)
+
+	s.IPIdentityCache.UpsertTunnelEndpointMapping(hostIP, mappedIP)
+	s.IPIdentityCache.Upsert(endpointIP, hostIP, 0, nil, Identity{
+		ID:     identity,
+		Source: source.KVStore,
+	})
+
+	require.Equal(t, hostIP, s.IPIdentityCache.ipToHostIPCache[endpointIP].IP)
+	actualMapping, ok := s.IPIdentityCache.GetTunnelEndpointMapping(hostIP)
+	require.True(t, ok)
+	require.Equal(t, mappedIP, actualMapping)
+}

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -84,22 +84,23 @@ type NodeManager interface {
 
 func newAllNodeManager(in struct {
 	cell.In
-	Logger         *slog.Logger
-	TunnelConf     tunnel.Config
-	Lifecycle      cell.Lifecycle
-	IPCache        *ipcache.IPCache
-	IPSetMgr       ipset.Manager
-	IPSetFilter    IPSetFilterFn `optional:"true"`
-	NodeMetrics    *nodeMetrics
-	Health         cell.Health
-	JobGroup       job.Group
-	DB             *statedb.DB
-	Devices        statedb.Table[*tables.Device]
-	WGConfig       wgTypes.Config
-	LocalNodeStore *node.LocalNodeStore
+	Logger                *slog.Logger
+	TunnelConf            tunnel.Config
+	Lifecycle             cell.Lifecycle
+	IPCache               *ipcache.IPCache
+	IPSetMgr              ipset.Manager
+	IPSetFilter           IPSetFilterFn `optional:"true"`
+	NodeMetrics           *nodeMetrics
+	Health                cell.Health
+	JobGroup              job.Group
+	DB                    *statedb.DB
+	Devices               statedb.Table[*tables.Device]
+	WGConfig              wgTypes.Config
+	LocalNodeStore        *node.LocalNodeStore
+	TEPMappingInitializer ipcache.TEPMappingInitializer
 },
 ) (NodeManager, error) {
-	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, in.LocalNodeStore)
+	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, in.LocalNodeStore, in.TEPMappingInitializer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -86,6 +86,8 @@ type IPCache interface {
 	RemoveIdentityOverride(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, resource ipcacheTypes.ResourceID)
 	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
+	UpsertTunnelEndpointMapping(from, to net.IP)
+	DeleteTunnelEndpointMapping(from net.IP)
 }
 
 // IPSetFilterFn is a function allowing to optionally filter out the insertion
@@ -177,6 +179,8 @@ type manager struct {
 	wgConfig types.Config
 
 	localNodeStore *node.LocalNodeStore
+
+	tepMappingInitializer ipcache.TEPMappingInitializer
 }
 
 // Subscribe subscribes the given node handler to node events.
@@ -275,6 +279,7 @@ func New(
 	devices statedb.Table[*tables.Device],
 	wgCfg types.Config,
 	localNodeStore *node.LocalNodeStore,
+	tepMappingInitializer ipcache.TEPMappingInitializer,
 ) (*manager, error) {
 	if ipsetFilter == nil {
 		ipsetFilter = func(*nodeTypes.Node) bool { return false }
@@ -300,6 +305,7 @@ func New(
 		prefixClusterMutatorFn: func(node *nodeTypes.Node) []cmtypes.PrefixClusterOpts { return nil },
 		wgConfig:               wgCfg,
 		localNodeStore:         localNodeStore,
+		tepMappingInitializer:  tepMappingInitializer,
 	}
 
 	return m, nil
@@ -786,6 +792,18 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	// the nodeIP as the tunnel endpoint (no tunnel endpoint fallback is needed
 	// for the local node).
 	if !n.IsLocal() {
+		if m.conf.EnableFloatingTunnelEndpoint {
+			if nodeIP.Is6() {
+				if internalIPv6 := n.GetCiliumInternalIP(true); internalIPv6 != nil {
+					m.ipcache.UpsertTunnelEndpointMapping(nodeIP.AsSlice(), internalIPv6)
+				}
+			} else {
+				if internalIPv4 := n.GetCiliumInternalIP(false); internalIPv4 != nil {
+					m.ipcache.UpsertTunnelEndpointMapping(nodeIP.AsSlice(), internalIPv4)
+				}
+			}
+		}
+
 		ipv4PodCIDRs := n.GetIPv4AllocCIDRs()
 		ipv6PodCIDRs := n.GetIPv6AllocCIDRs()
 
@@ -1080,6 +1098,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			ipcacheTypes.TunnelPeer{Addr: oldNodeIP},
 			m.endpointEncryptionKey(&oldNode))
 	}
+
+	m.ipcache.DeleteTunnelEndpointMapping(oldNodeIP.AsSlice())
 }
 
 // NodeDeleted is called after a node has been deleted. It removes the node
@@ -1151,6 +1171,27 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 		m.metrics.NumNodes.Dec()
 	}
 
+	if !n.IsLocal() {
+		var nodeIP netip.Addr
+		if nIP := n.GetNodeIP(m.underlay == tunnel.IPv6); nIP != nil {
+			// GH-24829: Support IPv6-only nodes.
+
+			// Skip returning the error here because at this level, we assume that
+			// the IP is valid as long as it's coming from nodeTypes.Node. This
+			// object is created either from the node discovery (K8s) or from an
+			// event from the kvstore.
+			nodeIP, _ = netipx.FromStdIP(nIP)
+		}
+
+		if m.conf.EnableFloatingTunnelEndpoint {
+			if nodeIP.Is6() {
+				m.ipcache.DeleteTunnelEndpointMapping(nodeIP.AsSlice())
+			} else {
+				m.ipcache.DeleteTunnelEndpointMapping(nodeIP.AsSlice())
+			}
+		}
+	}
+
 	entry.mutex.Lock()
 	delete(m.nodes, nodeIdentifier)
 	if m.nodeCheckpointer != nil {
@@ -1188,6 +1229,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 // deletion of possible stale nodes.
 func (m *manager) NodeSync() {
 	m.ipsetInitializer.InitDone()
+	m.tepMappingInitializer.Initialize()
 
 	// Due to the complexity around kvstore vs k8s as node sources, it may occur
 	// that both sources call NodeSync at some point. Ensure we only run this

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -132,6 +132,10 @@ func (i *ipcacheMock) RemoveMetadataBatch(updates ...ipcache.MU) (revision uint6
 	return 0
 }
 
+func (i *ipcacheMock) UpsertTunnelEndpointMapping(from, to net.IP) {}
+
+func (i *ipcacheMock) DeleteTunnelEndpointMapping(from net.IP) {}
+
 type ipsetMock struct {
 	v4 map[string]struct{}
 	v6 map[string]struct{}
@@ -259,7 +263,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -356,7 +360,7 @@ func TestNodeLabels(t *testing.T) {
 		Source:  source.Unspec,
 	}
 
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{Node: nLocal}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{Node: nLocal}), nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	mngr.NodeUpdated(nRemote)
@@ -430,7 +434,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -514,7 +518,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	dp := fakenode.NewHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(b)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -537,7 +541,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakenode.NewHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -563,7 +567,7 @@ func TestBackgroundSync(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -633,7 +637,7 @@ func TestIpcache(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -778,7 +782,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -825,7 +829,7 @@ func TestNodeEncryption(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		EncryptNode: true,
-	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -949,7 +953,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1211,7 +1215,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		LocalRouterIPv4: "169.254.4.6",
-	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1312,7 +1316,7 @@ func TestNodeIpset(t *testing.T) {
 	mngr, err := New(logger, &option.DaemonConfig{
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
-	}, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -1493,7 +1497,7 @@ func TestNodesStartupPruning(t *testing.T) {
 		mngr, err := New(logger, &option.DaemonConfig{
 			StateDir:    stateDir,
 			ClusterName: "c1",
-		}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+		}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			mngr.Stop(context.TODO())
@@ -1619,4 +1623,63 @@ func TestNodesStartupPruning(t *testing.T) {
 		assert.Equal(t, float64(2), mngr.metrics.EventsReceived.WithLabelValues("delete", string(source.Restored)).Get())
 		assert.Equal(t, float64(3), mngr.metrics.NumNodes.Get())
 	})
+}
+
+func TestNodeMultipathTunnelEndpoint(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	allocator := testidentity.NewMockIdentityAllocator(nil)
+	ipcache := ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           ctx,
+		Logger:            hivetest.Logger(t),
+		IdentityAllocator: allocator,
+		IdentityUpdater:   &mockUpdater{},
+	})
+	defer cancel()
+	dp := newSignalNodeHandler()
+	dp.EnableNodeAddEvent = true
+	dp.EnableNodeUpdateEvent = true
+	dp.EnableNodeDeleteEvent = true
+	h, _ := cell.NewSimpleHealth()
+	mngr, err := New(logger, &option.DaemonConfig{
+		LocalRouterIPv4:              "169.254.4.6",
+		EnableFloatingTunnelEndpoint: true,
+	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
+	require.NoError(t, err)
+	mngr.Subscribe(dp)
+	defer mngr.Stop(context.TODO())
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.128.0.40"),
+			},
+			{
+				Type: addressing.NodeExternalIP,
+				IP:   net.ParseIP("34.171.135.203"),
+			},
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP("169.254.4.6"),
+			},
+		},
+		Source: source.Local,
+	}
+	mngr.NodeUpdated(n1)
+
+	select {
+	case nodeEvent := <-dp.NodeAddEvent:
+		mapped, ok := ipcache.GetTunnelEndpointMapping(nodeEvent.GetNodeInternalIPv4())
+		assert.True(t, ok)
+		assert.Equal(t, mapped, nodeEvent.GetCiliumInternalIP(false))
+	case nodeEvent := <-dp.NodeUpdateEvent:
+		t.Errorf("Unexpected NodeUpdate() event %#v", nodeEvent)
+	case nodeEvent := <-dp.NodeDeleteEvent:
+		t.Errorf("Unexpected NodeDelete() event %#v", nodeEvent)
+	case <-time.After(3 * time.Second):
+		t.Errorf("timeout while waiting for NodeAdd() event for node1")
+	}
 }

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -37,7 +37,7 @@ func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	option.Config.IPv6ServiceRange = "auto"
 
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}), nil)
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -998,6 +998,12 @@ const (
 
 	// EnableCiliumNodeCRD is the name of the option to enable use of the CiliumNode CRD
 	EnableCiliumNodeCRDName = "enable-ciliumnode-crd"
+
+	// EnableFloatingTunnelEndpoint enables floating tunnel endpoints.
+	EnableFloatingTunnelEndpoint = "enable-floating-tunnel-endpoint"
+
+	// TunnelRoutingDevices is a list of devices to use for floating tunnel endpoints.
+	TunnelRoutingDevices = "tunnel-routing-devices"
 )
 
 // Default string arguments
@@ -1893,6 +1899,12 @@ type DaemonConfig struct {
 
 	// EnableCiliumNodeCRD enables the use of CiliumNode CRD
 	EnableCiliumNodeCRD bool
+
+	// EnableFloatingTunnelEndpoint enables multipath routing for tunnel traffic.
+	EnableFloatingTunnelEndpoint bool
+
+	// TunnelMultipathDevices is the list of devices to use for tunnel multipath routing.
+	TunnelMultipathDevices []string
 }
 
 var (
@@ -1953,6 +1965,8 @@ var (
 		EnableCiliumNodeCRD: defaults.EnableCiliumNodeCRD,
 
 		PolicyAccounting: defaults.PolicyAccounting,
+
+		EnableFloatingTunnelEndpoint: defaults.EnableFloatingTunnelEndpoint,
 	}
 )
 
@@ -2294,6 +2308,11 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 		return err
 	}
 
+	if c.EnableFloatingTunnelEndpoint && c.RoutingMode == RoutingModeTunnel && len(c.TunnelMultipathDevices) == 0 {
+		return fmt.Errorf("at least one device pattern must be specified in %q when %s is enabled with %s routing mode",
+			TunnelRoutingDevices, EnableFloatingTunnelEndpoint, RoutingModeTunnel)
+	}
+
 	return nil
 }
 
@@ -2552,6 +2571,8 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.BootIDFile = vp.GetString(BootIDFilename)
 	c.EnableExtendedIPProtocols = vp.GetBool(EnableExtendedIPProtocols)
 	c.IPTracingOptionType = vp.GetUint(IPTracingOptionType)
+	c.EnableFloatingTunnelEndpoint = vp.GetBool(EnableFloatingTunnelEndpoint)
+	c.TunnelMultipathDevices = vp.GetStringSlice(TunnelRoutingDevices)
 	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
 	switch c.ServiceNoBackendResponse {
 	case ServiceNoBackendResponseReject, ServiceNoBackendResponseDrop:


### PR DESCRIPTION
This commit adds optional support for multi-path routing of tunnel traffic. Normally, we use the primary IP of a target node as tunnel endpoint. Since this primary IP can only be assigned to a single device, all tunnel traffic is forced over a single path.

By enabling the new option `enable-floating-tunnel-endpoint` introduced by this commit, we use the routing IP of a target node as tunnel endpoint. The routing IP is automatically allocated from the pod IP range delegated to a node and is assigned to the `cilium_host` device which is virtual. This causes nodes to respond to ARP requests for the router IP on all devices, and to accept traffic for the router IP into the network stack. This applies to tunneled traffic in the tunnel routing mode as well as egress gateway traffic.

In tunnel routing mode, the `tunnel-routing-devices` should also be configured. This option create multi-path routes for the router IPs of remote nodes.

In direct routing mode, the `tunnel-routing-devices` option can be used to supplement ADNR, but users can also manually configure the multi-path routes or use BGP to achieve the same result.

```release-note
Add support for multi-path routing of tunnel traffic
```
