### PR TITLE
policy: fix ResourceID leak in policy importer during policy churn

### DIFF
--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -152,8 +152,8 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 			delete(i.prefixesByResource, resource)
 			if len(oldPrefixes) > 0 {
 				toPrune[resource] = oldPrefixes
-				continue
 			}
+			continue
 		}
 
 		// Otherwise, update bookkeeping, upsert any net-new prefixes.

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -106,15 +106,17 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	pi.repo.GetSubjectSelectorCache().UpdateIdentities(ids, nil, nil)
 	pi.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
-	writeRule := func(r *policyapi.Rule) uint64 {
+	writeRules := func(rules ...*policyapi.Rule) uint64 {
 		t.Helper()
 
-		require.NoError(t, r.Sanitize())
+		for _, r := range rules {
+			require.NoError(t, r.Sanitize())
+		}
 
 		dc := make(chan uint64, 1)
 		pi.processUpdates(context.Background(), []*policytypes.PolicyUpdate{
 			{
-				Rules:    policyutils.RulesToPolicyEntries([]*policyapi.Rule{r}),
+				Rules:    policyutils.RulesToPolicyEntries(rules),
 				Resource: resource,
 				DoneChan: dc,
 			},
@@ -122,7 +124,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 		return <-dc
 	}
 
-	rev := writeRule(policyapi.NewRule().
+	rev := writeRules(policyapi.NewRule().
 		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
 			&slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -146,7 +148,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 
 	// Update to new rule that selects id 102 and has two prefixes
 	// we should see 1 new prefix, and 2 regenerated endpoints
-	rev = writeRule(policyapi.NewRule().
+	rev = writeRules(policyapi.NewRule().
 		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
 			&slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -174,7 +176,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	require.ElementsMatch(t, epm.regen.AsSlice(), []identity.NumericIdentity{100, 101})
 
 	// Swap endpoints and prefixes
-	rev = writeRule(policyapi.NewRule().
+	rev = writeRules(policyapi.NewRule().
 		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
 			&slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -195,5 +197,39 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	// Check that the right endpoints were updated
 	require.Equal(t, rev, epm.toRev)
 	require.ElementsMatch(t, epm.regen.AsSlice(), []identity.NumericIdentity{101, 102})
+
+	// Remove all CIDRs
+	rev = writeRules(policyapi.NewRule().
+		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
+			&slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"id": "102",
+				},
+			}),
+		).
+		WithEgressRules([]policyapi.EgressRule{{
+			EgressCommonRule: policyapi.EgressCommonRule{
+				ToEntities: policyapi.EntitySlice{policyapi.EntityHost},
+			}}}))
+
+	require.True(t, ipc.waited)
+
+	// We only remove 1 cidr
+	require.ElementsMatch(t, ipc.removed.AsSlice(), []string{"2.0.0.0/24"})
+	// When no new CIDRs are added the ipc.added value is not updated
+	// require.ElementsMatch(t, ipc.added.AsSlice(), []string{})
+
+	// Check that the right endpoints were updated
+	require.Equal(t, rev, epm.toRev)
+	require.ElementsMatch(t, epm.regen.AsSlice(), []identity.NumericIdentity{102})
+
+	require.ElementsMatch(t, pi.prefixesByResource[resource], []netip.Prefix{})
+
+	rev = writeRules()
+
+	// We removed the rule, so the prefix should no longer be counted
+	_, found := pi.prefixesByResource[resource]
+	require.False(t, found)
+	require.Equal(t, rev, epm.toRev)
 
 }


### PR DESCRIPTION
This fixes a slow leak where the ResourceID of a given policy is leaked
in the prefixesByResource map when a policy without a single CIDR rule
is removed.

This is a rather slow leak, where our testing shows that churning ~10
policies that all leak, results in ~75MiB of leaked memory after 24
hours. For testing purposes, we did this with both namespaces and names
of policies being UUIDs to get consistent results. This affects all
agents in the cluster, no matter if the policies select endpoints on the
node or not.

This affects cilium v1.17, and given the code has not changed, it most
likely also affects all stable versions. A following test update shows
this is indeed the case. This code was introduced in the first mentioned
commit below, but it was initially unused. Then, the last referenced
commit is the one that made policy imports use this code.

This code does deserve some rewrite to make it simpler to avoid this,
but keeping this as a simple fix to ease backports.

Fixes: https://github.com/cilium/cilium/commit/783465b85fba9491d7e2fe810b81e5bfde00fdab ("policy: add policy import cell")
Fixes: https://github.com/cilium/cilium/commit/b762c3ff2794551d5a0a5b79ff8cf5e907d07aab ("policy/k8s: switch to policy importer cell")

Fixes: #issue-number

```release-note
Fix memory leak triggered by policies being created and deleted
```
