### PR TITLE
fix: using a local action needs checkout in eks-cluster-delete

### DIFF
--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -158,7 +158,7 @@ runs:
           clusterEndpoints:
             publicAccess: true
             privateAccess: true
-          publicAccessCidrs: [ "${{ steps.get-runner-ip.outputs.cidr }}" ]
+          publicAccessCIDRs: [ "${{ steps.get-runner-ip.outputs.cidr }}" ]
 
         addonsConfig:
           disableDefaultAddons: true

--- a/.github/workflows/eks-cluster-delete.yaml
+++ b/.github/workflows/eks-cluster-delete.yaml
@@ -27,6 +27,11 @@ jobs:
     timeout-minutes: 30
     continue-on-error: true
     steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Install eksctl CLI
         run: |
           curl -LO "https://github.com/eksctl-io/eksctl/releases/download/${{ env.eksctl_version }}/eksctl_$(uname -s)_amd64.tar.gz"


### PR DESCRIPTION
1. To retrieve the runner IP, the step needs to checkout repo which was missing.
2. looks like the typo in case is silently ignored by eksctl.conf. setting the correct case.
