### PR TITLE
Fix(gateway): Fix behavior on invalid BackendTLSPolicy

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1135,7 +1135,7 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 		// the sectionName here.
 
 		validBTLSPs := collection.Valid
-		for _, original := range validBTLSPs {
+		for sectionName, original := range validBTLSPs {
 
 			btlsp := original.DeepCopy()
 
@@ -1178,6 +1178,12 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 					Name:      btlsp.GetName(),
 					Namespace: btlsp.GetNamespace(),
 				}] = struct{}{}
+			} else {
+				if collection.Invalid == nil {
+					collection.Invalid = make(map[gatewayv1.SectionName]*gatewayv1.BackendTLSPolicy)
+				}
+				collection.Invalid[sectionName] = original
+				delete(collection.Valid, sectionName)
 			}
 
 			// Checks finished, apply the status to the actual objects.

--- a/operator/pkg/gateway-api/helpers/backendtlspolicies.go
+++ b/operator/pkg/gateway-api/helpers/backendtlspolicies.go
@@ -41,6 +41,9 @@ type BackendTLSPolicyTargetServiceCollection struct {
 	// target this Service, with the map key being the object's full name.
 	// This avoids traversing a slice to find a match all the time.
 	Conflicted map[types.NamespacedName]*gatewayv1.BackendTLSPolicy
+	// Invalid holds the BackendTLSPolicies that target this Service but
+	// failed validation checks. Key is the section name on the Service.
+	Invalid map[gatewayv1.SectionName]*gatewayv1.BackendTLSPolicy
 }
 
 func (b *BackendTLSPolicyTargetServiceCollection) UpsertValidPolicy(sectionName gatewayv1.SectionName, btlsp *gatewayv1.BackendTLSPolicy) {

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-ca-cert/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-ca-cert/output/cec-same-namespace.yaml
@@ -12,15 +12,6 @@ metadata:
       kind: Gateway
       name: same-namespace
 spec:
-  backendServices:
-    - name: backendtlspolicy-malformed-ca-certificate-ref-test
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
-    - name: backendtlspolicy-nonexistent-ca-certificate-ref-test
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
@@ -84,64 +75,16 @@ spec:
           routes:
             - match:
                 path: /backendtlspolicy-nonexistent-ca-certificate-ref
-              route:
-                cluster: gateway-conformance-infra:backendtlspolicy-nonexistent-ca-certificate-ref-test:443
-                maxStreamDuration:
-                  maxStreamDuration: 0s
+              directResponse:
+                body:
+                  inlineString: ""
+                status: 500
             - match:
                 path: /backendtlspolicy-malformed-ca-certificate-ref
-              route:
-                cluster: gateway-conformance-infra:backendtlspolicy-malformed-ca-certificate-ref-test:443
-                maxStreamDuration:
-                  maxStreamDuration: 0s
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/backendtlspolicy-malformed-ca-certificate-ref-test:443
-      name: gateway-conformance-infra:backendtlspolicy-malformed-ca-certificate-ref-test:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext: {}
-              validationContextSdsSecretConfig:
-                name: cilium-secrets/gateway-conformance-infra-cfgmap-malformed-ca-certificate
-          sni: abc.example.com
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 60s
-          useDownstreamProtocolConfig:
-            http2ProtocolOptions: {}
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/backendtlspolicy-nonexistent-ca-certificate-ref-test:443
-      name: gateway-conformance-infra:backendtlspolicy-nonexistent-ca-certificate-ref-test:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext: {}
-              validationContextSdsSecretConfig:
-                name: cilium-secrets/gateway-conformance-infra-cfgmap-nonexistent-ca-certificate
-          sni: abc.example.com
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 60s
-          useDownstreamProtocolConfig:
-            http2ProtocolOptions: {}
+              directResponse:
+                body:
+                  inlineString: ""
+                status: 500
   services:
     - listener: ""
       name: cilium-gateway-same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-kind/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-kind/output/cec-same-namespace.yaml
@@ -12,11 +12,6 @@ metadata:
       kind: Gateway
       name: same-namespace
 spec:
-  backendServices:
-    - name: backendtlspolicy-invalid-kind-test
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
@@ -80,34 +75,10 @@ spec:
           routes:
             - match:
                 path: /backendtlspolicy-invalid-kind
-              route:
-                cluster: gateway-conformance-infra:backendtlspolicy-invalid-kind-test:443
-                maxStreamDuration:
-                  maxStreamDuration: 0s
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/backendtlspolicy-invalid-kind-test:443
-      name: gateway-conformance-infra:backendtlspolicy-invalid-kind-test:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext: {}
-              validationContextSdsSecretConfig:
-                name: cilium-secrets/gateway-conformance-infra-cfgmap-invalid-kind
-          sni: abc.example.com
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 60s
-          useDownstreamProtocolConfig:
-            http2ProtocolOptions: {}
+              directResponse:
+                body:
+                  inlineString: ""
+                status: 500
   services:
     - listener: ""
       name: cilium-gateway-same-namespace

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -277,7 +277,10 @@ func extractRoutes(logger *slog.Logger,
 			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services)
 			if svc != nil {
 				toAppend := backendToModelBackend(*svc, be.BackendRef, hr.Namespace)
-				toAppend = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
+				toAppend, err := addBackendTLSDetails(logger, toAppend, svc, btlspMap)
+				if err != nil {
+					continue
+				}
 				bes = append(bes, toAppend)
 				for _, f := range be.Filters {
 					switch f.Type {
@@ -382,7 +385,7 @@ func extractRoutes(logger *slog.Logger,
 	return httpRoutes
 }
 
-func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Service, btlspMap helpers.BackendTLSPolicyServiceMap) model.Backend {
+func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Service, btlspMap helpers.BackendTLSPolicyServiceMap) (model.Backend, error) {
 	svcFullName := types.NamespacedName{Name: svc.GetName(), Namespace: svc.GetNamespace()}
 
 	log = log.With(logfields.Service, svcFullName)
@@ -398,6 +401,14 @@ func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Servic
 			if port.Port != int32(be.Port.Port) {
 				continue
 			}
+
+			// Before checking valid sections, ensure the policy isn't known to be invalid for this proxy
+			for sectionName := range collection.Invalid {
+				if port.Name == string(sectionName) || sectionName == "" {
+					return be, fmt.Errorf("backend has an invalid BackendTLSPolicy")
+				}
+			}
+
 			// Port matches, so now we need to check the sections that are valid.
 			// There are two possibilities here:
 			// * Specific section name, matches only that Service port.
@@ -436,38 +447,50 @@ func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Servic
 							Namespace: btlsp.GetNamespace(),
 						}
 					}
+
+					return be, nil
+				}
+			}
+
+			// If we got here, we've checked all the specific section names inside the Valid map,
+			// and haven't found a match.
+			// Next, we check if there's an all port match.
+			if btlsp, ok := collection.Valid[""]; ok {
+				scopedLog := log.With(
+					logfields.BackendTLSPolicyName, btlsp.Name,
+					logfields.Port, port.Name,
+					logfields.Section, "")
+
+				scopedLog.Debug("Got a match for valid BTLSP on all ports, adding")
+
+				if be.TLS != nil {
+					// We've already set the TLS for this backend, so we don't need to do it again.
+					return be, nil
 				}
 
-				if sectionName == "" {
-					scopedLog.Debug("Got a match for valid BTLSP on all ports, adding")
-					// If the TLS is already set, then a specific target reference has already claimed this port, and
-					// we need to skip it.
-					if be.TLS == nil {
-						be.TLS = &model.BackendTLSOrigination{
-							SNI: string(btlsp.Spec.Validation.Hostname),
-						}
-						if len(btlsp.Spec.Validation.CACertificateRefs) > 0 {
-							// Cilium only supports ConfigMap currently
-							be.TLS.CACertRef = &model.FullyQualifiedResource{
-								Group:     "",
-								Kind:      "ConfigMap",
-								Version:   "v1",
-								Name:      string(btlsp.Spec.Validation.CACertificateRefs[0].Name),
-								Namespace: btlsp.GetNamespace(),
-							}
-						}
+				// We need to add the BackendTLSPolicy details into the backend, then eject
+				be.TLS = &model.BackendTLSOrigination{
+					SNI: string(btlsp.Spec.Validation.Hostname),
+				}
+
+				if len(btlsp.Spec.Validation.CACertificateRefs) > 0 {
+					// Cilium only supports ConfigMap currently
+					be.TLS.CACertRef = &model.FullyQualifiedResource{
+						Group:     "",
+						Kind:      "ConfigMap",
+						Version:   "v1",
+						Name:      string(btlsp.Spec.Validation.CACertificateRefs[0].Name),
+						Namespace: btlsp.GetNamespace(),
 					}
 				}
 
+				return be, nil
 			}
-			if be.TLS != nil {
-				return be
-			}
-
 		}
+
 	}
