### PR TITLE
Do not require iptables for L7 proxy when BPF TProxy is enabled

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1053,8 +1053,8 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 		logging.Fatal(logger, "Unable to parse Label prefix configuration", logfields.Error, err)
 	}
 
-	if option.Config.EnableL7Proxy && !option.Config.InstallIptRules {
-		logging.Fatal(logger, "L7 proxy requires iptables rules (--install-iptables-rules=\"true\")")
+	if option.Config.EnableL7Proxy && !option.Config.InstallIptRules && !option.Config.EnableBPFTProxy {
+		logging.Fatal(logger, "L7 proxy requires iptables rules (--install-iptables-rules=\"true\") or BPF TProxy (--enable-bpf-tproxy=\"true\")")
 	}
 
 	if option.Config.EnableRemoteNodeMasquerade && !option.Config.EnableBPFMasquerade {


### PR DESCRIPTION
The startup validation unconditionally required install-iptables-rules=true when enable-l7-proxy=true, which appears to be a bug in the configuration check. L7 proxy works well with BPF TProxy (enable-bpf-tproxy=true) as an alternative proxy redirection mechanism via BPF socket assign, and does not need iptables in that case.

Somewhat related to https://github.com/cilium/cilium/issues/12879

```release-note
Do not require iptables for L7 proxy when BPF TProxy is enabled
```