### PR TITLE
[v1.17] bpf: nodeport: use hairpin redirect for L7 LB on bridge devices

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1245,6 +1245,10 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 #  if defined(ENABLE_TPROXY)
 		return ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
 #  else
+		/* See IPv4 codepath for comments. */
+		if (CONFIG(proxy_redirect_via_cilium_net))
+			return ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
+
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
 		ctx->mark = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
@@ -2549,6 +2553,13 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 #  if defined(ENABLE_TPROXY)
 		return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
 #  else
+		/* Even if BPF tproxy is disabled, there are cases in which we
+		 * must hairpin the packet through cilium_net (ex. when we attach
+		 * cil_from_netdev to a bridge iface).
+		 */
+		if (CONFIG(proxy_redirect_via_cilium_net))
+			return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
+
 		/* Pass the packet straight to the proxy, without redirecting via
 		 * cilium_host.
 		 */

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -13,6 +13,8 @@
 #include "csum.h"
 #include "l4.h"
 
+DECLARE_CONFIG(bool, proxy_redirect_via_cilium_net, "Whether to redirect to the proxy via cilium_net (hairpin) or via stack")
+
 #if defined(HOST_IFINDEX_MAC) && defined(HOST_IFINDEX)
 
 /** Redirect to the proxy by hairpinning the packet out the incoming

--- a/bpf/tests/l7_lb_hairpin.c
+++ b/bpf/tests/l7_lb_hairpin.c
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_L7_LB
+#define ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_PORT		tcp_svc_one
+
+#define LB_IP			v4_node_one
+#define IPV4_DIRECT_ROUTING	LB_IP
+
+#define ENCAP_IFINDEX		0
+
+#define PROXY_PORT		10000
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *lb_mac = mac_host;
+
+/* Track ctx_redirect calls */
+static volatile __u32 redirect_ifindex;
+
+#define fib_lookup mock_fib_lookup
+
+long mock_fib_lookup(const __maybe_unused void *ctx,
+		     const struct bpf_fib_lookup *params __maybe_unused,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	return BPF_FIB_LKUP_RET_NO_NEIGH;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex, __u32 flags __maybe_unused)
+{
+	redirect_ifindex = (__u32)ifindex;
+	return CTX_ACT_REDIRECT;
+}
+
+#include "bpf_host.c"
+
+#include "lib/lb.h"
+#include "lib/ipcache.h"
+#include "lib/clear.h"
+
+ASSIGN_CONFIG(__u32, cilium_net_ifindex, HOST_IFINDEX)
+
+/* Enable redirect via cilium_net to test hairpinning when cil_from_netdev
+ * is attached to a bridge device.
+ */
+ASSIGN_CONFIG(bool, proxy_redirect_via_cilium_net, true)
+
+#define FROM_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+	},
+};
+
+/* Test 1: IPv4 L7 LB on bridge device. Ensure packets is hairpinned via cilium_net. */
+PKTGEN("tc", "l7_lb_hairpin_v4")
+int l7_lb_hairpin_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_hairpin_v4")
+int l7_lb_hairpin_v4_setup(struct __ctx_buff *ctx)
+{
+	clear_map(&LB4_SERVICES_MAP_V2);
+	clear_map(&LB4_REVERSE_NAT_MAP);
+
+	lb_v4_add_l7_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, PROXY_PORT);
+
+	ipcache_v4_add_entry(FRONTEND_IP, 0, 112233, 0, 0);
+
+	redirect_ifindex = 0;
+
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "l7_lb_hairpin_v4")
+int l7_lb_hairpin_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	if (redirect_ifindex != CONFIG(cilium_net_ifindex))
+		test_fatal("expected redirect to cilium_net (ifindex %d), got ifindex %d",
+			   CONFIG(cilium_net_ifindex), redirect_ifindex);
+
+	test_finish();
+}
+
+/* Test 1: IPv6 L7 LB on bridge device. Ensure packets is hairpinned via cilium_net. */
+PKTGEN("tc", "l7_lb_hairpin_v6")
+int l7_lb_hairpin_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  (__u8 *)v6_ext_node_one,
+					  (__u8 *)v6_svc_one,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_hairpin_v6")
+int l7_lb_hairpin_v6_setup(struct __ctx_buff *ctx)
+{
+	clear_map(&LB6_SERVICES_MAP_V2);
+	clear_map(&LB6_REVERSE_NAT_MAP);
+
+	lb_v6_add_l7_service((union v6addr *)v6_svc_one, FRONTEND_PORT,
+			     IPPROTO_TCP, 1, PROXY_PORT);
+
+	ipcache_v6_add_entry((union v6addr *)v6_svc_one, 0, 112233, 0, 0);
+
+	redirect_ifindex = 0;
+
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "l7_lb_hairpin_v6")
+int l7_lb_hairpin_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	if (redirect_ifindex != CONFIG(cilium_net_ifindex))
+		test_fatal("expected redirect to cilium_net (ifindex %d), got ifindex %d",
+			   CONFIG(cilium_net_ifindex), redirect_ifindex);
+
+	test_finish();
+}

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -57,6 +57,34 @@ lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u16 backend_count, __u1
 }
 
 static __always_inline void
