### PR TITLE
[1.17] gha: Use eks 1.30 from us-west-2

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -6,7 +6,7 @@ include:
   - version: "1.29"
     region: us-east-2
   - version: "1.30"
-    region: ca-central-1
+    region: us-west-2
     default: true
     kpr: true
   - version: "1.31"

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -7,7 +7,7 @@ include:
     region: us-east-2
     ipsec: true
   - version: "1.30"
-    region: ca-central-1
+    region: us-west-2
     default: true
     ipsec: true
     kpr: true


### PR DESCRIPTION
Relates: https://github.com/cilium/cilium/issues/44695

