### PR TITLE
envoy: Fix xds server npds listeners accounting

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -41,6 +41,9 @@ var (
 	//go:embed manifests/client-egress-to-fqdns-and-http-get.yaml
 	clientEgressToFQDNsAndHTTPGetPolicyYAML string
 
+	//go:embed manifests/client-egress-to-fqdns-and-ccec-listener.yaml
+	clientEgressToFQDNsAndCCECListenerYAML string
+
 	//go:embed manifests/echo-ingress-from-other-client.yaml
 	echoIngressFromOtherClientPolicyYAML string
 
@@ -369,6 +372,7 @@ func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Par
 		"clientEgressL7HTTPNamedPortPolicyYAML":                      clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                              clientEgressToFQDNsPolicyYAML,
 		"clientEgressToFQDNsAndHTTPGetPolicyYAML":                    clientEgressToFQDNsAndHTTPGetPolicyYAML,
+		"clientEgressToFQDNsAndCCECListenerYAML":                     clientEgressToFQDNsAndCCECListenerYAML,
 		"clientEgressTLSSNIPolicyYAML":                               clientEgressTLSSNIPolicyYAML,
 		"clientEgressTLSSNIWildcardPolicyYAML":                       clientEgressTLSSNIWildcardPolicyYAML,
 		"clientEgressTLSSNIRandomWildcardPolicyYAML":                 clientEgressTLSSNIRandomWildcardPolicyYAML,

--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-fqdns-and-ccec-listener.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-fqdns-and-ccec-listener.yaml
@@ -1,0 +1,60 @@
+# CiliumEnvoyConfig to proxy any incoming HTTP request on the listener to the
+# configured destination.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideEnvoyConfig
+metadata:
+  name: client-egress-to-fqdns-proxy-{{trimSuffix .ExternalTarget "."}}
+spec:
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: proxy-{{trimSuffix .ExternalTarget "."}}-listener
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: test-listener
+          route_config:
+            name: default-route
+            virtual_hosts:
+            - name: default-vhost
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: proxy-{{trimSuffix .ExternalTarget "."}}-cluster
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    connectTimeout: 55s
+    name: proxy-{{trimSuffix .ExternalTarget "."}}-cluster
+    type: ORIGINAL_DST
+    lb_policy: CLUSTER_PROVIDED
+
+---
+
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-to-fqdns-proxy-{{trimSuffix .ExternalTarget "."}}
+spec:
+  endpointSelector:
+    matchLabels:
+      kind: client
+  egress:
+  - toFQDNs:
+    - matchName: {{trimSuffix .ExternalTarget "."}}
+    toPorts:
+    - listener:
+        envoyConfig:
+          kind: CiliumClusterwideEnvoyConfig
+          name: client-egress-to-fqdns-proxy-{{trimSuffix .ExternalTarget "."}}
+        name: proxy-{{trimSuffix .ExternalTarget "."}}-listener
+        priority: 1
+      ports:
+      - port: "80"
+        protocol: TCP

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -109,4 +109,29 @@ func (t toFqdnsWithProxy) build(ct *check.ConnectivityTest, templates map[string
 			// No HTTP proxy on other ports
 			return check.ResultDNSOKDropCurlTimeout, check.ResultNone
 		})
+
+	newTest("to-fqdns-with-ccec-listener", ct).
+		WithCiliumPolicy(templates["clientEgressToFQDNsAndCCECListenerYAML"]).
+		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).
+		WithCiliumVersion(">=1.20.0").
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithFeatureRequirements(features.RequireEnabled(features.EnableEnvoyConfig)).
+		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
+		WithScenarios(
+			tests.PodToWorld(ct.Params().ExternalTargetIPv6Capable, false),
+			tests.PodToWorld2(ct.Params().ExternalTargetIPv6Capable, false), // resolves to ExternalOtherTarget
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			extTarget := ct.Params().ExternalTarget
+			if a.Destination().Port() == 80 && a.Destination().Address(features.GetIPFamily(extTarget)) == extTarget {
+				egress = check.ResultDNSOK
+				egress.HTTP = check.HTTP{
+					Method: "GET",
+					URL:    fmt.Sprintf("http://%s/", strings.TrimSuffix(extTarget, ".")),
+				}
+				return egress, check.ResultNone
+			}
+			// No HTTP proxy on other ports/target
+			return check.ResultDNSOKDropCurlTimeout, check.ResultNone
+		})
 }