-	// There was no relevant BackendTLSPolicy, no changes.
-	return be
+
+	return be, nil
 }
 
 func toTimeout(timeouts *gatewayv1.HTTPRouteTimeouts) model.Timeout {


### PR DESCRIPTION
I was taking a look to some failed runs and the actual k8s test:
```
t.Run("HTTP Request to backend targeted by an invalid BackendTLSPolicy receive a 5xx", func(t *testing.T) {
			h.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr,
				h.ExpectedResponse{
					Namespace: ns,
					Request: h.Request{
						Host: serverStr,
						Path: "/backendtlspolicy-" + policyNN.Name,
					},
					Response: h.Response{
						StatusCodes: []int{500, 502, 503},
					},
				})
		})
	},
```

Ans as I see previously, if a BackendTLSPolicy was created with an invalid configuration the policy was correctly marked with ResolvedRefs=False, but the proxy configuration ignored the invalid TLS settings.

This resulted in a scenario where Envoy would forward the traffic as unencrypted HTTP to a secure backend port, leading to an 400 Bad Request from the backend service rather than the expected 500 Internal Server Error from the Gateway.

This commit resolves the issue by explicitly marking invalid policies in an Invalid map. When translating the Envoy configuration, the presence of an invalid policy now explicitly returns error and drops the target backend. When all backends for a route are dropped, this correctly triggers the native 500 Direct Response fallback, satisfying required specs.

Fixes: #44617
