### PR TITLE
workflows/kpr: Split across cloud providers

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -17,7 +17,9 @@ triggers:
     - conformance-ingress.yaml
     - conformance-l3-l4.yaml
     - conformance-l7.yaml
-    - conformance-kpr.yaml
+    - conformance-kpr-aks.yaml
+    - conformance-kpr-eks.yaml
+    - conformance-kpr-gke.yaml
     - conformance-multi-pool.yaml
     - conformance-race.yaml
     - conformance-runtime.yaml
@@ -99,9 +101,19 @@ triggers:
   /ci-integration:
     workflows:
     - integration-test.yaml
-  /ci-kpr:
+  /ci-kpr-aks:
     workflows:
-    - conformance-kpr.yaml
+    - conformance-kpr-aks.yaml
+    depends-on:
+    - /build-images-dependency
+  /ci-kpr-eks:
+    workflows:
+    - conformance-kpr-eks.yaml
+    depends-on:
+    - /build-images-dependency
+  /ci-kpr-gke:
+    workflows:
+    - conformance-kpr-gke.yaml
     depends-on:
     - /build-images-dependency
   /ci-kubespray:
@@ -199,7 +211,11 @@ workflows:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-ingress.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
-  conformance-kpr.yaml:
+  conformance-kpr-aks.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  conformance-kpr-eks.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  conformance-kpr-gke.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-kubespray.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)

--- a/.github/workflows/conformance-kpr-aks.yaml
+++ b/.github/workflows/conformance-kpr-aks.yaml
@@ -1,0 +1,144 @@
+name: Conformance KPR AKS (ci-kpr-aks)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      base-SHA:
+        description: "SHA of the base branch (target branch of the PR)."
+        required: false
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+  # Run every 12 hours
+  schedule:
+    - cron:  '0 4/12 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
+concurrency:
+  # Structure:
+  # - Parent concurrency group name to avoid deadlock with child workflows
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    parent
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: cilium/cilium/.github/actions/set-commit-status@main
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+          images: cilium-ci operator-generic-ci hubble-relay-ci
+
+  conformance-aks-kpr:
+    name: Conformance AKS with KPR
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-aks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 1
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "advanced-features": true}'
+
+  conformance-aks-kpr-ipsec:
+    name: Conformance AKS with KPR + IPsec
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-aks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 2
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
+
+  conformance-aks-kpr-wireguard:
+    name: Conformance AKS with KPR + WireGuard
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-aks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 3
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: [conformance-aks-kpr, conformance-aks-kpr-ipsec, conformance-aks-kpr-wireguard]
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      success: ${{ (needs.conformance-aks-kpr.result == 'success' && needs.conformance-aks-kpr-ipsec.result == 'success' && needs.conformance-aks-kpr-wireguard.result == 'success') }}

--- a/.github/workflows/conformance-kpr-eks.yaml
+++ b/.github/workflows/conformance-kpr-eks.yaml
@@ -1,4 +1,4 @@
-name: Conformance KPR (ci-kpr)
+name: Conformance KPR EKS (ci-kpr-eks)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -135,85 +135,13 @@ jobs:
       extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
       test-concurrency: 2
 
-  conformance-gke-kpr:
-    name: Conformance GKE with KPR
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-gke.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 1
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true}'
-
-  conformance-gke-kpr-ipsec:
-    name: Conformance GKE with KPR + IPsec
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-gke.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 2
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
-
-  conformance-gke-kpr-wireguard:
-    name: Conformance GKE with KPR + WireGuard
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-gke.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 3
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
-
-  conformance-aks-kpr:
-    name: Conformance AKS with KPR
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-aks.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 1
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true}'
-
-  conformance-aks-kpr-ipsec:
-    name: Conformance AKS with KPR + IPsec
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-aks.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 2
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
-
-  conformance-aks-kpr-wireguard:
-    name: Conformance AKS with KPR + WireGuard
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-aks.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 3
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
-
   merge-upload-and-status:
     name: Merge Upload and Status
     if: ${{ always() }}
-    needs: [conformance-eks-kpr, conformance-eks-kpr-ipsec, conformance-eks-kpr-wireguard, conformance-gke-kpr, conformance-gke-kpr-ipsec, conformance-gke-kpr-wireguard, conformance-aks-kpr, conformance-aks-kpr-ipsec, conformance-aks-kpr-wireguard]
+    needs: [conformance-eks-kpr, conformance-eks-kpr-ipsec, conformance-eks-kpr-wireguard]
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-eks-kpr.result == 'success' && needs.conformance-eks-kpr-ipsec.result == 'success' && needs.conformance-eks-kpr-wireguard.result == 'success' && needs.conformance-gke-kpr.result == 'success' && needs.conformance-gke-kpr-ipsec.result == 'success' && needs.conformance-gke-kpr-wireguard.result == 'success' && needs.conformance-aks-kpr.result == 'success' && needs.conformance-aks-kpr-ipsec.result == 'success' && needs.conformance-aks-kpr-wireguard.result == 'success') }}
+      success: ${{ (needs.conformance-eks-kpr.result == 'success' && needs.conformance-eks-kpr-ipsec.result == 'success' && needs.conformance-eks-kpr-wireguard.result == 'success') }}

--- a/.github/workflows/conformance-kpr-gke.yaml
+++ b/.github/workflows/conformance-kpr-gke.yaml
@@ -1,0 +1,144 @@
+name: Conformance KPR GKE (ci-kpr-gke)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      base-SHA:
+        description: "SHA of the base branch (target branch of the PR)."
+        required: false
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+  # Run every 12 hours
+  schedule:
+    - cron:  '0 4/12 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+  # To be able to request the JWT from GitHub's OIDC provider
+  id-token: write
+
+concurrency:
+  # Structure:
+  # - Parent concurrency group name to avoid deadlock with child workflows
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    parent
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: cilium/cilium/.github/actions/set-commit-status@main
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  wait-for-images:
+    name: Wait for images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+          images: cilium-ci operator-generic-ci hubble-relay-ci
+
+  conformance-gke-kpr:
+    name: Conformance GKE with KPR
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-gke.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 1
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "advanced-features": true}'
+
+  conformance-gke-kpr-ipsec:
+    name: Conformance GKE with KPR + IPsec
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-gke.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 2
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
+
+  conformance-gke-kpr-wireguard:
+    name: Conformance GKE with KPR + WireGuard
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-gke.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 3
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
+
+  merge-upload-and-status:
+    name: Merge Upload and Status
+    if: ${{ always() }}
+    needs: [conformance-gke-kpr, conformance-gke-kpr-ipsec, conformance-gke-kpr-wireguard]
+    uses: ./.github/workflows/common-post-jobs.yaml
+    secrets: inherit
+    with:
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      sha: ${{ inputs.SHA || github.sha }}
+      success: ${{ (needs.conformance-gke-kpr.result == 'success' && needs.conformance-gke-kpr-ipsec.result == 'success' && needs.conformance-gke-kpr-wireguard.result == 'success') }}


### PR DESCRIPTION
The Conformance KPR workflow currently includes coverage for several advanced features across all three cloud providers covered in CI. That a pretty large coverage and any failure in one of the configs/cloud providers results in a workflow failure.

To make the flakes more manageable, we decided to split it across the cloud providers, having three workflows instead of one. This commit simply (1) copies the file three times and removes the code specific to two of the providers in each file and (2) updates the Ariane accordingly.

Note for GKE and AKS, we can relax the permissions to read-only for actions as write permission was only needed to trigger the `eks-cluster-pool-manager.yaml` workflow.