### PR TITLE
Auto-generate feature metrics documentation for agent and operator - v2

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -47,6 +47,7 @@ jobs:
               - 'hubble-relay/cmd/**'
               - 'install/kubernetes/**'
               - 'operator/cmd/**'
+              - 'pkg/metrics/features/**'
               - README.rst
 
   # Runs only if code under Documentation or */cmd/ is changed as the docs

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -162,7 +162,6 @@ jobs:
             --from-file=${CLIENT_KEY}=${CLIENT_KEY}
 
           echo operator_prometheus_tls_secret_name=${OPERATOR_PROMETHEUS_TLS_SECRET_NAME} >> $GITHUB_OUTPUT
-          echo server_name=${SERVER_NAME} >> $GITHUB_OUTPUT
 
       - name: Set up install variables
         id: vars
@@ -215,67 +214,6 @@ jobs:
         run: |
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
-
-      - name: Check prometheus metrics
-        if: ${{ success() }}
-        run: |
-          cd $HOME
-          cilium_pod_ip=$(kubectl -n kube-system get po -o name --field-selector=status.phase==Running -l 'k8s-app=cilium' -o jsonpath='{.items[0].status.podIP}' )
-          curl http://${cilium_pod_ip}:9962/metrics > metrics-agent.prom
-
-          kubectl get secret ${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
-            -n kube-system \
-            -o jsonpath='{.data.client\.crt}' \
-            | base64 -d > client.crt
-
-          kubectl get secret ${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
-            -n kube-system \
-            -o jsonpath='{.data.client\.key}' \
-            | base64 -d > client.key
-
-          kubectl get secret ${{ steps.gen_certs.outputs.operator_prometheus_tls_secret_name }} \
-            -n kube-system \
-            -o jsonpath='{.data.ca\.crt}' \
-            | base64 -d > ca.crt
-
-          operator_ip=$(kubectl get pods -n kube-system -l io.cilium/app=operator -o jsonpath='{range .items[*]}{.status.podIP}{"\n"}{end}')
-          curl --retry 5 \
-            --cert client.crt \
-            --key client.key \
-            --cacert ca.crt \
-            --resolve ${{ steps.gen_certs.outputs.server_name }}:9963:${operator_ip} \
-            https://${{ steps.gen_certs.outputs.server_name }}:9963/metrics > metrics-operator.prom
-          # Install promtool binary release. `go install` doesn't work due to
-          # https://github.com/prometheus/prometheus/issues/8852 and related issues.
-          curl -sSL --remote-name-all https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/{prometheus-${PROM_VERSION}.linux-amd64.tar.gz,sha256sums.txt}
-          sha256sum --check --ignore-missing sha256sums.txt
-          tar -xzvf prometheus-${PROM_VERSION}.linux-amd64.tar.gz prometheus-${PROM_VERSION}.linux-amd64/promtool
-          rm -f prometheus-${PROM_VERSION}.linux-amd64.tar.gz
-          sudo mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/bin
-          cat metrics-agent.prom | promtool check metrics
-          cat metrics-operator.prom | promtool check metrics
-
-      - name: Check prometheus feature metrics documentation
-        if: ${{ success() }}
-        run: |
-          cd $HOME
-          cat metrics-agent.prom | grep cilium_feature > metrics-agent-features.prom
-          cat metrics-operator.prom | grep cilium_operator_feature > metrics-operator-features.prom
-          cd -
-          go run ./tools/feature-helm-generator \
-             --prom-file "$HOME/metrics-agent-features.prom" \
-             --metrics-prefix cilium_feature \
-             --metrics-separators adv_connect_and_lb,controlplane,datapath,network_policies \
-             > Documentation/observability/feature-metrics-agent.txt
-          go run ./tools/feature-helm-generator \
-             --prom-file "$HOME/metrics-operator-features.prom" \
-             --metrics-prefix cilium_operator_feature \
-             --metrics-separators adv_connect_and_lb \
-             > Documentation/observability/feature-metrics-operator.txt
-          if ! git diff --quiet; then
-            echo "Feature metrics documentation out-of-sync"
-            exit 1
-          fi
 
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -403,6 +403,7 @@ Makefile* @cilium/build
 /Documentation/reference-guides/xfrm/ @cilium/ipsec @cilium/docs-structure
 /Documentation/check-build.sh @cilium/docs-structure
 /Documentation/check-cmdref.sh @cilium/docs-structure
+/Documentation/check-feature-metrics.sh @cilium/docs-structure
 /Documentation/check-crd-compat-table.sh @cilium/docs-structure
 /Documentation/check-examples.sh @cilium/docs-structure
 /Documentation/check-helmvalues.sh @cilium/docs-structure
@@ -476,6 +477,7 @@ Makefile* @cilium/build
 /Documentation/security/threat-model.rst @cilium/security @cilium/docs-structure
 /Documentation/spelling_wordlist.txt @cilium/docs-structure
 /Documentation/update-cmdref.sh @cilium/docs-structure
+/Documentation/update-feature-metrics.sh @cilium/docs-structure
 /Documentation/update-spelling_wordlist.sh @cilium/docs-structure
 /Documentation/yaml.config @cilium/docs-structure
 /examples/ @cilium/docs-structure

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -80,6 +80,12 @@ update-cmdref: cilium-build ## Update the command reference documents (agent, bu
 	-$(QUIET)rm -rf cmdref/cilium*.md
 	$(QUIET)$(DOCKER_RUN) ./update-cmdref.sh
 
+.PHONY: update-feature-metrics
+update-feature-metrics: cilium-build ## Update the observability feature metrics documents (agent, operator).
+	@$(ECHO_GEN)feature-metrics
+	-$(QUIET)rm -rf observability/cilium*.feature-metrics.prom
+	$(QUIET)$(DOCKER_RUN) ./update-feature-metrics.sh
+
 .PHONY: codeowners.rst
 codeowners.rst:
 	@$(ECHO_GEN)$@
@@ -116,9 +122,11 @@ $(HELM_VALUES): FORCE
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 
-check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners update-redirects ## Validate command and Helm references, policy examples, and others.
+check: builder-image api-flaggen update-cmdref update-feature-metrics update-crdlist update-helm-values update-codeowners update-redirects ## Validate command and Helm references, policy examples, and others.
 	@$(ECHO_CHECK) cmdref
 	$(QUIET) ./check-cmdref.sh
+	@$(ECHO_CHECK) feature-metrics
+	$(QUIET) ./check-feature-metrics.sh
 	@$(ECHO_CHECK) $(HELM_VALUES)
 	$(QUIET) ./check-helmvalues.sh
 	@$(ECHO_CHECK) examples

--- a/Documentation/check-feature-metrics.sh
+++ b/Documentation/check-feature-metrics.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+observability_dir="${script_dir}/observability"
+
+# Ensure new files are also considered in the diff
+git add --intent-to-add -- "${observability_dir}"
+
+if ! git diff --quiet -- "${observability_dir}" ; then
+    git --no-pager diff "${observability_dir}"
+    echo "HINT: to fix this, run 'make -C Documentation update-feature-metrics'"
+    exit 1
+fi

--- a/Documentation/contributing/docs/docsframework.rst
+++ b/Documentation/contributing/docs/docsframework.rst
@@ -73,8 +73,9 @@ that they are all up-to-date:
 
 .. code-block:: makefile
 
-   check: builder-image api-flaggen update-cmdref update-crdlist update-helm-values update-codeowners update-redirects
+   check: builder-image api-flaggen update-cmdref update-feature-metrics update-crdlist update-helm-values update-codeowners update-redirects
      ./check-cmdref.sh
+     ./check-feature-metrics.sh
      ./check-helmvalues.sh
      $(DOCKER_RUN) ./check-examples.sh # Runs "cilium policy validate" and "yamllint"
      ./check-codeowners.sh
@@ -95,6 +96,12 @@ run. They are:
   - Runs ``./update-cmdref.sh``
   - Includes running various binaries with ``--cmdref``
   - Generates ``Documentation/cmdref/\*``
+
+- ``update-feature-metrics``
+
+  - Runs ``./update-feature-metrics.sh``
+  - Includes running various binaries with ``metrics dump features`` command
+  - Generates ``Documentation/observability/feature-metrics-agent.txt`` and ``Documentation/observability/feature-metrics-operator.txt``
 
 - ``update-crdlist``
 

--- a/Documentation/update-feature-metrics.sh
+++ b/Documentation/update-feature-metrics.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_dir="$(cd "${script_dir}/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+observability_dir="${script_dir}/observability"
+helm_generator="${source_dir}/tools/feature-helm-generator/feature-helm-generator"
+
+# cilium-agent
+${source_dir}/daemon/cilium-agent metrics dump features "${tmp_dir}"
+${helm_generator} --prom-file "${tmp_dir}/cilium-agent.feature-metrics.prom" \
+    --metrics-prefix cilium_feature \
+    --metrics-separators adv_connect_and_lb,controlplane,datapath,network_policies \
+    > "${observability_dir}/feature-metrics-agent.txt"
+
+# cilium-operator
+${source_dir}/operator/cilium-operator metrics dump features "${tmp_dir}"
+${helm_generator} --prom-file "${tmp_dir}/cilium-operator.feature-metrics.prom" \
+    --metrics-prefix cilium_operator_feature \
+    --metrics-separators adv_connect_and_lb \
+    > "${observability_dir}/feature-metrics-operator.txt"

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	agentFeatures "github.com/cilium/cilium/pkg/metrics/features"
+)
+
+func newMetricsCmd() *cobra.Command {
+	metricsCmd := &cobra.Command{
+		Use:    "metrics",
+		Short:  "Access metric status of the agent",
+		Hidden: true,
+	}
+
+	metricsCmd.AddCommand(agentFeatures.NewDumpCmd())
+
+	return metricsCmd
+}

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -63,6 +63,7 @@ func NewAgentCmd(hfn func() *hive.Hive) *cobra.Command {
 
 	rootCmd.AddCommand(
 		cmdref.NewCmd(rootCmd),
+		newMetricsCmd(),
 		hive.CiliumShellCmd,
 		h.Command(),
 	)

--- a/operator/cmd/metrics.go
+++ b/operator/cmd/metrics.go
@@ -5,10 +5,17 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	operatorFeatures "github.com/cilium/cilium/pkg/metrics/features/operator"
 )
 
 // MetricsCmd represents the metrics command for the operator.
 var MetricsCmd = &cobra.Command{
 	Use:   "metrics",
 	Short: "Access metric status of the operator",
+}
+
+func init() {
+	MetricsCmd.AddCommand(MetricsListCmd)
+	MetricsCmd.AddCommand(operatorFeatures.NewDumpCmd())
 }

--- a/operator/cmd/metrics_list.go
+++ b/operator/cmd/metrics_list.go
@@ -79,8 +79,6 @@ var MetricsListCmd = &cobra.Command{
 }
 
 func init() {
-	MetricsCmd.AddCommand(MetricsListCmd)
-
 	MetricsListCmd.Flags().StringVarP(&matchPattern, "match-pattern", "p", "", "Show only metrics whose names match matchpattern")
 	MetricsListCmd.Flags().StringVarP(&operatorAddr, "server-address", "s", api.OperatorAPIServeAddrDefault, "Address of the operator API server")
 	command.AddOutputOption(MetricsListCmd)

--- a/pkg/metrics/features/features.go
+++ b/pkg/metrics/features/features.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/pkg/metrics/promdump"
 )
 
 func updateAgentConfigMetricOnStart(jg job.Group, params featuresParams, m featureMetrics) error {
@@ -26,4 +30,26 @@ func updateAgentConfigMetricOnStart(jg job.Group, params featuresParams, m featu
 	}))
 
 	return nil
