### PR TITLE
Fix BPF compilation failure on transient direct routing device address loss

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -413,16 +413,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 					break
 				}
 			}
-			if ipv4 == 0 {
-				return fmt.Errorf("IPv4 direct routing device IP not found")
-			}
 			cDefinesMap["IPV4_DIRECT_ROUTING"] = fmt.Sprintf("%d", ipv4)
 		}
 		if option.Config.EnableIPv6 {
 			ip := preferredIPv6Address(drd.Addrs)
-			if ip.IsUnspecified() {
-				return fmt.Errorf("IPv6 direct routing device IP not found")
-			}
 			extraMacrosMap["IPV6_DIRECT_ROUTING"] = ip.String()
 			fw.WriteString(FmtDefineAddress("IPV6_DIRECT_ROUTING", ip.AsSlice()))
 		}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/google/renameio/v2"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -63,16 +64,16 @@ func (l *loader) writeNetdevHeader(dir string) error {
 
 func (l *loader) writeNodeConfigHeader(cfg *config.Config) error {
 	nodeConfigPath := option.Config.GetNodeConfigPath()
-	f, err := os.Create(nodeConfigPath)
+	f, err := renameio.TempFile(filepath.Dir(nodeConfigPath), nodeConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to create node configuration file at %s: %w", nodeConfigPath, err)
 	}
-	defer f.Close()
+	defer f.Cleanup()
 
 	if err = l.templateCache.WriteNodeConfig(f, cfg); err != nil {
 		return fmt.Errorf("failed to write node configuration file at %s: %w", nodeConfigPath, err)
 	}
-	return nil
+	return f.CloseAtomicallyReplace()
 }
 
 // Must be called with option.Config.EnablePolicyMU locked.

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -108,6 +108,14 @@ func newLocalNodeConfig(
 			return config.Config{}, directRoutingDevWatch, errors.New("direct routing device required but not configured")
 		}
 
+		// Ensure the device has at least one usable address for the enabled
+		// address families. If not, return the watch channel so we retry as
+		// soon as the device's addresses change.
+		if !directRoutingDeviceHasAddr(drd) {
+			return config.Config{}, directRoutingDevWatch,
+				fmt.Errorf("direct routing device %s has no usable addresses", drd.Name)
+		}
+
 		watchChans = append(watchChans, directRoutingDevWatch)
 		directRoutingDevice = drd
 	}
@@ -218,4 +226,21 @@ func getEphemeralPortRangeMin(sysctl sysctl.Sysctl) (int, error) {
 	}
 
 	return ephemeralPortMin, nil
+}
+
+// directRoutingDeviceHasAddr returns true if the device has at least one
+// usable address for the enabled address families.
+func directRoutingDeviceHasAddr(dev *tables.Device) bool {
+	for _, addr := range dev.Addrs {
+		if addr.Addr.IsUnspecified() {
+			continue
+		}
+		if option.Config.EnableIPv4 && addr.Addr.Is4() {
+			return true
+		}
+		if option.Config.EnableIPv6 && addr.Addr.Is6() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/datapath/orchestrator/localnodeconfig_test.go
+++ b/pkg/datapath/orchestrator/localnodeconfig_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package orchestrator
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestDirectRoutingDeviceHasAddr(t *testing.T) {
+	// Save and restore global config.
+	savedIPv4 := option.Config.EnableIPv4
+	savedIPv6 := option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4 = savedIPv4
+		option.Config.EnableIPv6 = savedIPv6
+	})
+	option.Config.EnableIPv4 = true
+	option.Config.EnableIPv6 = true
+
+	tests := []struct {
+		name  string
+		addrs []tables.DeviceAddress
+		want  bool
+	}{
+		{
+			name: "both addresses",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("192.0.2.1")},
+				{Addr: netip.MustParseAddr("2001:db8::1")},
+			},
+			want: true,
+		},
+		{
+			name: "only IPv4",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("192.0.2.1")},
+			},
+			want: true,
+		},
+		{
+			name: "only IPv6",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("2001:db8::1")},
+			},
+			want: true,
+		},
+		{
+			name:  "no addresses",
+			addrs: nil,
+			want:  false,
+		},
+		{
+			name: "only unspecified IPv4",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("0.0.0.0")},
+			},
+			want: false,
+		},
+		{
+			name: "only unspecified IPv6",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("::")},
+			},
+			want: false,
+		},
+		{
+			name: "both unspecified",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("0.0.0.0")},
+				{Addr: netip.MustParseAddr("::")},
+			},
+			want: false,
+		},
+		{
+			name: "valid IPv4 and unspecified IPv6",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("192.0.2.1")},
+				{Addr: netip.MustParseAddr("::")},
+			},
+			want: true,
+		},
+		{
+			name: "unspecified IPv4 and valid IPv6",
+			addrs: []tables.DeviceAddress{
+				{Addr: netip.MustParseAddr("0.0.0.0")},
+				{Addr: netip.MustParseAddr("2001:db8::1")},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev := &tables.Device{Name: "eth0", Index: 2, Addrs: tt.addrs}
+			assert.Equal(t, tt.want, directRoutingDeviceHasAddr(dev))
+		})
+	}
+}


### PR DESCRIPTION
When WriteNodeConfig encounters an error (e.g. direct routing device
temporarily loses its IPv4 during DHCP renewal), node_config.h is left
truncated because os.Create truncates the file before writing. Subsequent
BPF compilations fail with undefined symbol errors.

Additionally, when one stack loses its address, WriteNodeConfig would
fail mid-write and block Reinitialize even though the other stack was
still usable.

Fix both issues:
1. Use renameio to write node_config.h atomically. On error, the
   original file remains intact.
2. Validate direct routing device addresses in newLocalNodeConfig
   before invoking Reinitialize. If one stack is still usable, let
   Reinitialize proceed. If no usable addresses remain, fail early
   and return the watch channel so we retry as soon as addresses
   reappear.

Fixes: #44883