### PR TITLE
loadbalancer: Fix deletion of backends during resynchronization

### DIFF
--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"unsafe"
 
@@ -20,6 +21,7 @@ import (
 	apiext_fake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	versionapi "k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
@@ -234,10 +236,7 @@ func prependReactors(cs prepender, ot *statedbObjectTracker) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 		watch, err := ot.Watch(gvr, ns, opts)
-		if err != nil {
-			return false, nil, err
-		}
-		return true, watch, nil
+		return true, watch, err
 	})
 
 	// Switch out the tracker to our version.
@@ -251,16 +250,81 @@ func showGVR(gvr schema.GroupVersionResource) string {
 	return fmt.Sprintf("%s.%s.%s", gvr.Group, gvr.Version, gvr.Resource)
 }
 
+func resolveGVR(resource string, gvrks []gvrk) (schema.GroupVersionResource, schema.GroupVersionKind, string, bool) {
+	for _, gvrk := range gvrks {
+		res := showGVR(gvrk.GroupVersionResource)
+		if res == resource {
+			return gvrk.GroupVersionResource, gvrk.groupVersionKind(), "", true
+		}
+		if strings.Contains(res, resource) {
+			return gvrk.GroupVersionResource, gvrk.groupVersionKind(), res, true
+		}
+	}
+	return schema.GroupVersionResource{}, schema.GroupVersionKind{}, "", false
+}
+
 func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
