### PR TITLE
bpf: unconditionally define cilium_nodeport_nat_buffer

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -104,7 +104,6 @@ lxc_redirect_to_host(struct __ctx_buff *ctx, __u32 src_sec_identity,
 # define ENABLE_PER_PACKET_LB 1
 #endif
 
-#if defined(ENABLE_PER_PACKET_LB) && defined(ENABLE_NODEPORT)
 struct nodeport_nat_info {
 	union v6addr nat_addr;
 	__be16 nat_port;
@@ -116,7 +115,6 @@ struct {
 	__type(value, struct nodeport_nat_info);
 	__uint(max_entries, 1);
 } cilium_nodeport_nat_buffer __section_maps_btf;
-#endif /* ENABLE_PER_PACKET_LB && ENABLE_NODEPORT */
 
 #ifdef ENABLE_IPV4
 static __always_inline void


### PR DESCRIPTION
The cilium_nodeport_nat_buffer map is currently defined conditionally on `ENABLE_PER_PACKET_LB && ENABLE_NODEPORT`. Since the map spec registry requires an ELF with all map definitions, we make the map unconditionally defined.

Previous changes such as map pruning ensure we can do this without negative side effects.