### PR TITLE
Ensure completion.WaitGroup always has a timeout

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -198,6 +198,7 @@ cilium-agent [flags]
       --encryption-strict-egress-allow-remote-node-identities     Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
       --encryption-strict-egress-cidr string                      In strict-mode-egress encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped.
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --endpoint-policy-update-timeout duration                   Timeout duration for Endpoint policy updates (default 10s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -104,6 +104,7 @@ cilium-agent hive [flags]
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --enable-ztunnel                                            Use zTunnel as Cilium's encryption infrastructure
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --endpoint-policy-update-timeout duration                   Timeout duration for Endpoint policy updates (default 10s)
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -110,6 +110,7 @@ cilium-agent hive dot-graph [flags]
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --enable-ztunnel                                            Use zTunnel as Cilium's encryption infrastructure
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
+      --endpoint-policy-update-timeout duration                   Timeout duration for Endpoint policy updates (default 10s)
       --endpoint-regen-interval duration                          Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable (default 2m0s)
       --eni-delete-on-termination                                 Whether the ENI should be deleted when the associated instance is terminated at the node level (default true)
       --eni-disable-prefix-delegation                             Whether ENI prefix delegation should be disabled on this node at the node level

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1504,6 +1504,10 @@
      - Enable endpoint lockdown on policy map overflow.
      - bool
      - ``false``
+   * - :spelling:ignore:`endpointPolicyUpdateTimeoutDuration`
+     - Max duration to wait for envoy to respond to configuration changes. Default "10s".
+     - string
+     - ``nil``
    * - :spelling:ignore:`endpointRoutes.enabled`
      - Enable use of per endpoint routes instead of routing via the cilium_host interface.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -426,6 +426,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.ztunnel.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | ztunnel update strategy. |
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointLockdownOnMapOverflow | bool | `false` | Enable endpoint lockdown on policy map overflow. |
+| endpointPolicyUpdateTimeoutDuration | string | `nil` | Max duration to wait for envoy to respond to configuration changes. Default "10s". |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -467,6 +467,9 @@ data:
 {{- if has (kindOf .Values.bpf.policyMapPressureMetricsThreshold) (list "int64" "float64") }}
   bpf-policy-map-pressure-metrics-threshold: {{ .Values.bpf.policyMapPressureMetricsThreshold | quote }}
 {{- end }}
+{{- if .Values.endpointPolicyUpdateTimeoutDuration }}
+  endpoint-policy-update-timeout: {{ .Values.endpointPolicyUpdateTimeoutDuration | quote }}
+{{- end }}
 {{- if hasKey .Values.bpf "policyStatsMapMax" }}
   # bpf-policy-stats-map-max specifies the maximum number of entries in global
   # policy stats map

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2189,6 +2189,9 @@
     "endpointLockdownOnMapOverflow": {
       "type": "boolean"
     },
+    "endpointPolicyUpdateTimeoutDuration": {
+      "type": "null"
+    },
     "endpointRoutes": {
       "properties": {
         "enabled": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1249,6 +1249,8 @@ encryption:
 endpointHealthChecking:
   # -- Enable connectivity health checking between virtual endpoints.
   enabled: true
+# -- Max duration to wait for envoy to respond to configuration changes. Default "10s".
+endpointPolicyUpdateTimeoutDuration: null
 endpointRoutes:
   # @schema
   # type: [boolean, string]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1260,6 +1260,8 @@ encryption:
 endpointHealthChecking:
   # -- Enable connectivity health checking between virtual endpoints.
   enabled: true
+# -- Max duration to wait for envoy to respond to configuration changes. Default "10s".
+endpointPolicyUpdateTimeoutDuration: null
 endpointRoutes:
   # @schema
   # type: [boolean, string]

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -6,6 +6,7 @@ package completion
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -45,21 +46,23 @@ func (wg *WaitGroup) Context() context.Context {
 	return wg.ctx
 }
 
+type idFunc = func() string
+
 // AddCompletionWithCallback creates a new completion, adds it to the wait
 // group, and returns it. The callback will be called upon completion.
 // Completion can complete in a failure (err != nil)
-func (wg *WaitGroup) AddCompletionWithCallback(callback func(err error)) *Completion {
+func (wg *WaitGroup) AddCompletionWithCallback(id idFunc, callback func(err error)) *Completion {
 	wg.counterLocker.Lock()
 	defer wg.counterLocker.Unlock()
-	c := NewCompletion(wg.cancel, callback)
+	c := NewCompletion(id, wg.cancel, callback)
 	wg.pendingCompletions = append(wg.pendingCompletions, c)
 	return c
 }
 
 // AddCompletion creates a new completion, adds it into the wait group, and
 // returns it.
-func (wg *WaitGroup) AddCompletion() *Completion {
-	return wg.AddCompletionWithCallback(nil)
+func (wg *WaitGroup) AddCompletion(id idFunc) *Completion {
+	return wg.AddCompletionWithCallback(id, nil)
 }
 
 // updateError updates the error value to be returned from Wait()
@@ -105,10 +108,15 @@ Loop:
 		case <-wg.ctx.Done():
 			// Complete the remaining completions (if any) to make sure their completed
 			// channels are closed.
-			for _, comp := range wg.pendingCompletions[i:] {
+			ctxErr := wg.ctx.Err()
+			for _, c := range wg.pendingCompletions[i:] {
 				// 'comp' may have already completed on a different error
-				compErr := comp.Complete(wg.ctx.Err())
+				compErr := c.Complete(ctxErr)
 				err = updateError(err, compErr) // Keep the most severe error value we encounter
+			}
+			// override error with the hanging completion if deadline exceeded
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				err = fmt.Errorf("Waiting on %s: %w", comp.Id(), ctxErr)
 			}
 			break Loop
 		}
@@ -121,6 +129,9 @@ Loop:
 // Completion provides the Complete callback to be called when an asynchronous
 // computation is completed.
 type Completion struct {
+	// id is used for correlation for debugging only
+	id idFunc
+
 	// cancel is used to cancel the WaitGroup the completion belongs in case of an error
 	cancel context.CancelFunc
 
@@ -143,6 +154,13 @@ func (c *Completion) Err() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	return c.err
+}
+
+func (c *Completion) Id() string {
+	if c.id == nil {
+		return ""
+	}
+	return c.id()
 }
 
 // Complete notifies of the completion of the asynchronous computation.
@@ -181,8 +199,9 @@ func (c *Completion) Completed() <-chan struct{} {
 
 // NewCompletion creates a Completion which calls a function upon Complete().
 // 'cancel' is called if the associated operation fails for any reason.
-func NewCompletion(cancel context.CancelFunc, callback func(err error)) *Completion {
+func NewCompletion(id idFunc, cancel context.CancelFunc, callback func(err error)) *Completion {
 	return &Completion{
+		id:        id,
 		cancel:    cancel,
 		completed: make(chan struct{}),
 		callback:  callback,

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -45,7 +45,7 @@ func TestCompletionBeforeWait(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion()
+	comp := wg.AddCompletion(nil)
 
 	comp.Complete(nil)
 
@@ -62,7 +62,7 @@ func TestCompletionAfterWait(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion()
+	comp := wg.AddCompletion(nil)
 
 	go func() {
 		time.Sleep(CompletionDelay)
@@ -82,7 +82,7 @@ func TestCompletionAfterWaitWithCancelledContext(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion()
+	comp := wg.AddCompletion(nil)
 
 	wg.Cancel()
 
@@ -104,9 +104,9 @@ func TestCompletionBeforeAndAfterWait(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp1 := wg.AddCompletion()
+	comp1 := wg.AddCompletion(nil)
 
-	comp2 := wg.AddCompletion()
+	comp2 := wg.AddCompletion(nil)
 
 	comp1.Complete(nil)
 
@@ -131,7 +131,7 @@ func TestCompletionTimeout(t *testing.T) {
 	defer cancel()
 	wg := NewWaitGroup(wgCtx)
 
-	comp := wg.AddCompletionWithCallback(func(err error) {
+	comp := wg.AddCompletionWithCallback(nil, func(err error) {
 		// Callback gets called with context.DeadlineExceeded if the WaitGroup times out
 		require.Equal(t, context.DeadlineExceeded, err)
 	})
@@ -141,7 +141,11 @@ func TestCompletionTimeout(t *testing.T) {
 	// Wait should block until wgCtx expires.
 	err = wg.Wait()
 	require.Error(t, err)
-	require.Equal(t, wgCtx.Err(), err)
+
+	// Errors are now different when the context times out
+	require.NotEqual(t, wgCtx.Err(), err)
+	require.Equal(t, context.DeadlineExceeded, wgCtx.Err())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// Complete is idempotent and harmless, and can be called after the
 	// context is canceled.
@@ -157,7 +161,7 @@ func TestCompletionMultipleCompleteCalls(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion()
+	comp := wg.AddCompletion(nil)
 
 	// Complete is idempotent.
 	comp.Complete(nil)
@@ -179,7 +183,7 @@ func TestCompletionWithCallback(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletionWithCallback(func(err error) {
+	comp := wg.AddCompletionWithCallback(nil, func(err error) {
 		if err == nil {
 			callbackCount++
 		}
@@ -211,13 +215,13 @@ func TestCompletionWithCallbackError(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletionWithCallback(func(err error) {
+	comp := wg.AddCompletionWithCallback(nil, func(err error) {
 		callbackCount++
 		// Completion that completes with a failure gets the reason for the failure
 		require.Equal(t, err1, err)
 	})
 
-	wg.AddCompletionWithCallback(func(err error) {
+	wg.AddCompletionWithCallback(nil, func(err error) {
 		callbackCount2++
 		// When one completions fail the other completion callbacks
 		// are called with context.Canceled
@@ -251,12 +255,12 @@ func TestCompletionWithCallbackOtherError(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wg := NewWaitGroup(ctx)
 
-	wg.AddCompletionWithCallback(func(err error) {
+	wg.AddCompletionWithCallback(nil, func(err error) {
 		callbackCount++
 		require.Equal(t, context.Canceled, err)
 	})
 
-	comp2 := wg.AddCompletionWithCallback(func(err error) {
+	comp2 := wg.AddCompletionWithCallback(nil, func(err error) {
 		callbackCount2++
 		require.Equal(t, err2, err)
 	})
@@ -287,7 +291,7 @@ func TestCompletionWithCallbackTimeout(t *testing.T) {
 	defer cancel()
 	wg := NewWaitGroup(wgCtx)
 
-	comp := wg.AddCompletionWithCallback(func(err error) {
+	comp := wg.AddCompletionWithCallback(nil, func(err error) {
 		if err == nil {
 			callbackCount++
 		}
@@ -299,7 +303,10 @@ func TestCompletionWithCallbackTimeout(t *testing.T) {
 	// Wait should block until wgCtx expires.
 	err = wg.Wait()
 	require.Error(t, err)
-	require.Equal(t, wgCtx.Err(), err)
+	// Errors are now different when the context times out
+	require.NotEqual(t, wgCtx.Err(), err)
+	require.Equal(t, context.DeadlineExceeded, wgCtx.Err())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// Complete is idempotent and harmless, and can be called after the
 	// context is canceled.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1090,6 +1090,11 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 	if isDetached, t := e.desiredPolicy.SelectorPolicy.IsDetached(); isDetached {
 		metrics.EndpointDetachedSelectorPolicyTimeStats.WithLabelValues("incremental-update").Observe(time.Since(t).Seconds())
 	}
+
+	// NOTE: Since we create an ephemeral regenerationContext for the endpoint here,
+	// the revert functions of updated proxy network policies are not retained.
+	// This means that even if Envoy would end up NACKing a NetworkPolicy, it will remain in the
+	// xDS cache until the next update.
 	err := e.applyPolicyMapChangesLocked(&regenerationContext{
 		datapathRegenerationContext: &datapathRegenerationContext{
 			proxyWaitGroup: proxyWaitGroup,
@@ -1130,19 +1135,6 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 		return ErrComingOutOfLockdown
 	}
 
-	hasEnvoyRedirect := e.desiredPolicy.SelectorPolicy.L4Policy.HasEnvoyRedirect()
-	// updateEnvoy when policy has changed, if the endpoint has Envoy redirects,
-	// or is an Ingress endpoint, which needs to enforce also the full L3/4 policy.
-	//
-	// Even if there are no changes, we update the proxyWaitGroup for any in-progress
-	// NetworkPolicy update to be done if the endpoint has envoy redirects, so that the
-	// the expected policy is in place.
-	//
-	// 'updateEnvoy' is already set to 'true' if policy changed. In that case there can
-	// be new redirects and a full policy map update even if there were no incremental
-	// updates.
-	updateEnvoy := hasNewPolicy || hasEnvoyRedirect || e.isIngress
-
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 	var err error
@@ -1169,7 +1161,12 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	// NOTE: unlike regeneratePolicy, UpdateNetworkPolicy requires the endpoint read lock for
 	// 'e.desiredPolicy' access.
 	if !e.IsProxyDisabled() {
-		if updateEnvoy {
+		hasEnvoyRedirect := e.desiredPolicy.SelectorPolicy.L4Policy.HasEnvoyRedirect()
+
+		// updateEnvoy when policy has changed (due to the possible removed redirects), if
+		// the endpoint has Envoy redirects, or is an Ingress endpoint, which needs to
+		// enforce also the full L3/4 policy.
+		if hasNewPolicy || hasEnvoyRedirect || e.isIngress {
 			e.getLogger().Debug("applyPolicyMapChanges: Updating Envoy NetworkPolicy")
 			stats.proxyPolicyCalculation.Start()
 			var rf revert.RevertFunc
@@ -1178,10 +1175,6 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 			if err == nil {
 				datapathRegenCtxt.revertStack.Push(rf)
 			}
-		} else if hasEnvoyRedirect {
-			// Wait for a possible ongoing update to be done if there were no current changes.
-			e.getLogger().Debug("applyPolicyMapChanges: Using current Networkpolicy")
-			e.proxy.UseCurrentNetworkPolicy(e, e.desiredPolicy, proxyWaitGroup)
 		}
 	}
 

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -20,7 +20,6 @@ type EndpointProxy interface {
 	RemoveRedirect(id string)
 	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error)
-	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 	GetListenerProxyPort(listener string) uint16
 	IsSDPEnabled() bool
@@ -47,10 +46,6 @@ func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 polic
 
 // RemoveRedirect does nothing.
 func (f *FakeEndpointProxy) RemoveRedirect(id string) {
-}
-
-// UseCurrentNetworkPolicy does nothing.
-func (f *FakeEndpointProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
 }
 
 // UpdateNetworkPolicy does nothing.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -110,10 +110,6 @@ func (r *RedirectSuiteProxy) RemoveRedirect(id string) {
 	delete(r.redirects, id)
 }
 
-// UseCurrentNetworkPolicy does nothing.
-func (f *RedirectSuiteProxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
-}
-
 // UpdateNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -132,11 +132,11 @@ type EndpointManager interface {
 	// Unsubscribe from endpoint events.
 	Unsubscribe(s Subscriber)
 
-	// UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
-	// have had their PolicyMaps updated against the Endpoint's desired policy state.
-	//
-	// Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
-	UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup
+	// UpdatePolicyMaps updates policy maps and proxy network policies for all endpoints
+	// against the Endpoint's desired policy state.
+	// Waits for the policy updates to be completed before returning.
+	// Returns an error if the proxy policy update fails, times out, or is cancelled.
+	UpdatePolicyMaps(ctx context.Context) error
 
 	// RegenerateAllEndpoints calls a setState for each endpoint and
 	// regenerates if state transaction is valid. During this process, the endpoint

--- a/pkg/endpointmanager/config.go
+++ b/pkg/endpointmanager/config.go
@@ -21,6 +21,9 @@ type EndpointManagerConfig struct {
 	// EndpointRegenInterval is interval between periodic endpoint regenerations.
 	EndpointRegenInterval time.Duration
 
+	// EndpointPolicyUpdateTimeout is the timeout duration for Endpoint policy updates.
+	EndpointPolicyUpdateTimeout time.Duration
+
 	// BPFPolicyMapPressureMetricsThreshold is minimum rate for triggering policy map pressure metrics
 	BPFPolicyMapPressureMetricsThreshold float64
 }
@@ -46,6 +49,9 @@ func (def EndpointManagerConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration(option.EndpointRegenInterval, def.EndpointRegenInterval,
 		"Periodically recalculate and re-apply endpoint configuration. Set to 0 to disable")
 
+	flags.Duration(option.EndpointPolicyUpdateTimeout, def.EndpointPolicyUpdateTimeout,
+		"Timeout duration for Endpoint policy updates")
+
 	flags.Float64("bpf-policy-map-pressure-metrics-threshold", def.BPFPolicyMapPressureMetricsThreshold,
 		"Sets threshold for emitting pressure metrics of policy maps")
 }
@@ -53,5 +59,6 @@ func (def EndpointManagerConfig) Flags(flags *pflag.FlagSet) {
 var defaultEndpointManagerConfig = EndpointManagerConfig{
 	EndpointGCInterval:                   5 * time.Minute,
 	EndpointRegenInterval:                2 * time.Minute,
+	EndpointPolicyUpdateTimeout:          10 * time.Second,
 	BPFPolicyMapPressureMetricsThreshold: 0.1,
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -196,12 +196,11 @@ func (mgr *endpointManager) waitForProxyCompletions(proxyWaitGroup *completion.W
 	return nil
 }
 
-// UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
-// have had their PolicyMaps updated against the Endpoint's desired policy state.
+// UpdatePolicyMaps applies incremental policy map changes and waits for Envoy to have applied the
+// new policy. Returns the error from the wait on proxy completions.
 //
-// Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
-func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
-	var epWG sync.WaitGroup
+// The configured EndpointPolicyUpdateTimeout will be applied on the given context.
+func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context) error {
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithTimeout(ctx, mgr.config.EndpointPolicyUpdateTimeout)
@@ -210,36 +209,31 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 	proxyWaitGroup := completion.NewWaitGroup(ctx)
 
 	eps := mgr.GetEndpoints()
-	epWG.Add(len(eps))
+	wg.Add(len(eps))
 
-	// This is in a goroutine to allow the caller to proceed with other tasks before waiting for the ACKs to complete
-	wg.Go(func() {
-		// Wait for all the eps to have applied policy map
-		// changes before waiting for the changes to be ACKed
-		epWG.Wait()
-		if err := mgr.waitForProxyCompletions(proxyWaitGroup); err != nil {
-			mgr.logger.Warn("Failed to apply L7 proxy policy changes. These will be re-applied in future updates.", logfields.Error, err)
-		}
-
-		// Perform policy update call if required.
-		// This should not block the main flow for Endpoint.
-		mgr.policyUpdateCallback(&sync.WaitGroup{}, nil, true)
-
-	})
-
-	// TODO: bound by number of CPUs?
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
-			// Proceed only after all notifications have been delivered to endpoints
-			notifyWg.Wait()
 			if err := ep.ApplyPolicyMapChanges(proxyWaitGroup); err != nil && !errors.Is(err, endpoint.ErrNotAlive) {
 				ep.Logger("endpointmanager").Warn("Failed to apply policy map changes. These will be re-applied in future updates.", logfields.Error, err)
 			}
-			epWG.Done()
+			wg.Done()
 		}(ep)
 	}
 
-	return &wg
+	// Wait for all the eps to have applied policy map
+	// changes before waiting for the changes to be ACKed
+	wg.Wait()
+
+	err := mgr.waitForProxyCompletions(proxyWaitGroup)
+	if err != nil {
+		mgr.logger.Warn("Failed to apply L7 proxy policy changes. These will be re-applied in future updates.", logfields.Error, err)
+	}
+
+	// Perform policy update call if required.
+	// This should not block the main flow for Endpoint.
+	mgr.policyUpdateCallback(&sync.WaitGroup{}, nil, true)
+
+	return err
 }
 
 // InitMetrics hooks the endpointManager into the metrics subsystem. This can

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -51,6 +51,8 @@ const regenEndpointControllerName = "endpoint-periodic-regeneration"
 type endpointManager struct {
 	logger *slog.Logger
 
+	config EndpointManagerConfig
+
 	health cell.Health
 
 	// mutex protects endpoints and endpointsAux
@@ -112,6 +114,7 @@ type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error
 func New(logger *slog.Logger, registry *metrics.Registry, epSynchronizer EndpointResourceSynchronizer, lns *node.LocalNodeStore, health cell.Health, monitorAgent monitoragent.Agent, config EndpointManagerConfig) *endpointManager {
 	mgr := endpointManager{
 		logger:                       logger,
+		config:                       config,
 		health:                       health,
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
@@ -200,6 +203,9 @@ func (mgr *endpointManager) waitForProxyCompletions(proxyWaitGroup *completion.W
 func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
 	var epWG sync.WaitGroup
 	var wg sync.WaitGroup
+
+	ctx, cancel := context.WithTimeout(ctx, mgr.config.EndpointPolicyUpdateTimeout)
+	defer cancel()
 
 	proxyWaitGroup := completion.NewWaitGroup(ctx)
 

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -4,6 +4,7 @@
 package endpointmanager
 
 import (
+	"context"
 	"net/netip"
 	"sync"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	apiv1 "github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/completion"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
@@ -76,6 +78,25 @@ func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, hr 
 }
 
 func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
+func TestWaitForProxyCompletionsReturnsBlockingCompletionDetailsOnTimeout(t *testing.T) {
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	proxyWaitGroup := completion.NewWaitGroup(ctx)
+	const blockingCompletionID = "blocking-proxy-policy-update"
+
+	// Leave the completion pending so the wait group times out while waiting on it.
+	proxyWaitGroup.AddCompletion(func() string { return blockingCompletionID })
+
+	err := mgr.waitForProxyCompletions(proxyWaitGroup)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, "Waiting on "+blockingCompletionID)
 }
 
 func TestLookup(t *testing.T) {

--- a/pkg/envoy/secretsync.go
+++ b/pkg/envoy/secretsync.go
@@ -99,6 +99,7 @@ func (r *secretSyncer) upsertK8sSecretV1(ctx context.Context, secret *slim_corev
 	resource := Resources{
 		Secrets: []*envoy_extensions_tls_v3.Secret{envoySecret},
 	}
+	// UpsertEnvoyResources does not Wait for an Envoy response when only Secrets are upserted.
 	return r.envoyXdsServer.UpsertEnvoyResources(ctx, resource)
 }
 
@@ -116,6 +117,7 @@ func (r *secretSyncer) deleteK8sSecretV1(ctx context.Context, key resource.Key) 
 			},
 		},
 	}
+	// DeleteEnvoyResources does not Wait for an Envoy response when only Secrets are deleted.
 	return r.envoyXdsServer.DeleteEnvoyResources(ctx, resource)
 }
 

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -467,10 +467,6 @@ func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *p
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
-	panic("unimplemented")
-}
-
 func (*fakeXdsServer) GetPolicySecretSyncNamespace() string {
 	panic("unimplemented")
 }

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -8,6 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 
@@ -140,6 +144,32 @@ type pendingCompletion struct {
 	remainingNodesResources map[string]map[string]struct{}
 }
 
+func (pc *pendingCompletion) remainingString() string {
+	var sb strings.Builder
+
+	sb.WriteString("version:")
+	sb.WriteString(strconv.FormatUint(pc.version, 10))
+	sb.WriteString(",typeURL:")
+	sb.WriteString(pc.typeURL)
+	sb.WriteString(",remaining:[")
+	for i, node := range slices.Sorted(maps.Keys(pc.remainingNodesResources)) {
+		if i > 0 {
+			sb.WriteRune(',')
+		}
+		sb.WriteString(node)
+		sb.WriteString(":[")
+		for j, name := range slices.Sorted(maps.Keys(pc.remainingNodesResources[node])) {
+			if j > 0 {
+				sb.WriteRune(',')
+			}
+			sb.WriteString(name)
+		}
+		sb.WriteString("]")
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
 // NewAckingResourceMutatorWrapper creates a new AckingResourceMutatorWrapper
 // to wrap the given ResourceMutator.
 func NewAckingResourceMutatorWrapper(logger *slog.Logger, mutator ResourceMutator, metrics Metrics) *AckingResourceMutatorWrapper {
@@ -234,7 +264,7 @@ func (m *AckingResourceMutatorWrapper) addCurrentVersionCompletion(typeURL strin
 		typeURL:                 typeURL,
 		remainingNodesResources: remainingNodesResources,
 	}
-	c := wg.AddCompletionWithCallback(callback)
+	c := wg.AddCompletionWithCallback(comp.remainingString, callback)
 	m.pendingCompletions[c] = comp
 	return true
 }
@@ -327,9 +357,6 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 	}
 
 	if wait {
-		// Create a new completion
-		c := wg.AddCompletionWithCallback(callback)
-
 		comp := &pendingCompletion{
 			version:                 m.version,
 			typeURL:                 typeURL,
@@ -339,6 +366,8 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 			comp.remainingNodesResources[nodeID] = make(map[string]struct{}, 1)
 			comp.remainingNodesResources[nodeID][resourceName] = struct{}{}
 		}
+
+		c := wg.AddCompletionWithCallback(comp.remainingString, callback)
 		m.pendingCompletions[c] = comp
 	} else if callback != nil {
 		callback(nil)

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -212,18 +211,47 @@ func (m *AckingResourceMutatorWrapper) WaitForFirstAck(ctx context.Context, node
 	}
 }
 
-// AddVersionCompletion adds a completion to wait for any ACK for the
-// version and type URL, ignoring the ACKed resource names.
-func (m *AckingResourceMutatorWrapper) addVersionCompletion(typeURL string, version uint64, nodeIDs []string, c *completion.Completion) {
+// addCurrentVersionCompletion adds a completion to wait for any ACK for the
+// version and type URL for the given nodes, ignoring the ACKed resource names.
+// Nodes that have already acked the version are skipped. No completion is added if all nodes have
+// already acked the given version.
+// Returns true if the caller should wait for an ACK.
+func (m *AckingResourceMutatorWrapper) addCurrentVersionCompletion(typeURL string, nodeIPs []string, wg *completion.WaitGroup, callback func(error)) bool {
+	remainingNodesResources := make(map[string]map[string]struct{}, len(nodeIPs))
+	for _, nodeIP := range nodeIPs {
+		if acked, exists := m.ackedVersions[nodeIP]; exists && acked >= m.version {
+			m.logger.Debug("Skipping node that has already ACKed version",
+				logfields.XDSCachedVersion, m.version,
+				logfields.XDSAckedVersion, acked,
+				logfields.XDSClientNode, nodeIP,
+			)
+			continue
+		}
+		remainingNodesResources[nodeIP] = nil
+	}
+	if len(remainingNodesResources) == 0 {
+		return false
+	}
+
 	comp := &pendingCompletion{
-		version:                 version,
+		version:                 m.version,
 		typeURL:                 typeURL,
-		remainingNodesResources: make(map[string]map[string]struct{}, len(nodeIDs)),
+		remainingNodesResources: remainingNodesResources,
 	}
-	for _, nodeID := range nodeIDs {
-		comp.remainingNodesResources[nodeID] = nil
-	}
+	c := wg.AddCompletionWithCallback(callback)
 	m.pendingCompletions[c] = comp
+	return true
+}
+
+func (m *AckingResourceMutatorWrapper) maybeAddCurrentVersionCompletion(wait bool, typeURL string, nodeIPs []string, wg *completion.WaitGroup, callback func(error)) {
+	if wait {
+		wait = m.addCurrentVersionCompletion(typeURL, nodeIPs, wg, callback)
+	}
+
+	// Call callback immediately if there was nothing to wait for
+	if !wait && callback != nil {
+		callback(nil)
+	}
 }
 
 // UseCurrent adds a completion to the WaitGroup if the current
@@ -233,20 +261,20 @@ func (m *AckingResourceMutatorWrapper) UseCurrent(typeURL string, nodeIDs []stri
 	m.locker.Lock()
 	defer m.locker.Unlock()
 
-	wait := wg != nil
+	if wg == nil {
+		return
+	}
 
 	if m.restoring {
 		// Do not wait for acks when restoring state
 		m.logger.Debug("UseCurrent: Restoring, skipping wait for ACK",
 			logfields.XDSTypeURL, typeURL,
 		)
-
-		wait = false
+		return
 	}
 
-	if wait {
-		m.useCurrent(typeURL, nodeIDs, wg, nil)
-	}
+	// Add a completion object for the current version so that the caller may wait for the N/ACK
+	m.addCurrentVersionCompletion(typeURL, nodeIDs, wg, nil)
 }
 
 // DeleteNode frees resources held for the named nodes
@@ -319,24 +347,15 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 	m.version, updated, revert = m.mutator.Upsert(typeURL, resourceName, resource)
 
 	if !updated {
-		if wait {
-			m.useCurrent(typeURL, nodeIDs, wg, callback)
-		} else if callback != nil {
-			callback(nil)
-		}
+		// Add a completion object for the current version so that the caller may wait for
+		// the N/ACK
+		m.maybeAddCurrentVersionCompletion(wait, typeURL, nodeIDs, wg, callback)
 		return func() {}
 	}
 
 	if wait {
 		// Create a new completion
 		c := wg.AddCompletionWithCallback(callback)
-		if _, found := m.pendingCompletions[c]; found {
-			s := fmt.Sprintf("attempt to reuse completion to upsert xDS resource: %v", c)
-			logging.Fatal(m.logger, s,
-				logfields.XDSTypeURL, typeURL,
-				logfields.XDSResourceName, resourceName,
-			)
-		}
 
 		comp := &pendingCompletion{
 			version:                 m.version,
@@ -354,34 +373,14 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 
 	// Returned revert function locks again, so it can NOT be called from 'callback' directly,
 	// as 'callback' is called with the lock already held.
-	return func() {
-		if revert != nil {
+	if revert != nil {
+		return func() {
 			m.locker.Lock()
 			defer m.locker.Unlock()
 			m.version, _ = revert()
 		}
 	}
-}
-
-func (m *AckingResourceMutatorWrapper) useCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) {
-	if !m.currentVersionAcked(nodeIDs) {
-		// Add a completion object for 'version' so that the caller may wait for the N/ACK
-		m.addVersionCompletion(typeURL, m.version, nodeIDs, wg.AddCompletionWithCallback(callback))
-	}
-}
-
-func (m *AckingResourceMutatorWrapper) currentVersionAcked(nodeIDs []string) bool {
-	for _, node := range nodeIDs {
-		if acked, exists := m.ackedVersions[node]; !exists || acked < m.version {
-			m.logger.Debug("Node has not acked the current cached version yet",
-				logfields.XDSCachedVersion, m.version,
-				logfields.XDSAckedVersion, acked,
-				logfields.XDSClientNode, node,
-			)
-			return false
-		}
-	}
-	return true
+	return func() {}
 }
 
 func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName string, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc {
@@ -439,36 +438,17 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 		}
 	}
 
-	if !updated {
-		if wait {
-			m.useCurrent(typeURL, nodeIDs, wg, callback)
-		} else if callback != nil {
-			callback(nil)
-		}
-		return func() {}
-	}
+	// Add a completion object for the current version so that the caller may wait for the N/ACK
+	m.maybeAddCurrentVersionCompletion(wait, typeURL, nodeIDs, wg, callback)
 
-	if wait {
-		c := wg.AddCompletionWithCallback(callback)
-		if _, found := m.pendingCompletions[c]; found {
-			s := fmt.Sprintf("attempt to reuse completion to delete xDS resource: %v", c)
-			logging.Fatal(m.logger, s,
-				logfields.XDSTypeURL, typeURL,
-				logfields.XDSResourceName, resourceName)
-		}
-
-		m.addVersionCompletion(typeURL, m.version, nodeIDs, c)
-	} else if callback != nil {
-		callback(nil)
-	}
-
-	return func() {
-		if revert != nil {
+	if updated && revert != nil {
+		return func() {
 			m.locker.Lock()
 			defer m.locker.Unlock()
 			m.version, _ = revert()
 		}
 	}
+	return func() {}
 }
 
 // 'ackVersion' is the last version that was acked. 'nackVersion', if greater than 'ackVersion', is the last version that was NACKed.

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -73,10 +73,6 @@ type AckingResourceMutator interface {
 	// method call.
 	Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc
 
-	// UseCurrent inserts a completion that allows the caller to wait for the current
-	// version of the given typeURL to be ACKed.
-	UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup)
-
 	// DeleteNode frees resources held for the named node
 	DeleteNode(nodeID string)
 
@@ -252,29 +248,6 @@ func (m *AckingResourceMutatorWrapper) maybeAddCurrentVersionCompletion(wait boo
 	if !wait && callback != nil {
 		callback(nil)
 	}
-}
-
-// UseCurrent adds a completion to the WaitGroup if the current
-// version of the cached resource has not been acked yet, allowing the
-// caller to wait for the ACK.
-func (m *AckingResourceMutatorWrapper) UseCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup) {
-	m.locker.Lock()
-	defer m.locker.Unlock()
-
-	if wg == nil {
-		return
-	}
-
-	if m.restoring {
-		// Do not wait for acks when restoring state
-		m.logger.Debug("UseCurrent: Restoring, skipping wait for ACK",
-			logfields.XDSTypeURL, typeURL,
-		)
-		return
-	}
-
-	// Add a completion object for the current version so that the caller may wait for the N/ACK
-	m.addCurrentVersionCompletion(typeURL, nodeIDs, wg, nil)
 }
 
 // DeleteNode frees resources held for the named nodes

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -51,20 +51,14 @@ type ResourceVersionAckObserver interface {
 
 // AckingResourceMutatorRevertFunc is a function which reverts the effects of
 // an update on a AckingResourceMutator.
-// The completion, if not nil, is called back when the new resource update is
-// ACKed by the Envoy nodes.
-type AckingResourceMutatorRevertFunc func(completion *completion.Completion)
+type AckingResourceMutatorRevertFunc func()
 
 type AckingResourceMutatorRevertFuncList []AckingResourceMutatorRevertFunc
 
-func (rl AckingResourceMutatorRevertFuncList) Revert(wg *completion.WaitGroup) {
+func (rl AckingResourceMutatorRevertFuncList) Revert() {
 	// Revert the listed funcions in reverse order
 	for i := len(rl) - 1; i >= 0; i-- {
-		var c *completion.Completion
-		if wg != nil {
-			c = wg.AddCompletion()
-		}
-		rl[i](c)
+		rl[i]()
 	}
 }
 
@@ -330,7 +324,7 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 		} else if callback != nil {
 			callback(nil)
 		}
-		return func(completion *completion.Completion) {}
+		return func() {}
 	}
 
 	if wait {
@@ -360,19 +354,11 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 
 	// Returned revert function locks again, so it can NOT be called from 'callback' directly,
 	// as 'callback' is called with the lock already held.
-	return func(completion *completion.Completion) {
-		m.locker.Lock()
-		defer m.locker.Unlock()
-
+	return func() {
 		if revert != nil {
+			m.locker.Lock()
+			defer m.locker.Unlock()
 			m.version, _ = revert()
-
-			if completion != nil {
-				// We don't know whether the revert did an Upsert or a Delete, so as a
-				// best effort, just wait for any ACK for the version and type URL,
-				// and ignore the ACKed resource names, like for a Delete.
-				m.addVersionCompletion(typeURL, m.version, nodeIDs, completion)
-			}
 		}
 	}
 }
@@ -459,7 +445,7 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 		} else if callback != nil {
 			callback(nil)
 		}
-		return func(completion *completion.Completion) {}
+		return func() {}
 	}
 
 	if wait {
@@ -476,19 +462,11 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 		callback(nil)
 	}
 
-	return func(completion *completion.Completion) {
-		m.locker.Lock()
-		defer m.locker.Unlock()
-
+	return func() {
 		if revert != nil {
+			m.locker.Lock()
+			defer m.locker.Unlock()
 			m.version, _ = revert()
-
-			if completion != nil {
-				// We don't know whether the revert had any effect at all, so as a
-				// best effort, just wait for any ACK for the version and type URL,
-				// and ignore the ACKed resource names, like for a Delete.
-				m.addVersionCompletion(typeURL, m.version, nodeIDs, completion)
-			}
 		}
 	}
 }

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -113,6 +113,29 @@ func (m *AckingResourceMutatorWrapper) currentVersionAcked(nodeIDs []string) boo
 	return true
 }
 
+// useCurrent adds a completion to the WaitGroup if the current
+// version of the cached resource has not been acked yet, allowing the
+// caller to wait for the ACK.
+func (m *AckingResourceMutatorWrapper) useCurrent(typeURL string, nodeIDs []string, wg *completion.WaitGroup) {
+	m.locker.Lock()
+	defer m.locker.Unlock()
+
+	if wg == nil {
+		return
+	}
+
+	if m.restoring {
+		// Do not wait for acks when restoring state
+		m.logger.Debug("useCurrent: Restoring, skipping wait for ACK",
+			logfields.XDSTypeURL, typeURL,
+		)
+		return
+	}
+
+	// Add a completion object for the current version so that the caller may wait for the N/ACK
+	m.addCurrentVersionCompletion(typeURL, nodeIDs, wg, nil)
+}
+
 func TestUpsertSingleNode(t *testing.T) {
 	logger := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -206,7 +229,7 @@ func TestUseCurrent(t *testing.T) {
 	require.Equal(t, 0, metrics.cancel[typeURL])
 
 	// Use current version, not yet acked
-	acker.UseCurrent(typeURL, []string{node0}, wg)
+	acker.useCurrent(typeURL, []string{node0}, wg)
 	require.Len(t, acker.pendingCompletions, 2)
 
 	// Ack the right version, for another resource, from the right node.
@@ -214,7 +237,7 @@ func TestUseCurrent(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	// UseCurrent ignores resource names, so an ack of the same or later version from the right node will complete it
+	// useCurrent ignores resource names, so an ack of the same or later version from the right node will complete it
 	require.Len(t, acker.pendingCompletions, 1)
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
@@ -273,19 +296,19 @@ func TestUseCurrentSkipsNodesThatAlreadyAckedCurrentVersion(t *testing.T) {
 	defer currentCancel()
 	currentWG := completion.NewWaitGroup(currentCtx)
 
-	// UseCurrent must only wait for node1, as node0 has already ACKed version 3.
-	acker.UseCurrent(typeURL, []string{node0, node1}, currentWG)
+	// useCurrent must only wait for node1, as node0 has already ACKed version 3.
+	acker.useCurrent(typeURL, []string{node0, node1}, currentWG)
 	// There are now two outstanding waits for version 3:
 	// 1. the original Upsert completion, still waiting for node1 to ACK resources[1]
-	// 2. the new UseCurrent completion, which should only wait for nodes that have not ACKed
+	// 2. the new useCurrent completion, which should only wait for nodes that have not ACKed
 	//    the current version yet.
-	// If the old bug regresses, UseCurrent would add node0 again and the wait below would need
+	// If the old bug regresses, useCurrent would add node0 again and the wait below would need
 	// another ACK from node0 before completing.
 	require.Len(t, acker.pendingCompletions, 2)
 
 	var useCurrentPending *pendingCompletion
 	for _, pending := range acker.pendingCompletions {
-		// Both pending completions target the current version, so identify the UseCurrent
+		// Both pending completions target the current version, so identify the useCurrent
 		// one by its shape: it tracks nodes only, therefore node1 is present with a nil
 		// resource set.  The Upsert completion instead tracks per-resource ACKs, so its
 		// node entry has a non-nil resource-name map.
@@ -301,7 +324,7 @@ func TestUseCurrentSkipsNodesThatAlreadyAckedCurrentVersion(t *testing.T) {
 	require.Contains(t, useCurrentPending.remainingNodesResources, node1)
 	require.NotContains(t, useCurrentPending.remainingNodesResources, node0)
 
-	// ACKing node1 for version 3 must complete the UseCurrent wait without requiring a new ACK from node0.
+	// ACKing node1 for version 3 must complete the useCurrent wait without requiring a new ACK from node0.
 	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[1].Name}, typeURL, "")
 	// The same ACK must also complete the original Upsert completion for version 3.
 	require.Condition(t, completedComparison(compV3))

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -22,7 +22,8 @@ const (
 	node1 = "10.0.0.1"
 	node2 = "10.0.0.2"
 
-	MaxCompletionDuration = 250 * time.Millisecond
+	MaxCompletionDuration      = 100 * time.Millisecond
+	CompletionAssertionTimeout = 1 * time.Second
 )
 
 type compCheck struct {
@@ -53,17 +54,23 @@ func newCompCallback(logger *slog.Logger) (func(error), *compCheck) {
 
 func completedComparison(comp *compCheck) assert.Comparison {
 	return func() bool {
-		return completedInTime(comp)
+		return completedWithin(comp, CompletionAssertionTimeout)
 	}
 }
 
 func isNotCompletedComparison(comp *compCheck) assert.Comparison {
 	return func() bool {
-		return !completedInTime(comp)
+		return !completedWithin(comp, 0)
 	}
 }
 
-func completedInTime(comp *compCheck) bool {
+func doesNotCompleteComparison(comp *compCheck) assert.Comparison {
+	return func() bool {
+		return !completedWithin(comp, MaxCompletionDuration)
+	}
+}
+
+func completedWithin(comp *compCheck, wait time.Duration) bool {
 	if comp == nil {
 		return false
 	}
@@ -72,10 +79,22 @@ func completedInTime(comp *compCheck) bool {
 		return false
 	}
 
+	if wait <= 0 {
+		select {
+		case comp.err = <-comp.ch:
+			return comp.err == nil
+		default:
+			return false
+		}
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
 	select {
 	case comp.err = <-comp.ch:
 		return comp.err == nil
-	case <-time.After(MaxCompletionDuration):
+	case <-timer.C:
 		return false
 	}
 }

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -510,10 +510,7 @@ func TestDeleteMultipleNodes(t *testing.T) {
 
 func TestRevertInsert(t *testing.T) {
 	logger := hivetest.Logger(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
 	metrics := newMockMetrics()
 
 	cache := NewCache(logger)
@@ -534,9 +531,7 @@ func TestRevertInsert(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	comp := wg.AddCompletion()
-	defer comp.Complete(nil)
-	revert(comp)
+	revert()
 
 	res, err = cache.Lookup(typeURL, resources[0].Name)
 	require.NoError(t, err)
@@ -553,10 +548,7 @@ func TestRevertInsert(t *testing.T) {
 
 func TestRevertUpdate(t *testing.T) {
 	logger := hivetest.Logger(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
 	metrics := newMockMetrics()
 
 	cache := NewCache(logger)
@@ -584,9 +576,7 @@ func TestRevertUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[1], res)
 
-	comp := wg.AddCompletion()
-	defer comp.Complete(nil)
-	revert(comp)
+	revert()
 
 	res, err = cache.Lookup(typeURL, resources[0].Name)
 	require.NoError(t, err)
@@ -603,10 +593,7 @@ func TestRevertUpdate(t *testing.T) {
 
 func TestRevertDelete(t *testing.T) {
 	logger := hivetest.Logger(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
-	wg := completion.NewWaitGroup(ctx)
 	metrics := newMockMetrics()
 
 	cache := NewCache(logger)
@@ -638,9 +625,7 @@ func TestRevertDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	comp := wg.AddCompletion()
-	defer comp.Complete(nil)
-	revert(comp)
+	revert()
 
 	res, err = cache.Lookup(typeURL, resources[0].Name)
 	require.NoError(t, err)

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -591,6 +591,34 @@ func TestUpsertCompletionAfterDeletedResource(t *testing.T) {
 	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
+func TestPendingCompletionTimeoutErrorIncludesRemainingDetails(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), MaxCompletionDuration)
+	defer cancel()
+
+	wg := completion.NewWaitGroup(ctx)
+	pending := &pendingCompletion{
+		version: 7,
+		typeURL: "type.googleapis.com/envoy.config.v3.DummyConfiguration",
+		remainingNodesResources: map[string]map[string]struct{}{
+			node1: {
+				"node1-resource0": {},
+				"node1-resource1": {},
+			},
+			node0: {
+				"node0-resource0": {},
+				"node0-resource1": {},
+			},
+		},
+	}
+
+	wg.AddCompletion(pending.remainingString)
+
+	err := wg.Wait()
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.EqualError(t, err, "Waiting on version:7,typeURL:type.googleapis.com/envoy.config.v3.DummyConfiguration,remaining:[10.0.0.0:[node0-resource0,node0-resource1],10.0.0.1:[node1-resource0,node1-resource1]]: context deadline exceeded")
+}
+
 func TestDeleteMultipleNodes(t *testing.T) {
 	logger := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -80,6 +80,20 @@ func completedInTime(comp *compCheck) bool {
 	}
 }
 
+func (m *AckingResourceMutatorWrapper) currentVersionAcked(nodeIDs []string) bool {
+	for _, node := range nodeIDs {
+		if acked, exists := m.ackedVersions[node]; !exists || acked < m.version {
+			m.logger.Debug("Node has not acked the current cached version yet",
+				logfields.XDSCachedVersion, m.version,
+				logfields.XDSAckedVersion, acked,
+				logfields.XDSClientNode, node,
+			)
+			return false
+		}
+	}
+	return true
+}
+
 func TestUpsertSingleNode(t *testing.T) {
 	logger := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -203,6 +217,78 @@ func TestUseCurrent(t *testing.T) {
 	require.Equal(t, 2, metrics.ack[typeURL])
 	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.cancel[typeURL])
+}
+
+func TestUseCurrentSkipsNodesThatAlreadyAckedCurrentVersion(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	baselineWG := completion.NewWaitGroup(ctx)
+	metrics := newMockMetrics()
+
+	cache := NewCache(logger)
+	acker := NewAckingResourceMutatorWrapper(logger, cache, metrics)
+
+	// Create version 2 and fully ACK it so both nodes have a shared baseline.
+	callbackV2, compV2 := newCompCallback(logger)
+	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0, node1}, baselineWG, callbackV2)
+	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
+	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
+	require.Condition(t, completedComparison(compV2))
+	require.NoError(t, baselineWG.Wait())
+	require.Equal(t, uint64(2), acker.ackedVersions[node0])
+	require.Equal(t, uint64(2), acker.ackedVersions[node1])
+
+	// Create version 3, but only node0 ACKs it. Node1 remains outstanding.
+	upsertV3WG := completion.NewWaitGroup(ctx)
+	callbackV3, compV3 := newCompCallback(logger)
+	acker.Upsert(typeURL, resources[1].Name, resources[1], []string{node0, node1}, upsertV3WG, callbackV3)
+	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[1].Name}, typeURL, "")
+	require.Condition(t, isNotCompletedComparison(compV3))
+	require.Equal(t, uint64(3), acker.ackedVersions[node0])
+	require.Equal(t, uint64(2), acker.ackedVersions[node1])
+	require.Len(t, acker.pendingCompletions, 1)
+
+	currentCtx, currentCancel := context.WithTimeout(context.Background(), MaxCompletionDuration)
+	defer currentCancel()
+	currentWG := completion.NewWaitGroup(currentCtx)
+
+	// UseCurrent must only wait for node1, as node0 has already ACKed version 3.
+	acker.UseCurrent(typeURL, []string{node0, node1}, currentWG)
+	// There are now two outstanding waits for version 3:
+	// 1. the original Upsert completion, still waiting for node1 to ACK resources[1]
+	// 2. the new UseCurrent completion, which should only wait for nodes that have not ACKed
+	//    the current version yet.
+	// If the old bug regresses, UseCurrent would add node0 again and the wait below would need
+	// another ACK from node0 before completing.
+	require.Len(t, acker.pendingCompletions, 2)
+
+	var useCurrentPending *pendingCompletion
+	for _, pending := range acker.pendingCompletions {
+		// Both pending completions target the current version, so identify the UseCurrent
+		// one by its shape: it tracks nodes only, therefore node1 is present with a nil
+		// resource set.  The Upsert completion instead tracks per-resource ACKs, so its
+		// node entry has a non-nil resource-name map.
+		if pending.version == acker.version {
+			if remaining, found := pending.remainingNodesResources[node1]; found && remaining == nil {
+				useCurrentPending = pending
+				break
+			}
+		}
+	}
+	require.NotNil(t, useCurrentPending)
+	require.Len(t, useCurrentPending.remainingNodesResources, 1)
+	require.Contains(t, useCurrentPending.remainingNodesResources, node1)
+	require.NotContains(t, useCurrentPending.remainingNodesResources, node0)
+
+	// ACKing node1 for version 3 must complete the UseCurrent wait without requiring a new ACK from node0.
+	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[1].Name}, typeURL, "")
+	// The same ACK must also complete the original Upsert completion for version 3.
+	require.Condition(t, completedComparison(compV3))
+	require.NoError(t, upsertV3WG.Wait())
+	require.NoError(t, currentWG.Wait())
+	require.Empty(t, acker.pendingCompletions)
 }
 
 func TestCancelCompletions(t *testing.T) {

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	TestTimeout   = 10 * time.Second
-	StreamTimeout = 4 * time.Second
+	TestTimeout                 = 10 * time.Second
+	StreamTimeout               = 4 * time.Second
+	noResponseTestStreamTimeout = 1 * time.Second
 )
 
 var (
@@ -283,7 +284,7 @@ func TestAck(t *testing.T) {
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
@@ -295,7 +296,7 @@ func TestAck(t *testing.T) {
 	// This time, update the cache before sending the request.
 	callback2, comp2 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
-	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Condition(t, doesNotCompleteComparison(comp2))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -316,7 +317,7 @@ func TestAck(t *testing.T) {
 
 	// Version 2 was ACKed by the last request.
 	require.Condition(t, completedComparison(comp1))
-	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Condition(t, doesNotCompleteComparison(comp2))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -845,7 +846,7 @@ func TestNAck(t *testing.T) {
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Expecting a response with that resource.
 	resp, err = stream.RecvResponse()
@@ -873,10 +874,10 @@ func TestNAck(t *testing.T) {
 	wg = completion.NewWaitGroup(ctx)
 	callback2, comp2 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
-	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Condition(t, doesNotCompleteComparison(comp2))
 
 	// Version 2 was NACKed by the last request, so comp1 must NOT be completedInTime ever.
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 	require.EqualValues(t, &ProxyError{Err: ErrNackReceived, Detail: "NACKNACK"}, comp1.Err())
 
 	// Expecting a response with both resources.
@@ -886,8 +887,8 @@ func TestNAck(t *testing.T) {
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 
-	require.Condition(t, isNotCompletedComparison(comp1))
-	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Condition(t, doesNotCompleteComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp2))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 2, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.cancel[typeURL])
@@ -903,7 +904,7 @@ func TestNAck(t *testing.T) {
 	err = stream.SendRequest(req)
 	require.NoError(t, err)
 
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 	require.Condition(t, completedComparison(comp2))
 	require.Equal(t, 1, metrics.ack[typeURL])
 	require.Equal(t, 2, metrics.nack[typeURL])
@@ -973,7 +974,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1007,7 +1008,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 
 	// Version 2 was NACKed by the last request, so it must NOT be completedInTime successfully.
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Version 2 did not have a callback, so the completion was completedInTime with an error
 	require.Error(t, comp1.Err())
@@ -1019,7 +1020,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	// Create version 3 with resources 0 and 1.
 	callback2, comp2 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[1].Name, resources[1], []string{node0}, wg, callback2)
-	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Condition(t, doesNotCompleteComparison(comp2))
 
 	// Expecting a response with both resources.
 	// Note that the stream should not have a message that repeats the previous one!
@@ -1028,7 +1029,7 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
 	require.NotEmpty(t, resp.Nonce)
 
-	require.Condition(t, isNotCompletedComparison(comp2))
+	require.Condition(t, doesNotCompleteComparison(comp2))
 	require.Equal(t, 0, metrics.ack[typeURL])
 	require.Equal(t, 3, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.cancel[typeURL])
@@ -1094,7 +1095,7 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Request all resources, with a version higher than the version currently
 	// in Cilium's cache. This happens after the server restarts but the
@@ -1166,7 +1167,7 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Close previous stream and create a new one.
 	closeStream()
@@ -1240,7 +1241,7 @@ func TestNotAckedAfterRestart(t *testing.T) {
 	mutator := NewAckingResourceMutatorWrapper(logger, cache, metrics)
 
 	streamCtx, closeStream := context.WithCancel(ctx)
-	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
+	stream := NewMockStream(streamCtx, 1, 1, noResponseTestStreamTimeout, noResponseTestStreamTimeout)
 	defer stream.Close()
 
 	server := NewServer(logger, map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}}, nil, metrics)
@@ -1257,7 +1258,7 @@ func TestNotAckedAfterRestart(t *testing.T) {
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
 	mutator.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback1)
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 
 	// Request all resources, with a version higher than the version currently
 	// in Cilium's cache. This happens after the server restarts but the
@@ -1279,7 +1280,7 @@ func TestNotAckedAfterRestart(t *testing.T) {
 	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
 
 	// Version 2 was not ACKED by the last request, so it must NOT be completedInTime successfully.
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 	// Check that the completion was not NACKed
 	require.NoError(t, comp1.Err())
 	// Simulate that first request on a new stream was NACKed.
@@ -1299,7 +1300,7 @@ func TestNotAckedAfterRestart(t *testing.T) {
 	_, err = stream.RecvResponse()
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	// IsCompleted is true only for completions without error
-	require.Condition(t, isNotCompletedComparison(comp1))
+	require.Condition(t, doesNotCompleteComparison(comp1))
 	// Check that the completion was NACKed
 	require.Error(t, comp1.Err())
 
@@ -1400,11 +1401,11 @@ func TestWaitForAck(t *testing.T) {
 
 	cdsCallback, cdsComp := newCompCallback(logger)
 	cdsMutator.Upsert(ClusterTypeURL, clusterConf.Name, clusterConf, []string{node0}, wg, cdsCallback)
-	require.Condition(t, isNotCompletedComparison(cdsComp))
+	require.Condition(t, doesNotCompleteComparison(cdsComp))
 
 	ldsCallback, ldsComp := newCompCallback(logger)
 	ldsMutator.Upsert(ListenerTypeURL, listenerConf.Name, listenerConf, []string{node0}, wg, ldsCallback)
-	require.Condition(t, isNotCompletedComparison(ldsComp))
+	require.Condition(t, doesNotCompleteComparison(ldsComp))
 
 	// Request listener resources, with a version higher than the version currently
 	// in Cilium's cache. This happens after the server restarts but the
@@ -1599,7 +1600,7 @@ func TestWaitForAckNoClusters(t *testing.T) {
 
 	ldsCallback, ldsComp := newCompCallback(logger)
 	ldsMutator.Upsert(ListenerTypeURL, listenerConf.Name, listenerConf, []string{node0}, wg, ldsCallback)
-	require.Condition(t, isNotCompletedComparison(ldsComp))
+	require.Condition(t, doesNotCompleteComparison(ldsComp))
 
 	// Request listener resources, with a version higher than the version currently
 	// in Cilium's cache. This happens after the server restarts but the

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -105,8 +105,6 @@ type XDSServer interface {
 	//
 	// Only used for testing
 	GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error)
-	// UseCurrentNetworkPolicy waits for any pending update on NetworkPolicy to be acked.
-	UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup)
 	// UpdateNetworkPolicy adds or updates a network policy in the set published to L7 proxies.
 	// When the proxy acknowledges the network policy update, it will result in
 	// a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
@@ -1596,23 +1594,6 @@ func getNodeIDs(ep endpoint.EndpointUpdater, policy *policy.L4Policy) []string {
 	// Host proxy uses "127.0.0.1" as the nodeID
 	nodeIDs = append(nodeIDs, "127.0.0.1")
 	return nodeIDs
-}
-
-func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	// If there are no listeners configured, the local node's Envoy proxy won't
-	// query for network policies and therefore will never ACK them, and we'd
-	// wait forever.
-	if s.npdsListeners.Empty() {
-		wg = nil
-	}
-
-	nodeIDs := getNodeIDs(ep, &policy.SelectorPolicy.L4Policy)
-
-	// only wait for the most current policy to be acked when no (new) policy is given
-	s.networkPolicyMutator.UseCurrent(NetworkPolicyTypeURL, nodeIDs, wg)
 }
 
 // ErrNotImplemented is the error returned by gRPC methods that are not

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -873,9 +873,9 @@ func (s *xdsServer) upsertListener(name string, listenerConf *envoy_config_liste
 
 	// 'callback' is not called if there is no change and this configuration has already been acked.
 	revertFunc := s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConf, []string{"127.0.0.1"}, wg, callback)
-	return func(c *completion.Completion) {
+	return func() {
 		s.mutex.Lock()
-		revertFunc(c)
+		revertFunc()
 		revertNPDSTracking()
 		s.mutex.Unlock()
 	}
@@ -893,10 +893,10 @@ func (s *xdsServer) deleteListener(name string, wg *completion.WaitGroup, callba
 
 	// 'callback' is not called if there is no change and this configuration has already been acked.
 	revertFunc := s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, callback)
-	return func(c *completion.Completion) {
+	return func() {
 		s.mutex.Lock()
 		revertNPDSTracking()
-		revertFunc(c)
+		revertFunc()
 		s.mutex.Unlock()
 	}
 }
@@ -1080,10 +1080,10 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 	}
 	s.mutex.Unlock()
 
-	return func(completion *completion.Completion) {
+	return func() {
 		s.mutex.Lock()
 		if listenerRevertFunc != nil {
-			listenerRevertFunc(completion)
+			listenerRevertFunc()
 		}
 		if revertNPDSTracking != nil {
 			revertNPDSTracking()
@@ -1701,9 +1701,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 			}
 		}
 
-		// Don't wait for an ACK for the reverted xDS updates.
-		// This is best-effort.
-		revertFunc(nil)
+		revertFunc()
 
 		s.logger.Debug("Finished reverting xDS network policy update")
 
@@ -1881,7 +1879,7 @@ func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resource
 
 		// revert all changes in case of failure
 		if err != nil {
-			revertFuncs.Revert(nil)
+			revertFuncs.Revert()
 			s.logger.Debug("UpsertEnvoyResources: Finished reverting failed xDS transactions")
 			return err
 		}
@@ -1921,7 +1919,7 @@ func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resource
 
 		// revert all changes in case of failure
 		if err != nil {
-			revertFuncs.Revert(nil)
+			revertFuncs.Revert()
 			s.logger.Debug("UpsertEnvoyResources: Finished reverting failed xDS transactions")
 		}
 		return err
@@ -2151,7 +2149,7 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 
 		// revert all changes in case of failure
 		if err != nil {
-			revertFuncs.Revert(nil)
+			revertFuncs.Revert()
 			s.logger.Debug("UpdateEnvoyResources: Finished reverting failed xDS transactions")
 		}
 		return err
@@ -2219,7 +2217,7 @@ func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 
 		// revert all changes in case of failure
 		if err != nil {
-			revertFuncs.Revert(nil)
+			revertFuncs.Revert()
 			s.logger.Debug("DeleteEnvoyResources: Finished reverting failed xDS transactions")
 		}
 		return err

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -90,14 +90,25 @@ type XDSServer interface {
 
 	// UpsertEnvoyResources inserts or updates Envoy resources in 'resources' to the xDS cache,
 	// from where they will be delivered to Envoy via xDS streaming gRPC.
+	// 'ctx' is used in Wait for Envoy N/ACK if resources contains both listeners and
+	// clusters. This is needed due to the possible dependency between them. If this is possible
+	// that caller MUST pass a context with a timeout to prevent indefinite blocking in case
+	// Envoy never responds.
 	UpsertEnvoyResources(ctx context.Context, resources Resources) error
 	// UpdateEnvoyResources removes any resources in 'old' that are not
 	// present in 'new' and then adds or updates all resources in 'new'.
 	// Envoy does not support changing the listening port of an existing
 	// listener, so if the port changes we have to delete the old listener
 	// and then add the new one with the new port number.
+	// Uses 'ctx' in Wait for Envoy N/ACK if resources contains listeners. This is needed due to
+	// the possible dependency between listeners and listeners and clusters. If resources
+	// includes listeners the caller MUST pass a context with a timeout to prevent indefinite
+	// blocking in case Envoy never responds.
 	UpdateEnvoyResources(ctx context.Context, old, new Resources) error
-	// DeleteEnvoyResources deletes all Envoy resources in 'resources'.
+	// DeleteEnvoyResources deletes all Envoy resources in 'resources'.  Uses 'ctx' in Wait for
+	// Envoy N/ACK if resources contains listeners. If resources includes listeners the caller
+	// MUST pass a context with a timeout to prevent indefinite blocking in case Envoy never
+	// responds.
 	DeleteEnvoyResources(ctx context.Context, resources Resources) error
 
 	// GetNetworkPolicies returns the current version of the network policies with the given names.
@@ -1776,6 +1787,10 @@ func (old *Resources) ListenersAddedOrDeleted(new *Resources) bool {
 	return false
 }
 
+// UpsertEnvoyResources uses 'ctx' in Wait for Envoy N/ACK if resources contains both listeners and
+// clusters. This is needed due to the possible dependency between them. If this is the case the
+// caller MUST pass a context with a timeout to prevent indefinite blocking in case Envoy never
+// responds.
 func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resources) error {
 	if option.Config.Debug {
 		msg := ""
@@ -1908,6 +1923,10 @@ func (s *xdsServer) UpsertEnvoyResources(ctx context.Context, resources Resource
 	return nil
 }
 
+// UpdateEnvoyResources uses 'ctx' in Wait for Envoy N/ACK if resources contains listeners. This is
+// needed due to the possible dependency between listeners and listeners and clusters. If resources
+// includes listeners the caller MUST pass a context with a timeout to prevent indefinite blocking
+// in case Envoy never responds.
 func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources) error {
 	waitForDelete := false
 	var wg *completion.WaitGroup
@@ -2055,7 +2074,8 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 		revertFuncs = append(revertFuncs, s.deleteSecret(secret.Name, nil))
 	}
 
-	// Have to wait for deletes to complete before adding new listeners if a listener's port number is changed.
+	// Have to wait for deletes to complete before adding new listeners if a listener's port
+	// number is changed.
 	if wg != nil && waitForDelete {
 		start := time.Now()
 		s.logger.Debug("UpdateEnvoyResources: Waiting for proxy deletes to complete...")
@@ -2138,6 +2158,9 @@ func (s *xdsServer) UpdateEnvoyResources(ctx context.Context, old, new Resources
 	return nil
 }
 
+// DeleteEnvoyResources uses 'ctx' in Wait for Envoy N/ACK if resources contains listeners. If
+// resources includes listeners the caller MUST pass a context with a timeout to prevent indefinite
+// blocking in case Envoy never responds.
 func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resources) error {
 	s.logger.Debug("DeleteEnvoyResources: Deleting Envoy resources",
 		logfields.ResourceListeners, len(resources.Listeners),
@@ -2148,7 +2171,7 @@ func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 	)
 	var wg *completion.WaitGroup
 	var revertFuncs xds.AckingResourceMutatorRevertFuncList
-	// Wait only if new Listeners are added, as they will always be acked.
+	// Wait only if new Listeners are removed, as they will always be acked.
 	// (unreferenced routes or endpoints (and maybe clusters) are not ACKed or NACKed).
 	if len(resources.Listeners) > 0 {
 		wg = completion.NewWaitGroup(ctx)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"sync"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 
@@ -53,7 +52,7 @@ type endpointManager interface {
 	GetEndpoints() []*endpoint.Endpoint
 	GetHostEndpoint() *endpoint.Endpoint
 	GetEndpointsByPodName(string) []*endpoint.Endpoint
-	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+	UpdatePolicyMaps(context.Context) error
 }
 
 type nodeManager interface {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -752,6 +752,9 @@ const (
 	// EndpointRegenInterval is the interval of the periodic endpoint regeneration loop.
 	EndpointRegenInterval = "endpoint-regen-interval"
 
+	// EndpointPolicyUpdateTimeout is the timeout duration for Endpoint policy updates.
+	EndpointPolicyUpdateTimeout = "endpoint-policy-update-timeout"
+
 	// LocalRouterIPv4 is the link-local IPv4 address to use for Cilium router device
 	LocalRouterIPv4 = "local-router-ipv4"
 

--- a/pkg/policy/cell/identity_updater.go
+++ b/pkg/policy/cell/identity_updater.go
@@ -5,6 +5,7 @@ package policycell
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"maps"
 	"slices"
@@ -206,15 +207,24 @@ func (i *identityUpdater) doUpdatePolicyMaps(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	// UpdatePolicyMaps also waits for notifications to be complete, but we already waited :-)
-	noopWG := &sync.WaitGroup{}
-
 	// Direct all endpoints to consume the incremental changes and update policy.
-	// This returns a wg that is done when all endpoints have updated both their bpf
+	// This waits until all endpoints have updated both their bpf
 	// policymaps as well as Envoy. (Or if ctx is closed).
 	i.logger.Debug("Incremental policy update: triggering UpdatePolicyMaps for all endpoints")
-	updatedWG := i.epmanager.UpdatePolicyMaps(ctx, noopWG)
-	updatedWG.Wait()
+	err := i.epmanager.UpdatePolicyMaps(ctx)
+	if errors.Is(err, context.DeadlineExceeded) {
+		i.logger.Warn("Endpoint proxy policy update timed out. Retrying...",
+			logfields.Error, err)
+
+		// enqueue a dummy update and trigger again
+		wg := &sync.WaitGroup{}
+		i.enqueue(wg, time.Now(), false)
+		i.updatePolicyMaps.Trigger()
+
+		// proceed as if the proxy updates had completed. This is to guard against stalling
+		// for repeated timeouts
+	}
+
 	metrics.PolicyIncrementalUpdateDuration.WithLabelValues("global").Observe(time.Since(q.firstStartTime).Seconds())
 
 	// We mutated a selector, we must regenerate.

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -71,10 +71,6 @@ func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater,
 	return p.xdsServer.UpdateNetworkPolicy(ep, policy, wg)
 }
 
-func (p *envoyProxyIntegration) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
-	p.xdsServer.UseCurrentNetworkPolicy(ep, policy, wg)
-}
-
 func (p *envoyProxyIntegration) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	p.xdsServer.RemoveNetworkPolicy(ep)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -334,10 +334,6 @@ func (p *Proxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.
 	return p.envoyIntegration.UpdateNetworkPolicy(ep, policy, wg)
 }
 
-func (p *Proxy) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
-	p.envoyIntegration.UseCurrentNetworkPolicy(ep, policy, wg)
-}
-
 func (p *Proxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	p.envoyIntegration.RemoveNetworkPolicy(ep)
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -205,10 +205,6 @@ func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *p
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) {
-	panic("unimplemented")
-}
-
 func (*fakeXdsServer) GetPolicySecretSyncNamespace() string {
 	panic("unimplemented")
 }

--- a/pkg/ztunnel/reconciler/reconciler_test.go
+++ b/pkg/ztunnel/reconciler/reconciler_test.go
@@ -179,7 +179,7 @@ func (m *MockEndpointManager) Unsubscribe(s endpointmanager.Subscriber) {
 	delete(m.subscribers, s)
 }
 
-func (m *MockEndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
+func (m *MockEndpointManager) UpdatePolicyMaps(ctx context.Context) error {
 	panic("MockEndpointManager.UpdatePolicyMaps not implemented")
 }
 

--- a/pkg/ztunnel/xds/xds_server_test.go
+++ b/pkg/ztunnel/xds/xds_server_test.go
@@ -156,7 +156,7 @@ func (m *MockEndpointManager) Unsubscribe(s endpointmanager.Subscriber) {
 	m._Unsubscribe(s)
 }
 
-func (m *MockEndpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup {
+func (m *MockEndpointManager) UpdatePolicyMaps(ctx context.Context) error {
 	panic("MockEndpointManager.UpdatePolicyMaps not implemented")
 }
 


### PR DESCRIPTION
Add a new CLI option `--endpoint-policy-update-timeout`, and corresponding helm value `endpointPolicyUpdateTimeoutDuration` defaulting to 10 seconds. This is used on the context passed to `completion.NewWaitGroup`, so that by default endpointmanager waits for up to 10 seconds for Envoy
policy updates to be applied and acknowledged by Envoy.

Change `UpdatePolicyMaps()` to Wait before returning and return the error from `Wait`. Remove the unused 2nd parameter. Add `endpoint-policy-update-timeout` to the context for the proxyWaitGroup. If an error is returned, make the sole caller re-trigger the policy updates with an empty WaitGroup, so that if there are no other queued events, then the policy update is done immediately again.

When the `completion.WaitGroup` context times out, return the blocking Completion's remaining resources in the returned error.

Only wait for ACKs from xDS nodes not ACKed yet.

Fixes: #44543
