### PR TITLE
[v1.19] l7lb: bpf: fix use hairpin redirect for L7 LB on bridge devices

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1405,6 +1405,10 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 #  if defined(ENABLE_TPROXY)
 		return ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
 #  else
+		/* See IPv4 codepath for comments. */
+		if (CONFIG(proxy_redirect_via_cilium_net))
+			return ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
+
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
 		ctx->mark = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_POST, proxy_port);
@@ -2789,6 +2793,12 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 #  if defined(ENABLE_TPROXY)
 		return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
 #  else
+		/* Hairpin the packet through cilium_net when BPF tproxy is enabled
+		 * or when attaching the BPF program to a bridge network device.
+		 */
+		if (CONFIG(proxy_redirect_via_cilium_net))
+			return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
+
 		/* Pass the packet straight to the proxy, without redirecting via
 		 * cilium_host.
 		 */

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -13,6 +13,8 @@
 #include "l3.h"
 #include "l4.h"
 
+DECLARE_CONFIG(bool, proxy_redirect_via_cilium_net, "Whether to redirect to the proxy via cilium_net (hairpin) or via stack")
+
 /** Redirect to the proxy by hairpinning the packet out the incoming
  *  interface.
  *

--- a/bpf/tests/l7_lb_hairpin.c
+++ b/bpf/tests/l7_lb_hairpin.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_L7_LB
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_PORT		tcp_svc_one
+
+#define LB_IP			v4_node_one
+#define IPV4_DIRECT_ROUTING	LB_IP
+
+#define DEFAULT_IFACE		24
+#define ENCAP_IFINDEX		0
+
+#define PROXY_PORT		10000
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *lb_mac = mac_host;
+
+/* Track ctx_redirect calls */
+static volatile __u32 redirect_ifindex;
+
+#define fib_lookup mock_fib_lookup
+
+long mock_fib_lookup(const __maybe_unused void *ctx,
+		     const struct bpf_fib_lookup *params __maybe_unused,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	return BPF_FIB_LKUP_RET_NO_NEIGH;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex, __u32 flags __maybe_unused)
+{
+	redirect_ifindex = (__u32)ifindex;
+	return CTX_ACT_REDIRECT;
+}
+
+#include "lib/bpf_host.h"
+
+#include "lib/lb.h"
+#include "lib/ipcache.h"
+#include "lib/clear.h"
+
+ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
+
+/* Enable redirect via cilium_net to test hairpinning when cil_from_netdev
+ * is attached to a bridge device.
+ */
+ASSIGN_CONFIG(bool, proxy_redirect_via_cilium_net, true)
+
+/* Test 1: IPv4 L7 LB on bridge device. Ensure packets is hairpinned via cilium_net. */
+PKTGEN("tc", "l7_lb_hairpin_v4")
+int l7_lb_hairpin_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  CLIENT_IP, FRONTEND_IP,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_hairpin_v4")
+int l7_lb_hairpin_v4_setup(struct __ctx_buff *ctx)
+{
+	clear_map(&cilium_lb4_services_v2);
+	clear_map(&cilium_lb4_reverse_nat);
+
+	lb_v4_add_l7_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, PROXY_PORT);
+
+	ipcache_v4_add_entry(FRONTEND_IP, 0, 112233, 0, 0);
+
+	redirect_ifindex = 0;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "l7_lb_hairpin_v4")
+int l7_lb_hairpin_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	if (redirect_ifindex != CILIUM_NET_IFINDEX)
+		test_fatal("expected redirect to cilium_net (ifindex %d), got ifindex %d",
+			   CILIUM_NET_IFINDEX, redirect_ifindex);
+
+	test_finish();
+}
+
+/* Test 1: IPv6 L7 LB on bridge device. Ensure packets is hairpinned via cilium_net. */
+PKTGEN("tc", "l7_lb_hairpin_v6")
+int l7_lb_hairpin_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)client_mac, (__u8 *)lb_mac,
+					  (__u8 *)v6_ext_node_one,
+					  (__u8 *)v6_svc_one,
+					  CLIENT_PORT, FRONTEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_hairpin_v6")
+int l7_lb_hairpin_v6_setup(struct __ctx_buff *ctx)
+{
+	clear_map(&cilium_lb6_services_v2);
+	clear_map(&cilium_lb6_reverse_nat);
+
+	lb_v6_add_l7_service((union v6addr *)v6_svc_one, FRONTEND_PORT,
+			     IPPROTO_TCP, 1, PROXY_PORT);
+
+	ipcache_v6_add_entry((union v6addr *)v6_svc_one, 0, 112233, 0, 0);
+
+	redirect_ifindex = 0;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "l7_lb_hairpin_v6")
+int l7_lb_hairpin_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	if (redirect_ifindex != CILIUM_NET_IFINDEX)
+		test_fatal("expected redirect to cilium_net (ifindex %d), got ifindex %d",
+			   CILIUM_NET_IFINDEX, redirect_ifindex);
+
+	test_finish();
+}

