### PR TITLE
monitor: convert net.IP to netip.Addr

### DIFF
--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -9,8 +9,6 @@ import (
 	"net/netip"
 	"strings"
 
-	"go4.org/netipx"
-
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
@@ -100,9 +98,8 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	}
 	srcPort := uint16(0) // source port is not known for TraceSock events
 
-	// Ignore invalid IPs - getters will handle invalid values.
-	// IPs can be empty for Ethernet-only packets.
-	dstIP, _ := netipx.FromStdIP(sock.IP())
+	// IPs can be zero for Ethernet-only packets.
+	dstIP := sock.IP()
 	dstPort := sock.DstPort
 
 	datapathContext := common.DatapathContext{

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -251,8 +251,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	ip := decoded.GetIP()
 	if tn != nil && ip != nil {
 		if !tn.OriginalIP().IsUnspecified() {
-			// Ignore invalid IP - getters will handle invalid value.
-			srcIP, _ = netipx.FromStdIP(tn.OriginalIP())
+			srcIP = tn.OriginalIP()
 			// On SNAT the trace notification has OrigIP set to the pre
 			// translation IP and the source IP parsed from the header is the
 			// post translation IP. The check is here because sometimes we get

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 
 	// NOTE: syscall is deprecated, but it is replaced by golang.org/x/sys
 	//       which reuses syscall.Errno similarly to how we do below.
@@ -217,9 +217,9 @@ func l4CreateInfo(n *DebugMsg) string {
 }
 
 func ip4Str(arg1 uint32) string {
-	ip := make(net.IP, 4)
-	binary.NativeEndian.PutUint32(ip, arg1)
-	return ip.String()
+	var buf [4]byte
+	binary.NativeEndian.PutUint32(buf[:], arg1)
+	return netip.AddrFrom4(buf).String()
 }
 
 func ip6Str(arg1 uint32) string {

--- a/pkg/monitor/datapath_sock_trace.go
+++ b/pkg/monitor/datapath_sock_trace.go
@@ -6,7 +6,7 @@ package monitor
 import (
 	"encoding/binary"
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/types"
@@ -95,11 +95,13 @@ func (t *TraceSockNotify) XlatePointStr() string {
 }
 
 // IP returns the IPv4 or IPv6 address field.
-func (t *TraceSockNotify) IP() net.IP {
+func (t *TraceSockNotify) IP() netip.Addr {
 	if (t.Flags & TraceSockNotifyFlagIPv6) != 0 {
-		return t.DstIP[:]
+		return netip.AddrFrom16(t.DstIP)
 	}
-	return t.DstIP[:4]
+	var arr [4]byte
+	copy(arr[:], t.DstIP[:4])
+	return netip.AddrFrom4(arr)
 }
 
 func (t *TraceSockNotify) L4ProtoStr() string {

--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
@@ -317,11 +317,13 @@ func (n *TraceNotify) IsGeneve() bool {
 
 // OriginalIP returns the original source IP if reverse NAT was performed on
 // the flow
-func (n *TraceNotify) OriginalIP() net.IP {
+func (n *TraceNotify) OriginalIP() netip.Addr {
 	if n.IsIPv6() {
-		return n.OrigIP[:]
+		return netip.AddrFrom16(n.OrigIP)
 	}
-	return n.OrigIP[:4]
+	var arr [4]byte
+	copy(arr[:], n.OrigIP[:4])
+	return netip.AddrFrom4(arr)
 }
 
 // DataOffset returns the offset from the beginning of TraceNotify where the


### PR DESCRIPTION
Convert `TraceNotify.OriginalIP()`, `TraceSockNotify.IP()`, and
`ip4Str()` from `net.IP` to `netip.Addr`. This also removes the
`netipx.FromStdIP()` round-trip conversions in the Hubble parsers
that were immediately converting the results back to `netip.Addr`.

For #24246