### PR TITLE
metrics: Add high-level hive metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -759,6 +759,17 @@ Name                               Labels                           Default     
 ``fqdn_selectors``                                                  Enabled      Number of registered ToFQDN selectors
 ================================== ================================ ============ ========================================================
 
+Hive
+~~~~
+
+============================ ===================== ============ ========================================================
+Name                         Labels                Default      Description
+============================ ===================== ============ ========================================================
+``hive_start_duration``                            Enabled      Duration of the hive.Start method
+``hive_stop_duration``                             Disabled     Duration of the hive.Stop method. Not reported when metrics are handled by a hive (common in cilium-agent and cilium-operator)
+``hive_populate_duration``                         Enabled      Duration of the hive.Populate method
+============================ ===================== ============ ========================================================
+
 Jobs
 ~~~~
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -384,6 +384,10 @@ Added Metrics
   tagged by the status (``OK``, ``Warning``, ``Failure``) of each component (``BPF``, ``Policy``).
 * ``cilium_kubernetes_resource_sync_duration`` was added and reports duration in seconds
   of a specific Kubernetes resource sync.
+* ``cilium_hive_start_duration`` was added and reports the hive.Start method duration.
+* ``cilium_hive_stop_duration`` was added and reports the hive.Stop method duration.
+  Not reported when metrics are handled by a hive (common in cilium-agent and cilium-operator). Disabled by default.
+* ``cilium_hive_populate_duration`` was added and reports the hive.Populate method duration.
 
 Changed Metrics
 ###############

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -55,6 +55,12 @@ func New(cells ...cell.Cell) *Hive {
 			),
 		),
 
+		// Hive metrics
+		cell.Group(
+			metrics.Metric(newHiveCiliumMetrics),
+			cell.Provide(hiveMetrics),
+		),
+
 		// StateDB and its metrics
 		cell.Group(
 			statedb.Cell,

--- a/pkg/hive/metrics.go
+++ b/pkg/hive/metrics.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hive
+
+import (
+	"time"
+
+	"github.com/cilium/hive"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	hiveSubsystem = "hive"
+)
+
+type hiveCiliumMetrics struct {
+	StartDuration    metric.Vec[metric.Gauge]
+	StopDuration     metric.Vec[metric.Gauge]
+	PopulateDuration metric.Vec[metric.Gauge]
+}
+
+func newHiveCiliumMetrics() *hiveCiliumMetrics {
+	return &hiveCiliumMetrics{
+		StartDuration: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: hiveSubsystem,
+			Name:      "start_duration",
+			Help:      "Hive start duration",
+		}, []string{}),
+		StopDuration: metric.NewGaugeVec(metric.GaugeOpts{
+			Disabled:  true,
+			Namespace: metrics.Namespace,
+			Subsystem: hiveSubsystem,
+			Name:      "stop_duration",
+			Help:      "Hive stop duration",
+		}, []string{}),
+		PopulateDuration: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: hiveSubsystem,
+			Name:      "populate_duration",
+			Help:      "Hive populate duration",
+		}, []string{}),
+	}
+}
+
+var _ hive.Metrics = &hiveMetricsImpl{}
+
+type hiveMetricsImpl struct {
+	metrics *hiveCiliumMetrics
+}
+
+func (m *hiveMetricsImpl) StartDuration(duration time.Duration) {
+	m.metrics.StartDuration.WithLabelValues().Set(duration.Seconds())
+}
+
+func (m *hiveMetricsImpl) StopDuration(duration time.Duration) {
+	m.metrics.StopDuration.WithLabelValues().Set(duration.Seconds())
+}
+
+func (m *hiveMetricsImpl) PopulateDuration(duration time.Duration) {
+	m.metrics.PopulateDuration.WithLabelValues().Set(duration.Seconds())
+}
+
+func hiveMetrics(metrics *hiveCiliumMetrics) hive.Metrics {
+	return &hiveMetricsImpl{
+		metrics: metrics,
+	}
+}


### PR DESCRIPTION
This change introduces core hive metrics to `cilium-agent`:
- `hive_start_duration`: Duration of the hive.Start method.
- `hive_stop_duration`: Duration of the hive.Stop method. Keeping this
  one only for symmetry as we cannot leverage it for `cilium-agent` (since it is called once the `cilium-agent` stops).
- `hive_populate_duration`: Duration of the hive.Populate method.

Since these metrics represent a single observation per `cilium-agent` instance, they are implemented as *gauge*.

PR from `cilium/hive`: https://github.com/cilium/hive/pull/69
Corresponds to: https://github.com/cilium/hive/issues/68