### PR TITLE
gateway-api: fix listener isolation for shared hostnames and ports

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -639,6 +639,8 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
 	}
 
+	conflictedListeners := samePortCrossProtocolConflictedListeners(gw)
+
 	// Keep track of if there is at least one Valid Listener; if not, the Gateway cannot be Accepted.
 	oneValidListener := false
 	for _, l := range gw.Spec.Listeners {
@@ -647,6 +649,12 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		invalidReason := gatewayv1.ListenerReasonInvalid
 
 		var conds []metav1.Condition
+
+		if conflictMessage, ok := conflictedListeners[l.Name]; ok {
+			conds = merge(conds, gatewayListenerConflictedCondition(gw, gatewayv1.ListenerReasonProtocolConflict, conflictMessage))
+			invalidMessages = append(invalidMessages, conflictMessage)
+			isValid = false
+		}
 
 		allSupported := getSupportedRouteKinds(l.Protocol)
 		if allSupported == nil {
@@ -794,6 +802,43 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 	}
 	gw.Status.Listeners = newListenersStatus
 	return oneValidListener, nil
+}
+
+func samePortCrossProtocolConflictedListeners(gw *gatewayv1.Gateway) map[gatewayv1.SectionName]string {
+	conflicted := map[gatewayv1.SectionName]string{}
+
+	for i := range gw.Spec.Listeners {
+		for j := i + 1; j < len(gw.Spec.Listeners); j++ {
+			first := &gw.Spec.Listeners[i]
+			second := &gw.Spec.Listeners[j]
+			if !listenersHaveSamePortCrossProtocolHostnameConflict(first, second) {
+				continue
+			}
+
+			conflicted[first.Name] = samePortCrossProtocolConflictMessage(second.Name, first.Port)
+			conflicted[second.Name] = samePortCrossProtocolConflictMessage(first.Name, second.Port)
+		}
+	}
+
+	return conflicted
+}
+
+func listenersHaveSamePortCrossProtocolHostnameConflict(first, second *gatewayv1.Listener) bool {
+	if first.Port != second.Port {
+		return false
+	}
+
+	if helpers.IsHTTPSTerminatedListener(first) && helpers.IsTLSPassthroughListener(second) {
+		return helpers.SNIHostnamesIntersect(helpers.ListenerHostname(first), helpers.ListenerHostname(second))
+	}
+	if helpers.IsHTTPSTerminatedListener(second) && helpers.IsTLSPassthroughListener(first) {
+		return helpers.SNIHostnamesIntersect(helpers.ListenerHostname(first), helpers.ListenerHostname(second))
+	}
+	return false
+}
+
+func samePortCrossProtocolConflictMessage(listenerName gatewayv1.SectionName, port gatewayv1.PortNumber) string {
+	return fmt.Sprintf("Listener conflicts with listener %q: same port %d has overlapping HTTPS and TLS passthrough hostnames.", listenerName, port)
 }
 
 func validateTLSSecret(ctx context.Context, c client.Client, namespace, name string) error {

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -148,6 +148,17 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	btlspMap := helpers.BuildBackendTLSPolicyLookup(btlspList)
 
+	var namespaces []corev1.Namespace
+	if hasAllowedRoutesNamespaceSelector(gw) {
+		namespaceList := &corev1.NamespaceList{}
+		if err := r.Client.List(ctx, namespaceList); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list Namespaces", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+		namespaces = namespaceList.Items
+	}
+	namespaceLabels := helpers.NewNamespaceLabelIndex(namespaces)
+
 	// TODO(tam): Only list the services / ServiceImports used by accepted Routes
 	servicesList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, servicesList); err != nil {
@@ -194,9 +205,9 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Fail(err)
 	}
 
-	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, httpRouteList.Items)
-	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, tlsRouteList.Items)
-	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, grpcRouteList.Items)
+	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, httpRouteList.Items, namespaceLabels)
+	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, tlsRouteList.Items, namespaceLabels)
+	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, grpcRouteList.Items, namespaceLabels)
 
 	if err := r.setBackendTLSPolicyStatuses(scopedLog, ctx, httpRoutes, btlspMap, req.NamespacedName); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to update BackendTLSPolicy Status", logfields.Error, err)
@@ -211,13 +222,14 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		HTTPRoutes:          httpRoutes,
 		TLSRoutes:           tlsRoutes,
 		GRPCRoutes:          grpcRoutes,
+		Namespaces:          namespaces,
 		Services:            servicesList.Items,
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
 		BackendTLSPolicyMap: btlspMap,
 	})
 
-	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList)
+	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, namespaceLabels)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to set listener status", gatewayv1.GatewayReasonNoResources)
@@ -297,6 +309,21 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	scopedLog.InfoContext(ctx, "Successfully reconciled Gateway")
 	return controllerruntime.Success()
+}
+
+func hasAllowedRoutesNamespaceSelector(gw *gatewayv1.Gateway) bool {
+	for _, listener := range gw.Spec.Listeners {
+		if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
+			continue
+		}
+		if listener.AllowedRoutes.Namespaces.From != nil && *listener.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromSelector {
+			return true
+		}
+		if listener.AllowedRoutes.Namespaces.From == nil && listener.AllowedRoutes.Namespaces.Selector != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.Service) error {
@@ -392,34 +419,34 @@ func (r *gatewayReconciler) updateStatus(ctx context.Context, original *gatewayv
 	return r.Client.Status().Update(ctx, new)
 }
 
-func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
+func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
-			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
+			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
@@ -428,11 +455,11 @@ func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *
 	return filtered
 }
 
-func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
+func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
-			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
+			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
@@ -481,10 +508,10 @@ func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route
 	return false
 }
 
-func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
+func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) &&
 			len(computeHosts(gw, route.Spec.Hostnames, nil)) > 0 {
 			filtered = append(filtered, route)
 		}
@@ -492,11 +519,11 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 	return filtered
 }
 
-func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
+func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
-			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
+			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
@@ -606,7 +633,7 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	return nil
 }
 
-func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList) (bool, error) {
+func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, namespaceLabels helpers.NamespaceLabelIndex) (bool, error) {
 	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
@@ -731,9 +758,9 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 				gatewayListenerProgrammedCondition(gw, false, "Address not ready yet"))
 		}
 		var attachedRoutes int32
-		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, httpRoutes.Items)))
-		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, grpcRoutes.Items)))
-		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, tlsRoutes.Items)))
+		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, httpRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, grpcRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, tlsRoutes.Items, namespaceLabels)))
 
 		found := false
 		for i := range gw.Status.Listeners {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -300,6 +300,7 @@ func Test_Conformance(t *testing.T) {
 		{name: "gateway-multi-port-tls-passthrough", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-tls-passthrough", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gateway-multi-port-https-with-multi-port-tls-passthrough", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-https-with-multi-port-tls-passthrough", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gateway-cross-protocol-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-hostname", Namespace: "gateway-conformance-infra"}}}},
+		{name: "gateway-cross-protocol-same-port-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-port-same-hostname", Namespace: "gateway-conformance-infra"}, wantErr: true}}},
 		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 	}
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -297,6 +297,7 @@ func Test_Conformance(t *testing.T) {
 		{name: "tlsroute-mixed-protocol-listeners", gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "gateway-tlsroute-mixed", Namespace: "gateway-conformance-infra"}},
 		}},
+		{name: "gateway-multi-port-tls-passthrough", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-tls-passthrough", Namespace: "gateway-conformance-infra"}}}},
 	}
 
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -298,6 +298,9 @@ func Test_Conformance(t *testing.T) {
 			{FullName: types.NamespacedName{Name: "gateway-tlsroute-mixed", Namespace: "gateway-conformance-infra"}},
 		}},
 		{name: "gateway-multi-port-tls-passthrough", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-tls-passthrough", Namespace: "gateway-conformance-infra"}}}},
+		{name: "gateway-multi-port-https-with-multi-port-tls-passthrough", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-https-with-multi-port-tls-passthrough", Namespace: "gateway-conformance-infra"}}}},
+		{name: "gateway-cross-protocol-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-hostname", Namespace: "gateway-conformance-infra"}}}},
+		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 	}
 
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -280,6 +280,7 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-backendtlspolicy-conflict-resolution", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-backendtlspolicy-invalid-ca-cert", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-backendtlspolicy-invalid-kind", gateway: []gwDetails{gatewaySameNamespace}},
+		{name: "gateway-multi-port-https", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-https", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute-referencegrant", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-hostname-intersection", gateway: []gwDetails{

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -146,6 +146,17 @@ func gatewayListenerAcceptedCondition(gw *gatewayv1.Gateway, ready bool, reason 
 	}
 }
 
+func gatewayListenerConflictedCondition(gw *gatewayv1.Gateway, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
+	return metav1.Condition{
+		Type:               string(gatewayv1.ListenerConditionConflicted),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(reason),
+		Message:            msg,
+		ObservedGeneration: gw.GetGeneration(),
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+}
+
 func gatewayListenerInvalidRouteKinds(gw *gatewayv1.Gateway, msg string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(gatewayv1.ListenerConditionResolvedRefs),

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -4,18 +4,15 @@
 package gateway_api
 
 import (
-	"context"
-	"log/slog"
 	"maps"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	gatewayapihelpers "github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -53,83 +50,26 @@ func groupDerefOr(group *gatewayv1.Group, defaultGroup string) string {
 }
 
 // isAllowed returns true if the provided Route is allowed to attach to given gateway
-func isAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, route metav1.Object, logger *slog.Logger) bool {
+func isAllowed(gw *gatewayv1.Gateway, route metav1.Object, namespaceLabels gatewayapihelpers.NamespaceLabelIndex) bool {
 	for _, listener := range gw.Spec.Listeners {
-
-		// all routes in the same namespace are allowed for this listener
-		if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
-			if route.GetNamespace() == gw.GetNamespace() {
-				return true
-			}
-			continue
-		}
-
-		// check if route is kind-allowed
-		if !isKindAllowed(listener, route) {
-			continue
-		}
-
-		// check if route is namespace-allowed
-		switch *listener.AllowedRoutes.Namespaces.From {
-		case gatewayv1.NamespacesFromAll:
+		if listenerisAllowed(gw, &listener, route, namespaceLabels) {
 			return true
-		case gatewayv1.NamespacesFromSame:
-			if route.GetNamespace() == gw.GetNamespace() {
-				return true
-			}
-		case gatewayv1.NamespacesFromSelector:
-			nsList := &corev1.NamespaceList{}
-			selector, _ := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
-			if err := c.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-				logger.ErrorContext(ctx, "Unable to list namespaces", logfields.Error, err)
-				continue
-			}
-
-			for _, ns := range nsList.Items {
-				if ns.Name == route.GetNamespace() {
-					return true
-				}
-			}
 		}
 	}
 	return false
 }
 
-// listenerisAllowed is a single listener check to see if a route and listerner are valid
-func listenerisAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route metav1.Object, logger *slog.Logger) bool {
-	// all routes in the same namespace are allowed for this listener
+// listenerisAllowed reports whether route may attach to listener.
+func listenerisAllowed(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route metav1.Object, namespaceLabels gatewayapihelpers.NamespaceLabelIndex) bool {
 	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
-		return route.GetNamespace() == gw.GetNamespace()
+		return gatewayapihelpers.IsListenerNamespaceAllowed(*listener, route.GetNamespace(), gw.GetNamespace(), namespaceLabels)
 	}
 
 	// check if route is kind-allowed
 	if !isKindAllowed(*listener, route) {
 		return false
 	}
-	// check if route is namespace-allowed
-	switch *listener.AllowedRoutes.Namespaces.From {
-	case gatewayv1.NamespacesFromAll:
-		return true
-	case gatewayv1.NamespacesFromSame:
-		if route.GetNamespace() == gw.GetNamespace() {
-			return true
-		}
-		return false
-	case gatewayv1.NamespacesFromSelector:
-		nsList := &corev1.NamespaceList{}
-		selector, _ := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
-		if err := c.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-			logger.ErrorContext(ctx, "Unable to list namespaces", logfields.Error, err)
-			return false
-		}
-
-		for _, ns := range nsList.Items {
-			if ns.Name == route.GetNamespace() {
-				return true
-			}
-		}
-	}
-	return false
+	return gatewayapihelpers.IsListenerNamespaceAllowed(*listener, route.GetNamespace(), gw.GetNamespace(), namespaceLabels)
 }
 
 func isKindAllowed(listener gatewayv1.Listener, route metav1.Object) bool {

--- a/operator/pkg/gateway-api/helpers/gateway.go
+++ b/operator/pkg/gateway-api/helpers/gateway.go
@@ -39,6 +39,27 @@ func GatewayHasMatchingControllerFn(ctx context.Context, c client.Client, contro
 	}
 }
 
+// IsHTTPSTerminatedListener returns true for HTTPS listeners that terminate TLS.
+func IsHTTPSTerminatedListener(listener *gatewayv1.Listener) bool {
+	return listener.Protocol == gatewayv1.HTTPSProtocolType
+}
+
+// IsTLSPassthroughListener returns true for TLS listeners configured for passthrough mode.
+func IsTLSPassthroughListener(listener *gatewayv1.Listener) bool {
+	return listener.Protocol == gatewayv1.TLSProtocolType &&
+		listener.TLS != nil &&
+		listener.TLS.Mode != nil &&
+		*listener.TLS.Mode == gatewayv1.TLSModePassthrough
+}
+
+// ListenerHostname returns the listener hostname, or an empty string for catch-all listeners.
+func ListenerHostname(listener *gatewayv1.Listener) string {
+	if listener.Hostname == nil {
+		return ""
+	}
+	return string(*listener.Hostname)
+}
+
 // SNIHostnamesIntersect returns true when two hostnames can match the same
 // SNI value. Empty hostnames are normalized to catch-all.
 func SNIHostnamesIntersect(a, b string) bool {

--- a/operator/pkg/gateway-api/helpers/gateway.go
+++ b/operator/pkg/gateway-api/helpers/gateway.go
@@ -6,6 +6,8 @@ package helpers
 import (
 	"context"
 	"log/slog"
+	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,6 +15,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
+const allHosts = "*"
 
 func GatewayHasMatchingControllerFn(ctx context.Context, c client.Client, controllerName string, logger *slog.Logger) func(object client.Object) bool {
 	return func(obj client.Object) bool {
@@ -33,4 +37,89 @@ func GatewayHasMatchingControllerFn(ctx context.Context, c client.Client, contro
 
 		return string(gwc.Spec.ControllerName) == controllerName
 	}
+}
+
+// SNIHostnamesIntersect returns true when two hostnames can match the same
+// SNI value. Empty hostnames are normalized to catch-all.
+func SNIHostnamesIntersect(a, b string) bool {
+	a = normalizeHostname(a)
+	b = normalizeHostname(b)
+
+	if a == allHosts || b == allHosts {
+		return true
+	}
+	if a == b {
+		return true
+	}
+
+	aWildcard := strings.HasPrefix(a, allHosts)
+	bWildcard := strings.HasPrefix(b, allHosts)
+
+	switch {
+	case aWildcard && bWildcard:
+		return wildcardHostnamesIntersect(a, b)
+	case aWildcard:
+		return hostnameMatchesWildcardHostname(b, a)
+	case bWildcard:
+		return hostnameMatchesWildcardHostname(a, b)
+	default:
+		return false
+	}
+}
+
+func normalizeHostname(hostname string) string {
+	if hostname == "" {
+		return allHosts
+	}
+	return hostname
+}
+
+// hostnameMatchesWildcardHostname returns true if hostname has the non-wildcard
+// portion of wildcardHostname as a suffix, plus at least one DNS label matching the
+// wildcard.
+func hostnameMatchesWildcardHostname(hostname, wildcardHostname string) bool {
+	if !strings.HasSuffix(hostname, strings.TrimPrefix(wildcardHostname, allHosts)) {
+		return false
+	}
+
+	wildcardMatch := strings.TrimSuffix(hostname, strings.TrimPrefix(wildcardHostname, allHosts))
+	return len(wildcardMatch) > 0
+}
+
+func wildcardHostnamesIntersect(routeHostname, listenerHostname string) bool {
+	if routeHostname == allHosts || listenerHostname == allHosts {
+		return true
+	}
+
+	cutRouteHostname, found := strings.CutPrefix(routeHostname, "*.")
+	if !found || len(cutRouteHostname) == 0 {
+		return false
+	}
+	cutListenerHostname, found := strings.CutPrefix(listenerHostname, "*.")
+	if !found || len(cutListenerHostname) == 0 {
+		return false
+	}
+
+	routeSlice := strings.Split(routeHostname, ".")
+	listenerSlice := strings.Split(listenerHostname, ".")
+	slices.Reverse(routeSlice)
+	slices.Reverse(listenerSlice)
+
+	if len(routeSlice) == 0 || len(listenerSlice) == 0 {
+		return false
+	}
+
+	maxLength := max(len(routeSlice), len(listenerSlice))
+	matchingLabels := 0
+	for i := range maxLength {
+		if routeSlice[i] == allHosts || listenerSlice[i] == allHosts {
+			break
+		}
+		if routeSlice[i] == listenerSlice[i] {
+			matchingLabels++
+		} else {
+			return false
+		}
+	}
+	return matchingLabels > 0
 }

--- a/operator/pkg/gateway-api/helpers/gateway_test.go
+++ b/operator/pkg/gateway-api/helpers/gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -14,6 +15,70 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
+
+func TestSNIHostnamesIntersect(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{
+			name: "same exact hostname",
+			a:    "api.example.test",
+			b:    "api.example.test",
+			want: true,
+		},
+		{
+			name: "different exact hostnames",
+			a:    "api.example.test",
+			b:    "web.example.test",
+			want: false,
+		},
+		{
+			name: "global wildcard intersects exact hostname",
+			a:    "*",
+			b:    "api.example.test",
+			want: true,
+		},
+		{
+			name: "empty hostname is catch-all",
+			a:    "",
+			b:    "api.example.test",
+			want: true,
+		},
+		{
+			name: "wildcard intersects matching exact hostname",
+			a:    "*.example.test",
+			b:    "api.example.test",
+			want: true,
+		},
+		{
+			name: "wildcard does not match bare suffix",
+			a:    "*.example.test",
+			b:    "example.test",
+			want: false,
+		},
+		{
+			name: "wildcards with shared suffix intersect",
+			a:    "*.example.test",
+			b:    "*.test",
+			want: true,
+		},
+		{
+			name: "wildcards with disjoint suffixes do not intersect",
+			a:    "*.example.test",
+			b:    "*.example.org",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SNIHostnamesIntersect(tt.a, tt.b))
+			assert.Equal(t, tt.want, SNIHostnamesIntersect(tt.b, tt.a))
+		})
+	}
+}
 
 func Test_hasMatchingController(t *testing.T) {
 	logger := hivetest.Logger(t)

--- a/operator/pkg/gateway-api/helpers/namespaces.go
+++ b/operator/pkg/gateway-api/helpers/namespaces.go
@@ -4,12 +4,69 @@
 package helpers
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+// NamespaceLabelIndex indexes namespace labels by namespace name.
+type NamespaceLabelIndex map[string]map[string]string
 
 func NamespaceDerefOr(namespace *gatewayv1.Namespace, defaultNamespace string) string {
 	if namespace != nil && *namespace != "" {
 		return string(*namespace)
 	}
 	return defaultNamespace
+}
+
+func NewNamespaceLabelIndex(namespaces []corev1.Namespace) NamespaceLabelIndex {
+	index := make(NamespaceLabelIndex, len(namespaces))
+	for _, namespace := range namespaces {
+		index[namespace.GetName()] = namespace.GetLabels()
+	}
+	return index
+}
+
+// IsListenerNamespaceAllowed checks whether a route in routeNamespace is
+// permitted to attach to the given listener based on AllowedRoutes.Namespaces.
+func IsListenerNamespaceAllowed(listener gatewayv1.Listener, routeNamespace, gatewayNamespace string, namespaces NamespaceLabelIndex) bool {
+	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
+		// Default is Same per Gateway API spec.
+		return routeNamespace == gatewayNamespace
+	}
+
+	routeNamespaces := listener.AllowedRoutes.Namespaces
+	if routeNamespaces.From == nil {
+		if routeNamespaces.Selector != nil {
+			return isNamespaceSelected(routeNamespaces.Selector, routeNamespace, namespaces)
+		}
+		// Default is Same per Gateway API spec.
+		return routeNamespace == gatewayNamespace
+	}
+
+	switch *routeNamespaces.From {
+	case gatewayv1.NamespacesFromAll:
+		return true
+	case gatewayv1.NamespacesFromSame:
+		return routeNamespace == gatewayNamespace
+	case gatewayv1.NamespacesFromNone:
+		return false
+	case gatewayv1.NamespacesFromSelector:
+		return isNamespaceSelected(routeNamespaces.Selector, routeNamespace, namespaces)
+	default:
+		return false
+	}
+}
+
+func isNamespaceSelected(selector *metav1.LabelSelector, routeNamespace string, namespaces NamespaceLabelIndex) bool {
+	labelsForNamespace, ok := namespaces[routeNamespace]
+	if !ok {
+		return false
+	}
+	selectorMatcher, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return false
+	}
+	return selectorMatcher.Matches(labels.Set(labelsForNamespace))
 }

