### PR TITLE
fix: harden k8s apiserver endpoint access

### DIFF
--- a/.github/actions/get-runner-ip/README.md
+++ b/.github/actions/get-runner-ip/README.md
@@ -1,0 +1,86 @@
+# Get Runner IP
+
+This composite action fetches the runner public IP address from a provided `source` URL, parses the response (as text or JSON), validates it looks like an IP address, and returns it as an output.
+
+## Inputs
+
+- **`source`** (required)
+
+  URL to fetch the runner public IP from.
+
+- **`parsing`** (optional, default: `text`)
+
+  Parsing mode for the fetched response.
+
+  Supported values:
+
+  - `text`: treat the response body as the IP address (after trimming)
+  - `json`: parse the response body as JSON and extract an IP field
+
+- **`json-key`** (optional)
+
+  When `parsing: json`, an optional dot-separated key path used to extract the IP address from the parsed JSON.
+
+  If not set, the action attempts common keys:
+
+  - `ip`
+  - `origin`
+  - `query`
+  - `address`
+  - `data.ip`
+  - `data.address`
+
+## Outputs
+
+- **`ip`**
+
+  The parsed and validated runner public IP address.
+
+- **`mask`**
+
+  The parsed and validated runner public IP mask.
+
+- **`cidr`**
+
+  The parsed and validated runner public IP in CIDR notation.
+
+## Examples
+
+### Parse plain text
+
+```yaml
+- name: Get runner IP
+  id: runner-ip
+  uses: ./.github/actions/get-runner-ip
+  with:
+    source: https://api.ipify.org
+    parsing: text
+
+- name: Print
+  run: |
+    echo "Runner IP: ${{ steps.runner-ip.outputs.ip }}"
+    echo "Runner Mask: ${{ steps.runner-ip.outputs.mask }}"
+    echo "Runner CIDR: ${{ steps.runner-ip.outputs.cidr }}"
+```
+
+### Parse JSON using a known key
+
+```yaml
+- name: Get runner IP
+  id: runner-ip
+  uses: ./.github/actions/get-runner-ip
+  with:
+    source: https://httpbin.org/ip
+    parsing: json
+    json-key: origin
+```
+
+## Behavior and error handling
+
+- The action fails if:
+
+  - `source` is empty
+  - the HTTP request fails or returns a non-2xx response
+  - `parsing: json` is selected but the response is not valid JSON
+  - no IP-like value can be extracted
+  - the extracted value does not look like an IPv4 or IPv6 address

