### PR TITLE
gateway-api: remove backends with missing or invalid TLS policies

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1131,11 +1131,9 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 		}
 
 		// Lastly, pull out any valid BackendTLSPolicies, then check them.
-		// The SectionName logic has already deduplicated them, so we don't actually need to track
-		// the sectionName here.
-
-		validBTLSPs := collection.Valid
-		for _, original := range validBTLSPs {
+		// Policies that fail validation are moved from Valid to Invalid so
+		// the ingestion logic can distinguish "no policy" from "broken policy".
+		for sectionName, original := range collection.Valid {
 
 			btlsp := original.DeepCopy()
 
@@ -1178,6 +1176,12 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 					Name:      btlsp.GetName(),
 					Namespace: btlsp.GetNamespace(),
 				}] = struct{}{}
+			} else {
+				// This BackendTLSPolicy is invalid, so it should be removed from the valid
+				// map and added to the invalid map to ensure it's not used by the
+				// ingestion logic.
+				collection.DeleteValidPolicy(sectionName)
+				collection.UpsertInvalidPolicy(sectionName, original)
 			}
 
 			// Checks finished, apply the status to the actual objects.

--- a/operator/pkg/gateway-api/helpers/backendtlspolicies.go
+++ b/operator/pkg/gateway-api/helpers/backendtlspolicies.go
@@ -37,6 +37,9 @@ type BackendTLSPolicyTargetServiceCollection struct {
 	// Note that the an empty value for SectionName means
 	// "all sections", and will conflict with any other section name.
 	Valid map[gatewayv1.SectionName]*gatewayv1.BackendTLSPolicy
+	// Invalid holds the map of the section name on the Service
+	// to the BackendTLSPolicy that failed Cilium-specific validation.
+	Invalid map[gatewayv1.SectionName]*gatewayv1.BackendTLSPolicy
 	// Conflicted holds the all the conflicted BackendTLSPolicies that
 	// target this Service, with the map key being the object's full name.
 	// This avoids traversing a slice to find a match all the time.
@@ -49,6 +52,18 @@ func (b *BackendTLSPolicyTargetServiceCollection) UpsertValidPolicy(sectionName 
 	}
 
 	b.Valid[sectionName] = btlsp
+}
+
+func (b *BackendTLSPolicyTargetServiceCollection) DeleteValidPolicy(sectionName gatewayv1.SectionName) {
+	delete(b.Valid, sectionName)
+}
+
+func (b *BackendTLSPolicyTargetServiceCollection) UpsertInvalidPolicy(sectionName gatewayv1.SectionName, btlsp *gatewayv1.BackendTLSPolicy) {
+	if b.Invalid == nil {
+		b.Invalid = make(map[gatewayv1.SectionName]*gatewayv1.BackendTLSPolicy)
+	}
+
+	b.Invalid[sectionName] = btlsp
 }
 
 func (b *BackendTLSPolicyTargetServiceCollection) UpsertConflictedPolicy(btlspFullName types.NamespacedName, btlsp *gatewayv1.BackendTLSPolicy) {

--- a/operator/pkg/gateway-api/helpers/backendtlspolicies_test.go
+++ b/operator/pkg/gateway-api/helpers/backendtlspolicies_test.go
@@ -435,3 +435,94 @@ func Test_buildBackendTLSPolicyLookup(t *testing.T) {
 		})
 	}
 }
