### PR TITLE
policy: Prepare SelectorPolicy for external computation

### DIFF
--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -722,6 +722,11 @@ func (sp *testSelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, poli
 func (sp *testSelectorPolicy) GetSelectorSnapshot() policy.SelectorSnapshot {
 	return policy.SelectorSnapshot{}
 }
+func (sp *testSelectorPolicy) AddHold() bool       { return true }
+func (sp *testSelectorPolicy) ReleaseHold()        {}
+func (sp *testSelectorPolicy) Detach()             {}
+func (sp *testSelectorPolicy) MaybeDetach()        {}
+func (sp *testSelectorPolicy) GetRevision() uint64 { return 0 }
 
 // createSelectorCache creates a common selector cache setup used by both DNS and non-DNS policies
 func (sp *testSelectorPolicy) createSelectorCache() (policy.CachedSelector, *policy.SelectorCache) {

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -15,6 +15,8 @@ import (
 
 type IDManager interface {
 	Add(identity *identity.Identity)
+	Get(*identity.NumericIdentity) *identity.Identity
+	GetAll() []*identity.Identity
 	GetIdentityModels() []*models.IdentityEndpoints
 	Remove(identity *identity.Identity)
 	RemoveAll()
@@ -156,6 +158,35 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 		}
 	}
 
+}
+
+// Get returns the full identity based on the numeric identity. The returned
+// identity is a pointer to a live object; do not modify!
+func (idm *IdentityManager) Get(id *identity.NumericIdentity) *identity.Identity {
+	if id == nil {
+		return nil
+	}
+
+	idm.mutex.RLock()
+	defer idm.mutex.RUnlock()
+
+	idd, exists := idm.identities[*id]
+	if !exists {
+		return nil
+	}
+	return idd.identity
+}
+
+// GetAll returns all identities from the manager. The returned slices contains
+// identities that are pointers to a live objects; do not modify!
+func (idm *IdentityManager) GetAll() []*identity.Identity {
+	idm.mutex.RLock()
+	defer idm.mutex.RUnlock()
+	ids := make([]*identity.Identity, 0, len(idm.identities))
+	for _, v := range idm.identities {
+		ids = append(ids, v.identity)
+	}
+	return ids
 }
 
 // GetIdentityModels returns the API representation of the IdentityManager.

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -55,34 +55,42 @@ func newIdentityManager(logger *slog.Logger) *IdentityManager {
 // already in the identity manager, the reference count for the identity is
 // incremented.
 func (idm *IdentityManager) Add(identity *identity.Identity) {
+	if identity == nil {
+		return
+	}
+
+	idm.add(identity)
+}
+
+func (idm *IdentityManager) add(identity *identity.Identity) {
 	idm.logger.Debug(
 		"Adding identity to identity manager",
 		logfields.Identity, identity,
 	)
 
 	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
-	idm.add(identity)
+	added := idm.addLocked(identity)
+	idm.mutex.Unlock()
+
+	if added {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityAdded(identity)
+		}
+	}
 }
 
-func (idm *IdentityManager) add(identity *identity.Identity) {
-	if identity == nil {
-		return
-	}
-
+func (idm *IdentityManager) addLocked(identity *identity.Identity) (added bool) {
 	idMeta, exists := idm.identities[identity.ID]
 	if !exists {
 		idm.identities[identity.ID] = &identityMetadata{
 			identity: identity,
 			refCount: 1,
 		}
-		for o := range idm.observers {
-			o.LocalEndpointIdentityAdded(identity)
-		}
-
+		added = true
 	} else {
 		idMeta.refCount++
 	}
+	return
 }
 
 // RemoveOldAddNew removes old from the identity manager and inserts new
@@ -91,14 +99,15 @@ func (idm *IdentityManager) add(identity *identity.Identity) {
 // This is a no-op if both identities have the same numeric ID.
 func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
 
 	if old == nil && new == nil {
+		idm.mutex.Unlock()
 		return
 	}
 	// The host endpoint will always retain its reserved ID, but its labels may
 	// change so we need to update its identity.
 	if old != nil && new != nil && old.ID == new.ID && new.ID != identity.ReservedIdentityHost {
+		idm.mutex.Unlock()
 		return
 	}
 
@@ -108,8 +117,21 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 		logfields.New, new,
 	)
 
-	idm.remove(old)
-	idm.add(new)
+	removed := idm.removeLocked(old)
+	added := idm.addLocked(new)
+
+	idm.mutex.Unlock()
+
+	if removed {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityRemoved(old)
+		}
+	}
+	if added {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityAdded(new)
+		}
+	}
 }
 
 // RemoveAll removes all identities.
