### PR TITLE
docs: Remove Istio incompatibility note for BPF Host Routing

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -187,9 +187,6 @@ in any of the Cilium pods and look for the line reporting the status for
 "Host Routing" which should state "BPF".
 
 .. note::
-   BPF Host Routing is incompatible with Istio (see :gh-issue:`36022` for details).
-
-.. note::
    When using BPF Host Routing with IPsec, `a kernel bugfix <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c4327229948879814229b46aa26a750718888503>`_
    is required. If you observe connectivity problems, ensure that the kernel
    package on your nodes has been upgraded recently before reporting an issue.


### PR DESCRIPTION
I reviewed the previous documentation changes and the related issue discussion, and I saw that a PR was merged to revert the docs after confirming that there was no incompatibility with Istio.

However, I noticed that the tuning guide was not reverted. Unless there is a specific reason to keep it as-is, it seems more consistent to revert that document as well.

If there is another issue or context I might be missing, could you clarify?


Context : #38338 
Context : #39503 


