### PR TITLE
ci: change AWS CNI region from ca-central-1 to us-east-2 (v1.18)

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -6,7 +6,7 @@ include:
   - version: "1.31"
     region: us-east-2
   - version: "1.32"
-    region: ca-central-1
+    region: us-east-2
     default: true
     kpr: true
   - version: "1.33"


### PR DESCRIPTION
## Problem

CI for the AWS CNI tests is failing on the `v1.18` branch because the `ca-central-1` region is subject to an AWS Organizations **tag policy** that automatically injects duplicate resource tags. CloudFormation rejects EKS cluster creation when it detects those duplicate tags, causing every affected job to fail.

## Fix

Change the region used for the `1.32` EKS test matrix entry from `ca-central-1` to `us-east-2`, which is not affected by the tag policy injection.

Ref: #44695

## Checklist

- [x] `.github/actions/aws-cni/k8s-versions.yaml` line 9: `region: ca-central-1` → `region: us-east-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)