@@ -118,7 +140,7 @@ func (idm *IdentityManager) RemoveAll() {
 	defer idm.mutex.Unlock()
 
 	for id := range idm.identities {
-		idm.remove(idm.identities[id].identity)
+		idm.removeLocked(idm.identities[id].identity)
 	}
 }
 
@@ -127,20 +149,33 @@ func (idm *IdentityManager) RemoveAll() {
 // decremented. If the identity is not in the cache, this is a no-op. If the
 // ref count becomes zero, the identity is removed from the cache.
 func (idm *IdentityManager) Remove(identity *identity.Identity) {
-	idm.logger.Debug(
-		"Removing identity from identity manager",
-		logfields.Identity, identity,
-	)
+	if identity == nil {
+		return
+	}
 
-	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
 	idm.remove(identity)
 }
 
 func (idm *IdentityManager) remove(identity *identity.Identity) {
+	idm.mutex.Lock()
+	removed := idm.removeLocked(identity)
+	idm.mutex.Unlock()
+
+	if removed {
+		for o := range idm.observers {
+			o.LocalEndpointIdentityRemoved(identity)
+		}
+	}
+}
+func (idm *IdentityManager) removeLocked(identity *identity.Identity) (removed bool) {
 	if identity == nil {
 		return
 	}
+
+	idm.logger.Debug(
+		"Removing identity from identity manager",
+		logfields.Identity, identity,
+	)
 
 	idMeta, exists := idm.identities[identity.ID]
 	if !exists {
@@ -153,11 +188,9 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 	idMeta.refCount--
 	if idMeta.refCount == 0 {
 		delete(idm.identities, identity.ID)
-		for o := range idm.observers {
-			o.LocalEndpointIdentityRemoved(identity)
-		}
+		removed = true
 	}
-
+	return
 }
 
 // Get returns the full identity based on the numeric identity. The returned

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -30,6 +31,7 @@ var Cell = cell.Module(
 	cell.Provide(newPolicyRepo),
 	cell.Provide(newPolicyUpdater),
 	cell.Provide(newPolicyImporter),
+	cell.Provide(newPolicyCacheOut),
 	cell.Provide(newIdentityUpdater),
 	cell.Provide(newIPCacher),
 	cell.Config(defaultConfig),
@@ -100,6 +102,10 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 	})
 
 	return policyRepo
+}
+
+func newPolicyCacheOut(r policy.PolicyRepository) stream.Observable[policy.PolicyCacheChange] {
+	return r.PolicyCacheObservable()
 }
 
 type policyUpdaterParams struct {

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -124,10 +124,10 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 // is still referring to the old identity.
 //
 // Must be called with repo.Mutex held for reading.
-func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
+func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, *selectorPolicy, bool, error) {
 	cip, ok := cache.lookup(identity)
 	if !ok {
-		return nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
+		return nil, nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
 	}
 
 	// As long as UpdatePolicy() is triggered from endpoint
@@ -144,18 +144,16 @@ func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, e
 
 	// Don't resolve policy if it was already done for this or later revision.
 	if selPolicy := cip.getPolicy(); selPolicy != nil && selPolicy.Revision >= cache.repo.GetRevision() {
-		return selPolicy, false, nil
+		return selPolicy, nil, false, nil
 	}
 
 	// Resolve the policies, which could fail
 	selPolicy, err := cache.repo.resolvePolicyLocked(identity)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
 	}
 
-	cip.setPolicy(selPolicy, endpointID)
-
-	return selPolicy, true, nil
+	return selPolicy, cip.setPolicy(selPolicy, endpointID), true, nil
 }
 
 // LocalEndpointIdentityAdded creates a SelectorPolicy cache entry for the
@@ -238,10 +236,11 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 // the endpoint that initiated the old selector policy detach. Since detach
 // can trigger endpoint regenerations of all it users, this ensures
 // that endpoints do not continuously update themselves.
