### PR TITLE
v1.19 Backports 2026-03-16

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -35,7 +35,7 @@
                 return body.replace(/\'/g, '')
                   .replace(/"/g, '')
                   .replace(/`/g, '')
-                  .replace(/$/g, '')
+                  .replace(/\$/g, '')
               result-encoding: string
 
           - name: Update labels

--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -48,6 +48,10 @@
 # define __noinline		__attribute__((noinline))
 #endif
 
+#ifndef __weak
+# define __weak		__attribute__((weak))
+#endif
+
 #ifndef __stringify
 # define __stringify(X)		#X
 #endif

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1451,6 +1451,13 @@ struct {
 	__type(value, struct ipv6_nat_entry);
 } ipv6_nat_entry_storage __section_maps_btf;
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct ipv6_ct_tuple);
+} ipv6_ct_tuple_storage __section_maps_btf;
+
 static __always_inline int
 snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv6_ct_tuple *tuple,
@@ -1467,14 +1474,18 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 	*state = snat_v6_lookup(tuple);
 
 	if (needs_ct) {
-		struct ipv6_ct_tuple tuple_snat;
+		struct ipv6_ct_tuple *tuple_snat;
 		int ret;
 
-		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
-		/* Lookup with SCOPE_FORWARD. Ports are already in correct layout: */
-		ipv6_ct_tuple_swap_addrs(&tuple_snat);
+		tuple_snat = map_lookup_elem(&ipv6_ct_tuple_storage, &zero);
+		if (!tuple_snat)
+			return DROP_INVALID;
 
-		ret = ct_lazy_lookup6(get_ct_map6(&tuple_snat), &tuple_snat, ctx,
+		memcpy(tuple_snat, tuple, sizeof(*tuple_snat));
+		/* Lookup with SCOPE_FORWARD. Ports are already in correct layout: */
+		ipv6_ct_tuple_swap_addrs(tuple_snat);
+
+		ret = ct_lazy_lookup6(get_ct_map6(tuple_snat), tuple_snat, ctx,
 				      fraginfo, off, CT_EGRESS, SCOPE_FORWARD,
 				      CT_ENTRY_ANY, NULL, &trace->monitor);
 		if (ret < 0)
@@ -1482,8 +1493,8 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		trace->reason = (enum trace_reason)ret;
 		if (ret == CT_NEW) {
-			ret = ct_create6(get_ct_map6(&tuple_snat), NULL,
-					 &tuple_snat, ctx, CT_EGRESS,
+			ret = ct_create6(get_ct_map6(tuple_snat), NULL,
+					 tuple_snat, ctx, CT_EGRESS,
 					 NULL, ext_err);
 			if (IS_ERR(ret))
 				return ret;
@@ -1492,9 +1503,13 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (*state) {
 		int ret;
-		struct ipv6_ct_tuple rtuple = {};
+		struct ipv6_ct_tuple *rtuple;
 
-		set_v6_rtuple(tuple, *state, &rtuple);
+		rtuple = map_lookup_elem(&ipv6_ct_tuple_storage, &zero);
+		if (!rtuple)
+			return DROP_INVALID;
+
+		set_v6_rtuple(tuple, *state, rtuple);
 		if (ipv6_addr_equals(&target->addr, &(*state)->to_saddr) &&
 		    needs_ct == (*state)->common.needs_ct) {
 			/* Check for the reverse SNAT entry. If it is missing (e.g. due to LRU
@@ -1503,7 +1518,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			struct ipv6_nat_entry *rstate;
 			struct ipv6_nat_entry *lookup_result;
 
-			lookup_result = snat_v6_lookup(&rtuple);
+			lookup_result = snat_v6_lookup(rtuple);
 			if (!lookup_result) {
 				rstate = map_lookup_elem(&ipv6_nat_entry_storage, &zero);
 				if (!rstate)
@@ -1514,7 +1529,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 				rstate->to_dport = tuple->sport;
 				rstate->common.needs_ct = needs_ct;
 				rstate->common.created = bpf_mono_now();
-				ret = __snat_create(&cilium_snat_v6_external, &rtuple, rstate,
+				ret = __snat_create(&cilium_snat_v6_external, rtuple, rstate,
 						    false);
 				if (ret < 0) {
 					if (ext_err)
@@ -1531,9 +1546,9 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 		if (IS_ERR(ret))
 			return ret;
 
-		*state = snat_v6_lookup(&rtuple);
+		*state = snat_v6_lookup(rtuple);
 		if (*state)
-			__snat_delete(&cilium_snat_v6_external, &rtuple);
+			__snat_delete(&cilium_snat_v6_external, rtuple);
 	}
 
 	*state = map_lookup_elem(&ipv6_nat_entry_storage, &zero);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1736,12 +1736,14 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 
 static __always_inline int
 snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
-			 struct ipv6hdr *ip6, fraginfo_t fraginfo, int l4_off,
+			 fraginfo_t fraginfo, int l4_off,
 			 struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr = CONFIG(nat_ipv6_masquerade);
 	const struct remote_endpoint_info *remote_ep;
 	const struct endpoint_info *local_ep;
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
 
 	if (ipv6_addr_equals(&tuple->saddr, &masq_addr)) {
 		ipv6_addr_copy(&target->addr, &masq_addr);
@@ -1749,6 +1751,9 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 		return NAT_NEEDED;
 	}
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
 
 	local_ep = __lookup_ip6_endpoint(&tuple->saddr);
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1720,19 +1720,14 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 }
 
 static __always_inline int
-snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
-			 struct ipv6_ct_tuple *tuple __maybe_unused,
-			 struct ipv6hdr *ip6 __maybe_unused,
-			 fraginfo_t fraginfo __maybe_unused,
-			 int l4_off __maybe_unused,
-			 struct ipv6_nat_target *target __maybe_unused)
+snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
+			 struct ipv6hdr *ip6, fraginfo_t fraginfo, int l4_off,
+			 struct ipv6_nat_target *target)
 {
-	union v6addr masq_addr __maybe_unused = CONFIG(nat_ipv6_masquerade);
-	const struct remote_endpoint_info *remote_ep __maybe_unused;
-	const struct endpoint_info *local_ep __maybe_unused;
+	union v6addr masq_addr = CONFIG(nat_ipv6_masquerade);
+	const struct remote_endpoint_info *remote_ep;
+	const struct endpoint_info *local_ep;
 
-	/* See comments in snat_v4_needs_masquerade(). */
-#if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
 	if (ipv6_addr_equals(&tuple->saddr, &masq_addr)) {
 		ipv6_addr_copy(&target->addr, &masq_addr);
 		target->needs_ct = true;
@@ -1835,7 +1830,6 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 		ipv6_addr_copy(&target->addr, &masq_addr);
 		return NAT_NEEDED;
 	}
-#endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 
 	return NAT_PUNT_TO_STACK;
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1735,9 +1735,9 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 }
 
 static __always_inline int
-snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
-			 fraginfo_t fraginfo, int l4_off,
-			 struct ipv6_nat_target *target)
+__snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
+			   fraginfo_t fraginfo, int l4_off,
+			   struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr = CONFIG(nat_ipv6_masquerade);
 	const struct remote_endpoint_info *remote_ep;
@@ -1852,6 +1852,43 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	}
 
 	return NAT_PUNT_TO_STACK;
+}
+
+/* Store struct ipv6_ct_tuple and struct ipv6_nat_target objects in maps to
+ * optimize stack usage.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct ipv6_ct_tuple);
+} ct_tuple_storage __section_maps_btf;
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct ipv6_nat_target);
+} nat_target_storage __section_maps_btf;
+
+static __always_inline int
+snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
+			 fraginfo_t fraginfo __maybe_unused,
+			 int l4_off __maybe_unused)
+{
+	struct ipv6_nat_target *target;
+	struct ipv6_ct_tuple *tuple;
+	int ret, zero = 0;
+
+	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
+	if (!tuple)
+		return DROP_INVALID;
+	target = map_lookup_elem(&nat_target_storage, &zero);
+	if (!target)
+		return DROP_INVALID;
+
+	ret = __snat_v6_needs_masquerade(ctx, tuple, fraginfo, l4_off, target);
+
+	return ret;
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1870,7 +1870,7 @@ struct {
 	__type(value, struct ipv6_nat_target);
 } nat_target_storage __section_maps_btf;
 
-static __always_inline int
+__noinline __weak int
 snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 fraginfo_t fraginfo __maybe_unused,
 			 int l4_off __maybe_unused)

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -55,45 +55,54 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  __s8 *ext_err)
 {
 	int hdrlen, l4_off, ret = NAT_PUNT_TO_STACK;
-	struct ipv6_nat_target target = {
-		.min_port = NODEPORT_PORT_MIN_NAT,
-		.max_port = NODEPORT_PORT_MAX_NAT,
-	};
-	struct ipv6_ct_tuple tuple = {};
+	struct ipv6_nat_target *target;
+	struct ipv6_ct_tuple *tuple;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	fraginfo_t fraginfo;
+	int zero = 0;
+
+	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
+	if (!tuple)
+		return DROP_INVALID;
+	target = map_lookup_elem(&nat_target_storage, &zero);
+	if (!target)
+		return DROP_INVALID;
+
+	memset(target, 0, sizeof(*target));
+	target->min_port = NODEPORT_PORT_MIN_NAT;
+	target->max_port = NODEPORT_PORT_MAX_NAT;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	tuple.nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple.nexthdr, &fraginfo);
+	tuple->nexthdr = ip6->nexthdr;
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);
 	if (hdrlen < 0)
 		return hdrlen;
 
-	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, &tuple);
+	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, tuple);
 	l4_off = ETH_HLEN + hdrlen;
 
-	if (lb_is_svc_proto(tuple.nexthdr) &&
-	    nodeport_has_nat_conflict_ipv6(ip6, &target))
+	if (lb_is_svc_proto(tuple->nexthdr) &&
+	    nodeport_has_nat_conflict_ipv6(ip6, target))
 		goto apply_snat;
 
 #if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
-	ret = snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	ret = snat_v6_needs_masquerade(ctx, fraginfo, l4_off);
 #endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
-	if (target.egress_gateway) {
+	if (target->egress_gateway) {
 		/* Stay on the desired egress interface: */
-		if (target.ifindex && target.ifindex == CONFIG(interface_ifindex))
+		if (target->ifindex && target->ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
 
 		/* Send packet to the correct egress interface, and SNAT it there. */
-		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &target.addr,
-							   &tuple.daddr, target.ifindex,
+		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &target->addr,
+							   &tuple->daddr, target->ifindex,
 							   ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
@@ -104,9 +113,9 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 #endif
 
 apply_snat:
-	ipv6_addr_copy(saddr, &tuple.saddr);
-	ret = snat_v6_nat(ctx, &tuple, ip6, fraginfo, l4_off,
-			  &target, trace, ext_err);
+	ipv6_addr_copy(saddr, &tuple->saddr);
+	ret = snat_v6_nat(ctx, tuple, ip6, fraginfo, l4_off,
+			  target, trace, ext_err);
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -54,12 +54,12 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
+	int hdrlen, l4_off, ret = NAT_PUNT_TO_STACK;
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
 	struct ipv6_ct_tuple tuple = {};
-	int hdrlen, l4_off, ret;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	fraginfo_t fraginfo;
@@ -79,7 +79,9 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	    nodeport_has_nat_conflict_ipv6(ip6, &target))
 		goto apply_snat;
 
+#if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
 	ret = snat_v6_needs_masquerade(ctx, &tuple, ip6, fraginfo, l4_off, &target);
+#endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -80,7 +80,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		goto apply_snat;
 
 #if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
-	ret = snat_v6_needs_masquerade(ctx, &tuple, ip6, fraginfo, l4_off, &target);
+	ret = snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
 #endif /* ENABLE_MASQUERADE_IPV6 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;

--- a/hubble/pkg/printer/color.go
+++ b/hubble/pkg/printer/color.go
@@ -129,8 +129,12 @@ func (c *colorer) sequences() []string {
 			// should never happen
 			continue
 		}
-		unique[split[0]] = struct{}{}
-		unique[split[1]] = struct{}{}
+		if split[0] != "" {
+			unique[split[0]] = struct{}{}
+		}
+		if split[1] != "" {
+			unique[split[1]] = struct{}{}
+		}
 	}
 	return slices.Collect(maps.Keys(unique))
 }

--- a/hubble/pkg/printer/color_test.go
+++ b/hubble/pkg/printer/color_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package printer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColorersSequences(t *testing.T) {
+	tests := []struct {
+		colorerMode string
+		want        []string
+	}{
+		{
+			colorerMode: "never",
+			want:        []string{},
+		}, {
+			colorerMode: "auto",
+			want:        []string{},
+		}, {
+			colorerMode: "always",
+			want: []string{
+				"\x1b[31m", // red
+				"\x1b[32m", // green
+				"\x1b[34m", // blue
+				"\x1b[36m", // cyan
+				"\x1b[35m", // magenta
+				"\x1b[33m", // yellow
+				"\x1b[0m",  // reset
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s => %v", tt.colorerMode, tt.want), func(t *testing.T) {
+			colorer := newColorer(tt.colorerMode)
+			got := colorer.sequences()
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -559,7 +559,7 @@ spec:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
         {{- end }}
         command:
-        - sh
+        - bash
         - -ec
         # The statically linked Go program binary is invoked to avoid any
         # dependency on utilities like sh and mount that can be missing on certain
@@ -605,7 +605,7 @@ spec:
         - name: BIN_PATH
           value: {{ .Values.cni.binPath }}
         command:
-        - sh
+        - bash
         - -ec
         # The statically linked Go program binary is invoked to avoid any
         # dependency on utilities like sh that can be missing on certain
@@ -673,7 +673,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
         command:
-        - sh
+        - bash
         - -c
         - |
           until test -s {{ (print "/tmp/cilium-bootstrap.d/" (.Values.nodeinit.bootstrapFile | base)) | quote }}; do

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -355,6 +355,8 @@ func (a *Allocator) start() {
 		go func() {
 			select {
 			case <-a.initialListDone:
+			case <-a.stopGC:
+				return
 			case <-time.After(option.Config.AllocatorListTimeout):
 				logging.Fatal(a.logger, "Timeout while waiting for initial allocator state")
 			}

--- a/pkg/clustermesh/mcsapi/crdinstall.go
+++ b/pkg/clustermesh/mcsapi/crdinstall.go
@@ -83,35 +83,35 @@ func needsUpdateMCS(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinit
 	}
 
 	// release version check
-	v, ok := currentCRD.Labels[mcsapicrd.ReleaseVersionLabel]
+	currentVer, ok := currentCRD.Labels[mcsapicrd.ReleaseVersionLabel]
 	if !ok {
 		// no schema version detected
 		return true, nil
 	}
-	currentVersion, err := versioncheck.Version(v)
-	version, errTarget := versioncheck.Version(targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
+	currentVersion, err := versioncheck.Version(currentVer)
+	targetVersion, errTarget := versioncheck.Version(targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
 	if errTarget != nil {
 		return false, fmt.Errorf("invalid release version label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
 	}
 
-	if err != nil || currentVersion.LT(version) {
+	if err != nil || currentVersion.LT(targetVersion) {
 		// version in cluster is either unparsable or smaller than current version
 		return true, nil
 	}
 
 	// CRD Revision check
-	rev, ok := currentCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel]
+	currentRev, ok := currentCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel]
 	if !ok {
 		// no CRD revision detected
 		return true, nil
 	}
-	currentRevision, err := strconv.Atoi(rev)
-	revision, errTarget := strconv.Atoi(targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
+	currentRevision, err := strconv.Atoi(currentRev)
+	targetRevision, errTarget := strconv.Atoi(targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
 	if errTarget != nil {
 		return false, fmt.Errorf("invalid CRD revision label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
 	}
 
-	if err != nil || currentRevision < revision {
+	if err != nil || currentRevision < targetRevision {
 		// crd revision in cluster is either unparsable or smaller than current version
 		return true, nil
 	}

--- a/pkg/clustermesh/mcsapi/crdinstall.go
+++ b/pkg/clustermesh/mcsapi/crdinstall.go
@@ -94,9 +94,11 @@ func needsUpdateMCS(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinit
 		return false, fmt.Errorf("invalid release version label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.ReleaseVersionLabel])
 	}
 
-	if err != nil || currentVersion.LT(targetVersion) {
-		// version in cluster is either unparsable or smaller than current version
-		return true, nil
+	if err != nil || !currentVersion.EQ(targetVersion) {
+		// upgrade the CRD if the in cluster version is either unparsable or smaller
+		// than the target CRD. Stop here if the in cluster version is higher
+		// to prevent downgrading the CRD.
+		return err != nil || currentVersion.LT(targetVersion), nil
 	}
 
 	// CRD Revision check
@@ -111,10 +113,7 @@ func needsUpdateMCS(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinit
 		return false, fmt.Errorf("invalid CRD revision label on CRD %s: %s", targetCRD.Name, targetCRD.Labels[mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel])
 	}
 
-	if err != nil || currentRevision < targetRevision {
-		// crd revision in cluster is either unparsable or smaller than current version
-		return true, nil
-	}
-
-	return false, nil
+	// upgrade the CRD if the in cluster revision is either unparsable or smaller
+	// than the target CRD
+	return err != nil || currentRevision < targetRevision, nil
 }

--- a/pkg/clustermesh/mcsapi/crdinstall_test.go
+++ b/pkg/clustermesh/mcsapi/crdinstall_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mcsapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mcsapicrd "sigs.k8s.io/mcs-api/config/crd"
+)
+
+func newTestCRD(releaseVersion, revision string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				mcsapicrd.ReleaseVersionLabel:                         releaseVersion,
+				mcsapicrd.CustomResourceDefinitionSchemaRevisionLabel: revision,
+			},
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Schema: &apiextensionsv1.CustomResourceValidation{},
+			}},
+		},
+	}
+}
+
+func TestNeedsUpdateMCS(t *testing.T) {
+	targetCRD := newTestCRD("v0.3.0", "42")
+
+	tests := []struct {
+		name       string
+		currentCRD *apiextensionsv1.CustomResourceDefinition
+		want       bool
+	}{
+		{
+			name:       "updates when current release version is older",
+			currentCRD: newTestCRD("v0.2.0", "99"),
+			want:       true,
+		},
+		{
+			name:       "does not update when current release version is newer",
+			currentCRD: newTestCRD("v0.5.0", "0"),
+			want:       false,
+		},
+		{
+			name:       "updates when release version matches and revision is older",
+			currentCRD: newTestCRD("v0.3.0", "0"),
+			want:       true,
+		},
+		{
+			name:       "does not update when release version matches and revision matches",
+			currentCRD: newTestCRD("v0.3.0", "42"),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := needsUpdateMCS(targetCRD, tt.currentCRD)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/datapath/linux/ipsec/cell_test.go
+++ b/pkg/datapath/linux/ipsec/cell_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/reflectors"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/maps/encrypt"
 	"github.com/cilium/cilium/pkg/mtu"
@@ -133,15 +134,18 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 			source.Cell,
 			watchers.Cell,
 			dial.ServiceResolverCell,
+			reflectors.K8sReflectorCell,
 			clustermesh.Cell,
 			writer.Cell,
 			ipset.Cell,
 			k8s.ResourcesCell,
+			k8s.PodTableCell,
 			node.LocalNodeStoreTestCell,
 			k8sClient.FakeClientCell(),
 			kvstore.Cell(kvstore.DisabledBackendName),
 
 			cell.Provide(
+				reflectors.NetnsCookieSupportFunc,
 				newIPsecAgent,
 				newIPsecConfig,
 

--- a/pkg/dial/resolver.go
+++ b/pkg/dial/resolver.go
@@ -4,9 +4,11 @@
 package dial
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"iter"
+	"log/slog"
 	"math/rand/v2"
 	"net/netip"
 	"slices"
@@ -17,14 +19,17 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/reflectors"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -126,15 +131,23 @@ var _ Resolver = (*lbServiceResolver)(nil)
 
 // lbServiceResolver maps DNS names matching Kubernetes services to the
 // corresponding ClusterIP address using Table[*Frontend].
+// If the frontend table lookup fails, it falls back to fetching the service
+// directly from the kube-apiserver.
 type lbServiceResolver struct {
 	db        *statedb.DB
 	frontends statedb.Table[*loadbalancer.Frontend]
+	cs        k8sClient.Clientset
+	log       *slog.Logger
 }
 
-func newLBServiceResolver(_ reflectors.K8sReflectorRegistered, jg job.Group, db *statedb.DB, frontends statedb.Table[*loadbalancer.Frontend]) Resolver {
+// A dependency on reflector.K8sReflectorRegistered is used to ensure the order of initialization.
+// Otherwise, the resolver could be used before the frontends table is initialized.
+func newLBServiceResolver(_ reflectors.K8sReflectorRegistered, jg job.Group, db *statedb.DB, frontends statedb.Table[*loadbalancer.Frontend], cs k8sClient.Clientset, log *slog.Logger) Resolver {
 	return &lbServiceResolver{
 		db:        db,
 		frontends: frontends,
+		cs:        cs,
+		log:       log,
 	}
 }
 
@@ -152,8 +165,11 @@ func (sr *lbServiceResolver) resolve(ctx context.Context, host string) string {
 	// Wait for the frontends table to be initialized from k8s. We can't check that
 	// the table has been initialized by all initializers since at least ClusterMesh
 	// uses [Resolve] to look up KVStore address.
+	// If the frontends table is not initialized, fallback to kube-apiserver.
 	txn := sr.db.ReadTxn()
 	init, waitInit := sr.frontends.Initialized(txn)
+	// We give the frontends table 5 seconds to be initialized to avoid a deadlock.
+	initTimeout := time.After(5 * time.Second)
 	for !init {
 		pending := sr.frontends.PendingInitializers(txn)
 		if !slices.ContainsFunc(pending, func(s string) bool { return strings.HasPrefix(s, reflectors.K8sInitializerPrefix) }) {
@@ -164,6 +180,13 @@ func (sr *lbServiceResolver) resolve(ctx context.Context, host string) string {
 			return host
 		case <-waitInit:
 			init = true
+		case <-initTimeout:
+			sr.log.Warn(
+				"Frontends table not initialized, falling back to kube-apiserver",
+				logfields.K8sNamespace, nsname.Namespace,
+				logfields.K8sSvcName, nsname.Name,
+			)
+			return cmp.Or(sr.resolveFromAPIServer(ctx, nsname), host)
 		case <-time.After(100 * time.Millisecond):
 		}
 		txn = sr.db.ReadTxn()
@@ -181,6 +204,22 @@ func (sr *lbServiceResolver) resolve(ctx context.Context, host string) string {
 
 	// We could not find a ClusterIP frontend for this service
 	return host
+}
+
+// resolveFromAPIServer fetches the service directly from the kube-apiserver
+// as a fallback when the frontends table takes too long to be initialized.
+func (sr *lbServiceResolver) resolveFromAPIServer(ctx context.Context, nsname types.NamespacedName) string {
+	svc, err := sr.cs.Slim().CoreV1().Services(nsname.Namespace).Get(ctx, nsname.Name, metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+
+	if _, err := netip.ParseAddr(svc.Spec.ClusterIP); err != nil {
+		// The ClusterIP is not a valid IP address (e.g., headless service)
+		return ""
+	}
+
+	return svc.Spec.ClusterIP
 }
 
 func ServiceURLToNamespacedName(host string) (types.NamespacedName, error) {

--- a/pkg/dial/resolver.go
+++ b/pkg/dial/resolver.go
@@ -131,7 +131,7 @@ type lbServiceResolver struct {
 	frontends statedb.Table[*loadbalancer.Frontend]
 }
 
-func newLBServiceResolver(jg job.Group, db *statedb.DB, frontends statedb.Table[*loadbalancer.Frontend]) Resolver {
+func newLBServiceResolver(_ reflectors.K8sReflectorRegistered, jg job.Group, db *statedb.DB, frontends statedb.Table[*loadbalancer.Frontend]) Resolver {
 	return &lbServiceResolver{
 		db:        db,
 		frontends: frontends,

--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
-type NeedUpdateCRDFunc func(currentCRD, targetCRD *apiextensionsv1.CustomResourceDefinition) (bool, error)
+type NeedUpdateCRDFunc func(targetCRD, currentCRD *apiextensionsv1.CustomResourceDefinition) (bool, error)
 
 // CreateUpdateCRD ensures the CRD object is installed into the K8s cluster. It
 // will create or update the CRD and its validation schema as necessary. This

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -65,8 +65,9 @@ var K8sReflectorCell = cell.Module(
 	"k8s-reflector",
 	"Reflects load-balancing state from Kubernetes",
 
+	cell.Provide(provideK8sReflector),
 	cell.ProvidePrivate(newEventStream),
-	cell.Invoke(RegisterK8sReflector),
+	cell.Invoke(func(_ K8sReflectorRegistered) {}),
 )
 
 type reflectorParams struct {
@@ -86,6 +87,13 @@ type reflectorParams struct {
 	TestConfig             *loadbalancer.TestConfig `optional:"true"`
 	Nodes                  statedb.Table[*node.LocalNode]
 	SVCMetrics             SVCMetrics `optional:"true"`
+}
+
+type K8sReflectorRegistered struct{}
+
+func provideK8sReflector(p reflectorParams) K8sReflectorRegistered {
+	RegisterK8sReflector(p)
+	return K8sReflectorRegistered{}
 }
 
 func (p reflectorParams) waitTime() time.Duration {

--- a/pkg/maps/ctmap/cell.go
+++ b/pkg/maps/ctmap/cell.go
@@ -67,7 +67,7 @@ type ctMaps struct {
 var _ CTMaps = (*ctMaps)(nil)
 
 func (r *ctMaps) ActiveMaps() []*Map {
-	return slices.DeleteFunc([]*Map{r.v4AnyMap, r.v4TCPMap, r.v6AnyMap, r.v6TCPMap}, func(m *Map) bool { return m == nil })
+	return slices.DeleteFunc([]*Map{r.v4TCPMap, r.v4AnyMap, r.v6TCPMap, r.v6AnyMap}, func(m *Map) bool { return m == nil })
 }
 
 func (r *ctMaps) init() error {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -739,6 +739,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 
 			Namespace: Namespace,
 			Name:      "endpoint_regeneration_time_stats_seconds",
+			Buckets:   prometheus.ExponentialBuckets(10e-6, 10, 8),
 			Help:      "Endpoint regeneration time stats labeled by the scope",
 		}, []string{LabelScope, LabelStatus}),
 
@@ -782,6 +783,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 
 			Namespace: Namespace,
 			Name:      "policy_implementation_delay",
+			Buckets:   prometheus.ExponentialBuckets(10e-6, 10, 8),
 			Help:      "Time between a policy change and it being fully deployed into the datapath",
 		}, metric.Labels{
 			{

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -152,8 +152,8 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 			delete(i.prefixesByResource, resource)
 			if len(oldPrefixes) > 0 {
 				toPrune[resource] = oldPrefixes
-				continue
 			}
+			continue
 		}
 
 		// Otherwise, update bookkeeping, upsert any net-new prefixes.

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -106,15 +106,17 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	pi.repo.GetSubjectSelectorCache().UpdateIdentities(ids, nil, nil)
 	pi.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
-	writeRule := func(r *policyapi.Rule) uint64 {
+	writeRules := func(rules ...*policyapi.Rule) uint64 {
 		t.Helper()
 
-		require.NoError(t, r.Sanitize())
+		for _, r := range rules {
+			require.NoError(t, r.Sanitize())
+		}
 
 		dc := make(chan uint64, 1)
 		pi.processUpdates(context.Background(), []*policytypes.PolicyUpdate{
 			{
-				Rules:    policyutils.RulesToPolicyEntries([]*policyapi.Rule{r}),
+				Rules:    policyutils.RulesToPolicyEntries(rules),
 				Resource: resource,
 				DoneChan: dc,
 			},
@@ -122,7 +124,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 		return <-dc
 	}
 
-	rev := writeRule(policyapi.NewRule().
+	rev := writeRules(policyapi.NewRule().
 		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
 			&slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -146,7 +148,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 
 	// Update to new rule that selects id 102 and has two prefixes
 	// we should see 1 new prefix, and 2 regenerated endpoints
-	rev = writeRule(policyapi.NewRule().
+	rev = writeRules(policyapi.NewRule().
 		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
 			&slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -174,7 +176,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	require.ElementsMatch(t, epm.regen.AsSlice(), []identity.NumericIdentity{100, 101})
 
 	// Swap endpoints and prefixes
-	rev = writeRule(policyapi.NewRule().
+	rev = writeRules(policyapi.NewRule().
 		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
 			&slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -195,5 +197,39 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	// Check that the right endpoints were updated
 	require.Equal(t, rev, epm.toRev)
 	require.ElementsMatch(t, epm.regen.AsSlice(), []identity.NumericIdentity{101, 102})
+
+	// Remove all CIDRs
+	rev = writeRules(policyapi.NewRule().
+		WithEndpointSelector(policyapi.NewESFromK8sLabelSelector("",
+			&slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"id": "102",
+				},
+			}),
+		).
+		WithEgressRules([]policyapi.EgressRule{{
+			EgressCommonRule: policyapi.EgressCommonRule{
+				ToEntities: policyapi.EntitySlice{policyapi.EntityHost},
+			}}}))
+
+	require.True(t, ipc.waited)
+
+	// We only remove 1 cidr
+	require.ElementsMatch(t, ipc.removed.AsSlice(), []string{"2.0.0.0/24"})
+	// When no new CIDRs are added the ipc.added value is not updated
+	// require.ElementsMatch(t, ipc.added.AsSlice(), []string{})
+
+	// Check that the right endpoints were updated
+	require.Equal(t, rev, epm.toRev)
+	require.ElementsMatch(t, epm.regen.AsSlice(), []identity.NumericIdentity{102})
+
+	require.ElementsMatch(t, pi.prefixesByResource[resource], []netip.Prefix{})
+
+	rev = writeRules()
+
+	// We removed the rule, so the prefix should no longer be counted
+	_, found := pi.prefixesByResource[resource]
+	require.False(t, found)
+	require.Equal(t, rev, epm.toRev)
 
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -50,7 +50,8 @@ type Proxy struct {
 	// redirects is the map of all redirect configurations indexed by
 	// the redirect identifier. Redirects may be implemented by different
 	// proxies.
-	redirects map[string]RedirectImplementation
+	redirects      map[string]RedirectImplementation
+	redirectsCount map[types.ProxyType]int
 
 	envoyIntegration *envoyProxyIntegration
 	dnsIntegration   *dnsProxyIntegration
@@ -86,6 +87,7 @@ func createProxy(
 		logger:           logger,
 		localNodeStore:   localNodeStore,
 		redirects:        make(map[string]RedirectImplementation),
+		redirectsCount:   make(map[types.ProxyType]int),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 		proxyPorts:       proxyPorts,
@@ -258,13 +260,13 @@ func (p *Proxy) createNewRedirect(
 		logfields.Object, redirect,
 		logfields.ProxyPort, pp.ProxyPort)
 
-	p.redirects[id] = impl
+	p.addRedirect(id, impl)
 	p.updateRedirectMetrics()
 
 	revertFunc := func() error {
 		// Undo what we have done above.
 		p.mutex.Lock()
-		delete(p.redirects, id)
+		p.deleteRedirect(id, impl)
 		p.updateRedirectMetrics()
 		p.proxyPorts.ReleaseProxyPort(ppName)
 		p.mutex.Unlock()
@@ -310,7 +312,7 @@ func (p *Proxy) removeRedirect(id string) {
 		return
 	}
 	r := impl.GetRedirect()
-	delete(p.redirects, id)
+	p.deleteRedirect(id, impl)
 
 	impl.Close()
 
@@ -400,12 +402,19 @@ func (p *Proxy) getProxyIP(ctx context.Context) string {
 // updateRedirectMetrics updates the redirect metrics per application protocol
 // in Prometheus. Lock needs to be held to call this function.
 func (p *Proxy) updateRedirectMetrics() {
-	result := map[string]int{}
-	for _, impl := range p.redirects {
-		redirect := impl.GetRedirect()
-		result[string(redirect.proxyPort.ProxyType)]++
+	for proto, count := range p.redirectsCount {
+		metrics.ProxyRedirects.WithLabelValues(string(proto)).Set(float64(count))
 	}
-	for proto, count := range result {
-		metrics.ProxyRedirects.WithLabelValues(proto).Set(float64(count))
-	}
+}
+
+func (p *Proxy) addRedirect(id string, impl RedirectImplementation) {
+	proxyType := impl.GetRedirect().proxyPort.ProxyType
+	p.redirects[id] = impl
+	p.redirectsCount[proxyType]++
+}
+
+func (p *Proxy) deleteRedirect(id string, impl RedirectImplementation) {
+	proxyType := impl.GetRedirect().proxyPort.ProxyType
+	delete(p.redirects, id)
+	p.redirectsCount[proxyType]--
 }

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/reflectors"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
@@ -119,16 +120,19 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			source.Cell,
 			watchers.Cell,
 			dial.ServiceResolverCell,
+			reflectors.K8sReflectorCell,
 			clustermesh.Cell,
 			writer.Cell,
 			ipset.Cell,
 			k8s.ResourcesCell,
+			k8s.PodTableCell,
 			cell.Config(envoyCfg.SecretSyncConfig{}),
 			k8sClient.FakeClientCell(),
 			kvstore.Cell(kvstore.DisabledBackendName),
 			node.LocalNodeStoreTestCell,
 
 			cell.Provide(
+				reflectors.NetnsCookieSupportFunc,
 				newWireguardAgent,
 				newWireguardConfig,
 


### PR DESCRIPTION
 * [ ] #44119 (@tporeba)
 * [ ] #44589 (@asauber)
 * [x] #44638 (@peoyekunle)
 * [x] #44613 (@fristonio)
 * [x] #44729 (@brb)
 * [x] #44724 (@odinuge)
 * [ ] #44653 (@41ks)
 * [ ] #44544 (@pchaigno) :warning: resolved conflicts
 * [ ] #44615 (@shivdesh)
 * [x] #44738 (@MrFreezeex)

PRs skipped due to conflicts:

 * #43128 (@nddq): I see https://github.com/cilium/cilium/pull/38388 has not been backporter, so didn't know how to handle the too many conflicts.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 44119 44589 44638 44613 44729 44724 44653 44544 44615 44738
```
