### PR TITLE
lb: Skip nil slots during BPF map restore to prevent panic

### DIFF
--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -308,6 +308,9 @@ func (ops *BPFOps) ResetAndRestore() (err error) {
 				ops.restoredQuarantinedBackends[addr] = backends
 			}
 			for _, slot := range slots[1+master.GetCount():] {
+				if slot == nil {
+					continue
+				}
 				if addr, found := backendIDToAddress[slot.GetBackendID()]; found {
 					backends.Insert(addr)
 				}


### PR DESCRIPTION
When iterating over backend slots in ResetAndRestore, some slots beyond the master's count may be nil. Accessing `GetBackendID()` on a nil slot causes a nil pointer dereference panic.

Add a nil check to skip nil slots during the restore loop.
This adds a guard rail in case the slot is `nil` to allow agent to recover and not stuck in `Crashloopbackoff`

Related: #44896 

```release-note
lb: Skip nil slots during BPF map restore to prevent panic
```
