### PR TITLE
policy: Add script commands, fakes, and test infrastructure (2/3)

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -290,7 +290,7 @@ type Endpoint struct {
 
 	// policyMap is the policy related state of the datapath including
 	// reference to all policy related BPF
-	policyMap *policymap.PolicyMap
+	policyMap policymap.PolicyMap
 
 	// PolicyMapPressureUpdater updates the policymap pressure metric.
 	PolicyMapPressureUpdater policyMapPressureUpdater

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2784,3 +2784,64 @@ func (e *Endpoint) GetContainerNetnsPath() string {
 func (e *Endpoint) SetContainerNetnsPath(path string) {
 	e.containerNetnsPath = path
 }
+
+// CopyFromTemplate creates a copy of the calling Endpoint object and returns
+// it. This is used to create Endpoint objects without going through the New*()
+// code path which is useful in tests.
+func (e *Endpoint) CopyFromTemplate() *Endpoint {
+	if e == nil {
+		return nil
+	}
+
+	clone := &Endpoint{
+		DNSHistory:   e.DNSHistory,
+		DNSZombies:   e.DNSZombies,
+		ID:           e.ID,
+		IPv4:         e.IPv4,
+		IPv6:         e.IPv6,
+		K8sNamespace: e.K8sNamespace,
+		K8sPodName:   e.K8sPodName,
+
+		aliveCancel:        e.aliveCancel,
+		aliveCtx:           e.aliveCtx,
+		allocator:          e.allocator,
+		compilationLock:    e.compilationLock,
+		controllers:        e.controllers,
+		createdAt:          e.createdAt,
+		ctMapGC:            e.ctMapGC,
+		dnsRulesAPI:        e.dnsRulesAPI,
+		dockerEndpointID:   e.dockerEndpointID,
+		dockerNetworkID:    e.dockerNetworkID,
+		epBuildQueue:       e.epBuildQueue,
+		forcePolicyCompute: e.forcePolicyCompute,
+		hasBPFProgram:      e.hasBPFProgram,
+		identityManager:    e.identityManager,
+		ifIndex:            e.ifIndex,
+		ifName:             e.ifName,
+		kvstoreSyncher:     e.kvstoreSyncher,
+		loader:             e.loader,
+		lxcMap:             e.lxcMap,
+		monitorAgent:       e.monitorAgent,
+		nodeMAC:            e.nodeMAC,
+		orchestrator:       e.orchestrator,
+		policyMapFactory:   e.policyMapFactory,
+		policyRepo:         e.policyRepo,
+		proxy:              e.proxy,
+		state:              e.state,
+	}
+	clone.containerID.Store(e.containerID.Load())
+	clone.logger.Store(e.logger.Load())
+
+	clone.mutex = lock.RWMutex{}
+	clone.Options = option.NewIntOptions(&EndpointMutableOptionLibrary)
+	clone.labels = labels.NewOpLabels()
+	clone.status = NewEndpointStatus()
+	if e.controllers == nil {
+		clone.controllers = controller.NewManager()
+	}
+	clone.desiredPolicy = policy.NewEndpointPolicy(e.logger.Load(), e.policyRepo)
+	clone.realizedPolicy = clone.desiredPolicy
+	clone.initialEnvoyPolicyComputed = make(chan struct{})
+
+	return clone
+}

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -39,13 +39,24 @@ var Cell = cell.Module(
 	"endpoint-manager",
 	"Manages the collection of local endpoints",
 
+	defaultGroup,
+	cell.Invoke(
+		registerNamespaceUpdater,
+	),
+)
+
+var TestCell = cell.Module(
+	"test-endpoint-manager",
+	"Manages the collection of local endpoints",
+
+	defaultGroup,
+)
+
+var defaultGroup = cell.Group(
 	cell.Config(defaultEndpointManagerConfig),
 	cell.Provide(newDefaultEndpointManager),
 	cell.Provide(endpoint.NewEndpointBuildQueue),
 	cell.ProvidePrivate(newEndpointSynchronizer),
-	cell.Invoke(
-		registerNamespaceUpdater,
-	),
 )
 
 type EndpointsLookup interface {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -149,6 +149,11 @@ type EndpointManager interface {
 	// Returns immediately.
 	TriggerRegenerateAllEndpoints()
 
+	// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
+	// this function is called to be at a given policy revision.
+	// New endpoints appearing while waiting are ignored.
+	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
+
 	// OverrideEndpointOpts applies the given options to all endpoints.
 	OverrideEndpointOpts(om option.OptionMap)
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -830,6 +830,24 @@ func (mgr *endpointManager) initHostEndpointLabels(ctx context.Context, ep *endp
 	mgr.startNodeLabelsObserver(ln.Labels)
 }
 
+// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
+// this function is called to be at a given policy revision.
+// New endpoints appearing while waiting are ignored.
+func (mgr *endpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
+	eps := mgr.GetEndpoints()
+	for i := range eps {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-eps[i].WaitForPolicyRevision(ctx, rev, nil):
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+		}
+	}
+	return nil
+}
+
 // EndpointExists returns whether the endpoint with id exists.
 func (mgr *endpointManager) EndpointExists(id uint16) bool {
 	return mgr.LookupCiliumID(id) != nil

--- a/pkg/endpointmanager/script_cmds.go
+++ b/pkg/endpointmanager/script_cmds.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/script"
+	"github.com/davecgh/go-spew/spew"
+
+	endpointapi "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func ScriptCmds(epm EndpointManager, template *endpoint.Endpoint) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"endpoint/create": script.Command(
+			script.CmdUsage{
+				Summary: "Create Endpoint",
+				Args:    "'id' 'labels'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				allArgs := []string(args)
+				if len(allArgs) != 2 {
+					return nil, fmt.Errorf("expected two args but got %v, see usage details", len(allArgs))
+				}
+
+				num, err := strconv.Atoi(allArgs[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
+
+				var labelArr []labels.Label
+				for s := range strings.SplitSeq(allArgs[1], ",") {
+					labelArr = append(labelArr, labels.ParseLabel(s))
+				}
+
+				id := &identity.Identity{
+					ID:         identity.NumericIdentity(num),
+					Labels:     labels.FromSlice(labelArr),
+					LabelArray: labels.LabelArray(labelArr),
+				}
+
+				// The following order of steps simulate adding an Endpoint the
+				// way that the Agent does.
+				ep := template.CopyFromTemplate()
+				err = epm.AddEndpoint(ep)
+				if err != nil {
+					return nil, err
+				}
+				_ = ep.UpdateLabels(s.Context(), labels.LabelSourceAny, id.Labels, nil, true)
+				// Use RegenerateIfAlive to set the endpoint state to WaitingToRegenerate.
+				_ = ep.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "simulate Orchestrator",
+					RegenerationLevel: regeneration.RegenerateWithDatapath,
+					ParentContext:     s.Context(),
+				})
+				err = ep.WaitForFirstRegeneration(s.Context())
+				if err != nil {
+					return nil, err
+				}
+				<-ep.WaitForPolicyRevision(s.Context(), 1, nil)
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return "", "", err
+				}, nil
+			},
+		),
+		"endpoint/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all Endpoints",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var sb strings.Builder
+					sb.WriteRune('[')
+					for _, ep := range epm.GetEndpointList(endpointapi.GetEndpointParams{}) {
+						sb.WriteRune('{')
+						sb.WriteString(spew.Sdump(
+							"id", ep.ID,
+							"identity", ep.Status.Identity,
+							"status", ep.Status.Policy,
+						))
+						sb.WriteRune('}')
+						sb.WriteRune(',')
+						sb.WriteRune('\n')
+					}
+					sb.WriteString("]\n")
+					return sb.String(), "", nil
+				}, nil
+			},
+		),
+		"endpoint/regen-all": script.Command(
+			script.CmdUsage{
+				Summary: "Regenerate all Endpoints",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				wg := epm.RegenerateAllEndpoints(&regeneration.ExternalRegenerationMetadata{
+					Reason:            "simulate regeneration of all endpoints from script command",
+					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+					ParentContext:     s.Context(),
+				})
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					wg.Wait()
+					return "", "", nil
+				}, nil
+			},
+		),
+		"endpoint/wait-for-policy-revision": script.Command(
+			script.CmdUsage{
+				Summary: "Wait for all Endpoints to have the given policy revision",
+				Args:    "policy-rev",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				allArgs := []string(args)
+				if len(allArgs) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(allArgs))
+				}
+				rev, err := strconv.Atoi(allArgs[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					err = epm.WaitForEndpointsAtPolicyRev(s.Context(), uint64(rev))
+					if err != nil {
+						return "", "", fmt.Errorf("error waiting for all endpoints: %w", err)
+					}
+					return "", "", nil
+				}, nil
+			},
+		),
+	}
+}

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -11,8 +11,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync/atomic"
 