+
+func Test_UpsertInvalidPolicy(t *testing.T) {
+	btlsp := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("upsert into nil map initializes it", func(t *testing.T) {
+		collection := &BackendTLSPolicyTargetServiceCollection{}
+		collection.UpsertInvalidPolicy("https", btlsp)
+
+		if collection.Invalid == nil {
+			t.Fatal("Invalid map should be initialized")
+		}
+		if got := collection.Invalid[gatewayv1.SectionName("https")]; got != btlsp {
+			t.Errorf("expected policy in Invalid[\"https\"], got %v", got)
+		}
+	})
+
+	t.Run("upsert overwrites existing entry", func(t *testing.T) {
+		collection := &BackendTLSPolicyTargetServiceCollection{}
+		collection.UpsertInvalidPolicy("https", btlsp)
+
+		replacement := &gatewayv1.BackendTLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "replacement-policy",
+				Namespace: "default",
+			},
+		}
+		collection.UpsertInvalidPolicy("https", replacement)
+
+		if got := collection.Invalid[gatewayv1.SectionName("https")]; got != replacement {
+			t.Errorf("expected replacement policy, got %v", got)
+		}
+	})
+}
+
+func Test_DeleteValidPolicy(t *testing.T) {
+	btlsp := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("delete removes entry from Valid", func(t *testing.T) {
+		collection := &BackendTLSPolicyTargetServiceCollection{}
+		collection.UpsertValidPolicy("https", btlsp)
+		collection.DeleteValidPolicy("https")
+
+		if _, ok := collection.Valid[gatewayv1.SectionName("https")]; ok {
+			t.Error("expected entry to be deleted from Valid")
+		}
+	})
+
+	t.Run("delete on missing key is a no-op", func(t *testing.T) {
+		collection := &BackendTLSPolicyTargetServiceCollection{}
+		collection.UpsertValidPolicy("https", btlsp)
+		collection.DeleteValidPolicy("other")
+
+		if _, ok := collection.Valid[gatewayv1.SectionName("https")]; !ok {
+			t.Error("existing entry should not be affected")
+		}
+	})
+}
+
+func Test_MoveValidToInvalid(t *testing.T) {
+	btlsp := &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-policy",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("move from Valid to Invalid", func(t *testing.T) {
+		collection := &BackendTLSPolicyTargetServiceCollection{}
+		collection.UpsertValidPolicy("https", btlsp)
+
+		collection.DeleteValidPolicy("https")
+		collection.UpsertInvalidPolicy("https", btlsp)
+
+		if _, ok := collection.Valid[gatewayv1.SectionName("https")]; ok {
+			t.Error("entry should be removed from Valid")
+		}
+		if got := collection.Invalid[gatewayv1.SectionName("https")]; got != btlsp {
+			t.Errorf("entry should be in Invalid, got %v", got)
+		}
+	})
+}

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-ca-cert/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-ca-cert/output/cec-same-namespace.yaml
@@ -12,15 +12,6 @@ metadata:
       kind: Gateway
       name: same-namespace
 spec:
-  backendServices:
-    - name: backendtlspolicy-malformed-ca-certificate-ref-test
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
-    - name: backendtlspolicy-nonexistent-ca-certificate-ref-test
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
@@ -82,66 +73,18 @@ spec:
             - "abc.example.com:*"
           name: "abc.example.com"
           routes:
-            - match:
+            - direct_response:
+                body:
+                  inline_string: ""
+                status: 500
+              match:
                 path: /backendtlspolicy-nonexistent-ca-certificate-ref
-              route:
-                cluster: gateway-conformance-infra:backendtlspolicy-nonexistent-ca-certificate-ref-test:443
-                maxStreamDuration:
-                  maxStreamDuration: 0s
-            - match:
+            - direct_response:
+                body:
+                  inline_string: ""
+                status: 500
+              match:
                 path: /backendtlspolicy-malformed-ca-certificate-ref
-              route:
-                cluster: gateway-conformance-infra:backendtlspolicy-malformed-ca-certificate-ref-test:443
-                maxStreamDuration:
-                  maxStreamDuration: 0s
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/backendtlspolicy-malformed-ca-certificate-ref-test:443
-      name: gateway-conformance-infra:backendtlspolicy-malformed-ca-certificate-ref-test:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext: {}
-              validationContextSdsSecretConfig:
-                name: cilium-secrets/gateway-conformance-infra-cfgmap-malformed-ca-certificate
-          sni: abc.example.com
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 60s
-          useDownstreamProtocolConfig:
-            http2ProtocolOptions: {}
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/backendtlspolicy-nonexistent-ca-certificate-ref-test:443
-      name: gateway-conformance-infra:backendtlspolicy-nonexistent-ca-certificate-ref-test:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext: {}
-              validationContextSdsSecretConfig:
-                name: cilium-secrets/gateway-conformance-infra-cfgmap-nonexistent-ca-certificate
-          sni: abc.example.com
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 60s
-          useDownstreamProtocolConfig:
-            http2ProtocolOptions: {}
   services:
     - listener: ""
       name: cilium-gateway-same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-kind/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-invalid-kind/output/cec-same-namespace.yaml
@@ -12,11 +12,6 @@ metadata:
       kind: Gateway
       name: same-namespace
 spec:
-  backendServices:
-    - name: backendtlspolicy-invalid-kind-test
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
@@ -78,36 +73,12 @@ spec:
             - "abc.example.com:*"
           name: "abc.example.com"
           routes:
