### PR TITLE
fix(ipsec): panic in parseSPI on malformed input

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1092,7 +1092,11 @@ func (a *Agent) LoadIPSecKeys(r io.Reader) (int, uint8, error) {
 		// Scanning IPsec keys with one of the following formats:
 		// 1. [spi] aead-algo aead-key icv-len
 		// 2. [spi] auth-algo auth-key enc-algo enc-key [IP]
-		s := strings.Split(scanner.Text(), " ")
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		s := strings.Fields(line)
 		if len(s) < 3 {
 			// Regardless of the format used, the IPsec secret should have at
 			// least 3 fields separated by white spaces.
@@ -1176,8 +1180,14 @@ func (a *Agent) LoadIPSecKeys(r io.Reader) (int, uint8, error) {
 }
 
 func parseSPI(spiStr string) (uint8, int, error) {
+	if len(spiStr) == 0 {
+		return 0, 0, fmt.Errorf("empty SPI value")
+	}
 	if spiStr[len(spiStr)-1] == '+' {
 		spiStr = spiStr[:len(spiStr)-1]
+	}
+	if len(spiStr) == 0 {
+		return 0, 0, fmt.Errorf("empty SPI value after trimming")
 	}
 	spi, err := strconv.Atoi(spiStr)
 	if err != nil {


### PR DESCRIPTION
## Summary

This issue was found while fuzzing for different inputs, there doesn't seem to an existing issue that directly corresponds to this PR (#34029 does request for a better logging/error handling).

`parseSPI()` in the IPSec component panics with `index out of range [-1]` when given an empty string. 

The key file is sourced from a Kubernetes Secret (cilium-ipsec-keys), so Kubernetes user with permission to update the `cilium-ipsec-keys` Secret can intentionally/unintentionally to crash every cilium-agent into a permanent restart loop.

## Cause

`parseSPI()` accesses `spiStr[len(spiStr)-1]` without first checking whether the string is empty:

```go
func parseSPI(spiStr string) (uint8, int, error) {
    if spiStr[len(spiStr)-1] == '+' {   // panics when spiStr == ""
```

The caller, `LoadIPSecKeys()`, uses `strings.Split(line, " ")` to tokenize each line of the key file. When a line has leading whitespace (e.g. `" rfc4106(gcm(aes)) 0xdead 128"`), the split produces an empty first element `""`. The `len(s) < 3` guard passes because the slice still has enough elements, and the empty string reaches `parseSPI` unchecked.

A line consisting entirely of spaces (e.g. `"   "`) is similarly not rejected: `strings.Split("   ", " ")` yields `["", "", "", ""]` which has length 4, passing the guard.

## Causing the crash

The IPsec key file is projected from the `cilium-ipsec-keys` Kubernetes Secret. Any principal with RBAC `update` or `patch` on that Secret in the Cilium namespace can inject a malformed key:

```bash
kubectl patch secret cilium-ipsec-keys -n cilium --type merge \
  -p '{"stringData":{"keys":" rfc4106(gcm(aes)) 0xdeadbeef 128"}}'
```

The leading space makes `s[0]` empty after splitting. The fswatcher in cilium-agent detects the file change, calls `loadIPSecKeysFile()`, and the agent panics. Because the DaemonSet restarts the pod immediately and the Secret has not changed, the agent enters a **permanent crash loop**.

## Fix

Changes are in  `pkg/datapath/linux/ipsec/ipsec_linux.go`. This will ignore any malformed inputs. Please let me know if this should be better logged. Though we should probably be careful logging since it's sort of a secret key.

**1. `LoadIPSecKeys`: harden line tokenization**

Replace `strings.Split(line, " ")` with `strings.TrimSpace` + `strings.Fields` to skip blank and whitespace-only lines (`continue` on empty), and splits on any whitespace (tabs, multiple consecutive spaces), preventing empty tokens from appearing in the slice.

**2. `parseSPI`: add empty-string guards**

Check `len(spiStr) == 0` before indexing, both on entry and after trimming
the optional `+` suffix (since `"+"` alone would leave an empty string
after trimming).

## Reproduction

Here are some playloads that can crash the container:

| Payload | Mechanism |
|---------|-----------|
| `" rfc4106(gcm(aes)) 0xdead 128"` | Leading space: `s[0]` is `""` |
| `"   "` | Three spaces: splits to `["","","",""]`, `s[0]` is `""` |
| `"3 algo key\n   "` | Valid first line; blank second line triggers panic |

The first payload was reproduced with the following steps, same steps were taken to verify the fix:

```bash
make kind
make kind-image

# Valid key
kubectl create secret generic cilium-ipsec-keys -n kube-system \
  --from-literal=keys="3 rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"

cilium install \
  --set image.repository=localhost:5000/cilium/cilium-dev \
  --set image.tag=local \
  --set image.useDigest=false \
  --set encryption.enabled=true \
  --set encryption.type=ipsec

# Wait for Cilium pods to come up

# Monitor pods with kubectl get pods -n kube-system -l k8s-app=cilium -w
# Send invalid key
kubectl patch secret cilium-ipsec-keys -n kube-system --type merge \
  -p '{"stringData":{"keys":" rfc4106(gcm(aes)) 0xdeadbeef 128"}}'

# See pods start failing
```