### PR TITLE
.github: do not allow blank issues from being created

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: Get Enterprise Support
     url: https://cilium.io/enterprise/


### PR DESCRIPTION
The blank issues will not be allowed on being created for users that don't have write access to the repository.
Maintainers will still be able to do it.