+	"github.com/cilium/hive/script"
 	"github.com/cilium/stream"
 	"github.com/google/renameio/v2"
 	jsoniter "github.com/json-iterator/go"
@@ -1070,5 +1073,83 @@ func clusterNameValidator(clusterName string) allocator.CacheValidator {
 		}
 
 		return nil
+	}
+}
+
+func ScriptCmds(a *CachingIdentityAllocator) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"identity/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all identities in the allocator",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var sb strings.Builder
+					models := a.GetIdentities()
+					sb.WriteRune('[')
+					for _, m := range models {
+						sb.WriteString(strconv.FormatInt(m.ID, 10))
+						sb.WriteRune(' ')
+						sb.WriteRune('{')
+						sb.WriteString(strings.Join([]string(m.Labels), ","))
+						sb.WriteRune('}')
+						sb.WriteRune(' ')
+					}
+					sb.WriteRune(']')
+					sb.WriteRune('\n')
+					return sb.String(), "", nil
+				}, nil
+			},
+		),
+		"identity/allocate": script.Command(
+			script.CmdUsage{
+				Summary: "Allocate identity from the allocator",
+				Args:    "labels",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				var wait script.WaitFunc
+
+				allArgs := []string(args)
+				var labelArr []labels.Label
+				for s := range strings.SplitSeq(allArgs[0], ",") {
+					labelArr = append(labelArr, labels.ParseLabel(s))
+				}
+				id, _, err := a.AllocateIdentity(s.Context(), labels.LabelArray(labelArr).Labels(), true, identity.NumericIdentity(0))
+				if err != nil {
+					return wait, fmt.Errorf("allocate: %w", err)
+				}
+				wait = func(s *script.State) (stdout string, stderr string, err error) {
+					return id.String() + "\n", "", nil
+				}
+				return wait, nil
+			},
+		),
+		"identity/release": script.Command(
+			script.CmdUsage{
+				Summary: "Release identity from the allocator",
+				Args:    "numeric-id",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(args))
+				}
+				num, err := strconv.Atoi(args[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
+				nid := identity.NumericIdentity(num)
+				id := a.LookupIdentityByID(s.Context(), nid)
+				if id == nil {
+					return nil, fmt.Errorf("identity %d not found", nid)
+				}
+				released, err := a.Release(s.Context(), id, true)
+				if err != nil {
+					return nil, fmt.Errorf("release: %w", err)
+				}
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return fmt.Sprintf("released=%v\n", released), "", nil
+				}, nil
+			},
+		),
 	}
 }