-func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) {
+func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) *selectorPolicy {
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {
 		// Release the references the previous policy holds on the selector cache.
 		oldPolicy.detach(false, endpointID)
 	}
+	return oldPolicy
 }

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -11,11 +12,15 @@ import (
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/lock"
+
+	"github.com/cilium/stream"
 )
 
 // policyCache represents a cache of resolved policies for identities.
 type policyCache struct {
 	lock.Mutex
+	// Used to implement the stream.Observable interface.
+	stream.Observable[PolicyCacheChange]
 
 	// repo is a circular reference back to the Repository, but as
 	// we create only one Repository and one PolicyCache for each
@@ -23,13 +28,21 @@ type policyCache struct {
 	// collected.
 	repo     *Repository
 	policies map[identityPkg.NumericIdentity]*cachedSelectorPolicy
+
+	// emitChange is used with the observable embedded in this struct.
+	emitChange func(PolicyCacheChange)
 }
 
 // newPolicyCache creates a new cache of SelectorPolicy.
 func newPolicyCache(repo *Repository, idmgr identitymanager.IDManager) *policyCache {
+	mcast, emit, _ := stream.Multicast[PolicyCacheChange]()
 	cache := &policyCache{
+		Observable: mcast,
+
 		repo:     repo,
 		policies: make(map[identityPkg.NumericIdentity]*cachedSelectorPolicy),
+
+		emitChange: emit,
 	}
 	if idmgr != nil {
 		idmgr.Subscribe(cache)
@@ -84,6 +97,7 @@ func (cache *policyCache) insert(identity *identityPkg.Identity) *cachedSelector
 		cip = newCachedSelectorPolicy(identity)
 		cache.policies[identity.ID] = cip
 	}
+	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeInsert, ID: identity.ID})
 	return cip
 }
 
@@ -107,6 +121,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 			selPolicy.detach(true, 0)
 		}
 	}
+	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeDelete, ID: identity.ID})
 	return ok
 }
 
