### PR TITLE
fix(ipsec): panic in parseSPI on malformed input

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -1092,7 +1092,7 @@ func (a *agent) LoadIPSecKeys(r io.Reader) (int, uint8, error) {
 		// Scanning IPsec keys with one of the following formats:
 		// 1. [spi] aead-algo aead-key icv-len
 		// 2. [spi] auth-algo auth-key enc-algo enc-key [IP]
-		s := strings.Split(scanner.Text(), " ")
+		s := strings.Fields(strings.TrimSpace(scanner.Text()))
 		if len(s) < 3 {
 			// Regardless of the format used, the IPsec secret should have at
 			// least 3 fields separated by white spaces.

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -99,11 +99,27 @@ func TestPrivilegedInvalidLoadKeys(t *testing.T) {
 func testInvalidLoadKeys(t *testing.T, family string) {
 	local, remote := setup(t, family)
 
-	a := NewTestIPsecAgent(t)
-	keys := bytes.NewReader(invalidKeysDat)
-	_, _, err := a.LoadIPSecKeys(keys)
-	require.Error(t, err)
+	testCases := []struct {
+		name     string
+		input    []byte
+		expError string
+	}{
+		{"invalid keys", invalidKeysDat, "unable to decode authentication key string"},
+		{"empty line", []byte(" \n"), "missing IPSec key or invalid format"},
+		{"blank second line", []byte("4 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n   \n"), "missing IPSec key or invalid format"},
+		{"leading space", []byte(" rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n"), "the first argument of the IPsec secret is not a number"},
+		{"spi plus only", []byte("+ rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n"), "the first argument of the IPsec secret is not a number"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewTestIPsecAgent(t)
+			keys := bytes.NewReader(tc.input)
+			_, _, err := a.LoadIPSecKeys(keys)
+			require.ErrorContains(t, err, tc.expError)
+		})
+	}
 
+	a := NewTestIPsecAgent(t)
 	params := &types.Parameters{
 		LocalBootID:    localBootID,
 		RemoteBootID:   remoteBootID,
@@ -118,7 +134,7 @@ func testInvalidLoadKeys(t *testing.T, family string) {
 		ReqID:          DefaultReqID,
 	}
 
-	_, err = a.UpsertIPsecEndpoint(params)
+	_, err := a.UpsertIPsecEndpoint(params)
 	require.Error(t, err)
 }
 
@@ -161,6 +177,7 @@ func TestParseSPI(t *testing.T) {
 		{"3+", 3, 0, false},
 		{"abc", 0, 0, true},
 		{"0", 0, 0, true},
+		{"+", 0, 0, true},
 	}
 	for _, tc := range testCases {
 		spi, off, err := parseSPI(tc.input)


### PR DESCRIPTION
## Summary

`parseSPI()` panics on `spiStr[len(spiStr)-1]` when `LoadIPSecKeys` receives malformed input (e.g. a leading space in the IPsec secret). Since the key is sourced from a Kubernetes Secret, anyone with `update`/`patch` on `cilium-ipsec-keys` can crash every cilium-agent into a restart loop.

Fix by trimming and validating lines in `LoadIPSecKeys` before they reach `parseSPI`.

<details>

<summary>Reproduction</summary>

e.g. using value: `" rfc4106(gcm(aes)) 0xdead 128"`

```bash
make kind
make kind-image

# Valid key
kubectl create secret generic cilium-ipsec-keys -n kube-system \
  --from-literal=keys="3 rfc4106(gcm(aes)) $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64) 128"

cilium install \
  --set image.repository=localhost:5000/cilium/cilium-dev \
  --set image.tag=local \
  --set image.useDigest=false \
  --set encryption.enabled=true \
  --set encryption.type=ipsec

# Wait for Cilium pods to come up

# Monitor pods with kubectl get pods -n kube-system -l k8s-app=cilium -w
# Send invalid key
kubectl patch secret cilium-ipsec-keys -n kube-system --type merge \
  -p '{"stringData":{"keys":" rfc4106(gcm(aes)) 0xdeadbeef 128"}}'

# See pods start failing
```

</details>