+}
+
+func NewDumpCmd() *cobra.Command {
+	dumpCmd := &cobra.Command{
+		Use:    "dump",
+		Short:  "Dump metrics to an output directory",
+		Hidden: true,
+	}
+
+	dumpCmd.AddCommand(&cobra.Command{
+		Use:    "features [output directory]",
+		Short:  "Dump feature metrics to an output directory",
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return promdump.DumpGatherer(cmd.Root().Name(), args[0], "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+				return NewMetrics(true, true).toGatherer()
+			})
+		},
+	})
+
+	return dumpCmd
 }

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -5,6 +5,9 @@ package features
 
 import (
 	"fmt"
+	"reflect"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
@@ -970,6 +973,7 @@ func NewMetrics(withDefaults bool, withEnvVersion bool) Metrics {
 
 type featureMetrics interface {
 	update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.WireguardConfig, ipsecCfg datapath.IPsecConfig)
+	toGatherer() (prometheus.Gatherer, error)
 }
 
 func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig, wgCfg wgTypes.WireguardConfig, ipsecCfg datapath.IPsecConfig) {
@@ -1120,4 +1124,22 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 	if params.IsDynamicConfigSourceKindNodeConfig() {
 		m.ACLBCiliumNodeConfigEnabled.Set(1)
 	}
+}
+
+func (m Metrics) toGatherer() (prometheus.Gatherer, error) {
+	rv := reflect.ValueOf(m)
+	reg := prometheus.NewPedanticRegistry()
+	for i := 0; i < rv.NumField(); i++ {
+		if !rv.Field(i).CanInterface() {
+			continue
+		}
+		c, ok := rv.Field(i).Interface().(prometheus.Collector)
+		if !ok {
+			continue
+		}
+		if err := reg.Register(c); err != nil {
+			return nil, fmt.Errorf("registering metric: %w", err)
+		}
+	}
+	return reg, nil
 }