@@ -166,6 +181,45 @@ func (cache *policyCache) LocalEndpointIdentityAdded(identity *identityPkg.Ident
 // specified Identity.
 func (cache *policyCache) LocalEndpointIdentityRemoved(identity *identityPkg.Identity) {
 	cache.delete(identity)
+}
+
+// Implements stream.Observable. Replays initial state as a sequence of adds.
+func (cache *policyCache) Observe(ctx context.Context, next func(PolicyCacheChange), complete func(error)) {
+	cache.Lock()
+	defer cache.Unlock()
+
+	for id := range cache.policies {
+		select {
+		case <-ctx.Done():
+			complete(ctx.Err())
+			return
+		default:
+		}
+		next(PolicyCacheChange{Kind: PolicyChangeInsert, ID: id})
+	}
+
+	select {
+	case <-ctx.Done():
+		complete(ctx.Err())
+		return
+	default:
+	}
+	next(PolicyCacheChange{Kind: PolicyChangeSync})
+
+	cache.Observable.Observe(ctx, next, complete)
+}
+
+type PolicyChangeKind string
+
+const (
+	PolicyChangeSync   PolicyChangeKind = "sync"
+	PolicyChangeInsert PolicyChangeKind = "Insert"
+	PolicyChangeDelete PolicyChangeKind = "delete"
+)
+
+type PolicyCacheChange struct {
+	Kind PolicyChangeKind
+	ID   identityPkg.NumericIdentity
 }
 
 // getAuthTypes returns the AuthTypes required by the policy between the localID and remoteID, if

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -93,13 +93,13 @@ func TestCachePopulation(t *testing.T) {
 	cip1 := cache.insert(identity1)
 
 	// Calculate the policy and observe that it's cached
-	policy1, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy1, _, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, _, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.False(t, updated)
-	policy3, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy3, _, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NotNil(t, policy1)
 	require.Same(t, policy1, policy3)
 	cip2, ok := cache.lookup(identity1)
@@ -109,17 +109,17 @@ func TestCachePopulation(t *testing.T) {
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	_, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, _, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.Error(t, err)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint(t)
 	ep3.SetIdentity(1234, true)
-	_, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	_, _, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 	require.Error(t, err)
 
 	cache.insert(ep3.GetSecurityIdentity())
-	policy4, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	policy4, _, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 
 	// policy4 must be different from ep1, ep2
 	require.NoError(t, err)
@@ -132,9 +132,9 @@ func TestCachePopulation(t *testing.T) {
 	idp1 := policy5.getPolicy()
 	require.Nil(t, idp1)
 
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
-	require.NoError(t, err)
+	_, _, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
 	require.True(t, updated)
+	require.NoError(t, err)
 
 	idp1 = policy5.getPolicy()
 	require.NotNil(t, idp1)
@@ -142,13 +142,13 @@ func TestCachePopulation(t *testing.T) {
 	identity3 := ep3.GetSecurityIdentity()
 	policy6 := cache.insert(identity3)
 	require.NotEqual(t, policy5, policy6)
-	idp3, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
+	idp3, _, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
 	require.False(t, updated)
 	require.Equal(t, idp1, idp3)
 
 	repo.revision.Store(43)
-	idp3, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
+	idp3, _, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
 	require.True(t, updated)
 	idp1 = policy5.getPolicy()

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1516,6 +1516,14 @@ type L4Policy struct {
 	mutex lock.RWMutex
 	users map[*EndpointPolicy]struct{}
 
+	// holdCount prevents detachment between policy fetch and insertUser registration.
+	holdCount int
+
+	// superseded is set when this policy has been replaced by a newer one.
+	// shouldDetachLocked only performs full detachment for superseded policies,
+	// preventing premature detachment of policies still current in statedb.
+	superseded bool
+
 	// detachedTime can be used for users that don't need to grab the lock.
 	detachedTime atomic.Pointer[time.Time]
 }
@@ -1530,11 +1538,64 @@ func NewL4Policy(revision uint64) L4Policy {
 	}
 }
 
+// addHold prevents detachment between policy fetch and insertUser.
+// Returns false if already detached.
+func (l4 *L4Policy) addHold() bool {
+	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
+	if l4.users == nil {
+		return false
+	}
+	l4.holdCount++
+	return true
+}
+
+// releaseHold decrements the hold count, detaching the policy if no users
+// or holds remain. Used on error paths when insertUser will not be called.
+func (l4 *L4Policy) releaseHold(selectorCache *SelectorCache) {
+	l4.mutex.Lock()
+	if l4.holdCount > 0 {
+		l4.holdCount--
+	}
+	needsDetach := l4.shouldDetachLocked()
+	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
+}
+
+// shouldDetachLocked marks the policy as detached (users=nil) if no users,
+// holds, or active references remain. Returns true if the caller must call
+// finishDetach after releasing l4.mutex.
+//
+// The superseded check prevents premature detachment when removeUser drains
+// a policy that is still the current statedb entry — without it, removeUser
+// would create a permanently stale entry that traps endpoints in a regen loop.
+//
+// Must be called with l4.mutex held.
+func (l4 *L4Policy) shouldDetachLocked() bool {
+	if l4.holdCount == 0 && l4.users != nil && len(l4.users) == 0 && l4.superseded {
+		l4.users = nil
+		l4.detachedTime.Store(ptr.To(time.Now()))
+		return true
+	}
+	return false
+}
+
+// finishDetach removes cached selectors from the SelectorCache.
+// Must be called WITHOUT l4.mutex held (takes sc.mutex internally).
+func (l4 *L4Policy) finishDetach(selectorCache *SelectorCache) {
+	l4.Ingress.Detach(selectorCache)
+	l4.Egress.Detach(selectorCache)
+}
+
 // insertUser adds a user to the L4Policy so that incremental
 // updates of the L4Policy may be forwarded to the users of it.
 // May not call into SelectorCache, as SelectorCache is locked during this call.
-func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
+func (l4 *L4Policy) insertUser(user *EndpointPolicy, selectorCache *SelectorCache) {
 	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
 
 	// 'users' is set to nil when the policy is detached. This
 	// happens to the old policy when it is being replaced with a
@@ -1557,21 +1618,26 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 		})
 	}
 
-	l4.mutex.Unlock()
+	// Release hold; detach impossible here (user count >= 1 or already detached).
+	if l4.holdCount > 0 {
+		l4.holdCount--
+	}
 }
 
 // removeUser removes a user that no longer needs incremental updates
-// from the L4Policy.
-func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
-	// 'users' is set to nil when the policy is detached. This
-	// happens to the old policy when it is being replaced with a
-	// new one, or when the last endpoint using this policy is
-	// removed.
+// from the L4Policy. It detaches the policy if this was the last user
+// and there are no outstanding holds.
+func (l4 *L4Policy) removeUser(user *EndpointPolicy, selectorCache *SelectorCache) {
 	l4.mutex.Lock()
 	if l4.users != nil {
 		delete(l4.users, user)
 	}
+	needsDetach := l4.shouldDetachLocked()
 	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
 }
 
 // AccumulateMapChanges distributes the given changes to the registered users.
@@ -1701,26 +1767,34 @@ func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn SelectorSnapshot) {
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
 func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpointID uint64) {
-	l4.Ingress.Detach(selectorCache)
-	l4.Egress.Detach(selectorCache)
+	if isDelete {
+		l4.Ingress.Detach(selectorCache)
+		l4.Egress.Detach(selectorCache)
+		l4.mutex.Lock()
+		defer l4.mutex.Unlock()
+		l4.users = nil
+		l4.detachedTime.Store(ptr.To(time.Now()))
+		return
+	}
 
+	// Notify existing users to regenerate so they migrate to the new policy.
 	l4.mutex.Lock()
-	defer l4.mutex.Unlock()
-	// If this detach is a delete there is no reason to initiate
-	// a regenerate.
-	if !isDelete {
-		for ePolicy := range l4.users {
-			if endpointID != ePolicy.PolicyOwner.GetID() {
-				go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
-					Reason:            regeneration.ReasonSelectorPolicyStale,
-					Message:           "selector policy has changed because of another endpoint with the same identity",
-					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
-				})
-			}
+	for ePolicy := range l4.users {
+		if endpointID != ePolicy.PolicyOwner.GetID() {
+			go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+				Reason:            regeneration.ReasonSelectorPolicyStale,
+				Message:           "selector policy has changed because of another endpoint with the same identity",
+				RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+			})
 		}
 	}
