### PR TITLE
policy: Prepare SelectorPolicy for external computation (1/3)

### DIFF
--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -15,6 +15,8 @@ import (
 
 type IDManager interface {
 	Add(identity *identity.Identity)
+	Get(*identity.NumericIdentity) *identity.Identity
+	GetAll() []*identity.Identity
 	GetIdentityModels() []*models.IdentityEndpoints
 	Remove(identity *identity.Identity)
 	RemoveAll()
@@ -156,6 +158,35 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 		}
 	}
 
+}
+
+// Get returns the full identity based on the numeric identity. The returned
+// identity is a pointer to a live object; do not modify!
+func (idm *IdentityManager) Get(id *identity.NumericIdentity) *identity.Identity {
+	if id == nil {
+		return nil
+	}
+
+	idm.mutex.RLock()
+	defer idm.mutex.RUnlock()
+
+	idd, exists := idm.identities[*id]
+	if !exists {
+		return nil
+	}
+	return idd.identity
+}
+
+// GetAll returns all identities from the manager. The returned slices contains
+// identities that are pointers to a live objects; do not modify!
+func (idm *IdentityManager) GetAll() []*identity.Identity {
+	idm.mutex.RLock()
+	defer idm.mutex.RUnlock()
+	ids := make([]*identity.Identity, 0, len(idm.identities))
+	for _, v := range idm.identities {
+		ids = append(ids, v.identity)
+	}
+	return ids
 }
 
 // GetIdentityModels returns the API representation of the IdentityManager.

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -55,34 +55,31 @@ func newIdentityManager(logger *slog.Logger) *IdentityManager {
 // already in the identity manager, the reference count for the identity is
 // incremented.
 func (idm *IdentityManager) Add(identity *identity.Identity) {
-	idm.logger.Debug(
-		"Adding identity to identity manager",
-		logfields.Identity, identity,
-	)
-
-	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
-	idm.add(identity)
-}
-
-func (idm *IdentityManager) add(identity *identity.Identity) {
 	if identity == nil {
 		return
 	}
 
+	idm.mutex.Lock()
+	if idm.addLocked(identity) {
+		idm.notifyObserversLocked(identity, true)
+	}
+	idm.mutex.Unlock()
+}
+
+func (idm *IdentityManager) addLocked(identity *identity.Identity) (added bool) {
+	if identity == nil {
+		return false
+	}
 	idMeta, exists := idm.identities[identity.ID]
 	if !exists {
 		idm.identities[identity.ID] = &identityMetadata{
 			identity: identity,
 			refCount: 1,
 		}
-		for o := range idm.observers {
-			o.LocalEndpointIdentityAdded(identity)
-		}
-
-	} else {
-		idMeta.refCount++
+		return true
 	}
+	idMeta.refCount++
+	return false
 }
 
 // RemoveOldAddNew removes old from the identity manager and inserts new
@@ -90,9 +87,6 @@ func (idm *IdentityManager) add(identity *identity.Identity) {
 // Caller must have previously added the old identity with Add().
 // This is a no-op if both identities have the same numeric ID.
 func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
-	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
-
 	if old == nil && new == nil {
 		return
 	}
@@ -102,14 +96,14 @@ func (idm *IdentityManager) RemoveOldAddNew(old, new *identity.Identity) {
 		return
 	}
 
-	idm.logger.Debug(
-		"removing old and adding new identity",
-		logfields.Old, old,
-		logfields.New, new,
-	)
-
-	idm.remove(old)
-	idm.add(new)
+	idm.mutex.Lock()
+	if idm.removeLocked(old) {
+		idm.notifyObserversLocked(old, false)
+	}
+	if idm.addLocked(new) {
+		idm.notifyObserversLocked(new, true)
+	}
+	idm.mutex.Unlock()
 }
 
 // RemoveAll removes all identities.
@@ -118,7 +112,7 @@ func (idm *IdentityManager) RemoveAll() {
 	defer idm.mutex.Unlock()
 
 	for id := range idm.identities {
-		idm.remove(idm.identities[id].identity)
+		idm.removeLocked(idm.identities[id].identity)
 	}
 }
 
@@ -127,20 +121,35 @@ func (idm *IdentityManager) RemoveAll() {
 // decremented. If the identity is not in the cache, this is a no-op. If the
 // ref count becomes zero, the identity is removed from the cache.
 func (idm *IdentityManager) Remove(identity *identity.Identity) {
+	if identity == nil {
+		return
+	}
+
+	idm.mutex.Lock()
+	if idm.removeLocked(identity) {
+		idm.notifyObserversLocked(identity, false)
+	}
+	idm.mutex.Unlock()
+}
+
+func (idm *IdentityManager) notifyObserversLocked(identity *identity.Identity, added bool) {
+	for o := range idm.observers {
+		if added {
+			o.LocalEndpointIdentityAdded(identity)
+		} else {
+			o.LocalEndpointIdentityRemoved(identity)
+		}
+	}
+}
+func (idm *IdentityManager) removeLocked(identity *identity.Identity) (removed bool) {
+	if identity == nil {
+		return
+	}
+
 	idm.logger.Debug(
 		"Removing identity from identity manager",
 		logfields.Identity, identity,
 	)
-
-	idm.mutex.Lock()
-	defer idm.mutex.Unlock()
-	idm.remove(identity)
-}
-
-func (idm *IdentityManager) remove(identity *identity.Identity) {
-	if identity == nil {
-		return
-	}
 
 	idMeta, exists := idm.identities[identity.ID]
 	if !exists {
@@ -153,11 +162,9 @@ func (idm *IdentityManager) remove(identity *identity.Identity) {
 	idMeta.refCount--
 	if idMeta.refCount == 0 {
 		delete(idm.identities, identity.ID)
-		for o := range idm.observers {
-			o.LocalEndpointIdentityRemoved(identity)
-		}
+		removed = true
 	}
-
+	return
 }
 
 // Get returns the full identity based on the numeric identity. The returned

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -30,6 +31,7 @@ var Cell = cell.Module(
 	cell.Provide(newPolicyRepo),
 	cell.Provide(newPolicyUpdater),
 	cell.Provide(newPolicyImporter),
+	cell.Provide(newPolicyCacheOut),
 	cell.Provide(newIdentityUpdater),
 	cell.Provide(newIPCacher),
 	cell.Config(defaultConfig),
@@ -100,6 +102,10 @@ func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
 	})
 
 	return policyRepo
+}
+
+func newPolicyCacheOut(r policy.PolicyRepository) stream.Observable[policy.PolicyCacheChange] {
+	return r.PolicyCacheObservable()
 }
 
 type policyUpdaterParams struct {

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -11,11 +12,15 @@ import (
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/lock"
+
+	"github.com/cilium/stream"
 )
 
 // policyCache represents a cache of resolved policies for identities.
 type policyCache struct {
 	lock.Mutex
+	// Used to implement the stream.Observable interface.
+	stream.Observable[PolicyCacheChange]
 
 	// repo is a circular reference back to the Repository, but as
 	// we create only one Repository and one PolicyCache for each
@@ -23,13 +28,21 @@ type policyCache struct {
 	// collected.
 	repo     *Repository
 	policies map[identityPkg.NumericIdentity]*cachedSelectorPolicy
+
+	// emitChange is used with the observable embedded in this struct.
+	emitChange func(PolicyCacheChange)
 }
 
 // newPolicyCache creates a new cache of SelectorPolicy.
 func newPolicyCache(repo *Repository, idmgr identitymanager.IDManager) *policyCache {
+	mcast, emit, _ := stream.Multicast[PolicyCacheChange]()
 	cache := &policyCache{
+		Observable: mcast,
+
 		repo:     repo,
 		policies: make(map[identityPkg.NumericIdentity]*cachedSelectorPolicy),
+
+		emitChange: emit,
 	}
 	if idmgr != nil {
 		idmgr.Subscribe(cache)
@@ -84,6 +97,7 @@ func (cache *policyCache) insert(identity *identityPkg.Identity) *cachedSelector
 		cip = newCachedSelectorPolicy(identity)
 		cache.policies[identity.ID] = cip
 	}
+	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeInsert, ID: identity.ID, Identity: identity})
 	return cip
 }
 
@@ -107,6 +121,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 			selPolicy.detach(true, 0)
 		}
 	}
