### PR TITLE
lb: fix panic in orphan backend cleanup when addr is zero-value

### DIFF
--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -1473,6 +1473,7 @@ func (ops *BPFOps) needsUpdate(addr loadbalancer.L3n4Addr, rev statedb.Revision)
 func (ops *BPFOps) updateBackendRevision(id loadbalancer.BackendID, addr loadbalancer.L3n4Addr, rev statedb.Revision) {
 	s := ops.backendStates[addr]
 	s.id = id
+	s.addr = addr
 	s.revision = rev
 	ops.backendStates[addr] = s
 }

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -5,6 +5,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"slices"
@@ -148,10 +149,27 @@ type testCase struct {
 
 	delete bool
 
+	// expectErr when true causes UpdateService to fail on backend slots
+	// and expects Update to return an error.
+	expectErr bool
+
 	// maps and maglev are the dumped BPF maps. These should not be hand-written but rather
 	// pasted in from the failing test case when a new test-case is added.
 	// Sorted.
 	maps, maglev []maps.MapDump
+}
+
+// faultyLBMaps wraps an LBMaps and can inject errors on UpdateService.
+type faultyLBMaps struct {
+	maps.LBMaps
+	fail bool
+}
+
+func (m *faultyLBMaps) UpdateService(key maps.ServiceKey, value maps.ServiceValue) error {
+	if m.fail && key.GetBackendSlot() > 0 {
+		return errors.New("update service failed")
+	}
+	return m.LBMaps.UpdateService(key, value)
 }
 
 var testServiceName = loadbalancer.NewServiceName("test", "test")
@@ -205,7 +223,7 @@ func newTestBackend(addr loadbalancer.L3n4Addr, state loadbalancer.BackendState)
 }
 
 // newTestCase creates a testCase from a function that manipulates the base service and frontends.
