### PR TITLE
[v1.17] ipam: Fix race in multipool test helper causing flaky timeout

### DIFF
--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -688,7 +688,9 @@ func (f *fakeK8sCiliumNodeAPIResource) Events(ctx context.Context, _ ...resource
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
-	f.c = make(chan resource.Event[*ciliumv2.CiliumNode])
+	if f.c == nil {
+		f.c = make(chan resource.Event[*ciliumv2.CiliumNode])
+	}
 	return f.c
 }
 


### PR DESCRIPTION
`fakeK8sCiliumNodeAPIResource.Events()` unconditionally replaces `f.c`
with a new channel. Tests that call `go updateNode()` before
`newMultiPoolManager` can deadlock when the goroutine captures the old
channel before `Events()` replaces it, causing `waitForAllPools` to block
until the test timeout.

Only create the channel if one doesn't already exist.

Fixes: #44869