### PR TITLE
fix(gateway-api): fixes silent ignore of GRPCRoute in allowedRoutes

### DIFF
--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -215,6 +215,8 @@ func getGatewayKindForObject(obj metav1.Object) gatewayv1.Kind {
 	switch obj.(type) {
 	case *gatewayv1.HTTPRoute:
 		return kindHTTPRoute
+	case *gatewayv1.GRPCRoute:
+		return kindGRPCRoute
 	case *gatewayv1alpha2.TLSRoute:
 		return kindTLSRoute
 	case *gatewayv1alpha2.UDPRoute:

--- a/operator/pkg/gateway-api/helpers_test.go
+++ b/operator/pkg/gateway-api/helpers_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func Test_isKindAllowed(t *testing.T) {
+	listener := gatewayv1.Listener{
+		Name:     "https",
+		Protocol: gatewayv1.HTTPSProtocolType,
+		Port:     443,
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Kinds: []gatewayv1.RouteGroupKind{
+				{
+					Group: GroupPtr(gatewayv1.GroupName),
+					Kind:  kindHTTPRoute,
+				},
+				{
+					Group: GroupPtr(gatewayv1.GroupName),
+					Kind:  kindGRPCRoute,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		route    metav1.Object
+		expected bool
+	}{
+		{
+			name:     "HTTPRoute is allowed",
+			route:    &gatewayv1.HTTPRoute{},
+			expected: true,
+		},
+		{
+			name:     "GRPCRoute is allowed",
+			route:    &gatewayv1.GRPCRoute{},
+			expected: true,
+		},
+		{
+			name:     "TLSRoute is not allowed",
+			route:    &gatewayv1alpha2.TLSRoute{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isKindAllowed(listener, tt.route))
+		})
+	}
+}


### PR DESCRIPTION
The function getGatewayKindForObject maps a route object to its Gateway API kind string. It handled HTTPRoute, TLSRoute, UDPRoute, and TCPRoute but was missing a case for GRPCRoute, causing it to return \"Unknown\".

Traffic failed with no indication in the route status, which uses a separate code path (input.GetGVK()) and remained Accepted: True.

Fixes: #44824

```release-note
Fixes GRPCRoute being silently excluded from Envoy config when a Gateway listener explicitly sets allowedRoutes.kinds.
```