--- a/operator/pkg/gateway-api/helpers/namespaces_test.go
+++ b/operator/pkg/gateway-api/helpers/namespaces_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestNewNamespaceLabelIndex(t *testing.T) {
+	index := NewNamespaceLabelIndex([]corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "team-a", Labels: map[string]string{"env": "prod"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "team-b", Labels: map[string]string{"env": "dev"}}},
+	})
+
+	assert.Equal(t, NamespaceLabelIndex{
+		"team-a": {"env": "prod"},
+		"team-b": {"env": "dev"},
+	}, index)
+}
+
+func TestIsListenerNamespaceAllowed(t *testing.T) {
+	same := gatewayv1.NamespacesFromSame
+	all := gatewayv1.NamespacesFromAll
+	none := gatewayv1.NamespacesFromNone
+	selector := gatewayv1.NamespacesFromSelector
+	unknown := gatewayv1.FromNamespaces("Unknown")
+
+	namespaces := NewNamespaceLabelIndex([]corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "infra", Labels: map[string]string{"env": "infra"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "backend", Labels: map[string]string{"env": "prod"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "other", Labels: map[string]string{"env": "dev"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "unlabeled"}},
+	})
+
+	tests := []struct {
+		name             string
+		listener         gatewayv1.Listener
+		routeNamespace   string
+		gatewayNamespace string
+		namespaces       NamespaceLabelIndex
+		want             bool
+	}{
+		{
+			name:             "nil AllowedRoutes defaults to Same - same ns",
+			listener:         gatewayv1.Listener{Name: "l"},
+			routeNamespace:   "infra",
+			gatewayNamespace: "infra",
+			want:             true,
+		},
+		{
+			name:             "nil AllowedRoutes defaults to Same - different ns",
+			listener:         gatewayv1.Listener{Name: "l"},
+			routeNamespace:   "other",
+			gatewayNamespace: "infra",
+			want:             false,
+		},
+		{
+			name: "explicit Same - same ns",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &same},
+			}},
+			routeNamespace:   "infra",
+			gatewayNamespace: "infra",
+			want:             true,
+		},
+		{
+			name: "explicit Same - different ns",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &same},
+			}},
+			routeNamespace:   "backend",
+			gatewayNamespace: "infra",
+			want:             false,
+		},
+		{
+			name: "explicit All",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &all},
+			}},
+			routeNamespace:   "anywhere",
+			gatewayNamespace: "infra",
+			want:             true,
+		},
+		{
+			name: "explicit None",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &none},
+			}},
+			routeNamespace:   "infra",
+			gatewayNamespace: "infra",
+			want:             false,
+		},
+		{
+			name: "Selector matches namespace labels",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From:     &selector,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+				},
+			}},
+			routeNamespace:   "backend",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             true,
+		},
+		{
+			name: "Selector rejects non-matching namespace labels",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From:     &selector,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+				},
+			}},
+			routeNamespace:   "other",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             false,
+		},
+		{
+			name: "Selector rejects missing namespace",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From:     &selector,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+				},
+			}},
+			routeNamespace:   "missing",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             false,
+		},
+		{
+			name: "Selector rejects invalid selector",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					From: &selector,
+					Selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "env", Operator: metav1.LabelSelectorOperator("Invalid")},
+					}},
+				},
+			}},
+			routeNamespace:   "backend",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             false,
+		},
+		{
+			name: "Selector with nil selector rejects namespace",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &selector},
+			}},
+			routeNamespace:   "unlabeled",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             false,
+		},
+		{
+			name: "nil From with Selector follows selector behavior",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+				},
+			}},
+			routeNamespace:   "backend",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             true,
+		},
+		{
+			name: "nil From with Selector rejects non-matching namespace labels",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}},
+				},
+			}},
+			routeNamespace:   "other",
+			gatewayNamespace: "infra",
+			namespaces:       namespaces,
+			want:             false,
+		},
+		{
+			name: "nil From and nil Selector defaults to Same",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{},
+			}},
+			routeNamespace:   "other",
+			gatewayNamespace: "infra",
+			want:             false,
+		},
+		{
+			name: "unknown From value is denied",
+			listener: gatewayv1.Listener{Name: "l", AllowedRoutes: &gatewayv1.AllowedRoutes{
+				Namespaces: &gatewayv1.RouteNamespaces{From: &unknown},
+			}},
+			routeNamespace:   "infra",
+			gatewayNamespace: "infra",
+			want:             false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsListenerNamespaceAllowed(tt.listener, tt.routeNamespace, tt.gatewayNamespace, tt.namespaces))
+		})
+	}
+}

--- a/operator/pkg/gateway-api/helpers_test.go
+++ b/operator/pkg/gateway-api/helpers_test.go
@@ -4,19 +4,15 @@
 package gateway_api
 
 import (
-	"context"
-	"errors"
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	gatewayapihelpers "github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
 func Test_isKindAllowed(t *testing.T) {
@@ -68,18 +64,12 @@ func Test_isKindAllowed(t *testing.T) {
 }
 
 func Test_isAllowed(t *testing.T) {
-	scheme := runtime.NewScheme()
-	assert.NoError(t, gatewayv1.Install(scheme))
-	assert.NoError(t, corev1.AddToScheme(scheme))
-
-	logger := slog.New(slog.DiscardHandler)
-
 	tests := []struct {
-		name  string
-		gw    *gatewayv1.Gateway
-		route metav1.Object
-		c     client.Client
-		want  bool
+		name       string
+		gw         *gatewayv1.Gateway
+		route      metav1.Object
+		namespaces []corev1.Namespace
+		want       bool
 	}{
 		{
 			name: "nil AllowedRoutes listener rejects cross-namespace route, later All listener allows",
@@ -88,7 +78,6 @@ func Test_isAllowed(t *testing.T) {
 				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
 			),
 			route: testHTTPRoute("cross-ns"),
-			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
 			want:  true,
 		},
 		{
@@ -98,8 +87,25 @@ func Test_isAllowed(t *testing.T) {
 				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
 			),
 			route: testHTTPRoute("cross-ns"),
-			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
 			want:  true,
+		},
+		{
+			name: "selector listener allows matching route namespace",
+			gw: gatewayWithListeners(
+				listener("selector", selectorAllowedRoutes("allowed", "true")),
+			),
+			route:      testHTTPRoute("cross-ns"),
+			namespaces: []corev1.Namespace{namespace("cross-ns", map[string]string{"allowed": "true"})},
+			want:       true,
+		},
+		{
+			name: "selector listener rejects non-matching route namespace",
+			gw: gatewayWithListeners(
+				listener("selector", selectorAllowedRoutes("allowed", "true")),
+			),
+			route:      testHTTPRoute("cross-ns"),
+			namespaces: []corev1.Namespace{namespace("cross-ns", map[string]string{"allowed": "false"})},
+			want:       false,
 		},
 		{
 			name: "selector listener does not match route namespace, later All listener allows",
@@ -107,24 +113,9 @@ func Test_isAllowed(t *testing.T) {
 				listener("selector", selectorAllowedRoutes("allowed", "true")),
 				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
 			),
-			route: testHTTPRoute("cross-ns"),
-			c: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(namespace("other-ns", map[string]string{"allowed": "true"})).
-				Build(),
-			want: true,
-		},
-		{
-			name: "selector listener list error, later All listener allows",
-			gw: gatewayWithListeners(
-				listener("selector", selectorAllowedRoutes("allowed", "true")),
-				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
-			),
-			route: testHTTPRoute("cross-ns"),
-			c: namespaceListErrorClient{
-				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-			},
-			want: true,
+			route:      testHTTPRoute("cross-ns"),
+			namespaces: []corev1.Namespace{namespace("other-ns", map[string]string{"allowed": "true"})},
+			want:       true,
 		},
 		{
 			name: "same-namespace default listener allows same-namespace route",
@@ -132,7 +123,6 @@ func Test_isAllowed(t *testing.T) {
 				listener("same-namespace", nil),
 			),
 			route: testHTTPRoute("default"),
-			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
 			want:  true,
 		},
 		{
@@ -141,27 +131,16 @@ func Test_isAllowed(t *testing.T) {
 				listener("same-namespace", nil),
 			),
 			route: testHTTPRoute("cross-ns"),
-			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
 			want:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isAllowed(context.Background(), tt.c, tt.gw, tt.route, logger))
+			namespaceLabels := gatewayapihelpers.NewNamespaceLabelIndex(tt.namespaces)
+			assert.Equal(t, tt.want, isAllowed(tt.gw, tt.route, namespaceLabels))
 		})
 	}
-}
-
-type namespaceListErrorClient struct {
-	client.Client
-}
-
-func (c namespaceListErrorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	if _, ok := list.(*corev1.NamespaceList); ok {
-		return errors.New("unable to list namespaces")
-	}
-	return c.Client.List(ctx, list, opts...)
 }
 
 func gatewayWithListeners(listeners ...gatewayv1.Listener) *gatewayv1.Gateway {
@@ -215,8 +194,8 @@ func testHTTPRoute(namespace string) *gatewayv1.HTTPRoute {
 	}
 }
 