--- a/pkg/metrics/features/operator/features.go
+++ b/pkg/metrics/features/operator/features.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/pkg/metrics/promdump"
 )
 
 func updateOperatorConfigMetricOnStart(jg job.Group, params featuresParams, m featureMetrics) error {
@@ -18,4 +22,26 @@ func updateOperatorConfigMetricOnStart(jg job.Group, params featuresParams, m fe
 	}))
 
 	return nil
+}
+
+func NewDumpCmd() *cobra.Command {
+	dumpCmd := &cobra.Command{
+		Use:    "dump",
+		Short:  "Dump metrics to an output directory",
+		Hidden: true,
+	}
+
+	dumpCmd.AddCommand(&cobra.Command{
+		Use:    "features [output directory]",
+		Short:  "Dump feature metrics to an output directory",
+		Args:   cobra.ExactArgs(1),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return promdump.DumpGatherer(cmd.Root().Name(), args[0], "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+				return NewMetrics(true, true).toGatherer()
+			})
+		},
+	})
+
+	return dumpCmd
 }

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -4,6 +4,11 @@
 package features
 
 import (
+	"fmt"
+	"reflect"
+
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
@@ -80,6 +85,7 @@ func NewMetrics(withDefaults bool, withEnvVersion bool) Metrics {
 
 type featureMetrics interface {
 	update(params enabledFeatures, config *option.OperatorConfig)
+	toGatherer() (prometheus.Gatherer, error)
 }
 
 func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
@@ -103,4 +109,22 @@ func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 			m.CPKubernetesVersion.WithLabelValues(k8sVersionStr).Set(1)
 		}
 	}