+lb_v4_add_l7_service(__be32 addr, __be16 port, __u8 proto,
+		     __u16 rev_nat_index, __u32 proxy_port)
+{
+	struct lb4_key svc_key = {
+		.address = addr,
+		.dport = port,
+		.proto = proto,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	struct lb4_service svc_value = {
+		.l7_lb_proxy_port = proxy_port,
+		.count = 0,
+		.rev_nat_index = rev_nat_index,
+		.flags = SVC_FLAG_ROUTABLE,
+		.flags2 = SVC_FLAG_L7LOADBALANCER,
+	};
+
+	map_update_elem(&LB4_SERVICES_MAP_V2, &svc_key, &svc_value, BPF_ANY);
+
+	struct lb4_reverse_nat revnat_value = {
+		.address = addr,
+		.port = port,
+	};
+
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &rev_nat_index, &revnat_value, BPF_ANY);
+}
+
+static __always_inline void
 lb_v4_upsert_backend(__u32 backend_id, __be32 backend_addr, __be16 backend_port,
 		     __u8 backend_proto, __u8 flags, __u8 cluster_id)
 {
@@ -166,5 +194,33 @@ lb_v6_add_backend(const union v6addr *svc_addr, __be16 svc_port, __u16 backend_s
 
 	memcpy(&backend.address, backend_addr, sizeof(*backend_addr));
 	map_update_elem(&LB6_BACKEND_MAP, &backend_id, &backend, BPF_ANY);
+}
+
+static __always_inline void
+lb_v6_add_l7_service(const union v6addr *addr, __be16 port, __u8 proto,
+		     __u16 rev_nat_index, __u32 proxy_port)
+{
+	struct lb6_key svc_key __align_stack_8 = {
+		.dport = port,
+		.proto = proto,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	struct lb6_service svc_value = {
+		.l7_lb_proxy_port = proxy_port,
+		.count = 0,
+		.rev_nat_index = rev_nat_index,
+		.flags = SVC_FLAG_ROUTABLE,
+		.flags2 = SVC_FLAG_L7LOADBALANCER,
+	};
+
+	memcpy(&svc_key.address, addr, sizeof(*addr));
+	map_update_elem(&LB6_SERVICES_MAP_V2, &svc_key, &svc_value, BPF_ANY);
+
+	struct lb6_reverse_nat revnat_value __align_stack_8 = {
+		.port = port,
+	};
+
+	memcpy(&revnat_value.address, addr, sizeof(*addr));
+	map_update_elem(&LB6_REVERSE_NAT_MAP, &rev_nat_index, &revnat_value, BPF_ANY);
 }
 #endif

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -37,6 +37,7 @@ static volatile const __u8 mac_four[] =  {0x0D, 0x1D, 0x22, 0x59, 0xA9, 0xC2};
 static volatile const __u8 mac_five[] =  {0x15, 0x21, 0x39, 0x45, 0x4D, 0x5D};
 static volatile const __u8 mac_six[] =   {0x08, 0x14, 0x1C, 0x32, 0x52, 0x7E};
 static volatile const __u8 mac_zero[] =  {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+static volatile const __u8 mac_host[] = { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
 
 /* A collection of pre-defined IP addresses, so tests can reuse them without
  *  having to come up with custom ips.
@@ -87,6 +88,8 @@ static volatile const __section(".rodata") __u8 v6_node_three[] = {0xfd, 0x07, 0
 
 volatile const __u8 v6_ext_node_one[] = v6_ext_node_one_addr;
 volatile const __u8 v6_ext_node_two[] = v6_ext_node_two_addr;
+
+static volatile const __u8 v6_svc_one[] = {0xfd, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
 /* Source port to be used by a client */
 #define tcp_src_one	__bpf_htons(22330)

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -441,6 +441,11 @@ func attachNetworkDevices(cfg *datapath.LocalNodeConfiguration, ep datapath.Endp
 			return err
 		}
 
+		switch iface.(type) {
+		case *netlink.Bridge:
+			consts["proxy_redirect_via_cilium_net"] = 1
+		}
+
 		var netdevObj hostNetdevObjects
 		commit, err := bpf.LoadAndAssign(&netdevObj, spec, &bpf.CollectionOptions{
 			CollectionOptions: ebpf.CollectionOptions{


### PR DESCRIPTION
* [ ] #44658 (@smagnani96 ): Resolved conflicts, adapted implementation to old loader

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 44658
```
