### PR TITLE
policy/compute: Break out policy computation from endpoint (3/3)

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -85,6 +85,7 @@ import (
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
 	"github.com/cilium/cilium/pkg/pprof"
@@ -309,6 +310,9 @@ var (
 
 		// Provides PolicyRepository (List of policy rules)
 		policy.Cell,
+
+		// Provides PolicyRecomputer (policy computation).
+		compute.Cell,
 
 		// K8s policy resource watcher cell. It depends on the half-initialized daemon which is
 		// resolved by newDaemonPromise()

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -323,11 +323,12 @@ func unloadDNSPolicies(params daemonParams) {
 			"Triggering policy recalculation to remove DNS rules due to option",
 			logfields.Option, option.DNSPolicyUnloadOnShutdown,
 		)
-		params.Policy.BumpRevision()
 		regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 			Reason:            regeneration.ReasonDaemonConfigUpdate,
 			Message:           "unloading DNS rules on graceful shutdown",
 			RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+
+			PolicyRevisionToWaitFor: params.Policy.BumpRevision(),
 		}
 		wg := params.EndpointManager.RegenerateAllEndpoints(regenerationMetadata)
 		wg.Wait()

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/trigger"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -126,6 +127,7 @@ type configModifyEventHandlerParams struct {
 
 	Orchestrator    endpoint.Orchestrator
 	Policy          policy.PolicyRepository
+	PolicyComputer  compute.PolicyRecomputer
 	EndpointManager endpointmanager.EndpointManager
 	L7Proxy         *proxy.Proxy
 }
@@ -138,6 +140,7 @@ func newConfigModifyEventHandler(params configModifyEventHandlerParams) *ConfigM
 		logger:          params.Logger,
 		orchestrator:    params.Orchestrator,
 		policy:          params.Policy,
+		computer:        params.PolicyComputer,
 		endpointManager: params.EndpointManager,
 		l7Proxy:         params.L7Proxy,
 	}
@@ -181,6 +184,7 @@ type ConfigModifyEventHandler struct {
 
 	orchestrator    endpoint.Orchestrator
 	policy          policy.PolicyRepository
+	computer        compute.PolicyRecomputer
 	endpointManager endpointmanager.EndpointManager
 	l7Proxy         *proxy.Proxy
 }
@@ -188,11 +192,18 @@ type ConfigModifyEventHandler struct {
 func (h *ConfigModifyEventHandler) datapathRegen(reasons []string) {
 	reason := strings.Join(reasons, ", ")
 
+	// We expect the policy revision to have been bumped prior to this call
+	// here. All endpoints are about to be regenerated so recompute policy
+	// for all endpoints and then trigger regeneration.
+
 	regenerationMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            regeneration.ReasonDaemonConfigUpdate,
 		Message:           reason,
 		RegenerationLevel: regeneration.RegenerateWithDatapath,
+
+		PolicyRevisionToWaitFor: h.policy.GetRevision(),
 	}
+	h.computer.RecomputeIdentityPolicyForAllIdentities(regenerationMetadata.PolicyRevisionToWaitFor)
 	h.endpointManager.RegenerateAllEndpoints(regenerationMetadata)
 }
 