--- a/.github/actions/get-runner-ip/action.yml
+++ b/.github/actions/get-runner-ip/action.yml
@@ -1,131 +1,118 @@
-
- name: Get Runner IP
- description: Fetch the runner public IP from a source and return it as an output.
- inputs:
-   source:
-     description: URL to fetch the runner public IP from.
-     required: true
-   parsing:
-     description: Parsing mode for the fetched response. Supported values are 'text' and 'json'.
-     required: false
-     default: text
-   json-key:
-     description: Optional JSON key (dot-separated) to extract the IP from when parsing is 'json'. If not set, common keys are tried.
-     required: false
- outputs:
-   ip:
-     description: The parsed and validated runner public IP address.
-     value: ${{ steps.get-ip.outputs.ip }}
-   mask:
-     description: The parsed and validated runner public IP mask.
-     value: ${{ steps.get-ip.outputs.mask }}
-   cidr:
-     description: The parsed and validated runner public IP in CIDR notation.
-     value: ${{ steps.get-ip.outputs.cidr }}
- runs:
-   using: composite
-   steps:
-     - name: Get runner public IP
-       id: get-ip
-       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-       with:
-         script: |
-           const source = `${{ inputs.source }}`.trim();
-           const parsing = `${{ inputs.parsing }}`.trim().toLowerCase();
-           const jsonKey = `${{ inputs['json-key'] }}`.trim();
-           const net = require('node:net');
-
-           if (!source) {
-             core.setFailed("Input 'source' must be a non-empty URL");
-             return;
-           }
-
-           const isLikelyIp = (value) => {
-             if (typeof value !== 'string') return false;
-             const v = value.trim();
-             if (!v) return false;
-             return net.isIP(v) !== 0;
-           };
-
-           const getByDotPath = (obj, path) => {
-             if (!path) return undefined;
-             return path.split('.').reduce((acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined), obj);
-           };
-
-           let response;
-           const timeoutMs = 15000;
-           const controller = new AbortController();
-           const timeout = setTimeout(() => {
-             controller.abort(new Error(`Request timed out after ${timeoutMs}ms`));
-           }, timeoutMs);
-           try {
-             response = await fetch(source, {
-               signal: controller.signal,
-               headers: {
-                 'User-Agent': 'actions/github-script get-runner-ip',
-                 'Accept': parsing === 'json' ? 'application/json,*/*' : '*/*',
-               },
-             });
-           } catch (e) {
-             core.setFailed(`Failed to fetch '${source}': ${e?.message || e}`);
-             return;
-           } finally {
-             clearTimeout(timeout);
-           }
-
-           if (!response.ok) {
-             const body = await response.text().catch(() => '');
-             core.setFailed(`Fetch '${source}' failed: HTTP ${response.status} ${response.statusText}${body ? `; body: ${body.slice(0, 200)}` : ''}`);
-             return;
-           }
-
-           const rawText = await response.text();
-           const trimmed = (rawText || '').trim();
-
-           let ip;
-           if (parsing === 'text') {
-             ip = trimmed;
-           } else if (parsing === 'json') {
-             let data;
-             try {
-               data = JSON.parse(trimmed);
-             } catch (e) {
-               core.setFailed(`Failed to parse JSON from '${source}': ${e?.message || e}; body starts with: ${trimmed.slice(0, 200)}`);
-               return;
-             }
-
-             const candidates = [];
-             if (jsonKey) {
-               candidates.push(getByDotPath(data, jsonKey));
-             }
-             // Common response shapes from IP endpoints
-             candidates.push(data?.ip);
-             candidates.push(data?.origin);
-             candidates.push(data?.query);
-             candidates.push(data?.address);
-             candidates.push(data?.data?.ip);
-             candidates.push(data?.data?.address);
-
-             ip = candidates.find((c) => typeof c === 'string' && c.trim().length > 0);
-             if (typeof ip === 'string') {
-               ip = ip.trim();
-             }
-           } else {
-             core.setFailed(`Unsupported parsing mode '${parsing}'. Use 'text' or 'json'.`);
-             return;
-           }
-
-           if (!ip || typeof ip !== 'string') {
-             core.setFailed(`No IP address found in response from '${source}'.`);
-             return;
-           }
-
-           if (!isLikelyIp(ip)) {
-             core.setFailed(`Parsed value is not a valid IP address: '${ip}'`);
-             return;
-           }
-
-           core.setOutput('ip', ip);
-           const mask = net.isIPv6(ip) ? "128" : "32";
-           core.setOutput('mask', mask);
-           core.setOutput('cidr', `${ip}/${mask}`);
+name: Get Runner IP
+description: Fetch the runner public IP from a source and return it as an output.
+inputs:
+  source:
+    description: URL to fetch the runner public IP from.
+    required: true
+  parsing:
+    description: Parsing mode for the fetched response. Supported values are 'text' and 'json'.
+    required: false
+    default: text
+  json-key:
+    description: Optional JSON key (dot-separated) to extract the IP from when parsing is 'json'. If not set, common keys are tried.
+    required: false
+outputs:
+  ip:
+    description: The parsed and validated runner public IP address.
+    value: ${{ steps.get-ip.outputs.ip }}
+  mask:
+    description: The parsed and validated runner public IP mask.
+    value: ${{ steps.get-ip.outputs.mask }}
+  cidr:
+    description: The parsed and validated runner public IP in CIDR notation.
+    value: ${{ steps.get-ip.outputs.cidr }}
+runs:
+  using: composite
+  steps:
+    - name: Get runner public IP
+      id: get-ip
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      with:
+        script: |
+          const source = `${{ inputs.source }}`.trim();
+          const parsing = `${{ inputs.parsing }}`.trim().toLowerCase();
+          const jsonKey = `${{ inputs['json-key'] }}`.trim();
+          const net = require('node:net');
+          if (!source) {
+            core.setFailed("Input 'source' must be a non-empty URL");
+            return;
+          }
+          const isLikelyIp = (value) => {
+            if (typeof value !== 'string') return false;
+            const v = value.trim();
+            if (!v) return false;
+            return net.isIP(v) !== 0;
+          };
+          const getByDotPath = (obj, path) => {
+            if (!path) return undefined;
+            return path.split('.').reduce((acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined), obj);
+          };
+          let response;
+          const timeoutMs = 15000;
+          const controller = new AbortController();
+          const timeout = setTimeout(() => {
+            controller.abort(new Error(`Request timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
+          try {
+            response = await fetch(source, {
+              signal: controller.signal,
+              headers: {
+                'User-Agent': 'actions/github-script get-runner-ip',
+                'Accept': parsing === 'json' ? 'application/json,*/*' : '*/*',
+              },
+            });
+          } catch (e) {
+            core.setFailed(`Failed to fetch '${source}': ${e?.message || e}`);
+            return;
+          } finally {
+            clearTimeout(timeout);
+          }
+          if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            core.setFailed(`Fetch '${source}' failed: HTTP ${response.status} ${response.statusText}${body ? `; body: ${body.slice(0, 200)}` : ''}`);
+            return;
+          }
+          const rawText = await response.text();
+          const trimmed = (rawText || '').trim();
+          let ip;
+          if (parsing === 'text') {
+            ip = trimmed;
+          } else if (parsing === 'json') {
+            let data;
+            try {
+              data = JSON.parse(trimmed);
+            } catch (e) {
+              core.setFailed(`Failed to parse JSON from '${source}': ${e?.message || e}; body starts with: ${trimmed.slice(0, 200)}`);
+              return;
+            }
+            const candidates = [];
+            if (jsonKey) {
+              candidates.push(getByDotPath(data, jsonKey));
+            }
+            // Common response shapes from IP endpoints
+            candidates.push(data?.ip);
+            candidates.push(data?.origin);
+            candidates.push(data?.query);
+            candidates.push(data?.address);
+            candidates.push(data?.data?.ip);
+            candidates.push(data?.data?.address);
+            ip = candidates.find((c) => typeof c === 'string' && c.trim().length > 0);
+            if (typeof ip === 'string') {
+              ip = ip.trim();
+            }
+          } else {
+            core.setFailed(`Unsupported parsing mode '${parsing}'. Use 'text' or 'json'.`);
+            return;
+          }
+          if (!ip || typeof ip !== 'string') {
+            core.setFailed(`No IP address found in response from '${source}'.`);
+            return;
+          }
+          if (!isLikelyIp(ip)) {
+            core.setFailed(`Parsed value is not a valid IP address: '${ip}'`);
+            return;
+          }
+          core.setOutput('ip', ip);
+          const mask = net.isIPv6(ip) ? "128" : "32";
+          core.setOutput('mask', mask);
+          core.setOutput('cidr', `${ip}/${mask}`);

--- a/.github/actions/get-runner-ip/action.yml
+++ b/.github/actions/get-runner-ip/action.yml
@@ -1,0 +1,131 @@
+
+ name: Get Runner IP
+ description: Fetch the runner public IP from a source and return it as an output.
+ inputs:
+   source:
+     description: URL to fetch the runner public IP from.
+     required: true
+   parsing:
+     description: Parsing mode for the fetched response. Supported values are 'text' and 'json'.
+     required: false
+     default: text
+   json-key:
+     description: Optional JSON key (dot-separated) to extract the IP from when parsing is 'json'. If not set, common keys are tried.
+     required: false
+ outputs:
+   ip:
+     description: The parsed and validated runner public IP address.
+     value: ${{ steps.get-ip.outputs.ip }}
+   mask:
+     description: The parsed and validated runner public IP mask.
+     value: ${{ steps.get-ip.outputs.mask }}
+   cidr:
+     description: The parsed and validated runner public IP in CIDR notation.
+     value: ${{ steps.get-ip.outputs.cidr }}
+ runs:
+   using: composite
+   steps:
+     - name: Get runner public IP
+       id: get-ip
+       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+       with:
+         script: |
+           const source = `${{ inputs.source }}`.trim();
+           const parsing = `${{ inputs.parsing }}`.trim().toLowerCase();
+           const jsonKey = `${{ inputs['json-key'] }}`.trim();
+           const net = require('node:net');
+
+           if (!source) {
+             core.setFailed("Input 'source' must be a non-empty URL");
+             return;
+           }
+
+           const isLikelyIp = (value) => {
+             if (typeof value !== 'string') return false;
+             const v = value.trim();
+             if (!v) return false;
+             return net.isIP(v) !== 0;
+           };
+
+           const getByDotPath = (obj, path) => {
+             if (!path) return undefined;
+             return path.split('.').reduce((acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined), obj);
+           };
+
+           let response;
+           const timeoutMs = 15000;
+           const controller = new AbortController();
+           const timeout = setTimeout(() => {
+             controller.abort(new Error(`Request timed out after ${timeoutMs}ms`));
+           }, timeoutMs);
+           try {
+             response = await fetch(source, {
+               signal: controller.signal,
+               headers: {
+                 'User-Agent': 'actions/github-script get-runner-ip',
+                 'Accept': parsing === 'json' ? 'application/json,*/*' : '*/*',
+               },
+             });
+           } catch (e) {
+             core.setFailed(`Failed to fetch '${source}': ${e?.message || e}`);
+             return;
+           } finally {
+             clearTimeout(timeout);
+           }
+
+           if (!response.ok) {
+             const body = await response.text().catch(() => '');
+             core.setFailed(`Fetch '${source}' failed: HTTP ${response.status} ${response.statusText}${body ? `; body: ${body.slice(0, 200)}` : ''}`);
+             return;
+           }
+
+           const rawText = await response.text();
+           const trimmed = (rawText || '').trim();
+
+           let ip;
+           if (parsing === 'text') {
+             ip = trimmed;
+           } else if (parsing === 'json') {
+             let data;
+             try {
+               data = JSON.parse(trimmed);
+             } catch (e) {
+               core.setFailed(`Failed to parse JSON from '${source}': ${e?.message || e}; body starts with: ${trimmed.slice(0, 200)}`);
+               return;
+             }
+
+             const candidates = [];
+             if (jsonKey) {
+               candidates.push(getByDotPath(data, jsonKey));
+             }
+             // Common response shapes from IP endpoints
+             candidates.push(data?.ip);
+             candidates.push(data?.origin);
+             candidates.push(data?.query);
+             candidates.push(data?.address);
+             candidates.push(data?.data?.ip);
+             candidates.push(data?.data?.address);
+
+             ip = candidates.find((c) => typeof c === 'string' && c.trim().length > 0);
+             if (typeof ip === 'string') {
+               ip = ip.trim();
+             }
+           } else {
+             core.setFailed(`Unsupported parsing mode '${parsing}'. Use 'text' or 'json'.`);
+             return;
+           }
+
+           if (!ip || typeof ip !== 'string') {
+             core.setFailed(`No IP address found in response from '${source}'.`);
+             return;
+           }
+
+           if (!isLikelyIp(ip)) {
+             core.setFailed(`Parsed value is not a valid IP address: '${ip}'`);
+             return;
+           }
+
+           core.setOutput('ip', ip);
+           const mask = net.isIPv6(ip) ? "128" : "32";
+           core.setOutput('mask', mask);
+           core.setOutput('cidr', `${ip}/${mask}`);

--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -26,32 +26,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get Runner IP
+    - name: Get runner public IP
       id: get-runner-ip
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      uses: ./.github/actions/get-runner-ip
       with:
-        script: |
-          const net = require('net');
-          const url = 'https://whatismyip.azurewebsites.net/json/';
-          const res = await fetch(
-            url, {
-              method: 'GET',
-              headers: {
-                'Content-Type': 'application/json'
-              }
-            });
-
-          if (!res.ok) {
-            throw new Error(`Failed to fetch IP address: ${res.status} ${res.statusText}`);
-          }
-
-          const data = await res.json();
-          const ip = data.ip;
-          if (!net.isIP(ip)) {
-            throw new Error(`Invalid IP address: ${ip}`);
-          }
-
-          return `${ip}/32`;
+        source: https://whatismyip.azurewebsites.net/json/
+        parsing: json
+        json-key: ip
 
     - name: Create AKS cluster
       shell: bash
@@ -84,5 +65,5 @@ runs:
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
           --generate-ssh-keys \
-          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.result }}
+          --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }}
 

--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -39,6 +39,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Get runner public IP
+      id: get-runner-ip
+      uses: ./.github/actions/get-runner-ip
+      with:
+        source: https://checkip.amazonaws.com
+        parsing: text
+
     - name: Try to get cluster from pool
       id: get-from-pool
       if: ${{ inputs.create-cluster != 'true' }}
@@ -91,6 +98,12 @@ runs:
                 # Health check: verify cluster is accessible
                 echo "Checking cluster health for ${CLUSTER_NAME}..."
                 export KUBECONFIG="${KUBECONFIG_PATH}"
+
+                # add runner ip to allowed CIDRs if not already present (handles case where pool manager creates with different CIDR)
+                eksctl utils update-cluster-vpc-config --cluster "${CLUSTER_NAME}" \
+                  --public-access-cidrs="${{ steps.get-runner-ip.outputs.cidr }}" \
+                  --public-access=true --private-access=true --approve || \
+                  echo "Failed to update cluster endpoints (may not have permissions)."
 
                 if timeout 30 kubectl cluster-info &> /dev/null && \
                    timeout 30 kubectl get --raw /healthz &> /dev/null; then
@@ -145,6 +158,7 @@ runs:
           clusterEndpoints:
             publicAccess: true
             privateAccess: true
+          publicAccessCidrs: [ "${{ steps.get-runner-ip.outputs.cidr }}" ]
 
         addonsConfig:
           disableDefaultAddons: true

--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -35,19 +35,12 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: runner-ip
-      shell: bash
-      run: |
-        RUNNER_IP=$(curl -sf https://ipinfo.io/ip | tr -d '[:space:]')
-        if [[ -z "${RUNNER_IP}" ]]; then
-          echo "::error::Failed to fetch runner's public IP address"
-          exit 1
-        fi
-        if ! [[ "${RUNNER_IP}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "::error::Invalid IP address format: ${RUNNER_IP}"
-          exit 1
-        fi
-        echo "runner_ip=${RUNNER_IP}" >> $GITHUB_OUTPUT
+    - name: Get runner public IP
+      id: get-runner-ip
+      uses: ./.github/actions/get-runner-ip
+      with:
+        source: https://api.ipify.org
+        parsing: text
 
     - id: create-cluster
       shell: bash
@@ -81,7 +74,7 @@ runs:
           --disk-size 20GB \
           --no-enable-insecure-kubelet-readonly-port \
           --enable-master-authorized-networks \
-          --master-authorized-networks "${{ steps.runner-ip.outputs.runner_ip }}/32" \
+          --master-authorized-networks "${{ steps.get-runner-ip.outputs.cidr }}" \
           $VERSION \
           $LABELS \
           $TAINTS

--- a/.github/workflows/eks-cluster-delete.yaml
+++ b/.github/workflows/eks-cluster-delete.yaml
@@ -39,8 +39,18 @@ jobs:
           role-to-assume: ${{ secrets.AWS_PR_ASSUME_ROLE }}
           aws-region: ${{ inputs.region }}
 
+      - name: Get runner public IP
+        id: get-runner-ip
+        uses: ./.github/actions/get-runner-ip
+        with:
+          source: https://checkip.amazonaws.com
+          parsing: text
+
       - name: Delete EKS cluster
         run: |
+          eksctl utils update-cluster-vpc-config --cluster "${{ inputs.cluster_name }}" \
+            --public-access-cidrs="${{ steps.get-runner-ip.outputs.cidr }}" \
+            --public-access=true --private-access=true --approve || \
           eksctl delete cluster --name "${{ inputs.cluster_name }}" --region ${{ inputs.region }}
         shell: bash {0} # Disable default fail-fast behaviour
 

--- a/.github/workflows/eks-cluster-pool-manager.yaml
+++ b/.github/workflows/eks-cluster-pool-manager.yaml
@@ -88,6 +88,13 @@ jobs:
           role-to-assume: ${{ secrets.AWS_PR_ASSUME_ROLE }}
           aws-region: ${{ matrix.region }}
 
+      - name: Get runner public IP
+        id: get-runner-ip
+        uses: ./.github/actions/get-runner-ip
+        with:
+          source: https://checkip.amazonaws.com
+          parsing: text
+
       - name: List and delete old clusters
         env:
           REGION: ${{ matrix.region }}
@@ -176,6 +183,11 @@ jobs:
                 echo "Removing kubeconfigs for cluster ${cluster} from S3 bucket ${S3_BUCKET}"
                 aws s3 rm "s3://${S3_BUCKET}/kubeconfig-pool/" --recursive --exclude "*" --include "${cluster}-*" --region ${REGION} || true
               fi
+
+              eksctl utils update-cluster-vpc-config --cluster ${cluster} \
+                --public-access-cidrs="${{ steps.get-runner-ip.outputs.cidr }}" \
+                --public-access=true --private-access=true --approve || \
+                echo "Failed to update cluster endpoints (may not have permissions)."
 
               # Delete the cluster
               eksctl delete cluster --name ${cluster} --region ${REGION} --wait || {


### PR DESCRIPTION
This PR tries to harden the K8s server cluster apiservre endpoint by allowing access to runner IP alone.

Includes: 

https://github.com/cilium/cilium/pull/43694