### PR TITLE
envoy: Handle pending completions for deleted policies

### DIFF
--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -356,6 +356,11 @@ func (m *AckingResourceMutatorWrapper) currentVersionAcked(nodeIDs []string) boo
 }
 
 func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName string, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc {
+	scopedLogger := m.logger.With(
+		logfields.XDSResourceName, resourceName,
+		logfields.XDSTypeURL, typeURL,
+	)
+
 	m.locker.Lock()
 	defer m.locker.Unlock()
 
@@ -382,6 +387,28 @@ func (m *AckingResourceMutatorWrapper) Delete(typeURL string, resourceName strin
 	var updated bool
 	var revert ResourceMutatorRevertFunc
 	m.version, updated, revert = m.mutator.Delete(typeURL, resourceName)
+
+	// remove any possible pending completions for the deleted resourceName
+	for comp, pending := range m.pendingCompletions {
+		if comp.Err() != nil {
+			// Completion was canceled or timed out.
+			// Remove from pending list.
+			scopedLogger.Debug(
+				"completion context was canceled",
+				logfields.PendingCompletions, pending,
+			)
+			delete(m.pendingCompletions, comp)
+			continue
+		}
+		if pending.typeURL == typeURL {
+			for _, resourceNames := range pending.remainingNodesResources {
+				// resourceNames map is left in place even if empty, so that
+				// it can be found by HandleResourceVersionAck to complete
+				// the pending completion when an N/ACK is received
+				delete(resourceNames, resourceName)
+			}
+		}
+	}
 
 	if !updated {
 		if wait {

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -98,40 +98,40 @@ func TestUpsertSingleNode(t *testing.T) {
 	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback)
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Empty(t, acker.ackedVersions)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for the right resource, from another node.
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 1)
 	require.Equal(t, uint64(2), acker.ackedVersions[node1])
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for another resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[1].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestUseCurrent(t *testing.T) {
@@ -153,8 +153,8 @@ func TestUseCurrent(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Empty(t, acker.ackedVersions)
 	require.Len(t, acker.pendingCompletions, 1)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for the right resource, from another node.
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -162,8 +162,8 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.ackedVersions, 1)
 	require.Equal(t, uint64(2), acker.ackedVersions[node1])
 	require.Len(t, acker.pendingCompletions, 1)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Use current version, not yet acked
 	acker.UseCurrent(typeURL, []string{node0}, wg)
@@ -176,8 +176,8 @@ func TestUseCurrent(t *testing.T) {
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	// UseCurrent ignores resource names, so an ack of the same or later version from the right node will complete it
 	require.Len(t, acker.pendingCompletions, 1)
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
@@ -192,8 +192,8 @@ func TestUseCurrent(t *testing.T) {
 	require.Len(t, acker.ackedVersions, 2)
 	require.Equal(t, uint64(2), acker.ackedVersions[node0])
 	require.Empty(t, acker.pendingCompletions)
-	require.Equal(t, 2, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestUpsertMultipleNodes(t *testing.T) {
@@ -223,8 +223,8 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.False(t, acker.currentVersionAcked([]string{node0}))
 	require.False(t, acker.currentVersionAcked([]string{node1}))
 	require.True(t, acker.currentVersionAcked([]string{node2}))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for the right resource, from one of the nodes (node0).
 	// One of the nodes (node1) still needs to ACK.
@@ -235,8 +235,8 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node2}))
 	require.False(t, acker.currentVersionAcked([]string{node0, node1}))
 	require.True(t, acker.currentVersionAcked([]string{node0, node2}))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for the right resource, from the last remaining node (node1).
 	acker.HandleResourceVersionAck(2, 2, node1, []string{resources[0].Name}, typeURL, "")
@@ -245,8 +245,8 @@ func TestUpsertMultipleNodes(t *testing.T) {
 	require.True(t, acker.currentVersionAcked([]string{node1}))
 	require.True(t, acker.currentVersionAcked([]string{node2}))
 	require.True(t, acker.currentVersionAcked([]string{node0, node1, node2}))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestUpsertMoreRecentVersion(t *testing.T) {
@@ -269,14 +269,14 @@ func TestUpsertMoreRecentVersion(t *testing.T) {
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack a more recent version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(123, 123, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestUpsertMoreRecentVersionNack(t *testing.T) {
@@ -299,8 +299,8 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	// Ack an older version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 1, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// NAck a more recent version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(1, 2, node0, []string{resources[0].Name}, typeURL, "Detail")
@@ -308,8 +308,8 @@ func TestUpsertMoreRecentVersionNack(t *testing.T) {
 	require.Condition(t, isNotCompletedComparison(comp))
 	require.Error(t, comp.Err())
 	require.EqualValues(t, &ProxyError{Err: ErrNackReceived, Detail: "Detail"}, comp.Err())
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.nack[typeURL])
 }
 
 func TestDeleteSingleNode(t *testing.T) {
@@ -332,8 +332,8 @@ func TestDeleteSingleNode(t *testing.T) {
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Create version 3 with no resources.
 	callback, comp = newCompCallback(logger)
@@ -343,15 +343,15 @@ func TestDeleteSingleNode(t *testing.T) {
 	// Ack the right version, for another resource, from another node.
 	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[2].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for another resource, from the right node.
 	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
 	// The resource name is ignored. For delete, we only consider the version.
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 2, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestDeleteMultipleNodes(t *testing.T) {
@@ -374,8 +374,8 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	// Ack the right version, for the right resource, from the right node.
 	acker.HandleResourceVersionAck(2, 2, node0, []string{resources[0].Name}, typeURL, "")
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Create version 3 with no resources.
 	callback, comp = newCompCallback(logger)
@@ -385,15 +385,15 @@ func TestDeleteMultipleNodes(t *testing.T) {
 	// Ack the right version, for another resource, from one of the nodes.
 	acker.HandleResourceVersionAck(3, 3, node1, []string{resources[2].Name}, typeURL, "")
 	require.Condition(t, isNotCompletedComparison(comp))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Ack the right version, for another resource, from the remaining node.
 	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
 	// The resource name is ignored. For delete, we only consider the version.
 	require.Condition(t, completedComparison(comp))
-	require.Equal(t, 2, metrics.nack[typeURL])
-	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestRevertInsert(t *testing.T) {
@@ -434,8 +434,8 @@ func TestRevertInsert(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestRevertUpdate(t *testing.T) {
@@ -483,8 +483,8 @@ func TestRevertUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
 func TestRevertDelete(t *testing.T) {
@@ -536,6 +536,6 @@ func TestRevertDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resources[2], res)
 
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 }

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -354,6 +354,48 @@ func TestDeleteSingleNode(t *testing.T) {
 	require.Equal(t, 0, metrics.nack[typeURL])
 }
 
+func TestUpsertCompletionAfterDeletedResource(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	wg := completion.NewWaitGroup(ctx)
+	metrics := newMockMetrics()
+
+	// Empty cache is the version 1
+	cache := NewCache(logger)
+	acker := NewAckingResourceMutatorWrapper(logger, cache, metrics)
+
+	// Create version 2 with resource 0 and a completion that waits for ACK.
+	callback, comp := newCompCallback(logger)
+	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, callback)
+	require.Condition(t, isNotCompletedComparison(comp))
+	require.Len(t, acker.pendingCompletions, 1)
+	require.Equal(t, uint64(2), acker.version)
+
+	// Delete the same resource before the ACK for version 2 is received.
+	acker.Delete(typeURL, resources[0].Name, nil, nil, nil)
+	require.Condition(t, isNotCompletedComparison(comp))
+	require.Len(t, acker.pendingCompletions, 1)
+	require.Equal(t, uint64(3), acker.version)
+
+	// The pending completion must still be keyed by node so that ACK processing
+	// can find it, even though there are no resource names left.
+	for _, pending := range acker.pendingCompletions {
+		require.Equal(t, typeURL, pending.typeURL)
+		require.Contains(t, pending.remainingNodesResources, node0)
+		require.Empty(t, pending.remainingNodesResources[node0])
+	}
+
+	// ACK the newer version from the right node with a different resource name.
+	// This should complete the pending upsert completion after delete pruning.
+	acker.HandleResourceVersionAck(3, 3, node0, []string{resources[2].Name}, typeURL, "")
+	require.Condition(t, completedComparison(comp))
+	require.Empty(t, acker.pendingCompletions)
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+}
+
 func TestDeleteMultipleNodes(t *testing.T) {
 	logger := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/envoy/xds/metrics_mock_test.go
+++ b/pkg/envoy/xds/metrics_mock_test.go
@@ -8,11 +8,11 @@ type mockMetrics struct {
 	nack map[string]int
 }
 
-func (m *mockMetrics) IncreaseNACK(typeURL string) {
+func (m *mockMetrics) IncreaseACK(typeURL string) {
 	m.ack[typeURL]++
 }
 
-func (m *mockMetrics) IncreaseACK(typeURL string) {
+func (m *mockMetrics) IncreaseNACK(typeURL string) {
 	m.nack[typeURL]++
 }
 

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -127,8 +127,8 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -151,16 +151,16 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
 	v, mod, _ = cache.Upsert(typeURL, resources[1].Name, resources[1])
 	require.Equal(t, uint64(3), v)
 	require.True(t, mod)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -178,8 +178,8 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -202,8 +202,8 @@ func TestRequestAllResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -385,8 +385,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -409,8 +409,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Create version 3 with resource 0 and 1.
 	// This time, update the cache before sending the request.
@@ -434,8 +434,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -458,8 +458,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1], resources[2]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -496,8 +496,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "6", []proto.Message{resources[2]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Resource 1 has been deleted; Resource 2 exists. Confirm using Lookup().
 	rsrc, err := cache.Lookup(typeURL, resources[1].Name)
@@ -508,8 +508,8 @@ func TestRequestSomeResources(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rsrc)
 	require.Equal(t, resources[2], rsrc.(*envoy_config_route.RouteConfiguration))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -577,8 +577,8 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resource 1.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -614,8 +614,8 @@ func TestUpdateRequestResources(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[1], resources[2]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -675,8 +675,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -699,8 +699,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Create version 3 with resources 0 and 1.
 	// This time, update the cache before sending the request.
@@ -725,8 +725,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0], resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -749,8 +749,8 @@ func TestRequestStaleNonce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "4", []proto.Message{resources[1]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -809,8 +809,8 @@ func TestNAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -834,8 +834,8 @@ func TestNAck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -869,8 +869,8 @@ func TestNAck(t *testing.T) {
 
 	require.Condition(t, isNotCompletedComparison(comp1))
 	require.Condition(t, isNotCompletedComparison(comp2))
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -885,8 +885,8 @@ func TestNAck(t *testing.T) {
 
 	require.Condition(t, isNotCompletedComparison(comp1))
 	require.Condition(t, completedComparison(comp2))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 2, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 2, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -945,8 +945,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "1", nil, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Create version 2 with resource 0.
 	callback1, comp1 := newCompCallback(logger)
@@ -969,8 +969,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, resp.VersionInfo, resp.Nonce)
 	require.Condition(t, responseCheck(resp, "2", []proto.Message{resources[0]}, false, typeURL))
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.nack[typeURL])
 
 	// NACK the received version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1006,8 +1006,8 @@ func TestNAckFromTheStart(t *testing.T) {
 	require.NotEmpty(t, resp.Nonce)
 
 	require.Condition(t, isNotCompletedComparison(comp2))
-	require.Equal(t, 0, metrics.nack[typeURL])
-	require.Equal(t, 3, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 3, metrics.nack[typeURL])
 
 	// Request the next version of resources.
 	req = &envoy_service_discovery.DiscoveryRequest{
@@ -1022,8 +1022,8 @@ func TestNAckFromTheStart(t *testing.T) {
 
 	// Version 3 was ACKed by the last request.
 	require.Condition(t, completedComparison(comp2))
-	require.Equal(t, 1, metrics.nack[typeURL])
-	require.Equal(t, 3, metrics.ack[typeURL])
+	require.Equal(t, 1, metrics.ack[typeURL])
+	require.Equal(t, 3, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -1089,8 +1089,8 @@ func TestRequestHighVersionFromTheStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "65", []proto.Message{resources[0]}, false, typeURL))
 	require.NotEmpty(t, resp.Nonce)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()
@@ -1181,8 +1181,8 @@ func TestTheSameVersionOnRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.Condition(t, responseCheck(resp, "3", []proto.Message{resources[0]}, false, typeURL))
 	require.NotEmpty(t, resp.Nonce)
-	require.Equal(t, 0, metrics.nack[typeURL])
 	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
 
 	// Close the stream.
 	closeStream()

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1778,7 +1778,10 @@ func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 
 	epID := ep.GetID()
 	resourceName := strconv.FormatUint(epID, 10)
-	s.networkPolicyCache.Delete(NetworkPolicyTypeURL, resourceName)
+
+	// Safe to pass nodeIPs as nil when wg is also nil and the returned revert function is
+	// ignored.
+	s.NetworkPolicyMutator.Delete(NetworkPolicyTypeURL, resourceName, nil, nil, nil)
 
 	ip := ep.GetIPv6Address()
 	if ip != "" {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -176,10 +176,9 @@ type xdsServer struct {
 	// Envoy proxies.
 	networkPolicyCache *xds.Cache
 
-	// NetworkPolicyMutator wraps networkPolicyCache to publish policy
+	// networkPolicyMutator wraps networkPolicyCache to publish policy
 	// updates to Envoy proxies.
-	// Exported for testing only!
-	NetworkPolicyMutator xds.AckingResourceMutator
+	networkPolicyMutator xds.AckingResourceMutator
 
 	resourceConfig map[string]*xds.ResourceTypeConfiguration
 
@@ -304,7 +303,7 @@ func (s *xdsServer) initializeXdsConfigs() {
 	s.endpointMutator = edsMutator
 	s.secretMutator = sdsMutator
 	s.networkPolicyCache = npdsCache
-	s.NetworkPolicyMutator = npdsMutator
+	s.networkPolicyMutator = npdsMutator
 
 	s.resourceConfig = map[string]*xds.ResourceTypeConfiguration{
 		ListenerTypeURL:           ldsConfig,
@@ -1673,7 +1672,7 @@ func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy 
 	nodeIDs := getNodeIDs(ep, &policy.SelectorPolicy.L4Policy)
 
 	// only wait for the most current policy to be acked when no (new) policy is given
-	s.NetworkPolicyMutator.UseCurrent(NetworkPolicyTypeURL, nodeIDs, wg)
+	s.networkPolicyMutator.UseCurrent(NetworkPolicyTypeURL, nodeIDs, wg)
 }
 
 // ErrNotImplemented is the error returned by gRPC methods that are not
@@ -1741,7 +1740,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 	epID := ep.GetID()
 	nodeIDs := getNodeIDs(ep, l4policy)
 	resourceName := strconv.FormatUint(epID, 10)
-	revertFunc := s.NetworkPolicyMutator.Upsert(NetworkPolicyTypeURL, resourceName, networkPolicy, nodeIDs, wg, callback)
+	revertFunc := s.networkPolicyMutator.Upsert(NetworkPolicyTypeURL, resourceName, networkPolicy, nodeIDs, wg, callback)
 	revertUpdatedNetworkPolicyEndpoints := make(map[string]endpoint.EndpointUpdater, len(ips))
 	for _, ip := range ips {
 		revertUpdatedNetworkPolicyEndpoints[ip] = s.localEndpointStore.getLocalEndpoint(ip)
@@ -1781,7 +1780,7 @@ func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 
 	// Safe to pass nodeIPs as nil when wg is also nil and the returned revert function is
 	// ignored.
-	s.NetworkPolicyMutator.Delete(NetworkPolicyTypeURL, resourceName, nil, nil, nil)
+	s.networkPolicyMutator.Delete(NetworkPolicyTypeURL, resourceName, nil, nil, nil)
 
 	ip := ep.GetIPv6Address()
 	if ip != "" {
@@ -1791,7 +1790,7 @@ func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	if ip != "" {
 		s.localEndpointStore.removeLocalEndpoint(ip)
 		// Delete node resources held in the cache for the endpoint
-		s.NetworkPolicyMutator.DeleteNode(ip)
+		s.networkPolicyMutator.DeleteNode(ip)
 	}
 }
 


### PR DESCRIPTION
When a network policy is deleted, the resource names of them need to be deleted from any pending completions to allow the Wait on the WaitGroup to return when the ACK is received from Envoy.

Fixes: #44543
Fixes: #44714

```release-note
Fixed an issue where policy update ack is never completed after endpoint deletion.
```
