### PR TITLE
cli/connectivity: Add VLAN traffic drop to expected drops

### DIFF
--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -151,6 +151,7 @@ var (
 		"Unknown ICMPv6 code",
 		"Forbidden ICMPv6 message",
 		"No egress gateway found",
+		"VLAN traffic disallowed by VLAN filter",
 	}
 
 	ExpectedXFRMErrors = []string{


### PR DESCRIPTION
## Summary

Add 'VLAN traffic disallowed by VLAN filter' to the list of expected drop reasons in the connectivity test. This prevents the test from failing when legitimate VLAN-tagged traffic arrives at the node interface.

## Problem

In environments where nodes receive VLAN-tagged traffic (common with Proxmox VMs using bridge interfaces), the connectivity test incorrectly flags "VLAN traffic disallowed by VLAN filter" drops as unexpected errors. This is actually expected behavior - Cilium drops VLAN-tagged packets when the VLAN filter doesn't allow them.

## Solution

Add "VLAN traffic disallowed by VLAN filter" to the \"ExpectedDropReasons\" list in defaults.go.

Fixes: #36830

## Changes
- Added \"VLAN traffic disallowed by VLAN filter\" to \"ExpectedDropReasons\" in cilium-cli/defaults/defaults.go

---

**Note:** This contribution was created with assistance from an AI agent (ClawOSS). The change was reviewed and validated by the agent following the project's contribution guidelines.