-            - match:
+            - direct_response:
+                body:
+                  inline_string: ""
+                status: 500
+              match:
                 path: /backendtlspolicy-invalid-kind
-              route:
-                cluster: gateway-conformance-infra:backendtlspolicy-invalid-kind-test:443
-                maxStreamDuration:
-                  maxStreamDuration: 0s
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/backendtlspolicy-invalid-kind-test:443
-      name: gateway-conformance-infra:backendtlspolicy-invalid-kind-test:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          commonTlsContext:
-            combinedValidationContext:
-              defaultValidationContext: {}
-              validationContextSdsSecretConfig:
-                name: cilium-secrets/gateway-conformance-infra-cfgmap-invalid-kind
-          sni: abc.example.com
-      type: EDS
-      typedExtensionProtocolOptions:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          commonHttpProtocolOptions:
-            idleTimeout: 60s
-          useDownstreamProtocolConfig:
-            http2ProtocolOptions: {}
   services:
     - listener: ""
       name: cilium-gateway-same-namespace

--- a/operator/pkg/model/ingestion/backendtlspolicy_test.go
+++ b/operator/pkg/model/ingestion/backendtlspolicy_test.go
@@ -20,8 +20,9 @@ import (
 // which are hard to represent correctly in YAML.
 
 type BackendTLSPolicyMapEntry struct {
-	ServiceName   string                                 `json:"svcName,omitempty"`
-	ValidPolicies map[string]*gatewayv1.BackendTLSPolicy `json:"valid,omitempty"`
+	ServiceName     string                                 `json:"svcName,omitempty"`
+	ValidPolicies   map[string]*gatewayv1.BackendTLSPolicy `json:"valid,omitempty"`
+	InvalidPolicies map[string]*gatewayv1.BackendTLSPolicy `json:"invalid,omitempty"`
 }
 
 type BackendTLSPolicyMapFixture struct {
@@ -37,22 +38,25 @@ func (bm *BackendTLSPolicyMapFixture) ToBackendTLSPolicyMap() (helpers.BackendTL
 			return nil, fmt.Errorf("Service Name must consist of namespace/name, was %s", fixture.ServiceName)
 		}
 		svcFullName := types.NamespacedName{Namespace: svcNameSplit[0], Name: svcNameSplit[1]}
+
+		if _, ok := btlspMap[svcFullName]; !ok {
+			btlspMap[svcFullName] = &helpers.BackendTLSPolicyTargetServiceCollection{}
+		}
+
 		for sn, policy := range fixture.ValidPolicies {
 			sectionName := gatewayv1.SectionName(sn)
-			// If there's no service entry in the btlspMap already, add one
-			if _, ok := btlspMap[svcFullName]; !ok {
-				btlspMap[svcFullName] = &helpers.BackendTLSPolicyTargetServiceCollection{
-					Valid: map[gatewayv1.SectionName]*gatewayv1.BackendTLSPolicy{
-						sectionName: policy,
-					},
-				}
-				continue
-			}
-			// If there's already a sectionName entry, that's an error
 			if _, ok := btlspMap[svcFullName].Valid[sectionName]; ok {
 				return nil, fmt.Errorf("Can't have multiple identical sectionNames, got %s twice", sectionName)
 			}
-			btlspMap[svcFullName].Valid[sectionName] = policy
+			btlspMap[svcFullName].UpsertValidPolicy(sectionName, policy)
+		}
+
+		for sn, policy := range fixture.InvalidPolicies {
+			sectionName := gatewayv1.SectionName(sn)
+			if _, ok := btlspMap[svcFullName].Invalid[sectionName]; ok {
+				return nil, fmt.Errorf("Can't have multiple identical invalid sectionNames, got %s twice", sectionName)
+			}
+			btlspMap[svcFullName].UpsertInvalidPolicy(sectionName, policy)
 		}
 	}
 	return btlspMap, nil

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -277,7 +277,11 @@ func extractRoutes(logger *slog.Logger,
 			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services)
 			if svc != nil {
 				toAppend := backendToModelBackend(*svc, be.BackendRef, hr.Namespace)
-				toAppend = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
+				var include bool
+				toAppend, include = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
+				if !include {
+					continue
+				}
 				bes = append(bes, toAppend)
 				for _, f := range be.Filters {
 					switch f.Type {
@@ -382,7 +386,7 @@ func extractRoutes(logger *slog.Logger,
 	return httpRoutes
 }
 
-func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Service, btlspMap helpers.BackendTLSPolicyServiceMap) model.Backend {
+func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Service, btlspMap helpers.BackendTLSPolicyServiceMap) (model.Backend, bool) {
 	svcFullName := types.NamespacedName{Name: svc.GetName(), Namespace: svc.GetNamespace()}
 
 	log = log.With(logfields.Service, svcFullName)
@@ -461,13 +465,23 @@ func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Servic
 
 			}
 			if be.TLS != nil {
-				return be
+				return be, true
+			}
+
+			// No valid BackendTLSPolicy matched this port. Check if an invalid policy
+			// would have matched. If so, the backend must be excluded.
+			for sectionName := range collection.Invalid {
+				if port.Name == string(sectionName) || sectionName == "" {
+					log.Info("Service has an invalid BackendTLSPolicy for this port, excluding backend",
+						logfields.Section, sectionName)
+					return be, false
+				}
 			}
 
 		}
 	}
 	// There was no relevant BackendTLSPolicy, no changes.
-	return be
+	return be, true
 }
 
 func toTimeout(timeouts *gatewayv1.HTTPRouteTimeouts) model.Timeout {

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -50,6 +50,7 @@ func TestHTTPGatewayAPI(t *testing.T) {
 		"Conformance/HTTPRouteBackendTLSPolicy":                   {},
 		"Conformance/HTTPRouteBackendTLSPolicySystemCA":           {},
 		"Conformance/HTTPRouteBackendTLSPolicyConflictResolution": {},
+		"Conformance/HTTPRouteBackendTLSPolicyInvalidCA":          {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-backendtlspolicy.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-backendtlspolicy.yaml
@@ -1,0 +1,21 @@
+policies:
+  - svcName: gateway-conformance-infra/invalid-ca-test
+    invalid:
+      "btls":
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: BackendTLSPolicy
+        metadata:
+          name: invalid-ca-policy
+          namespace: gateway-conformance-infra
+        spec:
+          targetRefs:
+            - group: ""
+              kind: Service
+              name: "invalid-ca-test"
+              sectionName: "btls"
+          validation:
+            caCertificateRefs:
+              - group: ""
+                kind: ConfigMap
+                name: "nonexistent-ca-certificate"
+            hostname: "abc.example.com"

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-gateway.yaml
@@ -1,0 +1,14 @@
+metadata:
+  creationTimestamp: null
+  name: same-namespace
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-httproute.yaml
@@ -1,0 +1,19 @@
+- metadata:
+    name: backendtlspolicy-invalid-ca
+    namespace: gateway-conformance-infra
+  spec:
+    parentRefs:
+      - name: same-namespace
+        namespace: gateway-conformance-infra
+    hostnames:
+      - abc.example.com
+    rules:
+      - backendRefs:
+          - group: ""
+            kind: Service
+            name: invalid-ca-test
+            port: 443
+        matches:
+          - path:
+              type: Exact
+              value: /backendtlspolicy-invalid-ca

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/input-service.yaml
@@ -1,0 +1,11 @@
+- metadata:
+    name: invalid-ca-test
+    namespace: gateway-conformance-infra
+  spec:
+    selector:
+      app: tls-backend
+    ports:
+      - name: "btls"
+        protocol: TCP
+        port: 443
+        targetPort: 8443

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteBackendTLSPolicyInvalidCA/output-listeners.yaml
@@ -1,0 +1,17 @@
+- hostname: '*'
+  name: http
+  port: 80
+  routes:
+  - direct_response:
+      status_code: 500
+    hostnames:
+    - abc.example.com
+    path_match:
+      exact: /backendtlspolicy-invalid-ca
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: same-namespace
+    namespace: gateway-conformance-infra
+    version: v1


### PR DESCRIPTION
This change introduces a small change to how the Cilium Operator's Gateway API reconciler handles a BackendTLSPolicy that has a missing or invalid TLS certificate. In these cases, the backends are immediately removed from the Cilium Envoy Configuration.

Previously, if a backend required HTTPS but the policy wasn't in the cache yet (due to a resource creation race condition), the reconciler would generate a plain-text cluster. Envoy would then hold live traffic in a "warming" state waiting for an SDS secret for 30 seconds (`initial_fetch_timeout`), routing plain-text to the secure backend and causing unexpected HTTP 400 errors.

I have run `TestConformance/BackendTLSPolicyInvalidCACertificateRef` several hundred times locally to confirm this does address the flakiness seen in that test.

Fixes: #44043 
