### PR TITLE
[v1.19] ci: switch ca-central-1 to us-west-1 for eks tests

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -2,7 +2,7 @@
 ---
 include:
   - version: "1.32"
-    region: ca-central-1
+    region: us-west-1
   - version: "1.33"
     region: us-east-2
   - version: "1.34"

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -2,7 +2,7 @@
 ---
 include:
   - version: "1.32"
-    region: ca-central-1
+    region: us-west-1
   - version: "1.33"
     region: us-east-2
   - version: "1.34"


### PR DESCRIPTION
ca-central-1 seems to have some issues with tags that are breaking CI switch to us-west-1 which works fine and is already used in v1.18 and lower

related issue : https://github.com/cilium/cilium/issues/44695