+	readInputFile := func(s *script.State, file string) ([]byte, error) {
+		b, err := os.ReadFile(s.Path(file))
+		if err == nil {
+			return b, nil
+		}
+		// Try relative to current directory, e.g. to allow reading "testdata/foo.yaml"
+		b, err = os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", file, err)
+		}
+		return b, nil
+	}
+
+	decodeTrackerObjects := func(s *script.State, file string) ([]object, schema.GroupVersionResource, error) {
+		b, err := readInputFile(s, file)
+		if err != nil {
+			return nil, schema.GroupVersionResource{}, err
+		}
+
+		obj, gvk, err := testutils.DecodeObjectGVK(b)
+		if err != nil {
+			return nil, schema.GroupVersionResource{}, fmt.Errorf("decode: %w", err)
+		}
+		kobj, _, _ := testutils.DecodeKubernetesObject(b)
+		gvr, _ := meta.UnsafeGuessKindToResource(*gvk)
+
+		toObject := func(domain string, obj runtime.Object) (object, error) {
+			objMeta, err := meta.Accessor(obj)
+			if err != nil {
+				return object{}, fmt.Errorf("accessor: %w", err)
+			}
+			return object{
+				objectId: newObjectId(domain, gvr, objMeta.GetNamespace(), objMeta.GetName()),
+				kind:     gvk.Kind,
+				o:        obj,
+			}, nil
+		}
+
+		objs := make([]object, 0, 2)
+		o, err := toObject("*", obj)
+		if err != nil {
+			return nil, schema.GroupVersionResource{}, err
+		}
+		objs = append(objs, o)
+
+		if kobj != nil {
+			o, err := toObject("k8s", kobj)
+			if err != nil {
+				return nil, schema.GroupVersionResource{}, err
+			}
+			objs = append(objs, o)
+		}
+
+		return objs, gvr, nil
+	}
+
 	addUpdateOrDelete := func(s *script.State, action string, files []string) error {
 		for _, file := range files {
-			b, err := os.ReadFile(s.Path(file))
+			b, err := readInputFile(s, file)
 			if err != nil {
-				// Try relative to current directory, e.g. to allow reading "testdata/foo.yaml"
-				b, err = os.ReadFile(file)
-			}
-			if err != nil {
-				return fmt.Errorf("failed to read %s: %w", file, err)
+				return err
 			}
 			obj, gvk, err := testutils.DecodeObjectGVK(b)
 			if err != nil {
@@ -393,20 +457,13 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					return nil, script.ErrUsage
 				}
 
-				var gvr schema.GroupVersionResource
-				for gvrk := range fc.ot.getGVRKs() {
-					res := showGVR(gvrk.GroupVersionResource)
-					if res == args[0] {
-						gvr = gvrk.GroupVersionResource
-						break
-					} else if strings.Contains(res, args[0]) {
-						s.Logf("Using closest match %q\n", res)
-						gvr = gvrk.GroupVersionResource
-						break
-					}
-				}
-				if gvr.Resource == "" {
+				gvrks := slices.Collect(fc.ot.getGVRKs())
+				gvr, _, match, ok := resolveGVR(args[0], gvrks)
+				if !ok {
 					return nil, fmt.Errorf("%q not a known resource, see 'k8s/resources' for full list", args[0])
+				}
+				if match != "" {
+					s.Logf("Using closest match %q\n", match)
 				}
 
 				ns, name, found := strings.Cut(args[1], "/")
@@ -454,23 +511,13 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					return nil, fmt.Errorf("%w: expected resource and namespace", script.ErrUsage)
 				}
 
-				var gvr schema.GroupVersionResource
-				var gvk schema.GroupVersionKind
-				for gvrk := range fc.ot.getGVRKs() {
-					res := showGVR(gvrk.GroupVersionResource)
-					if res == args[0] {
-						gvr = gvrk.GroupVersionResource
-						gvk = gvrk.groupVersionKind()
-						break
-					} else if strings.Contains(res, args[0]) {
-						s.Logf("Using closest match %q\n", res)
-						gvr = gvrk.GroupVersionResource
-						gvk = gvrk.groupVersionKind()
-						break
-					}
-				}
-				if gvr.Resource == "" {
+				gvrks := slices.Collect(fc.ot.getGVRKs())
+				gvr, gvk, match, ok := resolveGVR(args[0], gvrks)
+				if !ok {
 					return nil, fmt.Errorf("%q not a known resource, see 'k8s/resources' for full list", args[0])
+				}
+				if match != "" {
+					s.Logf("Using closest match %q\n", match)
 				}
 
 				return func(s *script.State) (stdout string, stderr string, err error) {
@@ -488,6 +535,57 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					}
 					return "", "", fmt.Errorf("%w: no tracker recognized %s", trackerErr, gvr)
 				}, nil
+			},
+		),
+
+		"k8s/resync": script.Command(
+			script.CmdUsage{
+				Summary: "Atomically replace tracked objects for a resource and restart watches",
+				Detail: []string{
+					"This closes matching watch streams, deletes the existing tracked",
+					"objects for the resource, and inserts the optional new objects.",
+				},
+				Args: "resource (files...)",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) == 0 {
+					return nil, fmt.Errorf("%w: expected resource and optional files", script.ErrUsage)
+				}
+
+				gvrks := slices.Collect(fc.ot.getGVRKs())
+				gvr, _, match, ok := resolveGVR(args[0], gvrks)
+				if !ok {
+					return nil, fmt.Errorf("%q not a known resource, see 'k8s/resources' for full list", args[0])
+				}
+				if match != "" {
+					s.Logf("Using closest match %q\n", match)
+				}
+
+				files := args[1:]
+
+				replacements := make([]object, 0, len(files)*2)
+				for _, file := range files {
+					objs, fileGVR, err := decodeTrackerObjects(s, file)
+					if err != nil {
+						return nil, err
+					}
+					if fileGVR != gvr {
+						return nil, fmt.Errorf("%s is %s, expected %s", file, showGVR(fileGVR), showGVR(gvr))
+					}
+					replacements = append(replacements, objs...)
+				}
+
+				return nil, func() error {
+					stopped, rev, err := fc.ot.Resync(gvr, replacements)
+					if err != nil {
+						return err
+					}
+					s.Logf(
+						"Restarted %d watch(es) for %s at revision %d with %d replacement object(s)\n",
+						stopped, showGVR(gvr), rev, len(replacements),
+					)
+					return nil
+				}()
 			},
 		),
 

