### PR TITLE
cilium-cli: inherit Azure profile env for az exec

### DIFF
--- a/cilium-cli/internal/utils/exec.go
+++ b/cilium-cli/internal/utils/exec.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -15,6 +16,7 @@ type Logger interface {
 
 func Exec(l Logger, command string, args ...string) ([]byte, error) {
 	c := exec.Command(command, args...)
+	c.Env = os.Environ()
 	bytes, err := c.CombinedOutput()
 	if err != nil {
 		cmdStr := fmt.Sprintf("%s %s", command, strings.Join(args, " "))

--- a/cilium-cli/internal/utils/exec_test.go
+++ b/cilium-cli/internal/utils/exec_test.go
@@ -4,38 +4,34 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-type failIfCalled struct {
-	t *testing.T
-}
+type testLogger struct{}
 
-func (f *failIfCalled) Log(_ string, _ ...any) {
-	f.t.Error("log method should not be called")
-}
+func (testLogger) Log(string, ...any) {}
 
-type countIfCalled struct {
-	count int
-}
+func TestExecInheritsEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
 
-func (c *countIfCalled) Log(_ string, _ ...any) {
-	c.count++
-}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "print-env.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s' \"$AZURE_CONFIG_DIR\"\n"), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
 
-func TestExec(t *testing.T) {
-	_, err := Exec(&failIfCalled{t}, "true")
-	assert.NoError(t, err)
+	t.Setenv("AZURE_CONFIG_DIR", "/tmp/azure-profile")
 
-	cl := &countIfCalled{0}
-	_, err = Exec(cl, "false")
-	assert.Error(t, err)
-	assert.Equal(t, 1, cl.count)
-
-	cl.count = 0
-	_, err = Exec(cl, "sh", "-c", "'echo foo; exit 1'")
-	assert.Error(t, err)
-	assert.Equal(t, 2, cl.count)
+	out, err := Exec(testLogger{}, script)
+	if err != nil {
+		t.Fatalf("Exec returned error: %v", err)
+	}
+	if string(out) != "/tmp/azure-profile" {
+		t.Fatalf("unexpected output %q", string(out))
+	}
 }


### PR DESCRIPTION
## Summary
- make the shared exec helper inherit the current process environment when spawning subprocesses
- add a regression test proving `AZURE_CONFIG_DIR` is preserved for child processes

## Why
- `cilium install` shells out to `az` for AKS Azure autodetection
- without inheriting the parent environment, `az` can ignore profile-specific environment such as `AZURE_CONFIG_DIR` and fall back to the default Azure CLI profile
- this PR is to address a bug found during testing that cilium-cli is not honoring `AZURE_CONFIG_DIR` to pick up Azure profile from an alternative folder

## Validation
- `go test ./cilium-cli/internal/utils/...`

Supersedes cilium/cilium-cli#3209, per maintainer request to open this change in `cilium/cilium` where the cilium-cli code now lives.