### PR TITLE
ci: change AWS CNI region from ca-central-1 to us-east-2 (v1.17)

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -6,7 +6,7 @@ include:
   - version: "1.29"
     region: us-east-2
   - version: "1.30"
-    region: ca-central-1
+    region: us-east-2
     default: true
     kpr: true
   - version: "1.31"


### PR DESCRIPTION
## Summary

This PR changes the AWS region used for EKS 1.30 CNI tests from `ca-central-1` to `us-east-2`.

## Problem

CI is failing because an AWS Organizations tag policy in `ca-central-1` is injecting duplicate tags into CloudFormation stack resources. This causes CloudFormation to reject EKS cluster creation with a tag duplication error.

## Fix

Switch the region for the `1.30` EKS test entry in `.github/actions/aws-cni/k8s-versions.yaml` from `ca-central-1` to `us-east-2`, which does not have the same Organizations tag policy conflict.

Ref: #44695

## Changes

- `.github/actions/aws-cni/k8s-versions.yaml`: `region: ca-central-1` → `region: us-east-2` for k8s 1.30 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)