### PR TITLE
bpf_lxc: improve per-packet LB for NodePort services

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -200,6 +200,8 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 		 */
 		if (!ct_has_egress_entry4(get_ct_map4(&tmp), &tmp)) {
 			svc = lb4_lookup_wildcard_nodeport_service(&key);
+			if (svc && !lb4_svc_is_nodeport(svc))
+				svc = NULL;
 			if (svc) {
 				struct nodeport_nat_info nat_info = {};
 				__u32 zero = 0;
@@ -378,6 +380,8 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 		 */
 		if (!ct_has_egress_entry6(get_ct_map6(&tmp), &tmp)) {
 			svc = lb6_lookup_wildcard_nodeport_service(&key);
+			if (svc && !lb6_svc_is_nodeport(svc))
+				svc = NULL;
 			if (svc) {
 				struct nodeport_nat_info nat_info = {};
 				__u32 zero = 0;

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -92,6 +92,15 @@ lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u8 proto, __u16 backend
 }
 
 static __always_inline void
+lb_v4_add_nodeport_service(__be32 addr, __be16 port, __u8 proto,
+			   __u16 backend_count, __u16 rev_nat_index,
+			   __u8 flags2)
+{
+	__lb_v4_add_service(addr, port, proto, proto, backend_count, rev_nat_index,
+			    SVC_FLAG_ROUTABLE | SVC_FLAG_NODEPORT, flags2, false, 0);
+}
+
+static __always_inline void
 lb_v4_add_l7_service(__be32 addr, __be16 port, __u8 proto,
 		     __u16 rev_nat_index, __u32 proxy_port)
 {
@@ -216,6 +225,15 @@ lb_v6_add_service_with_flags(const union v6addr *addr, __be16 port, __u8 proto,
 {
 	__lb_v6_add_service(addr, port, proto, backend_count, rev_nat_index, flags,
 			    flags2);
+}
+
+static __always_inline void
+lb_v6_add_nodeport_service(const union v6addr *addr, __be16 port, __u8 proto,
+			   __u16 backend_count, __u16 rev_nat_index,
+			   __u8 flags2)
+{
+	__lb_v6_add_service(addr, port, proto, backend_count, rev_nat_index,
+			    SVC_FLAG_ROUTABLE | SVC_FLAG_NODEPORT, flags2);
 }
 
 static __always_inline void

--- a/bpf/tests/tc_lxc_lb4_nodeport.c
+++ b/bpf/tests/tc_lxc_lb4_nodeport.c
@@ -109,7 +109,7 @@ int lxc_v4_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 
 	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
 
-	lb_v4_add_service(0, NODEPORT_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_nodeport_service(0, NODEPORT_PORT, IPPROTO_TCP, 1, revnat_id, 0);
 	lb_v4_add_backend(0, NODEPORT_PORT, 1, 125,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -318,8 +318,8 @@ int lxc_v4_remote_nodeport_dsr_local_backend_setup(struct __ctx_buff *ctx)
 
 	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
 
-	lb_v4_add_service_with_flags(0, NODEPORT_PORT_DSR, IPPROTO_TCP, 1, revnat_id,
-				     SVC_FLAG_ROUTABLE, SVC_FLAG_FWD_MODE_DSR);
+	lb_v4_add_nodeport_service(0, NODEPORT_PORT_DSR, IPPROTO_TCP, 1, revnat_id,
+				   SVC_FLAG_FWD_MODE_DSR);
 	lb_v4_add_backend(0, NODEPORT_PORT_DSR, 1, 125,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -527,7 +527,7 @@ int lxc_v4_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
 
 	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
 
-	lb_v4_add_service(0, NODEPORT_PORT_HAIRPIN, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_nodeport_service(0, NODEPORT_PORT_HAIRPIN, IPPROTO_TCP, 1, revnat_id, 0);
 	lb_v4_add_backend(0, NODEPORT_PORT_HAIRPIN, 1, 126,
 			  CLIENT_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -836,7 +836,7 @@ int lxc_v4_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 10;
 
-	lb_v4_add_service(0, NODEPORT_PORT_UDP, IPPROTO_UDP, 1, revnat_id);
+	lb_v4_add_nodeport_service(0, NODEPORT_PORT_UDP, IPPROTO_UDP, 1, revnat_id, 0);
 	lb_v4_add_backend(0, NODEPORT_PORT_UDP, 1, 130,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
 

--- a/bpf/tests/tc_lxc_lb6_nodeport.c
+++ b/bpf/tests/tc_lxc_lb6_nodeport.c
@@ -115,7 +115,7 @@ int lxc_v6_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 
 	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
 
-	lb_v6_add_service(&zero_addr, NODEPORT_PORT, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_nodeport_service(&zero_addr, NODEPORT_PORT, IPPROTO_TCP, 1, revnat_id, 0);
 	lb_v6_add_backend(&zero_addr, NODEPORT_PORT, 1, 125,
 			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -346,8 +346,8 @@ int lxc_v6_remote_nodeport_dsr_local_backend_setup(struct __ctx_buff *ctx)
 
 	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
 
-	lb_v6_add_service_with_flags(&zero_addr, NODEPORT_PORT_DSR, IPPROTO_TCP, 1, revnat_id,
-				     SVC_FLAG_ROUTABLE, SVC_FLAG_FWD_MODE_DSR);
+	lb_v6_add_nodeport_service(&zero_addr, NODEPORT_PORT_DSR, IPPROTO_TCP, 1, revnat_id,
+				   SVC_FLAG_FWD_MODE_DSR);
 	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_DSR, 1, 125,
 			  &backend_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -577,7 +577,7 @@ int lxc_v6_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
 
 	ipcache_v6_add_entry(&remote_node_ip, 0, REMOTE_NODE_ID, 0, 0);
 
-	lb_v6_add_service(&zero_addr, NODEPORT_PORT_HAIRPIN, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_nodeport_service(&zero_addr, NODEPORT_PORT_HAIRPIN, IPPROTO_TCP, 1, revnat_id, 0);
 	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_HAIRPIN, 1, 126,
 			  &client_ip, BACKEND_PORT, IPPROTO_TCP, 0);
 
@@ -913,7 +913,7 @@ int lxc_v6_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
 	__u16 revnat_id = 10;
 
 	/* NOW add the wildcard NodePort service with local backend */
-	lb_v6_add_service(&zero_addr, NODEPORT_PORT_UDP, IPPROTO_UDP, 1, revnat_id);
+	lb_v6_add_nodeport_service(&zero_addr, NODEPORT_PORT_UDP, IPPROTO_UDP, 1, revnat_id, 0);
 	lb_v6_add_backend(&zero_addr, NODEPORT_PORT_UDP, 1, 130,
 			  (union v6addr *)BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
 


### PR DESCRIPTION
- checked for SVC_FLAG_NODEPORT
- modify test wildcard services to use flags

Relates: #44620 