-	l4.users = nil
-	l4.detachedTime.Store(ptr.To(time.Now()))
+	l4.superseded = true
+	needsDetach := l4.shouldDetachLocked()
+	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
 }
 
 // Attach makes all the L4Filters to point back to the L4Policy that contains them.

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -7,20 +7,28 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"iter"
+	"log/slog"
 	"math/rand/v2"
 	"slices"
 	"sort"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/testutils"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -644,4 +652,191 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 			}
 		}
 	})
+}
+
+// TestHoldCountRealCodePath validates that holdCount prevents premature detachment
+// when multiple endpoints share a selectorPolicy through DistillPolicy.
+func TestHoldCountRealCodePath(t *testing.T) {
+	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo.revision.Store(1)
+	cache := repo.policyCache
+
+	ep1 := testutils.NewTestEndpoint(t)
+	identity1 := ep1.GetSecurityIdentity()
+
+	cache.insert(identity1)
+
+	policy, _, _, err := cache.updateSelectorPolicy(identity1, ep1.Id)
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+
+	require.Equal(t, 0, policy.L4Policy.holdCount, "policy should have no holds after updateSelectorPolicy")
+
+	logger := hivetest.Logger(t)
+	existingOwner := newTestPolicyOwner(100, logger)
+
+	held := policy.AddHold()
+	require.True(t, held, "AddHold should succeed on live policy")
+	require.Equal(t, 1, policy.L4Policy.holdCount, "hold should be added")
+
+	existingPolicy := policy.DistillPolicy(logger, existingOwner, nil)
+
+	require.Equal(t, 0, policy.L4Policy.holdCount, "hold should be released after DistillPolicy")
+	require.Len(t, policy.L4Policy.users, 1, "should have 1 user")
+
+	ownerA := newTestPolicyOwner(200, logger)
+	ownerB := newTestPolicyOwner(300, logger)
+
+	require.True(t, policy.AddHold())
+	require.True(t, policy.AddHold())
+	require.Equal(t, 2, policy.L4Policy.holdCount)
+
+	policyA := policy.DistillPolicy(logger, ownerA, nil)
+	require.NotNil(t, policyA)
+	require.Equal(t, 1, policy.L4Policy.holdCount, "one hold should remain for B")
+	require.Len(t, policy.L4Policy.users, 2, "should have existing user + A")
+
+	require.NotSame(t, existingPolicy, policyA, "each endpoint should have its own EndpointPolicy")
+	require.NotSame(t, existingOwner.PreviousMapState(), ownerA.PreviousMapState(), "each endpoint should have its own MapState")
+
+	policy.removeUser(existingPolicy)
+	require.Equal(t, 1, policy.L4Policy.holdCount, "B's hold still outstanding")
+	require.Len(t, policy.L4Policy.users, 1, "should have only A")
+
+	policy.removeUser(policyA)
+
+	// B's outstanding hold prevents detachment even though users is empty.
+	require.Equal(t, 1, policy.L4Policy.holdCount)
+	require.NotNil(t, policy.L4Policy.users)
+	require.Empty(t, policy.L4Policy.users)
+
+	policyB := policy.DistillPolicy(logger, ownerB, nil)
+	require.NotNil(t, policyB)
+	require.NotSame(t, policyB, policyA, "B should have its own EndpointPolicy")
+	require.NotSame(t, ownerB.PreviousMapState(), ownerA.PreviousMapState(), "B should have its own MapState")
+
+	require.Equal(t, 0, policy.L4Policy.holdCount, "B's hold released after DistillPolicy")
+	require.NotNil(t, policy.L4Policy.users, "policy should not be detached")
+	require.Len(t, policy.L4Policy.users, 1, "B should have registered successfully")
+}
+
+// TestAddHoldRejectsDetachedPolicy verifies AddHold returns false on a policy
+// that was detached by MaybeDetach, preventing the regen loop where DistillPolicy
+// fires RegenerateIfAlive on a dead policy.
+func TestAddHoldRejectsDetachedPolicy(t *testing.T) {
+	repo := NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo.revision.Store(1)
+	cache := repo.policyCache
+	logger := hivetest.Logger(t)
+
+	ep := testutils.NewTestEndpoint(t)
+	identity := ep.GetSecurityIdentity()
+	cache.insert(identity)
+
+	repo.mutex.RLock()
+	P, _, _, err := cache.updateSelectorPolicy(identity, 0)
+	repo.mutex.RUnlock()
+	require.NoError(t, err)
+	require.NotNil(t, P.L4Policy.users, "P should be live")
+
+	repo.BumpRevision()
+	repo.mutex.RLock()
+	Q, old, _, err := cache.updateSelectorPolicy(identity, 0)
+	repo.mutex.RUnlock()
+	require.NoError(t, err)
+	require.Same(t, P, old)
+	require.NotSame(t, P, Q)
+
+	old.MaybeDetach()
+	require.Nil(t, P.L4Policy.users, "P should be detached")
+
+	// Endpoint tries to use stale (detached) P.
+	regenOwner := newRegenTrackingOwner(100, logger)
+	held := P.AddHold()
+	if held {
+		P.DistillPolicy(logger, regenOwner, nil)
+	}
+
+	require.False(t, held, "AddHold must reject detached policy")
+	require.Never(t, func() bool {
+		return regenOwner.regenCount.Load() > 0
+	}, 200*time.Millisecond, 10*time.Millisecond,
+		"RegenerateIfAlive must not fire on detached policy")
+
+	// Live policy Q works normally.
+	held = Q.AddHold()
+	require.True(t, held)
+
+	safeOwner := newRegenTrackingOwner(200, logger)
+	epPolicy := Q.DistillPolicy(logger, safeOwner, nil)
+	require.NotNil(t, epPolicy)
+	require.Len(t, Q.L4Policy.users, 1, "endpoint registered on Q")
+	require.Equal(t, int32(0), safeOwner.regenCount.Load(),
+		"no spurious regen when using live policy")
+}
+
+// testPolicyOwner provides a PolicyOwner implementation for tests that need
+// per-endpoint state (logger, previousState).
+type testPolicyOwner struct {
+	id            uint64
+	previousState *MapState
+	logger        *slog.Logger
+}
+
+func newTestPolicyOwner(id uint64, logger *slog.Logger) *testPolicyOwner {
+	return &testPolicyOwner{
+		id:            id,
+		previousState: &MapState{},
+		logger:        logger,
+	}
+}
+
+func (t *testPolicyOwner) GetID() uint64 { return t.id }
+
+func (t *testPolicyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, _ iter.Seq[identity.NumericIdentity]) uint16 {
+	return 0
+}
+
+func (t *testPolicyOwner) PolicyDebug(msg string, attrs ...any) {
+	if t.logger != nil {
+		t.logger.Debug(msg, attrs...)
+	}
+}
+
+func (t *testPolicyOwner) IsHost() bool { return false }
+
+func (t *testPolicyOwner) PreviousMapState() *MapState {
+	return t.previousState
+}
+
+func (t *testPolicyOwner) RegenerateIfAlive(meta *regeneration.ExternalRegenerationMetadata) <-chan bool {
+	ch := make(chan bool, 1)
+	ch <- false
+	close(ch)
+	return ch
+}
+
+// regenTrackingOwner extends testPolicyOwner with an atomic regen counter
+// to detect when RegenerateIfAlive is fired (the regen loop trigger).
+type regenTrackingOwner struct {
+	testPolicyOwner
+	regenCount atomic.Int32
+}
+
+func newRegenTrackingOwner(id uint64, logger *slog.Logger) *regenTrackingOwner {
+	return &regenTrackingOwner{
+		testPolicyOwner: testPolicyOwner{
+			id:            id,
+			previousState: &MapState{},
+			logger:        logger,
+		},
+	}
+}
+
+func (t *regenTrackingOwner) RegenerateIfAlive(meta *regeneration.ExternalRegenerationMetadata) <-chan bool {
+	t.regenCount.Add(1)
+	ch := make(chan bool, 1)
+	ch <- false
+	close(ch)
+	return ch
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -552,7 +552,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	stats.SelectorPolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
+	sp, _, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
 	stats.SelectorPolicyCalculation().EndError(err)
 
 	// If we hit cache, reset the statistics.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -36,13 +36,18 @@ type PolicyRepository interface {
 	GetAuthTypes(localID identity.NumericIdentity, remoteID identity.NumericIdentity) AuthTypes
 	GetEnvoyHTTPRules(l7Rules *api.L7Rules, ns string) (*cilium.HttpNetworkPolicyRules, bool)
 
-	// GetSelectorPolicy computes the SelectorPolicy for a given identity.
+	// GetSelectorPolicy computes the SelectorPolicy for a given identity. It
+	// is only used in unit tests.
 	//
 	// It returns nil if skipRevision is >= than the already calculated version.
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
+
+	// ComputeSelectorPolicy computes the SelectorPolicy for a given identity,
+	// if it needs recomputing.
+	ComputeSelectorPolicy(id *identity.Identity, skipRevision uint64) (SelectorPolicy, uint64, SelectorPolicy, bool, error)
 
 	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
 	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
@@ -529,7 +534,8 @@ func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Se
 	})
 }
 
