### PR TITLE
cli/sysdump: collect clustermesh certificate generation artifacts

### DIFF
--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -11,116 +11,117 @@ cilium connectivity test [flags]
 ### Options
 
 ```
-      --agent-daemonset-name string                           Name of cilium agent daemonset (default "cilium")
-      --agent-pod-selector string                             Label on cilium-agent pods to select with (default "k8s-app=cilium")
-      --all-flows                                             Print all flows during flow validation
-      --assume-cilium-version string                          Assume Cilium version for connectivity tests
-      --chart-directory string                                Helm chart directory
-      --cilium-pod-selector string                            Label selector matching all cilium-related pods (default "app.kubernetes.io/part-of=cilium")
-      --cleanup                                               Cleanup all connectivity test artifacts (namespaces, deployments, services) without running tests
-      --collect-sysdump-on-failure                            Collect sysdump after a test fails
-      --conn-disrupt-dispatch-interval duration               TCP packet dispatch interval
-      --conn-disrupt-test-restarts-path string                Conn disrupt test temporary result file (used internally) (default "/tmp/cilium-conn-disrupt-restarts")
-      --conn-disrupt-test-setup                               Set up conn disrupt test dependencies
-      --conn-disrupt-test-xfrm-errors-path string             Conn disrupt test temporary result file (used internally) (default "/tmp/cilium-conn-disrupt-xfrm-errors")
-      --connect-timeout duration                              Maximum time to allow initiation of the connection to take (default 2s)
-      --curl-image string                                     Image path to use for curl (default "quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364")
-      --curl-insecure                                         Pass --insecure to curl
-      --curl-parallel uint                                    Number of parallel requests in curl commands (0 to disable)
-  -d, --debug                                                 Show debug messages
-      --dns-test-server-image string                          Image path to use for CoreDNS (default "registry.k8s.io/coredns/coredns:v1.14.2@sha256:e7e6440cfd1e919280958f5b5a6ab2b184d385bba774c12ad2a9e1e4183f90d9")
-      --echo-image string                                     Image path to use for echo server (default "gcr.io/k8s-staging-gateway-api/echo-advanced:v20251204-v1.4.1")
-      --exit-zero-on-failure                                  Exit with zero return code even when test failures are detected
-      --external-cidr string                                  IPv4 CIDR to use as external target in connectivity tests (default "1.0.0.0/8")
-      --external-cidrv6 string                                IPv6 CIDR to use as external target in connectivity tests (default "2606:4700:4700::/96")
-      --external-ip string                                    IPv4 to use as external target in connectivity tests (default "1.1.1.1")
-      --external-ipv6 string                                  IPv6 to use as external target in connectivity tests (default "2606:4700:4700::1111")
-      --external-other-ip string                              Other IPv4 to use as external target in connectivity tests (default "1.0.0.1")
-      --external-other-ipv6 string                            Other IPv6 to use as external target in connectivity tests (default "2606:4700:4700::1001")
-      --external-other-target string                          Domain name to use as a second external target in connectivity tests (default "k8s.io.")
-      --external-target string                                Domain name to use as external target in connectivity tests (default "one.one.one.one.")
-      --external-target-ca-name string                        Name of the CA secret for the external target. (default "cabundle")
-      --external-target-ca-namespace string                   Namespace of the CA secret for the external target.
-      --external-target-ipv6-capable                          External target is IPv6 capable
-      --flow-validation string                                Enable Hubble flow validation { disabled | warning | strict } (default "warning")
-      --force-deploy                                          Force re-deploying test artifacts
-      --frr-image string                                      Image path to use for FRR (default "quay.io/frrouting/frr:10.5.2@sha256:94e78424a15839e0953623e2515c3e54f308644946395bc341b25e43f5c2d323")
-      --helm-values-secret-name string                        Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed (default "cilium-cli-helm-values")
-  -h, --help                                                  help for test
-      --hubble                                                Automatically use Hubble for flow validation & troubleshooting (default true)
-      --hubble-server string                                  Address of the Hubble endpoint for flow validation (default "localhost:4245")
-      --include-conn-disrupt-test                             Include conn disrupt test
-      --include-conn-disrupt-test-egw                         Include conn disrupt test for Egress Gateway
-      --include-conn-disrupt-test-l7-traffic                  Include conn disrupt test for L7 traffic
-      --include-conn-disrupt-test-ns-traffic                  Include conn disrupt test for NS traffic
-      --ip-families strings                                   Restrict test actions to specific IP families (default [ipv4,ipv6])
-      --json-mock-image string                                Image path to use for json mock (default "quay.io/cilium/json-mock:v1.3.9@sha256:c98b26177a5a60020e5aa404896d55f0ab573d506f42acfb4aa4f5705a5c6f56")
-      --junit-file string                                     Generate junit report and write to file
-      --junit-property map                                    Add key=value properties to the generated junit file
-      --k8s-version string                                    Kubernetes server version in case auto-detection fails
-      --multi-cluster string                                  Test across clusters to given context
-      --namespace-labels map                                  Add labels to the connectivity test namespace
-      --node-cidr strings                                     one or more CIDRs that cover all nodes in the cluster
-      --node-selector map                                     Restrict connectivity pods to nodes matching this label
-  -p, --pause-on-fail                                         Pause execution on test failure
-      --post-test-sleep duration                              Wait time after each test before next test starts
-      --print-flows                                           Print flow logs for each test
-      --print-image-artifacts                                 Prints the used image artifacts
-      --request-timeout duration                              Maximum time to allow a request to take (default 10s)
-      --retry uint                                            Number of retries on connection failure to external targets (default 3)
-      --retry-delay duration                                  Delay between retries for external targets (default 3s)
-      --secondary-network-iface string                        Secondary network iface name (e.g., to test NodePort BPF on multiple networks)
-      --service-type string                                   Type of Kubernetes Services created for connectivity tests (default "NodePort")
-      --single-node                                           Limit to tests able to run on a single node
-      --socat-image string                                    Image path to use for multicast tests (default "docker.io/alpine/socat:1.8.0.3@sha256:5dc44a92103afe611c152fca347c524a170e1f3fda2411c29e2894d22a855099")
-      --sysdump-cilium-bugtool-flags stringArray              Optional set of flags to pass to cilium-bugtool command.
-      --sysdump-cilium-daemon-set-label-selector string       The labels used to target Cilium daemon set (default "k8s-app=cilium")
-      --sysdump-cilium-envoy-label-selector string            The labels used to target Cilium Envoy pods (default "k8s-app=cilium-envoy")
-      --sysdump-cilium-helm-release-name string               The Cilium Helm release name for which to get values. If not provided then the --helm-release-name global flag is used (if provided)
-      --sysdump-cilium-label-selector string                  The labels used to target Cilium pods (default "k8s-app=cilium")
-      --sysdump-cilium-namespace string                       The namespace Cilium is running in. If not provided then the --namespace global flag is used (if provided)
-      --sysdump-cilium-node-init-selector string              The labels used to target Cilium node init pods (default "app=cilium-node-init")
-      --sysdump-cilium-operator-label-selector string         The labels used to target Cilium operator pods (default "io.cilium/app=operator")
-      --sysdump-cilium-operator-namespace string              The namespace Cilium operator is running in. If not provided then the --namespace global flag is used (if provided)
-      --sysdump-cilium-spire-agent-selector string            The labels used to target Cilium spire-agent pods (default "app=spire-agent")
-      --sysdump-cilium-spire-namespace string                 The namespace Cilium SPIRE installation is running in
-      --sysdump-cilium-spire-server-selector string           The labels used to target Cilium spire-server pods (default "app=spire-server")
-      --sysdump-clustermesh-apiserver-label-selector string   The labels used to target 'clustermesh-apiserver' pods (default "k8s-app=clustermesh-apiserver")
-      --sysdump-cni-config-directory string                   Directory where CNI configs are located (default "/etc/cni/net.d/")
-      --sysdump-cni-configmap-name string                     The name of the CNI config map (default "cni-configuration")
-      --sysdump-collect-logs-from-not-ready-agents            Whether to collect logs from not ready Cilium agent pods (default true)
-      --sysdump-copy-retry-limit int                          Retry limit for file copying operations. If set to -1, copying will be retried indefinitely. Useful for collecting sysdump while on unreliable connection. (default 100)
-      --sysdump-debug                                         Whether to enable debug logging
-      --sysdump-detect-gops-pid                               Whether to automatically detect the gops agent PID.
-      --sysdump-extra-label-selectors stringArray             Optional set of labels selectors used to target additional pods for log collection.
-      --sysdump-hubble-flows-count int                        Number of Hubble flows to collect. Setting to zero disables collecting Hubble flows. (default 10000)
-      --sysdump-hubble-flows-timeout duration                 Timeout for collecting Hubble flows (default 5s)
-      --sysdump-hubble-generate-certs-labels string           The labels used to target Hubble UI pods (default "k8s-app=hubble-generate-certs")
-      --sysdump-hubble-label-selector string                  The labels used to target Hubble pods (default "k8s-app=hubble")
-      --sysdump-hubble-relay-labels string                    The labels used to target Hubble Relay pods (default "k8s-app=hubble-relay")
-      --sysdump-hubble-ui-labels string                       The labels used to target Hubble UI pods (default "k8s-app=hubble-ui")
-      --sysdump-logs-limit-bytes int                          The limit on the number of bytes to retrieve when collecting logs (default 1073741824)
-      --sysdump-logs-since-time duration                      How far back in time to go when collecting logs (default 8760h0m0s)
-      --sysdump-node-list string                              Comma-separated list of node IPs or names to filter pods for which to collect gops and logs
-      --sysdump-output-filename string                        The name of the resulting file (without extension)
-                                                              '<ts>' can be used as the placeholder for the timestamp (default "cilium-sysdump-<ts>")
-      --sysdump-profiling                                     Whether to enable scraping profiling data (default true)
-      --sysdump-quick                                         Whether to enable quick mode (i.e. skip collection of 'cilium-bugtool' output and logs)
-      --sysdump-tetragon-helm-release-name string             The Tetragon Helm release name for which to get values.
-      --sysdump-tetragon-label-selector string                The labels used to target Tetragon pods (default "app.kubernetes.io/name=tetragon")
-      --sysdump-tetragon-namespace string                     The namespace Tetragon is running in (default "kube-system")
-      --sysdump-tetragon-operator-label-selector string       The labels used to target Tetragon operator pods (default "app.kubernetes.io/name=tetragon-operator")
-      --sysdump-tracing                                       Whether to enable scraping tracing data
-      --sysdump-worker-count int                              The number of workers to use
-                                                              NOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards. Defaults to the number of available CPUs. (default 20)
-      --test strings                                          Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'
-      --test-concurrency int                                  Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1) (default 1)
-      --test-conn-disrupt-image string                        Image path to use for connection disruption tests (default "quay.io/cilium/test-connection-disruption:v0.0.17@sha256:62374cfd0e87e6541244331ccf477a21c527c3eefa9d841b97af79996939be0c")
-      --test-namespace string                                 Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1) (default "cilium-test")
-      --timeout duration                                      Maximum time to allow the connectivity test suite to take
-  -t, --timestamp                                             Show timestamp in messages
-      --tolerations strings                                   Extra NoSchedule tolerations added to test pods
-  -v, --verbose                                               Show informational messages and don't buffer any lines
+      --agent-daemonset-name string                                Name of cilium agent daemonset (default "cilium")
+      --agent-pod-selector string                                  Label on cilium-agent pods to select with (default "k8s-app=cilium")
+      --all-flows                                                  Print all flows during flow validation
+      --assume-cilium-version string                               Assume Cilium version for connectivity tests
+      --chart-directory string                                     Helm chart directory
+      --cilium-pod-selector string                                 Label selector matching all cilium-related pods (default "app.kubernetes.io/part-of=cilium")
+      --cleanup                                                    Cleanup all connectivity test artifacts (namespaces, deployments, services) without running tests
+      --collect-sysdump-on-failure                                 Collect sysdump after a test fails
+      --conn-disrupt-dispatch-interval duration                    TCP packet dispatch interval
+      --conn-disrupt-test-restarts-path string                     Conn disrupt test temporary result file (used internally) (default "/tmp/cilium-conn-disrupt-restarts")
+      --conn-disrupt-test-setup                                    Set up conn disrupt test dependencies
+      --conn-disrupt-test-xfrm-errors-path string                  Conn disrupt test temporary result file (used internally) (default "/tmp/cilium-conn-disrupt-xfrm-errors")
+      --connect-timeout duration                                   Maximum time to allow initiation of the connection to take (default 2s)
+      --curl-image string                                          Image path to use for curl (default "quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364")
+      --curl-insecure                                              Pass --insecure to curl
+      --curl-parallel uint                                         Number of parallel requests in curl commands (0 to disable)
+  -d, --debug                                                      Show debug messages
+      --dns-test-server-image string                               Image path to use for CoreDNS (default "registry.k8s.io/coredns/coredns:v1.14.2@sha256:e7e6440cfd1e919280958f5b5a6ab2b184d385bba774c12ad2a9e1e4183f90d9")
+      --echo-image string                                          Image path to use for echo server (default "gcr.io/k8s-staging-gateway-api/echo-advanced:v20251204-v1.4.1")
+      --exit-zero-on-failure                                       Exit with zero return code even when test failures are detected
+      --external-cidr string                                       IPv4 CIDR to use as external target in connectivity tests (default "1.0.0.0/8")
+      --external-cidrv6 string                                     IPv6 CIDR to use as external target in connectivity tests (default "2606:4700:4700::/96")
+      --external-ip string                                         IPv4 to use as external target in connectivity tests (default "1.1.1.1")
+      --external-ipv6 string                                       IPv6 to use as external target in connectivity tests (default "2606:4700:4700::1111")
+      --external-other-ip string                                   Other IPv4 to use as external target in connectivity tests (default "1.0.0.1")
+      --external-other-ipv6 string                                 Other IPv6 to use as external target in connectivity tests (default "2606:4700:4700::1001")
+      --external-other-target string                               Domain name to use as a second external target in connectivity tests (default "k8s.io.")
+      --external-target string                                     Domain name to use as external target in connectivity tests (default "one.one.one.one.")
+      --external-target-ca-name string                             Name of the CA secret for the external target. (default "cabundle")
+      --external-target-ca-namespace string                        Namespace of the CA secret for the external target.
+      --external-target-ipv6-capable                               External target is IPv6 capable
+      --flow-validation string                                     Enable Hubble flow validation { disabled | warning | strict } (default "warning")
+      --force-deploy                                               Force re-deploying test artifacts
+      --frr-image string                                           Image path to use for FRR (default "quay.io/frrouting/frr:10.5.2@sha256:94e78424a15839e0953623e2515c3e54f308644946395bc341b25e43f5c2d323")
+      --helm-values-secret-name string                             Secret name to store the auto-generated helm values file. The namespace is the same as where Cilium will be installed (default "cilium-cli-helm-values")
+  -h, --help                                                       help for test
+      --hubble                                                     Automatically use Hubble for flow validation & troubleshooting (default true)
+      --hubble-server string                                       Address of the Hubble endpoint for flow validation (default "localhost:4245")
+      --include-conn-disrupt-test                                  Include conn disrupt test
+      --include-conn-disrupt-test-egw                              Include conn disrupt test for Egress Gateway
+      --include-conn-disrupt-test-l7-traffic                       Include conn disrupt test for L7 traffic
+      --include-conn-disrupt-test-ns-traffic                       Include conn disrupt test for NS traffic
+      --ip-families strings                                        Restrict test actions to specific IP families (default [ipv4,ipv6])
+      --json-mock-image string                                     Image path to use for json mock (default "quay.io/cilium/json-mock:v1.3.9@sha256:c98b26177a5a60020e5aa404896d55f0ab573d506f42acfb4aa4f5705a5c6f56")
+      --junit-file string                                          Generate junit report and write to file
+      --junit-property map                                         Add key=value properties to the generated junit file
+      --k8s-version string                                         Kubernetes server version in case auto-detection fails
+      --multi-cluster string                                       Test across clusters to given context
+      --namespace-labels map                                       Add labels to the connectivity test namespace
+      --node-cidr strings                                          one or more CIDRs that cover all nodes in the cluster
+      --node-selector map                                          Restrict connectivity pods to nodes matching this label
+  -p, --pause-on-fail                                              Pause execution on test failure
+      --post-test-sleep duration                                   Wait time after each test before next test starts
+      --print-flows                                                Print flow logs for each test
+      --print-image-artifacts                                      Prints the used image artifacts
+      --request-timeout duration                                   Maximum time to allow a request to take (default 10s)
+      --retry uint                                                 Number of retries on connection failure to external targets (default 3)
+      --retry-delay duration                                       Delay between retries for external targets (default 3s)
+      --secondary-network-iface string                             Secondary network iface name (e.g., to test NodePort BPF on multiple networks)
+      --service-type string                                        Type of Kubernetes Services created for connectivity tests (default "NodePort")
+      --single-node                                                Limit to tests able to run on a single node
+      --socat-image string                                         Image path to use for multicast tests (default "docker.io/alpine/socat:1.8.0.3@sha256:5dc44a92103afe611c152fca347c524a170e1f3fda2411c29e2894d22a855099")
+      --sysdump-cilium-bugtool-flags stringArray                   Optional set of flags to pass to cilium-bugtool command.
+      --sysdump-cilium-daemon-set-label-selector string            The labels used to target Cilium daemon set (default "k8s-app=cilium")
+      --sysdump-cilium-envoy-label-selector string                 The labels used to target Cilium Envoy pods (default "k8s-app=cilium-envoy")
+      --sysdump-cilium-helm-release-name string                    The Cilium Helm release name for which to get values. If not provided then the --helm-release-name global flag is used (if provided)
+      --sysdump-cilium-label-selector string                       The labels used to target Cilium pods (default "k8s-app=cilium")
+      --sysdump-cilium-namespace string                            The namespace Cilium is running in. If not provided then the --namespace global flag is used (if provided)
+      --sysdump-cilium-node-init-selector string                   The labels used to target Cilium node init pods (default "app=cilium-node-init")
+      --sysdump-cilium-operator-label-selector string              The labels used to target Cilium operator pods (default "io.cilium/app=operator")
+      --sysdump-cilium-operator-namespace string                   The namespace Cilium operator is running in. If not provided then the --namespace global flag is used (if provided)
+      --sysdump-cilium-spire-agent-selector string                 The labels used to target Cilium spire-agent pods (default "app=spire-agent")
+      --sysdump-cilium-spire-namespace string                      The namespace Cilium SPIRE installation is running in
+      --sysdump-cilium-spire-server-selector string                The labels used to target Cilium spire-server pods (default "app=spire-server")
+      --sysdump-clustermesh-apiserver-label-selector string        The labels used to target 'clustermesh-apiserver' pods (default "k8s-app=clustermesh-apiserver")
+      --sysdump-clustermesh-generate-certs-label-selector string   The labels used to target the Cluster Mesh generate certs pods (default "k8s-app=clustermesh-apiserver-generate-certs")
+      --sysdump-cni-config-directory string                        Directory where CNI configs are located (default "/etc/cni/net.d/")
+      --sysdump-cni-configmap-name string                          The name of the CNI config map (default "cni-configuration")
+      --sysdump-collect-logs-from-not-ready-agents                 Whether to collect logs from not ready Cilium agent pods (default true)
+      --sysdump-copy-retry-limit int                               Retry limit for file copying operations. If set to -1, copying will be retried indefinitely. Useful for collecting sysdump while on unreliable connection. (default 100)
+      --sysdump-debug                                              Whether to enable debug logging
+      --sysdump-detect-gops-pid                                    Whether to automatically detect the gops agent PID.
+      --sysdump-extra-label-selectors stringArray                  Optional set of labels selectors used to target additional pods for log collection.
+      --sysdump-hubble-flows-count int                             Number of Hubble flows to collect. Setting to zero disables collecting Hubble flows. (default 10000)
+      --sysdump-hubble-flows-timeout duration                      Timeout for collecting Hubble flows (default 5s)
+      --sysdump-hubble-generate-certs-labels string                The labels used to target Hubble UI pods (default "k8s-app=hubble-generate-certs")
+      --sysdump-hubble-label-selector string                       The labels used to target Hubble pods (default "k8s-app=hubble")
+      --sysdump-hubble-relay-labels string                         The labels used to target Hubble Relay pods (default "k8s-app=hubble-relay")
+      --sysdump-hubble-ui-labels string                            The labels used to target Hubble UI pods (default "k8s-app=hubble-ui")
+      --sysdump-logs-limit-bytes int                               The limit on the number of bytes to retrieve when collecting logs (default 1073741824)
+      --sysdump-logs-since-time duration                           How far back in time to go when collecting logs (default 8760h0m0s)
+      --sysdump-node-list string                                   Comma-separated list of node IPs or names to filter pods for which to collect gops and logs
+      --sysdump-output-filename string                             The name of the resulting file (without extension)
+                                                                   '<ts>' can be used as the placeholder for the timestamp (default "cilium-sysdump-<ts>")
+      --sysdump-profiling                                          Whether to enable scraping profiling data (default true)
+      --sysdump-quick                                              Whether to enable quick mode (i.e. skip collection of 'cilium-bugtool' output and logs)
+      --sysdump-tetragon-helm-release-name string                  The Tetragon Helm release name for which to get values.
+      --sysdump-tetragon-label-selector string                     The labels used to target Tetragon pods (default "app.kubernetes.io/name=tetragon")
+      --sysdump-tetragon-namespace string                          The namespace Tetragon is running in (default "kube-system")
+      --sysdump-tetragon-operator-label-selector string            The labels used to target Tetragon operator pods (default "app.kubernetes.io/name=tetragon-operator")
+      --sysdump-tracing                                            Whether to enable scraping tracing data
+      --sysdump-worker-count int                                   The number of workers to use
+                                                                   NOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards. Defaults to the number of available CPUs. (default 20)
+      --test strings                                               Run tests that match one of the given regular expressions, skip tests by starting the expression with '!', target Scenarios with e.g. '/pod-to-cidr'
+      --test-concurrency int                                       Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1) (default 1)
+      --test-conn-disrupt-image string                             Image path to use for connection disruption tests (default "quay.io/cilium/test-connection-disruption:v0.0.17@sha256:62374cfd0e87e6541244331ccf477a21c527c3eefa9d841b97af79996939be0c")
+      --test-namespace string                                      Namespace to perform the connectivity in (always suffixed with a sequence number to be compliant with test-concurrency param, e.g.: cilium-test-1) (default "cilium-test")
+      --timeout duration                                           Maximum time to allow the connectivity test suite to take
+  -t, --timestamp                                                  Show timestamp in messages
+      --tolerations strings                                        Extra NoSchedule tolerations added to test pods
+  -v, --verbose                                                    Show informational messages and don't buffer any lines
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium_sysdump.md
+++ b/Documentation/cmdref/cilium_sysdump.md
@@ -11,47 +11,48 @@ cilium sysdump [flags]
 ### Options
 
 ```