+	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeDelete, ID: identity.ID})
 	return ok
 }
 
@@ -166,6 +181,46 @@ func (cache *policyCache) LocalEndpointIdentityAdded(identity *identityPkg.Ident
 // specified Identity.
 func (cache *policyCache) LocalEndpointIdentityRemoved(identity *identityPkg.Identity) {
 	cache.delete(identity)
+}
+
+// Implements stream.Observable. Replays initial state as a sequence of adds.
+func (cache *policyCache) Observe(ctx context.Context, next func(PolicyCacheChange), complete func(error)) {
+	cache.Lock()
+	defer cache.Unlock()
+
+	for id := range cache.policies {
+		select {
+		case <-ctx.Done():
+			complete(ctx.Err())
+			return
+		default:
+		}
+		next(PolicyCacheChange{Kind: PolicyChangeInsert, ID: id, Identity: cache.policies[id].identity})
+	}
+
+	select {
+	case <-ctx.Done():
+		complete(ctx.Err())
+		return
+	default:
+	}
+	next(PolicyCacheChange{Kind: PolicyChangeSync})
+
+	cache.Observable.Observe(ctx, next, complete)
+}
+
+type PolicyChangeKind string
+
+const (
+	PolicyChangeSync   PolicyChangeKind = "sync"
+	PolicyChangeInsert PolicyChangeKind = "Insert"
+	PolicyChangeDelete PolicyChangeKind = "delete"
+)
+
+type PolicyCacheChange struct {
+	Kind     PolicyChangeKind
+	ID       identityPkg.NumericIdentity
+	Identity *identityPkg.Identity
 }
 
 // getAuthTypes returns the AuthTypes required by the policy between the localID and remoteID, if

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -124,10 +124,10 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 // is still referring to the old identity.
 //
 // Must be called with repo.Mutex held for reading.
-func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, bool, error) {
+func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, *selectorPolicy, bool, error) {
 	cip, ok := cache.lookup(identity)
 	if !ok {
-		return nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
+		return nil, nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
 	}
 
 	// As long as UpdatePolicy() is triggered from endpoint
@@ -144,18 +144,16 @@ func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, e
 
 	// Don't resolve policy if it was already done for this or later revision.
 	if selPolicy := cip.getPolicy(); selPolicy != nil && selPolicy.Revision >= cache.repo.GetRevision() {
-		return selPolicy, false, nil
+		return selPolicy, nil, false, nil
 	}
 
 	// Resolve the policies, which could fail
 	selPolicy, err := cache.repo.resolvePolicyLocked(identity)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
 	}
 
