### PR TITLE
bpf: test: remove test for conflict of NAT LB with catch-all EGW policy

### DIFF
--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -9,13 +9,10 @@
 #define ENABLE_IPV4
 #define ENABLE_NODEPORT
 #define ENABLE_HOST_ROUTING
-#define ENABLE_EGRESS_GATEWAY	1
-#define ENABLE_MASQUERADE_IPV4	1
 
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
 #define CLIENT_IP_2		v4_ext_two
-#define CLIENT_NODE_IP		v4_node_two
 
 #define FRONTEND_IP_LOCAL	v4_svc_one
 #define FRONTEND_IP_REMOTE	v4_svc_two
@@ -31,7 +28,6 @@
 #define DEFAULT_IFACE		24
 #define BACKEND_IFACE		25
 #define SVC_EGRESS_IFACE	26
-#define ENCAP_IFINDEX		42
 
 #define BACKEND_EP_ID		127
 
@@ -150,7 +146,6 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 
 #include "lib/bpf_host.h"
 
-#include "lib/egressgw_policy.h"
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/lb.h"
@@ -846,33 +841,6 @@ int nodeport_nat_fwd_reply_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
 {
-	return check_reply(ctx);
-}
-
-/* Test that the LB RevDNATs and RevSNATs a reply from the
- * NAT remote backend, and sends it back to the client.
- * Even when there's a catch-all EGW policy configured.
- */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply2_egw")
-int nodeport_nat_fwd_reply2_egw_pktgen(struct __ctx_buff *ctx)
-{
-	return build_reply(ctx);
-}
-
-SETUP("tc", "tc_nodeport_nat_fwd_reply2_egw")
-int nodeport_nat_fwd_reply2_egw_setup(struct __ctx_buff *ctx)
-{
-	ipcache_v4_add_entry(CLIENT_IP, 0, 112200, CLIENT_NODE_IP, 0);
-	add_egressgw_policy_entry(CLIENT_IP, v4_all, 0, LB_IP, LB_IP);
-
-	return netdev_receive_packet(ctx);
-}
-
-CHECK("tc", "tc_nodeport_nat_fwd_reply2_egw")
-int nodeport_nat_fwd_reply2_egw_check(const struct __ctx_buff *ctx)
-{
-	del_egressgw_policy_entry(CLIENT_IP, v4_all, 0);
-
 	return check_reply(ctx);
 }
 


### PR DESCRIPTION
This removes the test introduced by
a899c4a80a4e ("bpf: test: cover NAT LB with catch-all EGW policy"), as part of https://github.com/cilium/cilium/pull/36929.

The test targeted the scenario of an in-cluster client which accesses a NodePort service on a remote node. But with the changes from https://github.com/cilium/cilium/pull/44507, this type of access no longer exists, as the traffic will always get DNATed at the source node.