--- a/pkg/identity/identitymanager/manager.go
+++ b/pkg/identity/identitymanager/manager.go
@@ -5,6 +5,10 @@ package identitymanager
 
 import (
 	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive/script"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
@@ -229,4 +233,33 @@ type IdentitiesModel []*models.IdentityEndpoints
 // in index `j`
 func (s IdentitiesModel) Less(i, j int) bool {
 	return s[i].Identity.ID < s[j].Identity.ID
+}
+
+func ScriptCmds(idm *IdentityManager) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"idm/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all identities in the identity manager",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				var sb strings.Builder
+				models := idm.GetIdentityModels()
+				sb.WriteRune('[')
+				for _, m := range models {
+					sb.WriteString(strconv.FormatInt(m.Identity.ID, 10))
+					sb.WriteRune(' ')
+					sb.WriteRune('{')
+					sb.WriteString(strings.Join([]string(m.Identity.Labels), ","))
+					sb.WriteRune('}')
+					sb.WriteRune(' ')
+				}
+				sb.WriteRune(']')
+				sb.WriteRune('\n')
+
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return sb.String(), "", nil
+				}, nil
+			},
+		),
+	}
 }

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -57,6 +57,8 @@ var Cell = cell.Module(
 		// 'reserved:kube-apiserver' label.
 		registerAPIServerBackendWatcher,
 	),