+}
+
+func (m Metrics) toGatherer() (prometheus.Gatherer, error) {
+	rv := reflect.ValueOf(m)
+	reg := prometheus.NewPedanticRegistry()
+	for i := 0; i < rv.NumField(); i++ {
+		if !rv.Field(i).CanInterface() {
+			continue
+		}
+		c, ok := rv.Field(i).Interface().(prometheus.Collector)
+		if !ok {
+			continue
+		}
+		if err := reg.Register(c); err != nil {
+			return nil, fmt.Errorf("registering metric: %w", err)
+		}
+	}
+	return reg, nil
 }

--- a/pkg/metrics/promdump/promdump.go
+++ b/pkg/metrics/promdump/promdump.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package promdump
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+)
+
+// DumpGatherer writes all metrics from a prometheus.Gatherer
+// to a prometheus text-format file in the given output directory.
+func DumpGatherer(appName string, outputDir string, outputSuffix string, newGatherer func() (prometheus.Gatherer, error)) error {
+	if newGatherer == nil {
+		return fmt.Errorf("gatherer constructor is nil")
+	}
+	if outputSuffix == "" {
+		return fmt.Errorf("output suffix is empty")
+	}
+
+	g, err := newGatherer()
+	if err != nil {
+		return err
+	}
+	if g == nil {
+		return fmt.Errorf("gatherer is nil")
+	}
+
+	outputFile := filepath.Join(outputDir, fmt.Sprintf("%s.%s", appName, outputSuffix))
+	return dumpFromGatherer(g, outputFile)
+}
+
+func dumpFromGatherer(g prometheus.Gatherer, outputFile string) error {
+	mfs, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gather: %w", err)
+	}
+	sort.Slice(mfs, func(i, j int) bool { return mfs[i].GetName() < mfs[j].GetName() })
+
+	f, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("creating file: %s: %w", outputFile, err)
+	}
+	defer f.Close()
+
+	enc := expfmt.NewEncoder(f, expfmt.NewFormat(expfmt.TypeTextPlain))
+	for _, mf := range mfs {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding metric: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/metrics/promdump/promdump_test.go
+++ b/pkg/metrics/promdump/promdump_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package promdump
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type errorGatherer struct {
+	err error
+}
+
+func (g errorGatherer) Gather() ([]*dto.MetricFamily, error) {
+	return nil, g.err
+}
+
+func TestDumpGatherer(t *testing.T) {
+	t.Run("nil constructor", func(t *testing.T) {
+		err := DumpGatherer("cilium-agent", t.TempDir(), "feature-metrics.prom", nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty output suffix", func(t *testing.T) {
+		err := DumpGatherer("cilium-agent", t.TempDir(), "", func() (prometheus.Gatherer, error) {
+			return prometheus.NewRegistry(), nil
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("constructor error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		err := DumpGatherer("cilium-agent", t.TempDir(), "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+			return nil, wantErr
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("nil gatherer", func(t *testing.T) {
+		err := DumpGatherer("cilium-agent", t.TempDir(), "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+			return nil, nil
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("gather failure", func(t *testing.T) {
+		wantErr := errors.New("gather failed")
+		err := DumpGatherer("cilium-agent", t.TempDir(), "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+			return errorGatherer{err: wantErr}, nil
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("bad output directory", func(t *testing.T) {
+		outputDir := filepath.Join(t.TempDir(), "does-not-exist")
+		err := DumpGatherer("cilium-agent", outputDir, "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+			return prometheus.NewRegistry(), nil
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("app name creates missing subdirectory", func(t *testing.T) {
+		err := DumpGatherer("bad/name", t.TempDir(), "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+			return prometheus.NewRegistry(), nil
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("output suffix creates missing subdirectory", func(t *testing.T) {
+		err := DumpGatherer("cilium-agent", t.TempDir(), "bad/name.prom", func() (prometheus.Gatherer, error) {
+			return prometheus.NewRegistry(), nil
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("success writes sorted metrics", func(t *testing.T) {
+		outputDir := t.TempDir()
+		reg := prometheus.NewRegistry()
+
+		a := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "a_metric",
+			Help: "a",
+		})
+		z := prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "z_metric",
+			Help: "z",
+		})
+		a.Set(1)
+		z.Set(2)
+		require.NoError(t, reg.Register(z))
+		require.NoError(t, reg.Register(a))
+
+		err := DumpGatherer("cilium-agent", outputDir, "feature-metrics.prom", func() (prometheus.Gatherer, error) {
+			return reg, nil
+		})
+		require.NoError(t, err)
+
+		outputFile := filepath.Join(outputDir, "cilium-agent.feature-metrics.prom")
+		raw, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+
+		text := string(raw)
+		assert.Contains(t, text, "a_metric")
+		assert.Contains(t, text, "z_metric")
+		assert.Less(t, strings.Index(text, "a_metric"), strings.Index(text, "z_metric"))
+	})
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-SUBDIRS := alignchecker mount slogloggercheck metricslint
+SUBDIRS := alignchecker mount slogloggercheck metricslint feature-helm-generator
 
 .PHONY: all $(SUBDIRS) clean install
 


### PR DESCRIPTION
Following #44114 CI will now fail if feature metric documentation is out of sync. However, [as noted](https://github.com/cilium/cilium/pull/44114#discussion_r2856236665), the developer U/X for this is poor.

This PR:

* Adds logic to dump feature-metrics directly from the Cilium agent and operator binaries without having to be installed

* Adds and integrates new scripts and build targets to Documentation folder so that someone can run `make -C Documentation update-feature-metrics` to re-generate the necessary documentation.

* Integrates checks on these files into the documentation workflow in Github, and removes the manual checking from the IPv4 smoke test workflow.

* For the most part, this PR is replicating the existing pattern and logic used to generate `cmdref` docs.

Note: this replaces an older attempt in: https://github.com/cilium/cilium/pull/44556

```release-note
Added logic to auto-generate Cilium feature metric documentation from command line.
```
