### PR TITLE
fix(egressGateway): skip unmatched gateways when using multiple gateway

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -914,6 +914,18 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap)
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
 
+	// Update one gateway so it no longer matches the policy and check that the endpoints get
+	// redistributed across the remaining gateways.
+	nodes[1].labels = nodeGroupNotFoundLabels
+	updatedNode := newCiliumNode(node2, node2IP, nodes[1].labels)
+	addNodeAndReconcile(t, k, egressGatewayManager, &updatedNode)
+	nodes[1].node = &updatedNode
+
+	ipV4ExpectedpolicyMap = assignEndpoints(eps, []testNodes{nodes[0], nodes[2]}, 0, true)
+	ipV6ExpectedpolicyMap = assignEndpoints(eps, []testNodes{nodes[0], nodes[2]}, ifIndex1, false)
+	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap)
+	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
+
 	// Remove two gateways to ensure the endpoints are migrated to the single gateway left.
 	policy1.policyGwParams = policy1.policyGwParams[:1]
 	addPolicyAndReconcile(t, egressGatewayManager, k.policies, &policy1)

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -156,7 +156,19 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 			break
 		}
 
+		if gwc.gatewayIP == GatewayNotFoundIPv4 {
+			continue
+		}
+
 		config.gatewayConfigs = append(config.gatewayConfigs, gwc)
+	}
+
+	if len(config.gatewayConfigs) == 0 {
+		config.gatewayConfigs = append(config.gatewayConfigs, gatewayConfig{
+			egressIP4: netip.IPv4Unspecified(),
+			egressIP6: netip.IPv6Unspecified(),
+			gatewayIP: GatewayNotFoundIPv4,
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes endpoint reassignment for multigateway egress gateway policies when one or more configured gateway nodes stops matching the policy, for example after a node label change.

Before this change, unmatched gateways could remain in the runtime gateway set as unresolved entries. Endpoint assignment would continue hashing across that full set, which could cause some endpoints to be assigned to `Not Found` instead of being redistributed across the remaining active gateways, contrary to the documented multigateway behavior.

The existing multigateway test covered removing gateways from the policy itself, but it did not cover the case where the policy still lists the same gateways and one of them becomes unmatched due to a node update. That is why this bug was not caught by the previous test.

## Changes

- Skip unmatched gateways when rebuilding runtime `gatewayConfigs`.
- Keep a single synthetic `Not Found` gateway config only when no configured gateways match any node.
- Extend `TestPrivilegedMultigatewayPolicy` to cover a node label change that makes one configured gateway stop matching while the policy still contains all gateway entries.
