### PR TITLE
pkg/datapath: deny netkit usage if using legacy host routing

### DIFF
--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -114,6 +114,11 @@ func canUseNetkit(p connectorParams) error {
 		return fmt.Errorf("netkit device probe failed, requires kernel 6.7.0+ and CONFIG_NETKIT")
 	}
 
+	// We should only run netkit with BPF Host Routing.
+	if p.DaemonConfig.UnsafeDaemonConfigOption.EnableHostLegacyRouting {
+		return fmt.Errorf("netkit devices cannot be used with --%s=true", option.EnableHostLegacyRouting)
+	}
+
 	// bpf.tproxy requires use of bpf_sk_assign() helper, which at the time of
 	// writing can only be called from TC ingress. However, netkit programs
 	// run at TC egress, so the helper returns -ENOTSUPP and tproxy cannot

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -75,6 +75,12 @@ var (
 		EnableIPv6:      true,
 		EnableBPFTProxy: true,
 	}
+	daemonConfigNetkitHostLegacyRouting = option.DaemonConfig{
+		DatapathMode:             datapathOption.DatapathModeNetkit,
+		EnableIPv4:               true,
+		EnableIPv6:               true,
+		UnsafeDaemonConfigOption: option.UnsafeDaemonConfig{EnableHostLegacyRouting: true},
+	}
 	daemonConfigNetkitL2 = option.DaemonConfig{
 		DatapathMode:    datapathOption.DatapathModeNetkitL2,
 		EnableIPv4:      true,
@@ -87,6 +93,12 @@ var (
 		EnableIPv6:      true,
 		EnableBPFTProxy: true,
 	}
+	daemonConfigNetkitL2HostLegacyRouting = option.DaemonConfig{
+		DatapathMode:             datapathOption.DatapathModeNetkitL2,
+		EnableIPv4:               true,
+		EnableIPv6:               true,
+		UnsafeDaemonConfigOption: option.UnsafeDaemonConfig{EnableHostLegacyRouting: true},
+	}
 	daemonConfigAuto = option.DaemonConfig{
 		DatapathMode:    datapathOption.DatapathModeAuto,
 		EnableIPv4:      true,
@@ -98,6 +110,12 @@ var (
 		EnableIPv4:      true,
 		EnableIPv6:      true,
 		EnableBPFTProxy: true,
+	}
+	daemonConfigAutoHostLegacyRouting = option.DaemonConfig{
+		DatapathMode:             datapathOption.DatapathModeAuto,
+		EnableIPv4:               true,
+		EnableIPv6:               true,
+		UnsafeDaemonConfigOption: option.UnsafeDaemonConfig{EnableHostLegacyRouting: true},
 	}
 
 	// WireguardConfigs
@@ -200,6 +218,15 @@ func TestNewConfig(t *testing.T) {
 			shouldSkip:     false,
 		},
 		{
+			name:           "datapath-netkit+legacy-host-routing",
+			daemonConfig:   &daemonConfigNetkitHostLegacyRouting,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkit,
+			shouldError:    true,
+			shouldSkip:     false,
+		},
+		{
 			name:           "datapath-netkit-l2",
 			daemonConfig:   &daemonConfigNetkitL2,
 			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
@@ -217,7 +244,15 @@ func TestNewConfig(t *testing.T) {
 			shouldError:    true,
 			shouldSkip:     false,
 		},
-
+		{
+			name:           "datapath-netkit-l2+legacy-host-routing",
+			daemonConfig:   &daemonConfigNetkitL2HostLegacyRouting,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkitL2,
+			shouldError:    true,
+			shouldSkip:     false,
+		},
 		{
 			name:           "datapath-auto(!netkit)+oper-veth",
 			daemonConfig:   &daemonConfigAuto,
@@ -237,6 +272,15 @@ func TestNewConfig(t *testing.T) {
 			shouldSkip:     hostSupportsNetkit(),
 		},
 		{
+			name:           "datapath-auto(!netkit)+legacy-host-routing+oper-veth",
+			daemonConfig:   &daemonConfigAutoHostLegacyRouting,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigAuto_Veth,
+			shouldError:    false,
+			shouldSkip:     hostSupportsNetkit(),
+		},
+		{
 			name:           "datapath-auto(netkit)+oper-netkit",
 			daemonConfig:   &daemonConfigAuto,
 			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
@@ -248,6 +292,15 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:           "datapath-auto(netkit)+tproxy+oper-veth",
 			daemonConfig:   &daemonConfigAutoTproxy,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigAuto_Veth,
+			shouldError:    false,
+			shouldSkip:     !hostSupportsNetkit(),
+		},
+		{
+			name:           "datapath-auto(netkit)+host-legacy-routing+oper-veth",
+			daemonConfig:   &daemonConfigAutoHostLegacyRouting,
 			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
 			tunnelConfig:   tunnelConfigNative,
 			expectedConfig: &connectorConfigAuto_Veth,


### PR DESCRIPTION
netkit device mode is documented as requiring BPF Host Routing, but the Cilium datapath connector does not currently raise an issue if BPF Host Routing is disabled.

This commit introduces a check for BPF Host Routing being disabled. (Or, more specifically, host legacy routing being enabled). The effect when datapathMode is hard-set to {netkit,netkit-l2} is a startup error. The effect when datapathMode is set to auto-detect is fallback to veth.

This commit also introduces testing for this permutation of config.

```release-note
Make BPF Host Routing a requirement for netkit datapath mode.
```
