### PR TITLE
loadbalancer: enforce loadBalancerSourceRanges on ExternalIPs frontends

### DIFF
--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -6,6 +6,7 @@ package loadbalancer
 import (
 	"bytes"
 	"encoding/json"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -649,6 +650,75 @@ func TestL4AddrParsing(t *testing.T) {
 		}
 
 		require.Equal(t, tc.output, addr)
+	}
+}
+
+func TestGetSourceRangesEnabled(t *testing.T) {
+	prefix := netip.MustParsePrefix("10.0.0.0/8")
+
+	tests := []struct {
+		name                  string
+		sourceRanges          []netip.Prefix
+		svcType               SVCType
+		lbSourceRangeAllTypes bool
+		want                  bool
+	}{
+		{
+			name:         "LoadBalancer with source ranges",
+			sourceRanges: []netip.Prefix{prefix},
+			svcType:      SVCTypeLoadBalancer,
+			want:         true,
+		},
+		{
+			// loadBalancerSourceRanges must also apply to ExternalIPs frontends (#44718).
+			name:         "ExternalIPs with source ranges",
+			sourceRanges: []netip.Prefix{prefix},
+			svcType:      SVCTypeExternalIPs,
+			want:         true,
+		},
+		{
+			name:    "ExternalIPs without source ranges",
+			svcType: SVCTypeExternalIPs,
+			want:    false,
+		},
+		{
+			name:                  "ExternalIPs with source ranges, allTypes=true",
+			sourceRanges:          []netip.Prefix{prefix},
+			svcType:               SVCTypeExternalIPs,
+			lbSourceRangeAllTypes: true,
+			want:                  true,
+		},
+		{
+			name:         "NodePort with source ranges, allTypes=false",
+			sourceRanges: []netip.Prefix{prefix},
+			svcType:      SVCTypeNodePort,
+			want:         false,
+		},
+		{
+			name:                  "NodePort with source ranges, allTypes=true",
+			sourceRanges:          []netip.Prefix{prefix},
+			svcType:               SVCTypeNodePort,
+			lbSourceRangeAllTypes: true,
+			want:                  true,
+		},
+		{
+			name:    "LoadBalancer without source ranges",
+			svcType: SVCTypeLoadBalancer,
+			want:    false,
+		},
+		{
+			name:         "ClusterIP with source ranges",
+			sourceRanges: []netip.Prefix{prefix},
+			svcType:      SVCTypeClusterIP,
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &Service{SourceRanges: tt.sourceRanges}
+			got := svc.GetSourceRangesEnabled(tt.svcType, tt.lbSourceRangeAllTypes)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -145,9 +145,10 @@ func (svc *Service) GetSourceRangesPolicy() SVCSourceRangesPolicy {
 func (svc *Service) GetSourceRangesEnabled(svcType SVCType, lbSourceRangeAllTypes bool) bool {
 	if lbSourceRangeAllTypes {
 		return len(svc.SourceRanges) > 0
-	} else {
-		return len(svc.SourceRanges) > 0 && svcType == SVCTypeLoadBalancer
 	}
+	// loadBalancerSourceRanges also applies to ExternalIPs frontends of a LoadBalancer service.
+	return len(svc.SourceRanges) > 0 &&
+		(svcType == SVCTypeLoadBalancer || svcType == SVCTypeExternalIPs)
 }
 
 func (svc *Service) GetAnnotations() map[string]string {

--- a/pkg/loadbalancer/tests/testdata/external-ips.txtar
+++ b/pkg/loadbalancer/tests/testdata/external-ips.txtar
@@ -1,0 +1,123 @@
+# Test that loadBalancerSourceRanges is enforced on ExternalIPs frontends (#44718).
+# A LoadBalancer service with both a LoadBalancerIP and an ExternalIP must enforce
+# source range filtering on both frontend types, not only on the LoadBalancerIP.
+
+hive start
+
+k8s/add service.yaml endpointslice.yaml
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# Validate that check source-range is set on both LoadBalancer and ExternalIPs frontends.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.expected lbmaps.actual
+
+# Cleanup
+k8s/delete service.yaml endpointslice.yaml
+
+# Maps and tables should be empty
+* db/empty services frontends backends
+* lb/maps-empty
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Cluster         SourceRanges=10.0.0.0/8
+
+-- frontends.table --
+Address               Type          ServiceName   PortName   Backends            Status
+10.0.0.1:80/TCP       ClusterIP     test/echo     http       10.244.1.1:80/TCP   Done
+10.0.0.2:80/TCP       LoadBalancer  test/echo     http       10.244.1.1:80/TCP   Done
+10.0.0.3:80/TCP       ExternalIPs   test/echo     http       10.244.1.1:80/TCP   Done
+
+-- backends.table --
+Service    Address            NodeName
+test/echo  10.244.1.1:80/TCP  nodeport-worker
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.0.0.1
+  externalIPs:
+    - 10.0.0.3
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: LoadBalancer
+  loadBalancerSourceRanges:
+    - 10.0.0.0/8
+status:
+  loadBalancer:
+    ingress:
+      - ip: 10.0.0.2
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Service
+    name: echo
+    uid: a49fe99c-3564-4754-acc4-780f2331a49b
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  targetRef:
+    kind: Pod
+    name: echo-757d4cb97f-9gmf7
+    namespace: test
+    uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- lbmaps.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=10.0.0.1:80
+REV: ID=2 ADDR=10.0.0.2:80
+REV: ID=3 ADDR=10.0.0.3:80
+SRCRANGE: ID=1 CIDR=10.0.0.0/8
+SRCRANGE: ID=2 CIDR=10.0.0.0/8
+SRCRANGE: ID=3 CIDR=10.0.0.0/8
+SVC: ID=0 ADDR=10.0.0.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=10.0.0.2:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=10.0.0.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.0.0.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.0.0.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+check source-range
+SVC: ID=2 ADDR=10.0.0.2:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+check source-range
+SVC: ID=3 ADDR=10.0.0.3:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ExternalIPs+check source-range
+SVC: ID=3 ADDR=10.0.0.3:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs+check source-range


### PR DESCRIPTION
ExternalIPs frontends of a LoadBalancer service were not subject to
`loadBalancerSourceRanges` filtering. Traffic from outside the allowed
source ranges could bypass the check via the ExternalIP address, while
the LoadBalancerIP frontend correctly enforced it.

Fix `GetSourceRangesEnabled` to return `true` for `SVCTypeExternalIPs`
in addition to `SVCTypeLoadBalancer`.

Fixes: #44718

```release-note
Fix `loadBalancerSourceRanges` not being enforced on ExternalIPs frontends of LoadBalancer services.
```