### PR TITLE
k8s: Add embed.FS containing CRD YAML files for v2 and v2alpha1 APIs

### DIFF
--- a/contrib/scripts/k8s-manifests-gen.sh
+++ b/contrib/scripts/k8s-manifests-gen.sh
@@ -46,16 +46,19 @@ go tool sigs.k8s.io/controller-tools/cmd/controller-gen ${CRD_OPTIONS} paths="${
 go run ${SCRIPT_ROOT}/../../tools/crdcheck "${TMPDIR}"
 
 # Clean up old CRD state and start with a blank state.
+# We only delete the yaml files in the directories because these directories
+# also contain an `embed.go` which exists to export the CRD manifests via Go's
+# `embed.FS`.
 for path in ${CRDS_CILIUM_PATHS}; do
-  rm -rf "${path}" && mkdir "${path}"
+  find "${path}" -type f -name '*.yaml' -delete
 done
 
 for file in ${CRDS_CILIUM_V2}; do
-  mv "${TMPDIR}/cilium.io_${file}.yaml" "${SCRIPT_ROOT}/../../pkg/k8s/apis/cilium.io/client/crds/v2/${file}.yaml";
+  mv "${TMPDIR}/cilium.io_${file}.yaml" "${SCRIPT_ROOT}/../../pkg/k8s/apis/cilium.io/client/crds/v2/${file}.yaml"
 done
 
 for file in ${CRDS_CILIUM_V2ALPHA1}; do
-  mv "${TMPDIR}/cilium.io_${file}.yaml" "${SCRIPT_ROOT}/../../pkg/k8s/apis/cilium.io/client/crds/v2alpha1/${file}.yaml";
+  mv "${TMPDIR}/cilium.io_${file}.yaml" "${SCRIPT_ROOT}/../../pkg/k8s/apis/cilium.io/client/crds/v2alpha1/${file}.yaml"
 done
 
 rm -rf "${TMPDIR}"

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/embed.go
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/embed.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v2
+
+import "embed"
+
+//go:embed *.yaml
+var EmbedFS embed.FS

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/embed.go
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/embed.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v2alpha1
+
+import "embed"
+
+//go:embed *.yaml
+var EmbedFS embed.FS


### PR DESCRIPTION
I'm implementing some client side CRD validation logic based on the apiextensions-apiserver package, and I need to be able to load the CRD YAML files. However, this requires the YAML files to be available at runtime, which can be tricky to do.

There are a few options:
- Reading them from the filesystem, but this requires the user to have them available locally.
- Bundling them into the Docker image and reading them from the filesystem, but this only works if using Docker.
- Downloading them from the Kubernetes API server, but this requires a connection to a Kubernetes cluster with the specific CRDs installed.
- Downloading them from a remote repository, but this requires an internet connection and can be slow, requires the repository to be available and the files must be at a known location.
- Embedding them into the Go binary using the embed package, which allows us to include the YAML files directly in the compiled binary and access them at runtime without needing to worry about file paths or external dependencies.

While all the other options are something that can and should be supported, the idea of embedding the YAML files into the Go binary is appealing because it allows us to have the CRD definitions available at runtime without needing to worry about file paths or external dependencies. This can be used as a fallback option if the other methods fail, or even as the primary method for loading the CRD definitions if nothing else is available.

So to support this, I'm proposing adding an embed.FS to both the v2 and v2alpha1 API packages that contains the CRD YAML files. This allows consumers to simply import the package and access the CRD definitions without needing to manually maintain a separate copy of the YAML files.


```release-note
k8s: Add embed.FS containing CRD YAML files for v2 and v2alpha1 APIs
```
