### PR TITLE
docs: document reverse_sk map exhaustion impact on socket termination

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1798,6 +1798,28 @@ The following scenarios are prone to this problem:
 
 Therefore, it is highly recommended not to expose a backend endpoint via multiple VIPs :gh-issue:`11810` :gh-issue:`18632`.
 
+Socket Termination Unreliable Due to Reverse SK Map Exhaustion
+**************************************************************
+
+When socket-LB is enabled, Cilium forcefully terminates application sockets that are connected to deleted service
+backends, so that applications can be re-load-balanced to active backends (see :ref:`Limitations`).
+Before terminating a socket, Cilium verifies that the socket was actually load-balanced by socket-LB by looking up
+the socket's cookie and destination in the ``cilium_lb4_reverse_sk`` and ``cilium_lb6_reverse_sk`` BPF maps.
+This prevents unrelated sockets from being terminated. When these maps become full, LRU eviction may remove entries
+belonging to active connections, causing those connections to fail the verification and be skipped during socket termination.
+
+A cleanup mechanism exists to remove entries from these maps when sockets are closed, but there are cases where cleanup
+does not work correctly: unconnected UDP sockets (i.e. the ``create → sendto() → close`` pattern without calling ``connect()``),
+and connected UDP sockets terminated via abort.
+
+On nodes with workloads that trigger these cases, the maps may gradually fill up, and socket termination may become
+unreliable until the node is restarted. If this becomes an issue, consider disabling socket-LB in pod namespaces by setting
+``socketLB.hostNamespaceOnly=true``. See :gh-issue:`42649` and :gh-issue:`28820` for details.
+
+Replacing these maps with BPF socket storage (:gh-issue:`42658`) would resolve this issue.
+
+.. _Limitations:
+
 Limitations
 ###########
 


### PR DESCRIPTION
The cilium_lb[4,6]_reverse_sk BPF maps can accumulate stale entries when unconnected UDP sockets or connected UDP sockets terminated via abort are not properly cleaned up on close. When these maps fill up, LRU eviction may remove entries for active connections, causing socket termination to skip those connections when service backends are deleted.

Document this as a known issue in the kube-proxy replacement guide, along with the workaround of disabling socket-LB in pod namespaces via socketLB.hostNamespaceOnly=true.

Ref: #42649
Ref: #42658
Ref: #28820