-// GetSelectorPolicy computes the SelectorPolicy for a given identity.
+// GetSelectorPolicy computes the SelectorPolicy for a given identity. It is
+// only used in unit tests.
 //
 // It returns nil if skipRevision is >= than the already calculated version.
 // This is used to skip policy calculation when a certain revision delta is
@@ -561,6 +567,21 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	}
 
 	return sp, rev, err
+}
+
+// ComputeSelectorPolicy computes the SelectorPolicy for a given identity, if
+// it needs recomputing.
+func (r *Repository) ComputeSelectorPolicy(id *identity.Identity, skipRevision uint64) (SelectorPolicy, uint64, SelectorPolicy, bool, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	rev := r.GetRevision()
+	sp, old, release, err := r.policyCache.updateSelectorPolicy(id, 0)
+	if err != nil {
+		return nil, 0, nil, release, err
+	}
+
+	return sp, rev, old, release, err
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/cilium/stream"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -58,6 +59,8 @@ type PolicyRepository interface {
 	Iterate(f func(rule *types.PolicyEntry))
 	ReplaceByResource(rules types.PolicyEntries, resource ipcachetypes.ResourceID) (affectedIDs *set.Set[identity.NumericIdentity], rev uint64, oldRevCnt int)
 	Search() (types.PolicyEntries, uint64)
+
+	PolicyCacheObservable() stream.Observable[PolicyCacheChange]
 }
 
 type GetPolicyStatistics interface {
@@ -633,4 +636,8 @@ func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPo
 	defer p.mutex.RUnlock()
 
 	return p.policyCache.GetPolicySnapshot()
+}
+
+func (p *Repository) PolicyCacheObservable() stream.Observable[PolicyCacheChange] {
+	return p.policyCache
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -163,6 +163,11 @@ type SelectorPolicy interface {
 
 	// GetSelectorSnapshot returns a selector snapshot if available and valid
 	GetSelectorSnapshot() SelectorSnapshot
+	AddHold() bool
+	ReleaseHold()
+	Detach()
+	MaybeDetach()
+	GetRevision() uint64
 }
 
 // selectorPolicy is a structure which contains the resolved policy for a
@@ -285,16 +290,48 @@ func newSelectorPolicy(selectorCache *SelectorCache) *selectorPolicy {
 	}
 }
 