-func namespace(name string, labels map[string]string) *corev1.Namespace {
-	return &corev1.Namespace{
+func namespace(name string, labels map[string]string) corev1.Namespace {
+	return corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/input/cross-protocol-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/input/cross-protocol-same-hostname.yaml
@@ -1,0 +1,92 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-protocol-same-hostname
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "api.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: cross-protocol-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: tls-passthrough
+      protocol: TLS
+      port: 9443
+      hostname: "api.example.test"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: cross-protocol-same-hostname
+      sectionName: https
+  hostnames:
+    - api.example.test
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /secure
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: cross-protocol-same-hostname
+      namespace: gateway-conformance-infra
+      sectionName: tls-passthrough
+  hostnames:
+    - api.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cross-protocol-tls
+  namespace: gateway-conformance-infra
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVORENDQXB5Z0F3SUJBZ0lSQUtEL0JMRkJmd0tJWjBXR3JIdFRINmd3RFFZSktvWklodmNOQVFFTEJRQXcKZHpFZU1Cd0dBMVVFQ2hNVmJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElFTkJNU1l3SkFZRFZRUUxEQjEwWVcxdApZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tURXRNQ3NHQTFVRUF3d2tiV3RqWlhKMElIUmhiVzFoClkyaEFabVZrYjNKaExteGhiaUFvVkdGdElFMWhZMmdwTUI0WERUSXpNREl5TVRFeE1EZzBNMW9YRFRJMU1EVXkKTVRFeU1EZzBNMW93VVRFbk1DVUdBMVVFQ2hNZWJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElHTmxjblJwWm1sagpZWFJsTVNZd0pBWURWUVFMREIxMFlXMXRZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFNSVp5KzBKUlZqcXBXZ2VxMmRQKzFvbGlPNEEKQ2Zabk1nNHRTcVBhbGhEUUw2TWY2OEhZTGZpenlKSXBSek1KOTA1cllkMEFjbVhtdS9nMEVvOHlrSHhGRHo1VApzZVBzMlhRbmc4TU40YXpzUm1tMWw0Zjc0b3Zhd1F6UWNiODIyUVAxQ1M2SUxaM1Z0d05qUmgybkF3dGhZQk1vCkNrbmdER2VROEdsMHRqSExGbkJkVGRTd1FSbUUyanREQmNBZ3lFR3BxKzZSZVl0Ky80N25ObjdkQ2Z0c1ZxaEUKQllyOVhIM2l0ZWZIbXNiZmo3eldGYnB0ZGtvN3E5bE1Id25CZCswaGQ0ME1tSklYTVpyT0dHRlpqYXdKREJxUwpzQnEyUTNsNlhRejhYN1AvR0E0RG44aDR3M3JwcG1pYU43TE9tR1hla2kzeFgyd3FuTSswczZhWlpac0NBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUI0R0ExVWQKSXdRWU1CYUFGR1EyREIwNkNkUUZRQnNZUHllME5Cd0VyVU5FTUJjR0ExVWRFUVFRTUE2Q0RIVnVhWFIwWlhOMApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVlFQXJ0SGRLV1hSNmFFTHBmYWwxN2JpYWJDUHZJRjlqNm53CnVEemNkTVlRTHJYbThNK05IZTh4M2RwSTd1M2xsdE8rZHpMbmcrblZLUU9SM2FsUUFDU21SRDljN2llOGVUNWQKN3pLT1RrNmtlWTE5NUkxd1ZWNGpiTkxiTldhOXk0UkpRUlR2QkxBdkFQOU5WdFV3MlEvdy9FclVUcVN5eitvYgpkd250NGdZQ3c2ZEdubHVMeGxmRjM0REI5S2ZsdlZOU25reU1CL2dzQjRBM3IxR1BPSW8wR3lmNzRpZzNGV3JTCndIWUtuQmJ0WmZZTzBKVjBMQ29QeUhlOGcwWGFqWmU4RENiUC9FNlNtbFROQW1KRVNWamlnVFRjSUJBa0ZJK24KdG9CQWR4ZmhqS1VHYUNsT0hTMjljcGFpeW5qU2F5R200UmtIa3g3bWNBdWE5bFdQZjdwU2EzbUNjRmIrd0ZyMwpBQmtIRFBKSDJhY2ZhVUsxdmdLVGdPd2NHLzZLQTgyMC9QcmFvU2loTGFQSy9BN2VnNzdyMUVlWXB0ME5lcHBiClhqdlVwM1ltVmxJTVpYUHpyak9zYXN0b0RTcnN5Z2o1amRWdG00UHNsdjluUGh6RHJCamxacEVKU2NXNEpsYisKNnd0ZDdwMDNVREJTS2ZUYlZST1ZBZTVtdkp2QTBob1MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRENHY3Z0Q1VWWTZxVm8KSHF0blQvdGFKWWp1QUFuR1p6SU9MVXFqMnBZUTBDK2pIK3ZCMkMzNHM4aVNLVWN6Q2ZkT2EySGRBSEpsNXJ2NApOQktQTXBCOFJROCtVN0hqN05sMEo0UEREZUdzN0VacHRaZUgrK0tMMnNFTTBIRy9OdGtEOVFrdWlDMmQxYmNEClkwWWRwd01MWVdBVEtBcEo0QXhua1BCcGRMWXh5eFp3WFUzVXNFRVpoTm83UXdYQUlNaEJxYXZ1a1htTGZ2K08KNXpaKzNRbjdiRmFvUkFXSy9WeDk0clhueDVyRzM0KzgxaFc2YlhaS082dlpUQjhKd1hmdElYZU5ESmlTRnpHYQp6aGhoV1kyc0NRd2FrckFhdGtONWVsME0vRit6L3hnUEE1L0llTU42NmFab21qZXl6cGhsM3BJdDhWOXNLcHpQCnRMT21tV0diQWdNQkFBRUNnZ0VBRWpBU29NSjJvZzlTc24vMU5iZ1Q2RzJOK0NjK3d6MldQaWZXVDZaQzI0NTIKZUVXY2RNeUoranoyZFdPeXpVQ0kwT3RVL3oxMGVzSDFLUnZRQldVS2p1cDF0RFJwZmQ4S3ZVeWFseU5zMnlSRQpzTkVZUXVEQ2FMSjExbnFOdmdvb3FhdERVZjNtc0Z4L1NxejV1L3VUV0hTbWFRVWVlYStwMmVhRjhJdkVLc1FmCjZRTmtsa2VIc3YrR1ZQditpaWJmYlhYbmU2STVhVjM1UmM0UTA4elJDZ1lYL0JOMUFZWFY2aG80UkM5ZFpWR1AKSlVrU0x6UmFkZWdvay9FT05La3JxTFpPRkpWYjJ3dEZxODVnSjAxbE9ETS9najdHcU01OU0vd2s1NUNhUUlSRAo5eDVINFg0cnBNMnJobWlOTGtJTjB0R0xLTzhYMzF1cDdoVHg5YnZKY1FLQmdRRDUxTUxXWVlVUHovdW12U3JOClFPVDlVaEVISS9ieHRDYldRdGhXM0wxcXJWVDdEQjhKa28vNi94WWxYaGw3bndWd0p6MjRqSmY5dnV4V2JCcEwKSFpSZjBRc0RPMi9PNHJxaEtEb3YvR01VQ3gyc2h6YytKN2srVDkzS05WQU5ZYTA1Z3VxTWVCOG4zMEhQcm9rRgpMZ2loVkZGMjBrOVo2U2liVXZnVE1wRjFFd0tCZ1FERzVNQmdjOG9GWG1sci83cEhLaXpDNEYzZURBWFV4VkhNCldDSWJTd015ek9YS3FEY2RYTkR6OGNRcmpoS2EyckQxZktoRTBvUlIrUXZIejhJUEMrME1zVDdRNlFzSUhZajUKQ1h1YkhyMHM1azhQSkFwK0xrMkVkSGVQWlFNL0kvdmovZ1N3eG5KOVFzNjRGV1oyNUs5elluTk5zaW9qUWVsNwpXVm1JOUlWYVdRS0JnRDNCWWdnc1F3QU5vVjh1RTQ1NUpDR2FUNnM4TUthK3FYcjlPd3o5czdUUzg5YTZ3RkZWCmNWSFNERjlnUzF4TGlzU1dicU5YM1pwVHY0ZjlZT0tBaFZUS0Q3YlUwbWFKbFNpUkVSRWJpa0pDSFN1d29PODAKVW80Y24rNkVEeTIvbjFwQUNrcCt4dlRNTXpCckxHT2paVzY3c1FkMkpUZE1jMFV4MVRDcHAxc1JBb0dBYUVWSQpyY2hHWXlZcDhwcXcxOW8rZVRRVFFmUGZvcnFIdGErR3dmUkRpd0JzZ0NCTU5MS1NRVUhBZkcwUlIrbmExL2d3CloxUk9Wb05RTDhLMXBCbkdmdDcxWmFTblNldmlBVjE5VmNkNXVlNU1DRTRHeWp3UUc1N0xoM3VYaGlTaFM5ZkMKTWNMNEJyOWRqSmg3alYwNnRpMG84ZFN6enFRaGVhOVFCMExhSHBFQ2dZQXBjOG9Cb2lLNjlzMHdYeUk0K1BoeApTY0JKMFhxREJZRmt4eVhyOFk1cEVhckVhcUN0bDFPUFBNT2lRUkRXb3hSUitGd0EvMGxhU2ZoNXh3MFUzYitxCmlaMlhwa3JiUXAwMzRyQzBVUjZwK0ttMVN2OUFWQ0FDQWpyY1EzTlphZjhiRE9XcXZwbGE3QXVxMG9HOGk2VVgKaEVLQ0tmL04zZ0Uxb01yVHhWelVEUT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-cross-protocol-same-hostname
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.200
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/cec-cross-protocol-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/cec-cross-protocol-same-hostname.yaml
@@ -1,0 +1,167 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: cross-protocol-same-hostname
+  name: cilium-gateway-cross-protocol-same-hostname
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: cross-protocol-same-hostname
+  resourceVersion: 1
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - api.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:api.example.test
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - api.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-443
+                statPrefix: listener-443
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-cross-protocol-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-443
+      virtualHosts:
+        - domains:
+            - api.example.test
+            - api.example.test:*
+          name: api.example.test
+          routes:
+            - match:
+                pathSeparatedPrefix: /secure
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: listener-443
+      name: cilium-gateway-cross-protocol-same-hostname
+      namespace: gateway-conformance-infra
+      ports:
+        - 443
+    - listener: listener
+      name: cilium-gateway-cross-protocol-same-hostname
+      namespace: gateway-conformance-infra
+      ports:
+        - 9443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/cross-protocol-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/cross-protocol-same-hostname.yaml
@@ -1,0 +1,93 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-protocol-same-hostname
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: api.example.test
+      name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: cross-protocol-tls
+            namespace: gateway-conformance-infra
+    - allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+        namespaces:
+          from: Same
+      hostname: api.example.test
+      name: tls-passthrough
+      port: 9443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.255.200
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: tls-passthrough
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/httproute-https-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/httproute-https-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: cross-protocol-same-hostname
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /secure
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: cross-protocol-same-hostname
+        sectionName: https

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/tlsroute-tls-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/tlsroute-tls-route.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: cross-protocol-same-hostname
+      namespace: gateway-conformance-infra
+      sectionName: tls-passthrough
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: cross-protocol-same-hostname
+        namespace: gateway-conformance-infra
+        sectionName: tls-passthrough

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/input/cross-protocol-same-port-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/input/cross-protocol-same-port-same-hostname.yaml
@@ -1,0 +1,92 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-protocol-same-port-same-hostname
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "api.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: cross-protocol-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: tls-passthrough
+      protocol: TLS
+      port: 443
+      hostname: "api.example.test"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: cross-protocol-same-port-same-hostname
+      sectionName: https
+  hostnames:
+    - api.example.test
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /secure
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: cross-protocol-same-port-same-hostname
+      namespace: gateway-conformance-infra
+      sectionName: tls-passthrough
+  hostnames:
+    - api.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cross-protocol-tls
+  namespace: gateway-conformance-infra
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVORENDQXB5Z0F3SUJBZ0lSQUtEL0JMRkJmd0tJWjBXR3JIdFRINmd3RFFZSktvWklodmNOQVFFTEJRQXcKZHpFZU1Cd0dBMVVFQ2hNVmJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElFTkJNU1l3SkFZRFZRUUxEQjEwWVcxdApZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tURXRNQ3NHQTFVRUF3d2tiV3RqWlhKMElIUmhiVzFoClkyaEFabVZrYjNKaExteGhiaUFvVkdGdElFMWhZMmdwTUI0WERUSXpNREl5TVRFeE1EZzBNMW9YRFRJMU1EVXkKTVRFeU1EZzBNMW93VVRFbk1DVUdBMVVFQ2hNZWJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElHTmxjblJwWm1sagpZWFJsTVNZd0pBWURWUVFMREIxMFlXMXRZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFNSVp5KzBKUlZqcXBXZ2VxMmRQKzFvbGlPNEEKQ2Zabk1nNHRTcVBhbGhEUUw2TWY2OEhZTGZpenlKSXBSek1KOTA1cllkMEFjbVhtdS9nMEVvOHlrSHhGRHo1VApzZVBzMlhRbmc4TU40YXpzUm1tMWw0Zjc0b3Zhd1F6UWNiODIyUVAxQ1M2SUxaM1Z0d05qUmgybkF3dGhZQk1vCkNrbmdER2VROEdsMHRqSExGbkJkVGRTd1FSbUUyanREQmNBZ3lFR3BxKzZSZVl0Ky80N25ObjdkQ2Z0c1ZxaEUKQllyOVhIM2l0ZWZIbXNiZmo3eldGYnB0ZGtvN3E5bE1Id25CZCswaGQ0ME1tSklYTVpyT0dHRlpqYXdKREJxUwpzQnEyUTNsNlhRejhYN1AvR0E0RG44aDR3M3JwcG1pYU43TE9tR1hla2kzeFgyd3FuTSswczZhWlpac0NBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUI0R0ExVWQKSXdRWU1CYUFGR1EyREIwNkNkUUZRQnNZUHllME5Cd0VyVU5FTUJjR0ExVWRFUVFRTUE2Q0RIVnVhWFIwWlhOMApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVlFQXJ0SGRLV1hSNmFFTHBmYWwxN2JpYWJDUHZJRjlqNm53CnVEemNkTVlRTHJYbThNK05IZTh4M2RwSTd1M2xsdE8rZHpMbmcrblZLUU9SM2FsUUFDU21SRDljN2llOGVUNWQKN3pLT1RrNmtlWTE5NUkxd1ZWNGpiTkxiTldhOXk0UkpRUlR2QkxBdkFQOU5WdFV3MlEvdy9FclVUcVN5eitvYgpkd250NGdZQ3c2ZEdubHVMeGxmRjM0REI5S2ZsdlZOU25reU1CL2dzQjRBM3IxR1BPSW8wR3lmNzRpZzNGV3JTCndIWUtuQmJ0WmZZTzBKVjBMQ29QeUhlOGcwWGFqWmU4RENiUC9FNlNtbFROQW1KRVNWamlnVFRjSUJBa0ZJK24KdG9CQWR4ZmhqS1VHYUNsT0hTMjljcGFpeW5qU2F5R200UmtIa3g3bWNBdWE5bFdQZjdwU2EzbUNjRmIrd0ZyMwpBQmtIRFBKSDJhY2ZhVUsxdmdLVGdPd2NHLzZLQTgyMC9QcmFvU2loTGFQSy9BN2VnNzdyMUVlWXB0ME5lcHBiClhqdlVwM1ltVmxJTVpYUHpyak9zYXN0b0RTcnN5Z2o1amRWdG00UHNsdjluUGh6RHJCamxacEVKU2NXNEpsYisKNnd0ZDdwMDNVREJTS2ZUYlZST1ZBZTVtdkp2QTBob1MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRENHY3Z0Q1VWWTZxVm8KSHF0blQvdGFKWWp1QUFuR1p6SU9MVXFqMnBZUTBDK2pIK3ZCMkMzNHM4aVNLVWN6Q2ZkT2EySGRBSEpsNXJ2NApOQktQTXBCOFJROCtVN0hqN05sMEo0UEREZUdzN0VacHRaZUgrK0tMMnNFTTBIRy9OdGtEOVFrdWlDMmQxYmNEClkwWWRwd01MWVdBVEtBcEo0QXhua1BCcGRMWXh5eFp3WFUzVXNFRVpoTm83UXdYQUlNaEJxYXZ1a1htTGZ2K08KNXpaKzNRbjdiRmFvUkFXSy9WeDk0clhueDVyRzM0KzgxaFc2YlhaS082dlpUQjhKd1hmdElYZU5ESmlTRnpHYQp6aGhoV1kyc0NRd2FrckFhdGtONWVsME0vRit6L3hnUEE1L0llTU42NmFab21qZXl6cGhsM3BJdDhWOXNLcHpQCnRMT21tV0diQWdNQkFBRUNnZ0VBRWpBU29NSjJvZzlTc24vMU5iZ1Q2RzJOK0NjK3d6MldQaWZXVDZaQzI0NTIKZUVXY2RNeUoranoyZFdPeXpVQ0kwT3RVL3oxMGVzSDFLUnZRQldVS2p1cDF0RFJwZmQ4S3ZVeWFseU5zMnlSRQpzTkVZUXVEQ2FMSjExbnFOdmdvb3FhdERVZjNtc0Z4L1NxejV1L3VUV0hTbWFRVWVlYStwMmVhRjhJdkVLc1FmCjZRTmtsa2VIc3YrR1ZQditpaWJmYlhYbmU2STVhVjM1UmM0UTA4elJDZ1lYL0JOMUFZWFY2aG80UkM5ZFpWR1AKSlVrU0x6UmFkZWdvay9FT05La3JxTFpPRkpWYjJ3dEZxODVnSjAxbE9ETS9najdHcU01OU0vd2s1NUNhUUlSRAo5eDVINFg0cnBNMnJobWlOTGtJTjB0R0xLTzhYMzF1cDdoVHg5YnZKY1FLQmdRRDUxTUxXWVlVUHovdW12U3JOClFPVDlVaEVISS9ieHRDYldRdGhXM0wxcXJWVDdEQjhKa28vNi94WWxYaGw3bndWd0p6MjRqSmY5dnV4V2JCcEwKSFpSZjBRc0RPMi9PNHJxaEtEb3YvR01VQ3gyc2h6YytKN2srVDkzS05WQU5ZYTA1Z3VxTWVCOG4zMEhQcm9rRgpMZ2loVkZGMjBrOVo2U2liVXZnVE1wRjFFd0tCZ1FERzVNQmdjOG9GWG1sci83cEhLaXpDNEYzZURBWFV4VkhNCldDSWJTd015ek9YS3FEY2RYTkR6OGNRcmpoS2EyckQxZktoRTBvUlIrUXZIejhJUEMrME1zVDdRNlFzSUhZajUKQ1h1YkhyMHM1azhQSkFwK0xrMkVkSGVQWlFNL0kvdmovZ1N3eG5KOVFzNjRGV1oyNUs5elluTk5zaW9qUWVsNwpXVm1JOUlWYVdRS0JnRDNCWWdnc1F3QU5vVjh1RTQ1NUpDR2FUNnM4TUthK3FYcjlPd3o5czdUUzg5YTZ3RkZWCmNWSFNERjlnUzF4TGlzU1dicU5YM1pwVHY0ZjlZT0tBaFZUS0Q3YlUwbWFKbFNpUkVSRWJpa0pDSFN1d29PODAKVW80Y24rNkVEeTIvbjFwQUNrcCt4dlRNTXpCckxHT2paVzY3c1FkMkpUZE1jMFV4MVRDcHAxc1JBb0dBYUVWSQpyY2hHWXlZcDhwcXcxOW8rZVRRVFFmUGZvcnFIdGErR3dmUkRpd0JzZ0NCTU5MS1NRVUhBZkcwUlIrbmExL2d3CloxUk9Wb05RTDhLMXBCbkdmdDcxWmFTblNldmlBVjE5VmNkNXVlNU1DRTRHeWp3UUc1N0xoM3VYaGlTaFM5ZkMKTWNMNEJyOWRqSmg3alYwNnRpMG84ZFN6enFRaGVhOVFCMExhSHBFQ2dZQXBjOG9Cb2lLNjlzMHdYeUk0K1BoeApTY0JKMFhxREJZRmt4eVhyOFk1cEVhckVhcUN0bDFPUFBNT2lRUkRXb3hSUitGd0EvMGxhU2ZoNXh3MFUzYitxCmlaMlhwa3JiUXAwMzRyQzBVUjZwK0ttMVN2OUFWQ0FDQWpyY1EzTlphZjhiRE9XcXZwbGE3QXVxMG9HOGk2VVgKaEVLQ0tmL04zZ0Uxb01yVHhWelVEUT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-cross-protocol-same-port-same-hostname
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.200
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/output/cross-protocol-same-port-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/output/cross-protocol-same-port-same-hostname.yaml
@@ -1,0 +1,90 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-protocol-same-port-same-hostname
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: api.example.test
+      name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: cross-protocol-tls
+            namespace: gateway-conformance-infra
+    - allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+        namespaces:
+          from: Same
+      hostname: api.example.test
+      name: tls-passthrough
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+status:
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: 'Listener conflicts with listener "tls-passthrough": same port 443 has overlapping HTTPS and TLS passthrough hostnames.'
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: 'Listener not valid. Listener conflicts with listener "tls-passthrough": same port 443 has overlapping HTTPS and TLS passthrough hostnames.'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: 'Listener conflicts with listener "https": same port 443 has overlapping HTTPS and TLS passthrough hostnames.'
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: 'Listener not valid. Listener conflicts with listener "https": same port 443 has overlapping HTTPS and TLS passthrough hostnames.'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: tls-passthrough
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/output/httproute-https-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/output/httproute-https-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: cross-protocol-same-port-same-hostname
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /secure
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: cross-protocol-same-port-same-hostname
+        sectionName: https

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/output/tlsroute-tls-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-port-same-hostname/output/tlsroute-tls-route.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: cross-protocol-same-port-same-hostname
+      namespace: gateway-conformance-infra
+      sectionName: tls-passthrough
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: cross-protocol-same-port-same-hostname
+        namespace: gateway-conformance-infra
+        sectionName: tls-passthrough

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/input/multi-port-https-with-multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/input/multi-port-https-with-multi-port-tls-passthrough.yaml
@@ -1,0 +1,153 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-port-https-with-multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https-443
+      protocol: HTTPS
+      port: 443
+      hostname: "web.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https-50051
+      protocol: HTTPS
+      port: 50051
+      hostname: "api.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: tls-8443
+      protocol: TLS
+      port: 8443
+      hostname: "tls.example.test"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+    - name: tls-9443
+      protocol: TLS
+      port: 9443
+      hostname: "tls.example.test"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: web-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      sectionName: https-443
+  hostnames:
+    - web.example.test
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /web
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      sectionName: https-50051
+  hostnames:
+    - api.example.test
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-route-a
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-8443
+  hostnames:
+    - tls.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-route-b
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-9443
+  hostnames:
+    - tls.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: multi-port-https-tls
+  namespace: gateway-conformance-infra
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVORENDQXB5Z0F3SUJBZ0lSQUtEL0JMRkJmd0tJWjBXR3JIdFRINmd3RFFZSktvWklodmNOQVFFTEJRQXcKZHpFZU1Cd0dBMVVFQ2hNVmJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElFTkJNU1l3SkFZRFZRUUxEQjEwWVcxdApZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tURXRNQ3NHQTFVRUF3d2tiV3RqWlhKMElIUmhiVzFoClkyaEFabVZrYjNKaExteGhiaUFvVkdGdElFMWhZMmdwTUI0WERUSXpNREl5TVRFeE1EZzBNMW9YRFRJMU1EVXkKTVRFeU1EZzBNMW93VVRFbk1DVUdBMVVFQ2hNZWJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElHTmxjblJwWm1sagpZWFJsTVNZd0pBWURWUVFMREIxMFlXMXRZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFNSVp5KzBKUlZqcXBXZ2VxMmRQKzFvbGlPNEEKQ2Zabk1nNHRTcVBhbGhEUUw2TWY2OEhZTGZpenlKSXBSek1KOTA1cllkMEFjbVhtdS9nMEVvOHlrSHhGRHo1VApzZVBzMlhRbmc4TU40YXpzUm1tMWw0Zjc0b3Zhd1F6UWNiODIyUVAxQ1M2SUxaM1Z0d05qUmgybkF3dGhZQk1vCkNrbmdER2VROEdsMHRqSExGbkJkVGRTd1FSbUUyanREQmNBZ3lFR3BxKzZSZVl0Ky80N25ObjdkQ2Z0c1ZxaEUKQllyOVhIM2l0ZWZIbXNiZmo3eldGYnB0ZGtvN3E5bE1Id25CZCswaGQ0ME1tSklYTVpyT0dHRlpqYXdKREJxUwpzQnEyUTNsNlhRejhYN1AvR0E0RG44aDR3M3JwcG1pYU43TE9tR1hla2kzeFgyd3FuTSswczZhWlpac0NBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUI0R0ExVWQKSXdRWU1CYUFGR1EyREIwNkNkUUZRQnNZUHllME5Cd0VyVU5FTUJjR0ExVWRFUVFRTUE2Q0RIVnVhWFIwWlhOMApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVlFQXJ0SGRLV1hSNmFFTHBmYWwxN2JpYWJDUHZJRjlqNm53CnVEemNkTVlRTHJYbThNK05IZTh4M2RwSTd1M2xsdE8rZHpMbmcrblZLUU9SM2FsUUFDU21SRDljN2llOGVUNWQKN3pLT1RrNmtlWTE5NUkxd1ZWNGpiTkxiTldhOXk0UkpRUlR2QkxBdkFQOU5WdFV3MlEvdy9FclVUcVN5eitvYgpkd250NGdZQ3c2ZEdubHVMeGxmRjM0REI5S2ZsdlZOU25reU1CL2dzQjRBM3IxR1BPSW8wR3lmNzRpZzNGV3JTCndIWUtuQmJ0WmZZTzBKVjBMQ29QeUhlOGcwWGFqWmU4RENiUC9FNlNtbFROQW1KRVNWamlnVFRjSUJBa0ZJK24KdG9CQWR4ZmhqS1VHYUNsT0hTMjljcGFpeW5qU2F5R200UmtIa3g3bWNBdWE5bFdQZjdwU2EzbUNjRmIrd0ZyMwpBQmtIRFBKSDJhY2ZhVUsxdmdLVGdPd2NHLzZLQTgyMC9QcmFvU2loTGFQSy9BN2VnNzdyMUVlWXB0ME5lcHBiClhqdlVwM1ltVmxJTVpYUHpyak9zYXN0b0RTcnN5Z2o1amRWdG00UHNsdjluUGh6RHJCamxacEVKU2NXNEpsYisKNnd0ZDdwMDNVREJTS2ZUYlZST1ZBZTVtdkp2QTBob1MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRENHY3Z0Q1VWWTZxVm8KSHF0blQvdGFKWWp1QUFuR1p6SU9MVXFqMnBZUTBDK2pIK3ZCMkMzNHM4aVNLVWN6Q2ZkT2EySGRBSEpsNXJ2NApOQktQTXBCOFJROCtVN0hqN05sMEo0UEREZUdzN0VacHRaZUgrK0tMMnNFTTBIRy9OdGtEOVFrdWlDMmQxYmNEClkwWWRwd01MWVdBVEtBcEo0QXhua1BCcGRMWXh5eFp3WFUzVXNFRVpoTm83UXdYQUlNaEJxYXZ1a1htTGZ2K08KNXpaKzNRbjdiRmFvUkFXSy9WeDk0clhueDVyRzM0KzgxaFc2YlhaS082dlpUQjhKd1hmdElYZU5ESmlTRnpHYQp6aGhoV1kyc0NRd2FrckFhdGtONWVsME0vRit6L3hnUEE1L0llTU42NmFab21qZXl6cGhsM3BJdDhWOXNLcHpQCnRMT21tV0diQWdNQkFBRUNnZ0VBRWpBU29NSjJvZzlTc24vMU5iZ1Q2RzJOK0NjK3d6MldQaWZXVDZaQzI0NTIKZUVXY2RNeUoranoyZFdPeXpVQ0kwT3RVL3oxMGVzSDFLUnZRQldVS2p1cDF0RFJwZmQ4S3ZVeWFseU5zMnlSRQpzTkVZUXVEQ2FMSjExbnFOdmdvb3FhdERVZjNtc0Z4L1NxejV1L3VUV0hTbWFRVWVlYStwMmVhRjhJdkVLc1FmCjZRTmtsa2VIc3YrR1ZQditpaWJmYlhYbmU2STVhVjM1UmM0UTA4elJDZ1lYL0JOMUFZWFY2aG80UkM5ZFpWR1AKSlVrU0x6UmFkZWdvay9FT05La3JxTFpPRkpWYjJ3dEZxODVnSjAxbE9ETS9najdHcU01OU0vd2s1NUNhUUlSRAo5eDVINFg0cnBNMnJobWlOTGtJTjB0R0xLTzhYMzF1cDdoVHg5YnZKY1FLQmdRRDUxTUxXWVlVUHovdW12U3JOClFPVDlVaEVISS9ieHRDYldRdGhXM0wxcXJWVDdEQjhKa28vNi94WWxYaGw3bndWd0p6MjRqSmY5dnV4V2JCcEwKSFpSZjBRc0RPMi9PNHJxaEtEb3YvR01VQ3gyc2h6YytKN2srVDkzS05WQU5ZYTA1Z3VxTWVCOG4zMEhQcm9rRgpMZ2loVkZGMjBrOVo2U2liVXZnVE1wRjFFd0tCZ1FERzVNQmdjOG9GWG1sci83cEhLaXpDNEYzZURBWFV4VkhNCldDSWJTd015ek9YS3FEY2RYTkR6OGNRcmpoS2EyckQxZktoRTBvUlIrUXZIejhJUEMrME1zVDdRNlFzSUhZajUKQ1h1YkhyMHM1azhQSkFwK0xrMkVkSGVQWlFNL0kvdmovZ1N3eG5KOVFzNjRGV1oyNUs5elluTk5zaW9qUWVsNwpXVm1JOUlWYVdRS0JnRDNCWWdnc1F3QU5vVjh1RTQ1NUpDR2FUNnM4TUthK3FYcjlPd3o5czdUUzg5YTZ3RkZWCmNWSFNERjlnUzF4TGlzU1dicU5YM1pwVHY0ZjlZT0tBaFZUS0Q3YlUwbWFKbFNpUkVSRWJpa0pDSFN1d29PODAKVW80Y24rNkVEeTIvbjFwQUNrcCt4dlRNTXpCckxHT2paVzY3c1FkMkpUZE1jMFV4MVRDcHAxc1JBb0dBYUVWSQpyY2hHWXlZcDhwcXcxOW8rZVRRVFFmUGZvcnFIdGErR3dmUkRpd0JzZ0NCTU5MS1NRVUhBZkcwUlIrbmExL2d3CloxUk9Wb05RTDhLMXBCbkdmdDcxWmFTblNldmlBVjE5VmNkNXVlNU1DRTRHeWp3UUc1N0xoM3VYaGlTaFM5ZkMKTWNMNEJyOWRqSmg3alYwNnRpMG84ZFN6enFRaGVhOVFCMExhSHBFQ2dZQXBjOG9Cb2lLNjlzMHdYeUk0K1BoeApTY0JKMFhxREJZRmt4eVhyOFk1cEVhckVhcUN0bDFPUFBNT2lRUkRXb3hSUitGd0EvMGxhU2ZoNXh3MFUzYitxCmlaMlhwa3JiUXAwMzRyQzBVUjZwK0ttMVN2OUFWQ0FDQWpyY1EzTlphZjhiRE9XcXZwbGE3QXVxMG9HOGk2VVgKaEVLQ0tmL04zZ0Uxb01yVHhWelVEUT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-multi-port-https-with-multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.200
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/cec-multi-port-https-with-multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/cec-multi-port-https-with-multi-port-tls-passthrough.yaml
@@ -1,0 +1,297 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: multi-port-https-with-multi-port-tls-passthrough
+  name: cilium-gateway-multi-port-https-with-multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: multi-port-https-with-multi-port-tls-passthrough
+  resourceVersion: 1
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+    - name: tls-backend-2
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - web.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-443
+                statPrefix: listener-443
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-multi-port-https-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - api.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-50051
+                statPrefix: listener-50051
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-multi-port-https-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-50051
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - tls.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:tls.example.test
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-8443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - tls.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:tls.example.test
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-9443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-443
+      virtualHosts:
+        - domains:
+            - web.example.test
+            - web.example.test:*
+          name: web.example.test
+          routes:
+            - match:
+                pathSeparatedPrefix: /web
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-50051
+      virtualHosts:
+        - domains:
+            - api.example.test
+            - api.example.test:*
+          name: api.example.test
+          routes:
+            - match:
+                pathSeparatedPrefix: /api
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend-2:443
+      name: gateway-conformance-infra:tls-backend-2:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: listener-443
+      name: cilium-gateway-multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      ports:
+        - 443
+    - listener: listener-50051
+      name: cilium-gateway-multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      ports:
+        - 50051
+    - listener: listener-8443
+      name: cilium-gateway-multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      ports:
+        - 8443
+    - listener: listener-9443
+      name: cilium-gateway-multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      ports:
+        - 9443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/httproute-api-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/httproute-api-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      sectionName: https-50051
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-https-with-multi-port-tls-passthrough
+        sectionName: https-50051

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/httproute-web-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/httproute-web-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: web-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - web.example.test
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      sectionName: https-443
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /web
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-https-with-multi-port-tls-passthrough
+        sectionName: https-443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/multi-port-https-with-multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/multi-port-https-with-multi-port-tls-passthrough.yaml
@@ -1,0 +1,161 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-port-https-with-multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: web.example.test
+      name: https-443
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: api.example.test
+      name: https-50051
+      port: 50051
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+    - allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+        namespaces:
+          from: Same
+      hostname: tls.example.test
+      name: tls-8443
+      port: 8443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+    - allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+        namespaces:
+          from: Same
+      hostname: tls.example.test
+      name: tls-9443
+      port: 9443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.255.200
+  conditions:
+    - lastTransitionTime: "2026-05-05T13:26:39Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T13:26:39Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-443
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-50051
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: tls-8443
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: tls-9443
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/tlsroute-tls-route-a.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/tlsroute-tls-route-a.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-route-a
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - tls.example.test
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-8443
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-https-with-multi-port-tls-passthrough
+        namespace: gateway-conformance-infra
+        sectionName: tls-8443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/tlsroute-tls-route-b.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/tlsroute-tls-route-b.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-route-b
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - tls.example.test
+  parentRefs:
+    - name: multi-port-https-with-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-9443
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T13:26:39Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-https-with-multi-port-tls-passthrough
+        namespace: gateway-conformance-infra
+        sectionName: tls-9443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/input/multi-port-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/input/multi-port-https.yaml
@@ -1,0 +1,97 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-port-https
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: grpcs
+      protocol: HTTPS
+      port: 50051
+      hostname: "*.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-https
+      sectionName: https
+  hostnames:
+    - api.example.test
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /web
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-https
+      sectionName: grpcs
+  hostnames:
+    - api.example.test
+  rules:
+    - matches:
+        - method:
+            service: com.example.Grpc
+            method: Serve
+      backendRefs:
+        - name: grpc-infra-backend-v1
+          port: 8080
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: multi-port-https-tls
+  namespace: gateway-conformance-infra
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVORENDQXB5Z0F3SUJBZ0lSQUtEL0JMRkJmd0tJWjBXR3JIdFRINmd3RFFZSktvWklodmNOQVFFTEJRQXcKZHpFZU1Cd0dBMVVFQ2hNVmJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElFTkJNU1l3SkFZRFZRUUxEQjEwWVcxdApZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tURXRNQ3NHQTFVRUF3d2tiV3RqWlhKMElIUmhiVzFoClkyaEFabVZrYjNKaExteGhiaUFvVkdGdElFMWhZMmdwTUI0WERUSXpNREl5TVRFeE1EZzBNMW9YRFRJMU1EVXkKTVRFeU1EZzBNMW93VVRFbk1DVUdBMVVFQ2hNZWJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElHTmxjblJwWm1sagpZWFJsTVNZd0pBWURWUVFMREIxMFlXMXRZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFNSVp5KzBKUlZqcXBXZ2VxMmRQKzFvbGlPNEEKQ2Nabk1nNHRTcVBhbGhEUUw2TWY2OEhZTGZpenlKSXBSek1KOTA1cllkMEFjbVhtdS9nMEVvOHlrSHhGRHo1VApzZVBzMlhRbmc4TU40YXpzUm1tMWw0Zjc0b3Zhd1F6UWNiODIyUVAxQ1M2SUxaM1Z0d05qUmgybkF3dGhZQk1vCkNrbmdER2VROEdsMHRqSExGbkJkVGRTd1FSbUUyanREQmNBZ3lFR3BxKzZSZVl0Ky80N25ObjdkQ2Z0c1ZxaEUKQllyOVhIM2l0ZWZIbXNiZmo3eldGYnB0ZGtvN3E5bE1Id25CZCswaGQ0ME1tSklYTVpyT0dHRlpqYXdKREJxUwpzQnEyUTNsNlhRejhYN1AvR0E0RG44aDR3M3JwcG1pYU43TE9tR1hla2kzeFgyd3FuTSswczZhWlpac0NBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUI0R0ExVWQKSXdRWU1CYUFGR1EyREIwNkNkUUZRQnNZUHllME5Cd0VyVU5FTUJjR0ExVWRFUVFRTUE2Q0RIVnVhWFIwWlhOMApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVlFQXJ0SGRLV1hSNmFFTHBmYWwxN2JpYWJDUHZJRjlqNm53CnVEemNkTVlRTHJYbThNK05IZTh4M2RwSTd1M2xsdE8rZHpMbmcrblZLUU9SM2FsUUFDU21SRDljN2llOGVUNWQKN3pLT1RrNmtlWTE5NUkxd1ZWNGpiTkxiTldhOXk0UkpRUlR2QkxBdkFQOU5WdFV3MlEvdy9FclVUcVN5eitvYgpkd250NGdZQ3c2ZEdubHVMeGxmRjM0REI5S2ZsdlZOU25reU1CL2dzQjRBM3IxR1BPSW8wR3lmNzRpZzNGV3JTCndIWUtuQmJ0WmZZTzBKVjBMQ29QeUhlOGcwWGFqWmU4RENiUC9FNlNtbFROQW1KRVNWamlnVFRjSUJBa0ZJK24KdG9CQWR4ZmhqS1VHYUNsT0hTMjljcGFpeW5qU2F5R200UmtIa3g3bWNBdWE5bFdQZjdwU2EzbUNjRmIrd0ZyMwpBQmtIRFBKSDJhY2ZhVUsxdmdLVGdPd2NHLzZLQTgyMC9QcmFvU2loTGFQSy9BN2VnNzdyMUVlWXB0ME5lcHBiClhqdlVwM1ltVmxJTVpYUHpyak9zYXN0b0RTcnN5Z2o1amRWdG00UHNsdjluUGh6RHJCamxacEVKU2NXNEpsYisKNnd0ZDdwMDNVREJTS2ZUYlZST1ZBZTVtdkp2QTBob1MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRENHY3Z0Q1VWWTZxVm8KSHF0blQvdGFKWWp1QUFuR1p6SU9MVXFqMnBZUTBDK2pIK3ZCMkMzNHM4aVNLVWN6Q2ZkT2EySGRBSEpsNXJ2NApOQktQTXBCOFJROCtVN0hqN05sMEo0UEREZUdzN0VacHRaZUgrK0tMMnNFTTBIRy9OdGtEOVFrdWlDMmQxYmNEClkwWWRwd01MWVdBVEtBcEo0QXhua1BCcGRMWXh5eFp3WFUzVXNFRVpoTm83UXdYQUlNaEJxYXZ1a1htTGZ2K08KNXpaKzNRbjdiRmFvUkFXSy9WeDk0clhueDVyRzM0KzgxaFc2YlhaS082dlpUQjhKd1hmdElYZU5ESmlTRnpHYQp6aGhoV1kyc0NRd2FrckFhdGtONWVsME0vRit6L3hnUEE1L0llTU42NmFab21qZXl6cGhsM3BJdDhWOXNLcHpQCnRMT21tV0diQWdNQkFBRUNnZ0VBRWpBU29NSjJvZzlTc24vMU5iZ1Q2RzJOK0NjK3d6MldQaWZXVDZaQzI0NTIKZUVXY2RNeUoranoyZFdPeXpVQ0kwT3RVL3oxMGVzSDFLUnZRQldVS2p1cDF0RFJwZmQ4S3ZVeWFseU5zMnlSRQpzTkVZUXVEQ2FMSjExbnFOdmdvb3FhdERVZjNtc0Z4L1NxejV1L3VUV0hTbWFRVWVlYStwMmVhRjhJdkVLc1FmCjZRTmtsa2VIc3YrR1ZQditpaWJmYlhYbmU2STVhVjM1UmM0UTA4elJDZ1lYL0JOMUFZWFY2aG80UkM5ZFpWR1AKSlVrU0x6UmFkZWdvay9FT05La3JxTFpPRkpWYjJ3dEZxODVnSjAxbE9ETS9najdHcU01OU0vd2s1NUNhUUlSRAo5eDVINFg0cnBNMnJobWlOTGtJTjB0R0xLTzhYMzF1cDdoVHg5YnZKY1FLQmdRRDUxTUxXWVlVUHovdW12U3JOClFPVDlVaEVISS9ieHRDYldRdGhXM0wxcXJWVDdEQjhKa28vNi94WWxYaGw3bndWd0p6MjRqSmY5dnV4V2JCcEwKSFpSZjBRc0RPMi9PNHJxaEtEb3YvR01VQ3gyc2h6YytKN2srVDkzS05WQU5ZYTA1Z3VxTWVCOG4zMEhQcm9rRgpMZ2loVkZGMjBrOVo2U2liVXZnVE1wRjFFd0tCZ1FERzVNQmdjOG9GWG1sci83cEhLaXpDNEYzZURBWFV4VkhNCldDSWJTd015ek9YS3FEY2RYTkR6OGNRcmpoS2EyckQxZktoRTBvUlIrUXZIejhJUEMrME1zVDdRNlFzSUhZajUKQ1h1YkhyMHM1azhQSkFwK0xrMkVkSGVQWlFNL0kvdmovZ1N3eG5KOVFzNjRGV1oyNUs5elluTk5zaW9qUWVsNwpXVm1JOUlWYVdRS0JnRDNCWWdnc1F3QU5vVjh1RTQ1NUpDR2FUNnM4TUthK3FYcjlPd3o5czdUUzg5YTZ3RkZWCmNWSFNERjlnUzF4TGlzU1dicU5YM1pwVHY0ZjlZT0tBaFZUS0Q3YlUwbWFKbFNpUkVSRWJpa0pDSFN1d29PODAKVW80Y24rNkVEeTIvbjFwQUNrcCt4dlRNTXpCckxHT2paVzY3c1FkMkpUZE1jMFV4MVRDcHAxc1JBb0dBYUVWSQpyY2hHWXlZcDhwcXcxOW8rZVRRVFFmUGZvcnFIdGErR3dmUkRpd0JzZ0NCTU5MS1NRVUhBZkcwUlIrbmExL2d3CloxUk9Wb05RTDhLMXBCbkdmdDcxWmFTblNldmlBVjE5VmNkNXVlNU1DRTRHeWp3UUc1N0xoM3VYaGlTaFM5ZkMKTWNMNEJyOWRqSmg3alYwNnRpMG84ZFN6enFRaGVhOVFCMExhSHBFQ2dZQXBjOG9Cb2lLNjlzMHdYeUk0K1BoeApTY0JKMFhxREJZRmt4eVhyOFk1cEVhckVhcUN0bDFPUFBNT2lRUkRXb3hSUitGd0EvMGxhU2ZoNXh3MFUzYitxCmlaMlhwa3JiUXAwMzRyQzBVUjZwK0ttMVN2OUFWQ0FDQWpyY1EzTlphZjhiRE9XcXZwbGE3QXVxMG9HOGk2VVgKaEVLQ0tmL04zZ0Uxb01yVHhWelVEUT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-multi-port-https
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.200
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/cec-multi-port-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/cec-multi-port-https.yaml
@@ -1,0 +1,216 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: multi-port-https
+  name: cilium-gateway-multi-port-https
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: multi-port-https
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: grpc-infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - "*.example.test"
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-443
+                statPrefix: listener-443
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-multi-port-https-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - "*.example.test"
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-50051
+                statPrefix: listener-50051
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-multi-port-https-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-50051
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-443
+      virtualHosts:
+        - domains:
+            - api.example.test
+            - api.example.test:*
+          name: api.example.test
+          routes:
+            - match:
+                pathSeparatedPrefix: /web
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-50051
+      virtualHosts:
+        - domains:
+            - api.example.test
+            - api.example.test:*
+          name: api.example.test
+          routes:
+            - match:
+                path: /com.example.Grpc/Serve
+              route:
+                cluster: gateway-conformance-infra:grpc-infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/grpc-infra-backend-v1:8080
+      name: gateway-conformance-infra:grpc-infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          explicitHttpConfig:
+            http2ProtocolOptions: {}
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: listener-443
+      name: cilium-gateway-multi-port-https
+      namespace: gateway-conformance-infra
+      ports:
+        - 443
+    - listener: listener-50051
+      name: cilium-gateway-multi-port-https
+      namespace: gateway-conformance-infra
+      ports:
+        - 50051

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/grpcroute-grpc-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/grpcroute-grpc-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: multi-port-https
+      sectionName: grpcs
+  rules:
+    - matches:
+        - method:
+            service: com.example.Grpc
+            method: Serve
+      backendRefs:
+        - name: grpc-infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Accepted GRPCRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-https
+        sectionName: grpcs

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/httproute-http-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/httproute-http-route.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: multi-port-https
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /web
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-https
+        sectionName: https

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/multi-port-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/multi-port-https.yaml
@@ -1,0 +1,97 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-port-https
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: "*.example.test"
+      name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: "*.example.test"
+      name: grpcs
+      port: 50051
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: multi-port-https-tls
+            namespace: gateway-conformance-infra
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.255.200
+  conditions:
+    - lastTransitionTime: "2026-04-16T22:17:55Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-16T22:17:55Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-16T22:17:55Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: grpcs
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/input/multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/input/multi-port-tls-passthrough.yaml
@@ -1,0 +1,77 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tls-443
+      protocol: TLS
+      port: 443
+      hostname: "tls.example.test"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+    - name: tls-9443
+      protocol: TLS
+      port: 9443
+      hostname: "tls.example.test"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-route-a
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-443
+  hostnames:
+    - tls.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-route-b
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-9443
+  hostnames:
+    - tls.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.200
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/cec-multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/cec-multi-port-tls-passthrough.yaml
@@ -1,0 +1,120 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: multi-port-tls-passthrough
+  name: cilium-gateway-multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: multi-port-tls-passthrough
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+    - name: tls-backend-2
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - tls.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:tls.example.test
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - tls.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:tls.example.test
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-9443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend-2:443
+      name: gateway-conformance-infra:tls-backend-2:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - listener: listener-443
+      name: cilium-gateway-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      ports:
+        - 443
+    - listener: listener-9443
+      name: cilium-gateway-multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      ports:
+        - 9443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/multi-port-tls-passthrough.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-port-tls-passthrough
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      hostname: "tls.example.test"
+      name: tls-443
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+    - allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+      hostname: "tls.example.test"
+      name: tls-9443
+      port: 9443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.255.200
+  conditions:
+    - lastTransitionTime: "2026-04-29T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-29T00:00:00Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: tls-443
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: tls-9443
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/tlsroute-tls-route-a.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/tlsroute-tls-route-a.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-route-a
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+    - name: multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-443
+  hostnames:
+    - tls.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-tls-passthrough
+        namespace: gateway-conformance-infra
+        sectionName: tls-443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/tlsroute-tls-route-b.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/tlsroute-tls-route-b.yaml
@@ -1,0 +1,35 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: tls-route-b
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+    - name: multi-port-tls-passthrough
+      namespace: gateway-conformance-infra
+      sectionName: tls-9443
+  hostnames:
+    - tls.example.test
+  rules:
+    - backendRefs:
+        - name: tls-backend-2
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-04-29T00:00:00Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: multi-port-tls-passthrough
+        namespace: gateway-conformance-infra
+        sectionName: tls-9443

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multiple-listeners/output/cec-gateway-multiple-listeners.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multiple-listeners/output/cec-gateway-multiple-listeners.yaml
@@ -82,14 +82,9 @@ spec:
             - match:
                 prefix: /
               route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
                 maxStreamDuration:
                   maxStreamDuration: 0s
-                weightedClusters:
-                  clusters:
-                  - name: "gateway-conformance-infra:infra-backend-v1:8080"
-                    weight: 1
-                  - name: "gateway-conformance-infra:infra-backend-v1:8080"
-                    weight: 1
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/infra-backend-v1:8080

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/input/ns-restricted-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/input/ns-restricted-same-hostname.yaml
@@ -1,0 +1,96 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ns-restricted-same-hostname
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https-restricted
+      protocol: HTTPS
+      port: 443
+      hostname: "api.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: ns-restricted-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https-open
+      protocol: HTTPS
+      port: 50051
+      hostname: "api.example.test"
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: ns-restricted-tls
+            namespace: gateway-conformance-infra
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+# Route from a DIFFERENT namespace (app-backend), no sectionName.
+# Should only appear on listener https-open (from: All),
+# not on https-restricted (from: Same).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-ns-route
+  namespace: gateway-conformance-app-backend
+spec:
+  parentRefs:
+    - name: ns-restricted-same-hostname
+      namespace: gateway-conformance-infra
+  hostnames:
+    - api.example.test
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /cross-ns
+      backendRefs:
+        - name: infra-backend-v1
+          namespace: gateway-conformance-infra
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: cross-ns-route-to-infra-backend
+  namespace: gateway-conformance-infra
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: gateway-conformance-app-backend
+  to:
+    - group: ""
+      kind: Service
+      name: infra-backend-v1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ns-restricted-tls
+  namespace: gateway-conformance-infra
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVORENDQXB5Z0F3SUJBZ0lSQUtEL0JMRkJmd0tJWjBXR3JIdFRINmd3RFFZSktvWklodmNOQVFFTEJRQXcKZHpFZU1Cd0dBMVVFQ2hNVmJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElFTkJNU1l3SkFZRFZRUUxEQjEwWVcxdApZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tURXRNQ3NHQTFVRUF3d2tiV3RqWlhKMElIUmhiVzFoClkyaEFabVZrYjNKaExteGhiaUFvVkdGdElFMWhZMmdwTUI0WERUSXpNREl5TVRFeE1EZzBNMW9YRFRJMU1EVXkKTVRFeU1EZzBNMW93VVRFbk1DVUdBMVVFQ2hNZWJXdGpaWEowSUdSbGRtVnNiM0J0Wlc1MElHTmxjblJwWm1sagpZWFJsTVNZd0pBWURWUVFMREIxMFlXMXRZV05vUUdabFpHOXlZUzVzWVc0Z0tGUmhiU0JOWVdOb0tUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFNSVp5KzBKUlZqcXBXZ2VxMmRQKzFvbGlPNEEKQ2Zabk1nNHRTcVBhbGhEUUw2TWY2OEhZTGZpenlKSXBSek1KOTA1cllkMEFjbVhtdS9nMEVvOHlrSHhGRHo1VApzZVBzMlhRbmc0TU40YXpzUm1tMWw0Zjc0b3Zhd1F6UWNiODIyUVAxQ1M2SUxaM1Z0d05qUmgybkF3dGhZQk1vCkNrbmdER2VROEdsMHRqSExGbkJkVGRTd1FSbUUyanREQmNBZ3lFR3BxKzZSZVl0Ky80N25ObjdkQ2Z0c1ZxaEUKQllyOVhIM2l0ZWZIbXNiZmo3eldGYnB0ZGtvN3E5bE1Id25CZCswaGQ0ME1tSklYTVpyT0dHRlpqYXdKREJxUwpzQnEyUTNsNlhRejhYN1AvR0E0RG44aDR3M3JwcG1pYU43TE9tR1hla2kzeFgyd3FuTSswczZhWlpac0NBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUI0R0ExVWQKSXdRWU1CYUFGR1EyREIwNkNkUUZRQnNZUHllME5Cd0VyVU5FTUJjR0ExVWRFUVFRTUE2Q0RIVnVhWFIwWlhOMApMbU52YlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVlFQXJ0SGRLV1hSNmFFTHBmYWwxN2JpYWJDUHZJRjlqNm53CnVEemNkTVlRTHJYbThNK05IZTh4M2RwSTd1M2xsdE8rZHpMbmcrblZLUU9SM2FsUUFDU21SRDljN2llOGVUNWQKN3pLT1RrNmtlWTE5NUkxd1ZWNGpiTkxiTldhOXk0UkpRUlR2QkxBdkFQOU5WdFV3MlEvdy9FclVUcVN5eitvYgpkd250NGdZQ3c2ZEdubHVMeGxmRjM0REI5S2ZsdlZOU25reU1CL2dzQjRBM3IxR1BPSW8wR3lmNzRpZzNGV3JTCndIWUtuQmJ0WmZZTzBKVjBMQ29QeUhlOGcwWGFqWmU4RENiUC9FNlNtbFROQW1KRVNWamlnVFRjSUJBa0ZJK24KdG9CQWR4ZmhqS1VHYUNsT0hTMjljcGFpeW5qU2F5R200UmtIa3g3bWNBdWE5bFdQZjdwU2EzbUNjRmIrd0ZyMwpBQmtIRFBKSDJhY2ZhVUsxdmdLVGdPd2NHLzZLQTgyMC9QcmFvU2loTGFQSy9BN2VnNzdyMUVlWXB0ME5lcHBiClhqdlVwM1ltVmxJTVpYUHpyak9zYXN0b0RTcnN5Z2o1amRWdG00UHNsdjluUGh6RHJCamxacEVKU2NXNEpsYisKNnd0ZDdwMDNVREJTS2ZUYlZST1ZBZTVtdkp2QTBob1MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2QUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktZd2dnU2lBZ0VBQW9JQkFRRENHY3Z0Q1VWWTZxVm8KSHF0blQvdGFKWWp1QUFuR1p6SU9MVXFqMnBZUTBDK2pIK3ZCMkMzNHM4aVNLVWN6Q2ZkT2EySGRBSEpsNXJ2NApOQktQTXBCOFJROCtVN0hqN05sMEo0UEREZUdzN0VacHRaZUgrK0tMMnNFTTBIRy9OdGtEOVFrdWlDMmQxYmNEClkwWWRwd01MWVdBVEtBcEo0QXhua1BCcGRMWXh5eFp3WFUzVXNFRVpoTm83UXdYQUlNaEJxYXZ1a1htTGZ2K08KNXpaKzNRbjdiRmFvUkFXSy9WeDk0clhueDVyRzM0KzgxaFc2YlhaS082dlpUQjhKd1hmdElYZU5ESmlTRnpHYQp6aGhoV1kyc0NRd2FrckFhdGtONWVsME0vRit6L3hnUEE1L0llTU42NmFab21qZXl6cGhsM3BJdDhWOXNLcHpQCnRMT21tV0diQWdNQkFBRUNnZ0VBRWpBU29NSjJvZzlTc24vMU5iZ1Q2RzJOK0NjK3d6MldQaWZXVDZaQzI0NTIKZUVXY2RNeUoranoyZFdPeXpVQ0kwT3RVL3oxMGVzSDFLUnZRQldVS2p1cDF0RFJwZmQ4S3ZVeWFseU5zMnlSRQpzTkVZUXVEQ2FMSjExbnFOdmdvb3FhdERVZjNtc0Z4L1NxejV1L3VUV0hTbWFRVWVlYStwMmVhRjhJdkVLc1FmCjZRTmtsa2VIc3YrR1ZQditpaWJmYlhYbmU2STVhVjM1UmM0UTA4elJDZ1lYL0JOMUFZWFY2aG80UkM5ZFpWR1AKSlVrU0x6UmFkZWdvay9FT05La3JxTFpPRkpWYjJ3dEZxODVnSjAxbE9ETS9najdHcU01OU0vd2s1NUNhUUlSRAo5eDVINFg0cnBNMnJobWlOTGtJTjB0R0xLTzhYMzF1cDdoVHg5YnZKY1FLQmdRRDUxTUxXWVlVUHovdW12U3JOClFPVDlVaEVISS9ieHRDYldRdGhXM0wxcXJWVDdEQjhKa28vNi94WWxYaGw3bndWd0p6MjRqSmY5dnV4V2JCcEwKSFpSZjBRc0RPMi9PNHJxaEtEb3YvR01VQ3gyc2h6YytKN2srVDkzS05WQU5ZYTA1Z3VxTWVCOG4zMEhQcm9rRgpMZ2loVkZGMjBrOVo2U2liVXZnVE1wRjFFd0tCZ1FERzVNQmdjOG9GWG1sci83cEhLaXpDNEYzZURBWFV4VkhNCldDSWJTd015ek9YS3FEY2RYTkR6OGNRcmpoS2EyckQxZktoRTBvUlIrUXZIejhJUEMrME1zVDdRNlFzSUhZajUKQ1h1YkhyMHM1azhQSkFwK0xrMkVkSGVQWlFNL0kvdmovZ1N3eG5KOVFzNjRGV1oyNUs5elluTk5zaW9qUWVsNwpXVm1JOUlWYVdRS0JnRDNCWWdnc1F3QU5vVjh1RTQ1NUpDR2FUNnM4TUthK3FYcjlPd3o5czdUUzg5YTZ3RkZWCmNWSFNERjlnUzF4TGlzU1dicU5YM1pwVHY0ZjlZT0tBaFZUS0Q3YlUwbWFKbFNpUkVSRWJpa0pDSFN1d29PODAKVW80Y24rNkVEeTIvbjFwQUNrcCt4dlRNTXpCckxHT2paVzY3c1FkMkpUZE1jMFV4MVRDcHAxc1JBb0dBYUVWSQpyY2hHWXlZcDhwcXcxOW8rZVRRVFFmUGZvcnFIdGErR3dmUkRpd0JzZ0NCTU5MS1NRVUhBZkcwUlIrbmExL2d3CloxUk9Wb05RTDhLMXBCbkdmdDcxWmFTblNldmlBVjE5VmNkNXVlNU1DRTRHeWp3UUc1N0xoM3VYaGlTaFM5ZkMKTWNMNEJyOWRqSmg3alYwNnRpMG84ZFN6enFRaGVhOVFCMExhSHBFQ2dZQXBjOG9Cb2lLNjlzMHdYeUk0K1BoeApTY0JKMFhxREJZRmt4eVhyOFk1cEVhckVhcUN0bDFPUFBNT2lRUkRXb3hSUitGd0EvMGxhU2ZoNXh3MFUzYitxCmlaMlhwa3JiUXAwMzRyQzBVUjZwK0ttMVN2OUFWQ0FDQWpyY1EzTlphZjhiRE9XcXZwbGE3QXVxMG9HOGk2VVgKaEVLQ0tmL04zZ0Uxb01yVHhWelVEUT09Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-ns-restricted-same-hostname
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.200
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/cec-ns-restricted-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/cec-ns-restricted-same-hostname.yaml
@@ -1,0 +1,185 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: ns-restricted-same-hostname
+  name: cilium-gateway-ns-restricted-same-hostname
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: ns-restricted-same-hostname
+  resourceVersion: 1
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - api.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-443
+                statPrefix: listener-443
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-ns-restricted-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            serverNames:
+              - api.example.test
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-50051
+                statPrefix: listener-50051
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-ns-restricted-tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-50051
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-443
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-50051
+      virtualHosts:
+        - domains:
+            - api.example.test
+            - api.example.test:*
+          name: api.example.test
+          routes:
+            - match:
+                pathSeparatedPrefix: /cross-ns
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: listener-443
+      name: cilium-gateway-ns-restricted-same-hostname
+      namespace: gateway-conformance-infra
+      ports:
+        - 443
+    - listener: listener-50051
+      name: cilium-gateway-ns-restricted-same-hostname
+      namespace: gateway-conformance-infra
+      ports:
+        - 50051

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/httproute-cross-ns-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/httproute-cross-ns-route.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cross-ns-route
+  namespace: gateway-conformance-app-backend
+  resourceVersion: "1000"
+spec:
+  hostnames:
+    - api.example.test
+  parentRefs:
+    - name: ns-restricted-same-hostname
+      namespace: gateway-conformance-infra
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /cross-ns
+      backendRefs:
+        - name: infra-backend-v1
+          namespace: gateway-conformance-infra
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: ns-restricted-same-hostname
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/ns-restricted-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/ns-restricted-same-hostname.yaml
@@ -1,0 +1,97 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ns-restricted-same-hostname
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: api.example.test
+      name: https-restricted
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: ns-restricted-tls
+            namespace: gateway-conformance-infra
+    - allowedRoutes:
+        namespaces:
+          from: All
+      hostname: api.example.test
+      name: https-open
+      port: 50051
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: ns-restricted-tls
+            namespace: gateway-conformance-infra
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.255.200
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:46:37Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:46:37Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-restricted
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:46:37Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: https-open
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/input/httproute-allowed-kind-by-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/input/httproute-allowed-kind-by-section-name.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
@@ -1,7 +1,6 @@
 metadata:
   annotations:
     cec.cilium.io/use-original-source-address: "false"
-  creationTimestamp: null
   labels:
     gateway.networking.k8s.io/gateway-name: kind-restricted-multi-listener
   name: cilium-gateway-kind-restricted-multi-listener
@@ -11,8 +10,7 @@ metadata:
       controller: true
       kind: Gateway
       name: kind-restricted-multi-listener
-      uid: ""
-  resourceVersion: "1"
+  resourceVersion: 1
 spec:
   backendServices:
     - name: grpc-infra-backend-v1
@@ -26,34 +24,6 @@ spec:
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
-        - filterChainMatch:
-            transportProtocol: raw_buffer
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
         - filterChainMatch:
             transportProtocol: tls
           filters:
@@ -76,8 +46,8 @@ spec:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 internalAddressConfig: {}
                 rds:
-                  routeConfigName: listener-secure
-                statPrefix: listener-secure
+                  routeConfigName: listener-443
+                statPrefix: listener-443
                 streamIdleTimeout: 300s
                 upgradeConfigs:
                   - upgradeType: websocket
@@ -93,7 +63,66 @@ spec:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
             "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-      name: listener
+      name: listener-443
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-50051
+                statPrefix: listener-50051
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/gateway-conformance-infra-tls-checks-certificate
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener-50051
       socketOptions:
         - description: Enable TCP keep-alive (default to enabled)
           intValue: "1"
@@ -114,22 +143,29 @@ spec:
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
       name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-secure
+      name: listener-443
       virtualHosts:
         - domains:
-            - "*"
-          name: "*"
+            - '*'
+          name: '*'
+          routes:
+            - match:
+                pathSeparatedPrefix: /kind-allowed
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-50051
+      virtualHosts:
+        - domains:
+            - '*'
+          name: '*'
           routes:
             - match:
                 path: /com.example.KindAllowed/Check
               route:
                 cluster: gateway-conformance-infra:grpc-infra-backend-v1:8080
-                maxStreamDuration:
-                  maxStreamDuration: 0s
-            - match:
-                pathSeparatedPrefix: /kind-allowed
-              route:
-                cluster: gateway-conformance-infra:infra-backend-v1:8080
                 maxStreamDuration:
                   maxStreamDuration: 0s
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
@@ -161,8 +197,13 @@ spec:
           useDownstreamProtocolConfig:
             http2ProtocolOptions: {}
   services:
-    - name: cilium-gateway-kind-restricted-multi-listener
+    - listener: listener-443
+      name: cilium-gateway-kind-restricted-multi-listener
       namespace: gateway-conformance-infra
       ports:
         - 443
+    - listener: listener-50051
+      name: cilium-gateway-kind-restricted-multi-listener
+      namespace: gateway-conformance-infra
+      ports:
         - 50051

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/grpcroute-grpc-via-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/grpcroute-grpc-via-section-name.yaml
@@ -1,7 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
-  creationTimestamp: null
   name: grpc-via-section-name
   namespace: gateway-conformance-infra
   resourceVersion: "1000"
@@ -11,22 +10,22 @@ spec:
       namespace: gateway-conformance-infra
       sectionName: grpcs
   rules:
-    - matches:
-        - method:
-            service: com.example.KindAllowed
-            method: Check
-      backendRefs:
+    - backendRefs:
         - name: grpc-infra-backend-v1
           port: 8080
+      matches:
+        - method:
+            method: Check
+            service: com.example.KindAllowed
 status:
   parents:
     - conditions:
-        - lastTransitionTime: "2025-07-01T14:19:43Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted
-        - lastTransitionTime: "2025-07-01T14:19:43Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Service reference is valid
           reason: ResolvedRefs
           status: "True"

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/httproute-http-via-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/httproute-http-via-section-name.yaml
@@ -1,7 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  creationTimestamp: null
   name: http-via-section-name
   namespace: gateway-conformance-infra
   resourceVersion: "1000"
@@ -11,22 +10,22 @@ spec:
       namespace: gateway-conformance-infra
       sectionName: https
   rules:
-    - matches:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+      matches:
         - path:
             type: PathPrefix
             value: /kind-allowed
-      backendRefs:
-        - name: infra-backend-v1
-          port: 8080
 status:
   parents:
     - conditions:
-        - lastTransitionTime: "2025-07-01T14:19:43Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Accepted HTTPRoute
           reason: Accepted
           status: "True"
           type: Accepted
-        - lastTransitionTime: "2025-07-01T14:19:43Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Service reference is valid
           reason: ResolvedRefs
           status: "True"

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/kind-restricted-multi-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/kind-restricted-multi-listener.yaml
@@ -1,7 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  creationTimestamp: null
   name: kind-restricted-multi-listener
   namespace: gateway-conformance-infra
   resourceVersion: "1000"
@@ -47,12 +46,12 @@ status:
   listeners:
     - attachedRoutes: 1
       conditions:
-        - lastTransitionTime: "2025-07-01T05:52:17Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Resolved Refs
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
-        - lastTransitionTime: "2025-07-01T05:52:17Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Listener Accepted
           reason: Accepted
           status: "True"
@@ -68,12 +67,12 @@ status:
           kind: HTTPRoute
     - attachedRoutes: 1
       conditions:
-        - lastTransitionTime: "2025-07-01T05:52:17Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Resolved Refs
           reason: ResolvedRefs
           status: "True"
           type: ResolvedRefs
-        - lastTransitionTime: "2025-07-01T05:52:17Z"
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Listener Accepted
           reason: Accepted
           status: "True"

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/gateway-tlsroute-mixed.yaml
@@ -6,107 +6,115 @@ metadata:
 spec:
   gatewayClassName: cilium
   listeners:
-  - allowedRoutes:
-      namespaces:
-        from: Same
-    name: http
-    port: 80
-    protocol: HTTP
-  - allowedRoutes:
-      namespaces:
-        from: Same
-    name: https
-    port: 443
-    protocol: HTTPS
-    tls:
-      certificateRefs:
-      - name: tls-checks-certificate
-      mode: Terminate
-  - allowedRoutes:
-      namespaces:
-        from: Same
-    name: tls
-    port: 443
-    protocol: TLS
-    tls:
-      mode: Passthrough
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: tls-checks-certificate
+        mode: Terminate
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: tls
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
 status:
   conditions:
-  - lastTransitionTime: "2025-07-01T14:29:32Z"
-    message: Gateway successfully scheduled
-    reason: Accepted
-    status: "True"
-    type: Accepted
-  - lastTransitionTime: "2025-07-01T05:06:15Z"
-    message: Gateway waiting for address
-    reason: AddressNotAssigned
-    status: "False"
-    type: Programmed
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
   listeners:
-  - attachedRoutes: 0
-    conditions:
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Resolved Refs
-      reason: ResolvedRefs
-      status: "True"
-      type: ResolvedRefs
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Listener Accepted
-      reason: Accepted
-      status: "True"
-      type: Accepted
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Address not ready yet
-      reason: Pending
-      status: "False"
-      type: Programmed
-    name: http
-    supportedKinds:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-    - group: gateway.networking.k8s.io
-      kind: GRPCRoute
-  - attachedRoutes: 0
-    conditions:
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Resolved Refs
-      reason: ResolvedRefs
-      status: "True"
-      type: ResolvedRefs
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Listener Accepted
-      reason: Accepted
-      status: "True"
-      type: Accepted
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Address not ready yet
-      reason: Pending
-      status: "False"
-      type: Programmed
-    name: https
-    supportedKinds:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-    - group: gateway.networking.k8s.io
-      kind: GRPCRoute
-  - attachedRoutes: 1
-    conditions:
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Resolved Refs
-      reason: ResolvedRefs
-      status: "True"
-      type: ResolvedRefs
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Listener Accepted
-      reason: Accepted
-      status: "True"
-      type: Accepted
-    - lastTransitionTime: "2025-07-01T14:29:32Z"
-      message: Address not ready yet
-      reason: Pending
-      status: "False"
-      type: Programmed
-    name: tls
-    supportedKinds:
-    - group: gateway.networking.k8s.io
-      kind: TLSRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message:
+            'Listener conflicts with listener "tls": same port 443 has overlapping
+            HTTPS and TLS passthrough hostnames.'
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message:
+            'Listener not valid. Listener conflicts with listener "tls": same port
+            443 has overlapping HTTPS and TLS passthrough hostnames.'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message:
+            'Listener conflicts with listener "https": same port 443 has overlapping
+            HTTPS and TLS passthrough hostnames.'
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message:
+            'Listener not valid. Listener conflicts with listener "https": same
+            port 443 has overlapping HTTPS and TLS passthrough hostnames.'
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: tls
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TLSRoute

--- a/operator/pkg/model/helpers.go
+++ b/operator/pkg/model/helpers.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+
+	gatewayapihelpers "github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
 const (
@@ -187,6 +189,17 @@ func hostnameMatchesWildcardHostname(hostname, wildcardHostname string) bool {
 
 	wildcardMatch := strings.TrimSuffix(hostname, strings.TrimPrefix(wildcardHostname, allHosts))
 	return len(wildcardMatch) > 0
+}
+
+func normalizeHostname(hostname string) string {
+	if hostname == "" {
+		return allHosts
+	}
+	return hostname
+}
+
+func sniHostnamesIntersect(a, b string) bool {
+	return gatewayapihelpers.SNIHostnamesIntersect(a, b)
 }
 
 func wildcardHostnamesIntersect(routeHostname, listenerHostname string) bool {

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -38,6 +38,7 @@ type Input struct {
 	TLSRoutes           []gatewayv1.TLSRoute
 	GRPCRoutes          []gatewayv1.GRPCRoute
 	ReferenceGrants     []gatewayv1.ReferenceGrant
+	Namespaces          []corev1.Namespace
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
 	BackendTLSPolicyMap helpers.BackendTLSPolicyServiceMap
@@ -73,6 +74,8 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 		}
 	}
 
+	namespaceLabels := helpers.NewNamespaceLabelIndex(input.Namespaces)
+
 	// Find all the listener host names, so that we can match them with the routes
 	// Gateway API spec guarantees that the hostnames are unique across all listeners
 	listenerHostnamesByProtocol := make(map[gatewayv1.ProtocolType][]string)
@@ -94,8 +97,8 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 		}
 
 		var httpRoutes []model.HTTPRoute
-		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
-		httpRoutes = append(httpRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
+		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
+		httpRoutes = append(httpRoutes, toGRPCRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
 		resHTTP = append(resHTTP, model.HTTPListener{
 			Name: string(l.Name),
 			Sources: []model.FullyQualifiedResource{
@@ -131,7 +134,7 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 				},
 				Port:           uint32(l.Port),
 				Hostname:       toHostname(l.Hostname),
-				Routes:         toTLSRoutes(l, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toTLSRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -172,6 +175,8 @@ func getBackendServiceName(namespace string, services []corev1.Service, serviceI
 
 func toHTTPRoutes(log *slog.Logger,
 	listener gatewayv1.Listener,
+	gatewayNamespace string,
+	namespaceLabels helpers.NamespaceLabelIndex,
 	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
 	input []gatewayv1.HTTPRoute,
 	services []corev1.Service,
@@ -222,6 +227,10 @@ func toHTTPRoutes(log *slog.Logger,
 		}
 
 		if !listenerIsParent {
+			continue
+		}
+
+		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -559,6 +568,8 @@ func toHTTPRetry(retry *gatewayv1.HTTPRouteRetry) *model.HTTPRetry {
 }
 
 func toGRPCRoutes(listener gatewayv1beta1.Listener,
+	gatewayNamespace string,
+	namespaceLabels helpers.NamespaceLabelIndex,
 	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
 	input []gatewayv1.GRPCRoute,
 	services []corev1.Service,
@@ -575,6 +586,10 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 			}
 		}
 		if !isListener {
+			continue
+		}
+
+		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -686,7 +701,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 	return grpcRoutes
 }
 
-func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
+func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
 	for _, r := range input {
 		isListener := false
@@ -697,6 +712,10 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol m
 			}
 		}
 		if !isListener {
+			continue
+		}
+
+		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -71,6 +74,113 @@ func TestHTTPGatewayAPI(t *testing.T) {
 			assert.Equal(t, toYaml(t, expected), toYaml(t, listeners), "Listeners did not match")
 		})
 	}
+}
+
+func TestHTTPGatewayAPIFiltersSelectorNamespacesPerListener(t *testing.T) {
+	selector := gatewayv1.NamespacesFromSelector
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	listeners, _ := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "selector-listener-conflict-gateway",
+				Namespace: "gateway-system",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "http-selected",
+						Hostname: ptr.To[gatewayv1.Hostname]("selected.example.test"),
+						Port:     80,
+						Protocol: gatewayv1.HTTPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From:     &selector,
+								Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"expose": "true"}},
+							},
+						},
+					},
+					{
+						Name:     "http-unselected",
+						Hostname: ptr.To[gatewayv1.Hostname]("unselected.example.test"),
+						Port:     80,
+						Protocol: gatewayv1.HTTPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &selector,
+								Selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+									{Key: "expose", Operator: metav1.LabelSelectorOpDoesNotExist},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		HTTPRoutes: []gatewayv1.HTTPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "selector-conflict-route",
+					Namespace: "backend-a",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "selector-listener-conflict-gateway",
+								Namespace: ptr.To[gatewayv1.Namespace]("gateway-system"),
+							},
+						},
+					},
+					Hostnames: []gatewayv1.Hostname{
+						"selected.example.test",
+						"unselected.example.test",
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "api",
+											Port: ptr.To[gatewayv1.PortNumber](80),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Namespaces: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "backend-a",
+					Labels: map[string]string{"expose": "true"},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "api",
+					Namespace: "backend-a",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			},
+		},
+	})
+
+	require.Len(t, listeners, 2)
+	require.Equal(t, "http-selected", listeners[0].Name)
+	require.Len(t, listeners[0].Routes, 1)
+	assert.Equal(t, []string{"selected.example.test"}, listeners[0].Routes[0].Hostnames)
+
+	require.Equal(t, "http-unselected", listeners[1].Name)
+	assert.Empty(t, listeners[1].Routes)
 }
 
 func TestTLSGatewayAPI(t *testing.T) {
@@ -218,6 +328,7 @@ func readGatewayInput(t *testing.T, testName string) Input {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-httproute.yaml"), &input.HTTPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tlsroute.yaml"), &input.TLSRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-grpcroute.yaml"), &input.GRPCRoutes)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-namespace.yaml"), &input.Namespaces)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-service.yaml"), &input.Services)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-serviceimport.yaml"), &input.ServiceImports)
 

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteCrossNamespace/input-namespace.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/HTTPRouteCrossNamespace/input-namespace.yaml
@@ -1,0 +1,4 @@
+- metadata:
+    labels:
+      gateway-conformance: backend
+    name: gateway-conformance-web-backend

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -629,6 +629,33 @@ func (m *Model) IsHTTPSListenerConfigured() bool {
 	return false
 }
 
