### PR TITLE
fix(datapath): ignore link-local IPv6 addresses for NodePort binding

### DIFF
--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -513,7 +513,7 @@ func (n *nodeAddressController) getAddressesFromDevice(dev *Device, k8sIPv4, k8s
 			}
 		}
 
-		if addr.Addr.Is6() {
+		if addr.Addr.Is6() && !addr.Addr.IsLinkLocalUnicast() {
 			if addr.Addr == k8sIPv6 {
 				// Address matches the K8s Node IP. Prioritize it within its
 				// category (public or private) for NodePort address selection.

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -273,6 +273,33 @@ var nodeAddressTests = []struct {
 			netip.MustParseAddr("2001:db8::1"), // IPv6: only private IP
 		},
 	},
+
+	{
+		name: "ipv6 skip link-local",
+		addrs: []DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("2600:beef::1"), // public
+				Scope: RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  netip.MustParseAddr("fe80::1"), // link-local (should be skipped)
+				Scope: RT_SCOPE_LINK,
+			},
+		},
+		wantAddrs: []netip.Addr{
+			ciliumHostIP,
+			ciliumHostIPLinkScoped,
+			netip.MustParseAddr("2600:beef::1"),
+			netip.MustParseAddr("fe80::1"),
+		},
+		wantPrimary: []netip.Addr{
+			ciliumHostIP,
+			netip.MustParseAddr("2600:beef::1"),
+		},
+		wantNodePort: []netip.Addr{
+			netip.MustParseAddr("2600:beef::1"),
+		},
+	},
 }
 
 func TestNodeAddress(t *testing.T) {


### PR DESCRIPTION
Currently, in environments with dual-stack or IPv6 enabled, NodePorts can fail to route traffic because the agent incorrectly binds the IPv6 frontend to the node's unroutable link-local address (e.g., fe80::) instead of the global IPv6 address.

When dumping the eBPF load balancer maps (cilium-dbg bpf lb list), the NodePort incorrectly points to the link-local address:
```
[fe80::4001:aff:fe0b:102]:30884/TCP (0)   [::]:0 (16) (0) [NodePort]
```

In `pkg/datapath/tables/node_address.go` (getAddressesFromDevice), the agent evaluates the device's IPv6 addresses. Because a link-local IP isn't considered "public", the agent tags it as a valid "private" IP.

Later in the function, the fallback logic states: "Pick the NodePort addresses. Prefer private addresses if possible." Because of this, the unroutable link-local address wins the election and steals the NodePort binding from the actual global IPv6 address.

This fix should also be backported to 1.19

Fixes: #44436 