### PR TITLE
Allow Renovate to update Go to v1.25 on Cilium v1.17 and v1.18

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -446,16 +446,7 @@
       ],
       "allowedVersions": "<1.26",
       "matchBaseBranches": [
-        "v1.19"
-      ]
-    },
-    {
-      "matchPackageNames": [
-        "docker.io/library/golang",
-        "go"
-      ],
-      "allowedVersions": "<1.25",
-      "matchBaseBranches": [
+        "v1.19",
         "v1.18",
         "v1.17"
       ]


### PR DESCRIPTION
- Go v1.24 is now EOL and not receiving security updates
- Go v1.26 is now the latest version, so upgrade to v1.25 following the instructions at https://docs.cilium.io/en/stable/contributing/development/dev_setup/#update-a-golang-version