-      --cilium-bugtool-flags stringArray              Optional set of flags to pass to cilium-bugtool command.
-      --cilium-daemon-set-label-selector string       The labels used to target Cilium daemon set (default "k8s-app=cilium")
-      --cilium-envoy-label-selector string            The labels used to target Cilium Envoy pods (default "k8s-app=cilium-envoy")
-      --cilium-helm-release-name string               The Cilium Helm release name for which to get values. If not provided then the --helm-release-name global flag is used (if provided)
-      --cilium-label-selector string                  The labels used to target Cilium pods (default "k8s-app=cilium")
-      --cilium-namespace string                       The namespace Cilium is running in. If not provided then the --namespace global flag is used (if provided)
-      --cilium-node-init-selector string              The labels used to target Cilium node init pods (default "app=cilium-node-init")
-      --cilium-operator-label-selector string         The labels used to target Cilium operator pods (default "io.cilium/app=operator")
-      --cilium-operator-namespace string              The namespace Cilium operator is running in. If not provided then the --namespace global flag is used (if provided)
-      --cilium-spire-agent-selector string            The labels used to target Cilium spire-agent pods (default "app=spire-agent")
-      --cilium-spire-namespace string                 The namespace Cilium SPIRE installation is running in
-      --cilium-spire-server-selector string           The labels used to target Cilium spire-server pods (default "app=spire-server")
-      --clustermesh-apiserver-label-selector string   The labels used to target 'clustermesh-apiserver' pods (default "k8s-app=clustermesh-apiserver")
-      --cni-config-directory string                   Directory where CNI configs are located (default "/etc/cni/net.d/")
-      --cni-configmap-name string                     The name of the CNI config map (default "cni-configuration")
-      --collect-logs-from-not-ready-agents            Whether to collect logs from not ready Cilium agent pods (default true)
-      --copy-retry-limit int                          Retry limit for file copying operations. If set to -1, copying will be retried indefinitely. Useful for collecting sysdump while on unreliable connection. (default 100)
-      --debug                                         Whether to enable debug logging
-      --detect-gops-pid                               Whether to automatically detect the gops agent PID.
-      --extra-label-selectors stringArray             Optional set of labels selectors used to target additional pods for log collection.
-  -h, --help                                          help for sysdump
-      --hubble-flows-count int                        Number of Hubble flows to collect. Setting to zero disables collecting Hubble flows. (default 10000)
-      --hubble-flows-timeout duration                 Timeout for collecting Hubble flows (default 5s)
-      --hubble-generate-certs-labels string           The labels used to target Hubble UI pods (default "k8s-app=hubble-generate-certs")
-      --hubble-label-selector string                  The labels used to target Hubble pods (default "k8s-app=hubble")
-      --hubble-relay-labels string                    The labels used to target Hubble Relay pods (default "k8s-app=hubble-relay")
-      --hubble-ui-labels string                       The labels used to target Hubble UI pods (default "k8s-app=hubble-ui")
-      --logs-limit-bytes int                          The limit on the number of bytes to retrieve when collecting logs (default 1073741824)
-      --logs-since-time duration                      How far back in time to go when collecting logs (default 8760h0m0s)
-      --node-list string                              Comma-separated list of node IPs or names to filter pods for which to collect gops and logs
-      --output-filename string                        The name of the resulting file (without extension)
-                                                      '<ts>' can be used as the placeholder for the timestamp (default "cilium-sysdump-<ts>")
-      --profiling                                     Whether to enable scraping profiling data (default true)
-      --quick                                         Whether to enable quick mode (i.e. skip collection of 'cilium-bugtool' output and logs)
-      --tetragon-helm-release-name string             The Tetragon Helm release name for which to get values.
-      --tetragon-label-selector string                The labels used to target Tetragon pods (default "app.kubernetes.io/name=tetragon")
-      --tetragon-namespace string                     The namespace Tetragon is running in (default "kube-system")
-      --tetragon-operator-label-selector string       The labels used to target Tetragon operator pods (default "app.kubernetes.io/name=tetragon-operator")
-      --tracing                                       Whether to enable scraping tracing data
-      --worker-count int                              The number of workers to use
-                                                      NOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards. Defaults to the number of available CPUs. (default 20)
+      --cilium-bugtool-flags stringArray                   Optional set of flags to pass to cilium-bugtool command.
+      --cilium-daemon-set-label-selector string            The labels used to target Cilium daemon set (default "k8s-app=cilium")
+      --cilium-envoy-label-selector string                 The labels used to target Cilium Envoy pods (default "k8s-app=cilium-envoy")
+      --cilium-helm-release-name string                    The Cilium Helm release name for which to get values. If not provided then the --helm-release-name global flag is used (if provided)
+      --cilium-label-selector string                       The labels used to target Cilium pods (default "k8s-app=cilium")
+      --cilium-namespace string                            The namespace Cilium is running in. If not provided then the --namespace global flag is used (if provided)
+      --cilium-node-init-selector string                   The labels used to target Cilium node init pods (default "app=cilium-node-init")
+      --cilium-operator-label-selector string              The labels used to target Cilium operator pods (default "io.cilium/app=operator")
+      --cilium-operator-namespace string                   The namespace Cilium operator is running in. If not provided then the --namespace global flag is used (if provided)
+      --cilium-spire-agent-selector string                 The labels used to target Cilium spire-agent pods (default "app=spire-agent")
+      --cilium-spire-namespace string                      The namespace Cilium SPIRE installation is running in
+      --cilium-spire-server-selector string                The labels used to target Cilium spire-server pods (default "app=spire-server")
+      --clustermesh-apiserver-label-selector string        The labels used to target 'clustermesh-apiserver' pods (default "k8s-app=clustermesh-apiserver")
+      --clustermesh-generate-certs-label-selector string   The labels used to target the Cluster Mesh generate certs pods (default "k8s-app=clustermesh-apiserver-generate-certs")
+      --cni-config-directory string                        Directory where CNI configs are located (default "/etc/cni/net.d/")
+      --cni-configmap-name string                          The name of the CNI config map (default "cni-configuration")
+      --collect-logs-from-not-ready-agents                 Whether to collect logs from not ready Cilium agent pods (default true)
+      --copy-retry-limit int                               Retry limit for file copying operations. If set to -1, copying will be retried indefinitely. Useful for collecting sysdump while on unreliable connection. (default 100)
+      --debug                                              Whether to enable debug logging
+      --detect-gops-pid                                    Whether to automatically detect the gops agent PID.
+      --extra-label-selectors stringArray                  Optional set of labels selectors used to target additional pods for log collection.
+  -h, --help                                               help for sysdump
+      --hubble-flows-count int                             Number of Hubble flows to collect. Setting to zero disables collecting Hubble flows. (default 10000)
+      --hubble-flows-timeout duration                      Timeout for collecting Hubble flows (default 5s)
+      --hubble-generate-certs-labels string                The labels used to target Hubble UI pods (default "k8s-app=hubble-generate-certs")
+      --hubble-label-selector string                       The labels used to target Hubble pods (default "k8s-app=hubble")
+      --hubble-relay-labels string                         The labels used to target Hubble Relay pods (default "k8s-app=hubble-relay")
+      --hubble-ui-labels string                            The labels used to target Hubble UI pods (default "k8s-app=hubble-ui")
+      --logs-limit-bytes int                               The limit on the number of bytes to retrieve when collecting logs (default 1073741824)
+      --logs-since-time duration                           How far back in time to go when collecting logs (default 8760h0m0s)
+      --node-list string                                   Comma-separated list of node IPs or names to filter pods for which to collect gops and logs
+      --output-filename string                             The name of the resulting file (without extension)
+                                                           '<ts>' can be used as the placeholder for the timestamp (default "cilium-sysdump-<ts>")
+      --profiling                                          Whether to enable scraping profiling data (default true)
+      --quick                                              Whether to enable quick mode (i.e. skip collection of 'cilium-bugtool' output and logs)
+      --tetragon-helm-release-name string                  The Tetragon Helm release name for which to get values.
+      --tetragon-label-selector string                     The labels used to target Tetragon pods (default "app.kubernetes.io/name=tetragon")
+      --tetragon-namespace string                          The namespace Tetragon is running in (default "kube-system")
+      --tetragon-operator-label-selector string            The labels used to target Tetragon operator pods (default "app.kubernetes.io/name=tetragon-operator")
+      --tracing                                            Whether to enable scraping tracing data
+      --worker-count int                                   The number of workers to use
+                                                           NOTE: There is a lower bound requirement on the number of workers for the sysdump operation to be effective. Therefore, for low values, the actual number of workers may be adjusted upwards. Defaults to the number of available CPUs. (default 20)
 ```
 
 ### Options inherited from parent commands

--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -26,6 +26,7 @@ const (
 	ciliumSPIREServerConfigMapName     = defaults.SPIREServerConfigMapName
 	ciliumSPIREAgentConfigMapName      = defaults.SPIREAgentConfigMapName
 	clustermeshApiserverDeploymentName = defaults.ClusterMeshDeploymentName
+	clustermeshCertgenCronJobName      = "clustermesh-apiserver-generate-certs"
 	gkeConfigMapsName                  = "gke-config-maps"
 	gkeHubbleConfigMap                 = "cilium-hubble-config"
 	gkeOverrideConfigMap               = "cilium-config-emergency-override"
@@ -74,6 +75,8 @@ const (
 	ciliumOperatorDeploymentFileName         = "cilium-operator-deployment-<ts>.yaml"
 	ciliumPodIPPoolsFileName                 = "ciliumpodippools-<ts>.yaml"
 	clustermeshApiserverDeploymentFileName   = "clustermesh-apiserver-deployment-<ts>.yaml"
+	clustermeshCertgenCronJobFileName        = "clustermesh-generate-certs-cronjob-<ts>.yaml"
+	clustermeshCertManagerCertsFileName      = "clustermesh-certificates-<ts>.yaml"
 	metricsFileName                          = "metrics-%s-%s-<ts>.txt"
 	cniConfigMapFileName                     = "cni-configmap-<ts>.yaml"
 	cniConfigFileName                        = "cniconf-%s-%s-<ts>.txt"

--- a/cilium-cli/sysdump/defaults.go
+++ b/cilium-cli/sysdump/defaults.go
@@ -16,6 +16,7 @@ const (
 	DefaultCiliumEnvoyLabelSelector          = labelPrefix + "cilium-envoy"
 	DefaultCiliumOperatorLabelSelector       = "io.cilium/app=operator"
 	DefaultClustermeshApiserverLabelSelector = labelPrefix + "clustermesh-apiserver"
+	DefaultClustermeshCertgenLabelSelector   = labelPrefix + "clustermesh-apiserver-generate-certs"
 	DefaultCiliumNodeInitLabelSelector       = "app=cilium-node-init"
 	DefaultCiliumSpireAgentLabelSelector     = "app=spire-agent"
 	DefaultCiliumSpireServerLabelSelector    = "app=spire-server"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -72,6 +72,8 @@ type Options struct {
 	CiliumOperatorLabelSelector string
 	// The labels used to target 'clustermesh-apiserver' pods.
 	ClustermeshApiserverLabelSelector string
+	// The labels used to target the Cluster Mesh certgen pods.
+	ClustermeshCertgenLabelSelector string
 	// The labels used to target Cilium SPIRE server pods.
 	CiliumSPIREServerLabelSelector string
 	// The labels used to target Cilium SPIRE agent pods.
@@ -1204,6 +1206,56 @@ func (c *Collector) Run() error {
 					return fmt.Errorf("failed to collect the 'clustermesh-apiserver' deployment: %w", err)
 				}
 				return nil
+			},
+		},
+		{
+			Description: "Collecting the Cluster Mesh certgen cronjob",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.GetCronJob(ctx, c.Options.CiliumNamespace, clustermeshCertgenCronJobName, metav1.GetOptions{})
+				if err != nil {
+					if k8sErrors.IsNotFound(err) {
+						c.logWarn("cronjob %q not found in namespace %q - this is expected if Cluster Mesh is not enabled, or certificates are not generated via certgen",
+							clustermeshCertgenCronJobName, c.Options.CiliumNamespace)
+						return nil
+					}
+					return fmt.Errorf("failed to collect the Cluster Mesh certgen cronjob: %w", err)
+				}
+				if err := c.WriteYAML(clustermeshCertgenCronJobFileName, v); err != nil {
+					return fmt.Errorf("failed to collect the Cluster Mesh certgen cronjob: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting the Cluster Mesh certgen logs",
+			Quick:       false,
+			Task: func(ctx context.Context) error {
+				p, err := c.Client.ListPods(ctx, c.Options.CiliumNamespace, metav1.ListOptions{
+					LabelSelector: c.Options.ClustermeshCertgenLabelSelector,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to get logs from the Cluster Mesh certgen pods")
+				}
+				if err := c.SubmitLogsTasks(AllPods(p), c.Options.LogsSinceTime, c.Options.LogsLimitBytes); err != nil {
+					return fmt.Errorf("failed to collect logs from Cluster Mesh certgen pods")
+				}
+				return nil
+			},
+		},
+		{
+			Description: "Collecting the Cluster Mesh cert-manager certificates",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				return c.GatherResourceUnstructured(
+					ctx,
+					certificate,
+					clustermeshCertManagerCertsFileName,
+					"clustermesh-apiserver-admin-cert",
+					"clustermesh-apiserver-local-cert",
+					"clustermesh-apiserver-remote-cert",
+					"clustermesh-apiserver-server-cert",
+				)
 			},
 		},
 		{
@@ -3275,6 +3327,9 @@ func InitSysdumpFlags(cmd *cobra.Command, options *Options, optionPrefix string,
 	cmd.Flags().StringVar(&options.ClustermeshApiserverLabelSelector,
 		optionPrefix+"clustermesh-apiserver-label-selector", DefaultClustermeshApiserverLabelSelector,
 		"The labels used to target 'clustermesh-apiserver' pods")
+	cmd.Flags().StringVar(&options.ClustermeshCertgenLabelSelector,
+		optionPrefix+"clustermesh-generate-certs-label-selector", DefaultClustermeshCertgenLabelSelector,
+		"The labels used to target the Cluster Mesh generate certs pods")
 	cmd.Flags().StringVar(&options.CiliumNodeInitLabelSelector,
 		optionPrefix+"cilium-node-init-selector", DefaultCiliumNodeInitLabelSelector,
 		"The labels used to target Cilium node init pods")


### PR DESCRIPTION
Let's extend the sysdump collection tasks to additionally collect artifacts potentially useful to troubleshoot problems related to the generation of clustermesh certificates, and more specifically the certgen cronjob and associated pod logs, as well as the cert-manager certificate resources.

<!-- Description of change -->

```release-note
Additionally collect Cluster Mesh certificate generation artifacts in sysdumps
```