--- a/pkg/k8s/client/testutils/object_tracker.go
+++ b/pkg/k8s/client/testutils/object_tracker.go
@@ -31,11 +31,12 @@ import (
 
 	"github.com/cilium/cilium/pkg/container"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
-	logfieldGVR               = "gvr" //  GroupVersIonResource
+	logfieldGVR               = "gvr" //  GroupVersionResource
 	logfieldClientset         = "clientset"
 	logfieldResourceVersion   = "resourceVersion"
 	logfieldFieldSelector     = "fieldSelector"
@@ -51,12 +52,13 @@ const (
 //
 // https://pkg.go.dev/k8s.io/client-go/testing#ObjectTracker
 type statedbObjectTracker struct {
-	domain  string
-	log     *slog.Logger
-	db      *statedb.DB
-	scheme  *runtime.Scheme
-	decoder runtime.Decoder
-	tbl     statedb.RWTable[object]
+	domain   string
+	log      *slog.Logger
+	db       *statedb.DB
+	scheme   *runtime.Scheme
+	decoder  runtime.Decoder
+	tbl      statedb.RWTable[object]
+	registry *watchRegistry
 }
 
 func newStateDBObjectTracker(db *statedb.DB, log *slog.Logger) (*statedbObjectTracker, error) {
@@ -70,7 +72,72 @@ func newStateDBObjectTracker(db *statedb.DB, log *slog.Logger) (*statedbObjectTr
 		tbl:     tbl,
 		scheme:  testutils.Scheme,
 		decoder: testutils.Decoder(),
+		registry: &watchRegistry{
+			watches:     make(map[uint64]*statedbWatch),
+			watermarks:  make(map[watchKey]statedb.Revision),
+			generations: make(map[watchKey]uint64),
+		},
 	}, nil
+}
+
+type watchRegistry struct {
+	mu          lock.Mutex
+	nextID      uint64
+	nextGen     uint64
+	watches     map[uint64]*statedbWatch
+	watermarks  map[watchKey]statedb.Revision
+	generations map[watchKey]uint64
+}
+
+type watchKey struct {
+	gvr schema.GroupVersionResource
+	ns  string
+}
+
+func (r *watchRegistry) registerLocked(w *statedbWatch) uint64 {
+	r.nextID++
+	id := r.nextID
+	r.watches[id] = w
+	return id
+}
+
+func (r *watchRegistry) unregister(id uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.watches, id)
+}
+
+func watchOverlaps(resyncNS, watchNS string) bool {
+	if resyncNS == "" || watchNS == "" {
+		return true
+	}
+	return resyncNS == watchNS
+}
+
+func (r *watchRegistry) lowWatermarkLocked(gvr schema.GroupVersionResource, ns string) statedb.Revision {
+	var rev statedb.Revision
+	for key, watermark := range r.watermarks {
+		if key.gvr != gvr || !watchOverlaps(key.ns, ns) {
+			continue
+		}
+		if watermark > rev {
+			rev = watermark
+		}
+	}
+	return rev
+}
+
+func (r *watchRegistry) generationLocked(gvr schema.GroupVersionResource, ns string) uint64 {
+	var gen uint64
+	for key, candidate := range r.generations {
+		if key.gvr != gvr || !watchOverlaps(key.ns, ns) {
+			continue
+		}
+		if candidate > gen {
+			gen = candidate
+		}
+	}
+	return gen
 }
 
 type object struct {
@@ -167,6 +234,79 @@ func (s *statedbObjectTracker) For(domain string, scheme *runtime.Scheme, decode
 	o.scheme = scheme
 	o.decoder = decoder
 	return &o
+}
+
+func (s *statedbObjectTracker) Resync(gvr schema.GroupVersionResource, replacements []object) (int, statedb.Revision, error) {
+	s.registry.mu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			s.registry.mu.Unlock()
+		}
+	}()
+
+	matches := make([]*statedbWatch, 0)
+	for _, w := range s.registry.watches {
+		if w.gvr != gvr {
+			continue
+		}
+		matches = append(matches, w)
+	}
+
+	wtxn := s.db.WriteTxn(s.tbl)
+	defer wtxn.Abort()
+
+	key := watchKey{gvr: gvr}
+	rev := s.tbl.Revision(wtxn) + 1
+
+	for obj := range s.tbl.All(wtxn) {
+		if obj.gvr != gvr || obj.deleted {
+			continue
+		}
+		obj.deleted = true
+		if _, _, err := s.tbl.Insert(wtxn, obj); err != nil {
+			return 0, 0, err
+		}
+	}
+
+	for _, replacement := range replacements {
+		if replacement.gvr != gvr {
+			return 0, 0, fmt.Errorf("replacement %s does not match %s", replacement.gvr, gvr)
+		}
+
+		insert := replacement.o.DeepCopyObject()
+		objMeta, err := meta.Accessor(insert)
+		if err != nil {
+			return 0, 0, err
+		}
+		rev = s.tbl.Revision(wtxn) + 1
+		objMeta.SetResourceVersion(strconv.FormatUint(uint64(rev), 10))
+		fillTypeMetaIfNeeded(insert, gvr.GroupVersion().WithKind(replacement.kind))
+
+		if _, _, err := s.tbl.Insert(wtxn, object{
+			objectId: newObjectId(replacement.domain, gvr, objMeta.GetNamespace(), objMeta.GetName()),
+			kind:     replacement.kind,
+			o:        insert,
+		}); err != nil {
+			return 0, 0, err
+		}
+	}
+
+	if len(replacements) == 0 {
+		rev = s.tbl.Revision(wtxn)
+	}
+	s.registry.nextGen++
+	s.registry.watermarks[key] = rev
+	s.registry.generations[key] = s.registry.nextGen
+
+	wtxn.Commit()
+	locked = false
+	s.registry.mu.Unlock()
+
+	for _, w := range matches {
+		w.injectExpired()
+	}
+	return len(matches), rev, nil
 }
 
 func (s *statedbObjectTracker) ObjectReaction() testing.ReactionFunc {
@@ -631,9 +771,21 @@ func (s *statedbObjectTracker) Watch(gvr schema.GroupVersionResource, ns string,
 		stop:              make(chan struct{}),
 		stopped:           make(chan struct{}),
 		events:            make(chan watch.Event, 1),
+		injectErr:         make(chan runtime.Object, 1),
 		fieldSelector:     fieldSelector,
 		sendInitialEvents: sendInitialEvents,
+		registry:          s.registry,
 	}
+	s.registry.mu.Lock()
+	if minRV := s.registry.lowWatermarkLocked(gvr, ns); version > 0 && version < uint64(minRV) {
+		s.registry.mu.Unlock()
+		return nil, apierrors.NewResourceExpired(
+			fmt.Sprintf("resourceVersion %d is older than the minimum allowed %d after resync", version, minRV),
+		)
+	}
+	w.generation = s.registry.generationLocked(gvr, ns)
+	w.id = s.registry.registerLocked(w)
+	s.registry.mu.Unlock()
 	go w.feed()
 
 	return w, nil
@@ -653,13 +805,26 @@ type statedbWatch struct {
 	stopOnce          sync.Once
 	stopped           chan struct{}
 	events            chan watch.Event
+	injectErr         chan runtime.Object
 	fieldSelector     fields.Selector
 	sendInitialEvents bool
+	registry          *watchRegistry
+	generation        uint64
+	id                uint64
 }
 
 // ResultChan implements watch.Interface.
 func (w *statedbWatch) ResultChan() <-chan watch.Event {
 	return w.events
+}
+
+func (w *statedbWatch) superseded() bool {
+	if w.registry == nil {
+		return false
+	}
+	w.registry.mu.Lock()
+	defer w.registry.mu.Unlock()
+	return w.generation != w.registry.generationLocked(w.gvr, w.ns)
 }
 
 func (w *statedbWatch) feed() {
@@ -668,12 +833,21 @@ func (w *statedbWatch) feed() {
 	seen := sets.New[string]()
 	lastRev := w.version
 
+	if w.superseded() {
+		w.emitExpired("synthetic resync")
+		return
+	}
+
 	// WatchList semantics: if sendInitialEvents is true, first send Added events
 	// for all existing objects, then send a Bookmark event to signal the end of
 	// initial events.
 	if w.sendInitialEvents {
 		txn := w.db.ReadTxn()
 		for obj := range w.tbl.All(txn) {
+			if w.superseded() {
+				w.emitExpired("synthetic resync")
+				return
+			}
 			if obj.deleted {
 				continue
 			}
@@ -720,6 +894,10 @@ func (w *statedbWatch) feed() {
 			Object: w.createBookmarkObject(lastRev),
 		}
 		w.log.Debug("SendingBookmark", logfieldResourceVersion, lastRev)
+		if w.superseded() {
+			w.emitExpired("synthetic resync")
+			return
+		}
 		select {
 		case w.events <- ev:
 		case <-w.stop:
@@ -728,8 +906,16 @@ func (w *statedbWatch) feed() {
 	}
 
 	for {
+		if w.superseded() {
+			w.emitExpired("synthetic resync")
+			return
+		}
 		objs, objsWatch := w.tbl.LowerBoundWatch(w.db.ReadTxn(), statedb.ByRevision[object](lastRev+1))
 		for obj, rev := range objs {
+			if w.superseded() {
+				w.emitExpired("synthetic resync")
+				return
+			}
 			lastRev = rev
 			if obj.domain != w.clientset {
 				continue
@@ -776,6 +962,12 @@ func (w *statedbWatch) feed() {
 		}
 		select {
 		case <-w.stop:
+			return
+		case errObj := <-w.injectErr:
+			select {
+			case w.events <- watch.Event{Type: watch.Error, Object: errObj}:
+			case <-w.stop:
+			}
 			return
 		case <-objsWatch:
 		}
@@ -856,6 +1048,29 @@ func (w *statedbWatch) Stop() {
 		close(w.stop)
 	})
 	<-w.stopped
+	if w.registry != nil {
+		w.registry.unregister(w.id)
+	}
+}
+
+func (w *statedbWatch) injectExpired() {
+	w.sendExpired("synthetic resync")
+}
+
+func (w *statedbWatch) emitExpired(message string) {
+	status := apierrors.NewResourceExpired(message).ErrStatus.DeepCopyObject()
+	select {
+	case w.events <- watch.Event{Type: watch.Error, Object: status}:
+	case <-w.stop:
+	}
+}
+
+func (w *statedbWatch) sendExpired(message string) {
+	status := apierrors.NewResourceExpired(message).ErrStatus.DeepCopyObject()
+	select {
+	case w.injectErr <- status:
+	case <-w.stopped:
+	}
 }
 
 var _ watch.Interface = &statedbWatch{}

--- a/pkg/k8s/client/testutils/object_tracker_test.go
+++ b/pkg/k8s/client/testutils/object_tracker_test.go
@@ -5,13 +5,17 @@ package testutils
 
 import (
 	"log/slog"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -90,4 +94,76 @@ func TestStateDBObjectTracker_fillTypeMeta(t *testing.T) {
 	require.Equal(t, "cilium.io/v2", cn.TypeMeta.APIVersion)
 	require.Equal(t, "4", cn.GetResourceVersion())
 
+}
+
+func TestStateDBObjectTracker_ResyncInjectsExpiredWatchError(t *testing.T) {
+	db := statedb.New()
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	ot, err := newStateDBObjectTracker(db, log)
+	require.NoError(t, err)
+
+	svc := &v1.Service{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "echo",
+			Namespace: "test",
+		},
+	}
+	require.NoError(t, ot.Add(svc))
+	rv := strconv.FormatUint(ot.tbl.Revision(ot.db.ReadTxn()), 10)
+
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "services",
+	}
+
+	watchAll, err := ot.Watch(gvr, "", metav1.ListOptions{ResourceVersion: rv})
+	require.NoError(t, err)
+	t.Cleanup(watchAll.Stop)
+
+	watchOtherNS, err := ot.Watch(gvr, "other", metav1.ListOptions{ResourceVersion: rv})
+	require.NoError(t, err)
+	t.Cleanup(watchOtherNS.Stop)
+
+	stopped, rev, err := ot.Resync(gvr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, stopped)
+	require.GreaterOrEqual(t, rev, statedb.Revision(1))
+
+	ev := requireWatchEvent(t, watchAll.ResultChan())
+	require.Equal(t, watch.Error, ev.Type)
+	status, ok := ev.Object.(*metav1.Status)
+	require.True(t, ok, "expected watch error object to be *metav1.Status")
+	require.True(t, apierrors.IsResourceExpired(apierrors.FromObject(status)))
+	ev = requireWatchEvent(t, watchOtherNS.ResultChan())
+	require.Equal(t, watch.Error, ev.Type)
+	status, ok = ev.Object.(*metav1.Status)
+	require.True(t, ok, "expected watch error object to be *metav1.Status")
+	require.True(t, apierrors.IsResourceExpired(apierrors.FromObject(status)))
+
+	_, err = ot.Watch(gvr, "test", metav1.ListOptions{ResourceVersion: rv})
+	require.Error(t, err)
+	require.True(t, apierrors.IsResourceExpired(err))
+
+	freshRV := strconv.FormatUint(uint64(rev), 10)
+	freshWatch, err := ot.Watch(gvr, "test", metav1.ListOptions{ResourceVersion: freshRV})
+	require.NoError(t, err)
+	t.Cleanup(freshWatch.Stop)
+
+	watchList, err := ot.Watch(gvr, "test", metav1.ListOptions{ResourceVersion: "0"})
+	require.NoError(t, err)
+	t.Cleanup(watchList.Stop)
+}
+
+func requireWatchEvent(t *testing.T, ch <-chan watch.Event) watch.Event {
+	t.Helper()
+	select {
+	case ev, ok := <-ch:
+		require.True(t, ok, "expected watch event")
+		return ev
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watch event")
+	}
+	return watch.Event{}
 }

--- a/pkg/k8s/client/testutils/testdata/fake.txtar
+++ b/pkg/k8s/client/testutils/testdata/fake.txtar
@@ -52,6 +52,11 @@ grep 'name: test' actual.yaml
 # Validate the table output of 'k8s-object-tracker'
 db/cmp k8s-object-tracker object-tracker.table
 
+# Test the resync command against services (without watchers).
+k8s/resync v1.services service-alt.yaml
+k8s/get v1.services test/echo -o actual.yaml
+grep 'clusterIP: 10.96.50.105' actual.yaml
+
 # Delete objects from each clientset
 k8s/delete service.yaml limitrange.yaml ciliumenvoyconfig.yaml apiext_crd.yaml mcs_svcexport.yaml
 k8s/summary summary.actual
@@ -112,6 +117,15 @@ metadata:
   uid: a49fe99c-3564-4754-acc4-780f2331a49b
 spec:
   clusterIP: 10.96.50.104
+
+-- service-alt.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.105
 
 -- limitrange.yaml --
 apiVersion: v1

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -322,9 +322,13 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 
 				err := p.Writer.UpsertBackends(txn, name, source.Kubernetes, backends)
 				rh.update("eps:"+name.String(), err)
+				if err != nil {
+					continue
+				}
 
 				currentEndpoints[eps.EndpointSliceName] = endpointsEvent{
 					name:     eps.EndpointSliceName,
+					svcName:  name,
 					backends: eps.Backends,
 				}
 			}
@@ -379,11 +383,16 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 			}
 
 			err = p.Writer.UpsertAndReleaseBackends(txn, name, source.Kubernetes, backends, orphans)
+			if err != nil {
+				rh.update("eps:"+name.String(), err)
+				return
+			}
 
 			for ep := range allEps.All() {
 				if len(ep.backends) == 0 {
 					delete(currentEndpoints, ep.name)
 				} else {
+					ep.svcName = name
 					currentEndpoints[ep.name] = ep
 				}
 			}

--- a/pkg/loadbalancer/tests/testdata/resync.txtar
+++ b/pkg/loadbalancer/tests/testdata/resync.txtar
@@ -1,0 +1,89 @@
+# Preload the fake apiserver so the reflector initializes from Replace() and
+# thus rebuilds currentEndpoints from the sync path.
+k8s/add service.yaml endpointslice.yaml
+
+# Start and wait for initialization.
+hive/start
+db/cmp services services.table
+db/cmp backends backends.table
+db/cmp frontends frontends.table
+
+# Force a resync of the endpoint slices with empty set of endpoint slices.
+# The reflector will re-list and should remove all the now orphaned backends.
+k8s/resync discovery.k8s.io.v1.endpointslices
+
+# The backend should be gone after the resync
+* db/empty backends
+
+# Restore the EndpointSlice so the next resync starts from the same state.
+k8s/add endpointslice.yaml
+db/cmp frontends frontends.table
+
+# Force a resync of the services with empty set of services.
+# The reflector will re-list and should remove the service and frontends.
+k8s/resync v1.services
+
+# Services and frontends should now be empty and backends should be unaffected.
+* db/empty services
+* db/empty frontends
+db/cmp backends backends.table
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Cluster         
+
+-- backends.table --
+Service    Address
+test/echo  10.244.1.1:80/TCP
+
+-- frontends.table --
+Address               Type        ServiceName   PortName   Backends           Status
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP  Done
+
+-- frontends_no_backends.table --
+Address               Type        ServiceName   PortName   Backends  Status
+10.96.50.104:80/TCP   ClusterIP   test/echo     http                 Done
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP


### PR DESCRIPTION
The loadbalancer reflection of EndpointSlices kept track of what endpoints it had reflected and used this when doing a resync to remove orphan backends. This state held the service name, but this was incorrectly not set on the initial synchronization which could have caused backends to be left in the backend table if a resynchronization happened without processing an upsert event containing that backend between the initial and resynchronization. When this happened the following log message would have appeared:
```
msg="BUG: Unexpected failure to delete backends" module=agent.controlplane.loadbalancer-reflectors.k8s-reflector error="object not found"
```

This adds the `k8s/resync` command so we can simulate resynchronization (e.g. loss of api-server connectivity and failure to resume `Watch` leading to re-listing from scratch). On top of this a regression test is added to show the issue with a backend being left around after resynchronization, and finally a fix for the issue to set the missing `svcName`. 

```release-note
loadbalancer: Fix issue in resynchronization of state from api-server which may have left stale backends around until an updated EndpointSlice was received
```