+func (p *selectorPolicy) AddHold() bool {
+	return p.L4Policy.addHold()
+}
+
+func (p *selectorPolicy) ReleaseHold() {
+	if p == nil {
+		return
+	}
+	p.L4Policy.releaseHold(p.SelectorCache)
+}
+
+func (p *selectorPolicy) MaybeDetach() {
+	if p == nil {
+		return
+	}
+	p.L4Policy.mutex.Lock()
+	p.L4Policy.superseded = true
+	needsDetach := p.L4Policy.shouldDetachLocked()
+	p.L4Policy.mutex.Unlock()
+
+	if needsDetach {
+		p.L4Policy.finishDetach(p.SelectorCache)
+	}
+}
+
 // insertUser adds a user to the L4Policy so that incremental
 // updates of the L4Policy may be fowarded.
 func (p *selectorPolicy) insertUser(user *EndpointPolicy) {
-	p.L4Policy.insertUser(user)
+	p.L4Policy.insertUser(user, p.SelectorCache)
 }
 
 // removeUser removes a user from the L4Policy so the EndpointPolicy
 // can be freed when not needed any more
 func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
-	p.L4Policy.removeUser(user)
+	p.L4Policy.removeUser(user, p.SelectorCache)
+}
+
+func (p *selectorPolicy) Detach() {
+	if p == nil {
+		return
+	}
+	p.detach(true, 0)
 }
 
 // detach releases resources held by a selectorPolicy to enable
