### PR TITLE
bpf: nodeport: clarify usage of CB_NAT_46X64 in nodeport_svc_lb6()

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1512,8 +1512,8 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 		 * IPv4-in-IPv6 converted addresses.
 		 */
 		ctx_store_meta(ctx, CB_NAT_46X64,
-			       !is_v4_in_v6(&key->address) &&
-			       lb6_to_lb4_service(svc));
+			       !is_v4_in_v6(&key->address) && lb6_to_lb4_service(svc) ?
+			       NAT46x64_MODE_XLATE : 0);
 		return tail_call_internal(ctx, CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS,
 					  ext_err);
 	}


### PR DESCRIPTION
Spell out what NAT46x64_MODE_* macro we use here, and don't rely on the boolean expression resulting in the expected numeric value.