### PR TITLE
cilium-cli/connectivity: use `WithCiliumVersion` to skip tests per Cilium version

### DIFF
--- a/cilium-cli/connectivity/builder/bgp_control_plane.go
+++ b/cilium-cli/connectivity/builder/bgp_control_plane.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type bgpControlPlane struct{}
@@ -16,10 +15,9 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 	// prefix the test name with `seq-` to run it sequentially
 	newTest("seq-bgp-control-plane-v1", ct).
 		// NOTE: BGPv1 was removed in v1.19, this test can be removed once v1.18 is out of support
+		WithCiliumVersion(">=1.16.0 <1.19.0").
 		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) &&
-				versioncheck.MustCompile("<1.19.0")(ct.CiliumVersion) &&
-				ct.Params().IncludeUnsafeTests
+			return ct.Params().IncludeUnsafeTests
 		}).
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),
@@ -29,8 +27,9 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 
 	// prefix the test name with `seq-` to run it sequentially
 	newTest("seq-bgp-control-plane-v2", ct).
+		WithCiliumVersion(">=1.16.0").
 		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
+			return ct.Params().IncludeUnsafeTests
 		}).
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),

--- a/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 //go:embed manifests/client-egress-icmp.yaml
@@ -24,8 +23,9 @@ type egressGatewayWithL7Policy struct{}
 func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates map[string]string) {
 	// Prefix the test name with `seq-` to run it sequentially.
 	newTest("seq-egress-gateway-with-l7-policy", ct).
+		WithCiliumVersion(">=1.16.0").
 		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) && ct.Params().IncludeUnsafeTests
+			return ct.Params().IncludeUnsafeTests
 		}).
 		WithCiliumPolicy(clientEgressICMPYAML).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).  // DNS resolution only

--- a/cilium-cli/connectivity/builder/local_redirect_policy.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy.go
@@ -28,13 +28,9 @@ func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]stri
 	lrpFrontendIPSkipRedirectV6 := "fd00::169:254:169:248"
 
 	lrpTest := newTest("local-redirect-policy", ct).
+		WithCiliumVersion(">=1.16.0").
 		WithCondition(func() bool {
-			if versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) {
-				if ct.IsSocketLBFull() || versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion) {
-					return true
-				}
-			}
-			return false
+			return ct.IsSocketLBFull() || versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion)
 		}).
 		WithCiliumLocalRedirectPolicy(check.CiliumLocalRedirectPolicyParams{
 			Policy:                  localRedirectPolicyYAML,

--- a/cilium-cli/connectivity/builder/multicast.go
+++ b/cilium-cli/connectivity/builder/multicast.go
@@ -7,17 +7,13 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type multicast struct{}
 
 func (t multicast) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("multicast", ct).
-		WithCondition(func() bool {
-			return versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion)
-		}).
+		WithCiliumVersion(">=1.16.0").
 		WithCondition(func() bool {
 			return ct.Params().IncludeUnsafeTests
 		}).

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -22,9 +22,7 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("pod-to-pod-encryption", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
-		WithCondition(func() bool {
-			return !versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion)
-		}).
+		WithCiliumVersion("<1.18.0").
 		WithFeatureRequirements(features.RequireDisabled(features.Ztunnel)).
 		WithScenarios(
 			tests.PodToPodEncryption(features.RequireEnabled(features.EncryptionPod)),
@@ -32,10 +30,8 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 
 	newTest("pod-to-pod-with-l7-policy-encryption", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithCiliumVersion("<1.18.0").
 		WithCondition(func() bool {
-			if versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion) {
-				return false
-			}
 			if ok, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec")); ok {
 				// Introduced in v1.17.0, backported to v1.15.11 and v1.16.4.
 				if !versioncheck.MustCompile(">=1.15.11 <1.16.0 || >=1.16.4")(ct.CiliumVersion) {

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 type podToPodEncryptionV2 struct{}
@@ -19,10 +18,7 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("pod-to-pod-encryption-v2", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
-		WithCondition(func() bool {
-			// this test only runs post v1.18.0 clusters
-			return versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion)
-		}).
+		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(features.RequireDisabled(features.Ztunnel)).
 		WithScenarios(
 			tests.PodToPodEncryptionV2(),
@@ -30,10 +26,7 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 
 	newTest("pod-to-pod-with-l7-policy-encryption-v2", ct).
 		WithCondition(func() bool { return !ct.Params().SingleNode }).
-		WithCondition(func() bool {
-			// this test only runs post v1.18.0 clusters
-			return versioncheck.MustCompile(">=1.18.0")(ct.CiliumVersion)
-		}).
+		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(
 			features.RequireEnabled(features.L7Proxy),
 			features.RequireEnabled(features.EncryptionPod),


### PR DESCRIPTION
Use the dedicated `WithCiliumVersion` helper method to skip tests depending on Cilium version instead of open-coding it using `WithCondition`. This will also be reflected in a more informative test log output:

Before:

    [=] [cilium-test-1] Skipping test [pod-to-pod-with-l7-policy-encryption] [13/22] (skipped by condition)

After:

    [=] [cilium-test-1] Skipping test [pod-to-pod-with-l7-policy-encryption] [13/22] (requires Cilium version <1.18.0 but running 1.20.0)

Note that it is also safe to extract the cilium version out of existing conditions where it is part of a logical conjunction (AND) of several conditions because all the With* conditions on a test need to be satisfied for it to run.