### PR TITLE
 policy: remove port range trie from L4Policy 

### DIFF
--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1598,8 +1598,8 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 
 		var havePassRules bool
 		var wildcardSelectorPrecedence policyTypes.Precedence
-		for _, protocol := range []string{u8proto.ANY.String(), u8proto.TCP.String()} {
-			l4 := l4Policy[tier].ExactLookup("0", 0, protocol)
+		for _, protocol := range []u8proto.U8proto{u8proto.ANY, u8proto.TCP} {
+			l4 := l4Policy[tier].ExactLookupPortNum(0, 0, protocol)
 			if l4 != nil {
 				havePasses, wildcardPrecedence := addWildcardPortRules(l4, tierBasePriority, tierLastPriority)
 				if wildcardSelectorPrecedence < wildcardPrecedence {

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -31,6 +31,7 @@ import (
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/spanstat"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	"github.com/cilium/cilium/pkg/u8proto"
 )
 
 var (
@@ -364,7 +365,7 @@ var ExpectedPortNetworkPolicyRule1Wildcard = &cilium.PortNetworkPolicyRule{
 var L4PolicyMap1 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1: L7Rules12,
 		},
@@ -374,7 +375,7 @@ var L4PolicyMap1 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 var L4PolicyMap1HeaderMatch = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1: L7Rules12HeaderMatch,
 		},
@@ -384,7 +385,7 @@ var L4PolicyMap1HeaderMatch = policy.NewL4PolicyMapWithValues(map[string]*policy
 var L4PolicyMap1RequiresV2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1:           L7Rules1,
 			cachedRequiresV2Selector1: L7Rules12,
@@ -395,7 +396,7 @@ var L4PolicyMap1RequiresV2 = policy.NewL4PolicyMapWithValues(map[string]*policy.
 var L4PolicyMap2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"8080/TCP": {
 		Port:     8080,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector2: L7Rules1,
 		},
@@ -405,7 +406,7 @@ var L4PolicyMap2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 var L4PolicyMap1Deny2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"8080/TCP": {
 		Port:     8080,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1: denyPerSelectorPolicy,
 			cachedSelector2: L7Rules1,
@@ -416,7 +417,7 @@ var L4PolicyMap1Deny2 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Fil
 var L4PolicyMap3 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			wildcardCachedSelector: L7Rules12,
 		},
@@ -427,7 +428,7 @@ var L4PolicyMap3 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 var L4PolicyMap4 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1: &policy.PerSelectorPolicy{L7Rules: api.L7Rules{}},
 		},
@@ -438,7 +439,7 @@ var L4PolicyMap4 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 var L4PolicyMap5 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			wildcardCachedSelector: &policy.PerSelectorPolicy{L7Rules: api.L7Rules{}},
 		},
@@ -449,7 +450,7 @@ var L4PolicyMap5 = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 var L4PolicyMap5LowestPriority = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"80/TCP": {
 		Port:     80,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			wildcardCachedSelector: &policy.PerSelectorPolicy{
 				Priority: policyTypes.LowestPriority,
@@ -463,7 +464,7 @@ var L4PolicyMap5LowestPriority = policy.NewL4PolicyMapWithValues(map[string]*pol
 var L4PolicyMapSNI = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 	"443/TCP": {
 		Port:     443,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			wildcardCachedSelector: &policy.PerSelectorPolicy{
 				ServerNames: policy.NewStringSet([]string{
@@ -498,7 +499,7 @@ var L4PolicyMapPass = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filte
 	"0/TCP": {
 		Tier:     0,
 		Port:     0,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1: &policy.PerSelectorPolicy{
 				Priority: 0,
@@ -513,7 +514,7 @@ var L4PolicyMapPass = policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filte
 	"443/TCP": {
 		Tier:     1,
 		Port:     443,
-		Protocol: api.ProtoTCP,
+		Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 		PerSelectorPolicies: policy.L7DataMap{
 			cachedSelector1: &policy.PerSelectorPolicy{
 				Priority: 50,
@@ -934,7 +935,7 @@ func TestGetDirectionNetworkPolicyWildcardPass(t *testing.T) {
 			"0/TCP": {
 				Tier:     0,
 				Port:     0,
-				Protocol: api.ProtoTCP,
+				Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: policy.L7DataMap{
 					wildcardCachedSelector: {
 						Priority: policyTypes.HighestPriority,
@@ -945,7 +946,7 @@ func TestGetDirectionNetworkPolicyWildcardPass(t *testing.T) {
 			"443/TCP": {
 				Tier:     1,
 				Port:     443,
-				Protocol: api.ProtoTCP,
+				Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: policy.L7DataMap{
 					cachedSelector1: {
 						Priority: policyTypes.Priority(0x100),
@@ -980,7 +981,7 @@ func TestGetDirectionNetworkPolicyWildcardPass(t *testing.T) {
 		*l4DirectionPolicy = policy.NewL4DirectionPolicyForTest(policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 			"0/TCP": {
 				Port:     0,
-				Protocol: api.ProtoAny,
+				Protocol: api.ProtoAny, U8Proto: u8proto.ANY,
 				PerSelectorPolicies: policy.L7DataMap{
 					wildcardCachedSelector: {
 						Priority: passPriority,
@@ -990,7 +991,7 @@ func TestGetDirectionNetworkPolicyWildcardPass(t *testing.T) {
 			},
 			"80/TCP": {
 				Port:     80,
-				Protocol: api.ProtoTCP,
+				Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: policy.L7DataMap{
 					cachedSelector1: {
 						Priority: passPriority,
@@ -1043,7 +1044,7 @@ func TestGetDirectionNetworkPolicyWildcardPass(t *testing.T) {
 			},
 			"80/TCP": {
 				Port:     80,
-				Protocol: api.ProtoTCP,
+				Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: policy.L7DataMap{
 					cachedSelector1: {
 						Priority: passPriority + 1,
@@ -1168,18 +1169,21 @@ func TestGetDirectionNetworkPolicyWildcardRedirect(t *testing.T) {
 				ListenerPriority: policy.ListenerPriorityCRD,
 			}
 
+			u8p, err := u8proto.ParseProtocol(string(tc.redirectProtocol))
+			require.NoError(t, err)
+
 			l4DirectionPolicy := &policy.L4DirectionPolicy{
 				PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 					"0/" + string(tc.redirectProtocol): {
 						Port:     0,
-						Protocol: tc.redirectProtocol,
+						Protocol: tc.redirectProtocol, U8Proto: u8p,
 						PerSelectorPolicies: policy.L7DataMap{
 							wildcardCachedSelector: redirectPolicy,
 						},
 					},
 					"80/TCP": {
 						Port:     80,
-						Protocol: api.ProtoTCP,
+						Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 						PerSelectorPolicies: policy.L7DataMap{
 							cachedSelector1: tc.port80Policy,
 						},
@@ -1442,7 +1446,7 @@ func newL4PolicyTLSEgress(tls *policy.TLSContext) *policy.L4Policy {
 	return &policy.L4Policy{
 		Egress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 			"443/TCP": {
-				Port: 443, Protocol: api.ProtoTCP,
+				Port: 443, Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: policy.L7DataMap{
 					cachedSelector1: &policy.PerSelectorPolicy{
 						L7Parser:       "tls",
@@ -1509,7 +1513,7 @@ func newL4PolicyTLSIngress(tls *policy.TLSContext) *policy.L4Policy {
 	return &policy.L4Policy{
 		Ingress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 			"443/TCP": {
-				Port: 443, Protocol: api.ProtoTCP,
+				Port: 443, Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: policy.L7DataMap{
 					cachedSelector1: &policy.PerSelectorPolicy{
 						L7Parser:       "tls",
@@ -1552,7 +1556,7 @@ var ExpectedPerPortPoliciesTLSIngressNoSyncUseFullContext = newIngressPortNetwor
 var L4PolicyTLSFullContext = &policy.L4Policy{
 	Ingress: policy.L4DirectionPolicy{PortRules: policy.NewL4PolicyMapWithValues(map[string]*policy.L4Filter{
 		"443/TCP": {
-			Port: 443, Protocol: api.ProtoTCP,
+			Port: 443, Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 			PerSelectorPolicies: policy.L7DataMap{
 				cachedSelector1: &policy.PerSelectorPolicy{
 					L7Parser: "tls",

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 	"sync/atomic"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
@@ -21,7 +20,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/container/bitlpm"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/iana"
 	"github.com/cilium/cilium/pkg/identity"
@@ -1222,12 +1220,10 @@ func (l4 *L4Filter) String() string {
 // addL4Filter adds 'filterToMerge' into the 'resMap'. Returns an error if it
 // the 'filterToMerge' can't be merged with an existing filter for the same
 // port and proto.
-func (resMap *L4PolicyMap) addL4Filter(policyCtx PolicyContext,
-	p api.PortProtocol, filterToMerge *L4Filter,
-) error {
-	existingFilter := resMap.ExactLookup(p.Port, uint16(p.EndPort), string(p.Protocol))
+func (resMap *L4PolicyMap) addL4Filter(policyCtx PolicyContext, filterToMerge *L4Filter) error {
+	existingFilter := resMap.exactLookupFilter(filterToMerge)
 	if existingFilter == nil {
-		resMap.Upsert(p.Port, uint16(p.EndPort), string(p.Protocol), filterToMerge)
+		resMap.upsert(filterToMerge)
 		return nil
 	}
 
@@ -1236,16 +1232,15 @@ func (resMap *L4PolicyMap) addL4Filter(policyCtx PolicyContext,
 		return err
 	}
 
-	resMap.Upsert(p.Port, uint16(p.EndPort), string(p.Protocol), existingFilter)
+	resMap.upsert(existingFilter)
 	return nil
 }
 
 // makeL4PolicyMap creates an new L4PolicMap.
 func makeL4PolicyMap() L4PolicyMap {
 	return L4PolicyMap{
-		NamedPortMap:   make(map[string]*L4Filter),
-		RangePortMap:   make(map[portProtoKey]*L4Filter),
-		RangePortIndex: bitlpm.NewUintTrie[uint32, map[portProtoKey]struct{}](),
+		NamedPortMap: make(map[string]*L4Filter),
+		RangePortMap: make(map[portProtoKey]*L4Filter),
 	}
 }
 
@@ -1279,24 +1274,27 @@ func (ls L4PolicyMaps) Filters() iter.Seq[*L4Filter] {
 }
 
 // NewL4PolicyMapWithValues creates an new L4PolicMap, with an initial
-// set of values. The initMap argument does not support port ranges.
-// Only used for testing but from multiple packages.
+// set of values. The initMap keys are no longer used, but kept for
+// convenience reasons (who wants to rewrite hundreds of tests? not me.)
+// Only used for testing but from multiple packages. May panic.
 func NewL4PolicyMapWithValues(initMap map[string]*L4Filter) L4PolicyMaps {
 	l4M := L4PolicyMaps{makeL4PolicyMap()}
-	for k, v := range initMap {
+	for _, v := range initMap {
 		l4M.ensureTier(v.Tier)
-		portProtoSlice := strings.Split(k, "/")
-		if len(portProtoSlice) < 2 {
-			continue
+		if v.Protocol == api.ProtoAny && (v.Port != 0 || v.PortName != "") {
+			panic("proto ANY is not allowed with a specified port")
 		}
-		l4M[v.Tier].Upsert(portProtoSlice[0], 0, portProtoSlice[1], v)
+		if u8p, err := u8proto.ParseProtocol(string(v.Protocol)); err != nil || u8p != v.U8Proto {
+			panic(fmt.Sprintf("protocol %s does not match u8protocol %d, should be %d", v.Protocol, v.U8Proto, u8p))
+		}
+		l4M[v.Tier].upsert(v)
 	}
 	return l4M
 }
 
 type portProtoKey struct {
 	Port, EndPort uint16
-	Proto         uint8
+	Proto         u8proto.U8proto
 }
 
 // L4PolicyMap is the implementation of L4PolicyMap
@@ -1309,101 +1307,44 @@ type L4PolicyMap struct {
 	// RangePortMap is a map of all L4Filters indexed by their port-
 	// protocol.
 	RangePortMap map[portProtoKey]*L4Filter
-	// RangePortIndex is an index of all L4Filters so that
-	// L4Filters that have overlapping port ranges can be looked up
-	// by with a single port.
-	RangePortIndex *bitlpm.UintTrie[uint32, map[portProtoKey]struct{}]
 }
 
-func parsePortProtocol(port, protocol string) (uint16, uint8) {
-	// These string values have been validated many times
-	// over at this point.
-	prt, _ := strconv.ParseUint(port, 10, 16)
-	proto, _ := u8proto.ParseProtocol(protocol)
-	return uint16(prt), uint8(proto)
-}
-
-// makePolicyMapKey creates a protocol-port uint32 with the
-// upper 16 bits containing the protocol and the lower 16
-// bits containing the port.
-func makePolicyMapKey(port, mask uint16, proto uint8) uint32 {
-	return (uint32(proto) << 16) | uint32(port&mask)
-}
-
-// Upsert L4Filter adds an L4Filter indexed by protocol/port-endPort.
-func (l4M *L4PolicyMap) Upsert(port string, endPort uint16, protocol string, l4 *L4Filter) {
-	if iana.IsSvcName(port) {
-		l4M.NamedPortMap[port+"/"+protocol] = l4
+// upsert L4Filter adds an L4Filter indexed by protocol/port-endPort.
+func (l4M *L4PolicyMap) upsert(l4 *L4Filter) {
+	if l4.PortName != "" {
+		l4M.NamedPortMap[l4.PortName+"/"+string(l4.Protocol)] = l4
 		return
 	}
 
-	portU, protoU := parsePortProtocol(port, protocol)
 	ppK := portProtoKey{
-		Port:    portU,
-		EndPort: endPort,
-		Proto:   protoU,
+		Port:    l4.Port,
+		EndPort: l4.EndPort,
+		Proto:   l4.U8Proto,
 	}
-	_, indexExists := l4M.RangePortMap[ppK]
 	l4M.RangePortMap[ppK] = l4
-	// We do not need to reindex a key that already exists,
-	// even if the filter changed.
-	if !indexExists {
-		for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
-			k := makePolicyMapKey(mp.port, mp.mask, protoU)
-			prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
-			portProtoSet, ok := l4M.RangePortIndex.ExactLookup(prefix, k)
-			if !ok {
-				portProtoSet = make(map[portProtoKey]struct{})
-				l4M.RangePortIndex.Upsert(prefix, k, portProtoSet)
-			}
-			portProtoSet[ppK] = struct{}{}
-		}
+}
+
+// exactLookupFilter looks to see if there is an exact match for the
+// supplied filter
+func (l4M *L4PolicyMap) exactLookupFilter(l4 *L4Filter) *L4Filter {
+	if l4.PortName != "" {
+		return l4M.ExactLookupPortName(l4.PortName, l4.U8Proto)
+	} else {
+		return l4M.ExactLookupPortNum(l4.Port, l4.EndPort, l4.U8Proto)
 	}
 }
 
-// Delete an L4Filter from the index by protocol/port-endPort
-func (l4M *L4PolicyMap) Delete(port string, endPort uint16, protocol string) {
-	if iana.IsSvcName(port) {
-		delete(l4M.NamedPortMap, port+"/"+protocol)
-		return
-	}
-
-	portU, protoU := parsePortProtocol(port, protocol)
-	ppK := portProtoKey{
-		Port:    portU,
-		EndPort: endPort,
-		Proto:   protoU,
-	}
-	_, indexExists := l4M.RangePortMap[ppK]
-	delete(l4M.RangePortMap, ppK)
-	// Only delete the index if the key exists.
-	if indexExists {
-		for _, mp := range PortRangeToMaskedPorts(portU, endPort) {
-			k := makePolicyMapKey(mp.port, mp.mask, protoU)
-			prefix := 32 - uint(bits.TrailingZeros16(mp.mask))
-			portProtoSet, ok := l4M.RangePortIndex.ExactLookup(prefix, k)
-			if !ok {
-				return
-			}
-			delete(portProtoSet, ppK)
-			if len(portProtoSet) == 0 {
-				l4M.RangePortIndex.Delete(prefix, k)
-			}
-		}
-	}
+// ExactLookupPortName looks up an L4Filter by protocol and named port.
+func (l4M *L4PolicyMap) ExactLookupPortName(portName string, protocol u8proto.U8proto) *L4Filter {
+	return l4M.NamedPortMap[portName+"/"+protocol.String()]
 }
 
-// ExactLookup looks up an L4Filter by protocol/port-endPort and looks for an exact match.
-func (l4M *L4PolicyMap) ExactLookup(port string, endPort uint16, protocol string) *L4Filter {
-	if iana.IsSvcName(port) {
-		return l4M.NamedPortMap[port+"/"+protocol]
-	}
-
-	portU, protoU := parsePortProtocol(port, protocol)
+// ExactLookupPortNum looks up an L4Filter by protocol/port-endPort and looks for an exact match.
+func (l4M *L4PolicyMap) ExactLookupPortNum(port uint16, endPort uint16, protocol u8proto.U8proto) *L4Filter {
 	ppK := portProtoKey{
-		Port:    portU,
+		Port:    port,
 		EndPort: endPort,
-		Proto:   protoU,
+		Proto:   protocol,
 	}
 	return l4M.RangePortMap[ppK]
 }

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -506,7 +506,7 @@ func TestL3Wildcarding(t *testing.T) {
 		},
 	}
 
-	expected0 := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
+	expected0 := NewL4PolicyMapWithValues(map[string]*L4Filter{"0/TCP": {
 		Port: 0, Protocol: api.ProtoTCP, U8Proto: 6,
 		Ingress: true, wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
@@ -531,7 +531,7 @@ func TestL3Wildcarding(t *testing.T) {
 		},
 	}
 
-	expectedAny := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
+	expectedAny := NewL4PolicyMapWithValues(map[string]*L4Filter{"0/ANY": {
 		Port: 0, Protocol: api.ProtoAny, U8Proto: 0,
 		Ingress: true, wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -210,13 +210,8 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 
 		require.Equal(t, expected[i].Len(), actual[i].Len())
 		expected[i].ForEach(func(l4 *L4Filter) bool {
-			port := l4.PortName
-			if len(port) == 0 {
-				port = fmt.Sprintf("%d", l4.Port)
-			}
-
-			l4B := actual[i].ExactLookup(port, l4.EndPort, string(l4.Protocol))
-			require.NotNil(t, l4B, "Port Protocol lookup failed: [Port: %s, EndPort: %d, Protocol: %s]", port, l4.EndPort, string(l4.Protocol))
+			l4B := actual[i].exactLookupFilter(l4)
+			require.NotNil(t, l4B, "Port Protocol lookup failed: [PortName %s, Port: %s, EndPort: %d, Protocol: %s]", l4.PortName, l4.Port, l4.EndPort, string(l4.Protocol))
 
 			// If no available IDs are provided, we assume the same pointer for
 			// cached selector is used for both expected and actual L4PolicyMap,

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -343,12 +343,13 @@ func TestJSONMarshal(t *testing.T) {
 			"8080/TCP": {
 				Port:     8080,
 				Protocol: api.ProtoTCP,
+				U8Proto:  u8proto.TCP,
 				Ingress:  false,
 			},
 		})},
 		Ingress: L4DirectionPolicy{PortRules: NewL4PolicyMapWithValues(map[string]*L4Filter{
 			"80/TCP": {
-				Port: 80, Protocol: api.ProtoTCP,
+				Port: 80, Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: L7DataMap{
 					td.cachedFooSelector: &PerSelectorPolicy{
 						Verdict:  types.Allow,
@@ -361,7 +362,7 @@ func TestJSONMarshal(t *testing.T) {
 				Ingress: true,
 			},
 			"9090/TCP": {
-				Port: 9090, Protocol: api.ProtoTCP,
+				Port: 9090, Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: L7DataMap{
 					td.cachedFooSelector: &PerSelectorPolicy{
 						Verdict:  types.Allow,
@@ -374,7 +375,7 @@ func TestJSONMarshal(t *testing.T) {
 				Ingress: true,
 			},
 			"8080/TCP": {
-				Port: 8080, Protocol: api.ProtoTCP,
+				Port: 8080, Protocol: api.ProtoTCP, U8Proto: u8proto.TCP,
 				PerSelectorPolicies: L7DataMap{
 					td.cachedFooSelector: &PerSelectorPolicy{
 						Verdict:  types.Allow,

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
-	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -490,72 +489,6 @@ func TestJSONMarshal(t *testing.T) {
 	}
 
 	require.True(t, policy.HasEnvoyRedirect())
-}
-
-// TestL4PolicyMapPortRangeOverlaps tests the Upsert, ExactLookup,
-// and Delete methods with L4Filters that have overlapping ports.
-func TestL4PolicyMapPortRangeOverlaps(t *testing.T) {
-	portRanges := []struct {
-		startPort, endPort uint16
-	}{
-		{1, 65534}, {1, 1023}, {0, 65535}, {1024, 65535},
-	}
-	for i, portRange := range portRanges {
-		t.Run(fmt.Sprintf("%d-%d", portRange.startPort, portRange.endPort), func(tt *testing.T) {
-			l4Map := makeL4PolicyMap()
-			startFilter := &L4Filter{
-				U8Proto:  u8proto.TCP,
-				Protocol: api.ProtoTCP,
-				Port:     portRange.startPort,
-				EndPort:  portRange.endPort,
-			}
-			startPort := fmt.Sprintf("%d", portRange.startPort)
-			l4Map.Upsert(startPort, portRange.endPort, "TCP", startFilter)
-			// we need to make a copy of portRanges to splice.
-			pRs := make([]struct{ startPort, endPort uint16 }, len(portRanges))
-			copy(pRs, portRanges)
-			// Iterate over every port range except the one being tested.
-			for _, altPR := range slices.Delete(pRs, i, i+1) {
-				t.Logf("Checking for port range %d-%d on main port range %d-%d", altPR.startPort, altPR.endPort, portRange.startPort, portRange.endPort)
-				altStartPort := fmt.Sprintf("%d", altPR.startPort)
-				// This range should not exist yet.
-				altL4 := l4Map.ExactLookup(altStartPort, altPR.endPort, "TCP")
-				if altL4 != nil {
-					require.Nilf(t, altL4, "%d-%d range found and it should not have been as %d-%d", altPR.startPort, altPR.endPort, altL4.Port, altL4.EndPort)
-				}
-				require.Nil(t, altL4)
-				altFilter := &L4Filter{
-					U8Proto:  u8proto.TCP,
-					Protocol: api.ProtoTCP,
-					Port:     altPR.startPort,
-					EndPort:  altPR.endPort,
-				}
-				// Upsert overlapping port range.
-				l4Map.Upsert(altStartPort, altPR.endPort, "TCP", altFilter)
-				altL4 = l4Map.ExactLookup(altStartPort, altPR.endPort, "TCP")
-				require.NotNilf(t, altL4, "%d-%d range not found and it should have been", altPR.startPort, altPR.endPort)
-				require.True(t, altL4.Equals(altFilter), "%d-%d range lookup returned a range of %d-%d",
-					altPR.startPort, altPR.endPort, altL4.Port, altL4.EndPort)
-
-				gotMainFilter := l4Map.ExactLookup(startPort, portRange.endPort, "TCP")
-				require.Truef(t, gotMainFilter.Equals(startFilter), "main range look up failed after %d-%d range upsert", altPR.startPort, altPR.endPort)
-
-				// Delete overlapping port range, and make sure it's not there.
-				l4Map.Delete(altStartPort, altPR.endPort, "TCP")
-				altL4 = l4Map.ExactLookup(altStartPort, altPR.endPort, "TCP")
-				if altL4 != nil {
-					require.Nilf(t, altL4, "%d-%d range found after a delete and it should not have been as %d-%d", altPR.startPort, altPR.endPort, altL4.Port, altL4.EndPort)
-				}
-				require.Nil(t, altL4)
-
-				gotMainFilter = l4Map.ExactLookup(startPort, portRange.endPort, "TCP")
-				require.Truef(t, gotMainFilter.Equals(startFilter), "main range look up failed after %d-%d range delete", altPR.startPort, altPR.endPort)
-
-				// Put it back for the next iteration.
-				l4Map.Upsert(altStartPort, altPR.endPort, "TCP", altFilter)
-			}
-		})
-	}
 }
 
 func BenchmarkContainsAllL3L4(b *testing.B) {

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1125,7 +1125,7 @@ func TestMinikubeGettingStarted(t *testing.T) {
 		},
 	}
 
-	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"TCP/80": {
+	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{"80/TCP": {
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		PerSelectorPolicies: L7DataMap{
 			td.cachedSelectorB: &PerSelectorPolicy{

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -343,7 +343,7 @@ func (resMap *L4PolicyMap) addFilter(policyCtx PolicyContext, entry *types.Polic
 		return 0, err
 	}
 
-	err = resMap.addL4Filter(policyCtx, p, filterToMerge)
+	err = resMap.addL4Filter(policyCtx, filterToMerge)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -637,7 +637,7 @@ func TestICMPPolicy(t *testing.T) {
 		},
 	}
 
-	expectedIn := NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMP/8": {
+	expectedIn := NewL4PolicyMapWithValues(map[string]*L4Filter{"8/ICMP": {
 		Port:     8,
 		Protocol: api.ProtoICMP,
 		U8Proto:  u8proto.ProtoIDs["icmp"],
@@ -649,7 +649,7 @@ func TestICMPPolicy(t *testing.T) {
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	}})
 
-	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMP/9": {
+	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"9/ICMP": {
 		Port:     9,
 		Protocol: api.ProtoICMP,
 		U8Proto:  u8proto.ProtoIDs["icmp"],
@@ -684,7 +684,7 @@ func TestICMPPolicy(t *testing.T) {
 	}
 
 	expected := NewL4PolicyMapWithValues(map[string]*L4Filter{
-		"ICMP/8": {
+		"8/ICMP": {
 			Port:     8,
 			Protocol: api.ProtoICMP,
 			U8Proto:  u8proto.ProtoIDs["icmp"],
@@ -695,7 +695,7 @@ func TestICMPPolicy(t *testing.T) {
 			},
 			RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 		},
-		"TCP/80": {
+		"80/TCP": {
 			Port:     80,
 			Protocol: api.ProtoTCP,
 			U8Proto:  u8proto.ProtoIDs["tcp"],
@@ -726,10 +726,10 @@ func TestICMPPolicy(t *testing.T) {
 		},
 	}
 
-	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"ICMPV6/128": {
+	expected = NewL4PolicyMapWithValues(map[string]*L4Filter{"128/ICMPV6": {
 		Port:     128,
 		Protocol: api.ProtoICMPv6,
-		U8Proto:  u8proto.ProtoIDs["icmp"],
+		U8Proto:  u8proto.ICMPv6,
 		Ingress:  true,
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
@@ -783,7 +783,7 @@ func TestIPProtocolsWithNoTransportPorts(t *testing.T) {
 	}
 
 	expectedIn := NewL4PolicyMapWithValues(map[string]*L4Filter{
-		"0/vrrp": {
+		"0/VRRP": {
 			Port:     0,
 			Protocol: api.ProtoVRRP,
 			U8Proto:  u8proto.ProtoIDs["vrrp"],
@@ -811,7 +811,7 @@ func TestIPProtocolsWithNoTransportPorts(t *testing.T) {
 		},
 	})
 
-	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"0/egress": {
+	expectedOut := NewL4PolicyMapWithValues(map[string]*L4Filter{"0/VRRP": {
 		Port:     0,
 		Protocol: api.ProtoVRRP,
 		U8Proto:  u8proto.ProtoIDs["vrrp"],

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -5,7 +5,6 @@ package policy
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -81,32 +80,32 @@ func TestL4Policy(t *testing.T) {
 	}
 
 	expected := NewL4Policy(0)
-	expected.Ingress.PortRules[0].Upsert("80", 0, "TCP", &L4Filter{
+	expected.Ingress.PortRules[0].upsert(&L4Filter{
 		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard:            td.wildcardCachedSelector,
 		PerSelectorPolicies: l7map, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
-	expected.Ingress.PortRules[0].Upsert("8080", 0, "TCP", &L4Filter{
+	expected.Ingress.PortRules[0].upsert(&L4Filter{
 		Port: 8080, Protocol: api.ProtoTCP, U8Proto: 6,
 		wildcard:            td.wildcardCachedSelector,
 		PerSelectorPolicies: l7map, Ingress: true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
 
-	expected.Egress.PortRules[0].Upsert("3000", 0, "TCP", &L4Filter{
+	expected.Egress.PortRules[0].upsert(&L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		wildcard:            td.wildcardCachedSelector,
 		PerSelectorPolicies: l7mapLevelOnly,
 		RuleOrigin:          OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
-	expected.Egress.PortRules[0].Upsert("3000", 0, "UDP", &L4Filter{
+	expected.Egress.PortRules[0].upsert(&L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		wildcard:            td.wildcardCachedSelector,
 		PerSelectorPolicies: l7mapLevelOnly,
 		RuleOrigin:          OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
-	expected.Egress.PortRules[0].Upsert("3000", 0, "SCTP", &L4Filter{
+	expected.Egress.PortRules[0].upsert(&L4Filter{
 		Port: 3000, Protocol: api.ProtoSCTP, U8Proto: 132, Ingress: false,
 		wildcard:            td.wildcardCachedSelector,
 		PerSelectorPolicies: l7mapLevelOnly,
@@ -152,7 +151,7 @@ func TestL4Policy(t *testing.T) {
 	}
 
 	expected = NewL4Policy(0)
-	expected.Ingress.PortRules[0].Upsert("80", 0, "TCP", &L4Filter{
+	expected.Ingress.PortRules[0].upsert(&L4Filter{
 		Port:     80,
 		Protocol: api.ProtoTCP,
 		U8Proto:  6,
@@ -170,7 +169,7 @@ func TestL4Policy(t *testing.T) {
 		Ingress:    true,
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
-	expected.Egress.PortRules[0].Upsert("3000", 0, "TCP", &L4Filter{
+	expected.Egress.PortRules[0].upsert(&L4Filter{
 		Port: 3000, Protocol: api.ProtoTCP, U8Proto: 6, Ingress: false,
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
@@ -178,7 +177,7 @@ func TestL4Policy(t *testing.T) {
 		},
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
-	expected.Egress.PortRules[0].Upsert("3000", 0, "UDP", &L4Filter{
+	expected.Egress.PortRules[0].upsert(&L4Filter{
 		Port: 3000, Protocol: api.ProtoUDP, U8Proto: 17, Ingress: false,
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
@@ -186,7 +185,7 @@ func TestL4Policy(t *testing.T) {
 		},
 		RuleOrigin: OriginForTest(map[CachedSelector]labels.LabelArrayList{td.wildcardCachedSelector: {nil}}),
 	})
-	expected.Egress.PortRules[0].Upsert("3000", 0, "SCTP", &L4Filter{
+	expected.Egress.PortRules[0].upsert(&L4Filter{
 		Port: 3000, Protocol: api.ProtoSCTP, U8Proto: 132, Ingress: false,
 		wildcard: td.wildcardCachedSelector,
 		PerSelectorPolicies: L7DataMap{
@@ -1148,8 +1147,8 @@ func TestL3RuleLabels(t *testing.T) {
 
 			type expectedResult map[string]labels.LabelArrayList
 			mapDirectionalResultsToExpectedOutput := map[*L4Filter]expectedResult{
-				finalPolicy.L4Policy.Ingress.PortRules[0].ExactLookup("0", 0, "ANY"): test.expectedIngressLabels,
-				finalPolicy.L4Policy.Egress.PortRules[0].ExactLookup("0", 0, "ANY"):  test.expectedEgressLabels,
+				finalPolicy.L4Policy.Ingress.PortRules[0].ExactLookupPortNum(0, 0, u8proto.ANY): test.expectedIngressLabels,
+				finalPolicy.L4Policy.Egress.PortRules[0].ExactLookupPortNum(0, 0, u8proto.ANY):  test.expectedEgressLabels,
 			}
 			for filter, exp := range mapDirectionalResultsToExpectedOutput {
 				if len(exp) > 0 {
@@ -1297,8 +1296,12 @@ func TestL4RuleLabels(t *testing.T) {
 			}
 			require.Equal(t, len(test.expectedIngressLabels), ingressLen, test.description)
 			for portProto := range test.expectedIngressLabels {
-				portProtoSlice := strings.Split(portProto, "/")
-				out := finalPolicy.L4Policy.Ingress.PortRules[0].ExactLookup(portProtoSlice[0], 0, portProtoSlice[1])
+				var port uint16
+				var proto string
+				fmt.Sscanf(portProto, "%d/%s", &port, &proto)
+				u8p, err := u8proto.ParseProtocol(proto)
+				require.NoError(t, err)
+				out := finalPolicy.L4Policy.Ingress.PortRules[0].ExactLookupPortNum(port, 0, u8p)
 				require.NotNil(t, out, test.description)
 				require.Len(t, out.RuleOrigin, 1, test.description)
 				lbls := out.RuleOrigin[out.wildcard].GetLabelArrayList()
@@ -1311,8 +1314,12 @@ func TestL4RuleLabels(t *testing.T) {
 			}
 			require.Equal(t, len(test.expectedEgressLabels), egressLen, test.description)
 			for portProto := range test.expectedEgressLabels {
-				portProtoSlice := strings.Split(portProto, "/")
-				out := finalPolicy.L4Policy.Egress.PortRules[0].ExactLookup(portProtoSlice[0], 0, portProtoSlice[1])
+				var port uint16
+				var proto string
+				fmt.Sscanf(portProto, "%d/%s", &port, &proto)
+				u8p, err := u8proto.ParseProtocol(proto)
+				require.NoError(t, err)
+				out := finalPolicy.L4Policy.Egress.PortRules[0].ExactLookupPortNum(port, 0, u8p)
 				require.NotNil(t, out, test.description)
 				require.Len(t, out.RuleOrigin, 1, test.description)
 				lbls := out.RuleOrigin[out.wildcard].GetLabelArrayList()
@@ -1598,7 +1605,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 	require.NoError(t, err)
 	defer pol.detach(true, 0)
 
-	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookup("80", 0, "TCP")
+	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)
 	require.NotNil(t, filter)
 	require.Equal(t, uint16(80), filter.Port)
 	require.True(t, filter.Ingress)
@@ -1631,7 +1638,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 	defer pol.detach(true, 0)
 
 	require.Len(t, pol.L4Policy.Ingress.PortRules, 1)
-	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookup("port-80", 0, "TCP")
+	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookupPortName("port-80", u8proto.TCP)
 	require.NotNil(t, filter)
 	require.Equal(t, uint16(0), filter.Port)
 	require.Equal(t, "port-80", filter.PortName)
@@ -1691,7 +1698,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 
 	t.Log(pol.L4Policy.Egress.PortRules)
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
-	filter := pol.L4Policy.Egress.PortRules[0].ExactLookup("80", 0, "TCP")
+	filter := pol.L4Policy.Egress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)
 	require.NotNil(t, filter)
 	require.Equal(t, uint16(80), filter.Port)
 	require.False(t, filter.Ingress)
@@ -1728,7 +1735,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 	defer pol.detach(true, 0)
 
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
-	filter := pol.L4Policy.Egress.PortRules[0].ExactLookup("80", 0, "TCP")
+	filter := pol.L4Policy.Egress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)
 	require.NotNil(t, filter)
 	require.Equal(t, uint16(80), filter.Port)
 	require.False(t, filter.Ingress)
@@ -1764,7 +1771,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 	defer pol.detach(true, 0)
 
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
-	filter := pol.L4Policy.Egress.PortRules[0].ExactLookup("80", 0, "TCP")
+	filter := pol.L4Policy.Egress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)
 	require.NotNil(t, filter)
 	require.Equal(t, uint16(80), filter.Port)
 	require.False(t, filter.Ingress)


### PR DESCRIPTION
The port range trie was only necessary for policy simulation. Since that is long gone, we can remove this extra data structure keeping things around.

This also removes some unnecessary parameters from internal methods. For example, we were passing the port + proto around as an additional parameter, despite the fact that we already have it in the L4Filter.

This also fixes some bugs in the tests w.r.t. incorrect literals.