+// IsHTTPSPortConfigured returns true if the model contains an HTTPS listener
+// on the given port number.
+func (m *Model) IsHTTPSPortConfigured(port uint32) bool {
+	for _, l := range m.HTTP {
+		if len(l.TLS) > 0 && l.Port == port {
+			return true
+		}
+	}
+	return false
+}
+
+// HTTPSPortsSorted returns sorted, unique ports for all HTTPS listeners.
+func (m *Model) HTTPSPortsSorted() []uint32 {
+	var ports []uint32
+	for _, l := range m.HTTP {
+		if len(l.TLS) > 0 {
+			ports = append(ports, l.Port)
+		}
+	}
+	return slices.SortedUnique(ports)
+}
+
+// NeedsPerPortHTTPSListeners returns true if the model has more than one distinct HTTPS port.
+func (m *Model) NeedsPerPortHTTPSListeners() bool {
+	return len(m.HTTPSPortsSorted()) > 1
+}
+
 // IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.
 func (m *Model) IsTLSPassthroughListenerConfigured() bool {
 	for _, l := range m.TLSPassthrough {
@@ -718,6 +745,24 @@ func (m *Model) TLSSecretsToHostnames() map[TLSSecret][]string {
 	for _, h := range m.HTTP {
 		for _, s := range h.TLS {
 			res[s] = append(res[s], h.Hostname)
+		}
+	}
+	return res
+}
+
+// TLSListenerRef records a (hostname, port) pair for an HTTPS listener.
+type TLSListenerRef struct {
+	Hostname string
+	Port     uint32
+}
+
+// TLSSecretsToListeners returns, for each TLS secret, the set of
+// (hostname, port) pairs of all HTTPS listeners that reference it.
+func (m *Model) TLSSecretsToListeners() map[TLSSecret][]TLSListenerRef {
+	res := make(map[TLSSecret][]TLSListenerRef)
+	for _, l := range m.HTTP {
+		for _, s := range l.TLS {
+			res[s] = append(res[s], TLSListenerRef{Hostname: l.Hostname, Port: l.Port})
 		}
 	}
 	return res

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -631,7 +631,12 @@ func (m *Model) IsHTTPSListenerConfigured() bool {
 
 // IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.
 func (m *Model) IsTLSPassthroughListenerConfigured() bool {
-	return len(m.TLSPassthrough) > 0
+	for _, l := range m.TLSPassthrough {
+		if len(l.Routes) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // HTTPPorts returns a list of unique ports for all HTTP listeners.
@@ -660,7 +665,9 @@ func (m *Model) IsCORSFilterConfigured() bool {
 func (m *Model) TLSPassthroughPorts() []uint32 {
 	var ports []uint32
 	for _, l := range m.TLSPassthrough {
-		ports = append(ports, l.Port)
+		if len(l.Routes) > 0 {
+			ports = append(ports, l.Port)
+		}
 	}
 	return slices.SortedUnique(ports)
 }

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -661,9 +661,88 @@ func (m *Model) NeedsPerPortTLSPassthroughListeners() bool {
 }
 
 // NeedsPerPortListeners returns true if any protocol has enough distinct ports
-// to require per-port Envoy Listener resources.
+// to require per-port Envoy Listener resources, or if cross-protocol SNI overlap
+// would make a combined listener lose the Gateway listener port boundary.
 func (m *Model) NeedsPerPortListeners() bool {
-	return m.NeedsPerPortHTTPSListeners() || m.NeedsPerPortTLSPassthroughListeners()
+	return m.NeedsPerPortHTTPSListeners() || m.NeedsPerPortTLSPassthroughListeners() || m.NeedsCrossProtocolSplit()
+}
+
+// NeedsCrossProtocolSplit returns true when HTTPS and TLS passthrough filter
+// chains on different Gateway listener ports cannot safely share a combined
+// Envoy listener.
+//
+// Filter chains from different Gateway listener ports must not share any SNI
+// match because a combined Envoy listener would otherwise erase the original
+// Gateway listener port boundary and route traffic for one listener to another.
+// Same-port HTTPS and TLS passthrough conflicts cannot be fixed by per-port
+// listeners and need to be rejected before translation.
+func (m *Model) NeedsCrossProtocolSplit() bool {
+	for _, httpsMatch := range m.httpsFilterChainMatches() {
+		for _, tlsMatch := range m.tlsPassthroughFilterChainMatches() {
+			if httpsMatch.port == tlsMatch.port {
+				continue
+			}
+			if sniHostnamesIntersect(httpsMatch.hostname, tlsMatch.hostname) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type filterChainMatch struct {
+	hostname string
+	port     uint32
+}
+
+// httpsFilterChainMatches returns the normalized hostnames and ports that HTTPS
+// filter chains will use for SNI matching. Each HTTPS filter chain's ServerNames
+// derive from the listener-level hostname.
+func (m *Model) httpsFilterChainMatches() []filterChainMatch {
+	var matches []filterChainMatch
+	seen := map[filterChainMatch]struct{}{}
+	for _, l := range m.HTTP {
+		if len(l.TLS) == 0 {
+			continue
+		}
+		match := filterChainMatch{hostname: normalizeHostname(l.Hostname), port: l.Port}
+		if _, ok := seen[match]; ok {
+			continue
+		}
+		seen[match] = struct{}{}
+		matches = append(matches, match)
+	}
+	return matches
+}
+
+// tlsPassthroughFilterChainMatches returns the normalized hostnames and ports
+// that TLS passthrough filter chains will use for SNI matching. These derive
+// from route hostnames because each TLS passthrough route generates its own
+// filter chain.
+func (m *Model) tlsPassthroughFilterChainMatches() []filterChainMatch {
+	var matches []filterChainMatch
+	seen := map[filterChainMatch]struct{}{}
+	for _, l := range m.TLSPassthrough {
+		for _, r := range l.Routes {
+			if len(r.Hostnames) == 0 {
+				match := filterChainMatch{hostname: allHosts, port: l.Port}
+				if _, ok := seen[match]; !ok {
+					seen[match] = struct{}{}
+					matches = append(matches, match)
+				}
+				continue
+			}
+			for _, h := range r.Hostnames {
+				match := filterChainMatch{hostname: normalizeHostname(h), port: l.Port}
+				if _, ok := seen[match]; ok {
+					continue
+				}
+				seen[match] = struct{}{}
+				matches = append(matches, match)
+			}
+		}
+	}
+	return matches
 }
 
 // IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -4,7 +4,6 @@
 package model
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -656,6 +655,17 @@ func (m *Model) NeedsPerPortHTTPSListeners() bool {
 	return len(m.HTTPSPortsSorted()) > 1
 }
 
+// NeedsPerPortTLSPassthroughListeners returns true if the model has more than one distinct TLS passthrough port.
+func (m *Model) NeedsPerPortTLSPassthroughListeners() bool {
+	return len(m.TLSPassthroughPorts()) > 1
+}
+
+// NeedsPerPortListeners returns true if any protocol has enough distinct ports
+// to require per-port Envoy Listener resources.
+func (m *Model) NeedsPerPortListeners() bool {
+	return m.NeedsPerPortHTTPSListeners() || m.NeedsPerPortTLSPassthroughListeners()
+}
+
 // IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.
 func (m *Model) IsTLSPassthroughListenerConfigured() bool {
 	for _, l := range m.TLSPassthrough {
@@ -705,37 +715,6 @@ func (m *Model) AllPorts() []uint32 {
 	ports = append(ports, m.HTTPPorts()...)
 	ports = append(ports, m.TLSPassthroughPorts()...)
 	return slices.SortedUnique(ports)
-}
-
-type TLSBackendDetails struct {
-	BackendKey string
-	Hostnames  []string
-}
-
-// TLSBackends returns a slice of TLSBackendDetails.
-// This is only used for TLS Passthrough listeners.
-//
-// The slice keeps the ordering of the model Listeners,
-// as the model Listeners are correctly sorted by hostname,
-// in decreasing order of specificity.
-//
-// This ensures that the rules that end up generated in the translation
-// process are in the correct most-specific to least-specific order.
-func (m *Model) TLSBackends() []TLSBackendDetails {
-	res := []TLSBackendDetails{}
-
-	for _, h := range m.TLSPassthrough {
-		for _, route := range h.Routes {
-			for _, backend := range route.Backends {
-				key := fmt.Sprintf("%s:%s:%s", backend.Namespace, backend.Name, backend.Port.GetPort())
-				res = append(res, TLSBackendDetails{
-					BackendKey: key,
-					Hostnames:  route.Hostnames,
-				})
-			}
-		}
-	}
-	return res
 }
 
 // TLSSecretsToHostnames returns a map of TLS secrets to hostnames.

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -426,6 +426,259 @@ func TestNeedsPerPortHTTPSListeners(t *testing.T) {
 	}
 }
 
+func TestNeedsCrossProtocolSplit(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  bool
+	}{
+		{
+			name:  "empty model",
+			model: Model{},
+			want:  false,
+		},
+		{
+			name: "HTTPS only",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "api.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "TLS passthrough only",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "api.example.test", Routes: []TLSPassthroughRoute{{Hostnames: []string{"api.example.test"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "same hostname across protocols",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "api.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "api.example.test", Routes: []TLSPassthroughRoute{{Hostnames: []string{"api.example.test"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "same hostname and port across protocols does not trigger per-port split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "api.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Hostname: "api.example.test", Routes: []TLSPassthroughRoute{{Hostnames: []string{"api.example.test"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "disjoint hostnames across protocols",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "web.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "tls.example.test", Routes: []TLSPassthroughRoute{{Hostnames: []string{"tls.example.test"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "overlap via route hostname",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "shared.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"shared.example.test"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "catch-all hostnames on both protocols trigger split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "*", Routes: []TLSPassthroughRoute{{Hostnames: []string{"*"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "empty catch-all hostnames on both protocols trigger split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "", Routes: []TLSPassthroughRoute{{Hostnames: []string{""}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "catch-all HTTPS with specific TLS passthrough hostname on same port does not collide",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Hostname: "*", Routes: []TLSPassthroughRoute{{Hostnames: []string{"tls.example.test"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "catch-all HTTPS with specific TLS passthrough hostname on different ports triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "*", Routes: []TLSPassthroughRoute{{Hostnames: []string{"tls.example.test"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "specific HTTPS with catch-all TLS passthrough hostname on same port does not collide",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "web.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Hostname: "*", Routes: []TLSPassthroughRoute{{Hostnames: []string{"*"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "specific HTTPS with catch-all TLS passthrough hostname on different ports triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "web.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "*", Routes: []TLSPassthroughRoute{{Hostnames: []string{"*"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "catch-all HTTPS with empty TLS passthrough route hostnames triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "tls.example.test", Routes: []TLSPassthroughRoute{{}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "catch-all HTTPS with catch-all TLS route hostname triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Hostname: "tls.example.test", Routes: []TLSPassthroughRoute{{Hostnames: []string{"*"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPS wildcard does not collide with TLS route exact hostname on same port",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"api.example.test"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "HTTPS wildcard with TLS route exact hostname on different ports triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"api.example.test"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPS wildcard does not collide with TLS route different suffix",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"api.example.org"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "HTTPS exact hostname does not collide with TLS route wildcard on same port",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "api.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"*.example.test"}}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "HTTPS exact hostname with TLS route wildcard on different ports triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "api.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"*.example.test"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "same wildcard across protocols triggers split",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "*.example.test", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 9443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"*.example.test"}}}},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.NeedsCrossProtocolSplit())
+		})
+	}
+}
+
 func TestIsHTTPSPortConfigured(t *testing.T) {
 	m := Model{
 		HTTP: []HTTPListener{

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var testTLSListener = TLSPassthroughListener{
@@ -188,6 +190,123 @@ func TestModel_GRPCWebTranslationEnabled(t *testing.T) {
 			if got := tt.model.GRPCWebTranslationEnabled(); got != tt.want {
 				t.Errorf("Model.GRPCWebTranslationEnabled() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIsTLSPassthroughListenerConfigured(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  bool
+	}{
+		{
+			name:  "empty model",
+			model: Model{},
+			want:  false,
+		},
+		{
+			name: "listener with routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"example.com"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "listener without routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "mixed — one with routes, one without",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443},
+					{Port: 8443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"example.com"}}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multiple listeners all without routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443},
+					{Port: 8443},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.IsTLSPassthroughListenerConfigured())
+		})
+	}
+}
+
+func TestTLSPassthroughPorts(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  []uint32
+	}{
+		{
+			name:  "empty model",
+			model: Model{},
+			want:  nil,
+		},
+		{
+			name: "listeners with routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 8443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"a.com"}}}},
+					{Port: 443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"b.com"}}}},
+				},
+			},
+			want: []uint32{443, 8443},
+		},
+		{
+			name: "routeless listeners excluded",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443},
+					{Port: 8443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"a.com"}}}},
+					{Port: 9443},
+				},
+			},
+			want: []uint32{8443},
+		},
+		{
+			name: "all routeless",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443},
+					{Port: 8443},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "duplicate ports deduplicated",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{Port: 443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"a.com"}}}},
+					{Port: 443, Routes: []TLSPassthroughRoute{{Hostnames: []string{"b.com"}}}},
+				},
+			},
+			want: []uint32{443},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.TLSPassthroughPorts())
 		})
 	}
 }

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -310,3 +310,158 @@ func TestTLSPassthroughPorts(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPSPortsSorted(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  []uint32
+	}{
+		{
+			name:  "empty model",
+			model: Model{},
+			want:  nil,
+		},
+		{
+			name: "no HTTPS listeners",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 80},
+					{Port: 8080},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "single HTTPS port",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+			},
+			want: []uint32{443},
+		},
+		{
+			name: "two HTTPS ports sorted",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 8443, TLS: []TLSSecret{{Name: "cert-b", Namespace: "ns"}}},
+					{Port: 443, TLS: []TLSSecret{{Name: "cert-a", Namespace: "ns"}}},
+				},
+			},
+			want: []uint32{443, 8443},
+		},
+		{
+			name: "mixed HTTP and HTTPS",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 80},
+					{Port: 443, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+					{Port: 8080},
+					{Port: 50051, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+			},
+			want: []uint32{443, 50051},
+		},
+		{
+			name: "duplicate HTTPS ports deduplicated",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, Hostname: "a.com", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+					{Port: 443, Hostname: "b.com", TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+			},
+			want: []uint32{443},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.HTTPSPortsSorted())
+		})
+	}
+}
+
+func TestNeedsPerPortHTTPSListeners(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  bool
+	}{
+		{
+			name:  "empty model",
+			model: Model{},
+			want:  false,
+		},
+		{
+			name: "one HTTPS port",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "two HTTPS ports",
+			model: Model{
+				HTTP: []HTTPListener{
+					{Port: 443, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+					{Port: 50051, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTP only",
+			model: Model{
+				HTTP: []HTTPListener{{Port: 80}, {Port: 8080}},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.NeedsPerPortHTTPSListeners())
+		})
+	}
+}
+
+func TestIsHTTPSPortConfigured(t *testing.T) {
+	m := Model{
+		HTTP: []HTTPListener{
+			{Port: 80},
+			{Port: 443, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+			{Port: 50051, TLS: []TLSSecret{{Name: "cert", Namespace: "ns"}}},
+		},
+	}
+	assert.True(t, m.IsHTTPSPortConfigured(443))
+	assert.True(t, m.IsHTTPSPortConfigured(50051))
+	assert.False(t, m.IsHTTPSPortConfigured(80))
+	assert.False(t, m.IsHTTPSPortConfigured(9999))
+}
+
+func TestTLSSecretsToListeners(t *testing.T) {
+	certA := TLSSecret{Name: "cert-a", Namespace: "ns"}
+	certB := TLSSecret{Name: "cert-b", Namespace: "ns"}
+
+	m := Model{
+		HTTP: []HTTPListener{
+			{Port: 443, Hostname: "a.com", TLS: []TLSSecret{certA}},
+			{Port: 50051, Hostname: "a.com", TLS: []TLSSecret{certA}},
+			{Port: 8443, Hostname: "b.com", TLS: []TLSSecret{certB}},
+		},
+	}
+
+	got := m.TLSSecretsToListeners()
+
+	assert.ElementsMatch(t, []TLSListenerRef{
+		{Hostname: "a.com", Port: 443},
+		{Hostname: "a.com", Port: 50051},
+	}, got[certA])
+
+	assert.ElementsMatch(t, []TLSListenerRef{
+		{Hostname: "b.com", Port: 8443},
+	}, got[certB])
+
+	assert.Len(t, got, 2)
+}

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -157,7 +157,7 @@ func (i *cecTranslator) desiredBackendServices(m *model.Model) ([]*ciliumv2.Serv
 }
 
 func (i *cecTranslator) desiredServicesWithPorts(namespace string, name string, m *model.Model) ([]*ciliumv2.ServiceListener, error) {
-	if m.NeedsPerPortHTTPSListeners() {
+	if m.NeedsPerPortListeners() {
 		return i.desiredServicesWithPortsSplit(namespace, name, m)
 	}
 	return i.desiredServicesWithPortsCombined(namespace, name, m)
@@ -191,15 +191,23 @@ func (i *cecTranslator) desiredServicesWithPortsCombined(namespace string, name 
 	}, nil
 }
 
-// desiredServicesWithPortsSplit returns one ServiceListener per distinct HTTPS port.
+// desiredServicesWithPortsSplit returns per-port ServiceListeners for HTTPS and
+// TLS passthrough, plus one shared entry for plaintext HTTP ports.
 func (i *cecTranslator) desiredServicesWithPortsSplit(namespace string, name string, m *model.Model) ([]*ciliumv2.ServiceListener, error) {
 	shortenedName := shortener.ShortenK8sResourceName(name)
 	var result []*ciliumv2.ServiceListener
 
+	// All TLS passthrough ports are excluded from the plaintext HTTP port list,
+	// since they are handled by the TLS passthrough section below.
+	tlsPassthroughPorts := map[uint32]bool{}
+	for _, p := range m.TLSPassthroughPorts() {
+		tlsPassthroughPorts[p] = true
+	}
+
 	// Plaintext HTTP ports.
 	var httpPorts []uint16
 	for _, hl := range m.HTTP {
-		if len(hl.TLS) == 0 {
+		if len(hl.TLS) == 0 && !tlsPassthroughPorts[hl.Port] {
 			httpPorts = append(httpPorts, uint16(hl.Port))
 		}
 	}
@@ -226,21 +234,34 @@ func (i *cecTranslator) desiredServicesWithPortsSplit(namespace string, name str
 	}
 
 	// TLS passthrough ports.
-	var ptPorts []uint16
-	for _, tlsl := range m.TLSPassthrough {
-		if len(tlsl.Routes) > 0 {
-			ptPorts = append(ptPorts, uint16(tlsl.Port))
+	if m.NeedsPerPortTLSPassthroughListeners() {
+		// One entry per TLS passthrough port.
+		for _, port := range m.TLSPassthroughPorts() {
+			envoyListenerName := listenerNameForPort(port)
+			result = append(result, &ciliumv2.ServiceListener{
+				Namespace: namespace,
+				Name:      shortenedName,
+				Ports:     []uint16{uint16(port)},
+				Listener:  envoyListenerName,
+			})
 		}
-	}
-	goslices.Sort(ptPorts)
-	ptPorts = goslices.Compact(ptPorts)
-	if len(ptPorts) > 0 {
-		result = append(result, &ciliumv2.ServiceListener{
-			Namespace: namespace,
-			Name:      shortenedName,
-			Ports:     ptPorts,
-			Listener:  listenerName,
-		})
+	} else {
+		var ptPorts []uint16
+		for _, tlsl := range m.TLSPassthrough {
+			if len(tlsl.Routes) > 0 {
+				ptPorts = append(ptPorts, uint16(tlsl.Port))
+			}
+		}
+		goslices.Sort(ptPorts)
+		ptPorts = goslices.Compact(ptPorts)
+		if len(ptPorts) > 0 {
+			result = append(result, &ciliumv2.ServiceListener{
+				Namespace: namespace,
+				Name:      shortenedName,
+				Ports:     ptPorts,
+				Listener:  listenerName,
+			})
+		}
 	}
 
 	return result, nil

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -4,7 +4,6 @@
 package translation
 
 import (
-	"maps"
 	goslices "slices"
 	"sort"
 	"strconv"
@@ -20,8 +19,8 @@ import (
 )
 
 const (
-	secureHost   = "secure"
 	insecureHost = "insecure"
+	secureHost   = "secure"
 
 	AppProtocolH2C = "kubernetes.io/h2c"
 	AppProtocolWS  = "kubernetes.io/ws"
@@ -158,22 +157,30 @@ func (i *cecTranslator) desiredBackendServices(m *model.Model) ([]*ciliumv2.Serv
 }
 
 func (i *cecTranslator) desiredServicesWithPorts(namespace string, name string, m *model.Model) ([]*ciliumv2.ServiceListener, error) {
-	// Find all the ports used in the model and build a set of them
+	if m.NeedsPerPortHTTPSListeners() {
+		return i.desiredServicesWithPortsSplit(namespace, name, m)
+	}
+	return i.desiredServicesWithPortsCombined(namespace, name, m)
+}
+
+// desiredServicesWithPortsCombined returns a single ServiceListener covering all ports.
+func (i *cecTranslator) desiredServicesWithPortsCombined(namespace string, name string, m *model.Model) ([]*ciliumv2.ServiceListener, error) {
 	allPorts := make(map[uint16]struct{})
 
 	for _, hl := range m.HTTP {
-		if _, ok := allPorts[uint16(hl.Port)]; !ok {
-			allPorts[uint16(hl.Port)] = struct{}{}
-		}
+		allPorts[uint16(hl.Port)] = struct{}{}
 	}
 	for _, tlsl := range m.TLSPassthrough {
-		if _, ok := allPorts[uint16(tlsl.Port)]; !ok {
+		if len(tlsl.Routes) > 0 {
 			allPorts[uint16(tlsl.Port)] = struct{}{}
 		}
 	}
 
-	// ensure the ports are stably sorted
-	ports := goslices.Sorted(maps.Keys(allPorts))
+	ports := make([]uint16, 0, len(allPorts))
+	for p := range allPorts {
+		ports = append(ports, p)
+	}
+	goslices.Sort(ports)
 
 	return []*ciliumv2.ServiceListener{
 		{
@@ -182,6 +189,61 @@ func (i *cecTranslator) desiredServicesWithPorts(namespace string, name string, 
 			Ports:     ports,
 		},
 	}, nil
+}
+
+// desiredServicesWithPortsSplit returns one ServiceListener per distinct HTTPS port.
+func (i *cecTranslator) desiredServicesWithPortsSplit(namespace string, name string, m *model.Model) ([]*ciliumv2.ServiceListener, error) {
+	shortenedName := shortener.ShortenK8sResourceName(name)
+	var result []*ciliumv2.ServiceListener
+
+	// Plaintext HTTP ports.
+	var httpPorts []uint16
+	for _, hl := range m.HTTP {
+		if len(hl.TLS) == 0 {
+			httpPorts = append(httpPorts, uint16(hl.Port))
+		}
+	}
+	goslices.Sort(httpPorts)
+	httpPorts = goslices.Compact(httpPorts)
+	if len(httpPorts) > 0 {
+		result = append(result, &ciliumv2.ServiceListener{
+			Namespace: namespace,
+			Name:      shortenedName,
+			Ports:     httpPorts,
+			Listener:  listenerName,
+		})
+	}
+
+	// One entry per HTTPS port.
+	for _, port := range m.HTTPSPortsSorted() {
+		envoyListenerName := listenerNameForPort(port)
+		result = append(result, &ciliumv2.ServiceListener{
+			Namespace: namespace,
+			Name:      shortenedName,
+			Ports:     []uint16{uint16(port)},
+			Listener:  envoyListenerName,
+		})
+	}
+
+	// TLS passthrough ports.
+	var ptPorts []uint16
+	for _, tlsl := range m.TLSPassthrough {
+		if len(tlsl.Routes) > 0 {
+			ptPorts = append(ptPorts, uint16(tlsl.Port))
+		}
+	}
+	goslices.Sort(ptPorts)
+	ptPorts = goslices.Compact(ptPorts)
+	if len(ptPorts) > 0 {
+		result = append(result, &ciliumv2.ServiceListener{
+			Namespace: namespace,
+			Name:      shortenedName,
+			Ports:     ptPorts,
+			Listener:  listenerName,
+		})
+	}
+
+	return result, nil
 }
 
 func (i *cecTranslator) desiredResources(m *model.Model) ([]ciliumv2.XDSResource, error) {

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -234,14 +234,42 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 					},
 				},
 			},
+			// port not included: TLS passthrough listener has no routes.
 			want: []*ciliumv2.ServiceListener{
 				{
 					Name:      "cilium-ingress",
 					Namespace: "kube-system",
 					Ports: []uint16{
 						80,
-						443,
 					},
+				},
+			},
+		},
+		{
+			name: "multi-port HTTPS (Gateway API)",
+			fields: fields{
+				name:      "cilium-ingress",
+				namespace: "default",
+			},
+			model: multiPortHTTPSModel,
+			want: []*ciliumv2.ServiceListener{
+				{
+					Name:      "cilium-ingress",
+					Namespace: "default",
+					Ports:     []uint16{80},
+					Listener:  "listener",
+				},
+				{
+					Name:      "cilium-ingress",
+					Namespace: "default",
+					Ports:     []uint16{443},
+					Listener:  "listener-443",
+				},
+				{
+					Name:      "cilium-ingress",
+					Namespace: "default",
+					Ports:     []uint16{50051},
+					Listener:  "listener-50051",
 				},
 			},
 		},
@@ -551,6 +579,13 @@ func TestSharedIngressTranslator_getEnvoyHTTPRouteConfiguration(t *testing.T) {
 				m: multipleRouteHostnamesModel,
 			},
 			expectedRouteConfigs: multipleRouteHostnamesExpectedConfig,
+		},
+		{
+			name: "multi-port HTTPS (Gateway API)",
+			args: args{
+				m: multiPortHTTPSModel,
+			},
+			expectedRouteConfigs: multiPortHTTPSExpectedRouteConfigs,
 		},
 	}
 

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -273,6 +273,58 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "catch-all HTTPS with multi-port TLS passthrough",
+			fields: fields{
+				name:      "cilium-ingress",
+				namespace: "default",
+			},
+			model: &model.Model{
+				HTTP: []model.HTTPListener{
+					{
+						Port:     443,
+						Hostname: "*",
+						TLS: []model.TLSSecret{
+							{Name: "example-tls", Namespace: "default"},
+						},
+					},
+				},
+				TLSPassthrough: []model.TLSPassthroughListener{
+					{
+						Port: 50051,
+						Routes: []model.TLSPassthroughRoute{
+							{Hostnames: []string{"api.example.test"}},
+						},
+					},
+					{
+						Port: 9443,
+						Routes: []model.TLSPassthroughRoute{
+							{Hostnames: []string{"api.example.test"}},
+						},
+					},
+				},
+			},
+			want: []*ciliumv2.ServiceListener{
+				{
+					Name:      "cilium-ingress",
+					Namespace: "default",
+					Ports:     []uint16{443},
+					Listener:  "listener-443",
+				},
+				{
+					Name:      "cilium-ingress",
+					Namespace: "default",
+					Ports:     []uint16{9443},
+					Listener:  "listener-9443",
+				},
+				{
+					Name:      "cilium-ingress",
+					Namespace: "default",
+					Ports:     []uint16{50051},
+					Listener:  "listener-50051",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -49,6 +49,10 @@ const (
 	listenerName = "listener"
 )
 
+func listenerNameForPort(port uint32) string {
+	return fmt.Sprintf("%s-%d", listenerName, port)
+}
+
 type ListenerMutator func(*envoy_config_listener.Listener) *envoy_config_listener.Listener
 
 func withProxyProtocol() ListenerMutator {
@@ -188,6 +192,13 @@ func withHostNetworkPort(m *model.Model, ipv4Enabled bool, ipv6Enabled bool) Lis
 	}
 }
 
+func withHostNetworkPortSubset(ports []uint32, ipv4Enabled bool, ipv6Enabled bool) ListenerMutator {
+	return func(listener *envoy_config_listener.Listener) *envoy_config_listener.Listener {
+		listener.Address, listener.AdditionalAddresses = getHostNetworkListenerAddresses(ports, ipv4Enabled, ipv6Enabled)
+		return listener
+	}
+}
+
 func withSocketOption(tcpKeepAlive, tcpKeepIdleInSeconds, tcpKeepAliveProbeIntervalInSeconds, tcpKeepAliveMaxFailures int64) ListenerMutator {
 	return func(listener *envoy_config_listener.Listener) *envoy_config_listener.Listener {
 		listener.SocketOptions = []*envoy_config_core_v3.SocketOption{
@@ -232,12 +243,22 @@ func withSocketOption(tcpKeepAlive, tcpKeepIdleInSeconds, tcpKeepAliveProbeInter
 	}
 }
 
-// desiredEnvoyListener returns the desired Envoy listener for the given model.
+// desiredEnvoyListener returns the desired Envoy listeners for the given model.
+// When the model has multiple distinct HTTPS ports, one Listener is emitted per
+// HTTPS port; otherwise a single combined Listener is returned.
 func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	if m.IsEmpty() {
 		return nil, nil
 	}
 
+	if m.NeedsPerPortHTTPSListeners() {
+		return i.desiredEnvoyListenerPerPort(m)
+	}
+	return i.desiredEnvoyListenerCombined(m)
+}
+
+// desiredEnvoyListenerCombined returns a single Listener with all filter chains combined.
+func (i *cecTranslator) desiredEnvoyListenerCombined(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	filterChains, err := i.filterChains(listenerName, m)
 	if err != nil {
 		return nil, err
@@ -267,6 +288,7 @@ func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSReso
 	return []ciliumv2.XDSResource{res}, nil
 }
 
+// filterChains returns the filter chains for the given model.
 func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
 	var filterChains []*envoy_config_listener.FilterChain
 
@@ -279,23 +301,160 @@ func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_conf
 	}
 
 	if m.IsHTTPSListenerConfigured() {
-		httpsFilterChains, err := i.httpsFilterChains(name, m)
+		httpsFC, err := i.httpsFilterChains(name, m)
 		if err != nil {
 			return nil, err
 		}
-		filterChains = append(filterChains, httpsFilterChains...)
+		filterChains = append(filterChains, httpsFC...)
 	}
 
 	if m.IsTLSPassthroughListenerConfigured() {
-		tlsPTFilterChains := tlsPassthroughFilterChains(m)
-		filterChains = append(filterChains, tlsPTFilterChains...)
+		filterChains = append(filterChains, tlsPassthroughFilterChains(m)...)
 	}
 
 	return filterChains, nil
 }
 
+// httpsFilterChains returns the HTTPS filter chains for the given model.
+func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
+	tlsToHostnames := m.TLSSecretsToHostnames()
+	if len(tlsToHostnames) == 0 {
+		return nil, nil
+	}
+
+	var filterChains []*envoy_config_listener.FilterChain
+
+	orderedSecrets := goslices.SortedStableFunc(maps.Keys(tlsToHostnames), func(a, b model.TLSSecret) int {
+		return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
+	})
+
+	for _, secret := range orderedSecrets {
+		hostNames := tlsToHostnames[secret]
+
+		secureHCMName := fmt.Sprintf("%s-%s", name, secureHost)
+		secureHCM, err := i.desiredHTTPConnectionManager(secureHCMName, secureHCMName, m)
+		if err != nil {
+			return nil, err
+		}
+		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+			FilterChainMatch: toFilterChainMatch(hostNames),
+			Filters: []*envoy_config_listener.Filter{
+				{
+					Name: httpConnectionManagerType,
+					ConfigType: &envoy_config_listener.Filter_TypedConfig{
+						TypedConfig: secureHCM.Any,
+					},
+				},
+			},
+			TransportSocket: toTransportSocket(i.Config.SecretsNamespace, []model.TLSSecret{secret}),
+		})
+	}
+
+	return filterChains, nil
+}
+
+// desiredEnvoyListenerPerPort returns one Listener per distinct HTTPS port.
+func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.XDSResource, error) {
+	var allResources []ciliumv2.XDSResource
+
+	hasInsecure := false
+	for _, l := range m.HTTP {
+		if len(l.TLS) == 0 {
+			hasInsecure = true
+			break
+		}
+	}
+
+	if hasInsecure || m.IsTLSPassthroughListenerConfigured() {
+		var filterChains []*envoy_config_listener.FilterChain
+
+		if hasInsecure {
+			httpFC, err := i.httpFilterChain(listenerName, m)
+			if err != nil {
+				return nil, err
+			}
+			filterChains = append(filterChains, httpFC)
+		}
+
+		if m.IsTLSPassthroughListenerConfigured() {
+			filterChains = append(filterChains, tlsPassthroughFilterChains(m)...)
+		}
+
+		insecureListener := &envoy_config_listener.Listener{
+			Name:         listenerName,
+			FilterChains: filterChains,
+			ListenerFilters: []*envoy_config_listener.ListenerFilter{
+				{
+					Name: tlsInspectorType,
+					ConfigType: &envoy_config_listener.ListenerFilter_TypedConfig{
+						TypedConfig: toAny(&envoy_extensions_listener_tls_inspector_v3.TlsInspector{}),
+					},
+				},
+			},
+		}
+		var basePorts []uint32
+		for _, hl := range m.HTTP {
+			if len(hl.TLS) == 0 {
+				basePorts = append(basePorts, hl.Port)
+			}
+		}
+		basePorts = append(basePorts, m.TLSPassthroughPorts()...)
+		goslices.Sort(basePorts)
+		basePorts = goslices.Compact(basePorts)
+		for _, fn := range i.listenerMutatorsForPorts(m, basePorts) {
+			insecureListener = fn(insecureListener)
+		}
+		res, err := toXdsResource(insecureListener, envoy.ListenerTypeURL)
+		if err != nil {
+			return nil, err
+		}
+		allResources = append(allResources, res)
+	}
+
+	// one Listener per HTTPS port
+	for _, port := range m.HTTPSPortsSorted() {
+		lName := listenerNameForPort(port)
+
+		httpsFC, err := i.httpsFilterChainsForPort(lName, port, m)
+		if err != nil {
+			return nil, err
+		}
+		if len(httpsFC) == 0 {
+			continue
+		}
+
+		httpsListener := &envoy_config_listener.Listener{
+			Name:         lName,
+			FilterChains: httpsFC,
+			ListenerFilters: []*envoy_config_listener.ListenerFilter{
+				{
+					Name: tlsInspectorType,
+					ConfigType: &envoy_config_listener.ListenerFilter_TypedConfig{
+						TypedConfig: toAny(&envoy_extensions_listener_tls_inspector_v3.TlsInspector{}),
+					},
+				},
+			},
+		}
+		for _, fn := range i.listenerMutatorsForPorts(m, []uint32{port}) {
+			httpsListener = fn(httpsListener)
+		}
+		res, err := toXdsResource(httpsListener, envoy.ListenerTypeURL)
+		if err != nil {
+			return nil, err
+		}
+		allResources = append(allResources, res)
+	}
+
+	return allResources, nil
+}
+
 // listenerMutators returns a list of listener mutators to apply to the listener.
 func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
+	return i.listenerMutatorsForPorts(m, m.AllPorts())
+}
+
+// listenerMutatorsForPorts returns listener mutators for the given port subset.
+func (i *cecTranslator) listenerMutatorsForPorts(m *model.Model, ports []uint32) []ListenerMutator {
 	res := []ListenerMutator{
 		withSocketOption(
 			defaultTCPKeepAlive,
@@ -312,7 +471,7 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 	}
 
 	if i.Config.HostNetworkConfig.Enabled {
-		res = append(res, withHostNetworkPort(m, i.Config.IPConfig.IPv4Enabled, i.Config.IPConfig.IPv6Enabled))
+		res = append(res, withHostNetworkPortSubset(ports, i.Config.IPConfig.IPv4Enabled, i.Config.IPConfig.IPv6Enabled))
 	}
 
 	if i.Config.ListenerConfig.StreamIdleTimeoutSeconds > 0 {
@@ -351,23 +510,39 @@ func (i *cecTranslator) httpFilterChain(name string, m *model.Model) (*envoy_con
 	}, nil
 }
 
-func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
-	tlsToHostnames := m.TLSSecretsToHostnames()
-	if len(tlsToHostnames) == 0 {
+// httpsFilterChainsForPort returns the HTTPS filter chains for the given port.
+func (i *cecTranslator) httpsFilterChainsForPort(name string, port uint32, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
+	tlsToListeners := m.TLSSecretsToListeners()
+	if len(tlsToListeners) == 0 {
 		return nil, nil
 	}
 
-	var filterChains []*envoy_config_listener.FilterChain
+	hostsBySecret := map[model.TLSSecret][]string{}
+	for secret, refs := range tlsToListeners {
+		for _, ref := range refs {
+			if ref.Port == port {
+				hostsBySecret[secret] = append(hostsBySecret[secret], ref.Hostname)
+			}
+		}
+	}
 
-	orderedSecrets := goslices.SortedStableFunc(maps.Keys(tlsToHostnames), func(a, b model.TLSSecret) int {
+	if len(hostsBySecret) == 0 {
+		return nil, nil
+	}
+
+	orderedSecrets := make([]model.TLSSecret, 0, len(hostsBySecret))
+	for secret := range hostsBySecret {
+		orderedSecrets = append(orderedSecrets, secret)
+	}
+	goslices.SortStableFunc(orderedSecrets, func(a, b model.TLSSecret) int {
 		return cmp.Compare(a.Namespace+"/"+a.Name, b.Namespace+"/"+b.Name)
 	})
 
+	var filterChains []*envoy_config_listener.FilterChain
 	for _, secret := range orderedSecrets {
-		hostNames := tlsToHostnames[secret]
+		hostNames := hostsBySecret[secret]
 
-		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
-		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, m)
+		hcm, err := i.desiredHTTPConnectionManager(name, name, m)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +552,7 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy
 				{
 					Name: httpConnectionManagerType,
 					ConfigType: &envoy_config_listener.Filter_TypedConfig{
-						TypedConfig: secureHttpConnectionManager.Any,
+						TypedConfig: hcm.Any,
 					},
 				},
 			},

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -251,7 +251,7 @@ func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSReso
 		return nil, nil
 	}
 
-	if m.NeedsPerPortHTTPSListeners() {
+	if m.NeedsPerPortListeners() {
 		return i.desiredEnvoyListenerPerPort(m)
 	}
 	return i.desiredEnvoyListenerCombined(m)
@@ -353,19 +353,32 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy
 	return filterChains, nil
 }
 
-// desiredEnvoyListenerPerPort returns one Listener per distinct HTTPS port.
+// desiredEnvoyListenerPerPort returns one Listener per distinct HTTPS port
+// and, when applicable, per TLS passthrough port.
 func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	var allResources []ciliumv2.XDSResource
 
+	needsPerPortTLS := m.NeedsPerPortTLSPassthroughListeners()
+
+	// All TLS passthrough ports are excluded from the base insecure listener
+	// port list, since they are handled by their own section (either per-port
+	// listeners or a combined TLS passthrough block on the base listener).
+	tlsPassthroughPorts := map[uint32]bool{}
+	for _, p := range m.TLSPassthroughPorts() {
+		tlsPassthroughPorts[p] = true
+	}
+
 	hasInsecure := false
 	for _, l := range m.HTTP {
-		if len(l.TLS) == 0 {
+		if len(l.TLS) == 0 && !tlsPassthroughPorts[l.Port] {
 			hasInsecure = true
 			break
 		}
 	}
 
-	if hasInsecure || m.IsTLSPassthroughListenerConfigured() {
+	hasTLSPassthroughForBase := !needsPerPortTLS && m.IsTLSPassthroughListenerConfigured()
+
+	if hasInsecure || hasTLSPassthroughForBase {
 		var filterChains []*envoy_config_listener.FilterChain
 
 		if hasInsecure {
@@ -376,7 +389,7 @@ func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.
 			filterChains = append(filterChains, httpFC)
 		}
 
-		if m.IsTLSPassthroughListenerConfigured() {
+		if hasTLSPassthroughForBase {
 			filterChains = append(filterChains, tlsPassthroughFilterChains(m)...)
 		}
 
@@ -394,11 +407,13 @@ func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.
 		}
 		var basePorts []uint32
 		for _, hl := range m.HTTP {
-			if len(hl.TLS) == 0 {
+			if len(hl.TLS) == 0 && !tlsPassthroughPorts[hl.Port] {
 				basePorts = append(basePorts, hl.Port)
 			}
 		}
-		basePorts = append(basePorts, m.TLSPassthroughPorts()...)
+		if hasTLSPassthroughForBase {
+			basePorts = append(basePorts, m.TLSPassthroughPorts()...)
+		}
 		goslices.Sort(basePorts)
 		basePorts = goslices.Compact(basePorts)
 		for _, fn := range i.listenerMutatorsForPorts(m, basePorts) {
@@ -443,6 +458,39 @@ func (i *cecTranslator) desiredEnvoyListenerPerPort(m *model.Model) ([]ciliumv2.
 			return nil, err
 		}
 		allResources = append(allResources, res)
+	}
+
+	// One Listener per TLS passthrough port.
+	if needsPerPortTLS {
+		for _, port := range m.TLSPassthroughPorts() {
+			lName := listenerNameForPort(port)
+
+			tlsFC := tlsPassthroughFilterChainsForPort(port, m)
+			if len(tlsFC) == 0 {
+				continue
+			}
+
+			tlsListener := &envoy_config_listener.Listener{
+				Name:         lName,
+				FilterChains: tlsFC,
+				ListenerFilters: []*envoy_config_listener.ListenerFilter{
+					{
+						Name: tlsInspectorType,
+						ConfigType: &envoy_config_listener.ListenerFilter_TypedConfig{
+							TypedConfig: toAny(&envoy_extensions_listener_tls_inspector_v3.TlsInspector{}),
+						},
+					},
+				},
+			}
+			for _, fn := range i.listenerMutatorsForPorts(m, []uint32{port}) {
+				tlsListener = fn(tlsListener)
+			}
+			res, err := toXdsResource(tlsListener, envoy.ListenerTypeURL)
+			if err != nil {
+				return nil, err
+			}
+			allResources = append(allResources, res)
+		}
 	}
 
 	return allResources, nil
@@ -607,10 +655,46 @@ func getHostNetworkListenerAddresses(ports []uint32, ipv4Enabled, ipv6Enabled bo
 	}, additionalAddress
 }
 
+// tlsPassthroughFilterChains returns TLS passthrough filter chains for all backends.
+// These functions do not depend on cecTranslator state, so they are defined as
+// package-level helpers rather than receiver methods.
 func tlsPassthroughFilterChains(m *model.Model) []*envoy_config_listener.FilterChain {
 	var filterChains []*envoy_config_listener.FilterChain
 
 	for _, listener := range stableTLSPassthroughListeners(m.TLSPassthrough) {
+		for _, route := range stableTLSPassthroughRoutes(listener.Routes) {
+			backends := stableTLSPassthroughBackends(route.Backends)
+			if len(backends) == 0 {
+				continue
+			}
+
+			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+				FilterChainMatch: toFilterChainMatch(route.Hostnames),
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: tcpProxyType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route, backends)),
+						},
+					},
+				},
+			})
+		}
+	}
+
+	return filterChains
+}
+
+// tlsPassthroughFilterChainsForPort returns TLS passthrough filter chains for
+// routes on a specific port, used when per-port listeners are needed to scope
+// filter chains to the routes attached to a single listener port.
+func tlsPassthroughFilterChainsForPort(port uint32, m *model.Model) []*envoy_config_listener.FilterChain {
+	var filterChains []*envoy_config_listener.FilterChain
+
+	for _, listener := range stableTLSPassthroughListeners(m.TLSPassthrough) {
+		if listener.Port != port {
+			continue
+		}
 		for _, route := range stableTLSPassthroughRoutes(listener.Routes) {
 			backends := stableTLSPassthroughBackends(route.Backends)
 			if len(backends) == 0 {

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/cilium/cilium/operator/pkg/model"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
 func Test_getHostNetworkListenerAddresses(t *testing.T) {
@@ -727,4 +729,91 @@ func Test_withHostNetworkPortSorted(t *testing.T) {
 	if len(diffOutput) != 0 {
 		t.Errorf("Modified Envoy Listeners did not match for different order of http listener ports:\n%s\n", diffOutput)
 	}
+}
+
+// TestDesiredEnvoyListenerPerPort checks that desiredEnvoyListener emits one
+// Listener per distinct HTTPS port.
+func TestDesiredEnvoyListenerPerPort(t *testing.T) {
+	i := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+		},
+	}
+
+	res, err := i.desiredEnvoyListener(multiPortHTTPSModel)
+	require.NoError(t, err)
+	require.Len(t, res, 3, "expected 3 Envoy Listeners: insecure, listener-443, listener-50051")
+
+	decodeListener := func(r ciliumv2.XDSResource) *envoy_config_listener.Listener {
+		l := &envoy_config_listener.Listener{}
+		require.NoError(t, proto.Unmarshal(r.Value, l))
+		return l
+	}
+	decodeHCM := func(fc *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_hcm_v3.HttpConnectionManager {
+		require.Len(t, fc.Filters, 1)
+		hcm := &envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{}
+		require.NoError(t, proto.Unmarshal(fc.Filters[0].GetTypedConfig().GetValue(), hcm))
+		return hcm
+	}
+
+	// insecure listener
+	l0 := decodeListener(res[0])
+	require.Equal(t, "listener", l0.Name)
+	require.Len(t, l0.FilterChains, 1, "insecure listener: one HTTP filter chain")
+	require.Equal(t, rawBufferTransportProtocol, l0.FilterChains[0].FilterChainMatch.TransportProtocol)
+	hcm0 := decodeHCM(l0.FilterChains[0])
+	require.Equal(t, "listener-insecure", hcm0.StatPrefix)
+	require.Equal(t, "listener-insecure", hcm0.GetRds().GetRouteConfigName())
+
+	// port 443
+	l1 := decodeListener(res[1])
+	require.Equal(t, "listener-443", l1.Name)
+	require.Len(t, l1.FilterChains, 1, "HTTPS listener-443: one filter chain")
+	require.Equal(t, tlsTransportProtocol, l1.FilterChains[0].FilterChainMatch.TransportProtocol)
+	require.Equal(t, []string{"example.com"}, l1.FilterChains[0].FilterChainMatch.ServerNames)
+	hcm1 := decodeHCM(l1.FilterChains[0])
+	require.Equal(t, "listener-443", hcm1.GetRds().GetRouteConfigName())
+	require.Equal(t, tlsTransportSocketType, l1.FilterChains[0].TransportSocket.Name)
+
+	// port 50051
+	l2 := decodeListener(res[2])
+	require.Equal(t, "listener-50051", l2.Name)
+	require.Len(t, l2.FilterChains, 1, "HTTPS listener-50051: one filter chain")
+	require.Equal(t, tlsTransportProtocol, l2.FilterChains[0].FilterChainMatch.TransportProtocol)
+	require.Equal(t, []string{"example.com"}, l2.FilterChains[0].FilterChainMatch.ServerNames)
+	hcm2 := decodeHCM(l2.FilterChains[0])
+	require.Equal(t, "listener-50051", hcm2.GetRds().GetRouteConfigName())
+	require.Equal(t, tlsTransportSocketType, l2.FilterChains[0].TransportSocket.Name)
+}
+
+// TestDesiredEnvoyListenerSingleHTTPS checks that a single-HTTPS-port model
+// still produces one combined Listener, preserving the original behaviour.
+func TestDesiredEnvoyListenerSingleHTTPS(t *testing.T) {
+	i := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+		},
+	}
+
+	res, err := i.desiredEnvoyListener(hostRulesModel)
+	require.NoError(t, err)
+	require.Len(t, res, 1, "single HTTPS port: one combined listener")
+
+	l := &envoy_config_listener.Listener{}
+	require.NoError(t, proto.Unmarshal(res[0].Value, l))
+
+	require.Equal(t, "listener", l.Name)
+	require.Len(t, l.FilterChains, 2)
+
+	decodeHCM := func(fc *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_hcm_v3.HttpConnectionManager {
+		hcm := &envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{}
+		require.NoError(t, proto.Unmarshal(fc.Filters[0].GetTypedConfig().GetValue(), hcm))
+		return hcm
+	}
+
+	hcm0 := decodeHCM(l.FilterChains[0])
+	require.Equal(t, "listener-insecure", hcm0.GetRds().GetRouteConfigName())
+
+	hcm1 := decodeHCM(l.FilterChains[1])
+	require.Equal(t, "listener-secure", hcm1.GetRds().GetRouteConfigName())
 }

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -786,6 +786,94 @@ func TestDesiredEnvoyListenerPerPort(t *testing.T) {
 	require.Equal(t, tlsTransportSocketType, l2.FilterChains[0].TransportSocket.Name)
 }
 
+func TestDesiredEnvoyListenerCatchAllHTTPSWithMultiPortTLSPassthrough(t *testing.T) {
+	i := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+		},
+	}
+
+	m := &model.Model{
+		HTTP: []model.HTTPListener{
+			{
+				Port:     443,
+				Hostname: "*",
+				TLS: []model.TLSSecret{
+					{Name: "example-tls", Namespace: "default"},
+				},
+			},
+		},
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Port: 50051,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"api.example.test"},
+						Backends: []model.Backend{
+							{Name: "tls-backend-50051", Namespace: "default", Port: &model.BackendPort{Port: 9443}},
+						},
+					},
+				},
+			},
+			{
+				Port: 9443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"api.example.test"},
+						Backends: []model.Backend{
+							{Name: "tls-backend-9443", Namespace: "default", Port: &model.BackendPort{Port: 9443}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	res, err := i.desiredEnvoyListener(m)
+	require.NoError(t, err)
+	require.Len(t, res, 3, "expected listener-443 plus one listener per TLS passthrough port")
+
+	decodeListener := func(r ciliumv2.XDSResource) *envoy_config_listener.Listener {
+		l := &envoy_config_listener.Listener{}
+		require.NoError(t, proto.Unmarshal(r.Value, l))
+		return l
+	}
+	decodeHCM := func(fc *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_hcm_v3.HttpConnectionManager {
+		require.Len(t, fc.Filters, 1)
+		hcm := &envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{}
+		require.NoError(t, proto.Unmarshal(fc.Filters[0].GetTypedConfig().GetValue(), hcm))
+		return hcm
+	}
+
+	// HTTPS catch-all listener on port 443.
+	l0 := decodeListener(res[0])
+	require.Equal(t, "listener-443", l0.Name)
+	require.Len(t, l0.FilterChains, 1)
+	require.Equal(t, tlsTransportProtocol, l0.FilterChains[0].FilterChainMatch.TransportProtocol)
+	require.Empty(t, l0.FilterChains[0].FilterChainMatch.ServerNames)
+	hcm := decodeHCM(l0.FilterChains[0])
+	require.Equal(t, "listener-443", hcm.GetRds().GetRouteConfigName())
+	require.Equal(t, tlsTransportSocketType, l0.FilterChains[0].TransportSocket.Name)
+
+	// TLS passthrough listener on port 9443.
+	l1 := decodeListener(res[1])
+	require.Equal(t, "listener-9443", l1.Name)
+	require.Len(t, l1.FilterChains, 1)
+	require.Equal(t, tlsTransportProtocol, l1.FilterChains[0].FilterChainMatch.TransportProtocol)
+	require.Equal(t, []string{"api.example.test"}, l1.FilterChains[0].FilterChainMatch.ServerNames)
+	tcpProxy1 := getTCPProxy(t, l1.FilterChains[0])
+	require.Equal(t, "default:tls-backend-9443:9443", tcpProxy1.GetCluster())
+
+	// TLS passthrough listener on port 50051.
+	l2 := decodeListener(res[2])
+	require.Equal(t, "listener-50051", l2.Name)
+	require.Len(t, l2.FilterChains, 1)
+	require.Equal(t, tlsTransportProtocol, l2.FilterChains[0].FilterChainMatch.TransportProtocol)
+	require.Equal(t, []string{"api.example.test"}, l2.FilterChains[0].FilterChainMatch.ServerNames)
+	tcpProxy2 := getTCPProxy(t, l2.FilterChains[0])
+	require.Equal(t, "default:tls-backend-50051:9443", tcpProxy2.GetCluster())
+}
+
 // TestDesiredEnvoyListenerSingleHTTPS checks that a single-HTTPS-port model
 // still produces one combined Listener, preserving the original behaviour.
 func TestDesiredEnvoyListenerSingleHTTPS(t *testing.T) {

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -37,7 +37,7 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 		for _, r := range l.Routes {
 			port := insecureHost
 			if len(l.TLS) > 0 {
-				if m.NeedsPerPortHTTPSListeners() {
+				if m.NeedsPerPortListeners() {
 					port = fmt.Sprintf("%d", l.Port)
 				} else {
 					port = secureHost
@@ -181,8 +181,8 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 
 // httpsPortKeys returns sorted, unique port strings for all HTTPS listeners in the model.
 func httpsPortKeys(m *model.Model) []string {
-	if !m.NeedsPerPortHTTPSListeners() {
-		// Single (or zero) HTTPS port: use the legacy "secure" key.
+	if !m.NeedsPerPortListeners() {
+		// No per-port splitting needed: use the legacy "secure" key for the HTTPS port.
 		if m.IsHTTPSListenerConfigured() {
 			return []string{secureHost}
 		}

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"fmt"
 	goslices "slices"
+	"strconv"
 
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/slices"
 )
 
+// RouteConfigurationMutator transforms a RouteConfiguration before serialization.
 type RouteConfigurationMutator func(*envoy_config_route_v3.RouteConfiguration) *envoy_config_route_v3.RouteConfiguration
 
 // desiredEnvoyHTTPRouteConfiguration returns the route configuration for the given model.
@@ -34,8 +36,12 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 	for _, l := range m.HTTP {
 		for _, r := range l.Routes {
 			port := insecureHost
-			if l.TLS != nil {
-				port = secureHost
+			if len(l.TLS) > 0 {
+				if m.NeedsPerPortHTTPSListeners() {
+					port = fmt.Sprintf("%d", l.Port)
+				} else {
+					port = secureHost
+				}
 			}
 
 			if len(r.Hostnames) == 0 {
@@ -64,16 +70,54 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 		}
 	}
 
-	for _, port := range []string{insecureHost, secureHost} {
+	// Collect all port keys in a deterministic order.
+	allPorts := make([]string, 0, len(portHostNameRedirect))
+	for p := range portHostNameRedirect {
+		allPorts = append(allPorts, p)
+	}
+	goslices.Sort(allPorts)
+
+	// Also emit an empty RouteConfiguration for configured ports with no routes.
+	if !goslices.Contains(allPorts, insecureHost) && m.IsHTTPListenerConfigured() {
+		allPorts = append([]string{insecureHost}, allPorts...)
+	}
+	for _, httpsPort := range httpsPortKeys(m) {
+		if !goslices.Contains(allPorts, httpsPort) {
+			allPorts = append(allPorts, httpsPort)
+		}
+	}
+	goslices.SortFunc(allPorts, func(a, b string) int {
+		// "insecure" always sorts first to preserve backward-compatible ordering.
+		if a == insecureHost {
+			return -1
+		}
+		if b == insecureHost {
+			return 1
+		}
+		return cmp.Compare(a, b)
+	})
+
+	for _, port := range allPorts {
 		// the route name should match the value in http connection manager
 		// otherwise the request will be dropped by envoy
 		routeName := fmt.Sprintf("listener-%s", port)
 
 		hostNames, exists := portHostNameRedirect[port]
 		if !exists {
-			if port == insecureHost && !m.IsHTTPListenerConfigured() ||
-				port == secureHost && !m.IsHTTPSListenerConfigured() {
-				continue
+			if port == insecureHost {
+				if !m.IsHTTPListenerConfigured() {
+					continue
+				}
+			} else if port == secureHost {
+				// Legacy single-HTTPS-port mode.
+				if !m.IsHTTPSListenerConfigured() {
+					continue
+				}
+			} else {
+				// per-port mode: skip if no HTTPS listener uses this port.
+				if !m.IsHTTPSPortConfigured(parseUint32(port)) {
+					continue
+				}
 			}
 			rc, err := routeConfiguration(routeName, nil)
 			if err != nil {
@@ -85,18 +129,23 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 		var virtualhosts []*envoy_config_route_v3.VirtualHost
 
 		redirectedHost := map[string]struct{}{}
-		// Add HTTPs redirect virtual host for secure host
+		// Add HTTPS redirect virtual hosts across all configured HTTPS ports.
 		if port == insecureHost {
-			for _, h := range slices.Unique(portHostNameRedirect[secureHost]) {
-				if h.redirect {
-					vhs := i.desiredVirtualHost(hostNamePortRoutes[h.hostname][secureHost], VirtualHostParameter{
-						HostNames:      []string{h.hostname},
-						HTTPSRedirect:  true,
-						ListenerPort:   m.HTTP[0].Port,
-						AllAuthFilters: allAuthFilters,
-					})
-					virtualhosts = append(virtualhosts, vhs)
-					redirectedHost[h.hostname] = struct{}{}
+			for _, httpsPort := range httpsPortKeys(m) {
+				for _, h := range slices.Unique(portHostNameRedirect[httpsPort]) {
+					if h.redirect {
+						if _, already := redirectedHost[h.hostname]; already {
+							continue
+						}
+						redirectedHost[h.hostname] = struct{}{}
+						vhs := i.desiredVirtualHost(hostNamePortRoutes[h.hostname][httpsPort], VirtualHostParameter{
+							HostNames:      []string{h.hostname},
+							HTTPSRedirect:  true,
+							ListenerPort:   m.HTTP[0].Port,
+							AllAuthFilters: allAuthFilters,
+						})
+						virtualhosts = append(virtualhosts, vhs)
+					}
 				}
 			}
 		}
@@ -128,6 +177,37 @@ func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ci
 	}
 
 	return res, nil
+}
+
+// httpsPortKeys returns sorted, unique port strings for all HTTPS listeners in the model.
+func httpsPortKeys(m *model.Model) []string {
+	if !m.NeedsPerPortHTTPSListeners() {
+		// Single (or zero) HTTPS port: use the legacy "secure" key.
+		if m.IsHTTPSListenerConfigured() {
+			return []string{secureHost}
+		}
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, l := range m.HTTP {
+		if len(l.TLS) > 0 {
+			seen[fmt.Sprintf("%d", l.Port)] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	goslices.Sort(keys)
+	return keys
+}
+
+// parseUint32 parses a base-10 uint32 string. The callers only pass strings
+// produced by fmt.Sprintf("%d", l.Port) where l.Port is already a uint32, so
+// parse failure is not possible in practice; zero is returned on error.
+func parseUint32(s string) uint32 {
+	v, _ := strconv.ParseUint(s, 10, 32)
+	return uint32(v)
 }
 
 // routeConfiguration returns a new route configuration for a given list of http routes.

--- a/operator/pkg/model/translation/fixture_test.go
+++ b/operator/pkg/model/translation/fixture_test.go
@@ -1313,3 +1313,123 @@ var multipleRouteHostnamesExpectedConfig = []*envoy_config_route_v3.RouteConfigu
 		},
 	},
 }
+
+// multiPortHTTPSModel represents a Gateway with HTTP on port 80 and HTTPS on
+// two different ports (443 and 50051), triggering per-port listener splitting.
+var multiPortHTTPSModel = &model.Model{
+	HTTP: []model.HTTPListener{
+		{
+			Sources: []model.FullyQualifiedResource{
+				{Name: "my-gateway", Namespace: "default", Version: "v1", Kind: "Gateway"},
+			},
+			Port:     80,
+			Hostname: "example.com",
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{Prefix: "/"},
+					Backends: []model.Backend{
+						{
+							Name:      "http-backend",
+							Namespace: "default",
+							Port:      &model.BackendPort{Port: 8080},
+						},
+					},
+				},
+			},
+		},
+		{
+			Sources: []model.FullyQualifiedResource{
+				{Name: "my-gateway", Namespace: "default", Version: "v1", Kind: "Gateway"},
+			},
+			Port:     443,
+			Hostname: "example.com",
+			TLS: []model.TLSSecret{
+				{Name: "example-tls", Namespace: "default"},
+			},
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{Prefix: "/"},
+					Backends: []model.Backend{
+						{
+							Name:      "http-backend",
+							Namespace: "default",
+							Port:      &model.BackendPort{Port: 8080},
+						},
+					},
+				},
+			},
+		},
+		{
+			Sources: []model.FullyQualifiedResource{
+				{Name: "my-gateway", Namespace: "default", Version: "v1", Kind: "Gateway"},
+			},
+			Port:     50051,
+			Hostname: "example.com",
+			TLS: []model.TLSSecret{
+				{Name: "example-tls", Namespace: "default"},
+			},
+			Routes: []model.HTTPRoute{
+				{
+					PathMatch: model.StringMatch{Prefix: "/"},
+					Backends: []model.Backend{
+						{
+							Name:      "grpc-backend",
+							Namespace: "default",
+							Port:      &model.BackendPort{Port: 9090},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// multiPortHTTPSExpectedRouteConfigs is the expected route configuration for
+// multiPortHTTPSModel: one RouteConfiguration per listener.
+var multiPortHTTPSExpectedRouteConfigs = []*envoy_config_route_v3.RouteConfiguration{
+	{
+		Name: "listener-insecure",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "example.com",
+				Domains: domainsHelper("example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("default", "http-backend", "8080"),
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "listener-443",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "example.com",
+				Domains: domainsHelper("example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("default", "http-backend", "8080"),
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "listener-50051",
+		VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+			{
+				Name:    "example.com",
+				Domains: domainsHelper("example.com"),
+				Routes: []*envoy_config_route_v3.Route{
+					{
+						Match:  envoyRouteMatchRootPath(),
+						Action: envoyRouteAction("default", "grpc-backend", "9090"),
+					},
+				},
+			},
+		},
+	},
+}

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/cec-output.yaml
@@ -1,0 +1,318 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  backendServices:
+  - name: grpc-backend
+    namespace: default
+    number:
+    - "9090"
+  - name: http-backend
+    namespace: default
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - example.com
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          rds:
+            routeConfigName: listener-443
+          statPrefix: listener-443
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            tlsCertificateSdsSecretConfigs:
+            - name: cilium-secrets/default-example-tls
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener-443
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        serverNames:
+        - example.com
+        transportProtocol: tls
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          rds:
+            routeConfigName: listener-50051
+          statPrefix: listener-50051
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+      transportSocket:
+        name: envoy.transport_sockets.tls
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          commonTlsContext:
+            tlsCertificateSdsSecretConfigs:
+            - name: cilium-secrets/default-example-tls
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener-50051
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - example.com
+      - example.com:*
+      name: example.com
+      routes:
+      - match:
+          pathSeparatedPrefix: /web
+        route:
+          cluster: default:http-backend:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-443
+    virtualHosts:
+    - domains:
+      - example.com
+      - example.com:*
+      name: example.com
+      routes:
+      - match:
+          pathSeparatedPrefix: /web
+        route:
+          cluster: default:http-backend:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-50051
+    virtualHosts:
+    - domains:
+      - example.com
+      - example.com:*
+      name: example.com
+      routes:
+      - match:
+          pathSeparatedPrefix: /com.example.echo
+        route:
+          cluster: default:grpc-backend:9090
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: default/grpc-backend:9090
+    name: default:grpc-backend:9090
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: default/http-backend:8080
+    name: default:http-backend:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - listener: listener
+    name: cilium-gateway-my-gateway
+    namespace: default
+    ports:
+    - 80
+  - listener: listener-443
+    name: cilium-gateway-my-gateway
+    namespace: default
+    ports:
+    - 443
+  - listener: listener-50051
+    name: cilium-gateway-my-gateway
+    namespace: default
+    ports:
+    - 50051

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/config-input.yaml
@@ -1,0 +1,14 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config:
+  ipv4_enabled: true
+  ipv6_enabled: true
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/input.yaml
@@ -1,0 +1,61 @@
+http:
+- hostname: example.com
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: http-backend
+      namespace: default
+      port:
+        port: 8080
+    path_match:
+      prefix: /web
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1
+- hostname: example.com
+  name: https
+  port: 443
+  routes:
+  - backends:
+    - name: http-backend
+      namespace: default
+      port:
+        port: 8080
+    path_match:
+      prefix: /web
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1
+  tls:
+  - name: example-tls
+    namespace: default
+- hostname: example.com
+  name: grpc
+  port: 50051
+  routes:
+  - backends:
+    - name: grpc-backend
+      namespace: default
+      port:
+        port: 9090
+    path_match:
+      prefix: /com.example.echo
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1
+  tls:
+  - name: example-tls
+    namespace: default

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/service-output.yaml
@@ -1,0 +1,30 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: my-gateway
+      uid: ""
+spec:
+  ports:
+    - name: port-80
+      port: 80
+      protocol: TCP
+      targetPort: 0
+    - name: port-443
+      port: 443
+      protocol: TCP
+      targetPort: 0
+    - name: port-50051
+      port: 50051
+      protocol: TCP
+      targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -41,6 +41,7 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "basic_http_listener_load_balancer"},
 		{name: "basic_tls_sni_listener"},
 		{name: "tls_sni_weighted_backends"},
+		{name: "basic_https_multi_port_listener"},
 		{name: "conformance/httproute_simple_same_namespace"},
 		{name: "conformance/httproute_backend_protocol_h_2_c"},
 		{name: "conformance/httproute_cross_namespace"},


### PR DESCRIPTION
Emit separate Envoy Listener and RouteConfiguration resources for HTTPS and TLS passthrough listener ports when same-hostname multi-port or cross-protocol configurations require port-specific separation. The previous combined-listener approach could make Envoy reject the generated config, and it also made listener-specific policy/admission semantics too coarse.

This PR now covers:

- HTTPS listeners sharing a hostname on different ports.
- TLS passthrough listeners sharing a hostname on different ports.
- Mixed HTTPS and TLS passthrough listeners on the same hostname, including cross-protocol.
- Per-listener route attachment semantics, including namespace-restricted listeners.

This PR doesn't cover plain HTTP listeners.

Single-port Gateways and Ingress are unaffected (`NeedsPerPortListeners()` gates the new path). 

It's a big PR, review commit-by-commit for easier review.

This PR was prepared with AIL:3. I personally reviewed each line of the submission. I ran and verified all of the scenarios defined in https://github.com/eufriction/k8s-cilium-gapi#test-results-by-version for the column `#44889`.

### Notes

- The findings in #39974 with the 1,3 MB size limitation for the entire CEC could be exceeded for existing deployments with the changes in this PR as it adds additional configuration blocks. To my knowledge, I think it's unavoidable but might need to be feature-flagged or similar to reduce the risk. The difference in the test files is a ~1KB per added listener. I don't know if that is a big problem or not?
- https://github.com/cilium/cilium/pull/44889/changes/d7494601134475934303e17c0723a859764e4675 is seemingly unrelated but is required for the data plane fix of #42159.

Fixes: #44877 
Fixes: #45623
Fixes: #31122

```release-note
 gateway-api: Each HTTPS and TLS passthrough port now receives its own Envoy listener and RouteConfiguration.
```
