### PR TITLE
clustermesh: fix MCS-API need update CRD

### DIFF
--- a/pkg/clustermesh/mcsapi/crdinstall.go
+++ b/pkg/clustermesh/mcsapi/crdinstall.go
@@ -83,35 +83,35 @@ func needsUpdateMCS(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinit
 	}
 
 	// release version check
-	v, ok := currentCRD.Labels[mcsapicrd.ReleaseVersionLabel]
+	currentVer, ok := currentCRD.Labels[mcsapicrd.ReleaseVersionLabel]
 	if !ok {
 		// no schema version detected
 		return true, nil
 	}
-	currentVersion, err := versioncheck.Version(v)
-	version, errTarget := versioncheck.Version(targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
+	currentVersion, err := versioncheck.Version(currentVer)
+	targetVersion, errTarget := versioncheck.Version(targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
 	if errTarget != nil {
 		return false, fmt.Errorf("invalid release version label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
 	}
 
-	if err != nil || currentVersion.LT(version) {
+	if err != nil || currentVersion.LT(targetVersion) {
 		// version in cluster is either unparsable or smaller than current version
 		return true, nil
 	}
 
 	// CRD Revision check
-	rev, ok := currentCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel]
+	currentRev, ok := currentCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel]
 	if !ok {
 		// no CRD revision detected
 		return true, nil
 	}
-	currentRevision, err := strconv.Atoi(rev)
-	revision, errTarget := strconv.Atoi(targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
+	currentRevision, err := strconv.Atoi(currentRev)
+	targetRevision, errTarget := strconv.Atoi(targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
 	if errTarget != nil {
 		return false, fmt.Errorf("invalid CRD revision label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
 	}
 
-	if err != nil || currentRevision < revision {
+	if err != nil || currentRevision < targetRevision {
 		// crd revision in cluster is either unparsable or smaller than current version
 		return true, nil
 	}

--- a/pkg/clustermesh/mcsapi/crdinstall.go
+++ b/pkg/clustermesh/mcsapi/crdinstall.go
@@ -94,9 +94,11 @@ func needsUpdateMCS(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinit
 		return false, fmt.Errorf("invalid release version label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
 	}
 
-	if err != nil || currentVersion.LT(targetVersion) {
-		// version in cluster is either unparsable or smaller than current version
-		return true, nil
+	if err != nil || !currentVersion.EQ(targetVersion) {
+		// upgrade the CRD if the in cluster version is either unparsable or smaller
+		// than the target CRD. Stop here if the in cluster version is higher
+		// to prevent downgrading the CRD.
+		return err != nil || currentVersion.LT(targetVersion), nil
 	}
 
 	// CRD Revision check
@@ -111,10 +113,7 @@ func needsUpdateMCS(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinit
 		return false, fmt.Errorf("invalid CRD revision label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
 	}
 
-	if err != nil || currentRevision < targetRevision {
-		// crd revision in cluster is either unparsable or smaller than current version
-		return true, nil
-	}
-
-	return false, nil
+	// upgrade the CRD if the in cluster revision is either unparsable or smaller
+	// than the target CRD
+	return err != nil || currentRevision < targetRevision, nil
 }

--- a/pkg/clustermesh/mcsapi/crdinstall_test.go
+++ b/pkg/clustermesh/mcsapi/crdinstall_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mcsapicrd "sigs.k8s.io/mcs-api/config/crd"
+)
+
+func newTestCRD(releaseVersion, revision string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				mcsapicrd.ReleaseVersionLabel:                         releaseVersion,
+				mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel: revision,
+			},
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Schema: &apiextensionsv1.CustomResourceValidation{},
+			}},
+		},
+	}
+}
+
+func TestNeedsUpdateMCS(t *testing.T) {
+	targetCRD := newTestCRD("v0.3.0", "42")
+
+	tests := []struct {
+		name       string
+		currentCRD *apiextensionsv1.CustomResourceDefinition
+		want       bool
+	}{
+		{
+			name:       "updates when current release version is older",
+			currentCRD: newTestCRD("v0.2.0", "99"),
+			want:       true,
+		},
+		{
+			name:       "does not update when current release version is newer",
+			currentCRD: newTestCRD("v0.5.0", "0"),
+			want:       false,
+		},
+		{
+			name:       "updates when release version matches and revision is older",
+			currentCRD: newTestCRD("v0.3.0", "0"),
+			want:       true,
+		},
+		{
+			name:       "does not update when release version matches and revision matches",
+			currentCRD: newTestCRD("v0.3.0", "42"),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := needsUpdateMCS(targetCRD, tt.currentCRD)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
-type NeedUpdateCRDFunc func(currentCRD, targetCRD *apiextensionsv1.CustomResourceDefinition) (bool, error)
+type NeedUpdateCRDFunc func(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinition) (bool, error)
 
 // CreateUpdateCRD ensures the CRD object is installed into the K8s cluster. It
 // will create or update the CRD and its validation schema as necessary. This


### PR DESCRIPTION
The two first commits are mainly cleanups, the real bugfix is on the third commit

```release-note
clustermesh: fix a bug in the MCS-API CRD installl that could attempt a CRD downgrade when the version label is higher
```