+
+	cell.Provide(func(ipc *ipcache.IPCache) ipcache.MetadataBatchAPI { return ipc }),
 )
 
 type ipCacheParams struct {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -495,6 +495,14 @@ func (ipc *IPCache) DumpToListener(listener IPIdentityMappingListener) {
 	ipc.mutex.RUnlock()
 }
 
+type MetadataBatchAPI interface {
+	UpsertMetadataBatch(updates ...MU) (revision uint64)
+	RemoveMetadataBatch(updates ...MU) (revision uint64)
+	WaitForRevision(ctx context.Context, rev uint64) error
+}
+
+var _ MetadataBatchAPI = &IPCache{}
+
 // MU is a batched metadata update, the short name is to cut down on visual clutter.
 type MU struct {
 	Prefix   cmtypes.PrefixCluster

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -52,6 +52,7 @@ type endpointManager interface {
 	GetEndpoints() []*endpoint.Endpoint
 	GetHostEndpoint() *endpoint.Endpoint
 	GetEndpointsByPodName(string) []*endpoint.Endpoint
+	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
 	UpdatePolicyMaps(context.Context) error
 }
 

--- a/pkg/maps/policymap/cell.go
+++ b/pkg/maps/policymap/cell.go
@@ -49,7 +49,7 @@ func (def PolicyConfig) Flags(flags *pflag.FlagSet) {
 }
 
 type Factory interface {
-	OpenEndpoint(id uint16) (*PolicyMap, error)
+	OpenEndpoint(id uint16) (PolicyMap, error)
 	RemoveEndpoint(id uint16) error
 
 	PolicyMaxEntries() int
@@ -77,7 +77,7 @@ func newFactory(logger *slog.Logger, stats *StatsMap, policyMapEntries int) *fac
 // OpenEndpoint opens (or creates) a policy for the specified endpoint, which
 // is used to govern which peer identities can communicate with the endpoint
 // protected by this map.
-func (f *factory) OpenEndpoint(id uint16) (*PolicyMap, error) {
+func (f *factory) OpenEndpoint(id uint16) (PolicyMap, error) {
 	m, err := newPolicyMap(f.logger, id, f.policyMapEntries, f.stats)
 	if err != nil {
 		return nil, err

--- a/pkg/maps/policymap/fake/map.go
+++ b/pkg/maps/policymap/fake/map.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fake
+
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
+	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+type PolicyKey = policymap.PolicyKey
+type PolicyEntry = policymap.PolicyEntry
+type PolicyEntryDump = policymap.PolicyEntryDump
+type PolicyEntriesDump = policymap.PolicyEntriesDump
+type MapStateMap = types.MapStateMap
+
+var _ policymap.PolicyMap = (*fakePolicyMap)(nil)
+
+type fakePolicyMap struct {
+	Entries map[PolicyKey]PolicyEntry
+}
+
+func NewFakePolicyMap() *fakePolicyMap {
+	return &fakePolicyMap{
+		Entries: map[PolicyKey]PolicyEntry{},
+	}
+}
+
+func (pm *fakePolicyMap) Update(key *PolicyKey, entry *PolicyEntry) error {
+	pm.Entries[*key] = *entry
+	return nil
+}
+
+func (pm *fakePolicyMap) DeleteKey(key PolicyKey) error {
+	delete(pm.Entries, key)
+	return nil
+}
+
+func (pm *fakePolicyMap) DeleteEntry(entry *PolicyEntryDump) error {
+	delete(pm.Entries, entry.Key)
+	return nil
+}
+
+func (pm *fakePolicyMap) String() string {
+	return "fakepolicymap"
+}
+
+func (pm *fakePolicyMap) Dump() (string, error) {
+	entries, err := pm.DumpToSlice()
+	if err != nil {
+		return "", err
+	}
+	return entries.String(), nil
+}
+
+func (pm *fakePolicyMap) DumpToSlice() (PolicyEntriesDump, error) {
+	entries := make(PolicyEntriesDump, 0, len(pm.Entries))
+	for key, value := range pm.Entries {
+		entries = append(entries, PolicyEntryDump{
+			Key:         key,
+			PolicyEntry: value,
+		})
+	}
+	return entries, nil
+}
+
+// Keep this up-to-date with DumpToMapStateMap() from
+// pkg/maps/policymap/policymap.go.
+func (pm *fakePolicyMap) DumpToMapStateMap() (MapStateMap, error) {
+	out := make(MapStateMap)
+	for key, val := range pm.Entries {
+		// Convert from policymap.Key to policy.Key
+		policyKey := types.KeyForDirection(trafficdirection.TrafficDirection(key.TrafficDirection)).
+			WithIdentity(identity.NumericIdentity(key.Identity)).
+			WithPortProtoPrefix(u8proto.U8proto(key.Nexthdr), key.GetDestPort(), key.GetPortPrefixLen())
+
+		// Convert from policymap.PolicyEntry to policyTypes.MapStateEntry.
+		policyVal := types.MapStateEntry{
+			Precedence:      val.Precedence,
+			ProxyPort:       val.GetProxyPort(),
+			AuthRequirement: val.AuthRequirement,
+			Cookie:          val.Cookie,
+		}.WithDeny(val.IsDeny())
+		// if policymapEntry has invalid prefix length, force update by storing as an
+		// invalid MapStateEntry
+		if !val.IsValid(&key) {
+			policyVal.Invalidate()
+		}
+		out[policyKey] = policyVal
+	}
+	return out, nil
+}
+
+func (pm *fakePolicyMap) MaxEntries() uint32 { return 1024 }
+func (pm *fakePolicyMap) Close() error       { return nil }

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -29,7 +29,7 @@ func createStatsMapForTest(maxStatsEntries int) (*StatsMap, error) {
 	return m, m.OpenOrCreate()
 }
 
-func setupPolicyMapPrivilegedTestSuite(tb testing.TB) *PolicyMap {
+func setupPolicyMapPrivilegedTestSuite(tb testing.TB) PolicyMap {
 	testutils.PrivilegedTest(tb)
 
 	logger := hivetest.Logger(tb)
@@ -92,7 +92,7 @@ func TestPrivilegedPolicyMapDumpToSlice(t *testing.T) {
 func TestPrivilegedDeleteNonexistentKey(t *testing.T) {
 	testMap := setupPolicyMapPrivilegedTestSuite(t)
 	key := newKey(trafficdirection.Ingress, 27, u8proto.TCP, 80, SinglePortPrefixLen)
-	err := testMap.Map.Delete(&key)
+	err := testMap.DeleteKey(key)
 	require.Error(t, err)
 	var errno unix.Errno
 	require.ErrorAs(t, err, &errno)

--- a/pkg/maps/policymap/statsmap_privileged_test.go
+++ b/pkg/maps/policymap/statsmap_privileged_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestPrivilegedStatMap(t *testing.T) {
-	policyMap := setupPolicyMapPrivilegedTestSuite(t)
-	require.NotNil(t, policyMap)
+	pm := setupPolicyMapPrivilegedTestSuite(t)
+	require.NotNil(t, pm)
 
-	testMap := policyMap.stats
+	testMap := (pm.(*policyMap)).stats
 	require.NotNil(t, testMap)
 
 	fooKey := newKey(1, 1, 1, 1, SinglePortPrefixLen)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1240,7 +1240,7 @@ func (resMap *L4PolicyMap) addL4Filter(policyCtx PolicyContext, filterToMerge *L
 func makeL4PolicyMap() L4PolicyMap {
 	return L4PolicyMap{
 		NamedPortMap: make(map[string]*L4Filter),
-		RangePortMap: make(map[portProtoKey]*L4Filter),
+		RangePortMap: make(rangePortMap),
 	}
 }
 
@@ -1306,7 +1306,43 @@ type L4PolicyMap struct {
 	NamedPortMap map[string]*L4Filter
 	// RangePortMap is a map of all L4Filters indexed by their port-
 	// protocol.
-	RangePortMap map[portProtoKey]*L4Filter
+	RangePortMap rangePortMap
+}
+
+type rangePortMap map[portProtoKey]*L4Filter
+
+func (r rangePortMap) MarshalJSON() ([]byte, error) {
+	if len(r) == 0 {
+		return []byte{'{', '}'}, nil
+	}
+
+	first := true
+	buffer := bytes.NewBufferString("{")
+	for ppk, filter := range r {
+		if !first {
+			buffer.WriteRune(',')
+		}
+		first = false
+
+		buffer.WriteRune('"')
+		buffer.WriteString(strconv.FormatUint(uint64(ppk.Port), 10))
+		buffer.WriteRune('-')
+		buffer.WriteString(strconv.FormatUint(uint64(ppk.EndPort), 10))
+		buffer.WriteRune('/')
+		buffer.WriteString(strconv.FormatUint(uint64(ppk.Proto), 10))
+		buffer.WriteRune('"')
+
+		buffer.WriteRune(':')
+
+		b, err := json.Marshal(filter)
+		if err != nil {
+			return nil, err
+		}
+		buffer.Write(b)
+	}
+	buffer.WriteRune('}')
+
+	return buffer.Bytes(), nil
 }
 
 // upsert L4Filter adds an L4Filter indexed by protocol/port-endPort.

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -4,7 +4,6 @@
 package policy
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/policy/utils"
+	testcertificatemanager "github.com/cilium/cilium/pkg/testutils/certificatemanager"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
 
@@ -78,7 +78,7 @@ func newTestData(tb testing.TB, logger *slog.Logger) *testData {
 		identityManager:   idMgr,
 		sc:                testNewSelectorCache(tb, logger, nil),
 		subjectSc:         testNewSelectorCache(tb, logger, nil),
-		repo:              NewPolicyRepository(logger, nil, &fakeCertificateManager{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
+		repo:              NewPolicyRepository(logger, nil, &testcertificatemanager.Fake{}, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), idMgr, testpolicy.NewPolicyMetricsNoop()),
 		idSet:             set.NewSet[identity.NumericIdentity](),
 		testPolicyContext: &testPolicyContextType{logger: logger},
 	}
@@ -2729,22 +2729,4 @@ func TestDefaultAllowL7Rules(t *testing.T) {
 			require.True(t, anyPerSelectorPolicy, "Should have at least one PerSelectorPolicy")
 		})
 	}
-}
-
-type fakeCertificateManager struct{}
-
-const (
-	fakeCA         = "fake ca"
-	fakePublicKey  = "fake public key"
-	fakePrivateKey = "fake private key"
-)
-
-func (_ *fakeCertificateManager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, inlineSecrets bool, err error) {
-	name := tlsCtx.Secret.Name
-	public = fakePublicKey + " " + name
-	private = fakePrivateKey + " " + name
-	ca = fakeCA + " " + name
-
-	inlineSecrets = true
-	return
 }

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -5,12 +5,18 @@ package policy
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"maps"
+	"os"
+	"strconv"
 	"sync/atomic"
 
+	"github.com/cilium/hive/script"
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/cilium/stream"
+	"github.com/davecgh/go-spew/spew"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -21,6 +27,8 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -640,4 +648,92 @@ func (p *Repository) GetPolicySnapshot() map[identity.NumericIdentity]SelectorPo
 
 func (p *Repository) PolicyCacheObservable() stream.Observable[PolicyCacheChange] {
 	return p.policyCache
+}
+
+func RepositoryScriptCmds(p *Repository) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"policyrepo/list": script.Command(
+			script.CmdUsage{
+				Summary: "List all policies in the policy repository",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					policies := p.GetRulesList()
+					return string(policies.Policy), "", nil
+				}, nil
+			},
+		),
+		"policyrepo/selectorcache": script.Command(
+			script.CmdUsage{
+				Summary: "Dump the selector cache model",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					model := p.GetSelectorCache().GetModel()
+					return spew.Sprint(model), "", nil
+				}, nil
+			},
+		),
+		"policyrepo/add": script.Command(
+			script.CmdUsage{
+				Summary: "Add a policy to the policy repository",
+				Args:    "'policy'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(args))
+				}
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					file := args[0]
+
+					b, err := os.ReadFile(s.Path(file))
+					if err != nil {
+						b, err = os.ReadFile(file)
+					}
+					if err != nil {
+						return "", "", fmt.Errorf("failed to read %s: %w", file, err)
+					}
+					obj, _, err := testutils.DecodeObjectGVK(b)
+					if err != nil {
+						return "", "", fmt.Errorf("decode: %w", err)
+					}
+					robj, _ := testutils.DecodeObject(b)
+					objMeta, err := meta.Accessor(obj)
+					if err != nil {
+						return "", "", fmt.Errorf("accessor: %w", err)
+					}
+
+					var (
+						rules api.Rules
+						rev   uint64
+					)
+					if objMeta.GetNamespace() == "" {
+						ccnp := robj.(*v2.CiliumClusterwideNetworkPolicy)
+						rules, err = ccnp.Parse(p.logger, "")
+						if err != nil {
+							return "", "", fmt.Errorf("ccnp parse: %w", err)
+						}
+					} else {
+						cnp := robj.(*v2.CiliumNetworkPolicy)
+						rules, err = cnp.Parse(p.logger, "")
+						if err != nil {
+							return "", "", fmt.Errorf("cnp parse: %w", err)
+						}
+					}
+					_, rev = p.MustAddList(rules)
+					return fmt.Sprintf("Added rules, revision=%d\n", rev), "", nil
+				}, nil
+			},
+		),
+		"policyrepo/bump-revision": script.Command(
+			script.CmdUsage{
+				Summary: "Bump revision of the policy repository",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					return "Bumped revision to " + strconv.FormatUint(p.BumpRevision(), 10) + "\n", "", nil
+				}, nil
+			},
+		),
+	}
 }

--- a/pkg/testutils/certificatemanager/certmanager.go
+++ b/pkg/testutils/certificatemanager/certmanager.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testcertificatemanager
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+const (
+	fakeCA         = "fake ca"
+	fakePublicKey  = "fake public key"
+	fakePrivateKey = "fake private key"
+)
+
+func (_ *Fake) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, inlineSecrets bool, err error) {
+	name := tlsCtx.Secret.Name
+	public = fakePublicKey + " " + name
+	private = fakePrivateKey + " " + name
+	ca = fakeCA + " " + name
+
+	inlineSecrets = true
+	return
+}
+
+type Fake struct{}

--- a/pkg/testutils/monitor/agent.go
+++ b/pkg/testutils/monitor/agent.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testmonitor
+
+import (
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/monitor/agent/consumer"
+	"github.com/cilium/cilium/pkg/monitor/agent/listener"
+)
+
+type TestMonitorAgent struct{}
+
+func (*TestMonitorAgent) AttachToEventsMap(nPages int) error                       { return nil }
+func (*TestMonitorAgent) SendEvent(typ int, event any) error                       { return nil }
+func (*TestMonitorAgent) RegisterNewListener(newListener listener.MonitorListener) {}
+func (*TestMonitorAgent) RemoveListener(ml listener.MonitorListener)               {}
+func (*TestMonitorAgent) RegisterNewConsumer(newConsumer consumer.MonitorConsumer) {}
+func (*TestMonitorAgent) RemoveConsumer(mc consumer.MonitorConsumer)               {}
+func (*TestMonitorAgent) State() *models.MonitorStatus                             { return nil }

--- a/pkg/ztunnel/xds/xds_server_test.go
+++ b/pkg/ztunnel/xds/xds_server_test.go
@@ -168,6 +168,10 @@ func (m *MockEndpointManager) TriggerRegenerateAllEndpoints() {
 	panic("MockEndpointManager.TriggerRegenerateAllEndpoints not implemented")
 }
 
+func (m *MockEndpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
+	panic("MockEndpointManager.WaitForEndpointsAtPolicyRev not implemented")
+}
+
 func (m *MockEndpointManager) OverrideEndpointOpts(om option.OptionMap) {
 	panic("MockEndpointManager.OverrideEndpointOpts not implemented")
 }


### PR DESCRIPTION
## Series: Break out policy computation from endpoint package

Currently, each endpoint computes its own SelectorPolicy inline during
regeneration. This couples the endpoint lifecycle to the policy engine,
duplicates work when multiple endpoints share an identity, and makes it
difficult to test the policy computation path in isolation.

This series introduces a dedicated cell that computes SelectorPolicy per
identity and stores results in a statedb table. The endpoint reads from
this table via watch channels. Endpoints unaffected by a policy change
no longer need to regenerate.

[PR 1/3: API prep (no behavior change)](https://github.com/cilium/cilium/pull/44898)
**PR 2/3: Script commands, fakes, and test infrastructure**
[PR 3/3: Policy computation cell + script-based integration test](https://github.com/cilium/cilium/pull/44900)

Depends on:
* https://github.com/cilium/cilium/pull/44898

---

Add hive script commands for existing policy, identity, and endpoint subsystems
along with test fakes needed to compose a script-based integration test. The
script commands mirror each component's API (e.g. `endpoint/create`,
`identity/allocate`). The fakes (policymap, certificatemanager) are minimal
stubs. The endpoint manager gets a `TestCell` that skips periodic GC and
regeneration so tests don't race with background work.

Review commit-by-commit.