-func newTestCase(name string, mod func(*loadbalancer.Service, *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend), maps []maps.MapDump, maglev []maps.MapDump) testCase {
+func newTestCase(name string, mod func(*loadbalancer.Service, *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend), maps []maps.MapDump, maglev []maps.MapDump, expectErr bool) testCase {
 	svc := baseService
 	fe := baseFrontend
 	delete, bes := mod(&svc, &fe)
@@ -217,11 +235,12 @@ func newTestCase(name string, mod func(*loadbalancer.Service, *loadbalancer.Fron
 		nextBackendRevision++
 	}
 	return testCase{
-		name:     name,
-		frontend: fe,
-		delete:   delete,
-		maps:     maps,
-		maglev:   maglev,
+		name:      name,
+		frontend:  fe,
+		delete:    delete,
+		expectErr: expectErr,
+		maps:      maps,
+		maglev:    maglev,
 	}
 }
 
@@ -249,6 +268,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -266,6 +286,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -288,6 +309,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -316,6 +338,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -331,6 +354,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	// Test that adding another frontend allocates new IDs correctly.
@@ -350,6 +374,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=2 ADDR=10.0.0.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -361,6 +386,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	// Adding the same frontend again won't reuse the ID as it should have been released.
@@ -380,6 +406,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=3 ADDR=10.0.0.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -391,6 +418,7 @@ var clusterIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -398,6 +426,7 @@ var clusterIPTestCases = []testCase{
 		deleteFrontend(autoAddr, ClusterIP),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -422,6 +451,7 @@ var quarantineTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -444,6 +474,7 @@ var quarantineTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -451,6 +482,7 @@ var quarantineTestCases = []testCase{
 		deleteFrontend(autoAddr, ClusterIP),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -486,6 +518,7 @@ var nodePortTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=2 INNER=[1(511), 2(510)]",
 		},
+		false,
 	),
 
 	newTestCase(
@@ -493,6 +526,7 @@ var nodePortTestCases = []testCase{
 		deleteFrontend(zeroAddr, NodePort),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -519,6 +553,7 @@ var hostPortTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=2 INNER=[1(1021)]",
 		},
+		false,
 	),
 
 	newTestCase(
@@ -526,6 +561,7 @@ var hostPortTestCases = []testCase{
 		deleteFrontend(zeroAddr, HostPort),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 
 	// HostPort with fixed address.
@@ -546,6 +582,7 @@ var hostPortTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=3 INNER=[2(1021)]",
 		},
+		false,
 	),
 
 	newTestCase(
@@ -553,6 +590,7 @@ var hostPortTestCases = []testCase{
 		deleteFrontend(autoAddr, HostPort),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -581,12 +619,14 @@ var proxyTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
 		},
 		nil,
+		false,
 	),
 	newTestCase(
 		"L7Proxy_cleanup",
 		deleteFrontend(autoAddr, ClusterIP),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -612,6 +652,7 @@ var miscFlagsTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+46x64",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -628,6 +669,7 @@ var miscFlagsTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+InternalLocal+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -644,6 +686,7 @@ var miscFlagsTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -662,6 +705,7 @@ var miscFlagsTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+non-routable",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -669,6 +713,7 @@ var miscFlagsTestCases = []testCase{
 		deleteFrontend(autoAddr, ClusterIP),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -684,6 +729,7 @@ var miscFlagsTestCases = []testCase{
 			"SVC: ID=2 ADDR=10.0.0.2:80/TCP/i SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=HostPort+Local+InternalLocal",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -702,6 +748,7 @@ var miscFlagsTestCases = []testCase{
 			"SVC: ID=2 ADDR=10.0.0.2:80/TCP/i SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=HostPort+Local+two-scopes",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -709,6 +756,7 @@ var miscFlagsTestCases = []testCase{
 		deleteFrontend(extraFrontendInternal, ClusterIP),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -731,6 +779,7 @@ var loadBalancerTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -738,6 +787,7 @@ var loadBalancerTestCases = []testCase{
 		deleteFrontend(autoAddr, LoadBalancer),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -754,6 +804,7 @@ var externalIPTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs+Local+InternalLocal",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -761,6 +812,7 @@ var externalIPTestCases = []testCase{
 		deleteFrontend(autoAddr, ExternalIPs),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -780,6 +832,7 @@ var localRedirectTestCases = []testCase{
 			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect+Local+InternalLocal",
 		},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -787,6 +840,7 @@ var localRedirectTestCases = []testCase{
 		deleteFrontend(autoAddr, LocalRedirect),
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 }
 
@@ -823,6 +877,7 @@ var sessionAffinityTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=2 INNER=[1(511), 2(510)]",
 		},
+		false,
 	),
 
 	newTestCase(
@@ -855,6 +910,7 @@ var sessionAffinityTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=2 INNER=[2(1021)]",
 		},
+		false,
 	),
 	newTestCase(
 		"SessionAffinity_cleanup_1",
@@ -867,6 +923,7 @@ var sessionAffinityTestCases = []testCase{
 		},
 		[]maps.MapDump{},
 		nil,
+		false,
 	),
 
 	newTestCase(
@@ -891,6 +948,7 @@ var sessionAffinityTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=4 INNER=[3(1021)]",
 		},
+		false,
 	),
 
 	// Disable session affinity to verify that the affinity match maps are cleaned up.
@@ -914,6 +972,7 @@ var sessionAffinityTestCases = []testCase{
 		[]maps.MapDump{
 			"MAGLEV: ID=4 INNER=[3(1021)]",
 		},
+		false,
 	),
 
 	newTestCase(
@@ -928,6 +987,80 @@ var sessionAffinityTestCases = []testCase{
 		},
 		[]maps.MapDump{},
 		nil,
+		false,
+	),
+}
+
+// mapErrorTestCases exercises the UpdateService error path.
+var mapErrorTestCases = []testCase{
+	// Step 1: Create a ClusterIP with one backend. This succeeds and establishes
+	// backendReferences[fe] = {backend1}.
+	newTestCase(
+		"MapError_setup_1_backend",
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (bool, []loadbalancer.Backend) {
+			fe.Type = ClusterIP
+			fe.Address = autoAddr
+			return false, []loadbalancer.Backend{
+				newTestBackend(backend1, loadbalancer.BackendStateActive),
+			}
+		},
+		[]maps.MapDump{
+			"BE: ID=1 ADDR=10.1.0.1:80/TCP STATE=active",
+			"REV: ID=1 ADDR=<auto>",
+			"SVC: ID=0 ADDR=<auto>/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable",
+			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
+			"SVC: ID=1 ADDR=<auto>/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
+		},
+		nil,
+		false,
+	),
+
+	// Step 2: Switch to backend2 with an error injected. updateBackendRevision
+	// runs for backend2 (creating backendStates[backend2]) but upsertService
+	// fails on the slot, so updateReferences is skipped. The invariant check
+	// in runTests verifies that backendStates[backend2].addr is still set.
+	newTestCase(
+		"MapError_update_service_fails",
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (bool, []loadbalancer.Backend) {
+			fe.Type = ClusterIP
+			fe.Address = autoAddr
+			return false, []loadbalancer.Backend{
+				newTestBackend(backend2, loadbalancer.BackendStateActive),
+			}
+		},
+		nil, // maps not checked on error
+		nil,
+		true,
+	),
+
+	// Step 3: Retry without the error. The reconciler recovers and proceeds normally.
+	newTestCase(
+		"MapError_retry_succeeds",
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (bool, []loadbalancer.Backend) {
+			fe.Type = ClusterIP
+			fe.Address = autoAddr
+			return false, []loadbalancer.Backend{
+				newTestBackend(backend2, loadbalancer.BackendStateActive),
+			}
+		},
+		[]maps.MapDump{
+			"BE: ID=2 ADDR=10.1.0.2:80/TCP STATE=active",
+			"REV: ID=1 ADDR=<auto>",
+			"SVC: ID=0 ADDR=<auto>/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable",
+			"SVC: ID=1 ADDR=<auto>/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
+			"SVC: ID=1 ADDR=<auto>/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable",
+		},
+		nil,
+		false,
+	),
+
+	// Step 4: Clean up.
+	newTestCase(
+		"MapError_cleanup",
+		deleteFrontend(autoAddr, ClusterIP),
+		[]maps.MapDump{},
+		nil,
+		false,
 	),
 }
 
@@ -942,6 +1075,7 @@ var testCases = [][]testCase{
 	externalIPTestCases,
 	localRedirectTestCases,
 	sessionAffinityTestCases,
+	mapErrorTestCases,
 }
 
 type setWithAlgo struct {
@@ -975,12 +1109,14 @@ var perServiceAlgorithmCases = []setWithAlgo{
 				[]maps.MapDump{
 					"MAGLEV: ID=2 INNER=[1(1021)]",
 				},
+				false,
 			),
 			newTestCase(
 				"NodePorts_explicitMaglev_cleanup",
 				deleteFrontend(zeroAddr, NodePort),
 				[]maps.MapDump{},
 				nil,
+				false,
 			),
 		},
 		algo: loadbalancer.LBAlgorithmRandom,
@@ -1004,12 +1140,14 @@ var perServiceAlgorithmCases = []setWithAlgo{
 					"SVC: ID=2 ADDR=<nodePort>/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal",
 				},
 				nil,
+				false,
 			),
 			newTestCase(
 				"NodePorts_noExplicitMaglev_cleanup",
 				deleteFrontend(zeroAddr, NodePort),
 				[]maps.MapDump{},
 				nil,
+				false,
 			),
 		},
 		algo: loadbalancer.LBAlgorithmRandom,
@@ -1037,12 +1175,14 @@ var perServiceAlgorithmCases = []setWithAlgo{
 					"SVC: ID=2 ADDR=<nodePort>/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal",
 				},
 				nil,
+				false,
 			),
 			newTestCase(
 				"NodePorts_explicitRandom_cleanup",
 				deleteFrontend(zeroAddr, NodePort),
 				[]maps.MapDump{},
 				nil,
+				false,
 			),
 		},
 		algo: loadbalancer.LBAlgorithmMaglev,
