### PR TITLE
Separate method for highest precedence source

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -75,7 +75,7 @@ type metadata struct {
 	// If this mutex will be held at the same time as the IPCache mutex,
 	// this mutex must be taken first and then take the IPCache mutex in
 	// order to prevent deadlocks.
-	lock.Mutex
+	lock.RWMutex
 
 	// m is the actual map containing the mappings.
 	m map[cmtypes.PrefixCluster]*prefixInfo
@@ -258,15 +258,15 @@ func (m *metadata) upsertLocked(prefix cmtypes.PrefixCluster, src source.Source,
 // GetMetadataSourceByPrefix returns the highest precedence source which has
 // provided metadata for this prefix
 func (ipc *IPCache) GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source {
-	ipc.metadata.Lock()
-	defer ipc.metadata.Unlock()
-	return ipc.metadata.getLocked(prefix).Source()
+	ipc.metadata.RLock()
+	defer ipc.metadata.RUnlock()
+	return ipc.metadata.getLockedSource(prefix)
 }
 
 // get returns a deep copy of the flattened prefix info
 func (m *metadata) get(prefix cmtypes.PrefixCluster) *resourceInfo {
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 	return m.getLocked(prefix)
 }
 
@@ -283,6 +283,18 @@ func (m *metadata) getLocked(prefix cmtypes.PrefixCluster) *resourceInfo {
 		return pi.flattened.DeepCopy()
 	}
 	return nil
+}
+
+// getLockedSource returns the highest precedence source which has
+// provided metadata for this prefix
+func (m *metadata) getLockedSource(prefix cmtypes.PrefixCluster) source.Source {
+	if pi, ok := m.m[canonicalPrefix(prefix)]; ok {
+		if pi.flattened == nil {
+			return pi.highestPrecedenceSource()
+		}
+		return pi.flattened.source
+	}
+	return source.Unspec
 }
 
 // mergeParentLabels pulls down all labels from parent prefixes, with "longer" prefixes having

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1635,6 +1635,32 @@ func generateUniqueCIDRs(n int) []cmtypes.PrefixCluster {
 	return slices.Collect(maps.Keys(unique))
 }
 
+func BenchmarkGetMetadataSourceByPrefix(b *testing.B) {
+	logger := hivetest.Logger(b)
+	m := newMetadata(logger)
+
+	prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("1.1.1.1/32"))
+	lbls := labels.GetCIDRLabels(prefix.AsPrefix())
+
+	for _, v := range []int{5, 10, 20} {
+		b.Run(fmt.Sprintf("metadata_elements_%d", v), func(b *testing.B) {
+			sources := source.NewSources()
+			for i := range v {
+				resource := types.NewResourceID(types.ResourceKindCNP, fmt.Sprintf("namespace_%d", i), "my-policy")
+				m.upsertLocked(prefix, sources[rand.IntN(len(sources))], resource, lbls)
+			}
+
+			ipcache := &IPCache{metadata: m}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				ipcache.GetMetadataSourceByPrefix(prefix)
+			}
+		})
+	}
+}
+
 // TestResolveFQDNLabels ensures that FQDN labels are resolved consistently across the codebase.
 // This should match the logic in preallocator_test.go
 func TestResolveFQDNLabels(t *testing.T) {

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -393,3 +393,28 @@ func (s *prefixInfo) flatten(scopedLog *slog.Logger) *resourceInfo {
 
 	return out
 }
+
+func (s *prefixInfo) highestPrecedenceSource() source.Source {
+	if len(s.byResource) == 0 {
+		return source.Unspec
+	}
+	if len(s.byResource) == 1 {
+		for _, info := range s.byResource {
+			return info.source
+		}
+	}
+
+	var bestSrc source.Source
+	for _, info := range s.byResource {
+		if info.source == source.KubeAPIServer {
+			return info.source
+		}
+		if bestSrc == "" {
+			bestSrc = info.source
+		} else if bestSrc != info.source && source.AllowOverwrite(bestSrc, info.source) {
+			bestSrc = info.source
+		}
+	}
+
+	return bestSrc
+}

--- a/pkg/ipcache/types_test.go
+++ b/pkg/ipcache/types_test.go
@@ -234,3 +234,84 @@ func TestFlatten(t *testing.T) {
 		})
 	}
 }