@@ -555,6 +592,13 @@ func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolic
 			p.L4Policy.Egress.forEachRedirectFilter(yield)
 		}
 	}
+}
+
+func (p *selectorPolicy) GetRevision() uint64 {
+	if p == nil {
+		return 0
+	}
+	return p.Revision
 }
 
 func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, PerSelectorPolicyTuple) bool) bool {

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -204,6 +206,16 @@ func (rules ruleSlice) AsPolicyEntries() types.PolicyEntries {
 		policyRules = append(policyRules, &r.PolicyEntry)
 	}
 	return policyRules
+}
+
+func (rules ruleSlice) AllIdentitySelections() set.Set[identity.NumericIdentity] {
+	ids := set.NewSet[identity.NumericIdentity]()
+	for _, r := range rules {
+		for _, id := range r.getSubjects() {
+			ids.Insert(id)
+		}
+	}
+	return ids
 }
 
 // traceState is an internal structure used to collect information


### PR DESCRIPTION
## Series: Break out policy computation from endpoint package

Currently, each endpoint computes its own SelectorPolicy inline during
regeneration. This couples the endpoint lifecycle to the policy engine,
duplicates work when multiple endpoints share an identity, and makes it
difficult to test the policy computation path in isolation.

This series introduces a dedicated cell that computes SelectorPolicy per
identity and stores results in a statedb table. The endpoint reads from
this table via watch channels. Endpoints unaffected by a policy change
no longer need to regenerate.

PR 1/3: API prep (no behavior change)
PR 2/3: Script commands, fakes, and test infrastructure
PR 3/3: Policy computation cell + script-based integration test

Depends on:
* https://github.com/cilium/hive/pull/58
* https://github.com/cilium/statedb/pull/106

Fixes: https://github.com/cilium/cilium/issues/7515

---

Preparatory refactoring for breaking policy computation out of the endpoint
package. These expand the policy and identitymanager APIs so that an external
cell can compute policies and manage their lifecycle. No behavior changes.

The most notable commit is "Expand SelectorPolicy interface with lifecycle
methods" which adds reference counting (`AddHold`/`MaybeDetach`) to prevent a
SelectorPolicy from being detached while an endpoint is preparing to use it.

Review commit-by-commit.