--- a/daemon/restapi/policy.go
+++ b/daemon/restapi/policy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
 )
 
 var policyAPICell = cell.Module(
@@ -28,8 +29,9 @@ type policyAPIHandlerParams struct {
 
 	Log *slog.Logger
 
-	Repo     policy.PolicyRepository
-	Importer policycell.PolicyImporter
+	Repo           policy.PolicyRepository
+	PolicyComputer compute.PolicyRecomputer
+	Importer       policycell.PolicyImporter
 }
 
 type policyAPIHandlers struct {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -463,8 +463,8 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 	desiredMdl := &models.EndpointPolicy{
 		ID: int64(e.SecurityIdentity.ID),
 		// This field should be removed.
-		Build:                    int64(e.nextPolicyRevision),
-		PolicyRevision:           int64(e.nextPolicyRevision),
+		Build:                    int64(e.desiredPolicyRevision),
+		PolicyRevision:           int64(e.desiredPolicyRevision),
 		AllowedIngressIdentities: desiredIngressIdentities,
 		AllowedEgressIdentities:  desiredEgressIdentities,
 		DeniedIngressIdentities:  desiredDenyIngressIdentities,

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -438,7 +438,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	// support local Pods on the worker node, hence endpoint BPF regeneration
 	// is skipped everywhere.
 	if e.isProperty(endpointtypes.PropertyFakeEndpoint) {
-		return e.nextPolicyRevision, nil
+		return e.desiredPolicyRevision, nil
 	}
 
 	// Skip BPF if the endpoint has no policy map
@@ -466,7 +466,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 			return 0, newRegenerationErrorf(regenerationFailureReasonProxyPolicyError, "error waiting for proxy network policy update: %w", err)
 		}
 
-		return e.nextPolicyRevision, nil
+		return e.desiredPolicyRevision, nil
 	}
 
 	// Wait for connection tracking cleaning to complete

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -9,35 +9,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	linuxConfig "github.com/cilium/cilium/pkg/datapath/linux/config"
-	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
-	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/testutils"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
 )
 
 func TestWriteInformationalComments(t *testing.T) {
-	logger := hivetest.Logger(t)
 	s := setupEndpointSuite(t)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := EndpointParams{
-		Logger:          logger,
-		EPBuildQueue:    &MockEndpointBuildQueue{},
-		Orchestrator:    s.orchestrator,
-		PolicyRepo:      s.repo,
-		IdentityManager: identitymanager.NewIDManager(logger),
-		IPSecConfig:     fakeipsec.Config{},
-		WgConfig:        fakewireguard.Config{},
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -51,24 +34,13 @@ func TestWriteInformationalComments(t *testing.T) {
 type writeFunc func(io.Writer) error
 
 func BenchmarkWriteHeaderfile(b *testing.B) {
-	logger := hivetest.Logger(b)
 	testutils.IntegrationTest(b)
 
 	s := setupEndpointSuite(b)
 
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := EndpointParams{
-		Logger:          logger,
-		EPBuildQueue:    &MockEndpointBuildQueue{},
-		Orchestrator:    s.orchestrator,
-		PolicyRepo:      s.repo,
-		IdentityManager: identitymanager.NewIDManager(logger),
-		IPSecConfig:     fakeipsec.Config{},
-		WgConfig:        fakewireguard.Config{},
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(b, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -61,7 +61,7 @@ type epInfoCache struct {
 func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 	if e.isProperty(endpoint.PropertyAtHostNS) {
 		return &epInfoCache{
-			revision: e.nextPolicyRevision,
+			revision: e.desiredPolicyRevision,
 
 			id:         e.GetID(),
 			identity:   e.getIdentity(),
@@ -76,7 +76,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		}
 	}
 	return &epInfoCache{
-		revision: e.nextPolicyRevision,
+		revision: e.desiredPolicyRevision,
 
 		epdir:                  epdir,
 		id:                     e.GetID(),

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -436,9 +436,8 @@ type Endpoint struct {
 	// properties is used to store some internal properties about this Endpoint.
 	properties map[string]any
 
-	// Root scope for all of this endpoints reporters.
-	reporterScope       cell.Health
-	closeHealthReporter func()
+	// reporterScope is the health scope used by GetReporter.
+	reporterScope atomic.Pointer[cell.Health]
 
 	// NetNsCookie is the network namespace cookie of the Endpoint.
 	NetNsCookie uint64
@@ -460,11 +459,11 @@ func (e *Endpoint) GetPolicyNames() []string {
 }
 
 func (e *Endpoint) GetReporter(name string) cell.Health {
-	if e.reporterScope == nil {
-		_, h := cell.NewSimpleHealth()
-		return h.NewScope(name)
+	if s := e.reporterScope.Load(); s != nil {
+		return (*s).NewScope(name)
 	}
-	return e.reporterScope.NewScope(name)
+	_, h := cell.NewSimpleHealth()
+	return h.NewScope(name)
 }
 
 func (e *Endpoint) InitEndpointHealth(parent cell.Health) {
@@ -473,8 +472,7 @@ func (e *Endpoint) InitEndpointHealth(parent cell.Health) {
 	}
 	s := parent.NewScope(fmt.Sprintf("cilium-endpoint-%d (%s)", e.ID, e.GetK8sNamespaceAndPodName()))
 	if s != nil {
-		e.closeHealthReporter = s.Close
-		e.reporterScope = s
+		e.reporterScope.Store(&s)
 	}
 }
 
@@ -482,9 +480,8 @@ func (e *Endpoint) Close() {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
-	if e.closeHealthReporter != nil {
-		e.closeHealthReporter()
-		e.reporterScope = nil
+	if s := e.reporterScope.Swap(nil); s != nil {
+		(*s).Close()
 	}
 
 	if e.PolicyMapPressureUpdater != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -344,10 +344,12 @@ type Endpoint struct {
 	// You must hold Endpoint.proxyStatisticsMutex to read or write it.
 	proxyStatistics map[string]*models.ProxyStatistics
 
-	// nextPolicyRevision is the policy revision that the endpoint has
-	// updated to and that will become effective with the next regenerate.
-	// Must hold the endpoint mutex *and* buildMutex to write, and either to read.
-	nextPolicyRevision uint64
+	// desiredPolicyRevision is the revision of the policy in e.desiredPolicy.
+	// It can be less than policyRevision when UpdatePolicy bumps policyRevision
+	// without recomputing desired policy.
+	//
+	// To write, both ep.mutex and ep.buildMutex must be held.
+	desiredPolicyRevision uint64
 
 	// forcePolicyCompute full endpoint policy recomputation
 	// Set when endpoint options have been changed. Cleared right before releasing the

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -60,6 +60,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -138,7 +139,8 @@ type Endpoint struct {
 
 	epBuildQueue EndpointBuildQueue
 
-	policyRepo policy.PolicyRepository
+	policyRepo    policy.PolicyRepository
+	policyFetcher compute.PolicyRecomputer
 
 	// kvstoreSyncher updates the kvstore (e.g., etcd) with up-to-date
 	// information about endpoints. Initialized by manager.expose.
@@ -412,6 +414,12 @@ type Endpoint struct {
 	// skipped regeneration levels.
 	skippedRegenerationLevel regeneration.DatapathRegenerationLevel
 
+	// skippedPolicyRevision is the highest PolicyRevisionToWaitFor from a regeneration
+	// event that was skipped because the endpoint was already in StateWaitingToRegenerate.
+	// The queued regeneration is bumped to wait for this revision so it doesn't complete
+	// at an older one.
+	skippedPolicyRevision uint64
+
 	// DatapathConfiguration is the endpoint's datapath configuration as
 	// passed in via the plugin that created the endpoint, e.g. the CNI
 	// plugin which performed the plumbing will enable certain datapath
@@ -603,9 +611,10 @@ func createEndpoint(
 		wgConfig:           p.WgConfig,
 		ipsecConfig:        p.IPSecConfig,
 		lxcMap:             p.LxcMap,
+		localNodeStore:     p.LocalNodeStore,
 		policyMapFactory:   p.PolicyMapFactory,
 		policyRepo:         p.PolicyRepo,
-		localNodeStore:     p.LocalNodeStore,
+		policyFetcher:      p.PolicyFetcher,
 		ID:                 ID,
 		createdAt:          time.Now(),
 		proxy:              proxy,
@@ -704,7 +713,6 @@ func CreateIngressEndpoint(p EndpointParams,
 func CreateHostEndpoint(p EndpointParams,
 	dnsRulesAPI DNSRulesAPI, proxy EndpointProxy,
 	policyDebugLog io.Writer) (*Endpoint, error) {
-
 	iface, err := safenetlink.LinkByName(defaults.HostDevice)
 	if err != nil {
 		return nil, err
@@ -933,13 +941,14 @@ func ParseEndpoint(p EndpointParams,
 		wgConfig:         p.WgConfig,
 		ipsecConfig:      p.IPSecConfig,
 		lxcMap:           p.LxcMap,
+		localNodeStore:   p.LocalNodeStore,
 		policyMapFactory: p.PolicyMapFactory,
 		policyRepo:       p.PolicyRepo,
+		policyFetcher:    p.PolicyFetcher,
 		proxy:            proxy,
 		allocator:        p.Allocator,
 		ctMapGC:          p.CTMapGC,
 		kvstoreSyncher:   p.KVStoreSynchronizer,
-		localNodeStore:   p.LocalNodeStore,
 	}
 
 	if err := ep.UnmarshalJSON(epJSON); err != nil {
@@ -2429,6 +2438,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 		}
 	}
 
+	// Unconditionally force policy recomputation after a new identity has been
+	// assigned.
+	e.forcePolicyComputation()
+
 	readyToRegenerate := false
 	regenMetadata := &regeneration.ExternalRegenerationMetadata{
 		Reason:            regeneration.ReasonLabelsUpdate,
@@ -2447,10 +2460,6 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 	if e.ID != 0 {
 		readyToRegenerate = e.setRegenerateStateLocked(regenMetadata)
 	}
-
-	// Unconditionally force policy recomputation after a new identity has been
-	// assigned.
-	e.forcePolicyComputation()
 
 	// Trigger the sync-to-k8s-ciliumendpoint controller to sync the new
 	// endpoint's identity.
@@ -2921,6 +2930,7 @@ func (e *Endpoint) CopyFromTemplate() *Endpoint {
 		monitorAgent:       e.monitorAgent,
 		nodeMAC:            e.nodeMAC,
 		orchestrator:       e.orchestrator,
+		policyFetcher:      e.policyFetcher,
 		policyMapFactory:   e.policyMapFactory,
 		policyRepo:         e.policyRepo,
 		proxy:              e.proxy,

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -34,7 +34,7 @@ func TestGetCiliumEndpointStatus(t *testing.T) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, m, nil)
 	require.NoError(t, err)
 
 	status := e.GetCiliumEndpointStatus()
@@ -78,7 +78,7 @@ func TestGetCiliumEndpointStatusWithServiceAccount(t *testing.T) {
 		},
 		State: models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 	}
-	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, m, nil)
 	require.NoError(t, err)
 
 	// Create a mock pod with ServiceAccount

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -1027,6 +1027,16 @@ func (sp *testSelectorPolicy) GetEgressNamedPorts(name string, proto u8proto.U8p
 	}
 }
 
+func (sp *testSelectorPolicy) AddHold() bool { return true }
+
+func (sp *testSelectorPolicy) ReleaseHold() {}
+
+func (sp *testSelectorPolicy) Detach() {}
+
+func (sp *testSelectorPolicy) Supersede() {}
+
+func (sp *testSelectorPolicy) GetRevision() uint64 { return 0 }
+
 func TestProxyID(t *testing.T) {
 	setupEndpointSuite(t)
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -47,8 +47,10 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	proxyendpoint "github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/testutils"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
@@ -59,6 +61,7 @@ import (
 type EndpointSuite struct {
 	orchestrator endpoint.Orchestrator
 	repo         policy.PolicyRepository
+	fetcher      compute.PolicyRecomputer
 	mgr          *cache.CachingIdentityAllocator
 }
 
@@ -66,11 +69,14 @@ func setupEndpointSuite(tb testing.TB) *EndpointSuite {
 	testutils.IntegrationTest(tb)
 	logger := hivetest.Logger(tb)
 
+	idmgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
 	s := &EndpointSuite{
 		orchestrator: &fakeendpoint.FakeOrchestrator{},
-		repo:         policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop()),
+		repo:         repo,
 		mgr:          cache.NewCachingIdentityAllocator(logger, &testidentity.IdentityAllocatorOwnerMock{}, cache.NewTestAllocatorConfig()),
 	}
+	s.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupEndpointSuite", repo, idmgr)
 
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, "")
@@ -195,13 +201,14 @@ func TestEndpointStatus(t *testing.T) {
 	require.Equal(t, "OK", eps.String())
 }
 
-func createEndpointParams(tb testing.TB, o endpoint.Orchestrator, r policy.PolicyRepository) EndpointParams {
+func createEndpointParams(tb testing.TB, o endpoint.Orchestrator, r policy.PolicyRepository, fetcher compute.PolicyRecomputer) EndpointParams {
 	logger := hivetest.Logger(tb)
 	return EndpointParams{
 		Logger:           logger,
 		EPBuildQueue:     &MockEndpointBuildQueue{},
 		Orchestrator:     o,
 		PolicyRepo:       r,
+		PolicyFetcher:    fetcher,
 		IdentityManager:  identitymanager.NewIDManager(logger),
 		BandwidthManager: &fakebandwidth.Manager{},
 		IPSecConfig:      fakeipsec.Config{},
@@ -218,18 +225,19 @@ func createEndpointParams(tb testing.TB, o endpoint.Orchestrator, r policy.Polic
 
 func createTestEndpointParams(tb testing.TB) EndpointParams {
 	s := setupEndpointSuite(tb)
-	return createEndpointParams(tb, s.orchestrator, s.repo)
+	return createEndpointParams(tb, s.orchestrator, s.repo, s.fetcher)
 }
 
 func TestEndpointDatapathOptions(t *testing.T) {
-	m := &models.EndpointChangeRequest{
+	s := setupEndpointSuite(t)
+
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	p.Allocator = s.mgr
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, &models.EndpointChangeRequest{
 		DatapathConfiguration: &models.EndpointDatapathConfiguration{
 			DisableSipVerification: true,
 		},
-	}
-
-	p := createTestEndpointParams(t)
-	e, err := NewEndpointFromChangeModel(p, nil, nil, m, nil)
+	}, nil)
 	require.NoError(t, err)
 	require.Equal(t, option.OptionDisabled, e.Options.GetValue(option.SourceIPVerification))
 }
@@ -486,10 +494,11 @@ func TestApplySourceIPVerificationResetsToGlobalDefault(t *testing.T) {
 }
 
 func TestEndpointUpdateLabels(t *testing.T) {
-	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := createTestEndpointParams(t)
+	s := setupEndpointSuite(t)
 
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	model := newTestEndpointModel(100, StateWaitingForIdentity)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	e.Start(uint16(model.ID))
@@ -534,10 +543,15 @@ func TestEndpointUpdateLabels(t *testing.T) {
 func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 	newEndpoint := func(t *testing.T, securityIdentity *identity.Identity, current labels.Labels) *Endpoint {
 		model := newTestEndpointModel(100, StateWaitingForIdentity)
+		logger := hivetest.Logger(t)
+		idmgr := identitymanager.NewIDManager(logger)
+		repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+		fetcher := testcompute.InstantiateCellForTesting(t, logger, "endpoint", "TestInitialNamedPortsIdentityLabel", repo, idmgr)
 		p := createEndpointParams(
 			t,
 			&fakeendpoint.FakeOrchestrator{},
-			policy.NewPolicyRepository(hivetest.Logger(t), nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop()),
+			repo,
+			fetcher,
 		)
 
 		e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
@@ -714,9 +728,11 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 }
 
 func TestEndpointState(t *testing.T) {
+	s := setupEndpointSuite(t)
+
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := createTestEndpointParams(t)
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 	e.Start(uint16(model.ID))
 	t.Cleanup(e.Stop)
@@ -1196,6 +1212,8 @@ func (n *EndpointDeadlockEvent) Handle(ifc chan any) {
 // This unit test is a bit weird - see
 // https://github.com/cilium/cilium/pull/8687 .
 func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
+	s := setupEndpointSuite(t)
+
 	// Need to modify global configuration (hooray!), change back when test is
 	// done.
 	oldQueueSize := option.Config.EndpointQueueSize
@@ -1205,8 +1223,8 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 	}()
 
 	model := newTestEndpointModel(12345, StateReady)
-	p := createTestEndpointParams(t)
-	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
+	ep, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -1284,9 +1302,11 @@ func TestEndpointEventQueueDeadlockUponStop(t *testing.T) {
 }
 
 func BenchmarkEndpointGetModel(b *testing.B) {
+	s := setupEndpointSuite(b)
+
 	model := newTestEndpointModel(100, StateWaitingForIdentity)
-	p := createTestEndpointParams(b)
-	e, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+	p := createEndpointParams(b, s.orchestrator, s.repo, s.fetcher)
+	e, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 	require.NoError(b, err)
 
 	e.Start(uint16(model.ID))
@@ -1327,7 +1347,7 @@ func (e *Endpoint) getK8sPodLabels() labels.Labels {
 }
 
 func TestMetadataResolver(t *testing.T) {
-	p := createTestEndpointParams(t)
+	s := setupEndpointSuite(t)
 	logger := hivetest.Logger(t)
 
 	tests := []struct {
@@ -1365,8 +1385,9 @@ func TestMetadataResolver(t *testing.T) {
 			t.Run(fmt.Sprintf("%s (restored=%t)", tt.name, restored), func(t *testing.T) {
 				model := newTestEndpointModel(100, StateWaitingForIdentity)
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+				p := createEndpointParams(t, s.orchestrator, s.repo, s.fetcher)
 				p.KVStoreSynchronizer = kvstoreSync
-				ep, err := NewEndpointFromChangeModel(p, nil, nil, model, nil)
+				ep, err := NewEndpointFromChangeModel(p, nil, &FakeEndpointProxy{}, model, nil)
 				require.NoError(t, err)
 
 				ep.K8sNamespace, ep.K8sPodName, ep.K8sUID = "bar", "foo", "uid"
@@ -1404,8 +1425,6 @@ func (p *recordingRemoveNetworkPolicyProxy) RemoveNetworkPolicy(ep proxyendpoint
 	p.calls++
 	p.lastEndpointID = ep.GetID()
 }
-
-//TODODODODO
 
 func (g fakeNodeGetter) Get(ctx context.Context) (node.LocalNode, error) {
 	return node.LocalNode{}, nil

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -161,7 +161,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]any) {
 			e.policyLoggerAttrs.Store(logfields.EndpointID, e.ID)
 			e.policyLoggerAttrs.Store(logfields.ContainerID, e.GetShortContainerID())
 			e.policyLoggerAttrs.Store(logfields.DatapathPolicyRevision, e.policyRevision)
-			e.policyLoggerAttrs.Store(logfields.DesiredPolicyRevision, e.nextPolicyRevision)
+			e.policyLoggerAttrs.Store(logfields.DesiredPolicyRevision, e.desiredPolicyRevision)
 			e.policyLoggerAttrs.Store(logfields.IPv4, e.GetIPv4Address())
 			e.policyLoggerAttrs.Store(logfields.IPv6, e.GetIPv6Address())
 			e.policyLoggerAttrs.Store(logfields.K8sPodName, e.GetK8sNamespaceAndPodName())

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -30,8 +30,7 @@ func TestPolicyLog(t *testing.T) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
-	p := createTestEndpointParams(t)
-	p.PolicyRepo = do.repo
+	p := createEndpointParams(t, nil, do.repo, do.fetcher)
 	ep, err := NewEndpointFromChangeModel(p, nil, nil, model, f)
 	require.NoError(t, err)
 

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -54,7 +54,7 @@ type regenerationStatistics struct {
 	waitingForPolicyRepository spanstat.SpanStat
 	waitingForCTClean          spanstat.SpanStat
 	policyCalculation          spanstat.SpanStat
-	selectorPolicyCalculation  spanstat.SpanStat
+	waitForPolicyCompute       spanstat.SpanStat
 	endpointPolicyCalculation  spanstat.SpanStat
 	proxyConfiguration         spanstat.SpanStat
 	proxyPolicyCalculation     spanstat.SpanStat
@@ -98,7 +98,7 @@ func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 		"waitingForCTClean":          &s.waitingForCTClean,
 		"policyCalculation":          &s.policyCalculation,
 		"proxyConfiguration":         &s.proxyConfiguration,
-		"selectorPolicyCalculation":  &s.selectorPolicyCalculation,
+		"waitForPolicyCompute":       &s.waitForPolicyCompute,
 		"endpointPolicyCalculation":  &s.endpointPolicyCalculation,
 		"proxyPolicyCalculation":     &s.proxyPolicyCalculation,
 		"proxyWaitForAck":            &s.proxyWaitForAck,
@@ -114,11 +114,6 @@ func (s *regenerationStatistics) GetMap() map[string]*spanstat.SpanStat {
 // used by PolicyRepository.GetSelectorPolicy
 func (s *regenerationStatistics) WaitingForPolicyRepository() *spanstat.SpanStat {
 	return &s.waitingForPolicyRepository
-}
-
-// used by PolicyRepository.GetSelectorPolicy
-func (s *regenerationStatistics) SelectorPolicyCalculation() *spanstat.SpanStat {
-	return &s.selectorPolicyCalculation
 }
 
 // endpointPolicyStatusMap is a map to store the endpoint id and the policy

--- a/pkg/endpoint/params.go
+++ b/pkg/endpoint/params.go
@@ -20,6 +20,7 @@ import (
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 
 	"github.com/cilium/hive/cell"
@@ -41,6 +42,7 @@ type EndpointParams struct {
 	MonitorAgent        monitoragent.Agent
 	PolicyMapFactory    policymap.Factory
 	PolicyRepo          policy.PolicyRepository
+	PolicyFetcher       compute.PolicyRecomputer
 	Allocator           cache.IdentityAllocator
 	CTMapGC             ctmap.GCRunner
 	KVStoreSynchronizer *ipcache.IPIdentitySynchronizer

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -102,13 +102,13 @@ func (e *Endpoint) proxyIDs(selectorPolicy policy.SelectorPolicy, l4 *policy.L4F
 	}
 }
 
-// setNextPolicyRevision updates the desired policy revision field
+// setDesiredPolicyRevision updates the desired policy revision field
 // Must be called with the endpoint lock held for at least reading
-func (e *Endpoint) setNextPolicyRevision(revision uint64) {
-	e.nextPolicyRevision = revision
+func (e *Endpoint) setDesiredPolicyRevision(revision uint64) {
+	e.desiredPolicyRevision = revision
 	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
 		e.UpdateLogger(map[string]any{
-			logfields.DesiredPolicyRevision: e.nextPolicyRevision,
+			logfields.DesiredPolicyRevision: e.desiredPolicyRevision,
 		})
 	}
 }
@@ -380,10 +380,10 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 		return fmt.Errorf("endpoint %d SecurityIdentity revision changed during policy regeneration", e.ID)
 	}
 
-	oldNextPolicyRevision := e.nextPolicyRevision
+	oldDesiredPolicyRevision := e.desiredPolicyRevision
 	// Set the revision of this endpoint to the current revision of the policy
 	// repository.
-	e.setNextPolicyRevision(res.policyRevision)
+	e.setDesiredPolicyRevision(res.policyRevision)
 
 	if res.endpointPolicy != nil && res.endpointPolicy != e.desiredPolicy {
 		if e.desiredPolicy != e.realizedPolicy {
@@ -405,12 +405,12 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 			// Do nothing if e.policyMap was not initialized already
 			if e.policyMap != nil && e.desiredPolicy != e.realizedPolicy {
 				desiredPolicyMapLen := e.desiredPolicy.Len()
-				// Revert nextPolicyRevision; otherwise,
+				// Revert desiredPolicyRevision; otherwise,
 				// res.endpointPolicy will not be recalculated
 				// on the next regeneration attempt, and we
 				// won't advance to the true desired policy map
 				// state. See GH-38998.
-				e.setNextPolicyRevision(oldNextPolicyRevision)
+				e.setDesiredPolicyRevision(oldDesiredPolicyRevision)
 				e.desiredPolicy.Detach(e.getLogger())
 				e.desiredPolicy = e.realizedPolicy
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -33,6 +33,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
@@ -42,6 +43,9 @@ import (
 var (
 	endpointRegenerationRecoveryControllerGroup = controller.NewGroup("endpoint-regeneration-recovery")
 	syncAddressIdentityMappingControllerGroup   = controller.NewGroup("sync-address-identity-mapping")
+
+	errPolicyComputationStaleRevision = errors.New("policy computation result has stale revision")
+	errPolicyComputationNotFound      = errors.New("policy computation result not found in statedb")
 )
 
 // PreviousMapState returns an empty policy.MapState with preallocated map sizes from the current one.
@@ -183,7 +187,6 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 
 	// Copy out some values we care about, then unlock
-	forcePolicyCompute := e.forcePolicyCompute
 	securityIdentity := e.SecurityIdentity
 
 	// We are computing policy; set this to false.
@@ -207,31 +210,34 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	}
 	e.unlock()
 
-	e.getLogger().Debug("Starting policy recalculation...")
-	skipPolicyRevision := e.nextPolicyRevision
-	if forcePolicyCompute || e.desiredPolicy == nil {
-		e.getLogger().Debug("Forced policy recalculation")
-		skipPolicyRevision = 0
-	}
-
-	var selectorPolicy policy.SelectorPolicy
-	selectorPolicy, result.policyRevision, err = e.policyRepo.GetSelectorPolicy(securityIdentity, skipPolicyRevision, stats, e.GetID())
+	e.getLogger().Debug("Fetching policy recalculation",
+		logfields.Identity, securityIdentity.ID,
+		logfields.PolicyRevision, datapathRegenCtxt.policyRevisionToWaitFor,
+	)
+	var (
+		pcr            *compute.Result
+		selectorPolicy policy.SelectorPolicy
+	)
+	stats.waitForPolicyCompute.Start()
+	pcr, err = e.waitForPolicyComputationResult(datapathRegenCtxt, securityIdentity)
+	stats.waitForPolicyCompute.End(err == nil)
 	if err != nil {
-		e.getLogger().Warn("Failed to calculate SelectorPolicy", logfields.Error, err)
-		return err
+		return newRegenerationError(regenerationFailureReasonPolicyRegenerationError,
+			fmt.Errorf("failed waiting for policy computation result: %w", err))
+	} else if pcr != nil {
+		selectorPolicy = pcr.NewPolicy
+		result.policyRevision = pcr.Revision
+		err = pcr.Err
 	}
-
-	// selectorPolicy is nil if skipRevision was matched.
-	if selectorPolicy == nil {
-		e.getLogger().Debug(
-			"Skipping unnecessary endpoint policy recalculation",
-			logfields.PolicyRevisionNext, e.nextPolicyRevision,
-			logfields.PolicyRevisionRepo, result.policyRevision,
-			logfields.PolicyChanged, e.nextPolicyRevision > e.policyRevision,
-		)
-		datapathRegenCtxt.policyResult = result
-		return nil
+	// Release the hold taken in waitForPolicyComputationResult. On success
+	// DistillPolicy registers the endpoint as a user before this runs, so the
+	// policy stays attached.
+	defer selectorPolicy.ReleaseHold()
+	if err != nil {
+		return newRegenerationError(regenerationFailureReasonPolicyRegenerationError,
+			fmt.Errorf("failed fetching policy computation result: %w", err))
 	}
+	datapathRegenCtxt.policyResult = result
 
 	// Add new redirects before Consume() so that all required proxy ports are available for it.
 	var desiredRedirects map[string]uint16
@@ -267,8 +273,64 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 	result.endpointPolicy = selectorPolicy.DistillPolicy(e.getLogger(), e, desiredRedirects)
 	stats.endpointPolicyCalculation.End(true)
 
-	datapathRegenCtxt.policyResult = result
 	return nil
+}
+
+func (e *Endpoint) waitForPolicyComputationResult(
+	datapathRegenCtxt *datapathRegenerationContext,
+	securityIdentity *identityPkg.Identity,
+) (*compute.Result, error) {
+	wantedRevision := datapathRegenCtxt.policyRevisionToWaitFor
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	for {
+		computeResult, _, watch, found := e.policyFetcher.GetIdentityPolicyByIdentity(securityIdentity)
+		if found && computeResult.Revision >= wantedRevision {
+			if computeResult.NewPolicy.AddHold() {
+				e.getLogger().Debug(
+					"Retrieved identity policy from statedb",
+					logfields.PolicyRevision, computeResult.Revision,
+				)
+				return &computeResult, nil
+			}
+			// Policy was detached by a concurrent Supersede. Fall through
+			// to wait for the replacement.
+			e.getLogger().Debug(
+				"Policy was detached, waiting for replacement",
+				logfields.Identity, securityIdentity.ID,
+				logfields.PolicyRevision, computeResult.Revision,
+			)
+		} else if found {
+			e.getLogger().Debug(
+				"Policy computation result has stale revision, waiting for update",
+				logfields.Identity, securityIdentity.ID,
+				logfields.PolicyRevision, computeResult.Revision,
+				logfields.PolicyRevisionNext, wantedRevision,
+			)
+		} else {
+			e.getLogger().Debug(
+				"Policy computation result not found in statedb, waiting",
+				logfields.Identity, securityIdentity.ID,
+				logfields.PolicyRevisionNext, wantedRevision,
+			)
+		}
+
+		// Watch fires on insert/update of this identity's statedb entry.
+		select {
+		case <-watch:
+			continue
+		case <-timeout.C:
+			if found {
+				return nil, fmt.Errorf("%w: got rev=%d, want rev=%d",
+					errPolicyComputationStaleRevision,
+					computeResult.Revision,
+					wantedRevision)
+			}
+			return nil, errPolicyComputationNotFound
+		}
+	}
 }
 
 // setDesiredPolicy updates the endpoint with the results of a policy calculation.
@@ -443,6 +505,8 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 	}
 	// reset to the default lowest level
 	e.skippedRegenerationLevel = regeneration.Invalid
+
+	e.consumeSkippedPolicyRevision(ctx.datapathRegenerationContext)
 
 	e.unlock()
 
@@ -692,11 +756,24 @@ func (e *Endpoint) setRegenerateStateLocked(regenMetadata *regeneration.External
 		} else {
 			e.logStatusLocked(Other, OK, fmt.Sprintf("Skipped duplicate endpoint regeneration trigger due to %s", regenMetadata.GetRegenerationReason()))
 		}
+		// Keep the queued regen from completing at an older revision.
+		if regenMetadata.PolicyRevisionToWaitFor > e.skippedPolicyRevision {
+			e.skippedPolicyRevision = regenMetadata.PolicyRevisionToWaitFor
+		}
 		regen = false
 	default:
 		regen = e.setState(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.GetRegenerationReason()))
 	}
 	return regen
+}
+
+// consumeSkippedPolicyRevision transfers any buffered revision to ctx.
+// Must be called with e.mutex held.
+func (e *Endpoint) consumeSkippedPolicyRevision(ctx *datapathRegenerationContext) {
+	if e.skippedPolicyRevision > ctx.policyRevisionToWaitFor {
+		ctx.policyRevisionToWaitFor = e.skippedPolicyRevision
+	}
+	e.skippedPolicyRevision = 0
 }
 
 // UpdatePolicy updates the endpoint's policy.
@@ -750,9 +827,10 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 
 	// Policy change affected this endpoint's identity; queue regeneration
 	regenMetadata := &regeneration.ExternalRegenerationMetadata{
-		Reason:            regeneration.ReasonPolicyUpdate,
-		Message:           "policy rules updated",
-		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+		Reason:                  regeneration.ReasonPolicyUpdate,
+		Message:                 "policy rules updated",
+		RegenerationLevel:       regeneration.RegenerateWithoutDatapath,
+		PolicyRevisionToWaitFor: toRev,
 	}
 	regen := e.setRegenerateStateLocked(regenMetadata)
 	unlock()
@@ -973,7 +1051,9 @@ func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (erro
 			// Do not error out so that the policy regeneration is tried again.
 			return nil, release
 		}
-		finalize()
+		if finalize != nil {
+			finalize()
+		}
 	}
 
 	// Signal computation of the initial Envoy policy if not done yet

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -801,28 +801,22 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 		return
 	}
 
-	// If this endpoint's security ID has a policy update, we must regenerate. Otherwise,
-	// bump the policy revision directly (as long as we didn't miss an update somehow).
+	// If this endpoint's security ID has a policy update, we must regenerate.
+	// Otherwise, bump the policy revision directly.
 	if !idsToRegen.Has(secID) {
-		if e.policyRevision < fromRev {
-			// FIXME: https://github.com/cilium/cilium/issues/36493
-			// Currently policy repository version can be bumped through multiple triggers
-			// async to each other. This can lead to out of order processing of regeneration
-			// events. Continue with endpoint regeneration to be safe but log as Info.
-			e.getLogger().Info(
-				"Endpoint missed a policy revision; triggering regeneration",
-				logfields.PolicyRevision, fromRev,
-			)
-		} else {
-			e.getLogger().Debug(
-				"Policy update is a no-op, bumping policyRevision",
-				logfields.PolicyRevision, toRev,
-			)
-			e.setPolicyRevision(toRev)
-
+		if e.policyRevision == 0 {
+			// We are deferring to the upcoming regen since the endpoint is new.
 			unlock()
 			return
 		}
+		e.getLogger().Debug(
+			"Policy update is a no-op, bumping policyRevision",
+			logfields.PolicyRevision, toRev,
+		)
+		e.setPolicyRevision(toRev)
+
+		unlock()
+		return
 	}
 
 	// Policy change affected this endpoint's identity; queue regeneration

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -13,9 +13,12 @@ import (
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -23,6 +26,8 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
@@ -45,9 +50,11 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 	defer policy.SetPolicyEnabled(pe)
 
 	idcache := make(identity.IdentityMap, testfactor)
+	logger := hivetest.Logger(t)
 	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
 	idManager := identitymanager.NewIDManager(hivetest.Logger(t))
-	repo := policy.NewPolicyRepository(hivetest.Logger(t), fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", "TestIncrementalUpdatesDuringPolicyGeneration", repo, idManager)
 
 	addIdentity := func(labelKeys ...string) *identity.Identity {
 		t.Helper()
@@ -73,6 +80,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	ep := Endpoint{
 		policyRepo:       repo,
+		policyFetcher:    polComputer,
 		desiredPolicy:    policy.NewEndpointPolicy(hivetest.Logger(t), repo),
 		labels:           labels.NewOpLabels(),
 		SecurityIdentity: podID,
@@ -112,7 +120,8 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		},
 	}
 
-	repo.MustAddList(api.Rules{egressDenyRule})
+	_, rev := repo.MustAddList(api.Rules{egressDenyRule})
+	computePolicyForEPAndWait(t, &ep, polComputer, rev)
 
 	// Track all IDs we allocate so we can validate later that we never miss any
 	checkMutex := lock.Mutex{}
@@ -139,6 +148,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 
 	stats := new(regenerationStatistics)
 	datapathRegenCtxt := new(datapathRegenerationContext)
+	datapathRegenCtxt.policyRevisionToWaitFor = rev
 	// Continuously compute policy for the pod and ensure we never missed an incremental update.
 	for {
 		t.Log("Calculating policy...")
@@ -180,4 +190,285 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 			break
 		}
 	}
+}
+
+func computePolicyForEPAndWait(t *testing.T, ep *Endpoint, fetcher compute.PolicyRecomputer, rev uint64) {
+	t.Helper()
+
+	computedPolicyCh, err := fetcher.RecomputeIdentityPolicy(ep.SecurityIdentity, rev)
+	assert.NoError(t, err)
+	assert.NotNil(t, computedPolicyCh)
+	<-computedPolicyCh
+}
+
+type policyTestFixture struct {
+	repo        *policy.Repository
+	polComputer compute.PolicyRecomputer
+	idManager   identitymanager.IDManager
+	podID       *identity.Identity
+}
+
+func newPolicyTestFixture(t *testing.T) *policyTestFixture {
+	t.Helper()
+
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	t.Cleanup(func() { policy.SetPolicyEnabled(pe) })
+
+	logger := hivetest.Logger(t)
+	idcache := make(identity.IdentityMap)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	idManager := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, fakeAllocator.GetIdentityCache(), nil, nil, idManager, testpolicy.NewPolicyMetricsNoop())
+	polComputer := testcompute.InstantiateCellForTesting(t, logger, "endpoint-policy_test", t.Name(), repo, idManager)
+
+	podLbls := labels.Labels{"pod": labels.NewLabel("k8s:pod", "", "")}
+	podID, _, err := fakeAllocator.AllocateIdentity(context.Background(), podLbls, false, 0)
+	require.NoError(t, err)
+	wg := &sync.WaitGroup{}
+	repo.GetSelectorCache().UpdateIdentities(identity.IdentityMap{podID.ID: podID.LabelArray}, nil, wg)
+	wg.Wait()
+
+	idManager.Add(podID)
+
+	return &policyTestFixture{
+		repo:        repo,
+		polComputer: polComputer,
+		idManager:   idManager,
+		podID:       podID,
+	}
+}
+
+// TestStaleStatedbEntry covers the case where identity refcount drops to 0.
+// The DELETE handler must clean up the statedb entry even though the identity
+// is already gone from idmanager.
+func TestStaleStatedbEntry(t *testing.T) {
+	f := newPolicyTestFixture(t)
+	logger := hivetest.Logger(t)
+
+	epA := Endpoint{
+		policyRepo:       f.repo,
+		policyFetcher:    f.polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, f.repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: f.podID,
+		identityManager:  f.idManager,
+	}
+	epA.UpdateLogger(nil)
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	egressSelectLabel := labels.ParseSelectLabel("peer")
+	rule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(podSelectLabel),
+		EgressDeny: []api.EgressDenyRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(egressSelectLabel),
+					},
+				},
+				ToPorts: []api.PortDenyRule{
+					{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: "TCP"},
+						},
+					},
+				},
+			},
+		},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "testRule", labels.LabelSourceAny),
+		},
+	}
+	_, rev := f.repo.MustAddList(api.Rules{rule})
+
+	require.Eventually(t, func() bool {
+		_, _, _, found := f.polComputer.GetIdentityPolicyByNumericIdentity(f.podID.ID)
+		return found
+	}, 5*time.Second, 10*time.Millisecond)
+
+	computePolicyForEPAndWait(t, &epA, f.polComputer, rev)
+
+	statsA := new(regenerationStatistics)
+	regenCtxA := &datapathRegenerationContext{policyRevisionToWaitFor: rev}
+	err := epA.regeneratePolicy(statsA, regenCtxA)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxA.policyResult.endpointPolicy)
+	epA.desiredPolicy = regenCtxA.policyResult.endpointPolicy
+
+	epA.desiredPolicy.Ready()
+	epA.desiredPolicy.Detach(logger)
+	f.idManager.Remove(f.podID)
+
+	_, _, _, found := f.polComputer.GetIdentityPolicyByNumericIdentity(f.podID.ID)
+	require.False(t, found)
+
+	f.idManager.Add(f.podID)
+
+	epB := Endpoint{
+		policyRepo:       f.repo,
+		policyFetcher:    f.polComputer,
+		desiredPolicy:    policy.NewEndpointPolicy(logger, f.repo),
+		labels:           labels.NewOpLabels(),
+		SecurityIdentity: f.podID,
+		identityManager:  f.idManager,
+	}
+	epB.UpdateLogger(nil)
+
+	computePolicyForEPAndWait(t, &epB, f.polComputer, rev)
+
+	statsB := new(regenerationStatistics)
+	regenCtxB := &datapathRegenerationContext{policyRevisionToWaitFor: rev}
+	err = epB.regeneratePolicy(statsB, regenCtxB)
+	require.NoError(t, err)
+	require.NotNil(t, regenCtxB.policyResult.endpointPolicy)
+
+	regenCtxB.policyResult.endpointPolicy.Ready()
+	regenCtxB.policyResult.endpointPolicy.Detach(logger)
+	f.idManager.Remove(f.podID)
+}
+
+// TestSupersedeDuringRegen covers the race where a concurrent
+// computeSelectorPolicy adds a uniquely-labelled rule and returns the resulting
+// live SelectorPolicy for the fixture's identity.
+func computeSelectorPolicy(t *testing.T, f *policyTestFixture, name string) policy.SelectorPolicy {
+	t.Helper()
+	rule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("pod")),
+		EgressDeny: []api.EgressDenyRule{{
+			EgressCommonRule: api.EgressCommonRule{
+				ToEndpoints: []api.EndpointSelector{api.NewESFromLabels(labels.ParseSelectLabel("peer"))},
+			},
+			ToPorts: []api.PortDenyRule{{Ports: []api.PortProtocol{{Port: "80", Protocol: "TCP"}}}},
+		}},
+		Labels: labels.LabelArray{labels.NewLabel(k8sConst.PolicyLabelName, name, labels.LabelSourceAny)},
+	}
+	_, rev := f.repo.MustAddList(api.Rules{rule})
+	done, err := f.polComputer.RecomputeIdentityPolicy(f.podID, rev)
+	require.NoError(t, err)
+	<-done
+	res, _, _, found := f.polComputer.GetIdentityPolicyByIdentity(f.podID)
+	require.True(t, found)
+	require.NotNil(t, res.NewPolicy)
+	return res.NewPolicy
+}
+
+// supersedeFetcher serves a detached policy on the first read, then a live one.
+// Closing the first read's watch channel wakes the wait loop deterministically.
+type supersedeFetcher struct {
+	compute.PolicyRecomputer
+	results []compute.Result
+	watch   chan struct{}
+}
+
+func (f *supersedeFetcher) GetIdentityPolicyByIdentity(*identity.Identity) (compute.Result, statedb.Revision, <-chan struct{}, bool) {
+	res, watch := f.results[0], f.watch
+	if len(f.results) > 1 {
+		f.results = f.results[1:]
+		close(watch) // wake the wait loop so it re-reads the replacement
+		f.watch = make(chan struct{})
+	}
+	return res, 0, watch, true
+}
+
+// waitForPolicyComputationResult must skip a superseded policy and wait for the
+// replacement instead of failing.
+func TestWaitSkipsSupersededPolicy(t *testing.T) {
+	f := newPolicyTestFixture(t)
+	const rev = 1
+
+	detached := computeSelectorPolicy(t, f, "detached")
+	detached.Supersede()
+	require.False(t, detached.AddHold())
+
+	live := computeSelectorPolicy(t, f, "live")
+
+	fetcher := &supersedeFetcher{
+		PolicyRecomputer: f.polComputer,
+		results: []compute.Result{
+			{NewPolicy: detached, Revision: rev},
+			{NewPolicy: live, Revision: rev},
+		},
+		watch: make(chan struct{}),
+	}
+
+	ep := Endpoint{policyFetcher: fetcher, SecurityIdentity: f.podID}
+	ep.UpdateLogger(nil)
+
+	res, err := ep.waitForPolicyComputationResult(
+		&datapathRegenerationContext{policyRevisionToWaitFor: rev}, f.podID)
+	require.NoError(t, err)
+	require.Same(t, live, res.NewPolicy)
+
+	live.ReleaseHold()
+}
+
+// A duplicate regeneration trigger is skipped, but the queued regeneration must
+// still wait for the highest revision that was skipped.
+func TestSkippedPolicyRevision(t *testing.T) {
+	const (
+		rev1 = 198
+		rev2 = 199
+		rev3 = 200
+	)
+
+	newEP := func() *Endpoint {
+		ep := &Endpoint{status: NewEndpointStatus()}
+		ep.UpdateLogger(nil)
+		return ep
+	}
+
+	// skip triggers a regeneration while one is already queued and reports
+	// whether it was skipped.
+	skip := func(ep *Endpoint, rev uint64) bool {
+		ep.unconditionalLock()
+		defer ep.unlock()
+		return !ep.setRegenerateStateLocked(&regeneration.ExternalRegenerationMetadata{
+			Reason:                  regeneration.ReasonPolicyUpdate,
+			RegenerationLevel:       regeneration.RegenerateWithoutDatapath,
+			PolicyRevisionToWaitFor: rev,
+		})
+	}
+
+	consume := func(ep *Endpoint, ctx *datapathRegenerationContext) {
+		ep.unconditionalLock()
+		defer ep.unlock()
+		ep.consumeSkippedPolicyRevision(ctx)
+	}
+
+	t.Run("skip captures highest revision and regen consumes it", func(t *testing.T) {
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+
+		require.True(t, skip(ep, rev2))
+		require.Equal(t, uint64(rev2), ep.skippedPolicyRevision)
+
+		// A lower revision must not lower it. A higher one wins.
+		require.True(t, skip(ep, rev1))
+		require.Equal(t, uint64(rev2), ep.skippedPolicyRevision)
+		require.True(t, skip(ep, rev3))
+		require.Equal(t, uint64(rev3), ep.skippedPolicyRevision)
+
+		ctx := &datapathRegenerationContext{policyRevisionToWaitFor: rev1}
+		consume(ep, ctx)
+		require.Equal(t, uint64(rev3), ctx.policyRevisionToWaitFor)
+		require.Zero(t, ep.skippedPolicyRevision)
+	})
+
+	t.Run("consume does not lower a higher ctx revision", func(t *testing.T) {
+		ep := newEP()
+		ep.state = StateWaitingToRegenerate
+		require.True(t, skip(ep, rev2))
+
+		ctx := &datapathRegenerationContext{policyRevisionToWaitFor: rev3}
+		consume(ep, ctx)
+		require.Equal(t, uint64(rev3), ctx.policyRevisionToWaitFor)
+	})
+
+	t.Run("fresh trigger does not set skippedPolicyRevision", func(t *testing.T) {
+		ep := newEP()
+		ep.state = StateReady // not already queued, so the trigger is not a duplicate
+		require.False(t, skip(ep, rev2))
+		require.Zero(t, ep.skippedPolicyRevision)
+	})
 }

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -27,10 +27,12 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/testutils"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
@@ -69,6 +71,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 	s.do.idmgr = identitymanager.NewIDManager(logger)
 	s.do.repo = policy.NewPolicyRepository(logger, identityCache, nil, envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()), s.do.idmgr, testpolicy.NewPolicyMetricsNoop())
 	s.do.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	s.do.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupRedirectSuite", s.do.repo, s.do.idmgr)
 
 	s.rsp = &RedirectSuiteProxy{
 		parserProxyPortMap: map[string]uint16{
@@ -136,8 +139,9 @@ func (r *RedirectSuiteProxy) IsSDPEnabled() bool {
 
 // DummyOwner implements pkg/endpoint/regeneration/Owner. Used for unit testing.
 type DummyOwner struct {
-	repo  policy.PolicyRepository
-	idmgr identitymanager.IDManager
+	repo    policy.PolicyRepository
+	fetcher compute.PolicyRecomputer
+	idmgr   identitymanager.IDManager
 }
 
 // GetNodeSuffix does nothing.
@@ -168,6 +172,7 @@ func (s *RedirectSuite) createTestEndpointParams(tb testing.TB) EndpointParams {
 		EPBuildQueue:    &MockEndpointBuildQueue{},
 		Orchestrator:    &fakeendpoint.FakeOrchestrator{},
 		PolicyRepo:      s.do.repo,
+		PolicyFetcher:   s.do.fetcher,
 		IdentityManager: s.do.idmgr,
 		IPSecConfig:     fakeipsec.Config{},
 		WgConfig:        fakewireguard.Config{},
@@ -198,9 +203,13 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	return ep
 }
 
-func (s *RedirectSuite) AddRules(rules api.Rules) {
+func (s *RedirectSuite) AddRules(rules api.Rules) uint64 {
 	repo := s.do.repo.(*policy.Repository)
-	repo.MustAddList(rules)
+	orig := repo.GetRevision()
+	slice, rev := repo.MustAddList(rules)
+	affected := slice.AllIdentitySelections()
+	s.do.fetcher.UpdatePolicy(affected, orig, rev)
+	return rev
 }
 
 func (s *RedirectSuite) TearDownTest(t *testing.T) {
@@ -353,7 +362,7 @@ func TestRedirectWithDeny(t *testing.T) {
 	ep := s.NewTestEndpoint(t)
 
 	// Policy denies anything to "foo"
-	s.AddRules(api.Rules{
+	s.datapathRegenCtxt.policyRevisionToWaitFor = s.AddRules(api.Rules{
 		ruleL3DenyFoo.WithEndpointSelector(selectBar_),
 		ruleL4L7Allow.WithEndpointSelector(selectBar_),
 	})
@@ -482,7 +491,7 @@ func TestRedirectWithPriority(t *testing.T) {
 	api.TestAllowIngressListener = true
 	defer func() { api.TestAllowIngressListener = false }()
 
-	s.AddRules(api.Rules{
+	s.datapathRegenCtxt.policyRevisionToWaitFor = s.AddRules(api.Rules{
 		ruleL4AllowListener1.WithEndpointSelector(selectBar_),
 		ruleL4AllowPort80.WithEndpointSelector(selectBar_),
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),
@@ -535,7 +544,7 @@ func TestRedirectWithEqualPriority(t *testing.T) {
 
 	api.TestAllowIngressListener = true
 	defer func() { api.TestAllowIngressListener = false }()
-	s.AddRules(api.Rules{
+	s.datapathRegenCtxt.policyRevisionToWaitFor = s.AddRules(api.Rules{
 		ruleL4L7AllowListener1Priority1.WithEndpointSelector(selectBar_),
 		ruleL4AllowPort80.WithEndpointSelector(selectBar_),
 		ruleL4L7AllowListener2Priority1.WithEndpointSelector(selectBar_),

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -73,6 +73,10 @@ type ExternalRegenerationMetadata struct {
 	RegenerationLevel DatapathRegenerationLevel
 
 	ParentContext context.Context
+
+	// PolicyRevisionToWaitFor is the policy revision being requested to
+	// update the endpoint to.
+	PolicyRevisionToWaitFor uint64
 }
 
 func (m *ExternalRegenerationMetadata) GetRegenerationReason() string {

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -130,6 +130,8 @@ func ParseExternalRegenerationMetadata(ctx context.Context, logger *slog.Logger,
 		datapathRegenerationContext: &datapathRegenerationContext{
 			regenerationLevel: e.RegenerationLevel,
 			ctCleaned:         make(chan struct{}),
+
+			policyRevisionToWaitFor: e.PolicyRevisionToWaitFor,
 		},
 		parentContext: ctx,
 		cancelFunc:    c,
@@ -152,6 +154,10 @@ type datapathRegenerationContext struct {
 
 	policyMapSyncDone bool
 	policyMapDump     policy.MapStateMap
+
+	// policyRevisionToWaitFor is the policy revision being requested to
+	// update the endpoint to.
+	policyRevisionToWaitFor uint64
 
 	finalizeList revert.FinalizeList
 	revertStack  revert.RevertStack

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *EndpointSuite) createEndpointParams(tb testing.TB) EndpointParams {
-	return createEndpointParams(tb, s.orchestrator, s.repo)
+	return createEndpointParams(tb, s.orchestrator, s.repo, s.fetcher)
 }
 
 func (s *EndpointSuite) createEndpoints(t testing.TB) ([]*Endpoint, map[uint16]*Endpoint) {
@@ -137,11 +137,7 @@ func TestReadEPsFromDirNames(t *testing.T) {
 			epsNames = append(epsNames, ep.DirectoryPath())
 		}
 	}
-	p := s.createEndpointParams(t)
-	p.Logger = logger
-	p.Orchestrator = s.orchestrator
-	p.PolicyRepo = s.repo
-	eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epsNames)
+	eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: s.createEndpointParams(t)}, tmpDir, epsNames)
 	require.Len(t, eps, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -204,11 +200,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 		ep.DirectoryPath(), ep.NextDirectoryPath(),
 	}
 
-	p := s.createEndpointParams(t)
-	p.Logger = logger
-	p.Orchestrator = s.orchestrator
-	p.PolicyRepo = s.repo
-	epResult, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epNames)
+	epResult, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: s.createEndpointParams(t)}, tmpDir, epNames)
 	require.Len(t, epResult, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -261,11 +253,7 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	}
 
 	for b.Loop() {
-		p := s.createEndpointParams(b)
-		p.Logger = logger
-		p.Orchestrator = s.orchestrator
-		p.PolicyRepo = s.repo
-		eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epsNames)
+		eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: s.createEndpointParams(b)}, tmpDir, epsNames)
 		require.Len(b, eps, len(epsWanted))
 	}
 }

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -160,6 +160,12 @@ type EndpointManager interface {
 	// Returns immediately.
 	TriggerRegenerateAllEndpoints()
 
+	// RegenerateAllForPolicy regenerates all endpoints against the given policy
+	// revision. Each endpoint's regeneration waits for the compute cell to
+	// publish its identity's SelectorPolicy at waitFor before proceeding.
+	// Returns immediately.
+	RegenerateAllForPolicy(waitFor uint64)
+
 	// WaitForEndpointsAtPolicyRev waits for all endpoints which existed at the time
 	// this function is called to be at a given policy revision.
 	// New endpoints appearing while waiting are ignored.

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -14,13 +14,8 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/api/v1/models"
-	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
-	"github.com/cilium/cilium/pkg/identity/identitymanager"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
-	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
 )
 
 // fakeCheck detects endpoints as unhealthy if they have an even EndpointID.
@@ -48,16 +43,7 @@ func TestMarkAndSweep(t *testing.T) {
 	allEndpointIDs := append(healthyEndpointIDs, endpointIDToDelete)
 	for _, id := range allEndpointIDs {
 		model := newTestEndpointModel(int(id), endpoint.StateReady)
-		ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-			EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-			Allocator:       testidentity.NewMockIdentityAllocator(nil),
-			CTMapGC:         ctmap.NewFakeGCRunner(),
-			WgConfig:        &fakewireguard.Config{},
-			IPSecConfig:     fakeipsec.Config{},
-			Logger:          logger,
-			IdentityManager: identitymanager.NewIDManager(logger),
-			PolicyRepo:      s.repo,
-		}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+		ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 		require.NoError(t, err)
 
 		ep.Start(uint16(model.ID))

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -654,6 +654,21 @@ func (mgr *endpointManager) TriggerRegenerateAllEndpoints() {
 	mgr.policyUpdateCallback(&sync.WaitGroup{}, nil, false)
 }
 
+// RegenerateAllForPolicy regenerates all endpoints against the given policy
+// revision. Each endpoint's regeneration blocks until the compute cell has
+// published the SelectorPolicy for its identity at waitFor, ensuring
+// endpoints pick up the new policy instead of the stale one.
+func (mgr *endpointManager) RegenerateAllForPolicy(waitFor uint64) {
+	go mgr.RegenerateAllEndpoints(&regeneration.ExternalRegenerationMetadata{
+		Reason:                  regeneration.ReasonPolicyUpdate,
+		Message:                 "policy rules updated",
+		RegenerationLevel:       regeneration.RegenerateWithoutDatapath,
+		PolicyRevisionToWaitFor: waitFor,
+	})
+
+	mgr.policyUpdateCallback(&sync.WaitGroup{}, nil, false)
+}
+
 // OverrideEndpointOpts applies the given options to all endpoints.
 func (mgr *endpointManager) OverrideEndpointOpts(om option.OptionMap) {
 	for _, ep := range mgr.GetEndpoints() {

--- a/pkg/endpointmanager/manager_proxy_test.go
+++ b/pkg/endpointmanager/manager_proxy_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	proxyendpoint "github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
@@ -192,7 +194,7 @@ func (p *recordingEndpointProxy) IsSDPEnabled() bool {
 	return false
 }
 
-func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymanager.IDManager) {
+func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymanager.IDManager, compute.PolicyRecomputer) {
 	t.Helper()
 
 	logger := hivetest.Logger(t)
@@ -205,6 +207,7 @@ func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymana
 		idmgr,
 		testpolicy.NewPolicyMetricsNoop(),
 	)
+	fetcher := testcompute.InstantiateCellForTesting(t, logger, "endpointmanager", t.Name(), repo, idmgr)
 
 	oldPolicyMode := policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
@@ -230,10 +233,10 @@ func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymana
 		}},
 	}})
 
-	return repo, idmgr
+	return repo, idmgr, fetcher
 }
 
-func newUpdatePolicyMapsTestEndpoint(t *testing.T, mgr *endpointManager, repo policy.PolicyRepository, idmgr identitymanager.IDManager, proxy endpoint.EndpointProxy, modelID int, addr netip.Addr) *endpoint.Endpoint {
+func newUpdatePolicyMapsTestEndpoint(t *testing.T, mgr *endpointManager, repo policy.PolicyRepository, idmgr identitymanager.IDManager, fetcher compute.PolicyRecomputer, proxy endpoint.EndpointProxy, modelID int, addr netip.Addr) *endpoint.Endpoint {
 	t.Helper()
 
 	model := newTestEndpointModel(modelID, endpoint.StateWaitingForIdentity)
@@ -242,6 +245,7 @@ func newUpdatePolicyMapsTestEndpoint(t *testing.T, mgr *endpointManager, repo po
 		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
 		Orchestrator:    &fakeendpoint.FakeOrchestrator{},
 		PolicyRepo:      repo,
+		PolicyFetcher:   fetcher,
 		IdentityManager: idmgr,
 		IPSecConfig:     fakeipsec.Config{},
 		WgConfig:        &fakewireguard.Config{},
@@ -275,11 +279,11 @@ func newUpdatePolicyMapsTestEndpoint(t *testing.T, mgr *endpointManager, repo po
 func TestUpdatePolicyMapsFinalizesDeferredNetworkPolicyCallbacksAfterSuccessfulWait(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	repo, idmgr := newUpdatePolicyMapsTestRepo(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t)
 	proxy := newRecordingEndpointProxy()
 
-	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 101, netip.MustParseAddr("10.0.0.1"))
-	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 102, netip.MustParseAddr("10.0.0.2"))
+	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 101, netip.MustParseAddr("10.0.0.1"))
+	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 102, netip.MustParseAddr("10.0.0.2"))
 
 	proxy.expectUpdates(2)
 
@@ -306,11 +310,11 @@ func TestUpdatePolicyMapsFinalizesDeferredNetworkPolicyCallbacksAfterSuccessfulW
 func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	repo, idmgr := newUpdatePolicyMapsTestRepo(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t)
 	proxy := newRecordingEndpointProxy()
 
-	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 201, netip.MustParseAddr("10.0.1.1"))
-	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 202, netip.MustParseAddr("10.0.1.2"))
+	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 201, netip.MustParseAddr("10.0.1.1"))
+	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 202, netip.MustParseAddr("10.0.1.2"))
 
 	proxy.expectUpdates(2)
 
@@ -338,11 +342,11 @@ func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFail
 func TestUpdatePolicyMapsDoesNotDeferCallbacksForSynchronousApplyFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	repo, idmgr := newUpdatePolicyMapsTestRepo(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t)
 	proxy := newRecordingEndpointProxy()
 
-	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 301, netip.MustParseAddr("10.0.2.1"))
-	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 302, netip.MustParseAddr("10.0.2.2"))
+	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 301, netip.MustParseAddr("10.0.2.1"))
+	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 302, netip.MustParseAddr("10.0.2.2"))
 
 	proxy.expectUpdates(2)
 	proxy.setSynchronousError(ep1.GetID(), errors.New("sync proxy error"))

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -5,6 +5,7 @@ package endpointmanager
 
 import (
 	"context"
+	"log/slog"
 	"net/netip"
 	"sync"
 	"testing"
@@ -32,6 +33,19 @@ import (
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
 )
+
+func makeTestEndpointParams(logger *slog.Logger, repo policy.PolicyRepository) endpoint.EndpointParams {
+	return endpoint.EndpointParams{
+		Logger:          logger,
+		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
+		PolicyRepo:      repo,
+		IdentityManager: identitymanager.NewIDManager(logger),
+		IPSecConfig:     fakeipsec.Config{},
+		WgConfig:        fakewireguard.Config{},
+		CTMapGC:         ctmap.NewFakeGCRunner(),
+		Allocator:       testidentity.NewMockIdentityAllocator(nil),
+	}
+}
 
 func (mgr *endpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
@@ -419,16 +433,7 @@ func TestLookup(t *testing.T) {
 			logger := hivetest.Logger(t)
 			mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 			if tt.cm != nil {
-				ep, err = endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-					Allocator:       testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:         ctmap.NewFakeGCRunner(),
-					WgConfig:        &fakewireguard.Config{},
-					IPSecConfig:     fakeipsec.Config{},
-					Logger:          logger,
-					IdentityManager: identitymanager.NewIDManager(logger),
-					PolicyRepo:      s.repo,
-				}, nil, &endpoint.FakeEndpointProxy{}, tt.cm, nil)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, tt.cm, nil)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
 				err = mgr.expose(ep)
 				require.NoErrorf(t, err, "Test Name: %s", tt.name)
@@ -453,16 +458,7 @@ func TestLookupCiliumID(t *testing.T) {
 
 	model := newTestEndpointModel(2, endpoint.StateReady)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		PolicyRepo:      s.repo,
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          logger,
-		IdentityManager: identitymanager.NewIDManager(logger),
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -537,16 +533,7 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          logger,
-		IdentityManager: identitymanager.NewIDManager(logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, &apiv1.EndpointChangeRequest{
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
 	}, nil)
@@ -569,16 +556,7 @@ func TestLookupIPv4(t *testing.T) {
 
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(4, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          logger,
-		IdentityManager: identitymanager.NewIDManager(logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -731,16 +709,7 @@ func TestLookupCEPName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-			EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-			Allocator:       testidentity.NewMockIdentityAllocator(nil),
-			CTMapGC:         ctmap.NewFakeGCRunner(),
-			WgConfig:        &fakewireguard.Config{},
-			IPSecConfig:     fakeipsec.Config{},
-			Logger:          logger,
-			IdentityManager: identitymanager.NewIDManager(logger),
-			PolicyRepo:      s.repo,
-		}, nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
+		ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
 		tt.preTestRun(ep)
 		args := tt.setupArgs()
@@ -782,20 +751,10 @@ func TestUpdateReferences(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		var err error
 		logger := hivetest.Logger(t)
-		ep, err = endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-			EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-			Allocator:       testidentity.NewMockIdentityAllocator(nil),
-			CTMapGC:         ctmap.NewFakeGCRunner(),
-			WgConfig:        &fakewireguard.Config{},
-			IPSecConfig:     fakeipsec.Config{},
-			Logger:          logger,
-			IdentityManager: identitymanager.NewIDManager(logger),
-			PolicyRepo:      s.repo,
-		}, nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
+		var err error
+		ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, &tt.cm, nil)
 		require.NoErrorf(t, err, "Test Name: %s", tt.name)
-		//logger := hivetest.Logger(t)
 		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 
 		err = mgr.expose(ep)
@@ -829,16 +788,7 @@ func TestRemove(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
 	model := newTestEndpointModel(7, endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          logger,
-		IdentityManager: identitymanager.NewIDManager(logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -879,6 +829,137 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestWaitForEndpointsAtPolicyRev(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	model := newTestEndpointModel(1, endpoint.StateReady)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	require.NoError(t, err)
+
+	ep.Start(uint16(model.ID))
+	t.Cleanup(ep.Stop)
+	type args struct {
+		ctx    context.Context
+		rev    uint64
+		cancel context.CancelFunc
+	}
+	type want struct {
+		err      error
+		errCheck assert.ComparisonAssertionFunc
+	}
+	tests := []struct {
+		name        string
+		setupArgs   func() args
+		setupWant   func() want
+		preTestRun  func()
+		postTestRun func()
+	}{
+		{
+			name: "Endpoint with revision already set",
+			preTestRun: func() {
+				ep.ID = 1
+				ep.SetPolicyRevision(5)
+				require.NoError(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				return args{
+					ctx: context.Background(),
+					rev: 5,
+				}
+			},
+			setupWant: func() want {
+				return want{
+					err:      nil,
+					errCheck: assert.EqualValues,
+				}
+			},
+			postTestRun: func() {
+				mgr.WaitEndpointRemoved(ep)
+				model := newTestEndpointModel(1, endpoint.StateReady)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				require.NoError(t, err)
+
+				ep.Start(uint16(model.ID))
+				t.Cleanup(ep.Stop)
+			},
+		},
+		{
+			name: "Context already timed out",
+			preTestRun: func() {
+				ep.ID = 1
+				ep.SetPolicyRevision(5)
+				require.NoError(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				ctx, cancel := context.WithTimeout(context.Background(), 0)
+				return args{
+					ctx:    ctx,
+					rev:    5,
+					cancel: cancel,
+				}
+			},
+			setupWant: func() want {
+				return want{
+					err:      nil,
+					errCheck: assert.NotEqualValues,
+				}
+			},
+			postTestRun: func() {
+				mgr.WaitEndpointRemoved(ep)
+				model := newTestEndpointModel(1, endpoint.StateReady)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				require.NoError(t, err)
+
+				ep.Start(uint16(model.ID))
+				t.Cleanup(ep.Stop)
+			},
+		},
+		{
+			name: "Revision never reached before context times out",
+			preTestRun: func() {
+				ep.ID = 1
+				ep.SetPolicyRevision(4)
+				require.NoError(t, mgr.expose(ep))
+			},
+			setupArgs: func() args {
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				return args{
+					ctx:    ctx,
+					rev:    5,
+					cancel: cancel,
+				}
+			},
+			setupWant: func() want {
+				return want{
+					err:      nil,
+					errCheck: assert.NotEqualValues,
+				}
+			},
+			postTestRun: func() {
+				mgr.WaitEndpointRemoved(ep)
+				model := newTestEndpointModel(1, endpoint.StateReady)
+				ep, err = endpoint.NewEndpointFromChangeModel(makeTestEndpointParams(logger, s.repo), nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				require.NoError(t, err)
+
+				ep.Start(uint16(model.ID))
+				t.Cleanup(ep.Stop)
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt.preTestRun()
+		args := tt.setupArgs()
+		want := tt.setupWant()
+		got := mgr.WaitForEndpointsAtPolicyRev(args.ctx, args.rev)
+		want.errCheck(t, want.err, got, "Test Name: %s", tt.name)
+		if args.cancel != nil {
+			args.cancel()
+		}
+		tt.postTestRun()
+	}
+}
+
 func TestMissingNodeLabelsUpdate(t *testing.T) {
 	logger := hivetest.Logger(t)
 	// Initialize label filter config.
@@ -898,17 +979,11 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-		Allocator:           testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:             ctmap.NewFakeGCRunner(),
-		WgConfig:            &fakewireguard.Config{},
-		IPSecConfig:         fakeipsec.Config{},
-		Logger:              logger,
-		IdentityManager:     identitymanager.NewIDManager(logger),
-		PolicyRepo:          s.repo,
-		KVStoreSynchronizer: kvstoreSync,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := func() (*endpoint.Endpoint, error) {
+		p := makeTestEndpointParams(logger, s.repo)
+		p.KVStoreSynchronizer = kvstoreSync
+		return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	}()
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -960,17 +1035,11 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			name: "Add labels",
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
-				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-					Allocator:           testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:             ctmap.NewFakeGCRunner(),
-					WgConfig:            &fakewireguard.Config{},
-					IPSecConfig:         fakeipsec.Config{},
-					Logger:              logger,
-					IdentityManager:     identitymanager.NewIDManager(logger),
-					PolicyRepo:          s.repo,
-					KVStoreSynchronizer: kvstoreSync,
-				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				ep, err := func() (*endpoint.Endpoint, error) {
+					p := makeTestEndpointParams(logger, s.repo)
+					p.KVStoreSynchronizer = kvstoreSync
+					return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				}()
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1001,17 +1070,11 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-					Allocator:           testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:             ctmap.NewFakeGCRunner(),
-					WgConfig:            &fakewireguard.Config{},
-					IPSecConfig:         fakeipsec.Config{},
-					Logger:              logger,
-					IdentityManager:     identitymanager.NewIDManager(logger),
-					PolicyRepo:          s.repo,
-					KVStoreSynchronizer: kvstoreSync,
-				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				ep, err := func() (*endpoint.Endpoint, error) {
+					p := makeTestEndpointParams(logger, s.repo)
+					p.KVStoreSynchronizer = kvstoreSync
+					return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				}()
 				require.NoError(t, err)
 
 				ep.Start(uint16(model.ID))
@@ -1044,18 +1107,11 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
 				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
-
-				ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-					EPBuildQueue:        &endpoint.MockEndpointBuildQueue{},
-					Allocator:           testidentity.NewMockIdentityAllocator(nil),
-					CTMapGC:             ctmap.NewFakeGCRunner(),
-					WgConfig:            &fakewireguard.Config{},
-					IPSecConfig:         fakeipsec.Config{},
-					Logger:              logger,
-					IdentityManager:     identitymanager.NewIDManager(logger),
-					PolicyRepo:          s.repo,
-					KVStoreSynchronizer: kvstoreSync,
-				}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				ep, err := func() (*endpoint.Endpoint, error) {
+					p := makeTestEndpointParams(logger, s.repo)
+					p.KVStoreSynchronizer = kvstoreSync
+					return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+				}()
 				ep.SetIsHost(true)
 				require.NoError(t, err)
 

--- a/pkg/endpointmanager/script_cmds.go
+++ b/pkg/endpointmanager/script_cmds.go
@@ -98,12 +98,23 @@ func ScriptCmds(epm EndpointManager, template *endpoint.Endpoint) map[string]scr
 		"endpoint/regen-all": script.Command(
 			script.CmdUsage{
 				Summary: "Regenerate all Endpoints",
+				Args:    "policy-rev",
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				allArgs := []string(args)
+				if len(allArgs) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(allArgs))
+				}
+				rev, err := strconv.Atoi(allArgs[0])
+				if err != nil {
+					return nil, fmt.Errorf("atoi: %w", err)
+				}
 				wg := epm.RegenerateAllEndpoints(&regeneration.ExternalRegenerationMetadata{
 					Reason:            "simulate regeneration of all endpoints from script command",
 					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 					ParentContext:     s.Context(),
+
+					PolicyRevisionToWaitFor: uint64(rev),
 				})
 				return func(s *script.State) (stdout string, stderr string, err error) {
 					wg.Wait()

--- a/pkg/endpointmanager/script_cmds.go
+++ b/pkg/endpointmanager/script_cmds.go
@@ -101,20 +101,19 @@ func ScriptCmds(epm EndpointManager, template *endpoint.Endpoint) map[string]scr
 				Args:    "policy-rev",
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
-				allArgs := []string(args)
-				if len(allArgs) != 1 {
-					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(allArgs))
+				if len(args) != 1 {
+					return nil, fmt.Errorf("expected one arg but got %v, see usage details", len(args))
 				}
-				rev, err := strconv.Atoi(allArgs[0])
+				rev, err := strconv.ParseUint(args[0], 10, 64)
 				if err != nil {
-					return nil, fmt.Errorf("atoi: %w", err)
+					return nil, fmt.Errorf("parse policy-rev: %w", err)
 				}
 				wg := epm.RegenerateAllEndpoints(&regeneration.ExternalRegenerationMetadata{
 					Reason:            "simulate regeneration of all endpoints from script command",
 					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 					ParentContext:     s.Context(),
 
-					PolicyRevisionToWaitFor: uint64(rev),
+					PolicyRevisionToWaitFor: rev,
 				})
 				return func(s *script.State) (stdout string, stderr string, err error) {
 					wg.Wait()

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -89,15 +89,10 @@ func newProxyUpdaterMock(t testing.TB, namedPort uint16) *test.ProxyUpdaterMock 
 
 type dummyPolicyStats struct {
 	waitingForPolicyRepository spanstat.SpanStat
-	policyCalculation          spanstat.SpanStat
 }
 
 func (s *dummyPolicyStats) WaitingForPolicyRepository() *spanstat.SpanStat {
 	return &s.waitingForPolicyRepository
-}
-
-func (s *dummyPolicyStats) SelectorPolicyCalculation() *spanstat.SpanStat {
-	return &s.policyCalculation
 }
 
 var PortRuleHTTP1 = &api.PortRuleHTTP{

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -45,9 +45,11 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -56,6 +58,7 @@ import (
 
 type DNSProxyTestSuite struct {
 	repo         policy.PolicyRepository
+	fetcher      compute.PolicyRecomputer
 	dnsTCPClient *dns.Client
 	dnsServer    *dns.Server
 	proxy        *DNSProxy
@@ -81,6 +84,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	wg.Wait()
 
 	s.repo = policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	s.fetcher = testcompute.InstantiateCellForTesting(tb, logger, "endpoint", "setupDNSProxyTestSuite", s.repo, identitymanager.NewIDManager(logger))
 	s.dnsTCPClient = &dns.Client{Net: "tcp", Timeout: time.Second, SingleInflight: true}
 	s.dnsServer = setupServer(tb)
 	require.NotNil(tb, s.dnsServer, "unable to setup DNS server")
@@ -166,21 +170,26 @@ func (s *DNSProxyTestSuite) LookupByIdentity(nid identity.NumericIdentity) []str
 	}
 }
 
+func makeProxyTestEndpointParams(logger *slog.Logger, repo policy.PolicyRepository, fetcher compute.PolicyRecomputer) endpoint.EndpointParams {
+	return endpoint.EndpointParams{
+		Logger:          logger,
+		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
+		PolicyRepo:      repo,
+		PolicyFetcher:   fetcher,
+		IdentityManager: identitymanager.NewIDManager(logger),
+		IPSecConfig:     fakeipsec.Config{},
+		WgConfig:        fakewireguard.Config{},
+		CTMapGC:         ctmap.NewFakeGCRunner(),
+		Allocator:       testidentity.NewMockIdentityAllocator(nil),
+	}
+}
+
 func (s *DNSProxyTestSuite) LookupRegisteredEndpoint(ip netip.Addr) (*endpoint.Endpoint, bool, error) {
 	if s.restoring {
 		return nil, false, fmt.Errorf("No EPs available when restoring")
 	}
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          s.logger,
-		IdentityManager: identitymanager.NewIDManager(s.logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(s.logger, s.repo, s.fetcher), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	ep.Start(uint16(model.ID))
 	defer ep.Stop()
 	return ep, false, err
@@ -579,7 +588,6 @@ func assertRulesEqual(t *testing.T, da, db restore.DNSRules) {
 }
 
 func TestPrivilegedFullPathDependence(t *testing.T) {
-	logger := hivetest.Logger(t)
 	s := setupDNSProxyTestSuite(t)
 
 	// Test that we consider each of endpoint ID, destination SecID (via the
@@ -905,16 +913,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          hivetest.Logger(t),
-		IdentityManager: identitymanager.NewIDManager(logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep1, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(hivetest.Logger(t), s.repo, s.fetcher), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))
@@ -966,16 +965,7 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 
 	// Restore rules for epID3
 	modelEP3 := newTestEndpointModel(int(epID3), endpoint.StateReady)
-	ep3, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          hivetest.Logger(t),
-		IdentityManager: identitymanager.NewIDManager(logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep3, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(hivetest.Logger(t), s.repo, s.fetcher), nil, &endpoint.FakeEndpointProxy{}, modelEP3, nil)
 	require.NoError(t, err)
 
 	ep3.Start(uint16(modelEP3.ID))
@@ -1121,7 +1111,6 @@ func TestPrivilegedFullPathDependence(t *testing.T) {
 }
 
 func TestPrivilegedRestoredEndpoint(t *testing.T) {
-	logger := hivetest.Logger(t)
 	s := setupDNSProxyTestSuite(t)
 
 	// Respond with an actual answer for the query. This also tests that the
@@ -1187,16 +1176,7 @@ func TestPrivilegedRestoredEndpoint(t *testing.T) {
 	// restore rules, set the mock to restoring state
 	s.restoring = true
 	model := newTestEndpointModel(int(epID1), endpoint.StateReady)
-	ep1, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
-		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
-		Allocator:       testidentity.NewMockIdentityAllocator(nil),
-		CTMapGC:         ctmap.NewFakeGCRunner(),
-		WgConfig:        &fakewireguard.Config{},
-		IPSecConfig:     fakeipsec.Config{},
-		Logger:          hivetest.Logger(t),
-		IdentityManager: identitymanager.NewIDManager(logger),
-		PolicyRepo:      s.repo,
-	}, nil, &endpoint.FakeEndpointProxy{}, model, nil)
+	ep1, err := endpoint.NewEndpointFromChangeModel(makeProxyTestEndpointParams(hivetest.Logger(t), s.repo, s.fetcher), nil, &endpoint.FakeEndpointProxy{}, model, nil)
 	require.NoError(t, err)
 
 	ep1.Start(uint16(model.ID))

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -744,6 +744,11 @@ func (sp *testSelectorPolicy) RedirectFilters() iter.Seq2[*policy.L4Filter, poli
 func (sp *testSelectorPolicy) GetSelectorSnapshot() policy.SelectorSnapshot {
 	return policy.SelectorSnapshot{}
 }
+func (sp *testSelectorPolicy) AddHold() bool       { return true }
+func (sp *testSelectorPolicy) ReleaseHold()        {}
+func (sp *testSelectorPolicy) Detach()             {}
+func (sp *testSelectorPolicy) Supersede()          {}
+func (sp *testSelectorPolicy) GetRevision() uint64 { return 0 }
 
 // createSelectorCache creates a common selector cache setup used by both DNS and non-DNS policies
 func (sp *testSelectorPolicy) createSelectorCache() (policy.CachedSelector, *policy.SelectorCache) {

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/commands"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -115,6 +116,7 @@ type policyUpdaterParams struct {
 
 	Logger           *slog.Logger
 	PolicyRepository policy.PolicyRepository
+	PolicyComputer   compute.PolicyRecomputer
 	EndpointManager  endpointmanager.EndpointManager
 }
 
@@ -122,7 +124,5 @@ func newPolicyUpdater(params policyUpdaterParams) *policy.Updater {
 	// policyUpdater: forces policy recalculation on all endpoints.
 	// Called for various events, such as named port changes
 	// or certain identity updates.
-	policyUpdater := policy.NewUpdater(params.Logger, params.PolicyRepository, params.EndpointManager)
-
-	return policyUpdater
+	return policy.NewUpdater(params.Logger, params.PolicyRepository, params.PolicyComputer, params.EndpointManager)
 }

--- a/pkg/policy/cell/identity_updater.go
+++ b/pkg/policy/cell/identity_updater.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -43,6 +44,7 @@ type identityAllocatorParams struct {
 	Log              *slog.Logger
 	Registry         job.Registry
 	PolicyRepository policy.PolicyRepository
+	PolicyComputer   compute.PolicyRecomputer
 	EPManager        endpointmanager.EndpointManager
 	Health           cell.Health
 	Metrics          *identityUpdaterMetrics
@@ -55,6 +57,7 @@ type identityAllocatorParams struct {
 type identityUpdater struct {
 	logger    *slog.Logger
 	policy    policy.PolicyRepository
+	computer  compute.PolicyRecomputer
 	epmanager endpointmanager.EndpointManager
 
 	identityHandlers []identity.UpdateIdentities
@@ -83,6 +86,7 @@ func newIdentityUpdater(params identityAllocatorParams) IdentityUpdater {
 	i := &identityUpdater{
 		logger:    params.Log,
 		policy:    params.PolicyRepository,
+		computer:  params.PolicyComputer,
 		epmanager: params.EPManager,
 		pending: batch{
 			done: make(chan struct{}),
@@ -230,8 +234,9 @@ func (i *identityUpdater) doUpdatePolicyMaps(ctx context.Context) error {
 	// We mutated a selector, we must regenerate.
 	if q.forcePolicyRegen {
 		i.logger.Info("Incremental policy update mutated identities. Forcing policy recalculation.")
-		i.policy.BumpRevision()
-		i.epmanager.TriggerRegenerateAllEndpoints()
+		rev := i.policy.BumpRevision()
+		i.computer.RecomputeIdentityPolicyForAllIdentities(rev)
+		i.epmanager.RegenerateAllForPolicy(rev)
 	}
 
 	// inform waiters that the in-flight batch is done.

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -48,7 +48,7 @@ type policyImporterParams struct {
 	MonitorAgent    agent.Agent
 }
 
-type policyImporter struct {
+type Importer struct {
 	log          *slog.Logger
 	repo         policy.PolicyRepository
 	epm          epmanager
@@ -78,7 +78,7 @@ type epmanager interface {
 }
 
 func newPolicyImporter(cfg policyImporterParams) PolicyImporter {
-	i := &policyImporter{
+	i := &Importer{
 		log:          cfg.Log,
 		repo:         cfg.Repo,
 		epm:          cfg.EndpointManager,
@@ -100,7 +100,7 @@ func newPolicyImporter(cfg policyImporterParams) PolicyImporter {
 	return i
 }
 
-func (i *policyImporter) UpdatePolicy(u *policytypes.PolicyUpdate) {
+func (i *Importer) UpdatePolicy(u *policytypes.PolicyUpdate) {
 	i.q <- u
 }
 
@@ -117,7 +117,7 @@ func concat(buf []*policytypes.PolicyUpdate, in *policytypes.PolicyUpdate) []*po
 // to be allocated.
 //
 // It returns the set of stale prefixes that should be deallocated after policy updates are complete.
-func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policytypes.PolicyUpdate) (toPrune map[ipcachetypes.ResourceID][]netip.Prefix) {
+func (i *Importer) updatePrefixes(ctx context.Context, updates []*policytypes.PolicyUpdate) (toPrune map[ipcachetypes.ResourceID][]netip.Prefix) {
 	if i.ipc == nil {
 		return
 	}
@@ -203,7 +203,7 @@ func (i *policyImporter) updatePrefixes(ctx context.Context, updates []*policyty
 }
 
 // prunePrefixes removes the CIDR labels from the given set of (resource, prefix) pairs.
-func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID][]netip.Prefix) {
+func (i *Importer) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID][]netip.Prefix) {
 	if i.ipc == nil {
 		return
 	}
@@ -232,7 +232,7 @@ func (i *policyImporter) prunePrefixes(prunePrefixes map[ipcachetypes.ResourceID
 // It also handles prefix allocation in the ipcache when the supplied rules rely on
 // CIDR identities.
 // (Does not actually return error, just to satisfy the Job signature)
-func (i *policyImporter) processUpdates(ctx context.Context, updates []*policytypes.PolicyUpdate) error {
+func (i *Importer) processUpdates(ctx context.Context, updates []*policytypes.PolicyUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/agent"
 	monitorapi "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -43,6 +44,7 @@ type policyImporterParams struct {
 	Config   Config
 
 	Repo            policy.PolicyRepository
+	PolicyComputer  compute.PolicyRecomputer
 	EndpointManager endpointmanager.EndpointManager
 	IPCache         IPCacher
 	MonitorAgent    agent.Agent
@@ -51,6 +53,7 @@ type policyImporterParams struct {
 type Importer struct {
 	log          *slog.Logger
 	repo         policy.PolicyRepository
+	computer     compute.PolicyRecomputer
 	epm          epmanager
 	ipc          IPCacher
 	monitorAgent agent.Agent
@@ -81,6 +84,7 @@ func newPolicyImporter(cfg policyImporterParams) PolicyImporter {
 	i := &Importer{
 		log:          cfg.Log,
 		repo:         cfg.Repo,
+		computer:     cfg.PolicyComputer,
 		epm:          cfg.EndpointManager,
 		ipc:          cfg.IPCache,
 		monitorAgent: cfg.MonitorAgent,
@@ -317,6 +321,7 @@ func (i *Importer) processUpdates(ctx context.Context, updates []*policytypes.Po
 	// Unaffected endpoints can merely have their policy revision set.
 	i.log.Debug("Policy repository updates complete, triggering endpoint updates",
 		logfields.PolicyRevision, endRevision)
+	i.computer.UpdatePolicy(*idsToRegen, startRevision, endRevision)
 	if i.epm != nil {
 		i.epm.UpdatePolicy(idsToRegen, startRevision, endRevision)
 	}

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -5,7 +5,6 @@ package policycell
 
 import (
 	"context"
-	"log/slog"
 	"net/netip"
 	"sync"
 	"testing"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -23,6 +23,7 @@ import (
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	policyutils "github.com/cilium/cilium/pkg/policy/utils"
+	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
@@ -94,11 +95,17 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 		},
 	}
 
+	logger := hivetest.Logger(t)
+	idmgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, ids, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+	polComputer := testcompute.InstantiateCellForTesting(t, logger, "policy-cell", "TestAddReplaceRemoveRule", repo, idmgr)
+
 	pi := &Importer{
-		log:  slog.Default(),
-		repo: policy.NewPolicyRepository(hivetest.Logger(t), ids, nil, nil, nil, testpolicy.NewPolicyMetricsNoop()),
-		epm:  epm,
-		ipc:  ipc,
+		log:      logger,
+		repo:     repo,
+		computer: polComputer,
+		epm:      epm,
+		ipc:      ipc,
 
 		q: make(chan *policytypes.PolicyUpdate, 10),
 

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -94,7 +94,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 		},
 	}
 
-	pi := &policyImporter{
+	pi := &Importer{
 		log:  slog.Default(),
 		repo: policy.NewPolicyRepository(hivetest.Logger(t), ids, nil, nil, nil, testpolicy.NewPolicyMetricsNoop()),
 		epm:  epm,

--- a/pkg/policy/cell/script_cmds.go
+++ b/pkg/policy/cell/script_cmds.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policycell
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/hive/script"
+
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/policy/api"
+	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	policyutils "github.com/cilium/cilium/pkg/policy/utils"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+func PolicyImporterScriptCmds(p *Importer) map[string]script.Cmd {
+	parse := func(s *script.State, args []string, del bool) (api.Rules, ipcachetypes.ResourceID, error) {
+		if len(args) != 1 {
+			return nil, "", fmt.Errorf("expected one arg but got %d, see usage details", len(args))
+		}
+		file := args[0]
+
+		b, err := os.ReadFile(s.Path(file))
+		if err != nil {
+			b, err = os.ReadFile(file)
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read %s: %w", file, err)
+		}
+		robj, err := testutils.DecodeObject(b)
+		if err != nil {
+			return nil, "", fmt.Errorf("decode object: %w", err)
+		}
+
+		var (
+			rules      api.Rules
+			resourceID ipcachetypes.ResourceID
+		)
+		switch policy := robj.(type) {
+		case *v2.CiliumClusterwideNetworkPolicy:
+			rules, err = policy.Parse(p.log, "")
+			if err != nil {
+				return nil, "", fmt.Errorf("ccnp parse: %w", err)
+			}
+			resourceID = ipcachetypes.NewResourceID(
+				ipcachetypes.ResourceKindCCNP,
+				policy.ObjectMeta.Namespace,
+				policy.ObjectMeta.Name,
+			)
+		case *v2.CiliumNetworkPolicy:
+			rules, err = policy.Parse(p.log, "")
+			if err != nil {
+				return nil, "", fmt.Errorf("cnp parse: %w", err)
+			}
+			resourceID = ipcachetypes.NewResourceID(
+				ipcachetypes.ResourceKindCNP,
+				policy.ObjectMeta.Namespace,
+				policy.ObjectMeta.Name,
+			)
+		default:
+			return nil, "", fmt.Errorf("unsupported policy type: %T", robj)
+		}
+
+		if del {
+			return nil, resourceID, nil
+		}
+		return rules, resourceID, nil
+	}
+
+	return map[string]script.Cmd{
+		"policy/import": script.Command(
+			script.CmdUsage{
+				Summary: "Import a policy change",
+				Args:    "'policy'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				rules, resourceID, err := parse(s, []string(args), false)
+				if err != nil {
+					return nil, err
+				}
+				dc := make(chan uint64, 1)
+				p.UpdatePolicy(&policytypes.PolicyUpdate{
+					Rules:    policyutils.RulesToPolicyEntries(rules),
+					Source:   source.CustomResource,
+					Resource: resourceID,
+					DoneChan: dc,
+				})
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					rev := <-dc
+					return fmt.Sprintf("Imported policy change, rev=%d\n", rev), "", nil
+				}, nil
+			},
+		),
+		"policy/remove": script.Command(
+			script.CmdUsage{
+				Summary: "Remove a policy",
+				Args:    "'policy'",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				rules, resourceID, err := parse(s, []string(args), true)
+				if err != nil {
+					return nil, err
+				}
+				dc := make(chan uint64, 1)
+				p.UpdatePolicy(&policytypes.PolicyUpdate{
+					Rules:    policyutils.RulesToPolicyEntries(rules),
+					Source:   source.CustomResource,
+					Resource: resourceID,
+					DoneChan: dc,
+				})
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					rev := <-dc
+					return fmt.Sprintf("Removed policy, rev=%d\n", rev), "", nil
+				}, nil
+			},
+		),
+	}
+}

--- a/pkg/policy/compute/cell.go
+++ b/pkg/policy/compute/cell.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// Cell provides the IdentityPolicyRecomputer as a hive cell.
+var Cell = cell.Module(
+	"identity-policy-computer",
+	"Handles policy computation per identity",
+
+	cell.ProvidePrivate(NewPolicyComputationTable),
+	cell.Provide(
+		func(params Params) PolicyRecomputer {
+			return NewIdentityPolicyComputer(params)
+		},
+		statedb.RWTable[Result].ToTable,
+	),
+)
+
+func NewIdentityPolicyComputer(params Params) *IdentityPolicyComputer {
+	obj := &IdentityPolicyComputer{
+		db:  params.DB,
+		tbl: params.Table,
+
+		repo:      params.Repo,
+		idmanager: params.IDManager,
+
+		logger: params.Logger,
+
+		policyCacheEvents: params.PolicyCacheEvents,
+
+		trigger: make(chan struct{}, 1),
+	}
+
+	params.JobGroup.Add(
+		job.Observer[policy.PolicyCacheChange](
+			"policy-cache-observer",
+			obj.handlePolicyCacheEvent,
+			obj.policyCacheEvents,
+		),
+	)
+	params.JobGroup.Add(
+		job.OneShot("policy-computation-loop", func(ctx context.Context, health cell.Health) error {
+			return obj.processRequests(ctx)
+		}),
+	)
+	return obj
+}
+
+// IdentityPolicyComputer handles policy computation for specific identities.
+type IdentityPolicyComputer struct {
+	logger *slog.Logger
+
+	db  *statedb.DB
+	tbl statedb.RWTable[Result]
+
+	repo      policy.PolicyRepository
+	idmanager identitymanager.IDManager
+
+	policyCacheEvents stream.Observable[policy.PolicyCacheChange]
+
+	reqsMu  lock.Mutex
+	reqs    []computeRequest
+	trigger chan struct{}
+}
+
+type Params struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+	Logger    *slog.Logger
+	JobGroup  job.Group
+
+	DB    *statedb.DB
+	Table statedb.RWTable[Result]
+
+	Repo      policy.PolicyRepository
+	IDManager identitymanager.IDManager
+
+	PolicyCacheEvents stream.Observable[policy.PolicyCacheChange]
+}

--- a/pkg/policy/compute/compute.go
+++ b/pkg/policy/compute/compute.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type PolicyRecomputer interface {
+	RecomputeIdentityPolicy(identity *identity.Identity, toRev uint64) (<-chan struct{}, error)
+	RecomputeIdentityPolicyForAllIdentities(toRev uint64) (*statedb.WatchSet, error)
+	UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], fromRev, toRev uint64)
+	GetIdentityPolicyByNumericIdentity(identity identity.NumericIdentity) (Result, statedb.Revision, <-chan struct{}, bool)
+	GetIdentityPolicyByIdentity(identity *identity.Identity) (Result, statedb.Revision, <-chan struct{}, bool)
+}
+
+type Result struct {
+	Identity             identity.NumericIdentity
+	NewPolicy, OldPolicy policy.SelectorPolicy
+	Revision             uint64
+	NeedsRelease         bool
+	Err                  error
+}
+
+type computeRequest struct {
+	identity *identity.Identity
+	toRev    uint64
+	done     chan struct{}
+}
+
+func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], _, toRev uint64) {
+	// The lock order is IdentityManager.mutex before reqsMu, since the
+	// IdentityManager observer takes reqsMu. Resolve identities, which takes
+	// IdentityManager.mutex, before locking reqsMu.
+	ids := make([]*identity.Identity, 0, idsToRegen.Len())
+	for id := range idsToRegen.Members() {
+		if idd := r.idmanager.Get(&id); idd != nil {
+			ids = append(ids, idd)
+		} else {
+			r.logger.Debug("Policy recomputation skipped due to non-local identity", logfields.Identity, id)
+		}
+	}
+
+	r.reqsMu.Lock()
+	for _, idd := range ids {
+		r.enqueueLocked(idd, toRev)
+	}
+	r.reqsMu.Unlock()
+	r.notifyTrigger()
+}
+
+// enqueueLocked appends or coalesces a request and returns the done channel.
+// Must be called with r.reqsMu held. The caller must notifyTrigger after
+// unlocking.
+func (r *IdentityPolicyComputer) enqueueLocked(identity *identity.Identity, toRev uint64) <-chan struct{} {
+	for i, existing := range r.reqs {
+		if existing.identity.ID != identity.ID {
+			continue
+		}
+		if toRev > existing.toRev {
+			r.reqs[i].toRev = toRev
+		}
+		return r.reqs[i].done
+	}
+	req := computeRequest{
+		identity: identity,
+		toRev:    toRev,
+		done:     make(chan struct{}),
+	}
+	r.reqs = append(r.reqs, req)
+	return req.done
+}
+
+func (r *IdentityPolicyComputer) notifyTrigger() {
+	select {
+	case r.trigger <- struct{}{}:
+	default:
+	}
+}
+
+// RecomputeIdentityPolicy schedules a policy recomputation for identity at
+// toRev. The returned channel closes once the result is committed to the
+// table. A pending request for the same identity is reused, bumping its toRev
+// to max(existing, toRev), so there is at most one in-flight request per
+// identity.
+func (r *IdentityPolicyComputer) RecomputeIdentityPolicy(identity *identity.Identity, toRev uint64) (<-chan struct{}, error) {
+	r.reqsMu.Lock()
+	done := r.enqueueLocked(identity, toRev)
+	r.reqsMu.Unlock()
+	r.notifyTrigger()
+	return done, nil
+}
+
+// RecomputeIdentityPolicyForAllIdentities recomputes policy for all local identities.
+func (r *IdentityPolicyComputer) RecomputeIdentityPolicyForAllIdentities(toRev uint64) (*statedb.WatchSet, error) {
+	ws := statedb.NewWatchSet()
+
+	r.logger.Info("Recomputing policy for all identities")
+	// GetAll takes IdentityManager.mutex. Call it before locking reqsMu (see
+	// UpdatePolicy).
+	ids := r.idmanager.GetAll()
+
+	r.reqsMu.Lock()
+	for _, id := range ids {
+		ws.Add(r.enqueueLocked(id, toRev))
+	}
+	r.reqsMu.Unlock()
+	r.notifyTrigger()
+	return ws, nil
+}
+
+func (r *IdentityPolicyComputer) GetIdentityPolicyByNumericIdentity(identity identity.NumericIdentity) (Result, statedb.Revision, <-chan struct{}, bool) {
+	return r.tbl.GetWatch(r.db.ReadTxn(), PolicyComputationByIdentity(identity))
+}
+
+func (r *IdentityPolicyComputer) GetIdentityPolicyByIdentity(identity *identity.Identity) (Result, statedb.Revision, <-chan struct{}, bool) {
+	if identity == nil {
+		return Result{}, 0, nil, false
+	}
+	return r.GetIdentityPolicyByNumericIdentity(identity.ID)
+}
+
+// processRequests drains computation requests and processes them in batches.
+// Single requests are processed immediately. Bursts are naturally batched.
+func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
+	type pending struct {
+		computeRequest
+		rev statedb.Revision // statedb revision for CompareAndSwap
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Close any queued requests so waiters don't hang.
+			r.reqsMu.Lock()
+			abandoned := r.reqs
+			r.reqs = nil
+			r.reqsMu.Unlock()
+			r.logger.Debug("Draining pending policy computation requests on shutdown", logfields.Count, len(abandoned))
+			for _, req := range abandoned {
+				close(req.done)
+			}
+			return nil
+		case <-r.trigger:
+		}
+
+		r.reqsMu.Lock()
+		batch := r.reqs
+		r.reqs = nil
+		r.reqsMu.Unlock()
+		if len(batch) == 0 {
+			continue
+		}
+
+		r.logger.Debug("Processing policy computation batch", logfields.Count, len(batch))
+
+		// Check which requests actually need computation.
+		rtxn := r.db.ReadTxn()
+		var work []pending
+		for _, req := range batch {
+			obj, rev, found := r.tbl.Get(rtxn, PolicyComputationByIdentity(req.identity.ID))
+			if found && obj.Revision >= req.toRev {
+				close(req.done)
+				continue
+			}
+			work = append(work, pending{req, rev})
+		}
+		if len(work) == 0 {
+			continue
+		}
+
+		type result struct {
+			pending
+			res Result
+		}
+		results := make([]result, len(work))
+		var wg sync.WaitGroup
+		for i, w := range work {
+			wg.Go(func() {
+				start := time.Now()
+				results[i].pending = w
+				results[i].res.Identity = w.identity.ID
+				results[i].res.NewPolicy, results[i].res.Revision, results[i].res.OldPolicy, results[i].res.NeedsRelease, results[i].res.Err = r.repo.ComputeSelectorPolicy(w.identity, w.toRev)
+				outcome := metrics.LabelValueOutcomeSuccess
+				if results[i].res.Err != nil {
+					outcome = metrics.LabelValueOutcomeFailure
+				}
+				metrics.EndpointRegenerationTimeStats.
+					WithLabelValues("selectorPolicyCalculation", outcome).
+					Observe(time.Since(start).Seconds())
+			})
+		}
+		wg.Wait()
+
+		// Commit in a single WriteTxn.
+		wtxn := r.db.WriteTxn(r.tbl)
+		var retry []computeRequest
+		for i := range results {
+			if results[i].res.Err != nil {
+				// Cancel the retry because the identity no longer exists.
+				if errors.Is(results[i].res.Err, policy.ErrSelectorPolicyNotCached) {
+					r.logger.Debug("Skipping policy computation for removed identity",
+						logfields.Identity, results[i].res.Identity,
+					)
+					results[i].res = Result{}
+					continue
+				}
+				// This error will result in the relevant endpoints failing
+				// to regenerate.
+				r.logger.Error("Policy computation failed for identity",
+					logfields.Identity, results[i].res.Identity,
+					logfields.Error, results[i].res.Err,
+				)
+				// Re-enqueue so a transient failure (e.g. cert fetch)
+				// doesn't leave statedb without an entry forever.
+				//
+				// Retry is unbounded with no backoff. This matches the
+				// pre-cell behavior where endpoint regeneration retried
+				// the policy computation inline. Dropping a computation
+				// would leave endpoints on a stale policy, so we always
+				// retry.
+				retry = append(retry, computeRequest{
+					identity: results[i].identity,
+					toRev:    results[i].toRev,
+					done:     make(chan struct{}),
+				})
+				results[i].res = Result{}
+				continue
+			}
+			// CAS failure means a delete for this identity raced us. If
+			// the delete ran getPolicy() before our setPolicy() published
+			// NewPolicy, NewPolicy remains attached to the SelectorCache.
+			// Detach both NewPolicy and OldPolicy here, since the success
+			// path's OldPolicy detach loop below skips zeroed results.
+			if _, _, err := r.tbl.CompareAndSwap(wtxn, results[i].rev, results[i].res); err != nil {
+				if results[i].res.NeedsRelease {
+					if results[i].res.NewPolicy != nil {
+						results[i].res.NewPolicy.Supersede()
+					}
+					if results[i].res.OldPolicy != nil {
+						results[i].res.OldPolicy.Supersede()
+					}
+				}
+				results[i].res = Result{}
+			}
+		}
+		wtxn.Commit()
+
+		if len(retry) > 0 {
+			r.reqsMu.Lock()
+			r.reqs = append(r.reqs, retry...)
+			r.reqsMu.Unlock()
+			select {
+			case r.trigger <- struct{}{}:
+			default:
+			}
+		}
+
+		for _, cr := range results {
+			close(cr.done)
+			if cr.res.Identity == 0 {
+				continue // CAS failed
+			}
+			r.logger.Debug("Policy recomputation completed",
+				logfields.Identity, cr.res.Identity,
+				logfields.PolicyRevision, cr.toRev,
+			)
+			if cr.res.OldPolicy != nil && cr.res.NeedsRelease {
+				cr.res.OldPolicy.Supersede()
+			}
+		}
+	}
+}
+
+func (r *IdentityPolicyComputer) handlePolicyCacheEvent(ctx context.Context, event policy.PolicyCacheChange) error {
+	r.logger.Debug("Handle policy cache event", logfields.Identity, event.ID)
+
+	// The identity may already be gone from the manager by now, so clean up
+	// statedb on delete.
+	if event.Kind == policy.PolicyChangeDelete {
+		// Drop pending requests for this identity and close their done
+		// channels. No Result is committed. Endpoint regen retries on
+		// not-found.
+		r.reqsMu.Lock()
+		kept := r.reqs[:0]
+		for _, req := range r.reqs {
+			if req.identity.ID == event.ID {
+				close(req.done)
+				continue
+			}
+			kept = append(kept, req)
+		}
+		r.reqs = kept
+		r.reqsMu.Unlock()
+
+		wtxn := r.db.WriteTxn(r.tbl)
+		obj, _, found := r.tbl.Get(wtxn, PolicyComputationByIdentity(event.ID))
+		if !found {
+			wtxn.Abort()
+			return nil
+		}
+		_, _, err := r.tbl.Delete(wtxn, obj)
+		if err != nil {
+			wtxn.Abort()
+			return fmt.Errorf("failed to delete from statedb policy computation table: %w", err)
+		}
+		wtxn.Commit()
+		return nil
+	}
+
+	if event.Identity == nil {
+		return nil
+	}
+
+	if event.Kind == policy.PolicyChangeInsert {
+		_, err := r.RecomputeIdentityPolicy(event.Identity, 0)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/policy/compute/compute_test.go
+++ b/pkg/policy/compute/compute_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/testutils"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+)
+
+func TestRecomputeIdentityPolicy(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	t.Run("creates entry and fires waiting watch", func(t *testing.T) {
+		_, _, computer, idmgr := fixture(t)
+
+		targetID := identity.NumericIdentity(7)
+		id := identity.NewIdentity(targetID, labels.Labels{})
+		idmgr.Add(id)
+
+		_, _, watch, found := computer.GetIdentityPolicyByIdentity(id)
+		require.False(t, found)
+		require.NotNil(t, watch)
+
+		done, err := computer.RecomputeIdentityPolicy(id, 1)
+		require.NoError(t, err)
+		<-done
+
+		select {
+		case <-watch:
+		case <-time.After(time.Second):
+			t.Fatal("watch channel not closed after key creation")
+		}
+
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(id)
+		require.True(t, found)
+		assert.Equal(t, targetID, obj.Identity)
+	})
+
+	t.Run("update fires watch", func(t *testing.T) {
+		db, table, computer, idmgr := fixture(t)
+
+		targetID := identity.NumericIdentity(10)
+		id := identity.NewIdentity(targetID, labels.Labels{})
+		idmgr.Add(id)
+
+		done, err := computer.RecomputeIdentityPolicy(id, 1)
+		require.NoError(t, err)
+		<-done
+
+		obj, _, watch, found := computer.GetIdentityPolicyByNumericIdentity(targetID)
+		require.True(t, found)
+		require.NotNil(t, watch)
+
+		select {
+		case <-watch:
+			t.Fatal("watch channel closed before any update")
+		default:
+		}
+
+		wtxn := db.WriteTxn(table)
+		_, _, err = table.Insert(wtxn, Result{Identity: targetID, Revision: obj.Revision + 1})
+		require.NoError(t, err)
+		wtxn.Commit()
+
+		select {
+		case <-watch:
+		case <-time.After(time.Second):
+			t.Fatal("watch channel not closed after revision update")
+		}
+
+		newObj, _, _, found := computer.GetIdentityPolicyByNumericIdentity(targetID)
+		require.True(t, found)
+		assert.Equal(t, obj.Revision+1, newObj.Revision)
+	})
+
+	t.Run("watch loop converges to target revision", func(t *testing.T) {
+		db, table, computer, idmgr := fixture(t)
+
+		targetID := identity.NumericIdentity(20)
+		id := identity.NewIdentity(targetID, labels.Labels{})
+		idmgr.Add(id)
+
+		done, err := computer.RecomputeIdentityPolicy(id, 1)
+		require.NoError(t, err)
+		<-done
+
+		const wantedRevision = uint64(3)
+
+		// Write unrelated entries.
+		go func() {
+			for i := identity.NumericIdentity(100); i < 110; i++ {
+				wtxn := db.WriteTxn(table)
+				table.Insert(wtxn, Result{Identity: i, Revision: 1})
+				wtxn.Commit()
+			}
+			for _, rev := range []uint64{2, 3} {
+				wtxn := db.WriteTxn(table)
+				_, _, err := table.Insert(wtxn, Result{Identity: targetID, Revision: rev})
+				require.NoError(t, err)
+				wtxn.Commit()
+			}
+		}()
+
+		// Loop until the watch returns the target we want.
+		deadline := time.After(2 * time.Second)
+		for {
+			obj, _, watch, found := computer.GetIdentityPolicyByNumericIdentity(targetID)
+			if found && obj.Revision >= wantedRevision {
+				assert.Equal(t, targetID, obj.Identity)
+				return
+			}
+			if found {
+				require.Equal(t, targetID, obj.Identity)
+			}
+			select {
+			case <-watch:
+			case <-deadline:
+				t.Fatal("did not converge to wantedRevision in time")
+			}
+		}
+	})
+}
+
+func fixture(t *testing.T) (*statedb.DB, statedb.RWTable[Result], PolicyRecomputer, identitymanager.IDManager) {
+	t.Helper()
+
+	logger := hivetest.Logger(t)
+	idmgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(logger, nil, nil, nil, idmgr, testpolicy.NewPolicyMetricsNoop())
+
+	var (
+		db       *statedb.DB
+		table    statedb.RWTable[Result]
+		computer PolicyRecomputer
+	)
+
+	h := hive.New(
+		cell.Module("test", "test",
+			cell.Invoke(
+				func(t statedb.RWTable[Result], db_ *statedb.DB, c_ PolicyRecomputer) error {
+					table = t
+					db = db_
+					computer = c_
+					return nil
+				},
+			),
+
+			cell.ProvidePrivate(func() (policy.PolicyRepository, stream.Observable[policy.PolicyCacheChange]) {
+				return repo, repo.PolicyCacheObservable()
+			}),
+			cell.ProvidePrivate(func() identitymanager.IDManager { return idmgr }),
+
+			cell.Provide(
+				func(params Params) PolicyRecomputer {
+					return NewIdentityPolicyComputer(params)
+				},
+			),
+			cell.ProvidePrivate(NewPolicyComputationTable),
+		),
+	)
+
+	if err := h.Start(logger, context.Background()); err != nil {
+		t.Fatalf("failed to start hive: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(logger, context.Background()); err != nil {
+			t.Fatalf("failed to stop hive: %v", err)
+		}
+	})
+
+	assert.NotNil(t, db)
+	assert.NotNil(t, table)
+	assert.NotNil(t, computer)
+
+	return db, table, computer, idmgr
+}

--- a/pkg/policy/compute/script_cmds.go
+++ b/pkg/policy/compute/script_cmds.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"github.com/cilium/hive/script"
+)
+
+func PolicyComputerScriptCmds(pc *IdentityPolicyComputer) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"policy/compute-all": script.Command(
+			script.CmdUsage{
+				Summary: "Recompute policy for all identities",
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				// TODO: Maybe add a flag to control whether to bump the revision or not.
+				ws, err := pc.RecomputeIdentityPolicyForAllIdentities(pc.repo.GetRevision())
+				if err != nil {
+					return nil, err
+				}
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					_, err = ws.Wait(s.Context(), 0)
+					return "", "", err
+				}, nil
+			},
+		),
+	}
+}

--- a/pkg/policy/compute/table.go
+++ b/pkg/policy/compute/table.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package compute
+
+import (
+	"strconv"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+func NewPolicyComputationTable(db *statedb.DB) (statedb.RWTable[Result], statedb.Index[Result, identity.NumericIdentity], error) {
+	tbl, err := statedb.NewTable(
+		db,
+		"policy-computations",
+		PolicyComputationNameIndex,
+	)
+	return tbl, PolicyComputationNameIndex, err
+}
+
+var (
+	PolicyComputationNameIndex = statedb.Index[Result, identity.NumericIdentity]{
+		Name: "numeric-identity",
+		FromObject: func(r Result) index.KeySet {
+			return index.NewKeySet(index.Uint32(uint32(r.Identity)))
+		},
+		FromKey:    func(i identity.NumericIdentity) index.Key { return index.Uint32(uint32(i)) },
+		FromString: index.Uint32String,
+		Unique:     true,
+	}
+
+	PolicyComputationByIdentity = PolicyComputationNameIndex.Query
+)
+
+func (Result) TableHeader() []string {
+	return []string{"Identity", "NewPolicy", "OldPolicy", "Revision", "NeedsRelease", "Err"}
+}
+
+func (r Result) TableRow() []string {
+	var serr string
+	if r.Err != nil {
+		serr = r.Err.Error()
+	}
+	var newRev uint64
+	if r.NewPolicy != nil {
+		newRev = r.NewPolicy.GetRevision()
+	}
+	var oldRev uint64
+	if r.OldPolicy != nil {
+		oldRev = r.OldPolicy.GetRevision()
+	}
+	return []string{
+		r.Identity.String(),
+		strconv.FormatUint(newRev, 10),
+		strconv.FormatUint(oldRev, 10),
+		strconv.FormatUint(r.Revision, 10),
+		strconv.FormatBool(r.NeedsRelease),
+		serr,
+	}
+}

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -15,6 +16,10 @@ import (
 
 	"github.com/cilium/stream"
 )
+
+// ErrSelectorPolicyNotCached cancels the policy computation retry because the
+// identity no longer exists.
+var ErrSelectorPolicyNotCached = errors.New("SelectorPolicy not found in cache")
 
 // policyCache represents a cache of resolved policies for identities.
 type policyCache struct {
@@ -142,7 +147,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 func (cache *policyCache) updateSelectorPolicy(identity *identityPkg.Identity, endpointID uint64) (*selectorPolicy, *selectorPolicy, bool, error) {
 	cip, ok := cache.lookup(identity)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("SelectorPolicy not found in cache for ID %d", identity.ID)
+		return nil, nil, false, fmt.Errorf("%w for ID %d", ErrSelectorPolicyNotCached, identity.ID)
 	}
 
 	// As long as UpdatePolicy() is triggered from endpoint

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -118,7 +118,7 @@ func (cache *policyCache) delete(identity *identityPkg.Identity) bool {
 		delete(cache.policies, identity.ID)
 		selPolicy := cip.getPolicy()
 		if selPolicy != nil {
-			selPolicy.detach(true, 0)
+			selPolicy.Detach()
 		}
 	}
 	cache.emitChange(PolicyCacheChange{Kind: PolicyChangeDelete, ID: identity.ID})

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -292,15 +292,8 @@ func (cip *cachedSelectorPolicy) getPolicy() *selectorPolicy {
 }
 
 // setPolicy updates the reference to the SelectorPolicy that is cached.
-// Calls Detach() on the old policy, if any. It passes the endpointID of
-// the endpoint that initiated the old selector policy detach. Since detach
-// can trigger endpoint regenerations of all it users, this ensures
-// that endpoints do not continuously update themselves.
+// Callers are responsible for detaching the old policy as appropriate.
 func (cip *cachedSelectorPolicy) setPolicy(policy *selectorPolicy, endpointID uint64) *selectorPolicy {
 	oldPolicy := cip.policy.Swap(policy)
-	if oldPolicy != nil {
-		// Release the references the previous policy holds on the selector cache.
-		oldPolicy.detach(false, endpointID)
-	}
 	return oldPolicy
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -1597,6 +1597,13 @@ type L4Policy struct {
 	mutex lock.RWMutex
 	users map[*EndpointPolicy]struct{}
 
+	// holdCount prevents detachment between policy fetch and insertUser registration.
+	holdCount int
+
+	// superseded is set when this policy has been replaced by a newer one.
+	// Prevents premature detachment of policies still current in statedb.
+	superseded bool
+
 	// detachedTime can be used for users that don't need to grab the lock.
 	detachedTime atomic.Pointer[time.Time]
 }
@@ -1611,11 +1618,61 @@ func NewL4Policy(revision uint64) L4Policy {
 	}
 }
 
+// addHold prevents detachment between policy fetch and insertUser.
+// Returns false if the policy is already superseded or detached.
+func (l4 *L4Policy) addHold() bool {
+	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
+	if l4.users == nil || l4.superseded {
+		return false
+	}
+	l4.holdCount++
+	return true
+}
+
+// releaseHold decrements the hold count, detaching the policy if no users
+// or holds remain. Used on error paths when insertUser will not be called.
+func (l4 *L4Policy) releaseHold(selectorCache *SelectorCache) {
+	l4.mutex.Lock()
+	if l4.holdCount > 0 {
+		l4.holdCount--
+	}
+	needsDetach := l4.shouldDetachLocked()
+	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
+}
+
+// shouldDetachLocked marks the policy as detached (users=nil) if no users,
+// holds, or active references remain and the policy is superseded. Without the
+// superseded check, removeUser could detach a policy still current in statedb,
+// creating a stale entry that traps endpoints in a regen loop.
+// Returns true if the caller must call finishDetach after releasing l4.mutex.
+// Must be called with l4.mutex held.
+func (l4 *L4Policy) shouldDetachLocked() bool {
+	if l4.holdCount == 0 && l4.users != nil && len(l4.users) == 0 && l4.superseded {
+		l4.users = nil
+		l4.detachedTime.Store(ptr.To(time.Now()))
+		return true
+	}
+	return false
+}
+
+// finishDetach removes cached selectors from the SelectorCache.
+// Must be called WITHOUT l4.mutex held (takes sc.mutex internally).
+func (l4 *L4Policy) finishDetach(selectorCache *SelectorCache) {
+	l4.Ingress.Detach(selectorCache)
+	l4.Egress.Detach(selectorCache)
+}
+
 // insertUser adds a user to the L4Policy so that incremental
 // updates of the L4Policy may be forwarded to the users of it.
 // May not call into SelectorCache, as SelectorCache is locked during this call.
 func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 	l4.mutex.Lock()
+	defer l4.mutex.Unlock()
 
 	// 'users' is set to nil when the policy is detached. This
 	// happens to the old policy when it is being replaced with a
@@ -1637,22 +1694,22 @@ func (l4 *L4Policy) insertUser(user *EndpointPolicy) {
 			RegenerationLevel: regeneration.RegenerateWithoutDatapath,
 		})
 	}
-
-	l4.mutex.Unlock()
 }
 
 // removeUser removes a user that no longer needs incremental updates
-// from the L4Policy.
-func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
-	// 'users' is set to nil when the policy is detached. This
-	// happens to the old policy when it is being replaced with a
-	// new one, or when the last endpoint using this policy is
-	// removed.
+// from the L4Policy. It detaches the policy if this was the last user
+// and there are no outstanding holds.
+func (l4 *L4Policy) removeUser(user *EndpointPolicy, selectorCache *SelectorCache) {
 	l4.mutex.Lock()
 	if l4.users != nil {
 		delete(l4.users, user)
 	}
+	needsDetach := l4.shouldDetachLocked()
 	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
 }
 
 // AccumulateMapChanges distributes the given changes to the registered users.
@@ -1839,33 +1896,40 @@ func (l4Policy *L4Policy) SyncMapChanges(l4 *L4Filter, txn SelectorSnapshot) {
 }
 
 // detach makes the L4Policy ready for garbage collection, removing
-// circular pointer references.
-// The endpointID argument is only necessary if isDelete is false.
-// It ensures that detach does not call a regeneration trigger on
-// the same endpoint that initiated a selector policy update.
+// circular pointer references. Used when the policy is being deleted.
 // Note that the L4Policy itself is not modified in any way, so that it may still
 // be used concurrently.
-func (l4 *L4Policy) detach(selectorCache *SelectorCache, isDelete bool, endpointID uint64) {
+func (l4 *L4Policy) detach(selectorCache *SelectorCache) {
 	l4.Ingress.Detach(selectorCache)
 	l4.Egress.Detach(selectorCache)
-
 	l4.mutex.Lock()
 	defer l4.mutex.Unlock()
-	// If this detach is a delete there is no reason to initiate
-	// a regenerate.
-	if !isDelete {
-		for ePolicy := range l4.users {
-			if endpointID != ePolicy.PolicyOwner.GetID() {
-				go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
-					Reason:            regeneration.ReasonSelectorPolicyStale,
-					Message:           "selector policy has changed because of another endpoint with the same identity",
-					RegenerationLevel: regeneration.RegenerateWithoutDatapath,
-				})
-			}
-		}
-	}
 	l4.users = nil
 	l4.detachedTime.Store(ptr.To(time.Now()))
+}
+
+// supersede marks the L4Policy as superseded by a newer one and triggers
+// regeneration on existing users so they migrate. The endpoint identified by
+// endpointID is not regenerated, since it initiated the selector policy update.
+// supersede is the only place that sets l4.superseded.
+func (l4 *L4Policy) supersede(selectorCache *SelectorCache, endpointID uint64) {
+	l4.mutex.Lock()
+	for ePolicy := range l4.users {
+		if endpointID != ePolicy.PolicyOwner.GetID() {
+			go ePolicy.PolicyOwner.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+				Reason:            regeneration.ReasonSelectorPolicyStale,
+				Message:           "selector policy has changed because of another endpoint with the same identity",
+				RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+			})
+		}
+	}
+	l4.superseded = true
+	needsDetach := l4.shouldDetachLocked()
+	l4.mutex.Unlock()
+
+	if needsDetach {
+		l4.finishDetach(selectorCache)
+	}
 }
 
 // Attach makes all the L4Filters to point back to the L4Policy that contains them.

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -339,7 +339,7 @@ func (td *testData) policyMapEqualsPolicyEntries(t *testing.T, expectedIn, expec
 
 	selPolicy, err := td.repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer selPolicy.detach(true, 0)
+	defer selPolicy.Detach()
 
 	// Distill Selector policy to Endpoint Policy
 	epPolicy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, nil)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/testutils"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 	pkgTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -775,4 +777,79 @@ func BenchmarkEvaluateL4PolicyMapState(b *testing.B) {
 			}
 		}
 	})
+}
+
+// A hold taken by one endpoint must keep a shared selectorPolicy attached until
+// it is released, even after all current users have been removed.
+func TestHoldPreventsDetach(t *testing.T) {
+	logger := hivetest.Logger(t)
+	repo := NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo.revision.Store(1)
+	cache := repo.policyCache
+
+	ep := testutils.NewTestEndpoint(t)
+	id := ep.GetSecurityIdentity()
+	cache.insert(id)
+
+	sp, _, _, err := cache.updateSelectorPolicy(id, ep.Id)
+	require.NoError(t, err)
+	require.Equal(t, 0, sp.L4Policy.holdCount)
+
+	a := DummyOwner{logger: logger, previousMap: &mapState{}}
+	b := DummyOwner{logger: logger, previousMap: &mapState{}}
+
+	// DistillPolicy registers a user but leaves the hold for the caller.
+	require.True(t, sp.AddHold())
+	epA := sp.DistillPolicy(logger, a, nil)
+	require.Equal(t, 1, sp.L4Policy.holdCount)
+	require.Len(t, sp.L4Policy.users, 1)
+	sp.ReleaseHold()
+	require.Equal(t, 0, sp.L4Policy.holdCount)
+
+	// With A's user removed but B holding, the policy stays attached with no users.
+	require.True(t, sp.AddHold())
+	sp.removeUser(epA)
+	require.NotNil(t, sp.L4Policy.users)
+	require.Empty(t, sp.L4Policy.users)
+
+	epB := sp.DistillPolicy(logger, b, nil)
+	require.NotSame(t, epA, epB)
+	require.Len(t, sp.L4Policy.users, 1)
+	sp.ReleaseHold()
+	require.Equal(t, 0, sp.L4Policy.holdCount)
+}
+
+// AddHold must fail on a superseded policy so a stale endpoint doesn't attach to
+// a policy that is being replaced.
+func TestAddHoldRejectsDetached(t *testing.T) {
+	logger := hivetest.Logger(t)
+	repo := NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	repo.revision.Store(1)
+	cache := repo.policyCache
+
+	ep := testutils.NewTestEndpoint(t)
+	id := ep.GetSecurityIdentity()
+	cache.insert(id)
+
+	repo.mutex.RLock()
+	old, _, _, err := cache.updateSelectorPolicy(id, 0)
+	repo.mutex.RUnlock()
+	require.NoError(t, err)
+
+	repo.BumpRevision()
+	repo.mutex.RLock()
+	cur, prev, _, err := cache.updateSelectorPolicy(id, 0)
+	repo.mutex.RUnlock()
+	require.NoError(t, err)
+	require.Same(t, old, prev)
+	require.NotSame(t, old, cur)
+
+	old.Supersede()
+	require.Nil(t, old.L4Policy.users)
+	require.False(t, old.AddHold())
+
+	// The replacement is still usable.
+	require.True(t, cur.AddHold())
+	require.NotNil(t, cur.DistillPolicy(logger, DummyOwner{logger: logger}, nil))
+	require.Len(t, cur.L4Policy.users, 1)
 }

--- a/pkg/policy/lookup.go
+++ b/pkg/policy/lookup.go
@@ -151,13 +151,8 @@ func (ei *endpointInfo) RegenerateIfAlive(*regeneration.ExternalRegenerationMeta
 
 type dummyPolicyStats struct {
 	waitingForPolicyRepository spanstat.SpanStat
-	policyCalculation          spanstat.SpanStat
 }
 
 func (s *dummyPolicyStats) WaitingForPolicyRepository() *spanstat.SpanStat {
 	return &s.waitingForPolicyRepository
-}
-
-func (s *dummyPolicyStats) SelectorPolicyCalculation() *spanstat.SpanStat {
-	return &s.policyCalculation
 }

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -2531,7 +2531,7 @@ func TestDenyPreferredInsertLogic(t *testing.T) {
 	epPolicy.Ready()
 
 	n := epPolicy.policyMapState.Len()
-	p.detach(true, 0)
+	p.Detach()
 	assert.Positive(t, n)
 }
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -75,7 +75,6 @@ type PolicyRepository interface {
 
 type GetPolicyStatistics interface {
 	WaitingForPolicyRepository() *spanstat.SpanStat
-	SelectorPolicyCalculation() *spanstat.SpanStat
 }
 
 // Repository is a list of policy rules which in combination form the security
@@ -579,15 +578,11 @@ func (r *Repository) GetSelectorPolicy(id *identity.Identity, skipRevision uint6
 		return nil, rev, nil
 	}
 
-	stats.SelectorPolicyCalculation().Start()
 	// This may call back in to the (locked) repository to generate the
 	// selector policy
-	sp, _, updated, err := r.policyCache.updateSelectorPolicy(id, endpointID)
-	stats.SelectorPolicyCalculation().EndError(err)
-
-	// If we hit cache, reset the statistics.
-	if !updated {
-		stats.SelectorPolicyCalculation().Reset()
+	sp, old, _, err := r.policyCache.updateSelectorPolicy(id, endpointID)
+	if old != nil {
+		old.Supersede()
 	}
 
 	return sp, rev, err

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -346,21 +346,7 @@ func (p *selectorPolicy) Detach() {
 	if p == nil {
 		return
 	}
-	p.detach(true, 0)
-}
-
-// detach releases resources held by a selectorPolicy to enable
-// successful eventual GC.  Note that the selectorPolicy itself if not
-// modified in any way, so that it can be used concurrently.
-// The endpointID argument is only necessary if isDelete is false.
-// It ensures that detach does not call a regeneration trigger on
-// the same endpoint that initiated a selector policy update.
-func (p *selectorPolicy) detach(isDelete bool, endpointID uint64) {
-	if isDelete {
-		p.L4Policy.detach(p.SelectorCache)
-	} else {
-		p.L4Policy.supersede(p.SelectorCache, endpointID)
-	}
+	p.L4Policy.detach(p.SelectorCache)
 }
 
 // DistillPolicy filters down the specified selectorPolicy (which acts

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -167,6 +167,12 @@ type SelectorPolicy interface {
 
 	// GetEgressNamedPorts iterates named ports for the given identities
 	GetEgressNamedPorts(name string, proto u8proto.U8proto, idents iter.Seq[identity.NumericIdentity]) pkgTypes.NidPortSeq
+
+	AddHold() bool
+	ReleaseHold()
+	Detach()
+	Supersede()
+	GetRevision() uint64
 }
 
 type NamedPortsGetter interface {
@@ -303,6 +309,27 @@ func newSelectorPolicy(selectorCache *SelectorCache) *selectorPolicy {
 	}
 }
 
+func (p *selectorPolicy) AddHold() bool {
+	if p == nil {
+		return false
+	}
+	return p.L4Policy.addHold()
+}
+
+func (p *selectorPolicy) ReleaseHold() {
+	if p == nil {
+		return
+	}
+	p.L4Policy.releaseHold(p.SelectorCache)
+}
+
+func (p *selectorPolicy) Supersede() {
+	if p == nil {
+		return
+	}
+	p.L4Policy.supersede(p.SelectorCache, 0)
+}
+
 // insertUser adds a user to the L4Policy so that incremental
 // updates of the L4Policy may be fowarded.
 func (p *selectorPolicy) insertUser(user *EndpointPolicy) {
@@ -312,7 +339,14 @@ func (p *selectorPolicy) insertUser(user *EndpointPolicy) {
 // removeUser removes a user from the L4Policy so the EndpointPolicy
 // can be freed when not needed any more
 func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
-	p.L4Policy.removeUser(user)
+	p.L4Policy.removeUser(user, p.SelectorCache)
+}
+
+func (p *selectorPolicy) Detach() {
+	if p == nil {
+		return
+	}
+	p.detach(true, 0)
 }
 
 // detach releases resources held by a selectorPolicy to enable
@@ -322,7 +356,11 @@ func (p *selectorPolicy) removeUser(user *EndpointPolicy) {
 // It ensures that detach does not call a regeneration trigger on
 // the same endpoint that initiated a selector policy update.
 func (p *selectorPolicy) detach(isDelete bool, endpointID uint64) {
-	p.L4Policy.detach(p.SelectorCache, isDelete, endpointID)
+	if isDelete {
+		p.L4Policy.detach(p.SelectorCache)
+	} else {
+		p.L4Policy.supersede(p.SelectorCache, endpointID)
+	}
 }
 
 // DistillPolicy filters down the specified selectorPolicy (which acts
@@ -573,6 +611,13 @@ func (p *selectorPolicy) RedirectFilters() iter.Seq2[*L4Filter, PerSelectorPolic
 			p.L4Policy.Egress.forEachRedirectFilter(yield)
 		}
 	}
+}
+
+func (p *selectorPolicy) GetRevision() uint64 {
+	if p == nil {
+		return 0
+	}
+	return p.Revision
 }
 
 func (l4policy L4DirectionPolicy) forEachRedirectFilter(yield func(*L4Filter, PerSelectorPolicyTuple) bool) bool {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -195,7 +195,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		owner.previousMap = epPolicy.GetMapState()
 		epPolicy.Ready()
 	}
-	ip.detach(true, 0)
+	ip.Detach()
 	assert.Equal(b, 117515, owner.previousMap.Len())
 }
 
@@ -210,7 +210,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	epPolicy := ip.DistillPolicy(logger, owner, nil)
 	owner.previousMap = epPolicy.GetMapState()
 	epPolicy.Ready()
-	ip.detach(true, 0)
+	ip.Detach()
 	assert.Equal(t, 117515, owner.previousMap.Len())
 }
 
@@ -613,7 +613,7 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
-	policy.SelectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.Detach()
 	cachedSelectorTest = td.sc.findCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.Nil(t, cachedSelectorTest)
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -237,7 +237,7 @@ func BenchmarkResolveCIDRPolicyRules(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		ip.detach(true, 0)
+		ip.Detach()
 	}
 }
 
@@ -248,7 +248,7 @@ func BenchmarkResolveNoMatchingRules(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		ip.detach(true, 0)
+		ip.Detach()
 	}
 }
 
@@ -264,7 +264,7 @@ func BenchmarkRegenerateCIDRPolicyRules(b *testing.B) {
 		owner.previousMap = epPolicy.GetMapState()
 		epPolicy.Ready()
 	}
-	ip.detach(true, 0)
+	ip.Detach()
 	assert.Equal(b, 44596, owner.previousMap.Len())
 }
 
@@ -275,7 +275,7 @@ func BenchmarkResolveL3IngressPolicyRules(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
-		ip.detach(true, 0)
+		ip.Detach()
 	}
 }
 
@@ -287,7 +287,7 @@ func BenchmarkRegenerateL3IngressPolicyRules(b *testing.B) {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(hivetest.Logger(b), DummyOwner{logger: hivetest.Logger(b)}, nil)
 		policy.Ready()
-		ip.detach(true, 0)
+		ip.Detach()
 	}
 }
 
@@ -299,7 +299,7 @@ func BenchmarkRegenerateL3EgressPolicyRules(b *testing.B) {
 		ip, _ := td.repo.resolvePolicyLocked(fooIdentity)
 		policy := ip.DistillPolicy(hivetest.Logger(b), DummyOwner{logger: hivetest.Logger(b)}, nil)
 		policy.Ready()
-		ip.detach(true, 0)
+		ip.Detach()
 	}
 }
 
@@ -933,7 +933,7 @@ func TestMapStateWithIngress(t *testing.T) {
 
 	// Verify that cached selector is not found after Detach().
 	// Note that this depends on the other tests NOT using the same selector concurrently!
-	policy.SelectorPolicy.detach(true, 0)
+	policy.SelectorPolicy.Detach()
 	cachedSelectorTest = td.sc.findCachedIdentitySelector(api.NewESFromLabels(lblTest))
 	require.Nil(t, cachedSelectorTest)
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1651,7 +1651,7 @@ func TestIngressL4AllowAll(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idC)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.Detach()
 
 	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)
 	require.NotNil(t, filter)
@@ -1683,7 +1683,7 @@ func TestIngressL4AllowAllNamedPort(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idC)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.Detach()
 
 	require.Len(t, pol.L4Policy.Ingress.PortRules, 1)
 	filter := pol.L4Policy.Ingress.PortRules[0].ExactLookupPortName("port-80", u8proto.TCP)
@@ -1742,7 +1742,7 @@ func TestEgressL4AllowAll(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.Detach()
 
 	t.Log(pol.L4Policy.Egress.PortRules)
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
@@ -1780,7 +1780,7 @@ func TestEgressL4AllowWorld(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.Detach()
 
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
 	filter := pol.L4Policy.Egress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)
@@ -1816,7 +1816,7 @@ func TestEgressL4AllowAllEntity(t *testing.T) {
 
 	pol, err := repo.resolvePolicyLocked(idA)
 	require.NoError(t, err)
-	defer pol.detach(true, 0)
+	defer pol.Detach()
 
 	require.Len(t, pol.L4Policy.Egress.PortRules, 1)
 	filter := pol.L4Policy.Egress.PortRules[0].ExactLookupPortNum(80, 0, u8proto.TCP)

--- a/pkg/policy/test/bench_helpers_test.go
+++ b/pkg/policy/test/bench_helpers_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const benchAppLabel = "bench-app"
+
+// benchIdentityLabels returns the label set used for identity i.
+func benchIdentityLabels(i int) labels.LabelArray {
+	return labels.LabelArray{
+		labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceK8s),
+		labels.NewLabel(benchAppLabel, fmt.Sprintf("id-%d", i), labels.LabelSourceK8s),
+	}
+}
+
+// seedEndpoints allocates numIdentities identities and creates numEPs
+// endpoints, assigning identities round-robin.
+func seedEndpoints(tb testing.TB, ctx context.Context, f *testFixture, numEPs, numIdentities int) []*endpoint.Endpoint {
+	tb.Helper()
+	require.Positive(tb, numIdentities)
+	require.Positive(tb, numEPs)
+
+	ids := make([]*identity.Identity, numIdentities)
+	for i := range numIdentities {
+		id, _, err := f.allocator.AllocateIdentity(ctx, benchIdentityLabels(i).Labels(), true, identity.NumericIdentity(0))
+		require.NoError(tb, err)
+		ids[i] = id
+	}
+
+	eps := make([]*endpoint.Endpoint, numEPs)
+	for i := range numEPs {
+		ep := f.templateEP.CopyFromTemplate()
+		require.NoError(tb, f.epm.AddEndpoint(ep))
+		id := ids[i%numIdentities]
+		_ = ep.UpdateLabels(ctx, labels.LabelSourceAny, id.Labels, nil, true)
+		eps[i] = ep
+	}
+
+	// Wait for the initial regeneration from UpdateLabels to advance
+	// policyRevision past 0, otherwise a later UpdatePolicy hits the new-endpoint
+	// early return and the endpoint stays at an old revision.
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	for _, ep := range eps {
+		select {
+		case <-ep.WaitForPolicyRevision(waitCtx, 1, nil):
+		case <-waitCtx.Done():
+			tb.Fatalf("endpoint %d did not reach initial policy revision; state=%s identity=%d",
+				ep.ID, ep.GetState(), ep.GetIdentity())
+		}
+	}
+	return eps
+}
+
+// makeRuleSelectingAllIdentities returns a rule whose EndpointSelector matches
+// every identity seeded by seedEndpoints. The seed keeps the rule label unique
+// across iterations so successive UpdatePolicy calls are distinct imports.
+func makeRuleSelectingAllIdentities(numIdentities, seed int) *api.Rule {
+	selectors := make([]api.EndpointSelector, numIdentities)
+	for i := range numIdentities {
+		selectors[i] = api.NewESFromLabels(
+			labels.NewLabel(benchAppLabel, fmt.Sprintf("id-%d", i), labels.LabelSourceK8s),
+		)
+	}
+
+	return &api.Rule{
+		EndpointSelector: selectors[0],
+		Egress: []api.EgressRule{{
+			EgressCommonRule: api.EgressCommonRule{ToEndpoints: selectors},
+		}},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, fmt.Sprintf("bench-rule-%d", seed), labels.LabelSourceAny),
+		},
+	}
+}

--- a/pkg/policy/test/helpers_test.go
+++ b/pkg/policy/test/helpers_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+	apiv1 "github.com/cilium/cilium/api/v1/models"
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	"github.com/cilium/cilium/pkg/datapath/loader"
+	fakeloader "github.com/cilium/cilium/pkg/datapath/loader/fake"
+	"github.com/cilium/cilium/pkg/endpoint"
+	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	identitycache "github.com/cilium/cilium/pkg/identity/cache/cell"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipcache"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/synced"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/maps/lxcmap"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	fakepolicymap "github.com/cilium/cilium/pkg/maps/policymap/fake"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/promise"
+	testcertificatemanager "github.com/cilium/cilium/pkg/testutils/certificatemanager"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	testmonitor "github.com/cilium/cilium/pkg/testutils/monitor"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+)
+
+type testFixture struct {
+	hive *hive.Hive
+
+	idmgr      identitymanager.IDManager
+	allocator  cache.IdentityAllocator
+	epm        endpointmanager.EndpointManager
+	repo       policy.PolicyRepository
+	importer   policycell.PolicyImporter
+	templateEP *endpoint.Endpoint
+}
+
+func newTestFixture(t testing.TB, log *slog.Logger, certMgr certificatemanager.CertificateManager) *testFixture {
+	if certMgr == nil {
+		certMgr = &testcertificatemanager.Fake{}
+	}
+
+	f := &testFixture{}
+
+	f.hive = hive.New(
+		k8sClient.FakeClientCell(),
+		daemonk8s.ResourcesCell,
+		metrics.Cell,
+
+		cell.Provide(
+			func() *option.DaemonConfig {
+				return &option.DaemonConfig{
+					EnableIPv4: true,
+					EnableIPv6: true,
+				}
+			},
+		),
+
+		cell.Invoke(
+			func(client_ *k8sClient.FakeClientset, repo_ policy.PolicyRepository, idmgr_ identitymanager.IDManager,
+				alloc_ cache.IdentityAllocator,
+				imp_ policycell.PolicyImporter, epm_ endpointmanager.EndpointManager) error {
+				f.repo = repo_
+				f.idmgr = idmgr_
+				f.allocator = alloc_
+				f.importer = imp_
+				f.epm = epm_
+
+				option.Config.IdentityAllocationMode = option.IdentityAllocationModeCRD
+				defer func() { option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore }()
+
+				<-f.allocator.(*cache.CachingIdentityAllocator).InitIdentityAllocator(client_, nil)
+
+				f.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+
+				var err error
+				f.templateEP, err = endpoint.NewEndpointFromChangeModel(
+					endpoint.EndpointParams{
+						Logger:              log,
+						EPBuildQueue:        endpoint.NewEndpointBuildQueue(),
+						Loader:              &fakeloader.Loader{},
+						Orchestrator:        &fakeendpoint.FakeOrchestrator{},
+						CompilationLock:     loader.NewCompilationLock(),
+						IdentityManager:     f.idmgr,
+						MonitorAgent:        &testmonitor.TestMonitorAgent{},
+						PolicyMapFactory:    &fakePolicyMapFactory{},
+						PolicyRepo:          f.repo,
+						NamedPortsGetter:    testipcache.NewMockIPCache(),
+						Allocator:           f.allocator,
+						CTMapGC:             ctmap.NewFakeGCRunner(),
+						KVStoreSynchronizer: ipcache.NewIPIdentitySynchronizer(log, kvstore.SetupDummy(t, kvstore.DisabledBackendName)),
+						LocalNodeStore:      node.NewTestLocalNodeStore(node.LocalNode{}),
+						LxcMap:              &fakeLXCMap{},
+					},
+					&fakeDNSAPI{},
+					&endpoint.FakeEndpointProxy{},
+					&apiv1.EndpointChangeRequest{
+						ContainerID:            "foo",
+						ContainerInterfaceName: "bar",
+						State:                  models.NewEndpointState(models.EndpointStateWaitingDashForDashIdentity),
+					},
+					t.Output(),
+				)
+				return err
+			},
+		),
+
+		cell.ProvidePrivate(func() certificatemanager.CertificateManager { return certMgr }),
+		cell.ProvidePrivate(func() cmtypes.ClusterInfo { return cmtypes.DefaultClusterInfo }),
+		cell.ProvidePrivate(func() envoypolicy.EnvoyL7RulesTranslator {
+			return envoypolicy.NewEnvoyL7RulesTranslator(log, nil)
+		}),
+		cell.ProvidePrivate(func() types.PolicyMetrics { return testpolicy.NewPolicyMetricsNoop() }),
+		cell.ProvidePrivate(func() agent.Agent { return &testmonitor.TestMonitorAgent{} }),
+		cell.ProvidePrivate(func() synced.CacheStatus {
+			ch := make(chan struct{}, 1)
+			ch <- struct{}{}
+			return ch
+		}),
+		cell.ProvidePrivate(func() *ipcache.IPCache {
+			return ipcache.NewIPCache(&ipcache.Configuration{
+				Context:           t.Context(),
+				Logger:            log,
+				IdentityAllocator: f.allocator,
+				IdentityUpdater:   &mockUpdater{},
+			})
+		}),
+		cell.ProvidePrivate(regeneration.NewFence),
+		cell.ProvidePrivate(func() promise.Promise[endpointstate.Restorer] { return &fakeRestorer{} }),
+		identitymanager.Cell,
+		identitycache.Cell,
+		policycell.Cell,
+		endpointmanager.TestCell,
+		node.LocalNodeStoreTestCell,
+	)
+
+	require.NoError(t, f.hive.Start(log, context.Background()))
+	t.Cleanup(func() {
+		for _, ep := range f.epm.GetEndpoints() {
+			f.epm.RemoveEndpoint(ep, endpoint.DeleteConfig{})
+		}
+		assert.NoError(t, f.hive.Stop(log, context.TODO()))
+	})
+
+	return f
+}
+
+type fakeDNSAPI struct{}
+
+func (*fakeDNSAPI) GetDNSRules(epID uint16) restore.DNSRules { return nil }
+func (*fakeDNSAPI) RemoveRestoredDNSRules(epID uint16)       {}
+
+type fakePolicyMapFactory struct{}
+
+func (*fakePolicyMapFactory) OpenEndpoint(id uint16) (policymap.PolicyMap, error) {
+	return fakepolicymap.NewFakePolicyMap(), nil
+}
+func (*fakePolicyMapFactory) RemoveEndpoint(id uint16) error { return nil }
+func (*fakePolicyMapFactory) PolicyMaxEntries() int          { return 0 }
+func (*fakePolicyMapFactory) StatsMaxEntries() int           { return 0 }
+
+type fakeLXCMap struct{}
+
+func (*fakeLXCMap) WriteEndpoint(f lxcmap.EndpointFrontend) error                        { return nil }
+func (*fakeLXCMap) SyncHostEntry(addr netip.Addr) (bool, error)                          { return false, nil }
+func (*fakeLXCMap) DeleteEntry(addr netip.Addr) error                                    { return nil }
+func (*fakeLXCMap) DeleteElement(logger *slog.Logger, f lxcmap.EndpointFrontend) []error { return nil }
+func (*fakeLXCMap) Dump(hash map[string][]string) error                                  { return nil }
+func (*fakeLXCMap) DumpToMap() (map[netip.Addr]lxcmap.EndpointInfo, error)               { return nil, nil }
+
+type mockUpdater struct{}
+
+func (m *mockUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{} {
+	out := make(chan struct{})
+	close(out)
+	return out
+}
+
+type fakeRestorer struct{}
+
+func (r *fakeRestorer) Await(context.Context) (endpointstate.Restorer, error) {
+	return r, nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(_ context.Context) error {
+	return nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {
+	return nil
+}
+
+func (r *fakeRestorer) WaitForInitialPolicy(_ context.Context) error {
+	return nil
+}

--- a/pkg/policy/test/helpers_test.go
+++ b/pkg/policy/test/helpers_test.go
@@ -46,11 +46,11 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/promise"
 	testcertificatemanager "github.com/cilium/cilium/pkg/testutils/certificatemanager"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
-	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 	testmonitor "github.com/cilium/cilium/pkg/testutils/monitor"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
@@ -62,6 +62,7 @@ type testFixture struct {
 	allocator  cache.IdentityAllocator
 	epm        endpointmanager.EndpointManager
 	repo       policy.PolicyRepository
+	computer   compute.PolicyRecomputer
 	importer   policycell.PolicyImporter
 	templateEP *endpoint.Endpoint
 }
@@ -88,19 +89,20 @@ func newTestFixture(t testing.TB, log *slog.Logger, certMgr certificatemanager.C
 		),
 
 		cell.Invoke(
-			func(client_ *k8sClient.FakeClientset, repo_ policy.PolicyRepository, idmgr_ identitymanager.IDManager,
-				alloc_ cache.IdentityAllocator,
-				imp_ policycell.PolicyImporter, epm_ endpointmanager.EndpointManager) error {
-				f.repo = repo_
-				f.idmgr = idmgr_
-				f.allocator = alloc_
-				f.importer = imp_
-				f.epm = epm_
+			func(client *k8sClient.FakeClientset, repo policy.PolicyRepository, idmgr identitymanager.IDManager,
+				alloc cache.IdentityAllocator, comp compute.PolicyRecomputer,
+				imp policycell.PolicyImporter, epm endpointmanager.EndpointManager) error {
+				f.repo = repo
+				f.idmgr = idmgr
+				f.allocator = alloc
+				f.computer = comp
+				f.importer = imp
+				f.epm = epm
 
 				option.Config.IdentityAllocationMode = option.IdentityAllocationModeCRD
 				defer func() { option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore }()
 
-				<-f.allocator.(*cache.CachingIdentityAllocator).InitIdentityAllocator(client_, nil)
+				<-f.allocator.(*cache.CachingIdentityAllocator).InitIdentityAllocator(client, nil)
 
 				f.repo.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
@@ -116,7 +118,7 @@ func newTestFixture(t testing.TB, log *slog.Logger, certMgr certificatemanager.C
 						MonitorAgent:        &testmonitor.TestMonitorAgent{},
 						PolicyMapFactory:    &fakePolicyMapFactory{},
 						PolicyRepo:          f.repo,
-						NamedPortsGetter:    testipcache.NewMockIPCache(),
+						PolicyFetcher:       f.computer,
 						Allocator:           f.allocator,
 						CTMapGC:             ctmap.NewFakeGCRunner(),
 						KVStoreSynchronizer: ipcache.NewIPIdentitySynchronizer(log, kvstore.SetupDummy(t, kvstore.DisabledBackendName)),
@@ -163,6 +165,11 @@ func newTestFixture(t testing.TB, log *slog.Logger, certMgr certificatemanager.C
 		policycell.Cell,
 		endpointmanager.TestCell,
 		node.LocalNodeStoreTestCell,
+
+		cell.Provide(func(params compute.Params) compute.PolicyRecomputer {
+			return compute.NewIdentityPolicyComputer(params)
+		}),
+		cell.ProvidePrivate(compute.NewPolicyComputationTable),
 	)
 
 	require.NoError(t, f.hive.Start(log, context.Background()))

--- a/pkg/policy/test/regenerate_retry_test.go
+++ b/pkg/policy/test/regenerate_retry_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	testk8s "github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	policyutils "github.com/cilium/cilium/pkg/policy/utils"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type failOnceCertManager struct {
+	remaining atomic.Int32
+}
+
+func (m *failOnceCertManager) GetTLSContext(
+	_ context.Context, tlsCtx *api.TLSContext, _ string,
+) (ca, public, private string, inlineSecrets bool, err error) {
+	if m.remaining.Add(-1) >= 0 {
+		return "", "", "", false, errors.New("injected: transient cert fetch failure")
+	}
+	name := tlsCtx.Secret.Name
+	return "fake ca " + name, "fake public " + name, "fake private " + name, true, nil
+}
+
+func TestRegenerateRetries(t *testing.T) {
+	// trigger.waiter and SelectorCache.handleUserNotifications are known not to
+	// shut down on hive.Stop. They live for the test process lifetime in
+	// production too.
+	t.Cleanup(func() {
+		testutils.GoleakVerifyNone(t,
+			testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
+			testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/policy.(*SelectorCache).handleUserNotifications"),
+		)
+	})
+
+	version.Force(testk8s.DefaultVersion)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	log := hivetest.Logger(t)
+
+	certMgr := &failOnceCertManager{}
+	certMgr.remaining.Store(1)
+
+	f := newTestFixture(t, log, certMgr)
+
+	podLabels := labels.LabelArray{
+		labels.NewLabel("io.kubernetes.pod.namespace", "default", labels.LabelSourceK8s),
+		labels.NewLabel("app", "test", labels.LabelSourceK8s),
+	}
+	podID, _, err := f.allocator.AllocateIdentity(ctx, podLabels.Labels(), true, identity.NumericIdentity(0))
+	require.NoError(t, err)
+
+	ep := f.templateEP.CopyFromTemplate()
+	require.NoError(t, f.epm.AddEndpoint(ep))
+	_ = ep.UpdateLabels(ctx, labels.LabelSourceAny, podID.Labels, nil, true)
+
+	rule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(labels.NewLabel("app", "test", labels.LabelSourceK8s)),
+		Egress: []api.EgressRule{{
+			ToPorts: []api.PortRule{{
+				Ports: []api.PortProtocol{{Port: "443", Protocol: "TCP"}},
+				TerminatingTLS: &api.TLSContext{
+					Secret: &api.Secret{
+						Namespace: "default",
+						Name:      "tls-secret",
+					},
+				},
+				Rules: &api.L7Rules{HTTP: []api.PortRuleHTTP{{}}},
+			}},
+		}},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "retryRule", labels.LabelSourceAny),
+		},
+	}
+	require.NoError(t, rule.Sanitize())
+
+	done := make(chan uint64, 1)
+	f.importer.UpdatePolicy(&policytypes.PolicyUpdate{
+		Rules:    policyutils.RulesToPolicyEntries(api.Rules{rule}),
+		Source:   source.CustomResource,
+		Resource: ipcachetypes.NewResourceID(ipcachetypes.ResourceKindCNP, "default", "retry-test"),
+		DoneChan: done,
+	})
+
+	var rev uint64
+	select {
+	case rev = <-done:
+	case <-ctx.Done():
+		t.Fatal("policy import timed out")
+	}
+
+	_ = ep.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+		Reason:                  "transient cert failure test",
+		RegenerationLevel:       regeneration.RegenerateWithDatapath,
+		ParentContext:           ctx,
+		PolicyRevisionToWaitFor: rev,
+	})
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer waitCancel()
+	select {
+	case <-ep.WaitForPolicyRevision(waitCtx, rev, nil):
+	case <-waitCtx.Done():
+		t.Fatalf("endpoint did not reach policy revision %d", rev)
+	}
+
+	require.Negative(t, certMgr.remaining.Load())
+}

--- a/pkg/policy/test/script_test.go
+++ b/pkg/policy/test/script_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"maps"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	testk8s "github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/policy"
+	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/policy/compute"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+func TestScript(t *testing.T) {
+	// trigger.waiter and SelectorCache.handleUserNotifications do not shut
+	// down on hive.Stop in production either.
+	defer testutils.GoleakVerifyNone(t,
+		testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
+		testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/policy.(*SelectorCache).handleUserNotifications"),
+	)
+
+	version.Force(testk8s.DefaultVersion)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	var opts []hivetest.LogOption
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+		logging.SetLogLevel(slog.LevelDebug)
+	}
+
+	log := hivetest.Logger(t, opts...)
+	scripttest.Test(t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			f := newTestFixture(t, log, nil)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			f.hive.RegisterFlags(flags)
+
+			cmds, err := f.hive.ScriptCommands(log)
+			require.NoError(t, err)
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			maps.Insert(cmds, maps.All(compute.PolicyComputerScriptCmds(f.computer.(*compute.IdentityPolicyComputer))))
+			maps.Insert(cmds, maps.All(policy.RepositoryScriptCmds(f.repo.(*policy.Repository))))
+			maps.Insert(cmds, maps.All(identitymanager.ScriptCmds(f.idmgr.(*identitymanager.IdentityManager))))
+			maps.Insert(cmds, maps.All(cache.ScriptCmds(f.allocator.(*cache.CachingIdentityAllocator))))
+			maps.Insert(cmds, maps.All(policycell.PolicyImporterScriptCmds(f.importer.(*policycell.Importer))))
+			maps.Insert(cmds, maps.All(endpointmanager.ScriptCmds(f.epm, f.templateEP)))
+			return &script.Engine{
+				Cmds:          cmds,
+				RetryInterval: 10 * time.Millisecond,
+			}
+		}, []string{}, "testdata/*.txtar")
+}

--- a/pkg/policy/test/testdata/test.txtar
+++ b/pkg/policy/test/testdata/test.txtar
@@ -1,0 +1,88 @@
+hive/start
+db/show health
+
+# Initialize state: create host and health endpoints.
+identity/allocate reserved:host,reserved:kube-apiserver
+identity/allocate reserved:health
+endpoint/create 1 reserved:host,reserved:kube-apiserver
+endpoint/create 4 reserved:health
+
+# Import initial policy. Neither host nor health endpoint should have their
+# policy recomputed as this policy does not select them.
+k8s/add policy.yaml
+policy/import policy.yaml
+
+# Create first real endpoint selected by policy.yaml. Policy computation for
+# this endpoint should be at 2 now.
+env id1_labels=k8s:io.kubernetes.pod.namespace=default,k8s:foo=bar
+identity/allocate ${id1_labels}
+env --from-stdout id1
+endpoint/create ${id1} ${id1_labels}
+
+# Create second real endpoint selected by policy.yaml. Policy computation for
+# this endpoint should be at 2.
+env id2_labels=k8s:io.kubernetes.pod.namespace=default,k8s:baz=bar
+identity/allocate ${id2_labels}
+env --from-stdout id2
+endpoint/create ${id2} ${id2_labels}
+
+# Remove initial policy. Policy revision should be at 3.
+policy/remove policy.yaml
+
+# Add new policy that does not select foo=bar endpoint. Policy computation of
+# all identities should stay at 3 (doesn't bump if there is no need to
+# recompute), but the repo revision and endpoints' revision should be at 4.
+policy/import allow-env-prod.yaml
+
+# Wait until all endpoints' revision is at 4 which means they have consumed the
+# latest computation of revision 3.
+endpoint/wait-for-policy-revision 4
+
+# Perform assertion that all endpoints with a non-reserved identity (not host /
+# health) are still at policy revision 3.
+db/show --columns Identity,Revision policy-computations
+stdout host.+1
+stdout health.+1
+stdout ${id1}.+3
+stdout ${id2}.+3
+
+-- policy.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "policy"
+  namespace: "default"
+spec:
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+      - matchLabels: {}
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": kube-dns
+      toPorts:
+      - ports:
+        - port: "53"
+          protocol: "UDP"
+        rules:
+          dns:
+          - matchPattern: "*"
+    - toFQDNs:
+      - matchPattern: "*"
+      - matchPattern: "ifconfig.co"
+    - toCIDR:
+      - "1.1.1.1/32"
+
+-- allow-env-prod.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: "allow-env-prod"
+  namespace: "default"
+spec:
+  endpointSelector:
+    matchLabels:
+      env: prod
+  egress:
+  - {}

--- a/pkg/policy/test/updatepolicy_bench_test.go
+++ b/pkg/policy/test/updatepolicy_bench_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	testk8s "github.com/cilium/cilium/pkg/k8s/testutils"
+	"github.com/cilium/cilium/pkg/k8s/version"
+	"github.com/cilium/cilium/pkg/policy/api"
+	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	policyutils "github.com/cilium/cilium/pkg/policy/utils"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// BenchmarkUpdatePolicyThroughput measures end-to-end policy import latency
+// through the real policy importer, compute cell, and endpoint manager
+// dispatch, across varying endpoint and unique-identity counts. Each iteration
+// imports a single rule that selects every identity, so all endpoints
+// regenerate.
+//
+// Reported metrics:
+//   - ns/update: latency from importer.UpdatePolicy to all endpoints
+//     reaching the new revision.
+//   - peak_regen_queue: peak number of endpoints in StateWaitingToRegenerate
+//     or StateRegenerating during the iteration.
+func BenchmarkUpdatePolicyThroughput(b *testing.B) {
+	version.Force(testk8s.DefaultVersion)
+
+	for _, numEPs := range []int{100, 1000} {
+		for _, numIDs := range []int{10, 100, 1000} {
+			if numIDs > numEPs {
+				continue
+			}
+			name := fmt.Sprintf("eps=%d/ids=%d", numEPs, numIDs)
+			b.Run(name, func(b *testing.B) {
+				runUpdatePolicyBench(b, numEPs, numIDs)
+			})
+		}
+	}
+}
+
+func runUpdatePolicyBench(b *testing.B, numEPs, numIDs int) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	log := hivetest.Logger(b)
+	f := newTestFixture(b, log, nil)
+	eps := seedEndpoints(b, ctx, f, numEPs, numIDs)
+
+	var peakQueue atomic.Int64
+	stopSampler := make(chan struct{})
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		t := time.NewTicker(1 * time.Millisecond)
+		defer t.Stop()
+		for {
+			select {
+			case <-stopSampler:
+				return
+			case <-t.C:
+				var q int64
+				for _, ep := range eps {
+					s := ep.GetState()
+					if s == endpoint.StateWaitingToRegenerate || s == endpoint.StateRegenerating {
+						q++
+					}
+				}
+				for {
+					prev := peakQueue.Load()
+					if q <= prev || peakQueue.CompareAndSwap(prev, q) {
+						break
+					}
+				}
+			}
+		}
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rule := makeRuleSelectingAllIdentities(numIDs, i)
+		require.NoError(b, rule.Sanitize())
+
+		done := make(chan uint64, 1)
+		start := time.Now()
+		f.importer.UpdatePolicy(&policytypes.PolicyUpdate{
+			Rules:    policyutils.RulesToPolicyEntries(api.Rules{rule}),
+			Source:   source.CustomResource,
+			Resource: ipcachetypes.NewResourceID(ipcachetypes.ResourceKindCNP, "default", fmt.Sprintf("bench-%d", i)),
+			DoneChan: done,
+		})
+
+		var rev uint64
+		select {
+		case rev = <-done:
+		case <-ctx.Done():
+			b.Fatalf("policy import timed out at iter %d", i)
+		}
+
+		waitForEndpoints(b, ctx, eps, rev)
+
+		b.ReportMetric(float64(time.Since(start).Nanoseconds()), "ns/update")
+	}
+	b.StopTimer()
+
+	close(stopSampler)
+	<-samplerDone
+	b.ReportMetric(float64(peakQueue.Load()), "peak_regen_queue")
+}
+
+// waitForEndpoints blocks until every endpoint reaches rev.
+func waitForEndpoints(tb testing.TB, ctx context.Context, eps []*endpoint.Endpoint, rev uint64) {
+	tb.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	for _, ep := range eps {
+		select {
+		case <-ep.WaitForPolicyRevision(waitCtx, rev, nil):
+		case <-waitCtx.Done():
+			tb.Fatalf("endpoint %d did not reach policy revision %d; state=%s identity=%d",
+				ep.ID, rev, ep.GetState(), ep.GetIdentity())
+		}
+	}
+}

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -6,6 +6,8 @@ package policy
 import (
 	"log/slog"
 
+	"github.com/cilium/statedb"
+
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -15,30 +17,38 @@ import (
 // all cached policies. This is done when an additional resource
 // used in policy calculation has changed.
 func (u *Updater) TriggerPolicyUpdates(reason string) {
-	u.repo.BumpRevision()
+	rev := u.repo.BumpRevision()
+	u.computer.RecomputeIdentityPolicyForAllIdentities(rev)
 	u.logger.Info("Triggering full policy recalculation and regeneration of all endpoints", logfields.Reason, reason)
-	u.regen.TriggerRegenerateAllEndpoints()
+	u.regen.RegenerateAllForPolicy(rev)
 }
 
 // NewUpdater returns a new Updater instance to handle triggering policy
 // updates ready for use.
-func NewUpdater(logger *slog.Logger, r PolicyRepository, regen regenerator) *Updater {
+func NewUpdater(logger *slog.Logger, r PolicyRepository, c computer, regen regenerator) *Updater {
 	return &Updater{
-		logger: logger,
-		regen:  regen,
-		repo:   r,
+		logger:   logger,
+		regen:    regen,
+		repo:     r,
+		computer: c,
 	}
 }
 
 // Updater is responsible for triggering policy updates, in order to perform
 // policy recalculation.
 type Updater struct {
-	logger *slog.Logger
-	repo   PolicyRepository
-	regen  regenerator
+	logger   *slog.Logger
+	repo     PolicyRepository
+	computer computer
+	regen    regenerator
 }
 
 type regenerator interface {
-	// RegenerateAllEndpoints should trigger a regeneration of all endpoints.
-	TriggerRegenerateAllEndpoints()
+	// RegenerateAllForPolicy triggers regeneration of all endpoints against
+	// the given policy revision. See endpointmanager.EndpointManager.
+	RegenerateAllForPolicy(waitFor uint64)
+}
+
+type computer interface {
+	RecomputeIdentityPolicyForAllIdentities(toRev uint64) (*statedb.WatchSet, error)
 }

--- a/pkg/testutils/compute/compute.go
+++ b/pkg/testutils/compute/compute.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testcompute
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
+	"github.com/cilium/stream"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/policy"
+	policycompute "github.com/cilium/cilium/pkg/policy/compute"
+)
+
+func InstantiateCellForTesting(tb testing.TB, logger *slog.Logger, id, desc string, repo policy.PolicyRepository, idmgr identitymanager.IDManager) policycompute.PolicyRecomputer {
+	tb.Helper()
+
+	var pc policycompute.PolicyRecomputer
+
+	h := hive.New(
+		cell.Module(id, desc,
+			cell.Invoke(
+				func(c_ policycompute.PolicyRecomputer) error {
+					pc = c_
+					return nil
+				},
+			),
+
+			cell.ProvidePrivate(func() (policy.PolicyRepository, stream.Observable[policy.PolicyCacheChange]) {
+				return repo, repo.PolicyCacheObservable()
+			}),
+			cell.ProvidePrivate(func() identitymanager.IDManager { return idmgr }),
+
+			cell.Provide(
+				func(params policycompute.Params) policycompute.PolicyRecomputer {
+					return policycompute.NewIdentityPolicyComputer(params)
+				},
+			),
+			cell.Provide(policycompute.NewPolicyComputationTable),
+			cell.Provide(statedb.RWTable[policycompute.Result].ToTable),
+		),
+	)
+
+	if err := h.Start(logger, context.Background()); err != nil {
+		tb.Fatalf("failed to start hive: %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := h.Stop(logger, context.Background()); err != nil {
+			tb.Fatalf("failed to stop hive: %v", err)
+		}
+	})
+
+	return pc
+}

--- a/pkg/testutils/endpointmanager/endpointmanager.go
+++ b/pkg/testutils/endpointmanager/endpointmanager.go
@@ -169,6 +169,10 @@ func (*MockEndpointManager) TriggerRegenerateAllEndpoints() {
 	panic("MockEndpointManager.TriggerRegenerateAllEndpoints not implemented")
 }
 
+func (*MockEndpointManager) RegenerateAllForPolicy(waitFor uint64) {
+	panic("MockEndpointManager.RegenerateAllForPolicy not implemented")
+}
+
 func (*MockEndpointManager) WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error {
 	panic("MockEndpointManager.WaitForEndpointsAtPolicyRev not implemented")
 }


### PR DESCRIPTION
## Series: Break out policy computation from endpoint package

Currently, each endpoint computes its own SelectorPolicy inline during
regeneration. This couples the endpoint lifecycle to the policy engine,
duplicates work when multiple endpoints share an identity, and makes it
difficult to test the policy computation path in isolation.

This series introduces a dedicated cell that computes SelectorPolicy per
identity and stores results in a statedb table. The endpoint reads from
this table via watch channels. Endpoints unaffected by a policy change
no longer need to regenerate.

[PR 1/3: API prep (no behavior change)](https://github.com/cilium/cilium/pull/44898)
[PR 2/3: Script commands, fakes, and test infrastructure](https://github.com/cilium/cilium/pull/44899)
**PR 3/3: Policy computation cell + script-based integration test**

Depends on:
* https://github.com/cilium/cilium/pull/44898
* https://github.com/cilium/cilium/pull/44899

Fixes: https://github.com/cilium/cilium/issues/7515

---

This cell is responsible for computing policies (specifically SelectorPolicy
objects) per identity and storing the results in a `policy-computations`
statedb table. The endpoint's `regeneratePolicy()` now reads from this table
via watch channels instead of computing inline. Endpoints not affected by a
policy change no longer need to regenerate.

The script-based test (`test.txtar`) exercises the full flow: create endpoints,
import policies, verify computation reaches the correct revision, remove
policies, and verify correctness.

Review commit-by-commit. For convenience, the main commits are:

```
policy/compute: Add policy computation cell
endpoint: Plumb policy computer
policy/compute: Add script-based test
```