### PR TITLE
ipsec: publish spi after XFRM state configuration

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -249,7 +249,7 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		return err
 	}
 
-	if err := params.IPsecAgent.StartBackgroundJobs(params.NodeHandler); err != nil {
+	if err := params.IPsecAgent.StartBackgroundJobs(params.NodeHandler, params.Orchestrator.DatapathInitialized()); err != nil {
 		params.Logger.Error("Unable to start IPsec key watcher", logfields.Error, err)
 	}
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -32,6 +32,7 @@ import (
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
+	endpointTypes "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -1224,6 +1225,7 @@ type daemonParams struct {
 	Devices             statedb.Table[*datapathTables.Device]
 	DirectRoutingDevice datapathTables.DirectRoutingDevice
 	IPsecAgent          ipsec.Agent
+	Orchestrator        endpointTypes.Orchestrator
 	SyncHostIPs         *syncHostIPs
 	NodeDiscovery       *nodediscovery.NodeDiscovery
 	IPAMInitializer     *ipamcell.IPAMInitializer

--- a/pkg/datapath/linux/ipsec/cell_test.go
+++ b/pkg/datapath/linux/ipsec/cell_test.go
@@ -117,10 +117,11 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 		ns  = netns.NewNetNS(t)
 		log = hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
 
-		validKey        = []byte("4 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
-		anotherValidKey = []byte("5 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
-		invalidKey      = []byte("6 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
-		keyFile         = filepath.Join(testRunDir, "cilium_ipsec.key")
+		validKeySPI4   = []byte("4 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
+		validKeySPI5   = []byte("5 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
+		validKeySPI6   = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
+		invalidKeySPI6 = []byte("6 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
+		keyFile        = filepath.Join(testRunDir, "cilium_ipsec.key")
 
 		zeroKey = encrypt.EncryptKey{Key: 0}
 	)
@@ -233,7 +234,7 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 	t.Run("IPSecEnabled", func(t *testing.T) {
 		ns.Do(func() error {
 			// 0. Dump a valid IPSec key to file.
-			require.NoError(t, os.WriteFile(keyFile, validKey, 0644))
+			require.NoError(t, os.WriteFile(keyFile, validKeySPI4, 0644))
 
 			// 1. Create a hive with IPSec enabled.
 			hive := getHive(true)
@@ -250,23 +251,23 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 				assert.Equal(c, mtuConfig.GetDeviceMTU(), mtuConfig.GetRouteMTU()+overhead)
 			}, TestTimeout, 50*time.Millisecond)
 
-			// 5. Ensure local node has been updated.
+			// 5. Start background ipsec jobs (publishes SPI to local node and encrypt map).
+			require.NoError(t, ipsecAgent.StartBackgroundJobs(nodeHandler, nil))
+
+			// 6. Ensure local node has been updated.
 			localNode, err := nodeStore.Get(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, localNode.EncryptionKey, ipsecAgent.spi)
 
-			// 6. Ensure encrypt map is updated accordingly.
+			// 7. Ensure encrypt map is updated accordingly.
 			v, err := encryptMap.Lookup(zeroKey)
 			require.NoError(t, err)
 			assert.Equal(t, ipsecAgent.spi, v.KeyID)
 
-			// 6. Start background ipsec jobs.
-			require.NoError(t, ipsecAgent.StartBackgroundJobs(nodeHandler))
+			// 8. Dump another valid IPSec key to file.
+			require.NoError(t, os.WriteFile(keyFile, validKeySPI5, 0644))
 
-			// 7. Dump another valid IPSec key to file.
-			require.NoError(t, os.WriteFile(keyFile, anotherValidKey, 0644))
-
-			// 8. Ensure the ipsec agent updated the spi accordingly.
+			// 9. Ensure the ipsec agent updated the spi accordingly.
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				assert.Equal(c, uint8(5), ipsecAgent.spi)
 				v, err := encryptMap.Lookup(zeroKey)
@@ -275,10 +276,10 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 				assert.NotEmpty(c, ipsecAgent.ipSecKeysRemovalTime)
 			}, TestTimeout, 50*time.Millisecond)
 
-			// 8. Dump an invalid IPSec key to file.
-			require.NoError(t, os.WriteFile(keyFile, invalidKey, 0644))
+			// 10. Dump an invalid IPSec key to file.
+			require.NoError(t, os.WriteFile(keyFile, invalidKeySPI6, 0644))
 
-			// 9. Ensure the ipsec agent rejected the new key.
+			// 11. Ensure the ipsec agent rejected the new key.
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				assert.Equal(c, uint8(5), ipsecAgent.spi)
 				v, err := encryptMap.Lookup(zeroKey)
@@ -286,7 +287,58 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 				assert.Equal(c, ipsecAgent.spi, v.KeyID)
 			}, TestTimeout, 50*time.Millisecond)
 
-			// 10. Stop the hive.
+			// 12. Stop the hive.
+			require.NoError(t, hive.Stop(log, ctx))
+
+			return nil
+		})
+	})
+
+	t.Run("IPSecKeyRotation", func(t *testing.T) {
+		ns.Do(func() error {
+			// Encrypt map has SPI=5 from previous "IPSecEnabled" test.
+
+			// 0. Write a key file with SPI=6 (next SPI after 5, triggers rotation detection).
+			require.NoError(t, os.WriteFile(keyFile, validKeySPI6, 0644))
+
+			// 1. Create and start a hive with IPSec enabled.
+			hive := getHive(true)
+			require.NoError(t, hive.Start(log, ctx))
+
+			// 2. Verify rotation detected: agent keeps old SPI from BPF map,
+			// defers new SPI publication.
+			assert.Equal(t, uint8(5), ipsecAgent.spi)
+			assert.Equal(t, uint8(6), ipsecAgent.pendingSPI)
+
+			// 3. Verify BPF encrypt map was NOT updated (still old SPI=5).
+			v, err := encryptMap.Lookup(zeroKey)
+			require.NoError(t, err)
+			assert.Equal(t, uint8(5), v.KeyID)
+
+			// 4. Verify localNode has old SPI.
+			localNode, err := nodeStore.Get(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, uint8(5), localNode.EncryptionKey)
+
+			// 5. Start background jobs. The deferred-spi-update OneShot job
+			// waits for dpInitialized, then publishes the new SPI.
+			dpInitialized := make(chan struct{})
+			close(dpInitialized)
+			require.NoError(t, ipsecAgent.StartBackgroundJobs(nodeHandler, dpInitialized))
+
+			// 6. Verify that after dpInitialized, the new SPI is published everywhere.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, uint8(6), ipsecAgent.spi)
+				assert.Equal(c, uint8(0), ipsecAgent.pendingSPI)
+				v, err := encryptMap.Lookup(zeroKey)
+				assert.NoError(c, err)
+				assert.Equal(c, uint8(6), v.KeyID)
+				localNode, err := nodeStore.Get(ctx)
+				assert.NoError(c, err)
+				assert.Equal(c, uint8(6), localNode.EncryptionKey)
+			}, TestTimeout, 50*time.Millisecond)
+
+			// 7. Stop the hive.
 			require.NoError(t, hive.Stop(log, ctx))
 
 			return nil
@@ -296,7 +348,7 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 	t.Run("IPSecDisabled", func(t *testing.T) {
 		ns.Do(func() error {
 			// 0. Dump a valid IPSec key to file.
-			require.NoError(t, os.WriteFile(keyFile, validKey, 0644))
+			require.NoError(t, os.WriteFile(keyFile, validKeySPI4, 0644))
 
 			// 1. Create a hive with ipsec disabled.
 			hive := getHive(false)
@@ -318,7 +370,7 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 			assert.Zero(t, localNode.EncryptionKey)
 
 			// 6. Ensure the ipsec agent did not update the key.
-			//    Current key SPI would've been 4, but encryptMap still has 5 from previous test.
+			//    Current key SPI would've been 4, but encryptMap still has 6 from previous test.
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				assert.Equal(c, uint8(0), ipsecAgent.spi)
 				v, err := encryptMap.Lookup(zeroKey)

--- a/pkg/datapath/linux/ipsec/fake/ipsec.go
+++ b/pkg/datapath/linux/ipsec/fake/ipsec.go
@@ -27,7 +27,7 @@ func (*Agent) SPI() uint8 {
 	return 4
 }
 
-func (*Agent) StartBackgroundJobs(node.Handler) error {
+func (*Agent) StartBackgroundJobs(node.Handler, <-chan struct{}) error {
 	return nil
 }
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -136,8 +136,9 @@ var (
 	}
 )
 
-// Upon starting, the agent will load the ipsec key, set the SPI accordingly,
-// and update the EncryptionKey in the local node object to the SPI.
+// Upon starting, the agent will load the ipsec key. In case of an ongoing key rotation
+// detected, the SPI update is deferred in StartBackgroundJobs(), after ensuring
+// XFRM states are configured for all known peers.
 type agent struct {
 	ipSecLock lock.RWMutex
 
@@ -151,6 +152,7 @@ type agent struct {
 	// These are initialized in [newAgent].
 	authKeySize int
 	spi         uint8
+	pendingSPI  uint8
 	// ipSecKeysGlobal is a map of all global IPsec keys per IP, plus a key for
 	// the empty string which is used for the global key.
 	ipSecKeysGlobal map[string]*ipSecKey
@@ -181,6 +183,7 @@ func newAgent(lc cell.Lifecycle, log *slog.Logger, jg job.Group, lns *node.Local
 
 		authKeySize:          0,
 		spi:                  0,
+		pendingSPI:           0,
 		ipSecKeysGlobal:      map[string]*ipSecKey{},
 		ipSecKeysRemovalTime: map[uint8]time.Time{},
 		xfrmStateCache:       NewXfrmStateListCache(time.Minute, c.EnableIPsecXfrmStateCaching),
@@ -189,6 +192,11 @@ func newAgent(lc cell.Lifecycle, log *slog.Logger, jg job.Group, lns *node.Local
 	return ipsec
 }
 
+// Start initializes the agent by loading the IPsec keys and setting the SPI in
+// the BPF map and CiliumNode. If a key rotation is detected (the BPF map has
+// a valid SPI and the key file contains the next SPI), it defers the SPI update
+// until the datapath is initialized to avoid a window where remote peers send
+// traffic encrypted with the new SPI before we have matching XFRM IN states.
 func (a *agent) Start(cell.HookContext) error {
 	if !a.config.EncryptNode {
 		a.deleteIPsecEncryptRoute()
@@ -197,13 +205,21 @@ func (a *agent) Start(cell.HookContext) error {
 		return nil
 	}
 
-	var err error
-	a.authKeySize, a.spi, err = a.loadIPSecKeysFile(a.config.IPsecKeyFile)
+	v, err := a.encryptMap.Lookup(encrypt.EncryptKey{Key: 0})
 	if err != nil {
 		return err
 	}
-	if err := a.setIPSecSPI(a.spi); err != nil {
+	a.spi = v.KeyID
+
+	a.authKeySize, a.pendingSPI, err = a.loadIPSecKeysFile(a.config.IPsecKeyFile)
+	if err != nil {
 		return err
+	}
+
+	if !a.ongoingRotation() {
+		if err := a.setIPSecSPI(a.pendingSPI); err != nil {
+			return err
+		}
 	}
 
 	a.localNode.Update(func(n *node.LocalNode) {
@@ -214,13 +230,39 @@ func (a *agent) Start(cell.HookContext) error {
 }
 
 // StartBackgroundJobs starts the keyfile watcher and stale key reclaimer jobs.
-func (a *agent) StartBackgroundJobs(handler node.Handler) error {
+// dpInitialized is closed when the datapath has been initialized and XFRM
+// states are ready. It is used to defer the new SPI publication during key rotation.
+func (a *agent) StartBackgroundJobs(handler node.Handler, dpInitialized <-chan struct{}) error {
 	if !a.Enabled() {
 		return nil
 	}
-	if err := a.startKeyfileWatcher(handler); err != nil {
-		return fmt.Errorf("failed to start IPsec keyfile watcher: %w", err)
+
+	if a.ongoingRotation() {
+		a.jobs.Add(job.OneShot("deferred-spi-update", func(ctx context.Context, _ cell.Health) error {
+			select {
+			case <-dpInitialized:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			a.log.Info("Datapath initialized, publishing updated SPI",
+				logfields.OldSPI, a.spi,
+				logfields.SPI, a.pendingSPI,
+			)
+			if err := a.publishPendingSPI(handler); err != nil {
+				return err
+			}
+			if err := a.startKeyfileWatcher(handler); err != nil {
+				return fmt.Errorf("failed to start IPsec keyfile watcher: %w", err)
+			}
+			return nil
+		}))
+	} else {
+		if err := a.startKeyfileWatcher(handler); err != nil {
+			return fmt.Errorf("failed to start IPsec keyfile watcher: %w", err)
+		}
 	}
+
 	a.jobs.Add(job.Timer("stale-key-reclaimer", a.onTimer, time.Minute))
 	return nil
 }
@@ -1204,6 +1246,44 @@ func (a *agent) setIPSecSPI(spi uint8) error {
 	return nil
 }
 
+// ongoingRotation returns true if there is an ongoing key rotation, which is the
+// case when both the current [*agent.spi] and pending [*agent.pendingSPI] are valid,
+// and the pending SPI is the next one.
+func (a *agent) ongoingRotation() bool {
+	if a.spi == 0 || a.pendingSPI == 0 {
+		return false
+	}
+	return a.pendingSPI == a.spi%linux_defaults.IPsecMaxKeyVersion+1
+}
+
+// publishPendingSPI publishes the pending SPI to the datapath and CiliumNode.
+//
+//  1. AllNodeValidateImplementation will eventually call nodeUpdate(), which is
+//     responsible for updating the IPSec policies and states for all the different
+//     EPs with ipsec.UpsertIPsecEndpoint(). We do this before advertising the new
+//     SPI to ensure our ingress XFRM states are ready before peers start sending
+//     traffic encrypted with the new key.
+//
+//  2. Update the IPSec key identity in the local node. This will set
+//     addrs.ipsecKeyIdentity in the node package, and eventually trigger an
+//     update to publish the updated information to k8s/kvstore.
+//
+//  3. Push SPI update into BPF datapath now that XFRM state is configured.
+func (a *agent) publishPendingSPI(handler node.Handler) error {
+	handler.AllNodeValidateImplementation()
+
+	a.localNode.Update(func(n *node.LocalNode) {
+		n.EncryptionKey = a.pendingSPI
+	})
+
+	if err := a.setIPSecSPI(a.pendingSPI); err != nil {
+		return fmt.Errorf("failed to set IPsec SPI: %w", err)
+	}
+
+	a.pendingSPI = 0
+	return nil
+}
+
 // deleteIPsecEncryptRoute removes nodes in main routing table by walking
 // routes and matching route protocol type.
 func (a *agent) deleteIPsecEncryptRoute() {
@@ -1229,7 +1309,7 @@ func (a *agent) deleteIPsecEncryptRoute() {
 	}
 }
 
-func (a *agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath string, nodeHandler node.Handler, health cell.Health) error {
+func (a *agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath string, nodeHandler node.Handler, health cell.Health) (err error) {
 	for {
 		select {
 		case event := <-watcher.Events:
@@ -1256,39 +1336,20 @@ func (a *agent) keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, 
 				}
 			}
 
-			_, spi, err := a.loadIPSecKeysFile(keyfilePath)
+			a.authKeySize, a.pendingSPI, err = a.loadIPSecKeysFile(keyfilePath)
 			if err != nil {
 				health.Degraded(fmt.Sprintf("Failed to load keyfile %q", keyfilePath), err)
 				a.log.Error("Failed to load IPsec keyfile", logfields.Error, err)
 				continue
 			}
 			a.log.Info("Loaded IPsec keyfile",
-				logfields.SPI, spi,
+				logfields.SPI, a.pendingSPI,
 				logfields.Path, keyfilePath,
 			)
 
-			// AllNodeValidateImplementation will eventually call
-			// nodeUpdate(), which is responsible for updating the
-			// IPSec policies and states for all the different EPs
-			// with ipsec.UpsertIPsecEndpoint(). We do this before
-			// advertising the new SPI to ensure our ingress XFRM
-			// states are ready before peers start sending traffic
-			// encrypted with the new key.
-			nodeHandler.AllNodeValidateImplementation()
-
-			// Update the IPSec key identity in the local node.
-			// This will set addrs.ipsecKeyIdentity in the node
-			// package, and eventually trigger an update to
-			// publish the updated information to k8s/kvstore.
-			a.localNode.Update(func(ln *node.LocalNode) {
-				ln.EncryptionKey = spi
-			})
-
-			// Push SPI update into BPF datapath now that XFRM state
-			// is configured.
-			if err := a.setIPSecSPI(spi); err != nil {
-				health.Degraded("Failed to set IPsec SPI", err)
-				a.log.Error("Failed to set IPsec SPI", logfields.Error, err)
+			if err := a.publishPendingSPI(nodeHandler); err != nil {
+				health.Degraded("Failed to publish pending SPI", err)
+				a.log.Error("Failed to publish pending SPI", logfields.Error, err)
 				continue
 			}
 			health.OK("Watching keyfiles")

--- a/pkg/datapath/linux/ipsec/types/ipsec.go
+++ b/pkg/datapath/linux/ipsec/types/ipsec.go
@@ -19,7 +19,7 @@ type Agent interface {
 	Enabled() bool
 	AuthKeySize() int
 	SPI() uint8
-	StartBackgroundJobs(node.Handler) error
+	StartBackgroundJobs(node.Handler, <-chan struct{}) error
 	UpsertIPsecEndpoint(params *Parameters) (uint8, error)
 	DeleteIPsecEndpoint(nodeID uint16) error
 	DeleteXFRM(reqID int) error


### PR DESCRIPTION
Move SPI advertisement (eBPF map + CiliumNode update) out of Agent.Start() into a new PublishKeyIdentity() method. The orchestrator calls PublishKeyIdentity() in reinitialize() after XFRM states are configured, ensuring peers do not learn about a new key before the local node is ready to receive traffic encrypted with it.

This fixes a race condition when the key watcher is disabled: the SPI was previously published at agent startup before XFRM states existed, causing packet drops if remote nodes picked up the new key first.

```
Before: agent-restart -> load key → update BPF -> advertise → setup XFRM during reinitialze()
After:  agent-restart -> load key → setup XFRM during reinitialize() → advertise → update BPF
```

This race condition can be triggered if key-watcher is disabled and ipsec key rotation is done by doing agent-restart after cilium-ipsec-keys secret update.

Below is the release-note for this PR

```release-note
Fix IPsec packet drops during rolling restart with key rotation by deferring SPI advertisement until XFRM states are ready
```