### PR TITLE
chore: Use the latest version of renovate locally

### DIFF
--- a/Documentation/contributing/development/renovate.rst
+++ b/Documentation/contributing/development/renovate.rst
@@ -39,7 +39,7 @@ errors in the configuration.
                     -e GITHUB_COM_TOKEN="$(gh auth token)" \
                     -v /tmp:/tmp \
                     -v $(pwd):/usr/src/app \
-                    docker.io/renovate/renovate:slim \
+                    docker.io/renovate/renovate:latest \
                     renovate --platform=local \
          | tee renovate.log
 

--- a/Makefile
+++ b/Makefile
@@ -641,5 +641,5 @@ renovate-local: ## Run a local linter for the renovate configuration
 		-e GITHUB_COM_TOKEN="$(RENOVATE_GITHUB_COM_TOKEN)" \
 		-v /tmp:/tmp \
 		-v $(ROOT_DIR):/usr/src/app \
-		docker.io/renovate/renovate:slim \
+		docker.io/renovate/renovate:latest \
 			renovate --platform=local


### PR DESCRIPTION
No slim version has been published for a year. It is currently pointing to 37.440 whereas 43.46.5 is used in the workflows. `managerFilePatterns` is for instance not recognized.