-	cip.setPolicy(selPolicy, endpointID)
-
-	return selPolicy, true, nil
+	return selPolicy, cip.setPolicy(selPolicy, endpointID), true, nil
 }
 
 // LocalEndpointIdentityAdded creates a SelectorPolicy cache entry for the
@@ -238,10 +236,11 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 // the endpoint that initiated the old selector policy detach. Since detach
 // can trigger endpoint regenerations of all it users, this ensures
 // that endpoints do not continuously update themselves.
-func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) {
+func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) *selectorPolicy {
 	oldPolicy := cip.policy.Swap(policy)
 	if oldPolicy != nil {
 		// Release the references the previous policy holds on the selector cache.
 		oldPolicy.detach(false, endpointID)
 	}
+	return oldPolicy
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -93,13 +93,13 @@ func TestCachePopulation(t *testing.T) {
 	cip1 := cache.insert(identity1)
 
 	// Calculate the policy and observe that it's cached
-	policy1, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy1, _, updated, err := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.True(t, updated)
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, _, updated, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NoError(t, err)
 	require.False(t, updated)
-	policy3, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
+	policy3, _, _, _ := cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.NotNil(t, policy1)
 	require.Same(t, policy1, policy3)
 	cip2, ok := cache.lookup(identity1)
@@ -109,17 +109,17 @@ func TestCachePopulation(t *testing.T) {
 	// Remove the identity and observe that it is no longer available
 	cacheCleared := cache.delete(identity1)
 	require.True(t, cacheCleared)
-	_, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
+	_, _, _, err = cache.updateSelectorPolicy(identity1, ep1.Id)
 	require.Error(t, err)
 
 	// Attempt to update policy for non-cached endpoint and observe failure
 	ep3 := testutils.NewTestEndpoint(t)
 	ep3.SetIdentity(1234, true)
-	_, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	_, _, _, err = cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 	require.Error(t, err)
 
 	cache.insert(ep3.GetSecurityIdentity())
-	policy4, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
+	policy4, _, updated, err := cache.updateSelectorPolicy(ep3.GetSecurityIdentity(), ep3.Id)
 
 	// policy4 must be different from ep1, ep2
 	require.NoError(t, err)
@@ -132,9 +132,9 @@ func TestCachePopulation(t *testing.T) {
 	idp1 := policy5.getPolicy()
 	require.Nil(t, idp1)
 
-	_, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
-	require.NoError(t, err)
+	_, _, updated, err = cache.updateSelectorPolicy(identity1, ep1.GetID())
 	require.True(t, updated)
+	require.NoError(t, err)
 
 	idp1 = policy5.getPolicy()
 	require.NotNil(t, idp1)
@@ -142,13 +142,13 @@ func TestCachePopulation(t *testing.T) {
 	identity3 := ep3.GetSecurityIdentity()
 	policy6 := cache.insert(identity3)
 	require.NotEqual(t, policy5, policy6)
-	idp3, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
+	idp3, _, updated, err := cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
 	require.False(t, updated)
 	require.Equal(t, idp1, idp3)
 
 	repo.revision.Store(43)
-	idp3, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
+	idp3, _, updated, err = cache.updateSelectorPolicy(identity3, ep3.GetID())
 	require.NoError(t, err)
 	require.True(t, updated)
 	idp1 = policy5.getPolicy()

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -552,7 +552,7 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	stats.SelectorPolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
+	sp, _, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
 	stats.SelectorPolicyCalculation().EndError(err)
 
 	// If we hit cache, reset the statistics.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -36,13 +36,18 @@ type PolicyRepository interface {
 	GetAuthTypes(localID identity.NumericIdentity, remoteID identity.NumericIdentity) AuthTypes
 	GetEnvoyHTTPRules(l7Rules *api.L7Rules, ns string) (*cilium.HttpNetworkPolicyRules, bool)
 
-	// GetSelectorPolicy computes the SelectorPolicy for a given identity.
+	// GetSelectorPolicy computes the SelectorPolicy for a given identity. It
+	// is only used in unit tests.
 	//
 	// It returns nil if skipRevision is >= than the already calculated version.
 	// This is used to skip policy calculation when a certain revision delta is
 	// known to not affect the given identity. Pass a skipRevision of 0 to force
 	// calculation.
 	GetSelectorPolicy(id *identity.Identity, skipRevision uint64, stats GetPolicyStatistics, endpointID uint64) (SelectorPolicy, uint64, error)
+
+	// ComputeSelectorPolicy computes the SelectorPolicy for a given identity,
+	// if it needs recomputing.
+	ComputeSelectorPolicy(id *identity.Identity, skipRevision uint64) (SelectorPolicy, uint64, SelectorPolicy, bool, error)
 
 	// GetPolicySnapshot returns a map of all the SelectorPolicies in the repository.
 	GetPolicySnapshot() map[identity.NumericIdentity]SelectorPolicy
@@ -529,7 +534,8 @@ func (rules ruleSlice) addDefaultRule(subject *identity.Identity, peers types.Se
 	})
 }
 
-// GetSelectorPolicy computes the SelectorPolicy for a given identity.
+// GetSelectorPolicy computes the SelectorPolicy for a given identity. It is
+// only used in unit tests.
 //
 // It returns nil if skipRevision is >= than the already calculated version.
 // This is used to skip policy calculation when a certain revision delta is
@@ -561,6 +567,21 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 	}
 
 	return sp, rev, err
+}
+
+// ComputeSelectorPolicy computes the SelectorPolicy for a given identity, if
+// it needs recomputing.
+func (r *Repository) ComputeSelectorPolicy(id *identity.Identity, skipRevision uint64) (SelectorPolicy, uint64, SelectorPolicy, bool, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	rev := r.GetRevision()
+	sp, old, release, err := r.policyCache.updateSelectorPolicy(id, 0)
+	if err != nil {
+		return nil, 0, nil, release, err
+	}
+
+	return sp, rev, old, release, err
 }
 
 // ReplaceByResource replaces all rules by resource, returning the complete set of affected endpoints.

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
+	"github.com/cilium/stream"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -58,6 +59,8 @@ type PolicyRepository interface {
 	Iterate(f func(rule *types.PolicyEntry))
 	ReplaceByResource(rules types.PolicyEntries, resource ipcachetypes.ResourceID) (affectedIDs *set.Set[identity.NumericIdentity], rev uint64, oldRevCnt int)
 	Search() (types.PolicyEntries, uint64)
+
+	PolicyCacheObservable() stream.Observable[PolicyCacheChange]
 }
 
 type GetPolicyStatistics interface {
@@ -633,4 +636,8 @@ func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPo
 	defer p.mutex.RUnlock()
 
 	return p.policyCache.GetPolicySnapshot()
+}
+
+func (p *Repository) PolicyCacheObservable() stream.Observable[PolicyCacheChange] {
+	return p.policyCache
 }

--- a/pkg/policy/rules.go
+++ b/pkg/policy/rules.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -204,6 +206,16 @@ func (rules ruleSlice) AsPolicyEntries() types.PolicyEntries {
 		policyRules = append(policyRules, &r.PolicyEntry)
 	}
 	return policyRules
+}
+
+func (rules ruleSlice) AllIdentitySelections() set.Set[identity.NumericIdentity] {
+	ids := set.NewSet[identity.NumericIdentity]()
+	for _, r := range rules {
+		for _, id := range r.getSubjects() {
+			ids.Insert(id)
+		}
+	}
+	return ids
 }
 
 // traceState is an internal structure used to collect information


### PR DESCRIPTION
## Series: Break out policy computation from endpoint package

Currently, each endpoint computes its own SelectorPolicy inline during
regeneration. This couples the endpoint lifecycle to the policy engine,
duplicates work when multiple endpoints share an identity, and makes it
difficult to test the policy computation path in isolation.

This series introduces a dedicated cell that computes SelectorPolicy per
identity and stores results in a statedb table. The endpoint reads from
this table via watch channels. Endpoints unaffected by a policy change
no longer need to regenerate.

**PR 1/3: API prep (no behavior change)**
[PR 2/3: Script commands, fakes, and test infrastructure](https://github.com/cilium/cilium/pull/44899)
[PR 3/3: Policy computation cell + script-based integration test](https://github.com/cilium/cilium/pull/44900)

---

Preparatory refactoring for breaking policy computation out of the endpoint
package. These expand the policy and identitymanager APIs so that an external
cell can compute policies and manage their lifecycle. No behavior changes.

Notable changes:
- PolicyCacheChange events carry the full identity object so downstream
  consumers do not need to call back into the identity manager during the
  synchronous notification path.
- Policy cache emits an observable stream of changes for external consumers.

Review commit-by-commit.