--- a/pkg/envoy/utils.go
+++ b/pkg/envoy/utils.go
@@ -6,6 +6,15 @@ package envoy
 import (
 	"regexp"
 	"strings"
+
+	cilium "github.com/cilium/proxy/go/cilium/api"
+	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+
+	"github.com/cilium/cilium/pkg/bpf"
+)
+
+const (
+	ciliumBPFMetadataListenerFilterName = "cilium.bpf_metadata"
 )
 
 var (
@@ -57,4 +66,27 @@ func sanitizeServerNamePattern(pattern string) string {
 		return subdomainWildcardSpecifierPrefix + pattern
 	}
 	return pattern
+}
+
+// listenerRequiresNPDS returns true if the listener carries a cilium.bpf_metadata
+// listener filter that will start an NPDS (Network Policy Discovery Service) client.
+//
+// For the listener to start the NPDS client it must have a correctly configured
+// bpf_root (matching the system's BPF filesystem root)
+//
+// Corresponding proxy logic: https://github.com/cilium/proxy/blob/4054ac22c6338f0372aac9f23a7cda99e8ebf6da/cilium/bpf_metadata.cc#L273
+func listenerRequiresNPDS(listener *envoy_config_listener.Listener) bool {
+	for _, lf := range listener.GetListenerFilters() {
+		if lf.GetName() != ciliumBPFMetadataListenerFilterName || lf.GetTypedConfig() == nil {
+			continue
+		}
+
+		var bpfMeta cilium.BpfMetadata
+		err := lf.GetTypedConfig().UnmarshalTo(&bpfMeta)
+
+		if err == nil && bpfMeta.GetBpfRoot() == bpf.BPFFSRoot() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -166,11 +166,12 @@ type xdsServer struct {
 	// Value holds the number of redirects using the listener named by the key.
 	listenerCount map[string]uint
 
-	// proxyListeners is the count of redirection proxy listeners in 'listeners'.
-	// When this is zero, cilium should not wait for NACKs/ACKs from envoy.
-	// This value is different from len(listeners) due to non-proxy listeners
-	// (e.g., prometheus listener)
-	proxyListeners int
+	// npdsListeners tracks the set of listener names configured to start an NPDS client
+	// for network policy enforcement.
+	// When this set is empty, cilium should not wait for NACKs/ACKs from envoy for
+	// network policy mutations.
+	// mutex must be held during access.
+	npdsListeners npdsListenersTracker
 
 	// networkPolicyCache publishes network policy configuration updates to
 	// Envoy proxies.
@@ -195,6 +196,37 @@ type xdsServer struct {
 
 	l7RulesTranslator envoypolicy.EnvoyL7RulesTranslator
 	secretManager     certificatemanager.SecretManager
+}
+
+// npdsListenersTracker tracks the set of listener names that require NPDS.
+type npdsListenersTracker map[string]struct{}
+
+// Add inserts name into the tracker and returns a function that reverts the change.
+func (t npdsListenersTracker) Add(name string) func() {
+	if _, ok := t[name]; ok {
+		return func() {}
+	}
+
+	t[name] = struct{}{}
+	return func() { delete(t, name) }
+}
+
+// Delete removes name from the tracker and returns a function that reverts the removal.
+// If name was not present the returned revert is a no-op.
+func (t npdsListenersTracker) Delete(name string) func() {
+	if _, ok := t[name]; !ok {
+		return func() {}
+	}
+
+	delete(t, name)
+	return func() {
+		t[name] = struct{}{}
+	}
+}
+
+// Empty returns true when no listeners are tracked.
+func (t npdsListenersTracker) Empty() bool {
+	return len(t) == 0
 }
 
 func toAny(pb proto.Message) *anypb.Any {
@@ -230,6 +262,7 @@ func newXDSServer(logger *slog.Logger, restorerPromise promise.Promise[endpoints
 		logger:             logger,
 		restorerPromise:    restorerPromise,
 		listenerCount:      make(map[string]uint),
+		npdsListeners:      make(npdsListenersTracker),
 		ipCache:            ipCache,
 		localEndpointStore: localEndpointStore,
 
@@ -827,7 +860,7 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 	count := s.listenerCount[name]
 	if count == 0 {
 		if isProxyListener {
-			s.proxyListeners++
+			_ = s.npdsListeners.Add(name)
 		}
 		s.logger.Info("Envoy: Upserting new listener",
 			logfields.Listener, name,
@@ -835,8 +868,7 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 	}
 	count++
 	s.listenerCount[name] = count
-
-	s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConfig, []string{"127.0.0.1"}, wg,
+	_ = s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConfig, []string{"127.0.0.1"}, wg,
 		func(err error) {
 			if cb != nil {
 				cb(err)
@@ -849,16 +881,47 @@ func (s *xdsServer) addListener(name string, listenerConf func() *envoy_config_l
 func (s *xdsServer) upsertListener(name string, listenerConf *envoy_config_listener.Listener, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	var revertNPDSTracking func()
+
+	requireNPDS := listenerRequiresNPDS(listenerConf)
+	if requireNPDS {
+		revertNPDSTracking = s.npdsListeners.Add(name)
+	} else {
+		revertNPDSTracking = s.npdsListeners.Delete(name)
+		if s.npdsListeners.Empty() {
+			s.networkPolicyMutator.CancelCompletions(NetworkPolicyTypeURL)
+		}
+	}
+
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConf, []string{"127.0.0.1"}, wg, callback)
+	revertFunc := s.listenerMutator.Upsert(ListenerTypeURL, name, listenerConf, []string{"127.0.0.1"}, wg, callback)
+	return func(c *completion.Completion) {
+		s.mutex.Lock()
+		revertFunc(c)
+		revertNPDSTracking()
+		s.mutex.Unlock()
+	}
 }
 
 // deleteListener deletes an LDS Envoy Listener.
 func (s *xdsServer) deleteListener(name string, wg *completion.WaitGroup, callback func(error)) xds.AckingResourceMutatorRevertFunc {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	revertNPDSTracking := s.npdsListeners.Delete(name)
+	if s.npdsListeners.Empty() {
+		s.networkPolicyMutator.CancelCompletions(NetworkPolicyTypeURL)
+	}
+
 	// 'callback' is not called if there is no change and this configuration has already been acked.
-	return s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, callback)
+	revertFunc := s.listenerMutator.Delete(ListenerTypeURL, name, []string{"127.0.0.1"}, wg, callback)
+	return func(c *completion.Completion) {
+		s.mutex.Lock()
+		revertNPDSTracking()
+		revertFunc(c)
+		s.mutex.Unlock()
+	}
 }
 
 // upsertRoute either updates an existing RDS route with 'name', or creates a new one.
@@ -1021,6 +1084,7 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 	)
 
 	var listenerRevertFunc xds.AckingResourceMutatorRevertFunc
+	var revertNPDSTracking func()
 
 	s.mutex.Lock()
 	count := s.listenerCount[name]
@@ -1028,13 +1092,7 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 		count--
 		if count == 0 {
 			if isProxyListener {
-				s.proxyListeners--
-				if s.proxyListeners < 0 {
-					s.logger.Error("Envoy: RemoveListener: negative proxyListener count",
-						logfields.Listener, name,
-						logfields.Count, s.proxyListeners,
-					)
-				}
+				revertNPDSTracking = s.npdsListeners.Delete(name)
 			}
 			delete(s.listenerCount, name)
 			s.logger.Info("Envoy: Deleting listener",
@@ -1044,7 +1102,7 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 
 			// cancel all pending network policy completions if this was the last
 			// listener with bpf metadata listener filter with bpf path configured.
-			if s.proxyListeners <= 0 {
+			if s.npdsListeners.Empty() {
 				s.networkPolicyMutator.CancelCompletions(NetworkPolicyTypeURL)
 			}
 		} else {
@@ -1062,9 +1120,9 @@ func (s *xdsServer) removeListener(name string, wg *completion.WaitGroup, isProx
 		s.mutex.Lock()
 		if listenerRevertFunc != nil {
 			listenerRevertFunc(completion)
-			if isProxyListener {
-				s.proxyListeners++
-			}
+		}
+		if revertNPDSTracking != nil {
+			revertNPDSTracking()
 		}
 		s.listenerCount[name] = s.listenerCount[name] + 1
 		s.mutex.Unlock()
@@ -1677,7 +1735,7 @@ func (s *xdsServer) UseCurrentNetworkPolicy(ep endpoint.EndpointUpdater, policy 
 	// If there are no listeners configured, the local node's Envoy proxy won't
 	// query for network policies and therefore will never ACK them, and we'd
 	// wait forever.
-	if s.proxyListeners == 0 {
+	if s.npdsListeners.Empty() {
 		wg = nil
 	}
 
@@ -1736,7 +1794,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 	// If there are no listeners configured, the local node's Envoy proxy won't
 	// query for network policies and therefore will never ACK them, and we'd
 	// wait forever.
-	if s.proxyListeners == 0 {
+	if s.npdsListeners.Empty() {
 		wg = nil
 	}
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1623,8 +1623,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 			var err error
 			proxyPort, err = epPolicy.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port, listener)
 			if err != nil {
-				logger.Warn(
-					"AccumulateMapChanges: Missing redirect.",
+				logArgs := []any{
 					logfields.EndpointSelector, cs,
 					logfields.Port, port,
 					logfields.Protocol, proto,
@@ -1633,7 +1632,16 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 					logfields.IsRedirect, redirect,
 					logfields.Listener, listener,
 					logfields.ListenerPriority, listenerPriority,
-				)
+				}
+				// If the redirect is configured through a listener, it is possible that listener
+				// configuration is in progress. Policy will be automatically regenerated once
+				// the listener is programmed.
+				if len(listener) != 0 {
+					logger.Info("AccumulateMapChanges: Missing redirect.", logArgs...)
+				} else {
+					logger.Warn("AccumulateMapChanges: Missing redirect.", logArgs...)
+				}
+
 				continue
 			}
 		}


### PR DESCRIPTION
See commit message for details.

This affects v1.17 where if a `toFQDNs` rule is compounded with a CEC listener(and no other proxy listeners), the DNS response to client would skip waiting for Envoy network policy configuration. This leads to a race, where envoy
network policy update happens after client resolves the DNS and makes the request causing connection failure. For cilium version >= v1.18 we [preallocate identities for FQDN selectors](https://github.com/cilium/cilium/pull/39868), so envoy doesn't need network policy update on DNS lookup.