--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -92,6 +92,34 @@ lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u8 proto, __u16 backend
 }
 
 static __always_inline void
+lb_v4_add_l7_service(__be32 addr, __be16 port, __u8 proto,
+		     __u16 rev_nat_index, __u32 proxy_port)
+{
+	struct lb4_key svc_key = {
+		.address = addr,
+		.dport = port,
+		.proto = proto,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	struct lb4_service svc_value = {
+		.l7_lb_proxy_port = proxy_port,
+		.count = 0,
+		.rev_nat_index = rev_nat_index,
+		.flags = SVC_FLAG_ROUTABLE,
+		.flags2 = SVC_FLAG_L7_LOADBALANCER,
+	};
+
+	map_update_elem(&cilium_lb4_services_v2, &svc_key, &svc_value, BPF_ANY);
+
+	struct lb4_reverse_nat revnat_value = {
+		.address = addr,
+		.port = port,
+	};
+
+	map_update_elem(&cilium_lb4_reverse_nat, &rev_nat_index, &revnat_value, BPF_ANY);
+}
+
+static __always_inline void
 lb_v4_upsert_backend(__u32 backend_id, __be32 backend_addr, __be16 backend_port,
 		     __u8 backend_proto, __u8 flags, __u8 cluster_id)
 {
@@ -218,5 +246,33 @@ lb_v6_add_backend(const union v6addr *svc_addr, __be16 svc_port, __u16 backend_s
 
 	memcpy(&backend.address, backend_addr, sizeof(*backend_addr));
 	map_update_elem(&cilium_lb6_backends_v3, &backend_id, &backend, BPF_ANY);
+}
+
+static __always_inline void
+lb_v6_add_l7_service(const union v6addr *addr, __be16 port, __u8 proto,
+		     __u16 rev_nat_index, __u32 proxy_port)
+{
+	struct lb6_key svc_key __align_stack_8 = {
+		.dport = port,
+		.proto = proto,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	struct lb6_service svc_value = {
+		.l7_lb_proxy_port = proxy_port,
+		.count = 0,
+		.rev_nat_index = rev_nat_index,
+		.flags = SVC_FLAG_ROUTABLE,
+		.flags2 = SVC_FLAG_L7_LOADBALANCER,
+	};
+
+	memcpy(&svc_key.address, addr, sizeof(*addr));
+	map_update_elem(&cilium_lb6_services_v2, &svc_key, &svc_value, BPF_ANY);
+
+	struct lb6_reverse_nat revnat_value __align_stack_8 = {
+		.port = port,
+	};
+
+	memcpy(&revnat_value.address, addr, sizeof(*addr));
+	map_update_elem(&cilium_lb6_reverse_nat, &rev_nat_index, &revnat_value, BPF_ANY);
 }
 #endif

--- a/pkg/datapath/config/host.go
+++ b/pkg/datapath/config/host.go
@@ -153,5 +153,14 @@ func Netdev(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfigurat
 
 	cfg.EphemeralMin = lnc.EphemeralMin
 
+	switch link.(type) {
+	case *netlink.Bridge:
+		// When a bridge device has br_netfilter with bridge-nf-call-iptables=1,
+		// the packet must be hairpinned via cilium_net instead of punting to the
+		// stack, because ip_sabotage_in() would skip the TPROXY rule. We simplify
+		// the logic by always hairpinning to the proxy when it's a bridge.
+		cfg.ProxyRedirectViaCiliumNet = true
+	}
+
 	return cfg
 }

--- a/pkg/datapath/config/host_config.go
+++ b/pkg/datapath/config/host_config.go
@@ -43,6 +43,8 @@ type BPFHost struct {
 	NATIPv4Masquerade [4]byte `config:"nat_ipv4_masquerade"`
 	// Masquerade address for IPv6 traffic.
 	NATIPv6Masquerade [16]byte `config:"nat_ipv6_masquerade"`
+	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
+	ProxyRedirectViaCiliumNet bool `config:"proxy_redirect_via_cilium_net"`
 	// The endpoint's security label.
 	SecurityLabel uint32 `config:"security_label"`
 	// VXLAN tunnel endpoint network mask.
@@ -60,5 +62,5 @@ func NewBPFHost(node Node) *BPFHost {
 		0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		0x0, [4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		0x0, 0x0, 0x0, 0x0, node}
+		false, 0x0, 0x0, 0x0, 0x0, node}
 }

--- a/pkg/datapath/config/lxc_config.go
+++ b/pkg/datapath/config/lxc_config.go
@@ -48,6 +48,8 @@ type BPFLXC struct {
 	NATIPv6Masquerade [16]byte `config:"nat_ipv6_masquerade"`
 	// The log level for policy verdicts in workload endpoints.
 	PolicyVerdictLogFilter uint32 `config:"policy_verdict_log_filter"`
+	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
+	ProxyRedirectViaCiliumNet bool `config:"proxy_redirect_via_cilium_net"`
 	// The endpoint's security label.
 	SecurityLabel uint32 `config:"security_label"`
 	// VXLAN tunnel endpoint network mask.
@@ -62,5 +64,5 @@ func NewBPFLXC(node Node) *BPFLXC {
 		0x0, 0x0, 0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		0x0, 0x0, 0x0, node}
+		0x0, false, 0x0, 0x0, node}
 }

--- a/pkg/datapath/config/overlay_config.go
+++ b/pkg/datapath/config/overlay_config.go
@@ -32,6 +32,8 @@ type BPFOverlay struct {
 	NATIPv4Masquerade [4]byte `config:"nat_ipv4_masquerade"`
 	// Masquerade address for IPv6 traffic.
 	NATIPv6Masquerade [16]byte `config:"nat_ipv6_masquerade"`
+	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
+	ProxyRedirectViaCiliumNet bool `config:"proxy_redirect_via_cilium_net"`
 	// VXLAN tunnel endpoint network mask.
 	VTEPMask uint32 `config:"vtep_mask"`
 
@@ -42,5 +44,5 @@ func NewBPFOverlay(node Node) *BPFOverlay {
 	return &BPFOverlay{0x5dc, false, false, false, false, false, 0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		0x0, node}
+		false, 0x0, node}
 }

--- a/pkg/datapath/config/wireguard_config.go
+++ b/pkg/datapath/config/wireguard_config.go
@@ -30,6 +30,8 @@ type BPFWireguard struct {
 	NATIPv4Masquerade [4]byte `config:"nat_ipv4_masquerade"`
 	// Masquerade address for IPv6 traffic.
 	NATIPv6Masquerade [16]byte `config:"nat_ipv6_masquerade"`
+	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
+	ProxyRedirectViaCiliumNet bool `config:"proxy_redirect_via_cilium_net"`
 
 	Node
 }
@@ -38,5 +40,5 @@ func NewBPFWireguard(node Node) *BPFWireguard {
 	return &BPFWireguard{0x5dc, false, false, false, false, 0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		node}
+		false, node}
 }

--- a/pkg/datapath/config/xdp_config.go
+++ b/pkg/datapath/config/xdp_config.go
@@ -28,6 +28,8 @@ type BPFXDP struct {
 	NATIPv4Masquerade [4]byte `config:"nat_ipv4_masquerade"`
 	// Masquerade address for IPv6 traffic.
 	NATIPv6Masquerade [16]byte `config:"nat_ipv6_masquerade"`
+	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
+	ProxyRedirectViaCiliumNet bool `config:"proxy_redirect_via_cilium_net"`
 
 	Node
 }
@@ -36,5 +38,5 @@ func NewBPFXDP(node Node) *BPFXDP {
 	return &BPFXDP{0x5dc, false, false, false, 0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		node}
+		false, node}
 }


### PR DESCRIPTION
* [ ] #44658 (@smagnani96 ): Resolved conflicts, adapted implementation to old loader

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 44658
```
