### PR TITLE
ctmap: Change order of active maps

### DIFF
--- a/pkg/maps/ctmap/cell.go
+++ b/pkg/maps/ctmap/cell.go
@@ -67,7 +67,7 @@ type ctMaps struct {
 var _ CTMaps = (*ctMaps)(nil)
 
 func (r *ctMaps) ActiveMaps() []*Map {
-	return slices.DeleteFunc([]*Map{r.v4AnyMap, r.v4TCPMap, r.v6AnyMap, r.v6TCPMap}, func(m *Map) bool { return m == nil })
+	return slices.DeleteFunc([]*Map{r.v4TCPMap, r.v4AnyMap, r.v6TCPMap, r.v6AnyMap}, func(m *Map) bool { return m == nil })
 }
 
 func (r *ctMaps) init() error {


### PR DESCRIPTION
The ActiveMaps() method returns list of open CT maps. The list is used by the GC routine. The routine passes relevant CT maps to the PurgeOrphanNATEntries. The latter expects the TCP CT map to be the first one:

    ctMapTCP, ctMapAny := maps[i], maps[i+1]

However, the 3872944a6b7 commit changed the order of the maps in the list. Bring it back, otherwise the PurgeOrphanNATEntries keeps deleting valid NAT entries (as it cannot find in the CT map).

Fixes: 3872944a6b7 ("ct/map: introduce hive cell") (cc @mhofstetter)

NOTE: will make the code more robust in a subsequent PR.

Fix #44727