+
+func TestHighestPrecedenceSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		infos    map[types.ResourceID]*resourceInfo
+		expected source.Source
+	}{
+		{
+			name:     "empty byResource",
+			infos:    map[types.ResourceID]*resourceInfo{},
+			expected: source.Unspec,
+		},
+		{
+			name: "single resource",
+			infos: map[types.ResourceID]*resourceInfo{
+				"res1": {source: source.Local},
+			},
+			expected: source.Local,
+		},
+		{
+			name: "two resources - local wins over generated",
+			infos: map[types.ResourceID]*resourceInfo{
+				"res1": {source: source.Local},
+				"res2": {source: source.Generated},
+			},
+			expected: source.Local,
+		},
+		{
+			name: "two resources - kubernetes wins over unspec",
+			infos: map[types.ResourceID]*resourceInfo{
+				"res1": {source: source.Unspec},
+				"res2": {source: source.Kubernetes},
+			},
+			expected: source.Kubernetes,
+		},
+		{
+			name: "three resources - KubeAPIServer causes early exit",
+			infos: map[types.ResourceID]*resourceInfo{
+				"res1": {source: source.Local},
+				"res2": {source: source.KVStore},
+				"res3": {source: source.KubeAPIServer}, // KubeAPIServer wins over all
+			},
+			expected: source.KubeAPIServer,
+		},
+		{
+			name: "same source multiple times",
+			infos: map[types.ResourceID]*resourceInfo{
+				"res1": {source: source.Kubernetes},
+				"res2": {source: source.Kubernetes},
+				"res3": {source: source.Kubernetes},
+			},
+			expected: source.Kubernetes,
+		},
+		{
+			name: "all sources with local winning",
+			infos: map[types.ResourceID]*resourceInfo{
+				"res1": {source: source.Restored},
+				"res2": {source: source.Generated},
+				"res3": {source: source.LocalAPI},
+				"res4": {source: source.Directory},
+				"res5": {source: source.ClusterMesh},
+				"res6": {source: source.Kubernetes},
+				"res7": {source: source.CustomResource},
+				"res8": {source: source.KVStore},
+				"res9": {source: source.Local},
+			},
+			expected: source.Local,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pi := newPrefixInfo()
+			pi.byResource = test.infos
+			source := pi.highestPrecedenceSource()
+			assert.Equal(t, test.expected, source)
+		})
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -4,7 +4,7 @@
 package source
 
 import (
-	"slices"
+	"sync"
 
 	"github.com/cilium/hive/cell"
 )
@@ -82,21 +82,27 @@ var defaultSources Sources = []Source{
 	Unspec,
 }
 
+var getSourcePriorities = sync.OnceValue(func() map[Source]int {
+	m := make(map[Source]int, len(defaultSources))
+	for i, src := range defaultSources {
+		m[src] = i
+	}
+	return m
+})
+
 // AllowOverwrite returns true if new state from a particular source is allowed
 // to overwrite existing state from another source
-func AllowOverwrite(existing, new Source) bool {
-	overflowNegative := overflowNegativeTo(len(defaultSources))
-	return overflowNegative(slices.Index(defaultSources, new)) <= overflowNegative(slices.Index(defaultSources, existing))
-}
-
-func overflowNegativeTo(infinity int) func(int) int {
-	return func(n int) int {
-		if n < 0 {
-			return infinity
-		} else {
-			return n
-		}
+func AllowOverwrite(existing, next Source) bool {
+	priorities := getSourcePriorities()
+	pNext, ok := priorities[next]
+	if !ok {
+		pNext = len(defaultSources)
 	}
+	pExisting, ok := priorities[existing]
+	if !ok {
+		pExisting = len(defaultSources)
+	}
+	return pNext <= pExisting
 }
 
 var Cell = cell.Module(


### PR DESCRIPTION
This PR introduces new `prefixInfo.highestPrecedenceSource` method for retrieving only the source for `IPCache.GetMetadataSourceByPrefix` method. 

Motivation for such change is huge Cilium Node processing time for big clusters. For every `CiliumNode` we need to run [IPCache.GetMetadataSourceByPrefix](https://github.com/cilium/cilium/blob/6101dec110eb9fd6232c4c5603f7566a2872d7ca/pkg/node/manager/manager.go#L745), implementation was suboptimal - with unnecessary sorting and slice index retrieval - causing [timeouts](https://github.com/cilium/cilium/blob/b9730e497df2e93a11aacaf8f6caa69808893b7c/pkg/defaults/defaults.go#L280) during CiliumNodes processing. Separate methods were introduced now to break existing functionalities.

Benchmark results based on `BenchmarkGetMetadataSourceByPrefix`, "old" is `GetMetadataSourceByPrefix` method based on `metadata.getLocked`, "new" is optimized implementation.

```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/ipcache
cpu: AMD EPYC 7B12
                                                  │   old.txt   │               new.txt               │
                                                  │   sec/op    │    sec/op     vs base               │
GetMetadataSourceByPrefix/metadata_elements_5-24    640.5n ± 3%   265.1n ± 12%  -58.61% (p=0.002 n=6)
GetMetadataSourceByPrefix/metadata_elements_10-24   632.5n ± 3%   278.2n ± 74%  -56.02% (p=0.002 n=6)
GetMetadataSourceByPrefix/metadata_elements_20-24   632.9n ± 4%   455.2n ± 86%        ~ (p=0.065 n=6)
geomean                                             635.3n        322.6n        -49.22%

                                                  │  old.txt   │               new.txt                │
                                                  │    B/op    │   B/op    vs base                    │
GetMetadataSourceByPrefix/metadata_elements_5-24    768.0 ± 0%   0.0 ± 0%  -100.00% (p=0.002 n=6)
GetMetadataSourceByPrefix/metadata_elements_10-24   768.0 ± 0%   0.0 ± 0%  -100.00% (p=0.002 n=6)
GetMetadataSourceByPrefix/metadata_elements_20-24   768.0 ± 0%   0.0 ± 0%  -100.00% (p=0.002 n=6)

                                                  │  old.txt   │                new.txt                 │
                                                  │ allocs/op  │ allocs/op   vs base                    │
GetMetadataSourceByPrefix/metadata_elements_5-24    3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
GetMetadataSourceByPrefix/metadata_elements_10-24   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
GetMetadataSourceByPrefix/metadata_elements_20-24   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
```