@@ -1068,12 +1208,14 @@ var perServiceAlgorithmCases = []setWithAlgo{
 				[]maps.MapDump{
 					"MAGLEV: ID=2 INNER=[1(1021)]",
 				},
+				false,
 			),
 			newTestCase(
 				"NodePorts_noExplicitMaglev_cleanup",
 				deleteFrontend(zeroAddr, NodePort),
 				[]maps.MapDump{},
 				nil,
+				false,
 			),
 		},
 		algo: loadbalancer.LBAlgorithmMaglev,
@@ -1136,6 +1278,8 @@ func TestBPFOps(t *testing.T) {
 	}
 	wtxn.Commit()
 
+	faultMaps := &faultyLBMaps{LBMaps: lbmaps}
+
 	runTests := func(ops *BPFOps, testCaseSet []testCase, algo string, addr loadbalancer.L3n4Addr, validateMaglev bool) {
 		for _, testCase := range testCaseSet {
 			t.Run(fmt.Sprintf("%s/%s/ipv6:%v", testCase.name, algo, addr.IsIPv6()), func(t *testing.T) {
@@ -1162,6 +1306,11 @@ func TestBPFOps(t *testing.T) {
 					}
 				}
 
+				if testCase.expectErr {
+					faultMaps.fail = true
+					defer func() { faultMaps.fail = false }()
+				}
+
 				if !testCase.delete {
 					err := ops.Update(
 						context.TODO(),
@@ -1169,7 +1318,17 @@ func TestBPFOps(t *testing.T) {
 						0,
 						&frontend,
 					)
-					require.NoError(t, err, "Update")
+					if testCase.expectErr {
+						require.Error(t, err, "Update")
+					} else {
+						require.NoError(t, err, "Update")
+					}
+
+					// Invariant: every backendStates entry must have a non-zero addr.
+					for beAddr, state := range ops.backendStates {
+						require.NotEqual(t, loadbalancer.L3n4Addr{}, state.addr,
+							"backendStates[%s] has zero-value addr; would panic in orphan cleanup", beAddr)
+					}
 				} else {
 					err := ops.Delete(
 						context.TODO(),
@@ -1178,6 +1337,12 @@ func TestBPFOps(t *testing.T) {
 						&frontend,
 					)
 					require.NoError(t, err, "Delete")
+				}
+
+				// Skip map validation and prune for error cases since the BPF maps
+				// are in a partially inconsistent state after a failed Update.
+				if testCase.expectErr {
+					return
 				}
 
 				// Prune to catch unexpected deletions.
@@ -1248,7 +1413,7 @@ func TestBPFOps(t *testing.T) {
 					Log:            log,
 					Config:         cfg,
 					ExternalConfig: external,
-					LBMaps:         lbmaps,
+					LBMaps:         faultMaps,
 					Maglev:         maglev,
 					DB:             db,
 					NodeAddresses:  nodeAddrs,
@@ -1274,7 +1439,7 @@ func TestBPFOps(t *testing.T) {
 				Log:            log,
 				Config:         cfg,
 				ExternalConfig: external,
-				LBMaps:         lbmaps,
+				LBMaps:         faultMaps,
 				Maglev:         maglev,
 				DB:             db,
 				NodeAddresses:  nodeAddrs,


### PR DESCRIPTION
When a BPF map write fails (E2BIG) during service reconciliation, updateReferences is never called, leaving backendReferences stale. If a backend is later released as an orphan and then re-added, updateBackendRevision creates a new backendStates entry but did not set the addr field — leaving it as a zero-value L3n4Addr.

On the next reconciliation, orphanBackends returns this entry and the agent calls orphanState.addr.IsIPv6() on the zero-value address, which panics with a nil pointer dereference.

Fix this by setting s.addr = addr in updateBackendRevision so that backendStates entries always have a valid address regardless of whether updateReferences runs.

Fixes: #44852

```release-note
lb: fix panic in orphan backend cleanup when addr is zero-value
```
