### PR TITLE
[envoy] Rename embedded envoy test

### DIFF
--- a/pkg/envoy/standalone_envoy.go
+++ b/pkg/envoy/standalone_envoy.go
@@ -94,13 +94,13 @@ func mapLogLevel(agentLogLevel slog.Level, defaultEnvoyLogLevel string) string {
 
 // Envoy manages a running Envoy proxy instance via the
 // ListenerDiscoveryService and RouteDiscoveryService gRPC APIs.
-type EmbeddedEnvoy struct {
+type StandaloneEnvoy struct {
 	stopCh chan struct{}
 	errCh  chan error
 	admin  *EnvoyAdminClient
 }
 
-type embeddedEnvoyConfig struct {
+type standaloneEnvoyConfig struct {
 	runDir                         string
 	logPath                        string
 	defaultLogLevel                string
@@ -116,9 +116,9 @@ type embeddedEnvoyConfig struct {
 	maxRequests                    uint32
 }
 
-// startEmbeddedEnvoyInternal starts an Envoy proxy instance.
-func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConfig) (*EmbeddedEnvoy, error) {
-	envoy := &EmbeddedEnvoy{
+// startStandaloneEnvoyInternal starts an Envoy proxy instance.
+func (o *onDemandXdsStarter) startStandaloneEnvoyInternal(config standaloneEnvoyConfig) (*StandaloneEnvoy, error) {
+	envoy := &StandaloneEnvoy{
 		stopCh: make(chan struct{}),
 		errCh:  make(chan error, 1),
 		admin:  NewEnvoyAdminClientForSocket(o.logger, GetSocketDir(config.runDir), config.defaultLogLevel),
@@ -152,7 +152,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConf
 		maxRequests:                    config.maxRequests,
 	})
 
-	o.logger.Debug("Envoy: Starting embedded Envoy")
+	o.logger.Debug("Envoy: Starting standalone Envoy")
 
 	// make it a buffered channel, so we can not only
 	// read the written value but also skip it in
@@ -246,7 +246,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConf
 				// Start Envoy again
 				continue
 			case <-envoy.stopCh:
-				o.logger.Info("Envoy: Stopping embedded Envoy proxy",
+				o.logger.Info("Envoy: Stopping standalone Envoy proxy",
 					logfields.PID, cmd.Process.Pid,
 				)
 				if err := envoy.admin.quit(); err != nil {
@@ -271,7 +271,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoyInternal(config embeddedEnvoyConf
 		return envoy, nil
 	}
 
-	return nil, errors.New("failed to start embedded Envoy server")
+	return nil, errors.New("failed to start standalone Envoy server")
 }
 
 // newEnvoyLogPiper creates a writer that parses and logs log messages written by Envoy.
@@ -342,9 +342,9 @@ func (o *onDemandXdsStarter) newEnvoyLogPiper() io.WriteCloser {
 	return writer
 }
 
-// Stop kills the Envoy process started with startEmbeddedEnvoy. The gRPC API streams are terminated
+// Stop kills the Envoy process started with startStandaloneEnvoy. The gRPC API streams are terminated
 // first.
-func (e *EmbeddedEnvoy) Stop() error {
+func (e *StandaloneEnvoy) Stop() error {
 	close(e.stopCh)
 	err, ok := <-e.errCh
 	if ok {
@@ -353,7 +353,7 @@ func (e *EmbeddedEnvoy) Stop() error {
 	return nil
 }
 
-func (e *EmbeddedEnvoy) GetAdminClient() *EnvoyAdminClient {
+func (e *StandaloneEnvoy) GetAdminClient() *EnvoyAdminClient {
 	return e.admin
 }
 
@@ -570,8 +570,8 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) {
 	}
 }
 
-// getEmbeddedEnvoyVersion returns the envoy binary version string
-func getEmbeddedEnvoyVersion() (string, error) {
+// getStandaloneEnvoyVersion returns the envoy binary version string
+func getStandaloneEnvoyVersion() (string, error) {
 	out, err := exec.Command(ciliumEnvoy, "--version").Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to execute '%s --version': %w", ciliumEnvoy, err)

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -22,7 +22,9 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
-// To run the embedded_envoy_test, the following have to be met:
+// This test is not run in CI and is meant to be run locally when iterating on the Envoy (xDS) integration.
+// It tests the basic functionality of the standalone Envoy proxy, including starting the proxy, adding and removing resources, and handling NACKs from Envoy.
+// To run the standalone_envoy_test, the following have to be met:
 //
 // - Environment variable `CILIUM_ENABLE_ENVOY_UNIT_TEST` must be set
 // - `cilium-envoy-starter` and `cilium-envoy` must exist in the PATH
@@ -103,7 +105,7 @@ func TestEnvoy(t *testing.T) {
 
 	// launch debug variant of the Envoy proxy
 	starter := &onDemandXdsStarter{logger: logger}
-	envoyProxy, err := starter.startEmbeddedEnvoyInternal(embeddedEnvoyConfig{
+	envoyProxy, err := starter.startStandaloneEnvoyInternal(standaloneEnvoyConfig{
 		runDir:                         testRunDir,
 		logPath:                        filepath.Join(testRunDir, "cilium-envoy.log"),
 		baseID:                         15,
@@ -226,7 +228,7 @@ func TestEnvoyNACK(t *testing.T) {
 
 	// launch debug variant of the Envoy proxy
 	starter := &onDemandXdsStarter{logger: logger}
-	envoyProxy, err := starter.startEmbeddedEnvoyInternal(embeddedEnvoyConfig{
+	envoyProxy, err := starter.startStandaloneEnvoyInternal(standaloneEnvoyConfig{
 		runDir:                         testRunDir,
 		logPath:                        filepath.Join(testRunDir, "cilium-envoy.log"),
 		baseID:                         42,

--- a/pkg/envoy/versioncheck.go
+++ b/pkg/envoy/versioncheck.go
@@ -45,7 +45,7 @@ func (r *envoyVersionChecker) getEnvoyVersion() (string, error) {
 	if r.externalEnvoy {
 		return r.getRemoteEnvoyVersion()
 	} else {
-		return getEmbeddedEnvoyVersion()
+		return getStandaloneEnvoyVersion()
 	}
 }
 

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -40,8 +40,8 @@ type onDemandXdsStarter struct {
 var _ XDSServer = &onDemandXdsStarter{}
 
 func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup, cb func(err error)) error {
-	if err := o.startEmbeddedEnvoy(nil); err != nil {
-		o.logger.Error("Envoy: Failed to start embedded Envoy proxy on demand",
+	if err := o.startStandaloneEnvoy(nil); err != nil {
+		o.logger.Error("Envoy: Failed to start standalone Envoy proxy on demand",
 			logfields.Error, err,
 		)
 	}
@@ -50,8 +50,8 @@ func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, 
 }
 
 func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources Resources) error {
-	if err := o.startEmbeddedEnvoy(nil); err != nil {
-		o.logger.Error("Envoy: Failed to start embedded Envoy proxy on demand",
+	if err := o.startStandaloneEnvoy(nil); err != nil {
+		o.logger.Error("Envoy: Failed to start standalone Envoy proxy on demand",
 			logfields.Error, err,
 		)
 	}
@@ -60,8 +60,8 @@ func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources
 }
 
 func (o *onDemandXdsStarter) UpdateEnvoyResources(ctx context.Context, old, new Resources) error {
-	if err := o.startEmbeddedEnvoy(nil); err != nil {
-		o.logger.Error("Envoy: Failed to start embedded Envoy proxy on demand",
+	if err := o.startStandaloneEnvoy(nil); err != nil {
+		o.logger.Error("Envoy: Failed to start standalone Envoy proxy on demand",
 			logfields.Error, err,
 		)
 	}
@@ -69,12 +69,12 @@ func (o *onDemandXdsStarter) UpdateEnvoyResources(ctx context.Context, old, new 
 	return o.XDSServer.UpdateEnvoyResources(ctx, old, new)
 }
 
-func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error {
+func (o *onDemandXdsStarter) startStandaloneEnvoy(wg *completion.WaitGroup) error {
 	var startErr error
 
 	o.envoyOnce.Do(func() {
-		// Start embedded Envoy on first invocation
-		_, startErr = o.startEmbeddedEnvoyInternal(embeddedEnvoyConfig{
+		// Start standalone Envoy on first invocation
+		_, startErr = o.startStandaloneEnvoyInternal(standaloneEnvoyConfig{
 			runDir:                         o.runDir,
 			logPath:                        o.envoyLogPath,
 			defaultLogLevel:                o.envoyDefaultLogLevel,


### PR DESCRIPTION
Renamed `embedded_envoy_test` and relevant types/methods to better reflect the actual setup of the test. Also added explanatory comments.
