### PR TITLE
Introduce "unsupported protocol action" logic via ipcache null_route flag

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -61,6 +61,7 @@ cilium-agent [flags]
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic
       --bpf-lb-sock-hostns-only                                   Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
+      --bpf-lb-unsupported-protocol-action string                 BPF load balancing unsupported protocol action ("forward", "drop") (default "forward")
       --bpf-map-dynamic-size-ratio float                          Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps (default 0.0025)
       --bpf-nat-global-max int                                    Maximum number of entries for the global BPF NAT table (default 524288)
       --bpf-neigh-global-max int                                  Maximum number of entries for the global BPF neighbor table (default 524288)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -32,6 +32,7 @@ cilium-agent hive [flags]
       --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
+      --bpf-lb-unsupported-protocol-action string                 BPF load balancing unsupported protocol action ("forward", "drop") (default "forward")
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-policy-map-pressure-metrics-threshold float           Sets threshold for emitting pressure metrics of policy maps (default 0.1)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -38,6 +38,7 @@ cilium-agent hive dot-graph [flags]
       --bpf-lb-mode-annotation                                    Enable service-level annotation for configuring BPF load balancing mode
       --bpf-lb-sock                                               Enable socket-based LB for E/W traffic
       --bpf-lb-source-range-all-types                             Propagate loadbalancerSourceRanges to all corresponding service types
+      --bpf-lb-unsupported-protocol-action string                 BPF load balancing unsupported protocol action ("forward", "drop") (default "forward")
       --bpf-node-map-max uint32                                   Sets size of node bpf map which will be the max number of unique Node IPs in the cluster (default 16384)
       --bpf-policy-map-max int                                    Maximum number of entries in endpoint policy map (per endpoint) (default 16384)
       --bpf-policy-map-pressure-metrics-threshold float           Sets threshold for emitting pressure metrics of policy maps (default 0.1)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -432,6 +432,10 @@
      - Enable loadBalancerSourceRanges CIDR filtering for all service types, not just LoadBalancer services. The corresponding NodePort and ClusterIP (if enabled for cluster-external traffic) will also apply the CIDR filter.
      - bool
      - ``false``
+   * - :spelling:ignore:`bpf.lbUnsupportedProtocolAction`
+     - Configure how the datapath should handle unsupported protocols (forward, drop) for Load Balancer VIPs. This can also be configured on a per- service basis through the network.cilium.io/unsupported-protocol-action annotation.
+     - string
+     - ``"forward"``
    * - :spelling:ignore:`bpf.mapDynamicSizeRatio`
      - Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
      - float64

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -158,6 +158,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
 | bpf.lbModeAnnotation | bool | `false` | Enable the option to define the load balancing mode (SNAT or DSR) on a per-service basis through service.cilium.io/forwarding-mode annotation. |
 | bpf.lbSourceRangeAllTypes | bool | `false` | Enable loadBalancerSourceRanges CIDR filtering for all service types, not just LoadBalancer services. The corresponding NodePort and ClusterIP (if enabled for cluster-external traffic) will also apply the CIDR filter. |
+| bpf.lbUnsupportedProtocolAction | string | `"forward"` | Configure how the datapath should handle unsupported protocols (forward, drop) for Load Balancer VIPs. This can also be configured on a per- service basis through the network.cilium.io/unsupported-protocol-action annotation. |
 | bpf.mapDynamicSizeRatio | float64 | `0.0025` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/network/ebpf/maps/ |
 | bpf.masquerade | bool | `false` | Enable native IP masquerade support in eBPF |
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -490,6 +490,10 @@ data:
   bpf-lb-mode-annotation: {{ .Values.bpf.lbModeAnnotation | quote }}
 {{- end }}
 
+{{- if hasKey .Values.bpf "lbUnsupportedProtocolAction" }}
+  bpf-lb-unsupported-protocol-action: {{ .Values.bpf.lbUnsupportedProtocolAction | quote }}
+{{- end }}
+
   bpf-distributed-lru: {{ .Values.bpf.distributedLRU.enabled | quote }}
   bpf-events-drop-enabled: {{ .Values.bpf.events.drop.enabled | quote }}
   bpf-events-policy-verdict-enabled: {{ .Values.bpf.events.policyVerdict.enabled | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -651,6 +651,9 @@
         "lbSourceRangeAllTypes": {
           "type": "boolean"
         },
+        "lbUnsupportedProtocolAction": {
+          "type": "string"
+        },
         "mapDynamicSizeRatio": {
           "type": [
             "null",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -698,6 +698,14 @@ bpf:
   # @default -- `false`
   lbModeAnnotation: false
   # @schema
+  # type: [string]
+  # @schema
+  # -- (string) Configure how the datapath should handle unsupported protocols
+  # (forward, drop) for Load Balancer VIPs. This can also be configured on a per-
+  # service basis through the network.cilium.io/unsupported-protocol-action annotation.
+  # @default -- `"forward"`
+  lbUnsupportedProtocolAction: "forward"
+  # @schema
   # type: [null, boolean]
   # @schema
   # -- (bool) Enable native IP masquerade support in eBPF

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -701,6 +701,14 @@ bpf:
   # @default -- `false`
   lbModeAnnotation: false
   # @schema
+  # type: [string]
+  # @schema
+  # -- (string) Configure how the datapath should handle unsupported protocols
+  # (forward, drop) for Load Balancer VIPs. This can also be configured on a per-
+  # service basis through the network.cilium.io/unsupported-protocol-action annotation.
+  # @default -- `"forward"`
+  lbUnsupportedProtocolAction: "forward"
+  # @schema
   # type: [null, boolean]
   # @schema
   # -- (bool) Enable native IP masquerade support in eBPF

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -535,6 +535,7 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 	sv.Ports = make([]slim_core_v1.ServicePort, len(svc.Spec.Ports))
 	copy(sv.Ports, svc.Spec.Ports)
 	sv.Namespace = svc.Namespace
+	sv.UnsupportedProtocolAction, _ = annotation.GetAnnotationUnsupportedProtoAction(svc)
 	sv.Selector = make(map[string]string)
 	maps.Copy(sv.Selector, svc.Spec.Selector)
 	sv.Status = svc.Status.DeepCopy()

--- a/pkg/annotation/datapath.go
+++ b/pkg/annotation/datapath.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package annotation
+
+import (
+	"fmt"
+	"strings"
+
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+)
+
+type UnsupportedProtoAction string
+
+const (
+	UnsupportedProtoActionUnspec  = UnsupportedProtoAction("")
+	UnsupportedProtoActionDrop    = UnsupportedProtoAction(datapathOption.UnsupportedProtoActionDrop)
+	UnsupportedProtoActionForward = UnsupportedProtoAction(datapathOption.UnsupportedProtoActionForward)
+)
+
+func GetAnnotationUnsupportedProtoAction(obj annotatedObject) (UnsupportedProtoAction, error) {
+	if value, ok := Get(obj, NetworkUnsupportedProtoAction); ok {
+		val := UnsupportedProtoAction(strings.ToLower(value))
+		switch val {
+		case UnsupportedProtoActionDrop, UnsupportedProtoActionForward:
+			return val, nil
+		default:
+			return UnsupportedProtoActionUnspec, fmt.Errorf("value %q is not valid for annotation %q", value, NetworkUnsupportedProtoAction)
+		}
+	}
+	return UnsupportedProtoActionUnspec, nil
+}

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -179,6 +179,18 @@ const (
 	//		use SNAT so that reply traffic comes back
 	ServiceForwardingMode = ServicePrefix + "/forwarding-mode"
 
+	// NetworkUnsupportedProtoAction annotations determine whether packets towards
+	// Service IPs with unsupported transport protocols are handled.
+	//
+	// Allowed values are of type annotation.UnsupportedProtoAction and map onto
+	// standard datapath option strings.
+	//
+	// Allowed values:
+	// - drop	Drop in datapath to avoid routing loops
+	// - forward	Forward to network stack for processing
+	//
+	NetworkUnsupportedProtoAction = NetworkPrefix + "/unsupported-protocol-action"
+
 	// NoTrack / NoTrackAlias is the annotation name used to store the port and
 	// protocol that we should bypass kernel conntrack for a given pod. This
 	// applies for both TCP and UDP connection. Current use case is NodeLocalDNS.

--- a/pkg/datapath/option/option.go
+++ b/pkg/datapath/option/option.go
@@ -23,3 +23,14 @@ const (
 	// L2 mode.
 	DatapathModeNetkitL2 = "netkit-l2"
 )
+
+// Available options for Unsupported Protocol Actions
+const (
+	// UnsupportedProtoActionDrop specifies that traffic carrying unsupported
+	// protocol types should be dropped in the datapath.
+	UnsupportedProtoActionDrop = "drop"
+
+	// UnsupportedProtoActionForward specifies that traffic carrying unsupported
+	// protocol types should be forwarded to the host for processing.
+	UnsupportedProtoActionForward = "forward"
+)

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -19,6 +19,7 @@ import (
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/ipcache/api"
+	"github.com/cilium/cilium/pkg/ipcache/nullroute"
 	restoration "github.com/cilium/cilium/pkg/ipcache/restore"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -44,6 +45,9 @@ var Cell = cell.Module(
 
 	// LocalIdentityRestorer restores the identities at startup
 	restoration.Cell,
+
+	// Null route reconciler
+	nullroute.Cell,
 
 	cell.Invoke(
 		// Register the watcher to the fence to ensure that we wait for ipcache

--- a/pkg/ipcache/nullroute/cell.go
+++ b/pkg/ipcache/nullroute/cell.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nullroute
+
+import "github.com/cilium/hive/cell"
+
+var Cell = cell.Module(
+	"null-route-reconciler",
+	"Null route reconciliation logic",
+
+	cell.ProvidePrivate(newLoadBalancerFrontendWatcher),
+	cell.Invoke(registerLoadBalancerFrontendWatcher),
+)

--- a/pkg/ipcache/nullroute/loadbalancer.go
+++ b/pkg/ipcache/nullroute/loadbalancer.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nullroute
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lbipamconfig"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+type metadataMutator interface {
+	UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
+	RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
+}
+
+// Assert the production IPCache still satisfies the narrow seam this package
+// depends on. This makes interface drift fail at compile time instead of only
+// surfacing later in Hive wiring or tests.
+var _ metadataMutator = (*ipcache.IPCache)(nil)
+
+type loadBalancerFrontendWatcher struct {
+	metadata             metadataMutator
+	db                   *statedb.DB
+	frontends            statedb.Table[*loadbalancer.Frontend]
+	dropByDefault        bool
+	defaultLBServiceIPAM string
+}
+
+type loadBalancerFrontendWatcherParams struct {
+	cell.In
+
+	IPCache   *ipcache.IPCache
+	DB        *statedb.DB
+	Frontends statedb.Table[*loadbalancer.Frontend]
+	LBConfig  loadbalancer.Config
+	ExtConfig loadbalancer.ExternalConfig
+}
+
+func newLoadBalancerFrontendWatcher(params loadBalancerFrontendWatcherParams) loadBalancerFrontendWatcher {
+	return loadBalancerFrontendWatcher{
+		metadata:             params.IPCache,
+		db:                   params.DB,
+		frontends:            params.Frontends,
+		dropByDefault:        params.LBConfig.LBUnsupportedProtoAction == loadbalancer.LBUnsupportedProtoActionDrop,
+		defaultLBServiceIPAM: params.ExtConfig.DefaultLBServiceIPAM,
+	}
+}
+
+func registerLoadBalancerFrontendWatcher(watcher loadBalancerFrontendWatcher, jobGroup job.Group) error {
+	jobGroup.Add(job.Observer(
+		"nullroute-loadbalancer-frontend-watcher",
+		watcher.onFrontendChange,
+		statedb.Observable(watcher.db, watcher.frontends),
+	))
+	return nil
+}
+
+// isNullRouteCandidate() returns true if a [loadbalancer.Frontend] is a candidate
+// to parent an IPCache entry with FlagNullRoute set.
+func (watcher loadBalancerFrontendWatcher) isNullRouteCandidate(fe *loadbalancer.Frontend) bool {
+	if fe.Address.AddrCluster().IsUnspecified() {
+		return false
+	}
+
+	switch fe.Type {
+	case loadbalancer.SVCTypeLoadBalancer,
+		loadbalancer.SVCTypeClusterIP:
+		// Only external scoped entries can parent null route entries.
+		if fe.Address.Scope() != loadbalancer.ScopeExternal {
+			return false
+		}
+
+		// We only want to reconcile null route entries if LB-IPAM has allocated
+		// the VIP, otherwise we risk reconciling Node internal IPs into IPCache
+		// and causing connectivity faults.
+		lbClass := fe.Service.LoadBalancerClass
+		if lbClass == nil {
+			return watcher.defaultLBServiceIPAM == lbipamconfig.DefaultLBClassLBIPAM
+		}
+
+		// The service has a loadBalancerClass, so we only include a null route
+		// entry if it's a class Cilium actively manages, again to avoid
+		// reconciling null route entries for IP addresses we don't manage.
+		//
+		// TODO: improve this in future, perhaps by matching against known
+		// CiliumInternalIPs.
+		return *lbClass == cilium_api_v2alpha1.BGPLoadBalancerClass ||
+			*lbClass == cilium_api_v2alpha1.L2AnnounceLoadBalancerClass
+
+	case loadbalancer.SVCTypeExternalIPs:
+		// ExternalIPs are provided by cluster admins, rather than being allocated
+		// by an IPAM, so the loadBalancerClass and default LB-IPAM checks above do
+		// not apply.
+		return fe.Address.Scope() == loadbalancer.ScopeExternal
+	}
+
+	return false
+}
+
+// useNullRouteFlag() returns true if the underlying Service of a Frontend has
+// UnsupportedProtoAction=drop. If this is unspecified, this returns the default
+// action from the watcher.
+func (watcher loadBalancerFrontendWatcher) useNullRouteFlag(fe *loadbalancer.Frontend) bool {
+	switch fe.Service.UnsupportedProtoAction {
+	case annotation.UnsupportedProtoActionForward:
+		return false
+	case annotation.UnsupportedProtoActionDrop:
+		return true
+	}
+
+	// Service does not express an action, so use the default setting
+	return watcher.dropByDefault
+}
+
+func (watcher loadBalancerFrontendWatcher) onFrontendChange(
+	ctx context.Context,
+	change statedb.Change[*loadbalancer.Frontend],
+) error {
+	fe := change.Object
+	if !watcher.isNullRouteCandidate(fe) {
+		return nil
+	}
+
+	// Compute the resource ID that uniquely identifies the references
+	// between this FE and the underlying IPCache entry. Note these are
+	// in a specific format, delimited by a forward-slash, so we delimit
+	// the FE L3n4Addr with a colon instead.
+	resourceID := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindService,
+		fe.Service.Name.Namespace(),
+		fe.Address.StringWithProtocolDelimited(":"),
+	)
+
+	flags := ipcacheTypes.EndpointFlags{}
+	if watcher.useNullRouteFlag(fe) {
+		flags.SetNullRoute(true)
+	}
+
+	addr := fe.Address.AddrCluster()
+	labels := make(labels.Labels, 1)
+	labels.AddWorldLabel(addr.Addr())
+
+	if change.Deleted || !flags.IsValid() {
+		watcher.metadata.RemoveMetadata(
+			addr.AsPrefixCluster(),
+			resourceID,
+			labels,
+			ipcacheTypes.EndpointFlags{},
+		)
+	} else {
+		watcher.metadata.UpsertMetadata(
+			addr.AsPrefixCluster(),
+			source.Generated,
+			resourceID,
+			labels,
+			flags,
+		)
+	}
+
+	return nil
+}

--- a/pkg/ipcache/nullroute/loadbalancer_test.go
+++ b/pkg/ipcache/nullroute/loadbalancer_test.go
@@ -1,0 +1,1065 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nullroute
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lbipamconfig"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+var (
+	svcNamespace = "test-namespace"
+	svcName1     = "foo-service"
+	svcName2     = "bar-service"
+
+	ipAddrAny  = "0.0.0.0"
+	ipAddr101  = "10.244.255.101"
+	ip6AddrAny = "::"
+	ip6Addr101 = "fd00:10:244::101"
+
+	bgpLoadBalancerClass   = cilium_api_v2alpha1.BGPLoadBalancerClass
+	l2LoadBalancerClass    = cilium_api_v2alpha1.L2AnnounceLoadBalancerClass
+	otherLoadBalancerClass = "other"
+
+	defaultLBIPAMExtConfig = loadbalancer.ExternalConfig{
+		DefaultLBServiceIPAM: lbipamconfig.DefaultLBClassLBIPAM,
+	}
+	defaultNodeIPAMExtConfig = loadbalancer.ExternalConfig{
+		DefaultLBServiceIPAM: lbipamconfig.DefaultLBClassNodeIPAM,
+	}
+
+	fooSvcKey  = resource.Key{Name: svcName1, Namespace: svcNamespace}
+	fooSvcName = loadbalancer.NewServiceName(fooSvcKey.Namespace, fooSvcKey.Name)
+	fooSvc     = &loadbalancer.Service{
+		Name:             fooSvcName,
+		Source:           source.Kubernetes,
+		ExtTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
+	}
+	fooSvcWithForwardAction = &loadbalancer.Service{
+		Name:                   fooSvcName,
+		Source:                 source.Kubernetes,
+		ExtTrafficPolicy:       loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:       loadbalancer.SVCTrafficPolicyCluster,
+		UnsupportedProtoAction: annotation.UnsupportedProtoActionForward,
+	}
+	fooSvcLBClassBGP = &loadbalancer.Service{
+		Name:              fooSvcName,
+		Source:            source.Kubernetes,
+		ExtTrafficPolicy:  loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:  loadbalancer.SVCTrafficPolicyCluster,
+		LoadBalancerClass: &bgpLoadBalancerClass,
+	}
+	fooSvcLBClassL2Announce = &loadbalancer.Service{
+		Name:              fooSvcName,
+		Source:            source.Kubernetes,
+		ExtTrafficPolicy:  loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:  loadbalancer.SVCTrafficPolicyCluster,
+		LoadBalancerClass: &l2LoadBalancerClass,
+	}
+	fooSvcLBClassOther = &loadbalancer.Service{
+		Name:              fooSvcName,
+		Source:            source.Kubernetes,
+		ExtTrafficPolicy:  loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:  loadbalancer.SVCTrafficPolicyCluster,
+		LoadBalancerClass: &otherLoadBalancerClass,
+	}
+
+	barSvcKey            = resource.Key{Name: svcName2, Namespace: svcNamespace}
+	barSvcName           = loadbalancer.NewServiceName(barSvcKey.Namespace, barSvcKey.Name)
+	barSvcWithDropAction = &loadbalancer.Service{
+		Name:                   barSvcName,
+		Source:                 source.Kubernetes,
+		ExtTrafficPolicy:       loadbalancer.SVCTrafficPolicyCluster,
+		IntTrafficPolicy:       loadbalancer.SVCTrafficPolicyCluster,
+		UnsupportedProtoAction: annotation.UnsupportedProtoActionDrop,
+	}
+)
+
+type mockIdentityUpdater struct{}
+
+func (mockIdentityUpdater) UpdateIdentities(identity.IdentityMap, identity.IdentityMap) <-chan struct{} {
+	done := make(chan struct{})
+	close(done)
+	return done
+}
+
+func newIPCache(tb testing.TB, log *slog.Logger) *ipcache.IPCache {
+	tb.Helper()
+
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           tb.Context(),
+		Logger:            log,
+		IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+		IdentityUpdater:   mockIdentityUpdater{},
+	})
+	tb.Cleanup(func() {
+		ipc.Shutdown()
+	})
+
+	return ipc
+}
+
+func newFrontend(
+	tb testing.TB,
+	svc *loadbalancer.Service,
+	svcType loadbalancer.SVCType,
+	addr string,
+	scope uint8,
+) *loadbalancer.Frontend {
+	tb.Helper()
+
+	svcAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, cmtypes.MustParseAddrCluster(addr), 80, scope)
+	return &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			ServiceName: svc.Name,
+			Address:     svcAddr,
+			Type:        svcType,
+		},
+		Service: svc,
+	}
+}
+
+func expectedResourceID(fe *loadbalancer.Frontend) ipcacheTypes.ResourceID {
+	return ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindService,
+		fe.Service.Name.Namespace(),
+		fe.Address.StringWithProtocolDelimited(":"),
+	)
+}
+
+func expectedWorldLabels(addr string) labels.Labels {
+	lbls := make(labels.Labels, 1)
+	lbls.AddWorldLabel(cmtypes.MustParseAddrCluster(addr).Addr())
+	return lbls
+}
+
+// Mock metadata recorder used to assert the direct outputs of onFrontendChange().
+type metadataRecord struct {
+	prefix   cmtypes.PrefixCluster
+	source   source.Source
+	resource ipcacheTypes.ResourceID
+	labels   labels.Labels
+	flags    ipcacheTypes.EndpointFlags
+}
+
+type mockMetadataMutator struct {
+	upserts []metadataRecord
+	removes []metadataRecord
+}
+
+func (m *mockMetadataMutator) UpsertMetadata(
+	prefix cmtypes.PrefixCluster,
+	src source.Source,
+	resource ipcacheTypes.ResourceID,
+	aux ...ipcache.IPMetadata,
+) {
+	m.upserts = append(m.upserts, newMetadataRecord(prefix, src, resource, aux...))
+}
+
+func (m *mockMetadataMutator) RemoveMetadata(
+	prefix cmtypes.PrefixCluster,
+	resource ipcacheTypes.ResourceID,
+	aux ...ipcache.IPMetadata,
+) {
+	m.removes = append(m.removes, newMetadataRecord(prefix, source.Unspec, resource, aux...))
+}
+
+func newMetadataRecord(
+	prefix cmtypes.PrefixCluster,
+	src source.Source,
+	resource ipcacheTypes.ResourceID,
+	aux ...ipcache.IPMetadata,
+) metadataRecord {
+	record := metadataRecord{
+		prefix:   prefix,
+		source:   src,
+		resource: resource,
+	}
+	for _, meta := range aux {
+		switch v := meta.(type) {
+		case labels.Labels:
+			record.labels = labels.NewFrom(v)
+		case ipcacheTypes.EndpointFlags:
+			record.flags = v
+		}
+	}
+	return record
+}
+
+// StateDB and listener fixtures used by the end-to-end watcher test.
+type frontendWatcherTestState struct {
+	db       *statedb.DB
+	svcTable statedb.RWTable[*loadbalancer.Service]
+	feTable  statedb.RWTable[*loadbalancer.Frontend]
+}
+
+func (state *frontendWatcherTestState) insertFrontend(tb testing.TB, svc *loadbalancer.Service, fes ...*loadbalancer.Frontend) {
+	tb.Helper()
+
+	wtxn := state.db.WriteTxn(state.svcTable, state.feTable)
+
+	_, hadOld, err := state.svcTable.Insert(wtxn, svc)
+	require.NoError(tb, err)
+	require.False(tb, hadOld)
+
+	for _, fe := range fes {
+		_, hadOld, err := state.feTable.Insert(wtxn, fe)
+		require.NoError(tb, err)
+		require.False(tb, hadOld)
+	}
+
+	wtxn.Commit()
+}
+
+func (state *frontendWatcherTestState) deleteFrontend(tb testing.TB, svc *loadbalancer.Service, fes ...*loadbalancer.Frontend) {
+	tb.Helper()
+
+	wtxn := state.db.WriteTxn(state.svcTable, state.feTable)
+	for _, fe := range fes {
+		_, hadOld, err := state.feTable.Delete(wtxn, fe)
+		require.NoError(tb, err)
+		require.True(tb, hadOld)
+	}
+
+	_, hadOld, err := state.svcTable.Delete(wtxn, svc)
+	require.NoError(tb, err)
+	require.True(tb, hadOld)
+
+	wtxn.Commit()
+}
+
+type listenerEvent struct {
+	modType       ipcache.CacheModification
+	prefix        cmtypes.PrefixCluster
+	endpointFlags uint8
+}
+
+type recordingListener struct {
+	events chan listenerEvent
+}
+
+func newRecordingListener() *recordingListener {
+	return &recordingListener{
+		events: make(chan listenerEvent, 16),
+	}
+}
+
+func (l *recordingListener) OnIPIdentityCacheChange(
+	modType ipcache.CacheModification,
+	cidrCluster cmtypes.PrefixCluster,
+	oldHostIP, newHostIP net.IP,
+	oldID *ipcache.Identity,
+	newID ipcache.Identity,
+	encryptKey uint8,
+	k8sMeta *ipcache.K8sMetadata,
+	endpointFlags uint8,
+) {
+	l.events <- listenerEvent{
+		modType:       modType,
+		prefix:        cidrCluster,
+		endpointFlags: endpointFlags,
+	}
+}
+
+func (l *recordingListener) waitFor(
+	tb testing.TB,
+	match func(listenerEvent) bool,
+) listenerEvent {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(tb.Context(), 5*time.Second)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			tb.Fatalf("timed out waiting for matching ipcache listener event")
+		case event := <-l.events:
+			if match(event) {
+				return event
+			}
+		}
+	}
+}
+
+func TestNewLoadBalancerFrontendWatcher(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultAction string
+		expected      bool
+		extConfig     loadbalancer.ExternalConfig
+	}{
+		{
+			name:          "default-upa-forward+default-lbipam",
+			defaultAction: loadbalancer.LBUnsupportedProtoActionForward,
+			expected:      false,
+			extConfig:     defaultLBIPAMExtConfig,
+		},
+		{
+			name:          "default-upa-drop+default-lbipam",
+			defaultAction: loadbalancer.LBUnsupportedProtoActionDrop,
+			expected:      true,
+			extConfig:     defaultLBIPAMExtConfig,
+		},
+		{
+			name:          "default-upa-forward+default-nodeipam",
+			defaultAction: loadbalancer.LBUnsupportedProtoActionForward,
+			expected:      false,
+			extConfig:     defaultNodeIPAMExtConfig,
+		},
+		{
+			name:          "default-upa-drop+default-nodeipam",
+			defaultAction: loadbalancer.LBUnsupportedProtoActionDrop,
+			expected:      true,
+			extConfig:     defaultNodeIPAMExtConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelInfo))
+			ipc := newIPCache(t, log)
+			db := statedb.New()
+
+			lbConfig := loadbalancer.DefaultConfig
+			lbConfig.LBUnsupportedProtoAction = tt.defaultAction
+			frontends, err := loadbalancer.NewFrontendsTable(lbConfig, db)
+			require.NoError(t, err)
+
+			watcher := newLoadBalancerFrontendWatcher(loadBalancerFrontendWatcherParams{
+				IPCache:   ipc,
+				DB:        db,
+				Frontends: frontends,
+				LBConfig:  lbConfig,
+				ExtConfig: tt.extConfig,
+			})
+
+			assert.Same(t, ipc, watcher.metadata)
+			assert.Same(t, db, watcher.db)
+			assert.Equal(t, frontends, watcher.frontends)
+			assert.Equal(t, tt.expected, watcher.dropByDefault)
+			assert.Equal(t, tt.extConfig.DefaultLBServiceIPAM, watcher.defaultLBServiceIPAM)
+		})
+	}
+}
+
+func TestIsNullRouteCandidate(t *testing.T) {
+	type testCase struct {
+		name        string
+		svcType     loadbalancer.SVCType
+		addr        string
+		scope       uint8
+		service     *loadbalancer.Service
+		extConfig   loadbalancer.ExternalConfig
+		isCandidate bool
+	}
+
+	tests := []testCase{
+		{
+			name:        "clusterip-ipv4-101-internal",
+			svcType:     loadbalancer.SVCTypeClusterIP,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeInternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "clusterip-ipv4-101-external-default-lbipam",
+			svcType:     loadbalancer.SVCTypeClusterIP,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			extConfig:   defaultLBIPAMExtConfig,
+			isCandidate: true,
+		},
+		{
+			name:        "loadbalancer-ipv6-101-internal",
+			svcType:     loadbalancer.SVCTypeLoadBalancer,
+			addr:        ip6Addr101,
+			scope:       loadbalancer.ScopeInternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "loadbalancer-ipv6-101-external-default-lbipam",
+			svcType:     loadbalancer.SVCTypeLoadBalancer,
+			addr:        ip6Addr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			extConfig:   defaultLBIPAMExtConfig,
+			isCandidate: true,
+		},
+		{
+			name:        "externalips-ipv4-any-internal",
+			svcType:     loadbalancer.SVCTypeExternalIPs,
+			addr:        ipAddrAny,
+			scope:       loadbalancer.ScopeInternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "externalips-ipv4-any-external",
+			svcType:     loadbalancer.SVCTypeExternalIPs,
+			addr:        ipAddrAny,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "externalips-ipv6-any-internal",
+			svcType:     loadbalancer.SVCTypeExternalIPs,
+			addr:        ip6AddrAny,
+			scope:       loadbalancer.ScopeInternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "externalips-ipv6-any-external",
+			svcType:     loadbalancer.SVCTypeExternalIPs,
+			addr:        ip6AddrAny,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "clusterip-external-managed-bgp-class",
+			svcType:     loadbalancer.SVCTypeClusterIP,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvcLBClassBGP,
+			isCandidate: true,
+		},
+		{
+			name:        "loadbalancer-external-managed-l2-class",
+			svcType:     loadbalancer.SVCTypeLoadBalancer,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvcLBClassL2Announce,
+			isCandidate: true,
+		},
+		{
+			name:        "clusterip-external-unmanaged-class",
+			svcType:     loadbalancer.SVCTypeClusterIP,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvcLBClassOther,
+			isCandidate: false,
+		},
+		{
+			name:        "loadbalancer-external-default-nodeipam",
+			svcType:     loadbalancer.SVCTypeLoadBalancer,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			extConfig:   defaultNodeIPAMExtConfig,
+			isCandidate: false,
+		},
+		{
+			name:        "externalips-external-managed-bgp-class",
+			svcType:     loadbalancer.SVCTypeExternalIPs,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvcLBClassBGP,
+			isCandidate: true,
+		},
+		{
+			name:        "externalips-external-default-nodeipam",
+			svcType:     loadbalancer.SVCTypeExternalIPs,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			extConfig:   defaultNodeIPAMExtConfig,
+			isCandidate: true,
+		},
+		{
+			name:        "none-external",
+			svcType:     loadbalancer.SVCTypeNone,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "hostport-external",
+			svcType:     loadbalancer.SVCTypeHostPort,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "nodeport-external",
+			svcType:     loadbalancer.SVCTypeNodePort,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+		{
+			name:        "localredirect-external",
+			svcType:     loadbalancer.SVCTypeLocalRedirect,
+			addr:        ipAddr101,
+			scope:       loadbalancer.ScopeExternal,
+			service:     fooSvc,
+			isCandidate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := loadBalancerFrontendWatcher{defaultLBServiceIPAM: tt.extConfig.DefaultLBServiceIPAM}
+			frontend := newFrontend(t, tt.service, tt.svcType, tt.addr, tt.scope)
+			assert.Equal(t, tt.isCandidate, watcher.isNullRouteCandidate(frontend))
+		})
+	}
+}
+
+func TestUseNullRouteFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultAction annotation.UnsupportedProtoAction
+		svc           *loadbalancer.Service
+		addr          string
+		shouldUseFlag bool
+	}{
+		{
+			name:          "default-unspec+svc-unspec+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionUnspec,
+			svc:           fooSvc,
+			addr:          ipAddr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-unspec+svc-unspec+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionUnspec,
+			svc:           fooSvc,
+			addr:          ip6Addr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-unspec+svc-forward+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionUnspec,
+			svc:           fooSvcWithForwardAction,
+			addr:          ipAddr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-unspec+svc-forward+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionUnspec,
+			svc:           fooSvcWithForwardAction,
+			addr:          ip6Addr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-unspec+svc-drop+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionUnspec,
+			svc:           barSvcWithDropAction,
+			addr:          ipAddr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-unspec+svc-drop+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionUnspec,
+			svc:           barSvcWithDropAction,
+			addr:          ip6Addr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-forward+svc-unspec+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionForward,
+			svc:           fooSvc,
+			addr:          ipAddr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-forward+svc-unspec+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionForward,
+			svc:           fooSvc,
+			addr:          ip6Addr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-forward+svc-forward+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionForward,
+			svc:           fooSvcWithForwardAction,
+			addr:          ipAddr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-forward+svc-forward+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionForward,
+			svc:           fooSvcWithForwardAction,
+			addr:          ip6Addr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-forward+svc-drop+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionForward,
+			svc:           barSvcWithDropAction,
+			addr:          ipAddr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-forward+svc-drop+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionForward,
+			svc:           barSvcWithDropAction,
+			addr:          ip6Addr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-drop+svc-unspec+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionDrop,
+			svc:           fooSvc,
+			addr:          ipAddr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-drop+svc-unspec+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionDrop,
+			svc:           fooSvc,
+			addr:          ip6Addr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-drop+svc-forward+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionDrop,
+			svc:           fooSvcWithForwardAction,
+			addr:          ipAddr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-drop+svc-forward+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionDrop,
+			svc:           fooSvcWithForwardAction,
+			addr:          ip6Addr101,
+			shouldUseFlag: false,
+		},
+		{
+			name:          "default-drop+svc-drop+ipv4",
+			defaultAction: annotation.UnsupportedProtoActionDrop,
+			svc:           barSvcWithDropAction,
+			addr:          ipAddr101,
+			shouldUseFlag: true,
+		},
+		{
+			name:          "default-drop+svc-drop+ipv6",
+			defaultAction: annotation.UnsupportedProtoActionDrop,
+			svc:           barSvcWithDropAction,
+			addr:          ip6Addr101,
+			shouldUseFlag: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := loadBalancerFrontendWatcher{
+				dropByDefault: tt.defaultAction == annotation.UnsupportedProtoActionDrop,
+			}
+			frontend := newFrontend(t, tt.svc, loadbalancer.SVCTypeLoadBalancer, tt.addr, loadbalancer.ScopeExternal)
+			assert.Equal(t, tt.shouldUseFlag, watcher.useNullRouteFlag(frontend))
+		})
+	}
+}
+
+// TestOnFrontendChangeUpdatesMetadata verifies the translation logic in
+// onFrontendChange() directly. This keeps the test focused on which metadata
+// mutations are emitted for a given frontend event without depending on IPCache
+// internals or asynchronous StateDB/job wiring.
+func TestOnFrontendChangeUpdatesMetadata(t *testing.T) {
+	watcher := loadBalancerFrontendWatcher{
+		metadata:             &mockMetadataMutator{},
+		defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+	}
+	mutator := watcher.metadata.(*mockMetadataMutator)
+
+	forwardFrontend := newFrontend(t, fooSvcWithForwardAction, loadbalancer.SVCTypeLoadBalancer, ipAddr101, loadbalancer.ScopeExternal)
+	dropFrontend := newFrontend(t, barSvcWithDropAction, loadbalancer.SVCTypeLoadBalancer, ip6Addr101, loadbalancer.ScopeExternal)
+
+	require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+		Object: forwardFrontend,
+	}))
+	require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+		Object: dropFrontend,
+	}))
+	require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+		Deleted: true,
+		Object:  dropFrontend,
+	}))
+
+	require.Len(t, mutator.upserts, 1)
+	require.Len(t, mutator.removes, 2)
+
+	upsert := mutator.upserts[0]
+	assert.Equal(t, dropFrontend.Address.AddrCluster().AsPrefixCluster(), upsert.prefix)
+	assert.Equal(t, source.Generated, upsert.source)
+	assert.Equal(t, expectedResourceID(dropFrontend), upsert.resource)
+	assert.Equal(t, expectedWorldLabels(ip6Addr101), upsert.labels)
+	assert.True(t, upsert.flags.IsValid())
+	assert.NotZero(t, upsert.flags.Uint8()&ipcacheTypes.FlagNullRoute)
+
+	removeForward := mutator.removes[0]
+	assert.Equal(t, forwardFrontend.Address.AddrCluster().AsPrefixCluster(), removeForward.prefix)
+	assert.Equal(t, expectedResourceID(forwardFrontend), removeForward.resource)
+	assert.Equal(t, expectedWorldLabels(ipAddr101), removeForward.labels)
+	assert.False(t, removeForward.flags.IsValid())
+
+	removeDrop := mutator.removes[1]
+	assert.Equal(t, dropFrontend.Address.AddrCluster().AsPrefixCluster(), removeDrop.prefix)
+	assert.Equal(t, expectedResourceID(dropFrontend), removeDrop.resource)
+	assert.Equal(t, expectedWorldLabels(ip6Addr101), removeDrop.labels)
+	assert.False(t, removeDrop.flags.IsValid())
+}
+
+// TestOnFrontendChangeIgnoresNonCandidates verifies that non-candidate
+// frontends are ignored entirely by onFrontendChange().
+func TestOnFrontendChangeIgnoresNonCandidates(t *testing.T) {
+	tests := []struct {
+		name                 string
+		service              *loadbalancer.Service
+		svcType              loadbalancer.SVCType
+		addr                 string
+		scope                uint8
+		defaultLBServiceIPAM string
+	}{
+		{
+			name:                 "internal-scope",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeInternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "unspecified-ipv4",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddrAny,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "unsupported-service-type",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeNodePort,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "default-nodeipam",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultNodeIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "unmanaged-loadbalancer-class",
+			service:              fooSvcLBClassOther,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := loadBalancerFrontendWatcher{
+				metadata:             &mockMetadataMutator{},
+				defaultLBServiceIPAM: tt.defaultLBServiceIPAM,
+			}
+			mutator := watcher.metadata.(*mockMetadataMutator)
+			frontend := newFrontend(t, tt.service, tt.svcType, tt.addr, tt.scope)
+
+			require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+				Object: frontend,
+			}))
+
+			assert.Empty(t, mutator.upserts)
+			assert.Empty(t, mutator.removes)
+		})
+	}
+}
+
+// TestOnFrontendChangeUsesDefaultUnsupportedProtoAction verifies that an
+// unspecified service-level action inherits the watcher's default behaviour.
+func TestOnFrontendChangeUsesDefaultUnsupportedProtoAction(t *testing.T) {
+	tests := []struct {
+		name            string
+		dropByDefault   bool
+		expectUpsert    bool
+		expectRemove    bool
+		expectNullRoute bool
+	}{
+		{
+			name:            "default-forward",
+			dropByDefault:   false,
+			expectRemove:    true,
+			expectNullRoute: false,
+		},
+		{
+			name:            "default-drop",
+			dropByDefault:   true,
+			expectUpsert:    true,
+			expectNullRoute: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := loadBalancerFrontendWatcher{
+				metadata:             &mockMetadataMutator{},
+				dropByDefault:        tt.dropByDefault,
+				defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+			}
+			mutator := watcher.metadata.(*mockMetadataMutator)
+			frontend := newFrontend(t, fooSvc, loadbalancer.SVCTypeLoadBalancer, ipAddr101, loadbalancer.ScopeExternal)
+
+			require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+				Object: frontend,
+			}))
+
+			if tt.expectUpsert {
+				require.Len(t, mutator.upserts, 1)
+				assert.Empty(t, mutator.removes)
+				assert.Equal(t, expectedResourceID(frontend), mutator.upserts[0].resource)
+				assert.Equal(t, expectedWorldLabels(ipAddr101), mutator.upserts[0].labels)
+				assert.Equal(t, tt.expectNullRoute, mutator.upserts[0].flags.Uint8()&ipcacheTypes.FlagNullRoute != 0)
+			}
+			if tt.expectRemove {
+				require.Len(t, mutator.removes, 1)
+				assert.Empty(t, mutator.upserts)
+				assert.Equal(t, expectedResourceID(frontend), mutator.removes[0].resource)
+				assert.Equal(t, expectedWorldLabels(ipAddr101), mutator.removes[0].labels)
+				assert.False(t, mutator.removes[0].flags.IsValid())
+			}
+		})
+	}
+}
+
+// TestOnFrontendChangeDeletedNonCandidateIsNoOp verifies that delete events do
+// not bypass candidate filtering.
+func TestOnFrontendChangeDeletedNonCandidateIsNoOp(t *testing.T) {
+	tests := []struct {
+		name                 string
+		service              *loadbalancer.Service
+		svcType              loadbalancer.SVCType
+		addr                 string
+		scope                uint8
+		defaultLBServiceIPAM string
+	}{
+		{
+			name:                 "internal-scope",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeInternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "unspecified-ipv6",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ip6AddrAny,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "unsupported-service-type",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeHostPort,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "default-nodeipam",
+			service:              fooSvc,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultNodeIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+		{
+			name:                 "unmanaged-loadbalancer-class",
+			service:              fooSvcLBClassOther,
+			svcType:              loadbalancer.SVCTypeLoadBalancer,
+			addr:                 ipAddr101,
+			scope:                loadbalancer.ScopeExternal,
+			defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := loadBalancerFrontendWatcher{
+				metadata:             &mockMetadataMutator{},
+				defaultLBServiceIPAM: tt.defaultLBServiceIPAM,
+			}
+			mutator := watcher.metadata.(*mockMetadataMutator)
+			frontend := newFrontend(t, tt.service, tt.svcType, tt.addr, tt.scope)
+
+			require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+				Deleted: true,
+				Object:  frontend,
+			}))
+
+			assert.Empty(t, mutator.upserts)
+			assert.Empty(t, mutator.removes)
+		})
+	}
+}
+
+// TestOnFrontendChangeBuildsExpectedResourceIDAndLabels verifies the metadata
+// identity emitted by onFrontendChange() for both IPv4 and IPv6 frontends.
+func TestOnFrontendChangeBuildsExpectedResourceIDAndLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		service *loadbalancer.Service
+	}{
+		{
+			name:    "ipv4",
+			addr:    ipAddr101,
+			service: barSvcWithDropAction,
+		},
+		{
+			name:    "ipv6",
+			addr:    ip6Addr101,
+			service: barSvcWithDropAction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := loadBalancerFrontendWatcher{
+				metadata:             &mockMetadataMutator{},
+				defaultLBServiceIPAM: defaultLBIPAMExtConfig.DefaultLBServiceIPAM,
+			}
+			mutator := watcher.metadata.(*mockMetadataMutator)
+			frontend := newFrontend(t, tt.service, loadbalancer.SVCTypeLoadBalancer, tt.addr, loadbalancer.ScopeExternal)
+
+			require.NoError(t, watcher.onFrontendChange(t.Context(), statedb.Change[*loadbalancer.Frontend]{
+				Object: frontend,
+			}))
+
+			require.Len(t, mutator.upserts, 1)
+			record := mutator.upserts[0]
+			assert.Equal(t, frontend.Address.AddrCluster().AsPrefixCluster(), record.prefix)
+			assert.Equal(t, expectedResourceID(frontend), record.resource)
+			assert.Equal(t, expectedWorldLabels(tt.addr), record.labels)
+		})
+	}
+}
+
+// TestOnFrontendChangePropagatesToIPCache verifies the integrated watcher path
+// end-to-end. Rather than asserting internal metadata state, it registers the
+// watcher with Hive and observes the resulting IPCache listener events, which
+// is the public effect the rest of the system relies on.
+func TestOnFrontendChangePropagatesToIPCache(t *testing.T) {
+	ctx := t.Context()
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+	ipc := newIPCache(t, log)
+	listener := newRecordingListener()
+	ipc.AddListener(listener)
+
+	lbConfig := loadbalancer.DefaultConfig
+	extConfig := defaultLBIPAMExtConfig
+	state := &frontendWatcherTestState{}
+
+	h := hive.New(
+		node.LocalNodeStoreTestCell,
+		Cell,
+		cell.Provide(
+			func() loadbalancer.Config { return lbConfig },
+			func() loadbalancer.ExternalConfig { return extConfig },
+			loadbalancer.NewFrontendsTable,
+			statedb.RWTable[*loadbalancer.Frontend].ToTable,
+			loadbalancer.NewServicesTable,
+			statedb.RWTable[*loadbalancer.Service].ToTable,
+			func() *option.DaemonConfig {
+				return &option.DaemonConfig{
+					EnableIPv4: true,
+					EnableIPv6: true,
+				}
+			},
+			tables.NewNodeAddressTable,
+			statedb.RWTable[tables.NodeAddress].ToTable,
+			source.NewSources,
+			func() *ipcache.IPCache { return ipc },
+		),
+		cell.Invoke(
+			func(db *statedb.DB, svcTable statedb.RWTable[*loadbalancer.Service], feTable statedb.RWTable[*loadbalancer.Frontend]) {
+				state.db = db
+				state.svcTable = svcTable
+				state.feTable = feTable
+			},
+		),
+	)
+	require.NoError(t, h.Start(log, ctx))
+	t.Cleanup(func() {
+		h.Stop(log, ctx)
+	})
+
+	fooPrefix := cmtypes.MustParseAddrCluster(ipAddr101).AsPrefixCluster()
+	barPrefix := cmtypes.MustParseAddrCluster(ip6Addr101).AsPrefixCluster()
+
+	fooFrontendIPv4 := newFrontend(t, fooSvcWithForwardAction, loadbalancer.SVCTypeLoadBalancer, ipAddr101, loadbalancer.ScopeExternal)
+	barFrontendIPv6 := newFrontend(t, barSvcWithDropAction, loadbalancer.SVCTypeLoadBalancer, ip6Addr101, loadbalancer.ScopeExternal)
+
+	state.insertFrontend(t, fooSvcWithForwardAction, fooFrontendIPv4)
+	state.insertFrontend(t, barSvcWithDropAction, barFrontendIPv6)
+
+	upsertEvent := listener.waitFor(t, func(event listenerEvent) bool {
+		return event.modType == ipcache.Upsert && event.prefix == barPrefix
+	})
+	assert.NotZero(t, upsertEvent.endpointFlags&ipcacheTypes.FlagNullRoute)
+
+	_, exists := ipc.LookupByPrefix(fooPrefix.String())
+	assert.False(t, exists)
+
+	_, exists = ipc.LookupByPrefix(barPrefix.String())
+	assert.True(t, exists)
+
+	state.deleteFrontend(t, fooSvcWithForwardAction, fooFrontendIPv4)
+	state.deleteFrontend(t, barSvcWithDropAction, barFrontendIPv6)
+
+	listener.waitFor(t, func(event listenerEvent) bool {
+		return event.modType == ipcache.Delete && event.prefix == barPrefix
+	})
+
+	_, exists = ipc.LookupByPrefix(fooPrefix.String())
+	assert.False(t, exists)
+
+	_, exists = ipc.LookupByPrefix(barPrefix.String())
+	assert.False(t, exists)
+}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -36,6 +36,7 @@ var (
 	ResourceKindNetpol    = ResourceKind("netpol")
 	ResourceKindKCNP      = ResourceKind("kcnp")
 	ResourceKindNode      = ResourceKind("node")
+	ResourceKindService   = ResourceKind("svc")
 )
 
 // NewResourceID returns a ResourceID populated with the standard fields for

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/hive/cell"
 
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/lbipamconfig"
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
@@ -74,6 +75,10 @@ const (
 	// pushing packets to backends under DSR ("opt", "ipip", "geneve")
 	LoadBalancerDSRDispatchName = "bpf-lb-dsr-dispatch"
 
+	// LBUnsupportedProtoActionName is the config option for setting the action we
+	// take when processing unsupported transport protocols ("drop, forward")
+	LBUnsupportedProtoActionName = "bpf-lb-unsupported-protocol-action"
+
 	// ExternalClusterIPName is the name of the option to enable
 	// cluster external access to ClusterIP services.
 	ExternalClusterIPName = "bpf-lb-external-clusterip"
@@ -128,6 +133,12 @@ const (
 
 	// DSR dispatch mode to encapsulate to Geneve
 	DSRDispatchGeneve = "geneve"
+
+	// Unsupported Protocol Action is to forward as normal
+	LBUnsupportedProtoActionForward = datapathOption.UnsupportedProtoActionForward
+
+	// Unsupported Protocol Action is to drop
+	LBUnsupportedProtoActionDrop = datapathOption.UnsupportedProtoActionDrop
 )
 
 // UserConfig is the configuration provided by the user that has not been processed.
@@ -183,6 +194,9 @@ type UserConfig struct {
 	// DSRDispatch indicates the method for pushing packets to
 	// backends under DSR ("opt", "ipip", "geneve")
 	DSRDispatch string `mapstructure:"bpf-lb-dsr-dispatch"`
+
+	// LBUnsupportedProtocAction indicates how we handle unsupported transport protocols
+	LBUnsupportedProtoAction string `mapstructure:"bpf-lb-unsupported-protocol-action"`
 
 	// ExternalClusterIP enables routing to ClusterIP services from outside
 	// the cluster. This mirrors the behaviour of kube-proxy.
@@ -320,6 +334,9 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 
 	flags.String(LoadBalancerDSRDispatchName, def.DSRDispatch, "BPF load balancing DSR dispatch method (\"opt\", \"ipip\", \"geneve\")")
 
+	flags.String(LBUnsupportedProtoActionName, def.LBUnsupportedProtoAction, fmt.Sprintf("BPF load balancing unsupported protocol action (\"%s\", \"%s\")",
+		LBUnsupportedProtoActionForward, LBUnsupportedProtoActionDrop))
+
 	flags.Bool(ExternalClusterIPName, def.ExternalClusterIP, "Enable external access to ClusterIP services (default false)")
 
 	flags.Bool(AlgorithmAnnotationName, def.AlgorithmAnnotation, "Enable service-level annotation for configuring BPF load balancing algorithm")
@@ -452,6 +469,12 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig Depreca
 		return Config{}, fmt.Errorf("The value --%s=%s is not supported as default under annotation mode", LoadBalancerModeName, cfg.LBMode)
 	}
 
+	switch cfg.LBUnsupportedProtoAction {
+	case LBUnsupportedProtoActionDrop, LBUnsupportedProtoActionForward:
+	default:
+		return Config{}, fmt.Errorf("Invalid value for --%s: %s", LBUnsupportedProtoActionName, cfg.LBUnsupportedProtoAction)
+	}
+
 	/* FIXME:
 
 	if cfg.NodePortMode == option.NodePortModeDSR &&
@@ -499,6 +522,8 @@ var DefaultUserConfig = UserConfig{
 	LBMode: LBModeSNAT,
 
 	DSRDispatch: DSRDispatchOption,
+
+	LBUnsupportedProtoAction: LBUnsupportedProtoActionForward,
 
 	// Defaults to false to retain prior behaviour to not route external packets
 	// to ClusterIP services.

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -1072,15 +1072,22 @@ func (a L3n4Addr) String() string {
 // StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
 // format for IPv4 and "[IPv6]:Port/Protocol[/Scope]" format for IPv6.
 func (a L3n4Addr) StringWithProtocol() string {
+	return a.StringWithProtocolDelimited("/")
+}
+
+// StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
+// format for IPv4 and "[IPv6]:Port/Protocol[/Scope]" format for IPv6, where /
+// represents the provided delimiter.
+func (a L3n4Addr) StringWithProtocolDelimited(delim string) string {
 	rep := a.rep()
 	var scope string
 	if rep.scope == ScopeInternal {
-		scope = "/i"
+		scope = delim + "i"
 	}
 	if a.IsIPv6() {
-		return "[" + rep.addrCluster.String() + "]:" + strconv.FormatUint(uint64(rep.Port), 10) + "/" + rep.Protocol + scope
+		return "[" + rep.addrCluster.String() + "]:" + strconv.FormatUint(uint64(rep.Port), 10) + delim + rep.Protocol + scope
 	}
-	return rep.addrCluster.String() + ":" + strconv.FormatUint(uint64(rep.Port), 10) + "/" + rep.Protocol + scope
+	return rep.addrCluster.String() + ":" + strconv.FormatUint(uint64(rep.Port), 10) + delim + rep.Protocol + scope
 }
 
 // StringID returns the L3n4Addr as string to be used for unique identification

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -65,14 +65,15 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 
 	name := loadbalancer.NewServiceName(svc.Namespace, svc.Name)
 	s = &loadbalancer.Service{
-		Name:                name,
-		Source:              source,
-		Labels:              labels.Map2Labels(svc.Labels, string(source)),
-		Selector:            svc.Spec.Selector,
-		Annotations:         svc.Annotations,
-		HealthCheckNodePort: uint16(svc.Spec.HealthCheckNodePort),
-		ForwardingMode:      loadbalancer.SVCForwardingModeUndef,
-		LoadBalancerClass:   svc.Spec.LoadBalancerClass,
+		Name:                   name,
+		Source:                 source,
+		Labels:                 labels.Map2Labels(svc.Labels, string(source)),
+		Selector:               svc.Spec.Selector,
+		Annotations:            svc.Annotations,
+		HealthCheckNodePort:    uint16(svc.Spec.HealthCheckNodePort),
+		ForwardingMode:         loadbalancer.SVCForwardingModeUndef,
+		UnsupportedProtoAction: annotation.UnsupportedProtoActionUnspec,
+		LoadBalancerClass:      svc.Spec.LoadBalancerClass,
 	}
 
 	if cfg.LBModeAnnotation {
@@ -85,6 +86,16 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 				logfields.Annotations, annotation.ServiceForwardingMode,
 			)
 		}
+	}
+
+	unsupportedProtoAction, err := annotation.GetAnnotationUnsupportedProtoAction(svc)
+	if err == nil {
+		s.UnsupportedProtoAction = unsupportedProtoAction
+	} else {
+		log().Warn("Ignoring annotation",
+			logfields.Error, err,
+			logfields.Annotations, annotation.NetworkUnsupportedProtoAction,
+		)
 	}
 
 	if localNode != nil {

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -60,6 +60,10 @@ type Service struct {
 	// to the backend. If undefined the default mode is used (--bpf-lb-mode).
 	ForwardingMode SVCForwardingMode
 
+	// UnsupportedProtoAction controls whether we drop or forward traffic carrying
+	// unsupported transport protocols.
+	UnsupportedProtoAction annotation.UnsupportedProtoAction
+
 	// SessionAffinity if true will enable the client IP based session affinity.
 	SessionAffinity bool
 
@@ -255,6 +259,10 @@ func (svc *Service) TableRow() []string {
 
 	if svc.ForwardingMode != SVCForwardingModeUndef {
 		flags = append(flags, "ForwardingMode="+string(svc.ForwardingMode))
+	}
+
+	if svc.UnsupportedProtoAction != annotation.UnsupportedProtoActionUnspec {
+		flags = append(flags, "UnsupportedProtoAction="+string(svc.UnsupportedProtoAction))
 	}
 
 	if svc.TrafficDistribution != TrafficDistributionDefault {

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -62,6 +62,7 @@ test/echo  [2002::2]:8080/TCP
   "ExtTrafficPolicy": "Cluster",
   "IntTrafficPolicy": "Cluster",
   "ForwardingMode": "",
+  "UnsupportedProtoAction": "",
   "SessionAffinity": false,
   "SessionAffinityTimeout": 0,
   "LoadBalancerClass": null,
@@ -213,6 +214,7 @@ natpolicy: ""
 exttrafficpolicy: Cluster
 inttrafficpolicy: Cluster
 forwardingmode: ""
+unsupportedprotoaction: ""
 sessionaffinity: false
 sessionaffinitytimeout: 0s
 loadbalancerclass: null

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -244,6 +244,9 @@ func (in *Service) deepEqual(other *Service) bool {
 	if in.ForwardingMode != other.ForwardingMode {
 		return false
 	}
+	if in.UnsupportedProtoAction != other.UnsupportedProtoAction {
+		return false
+	}
 	if in.SessionAffinity != other.SessionAffinity {
 		return false
 	}

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -364,6 +364,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.DSRDispatch != other.DSRDispatch {
 		return false
 	}
+	if in.LBUnsupportedProtoAction != other.LBUnsupportedProtoAction {
+		return false
+	}
 	if in.ExternalClusterIP != other.ExternalClusterIP {
 		return false
 	}


### PR DESCRIPTION
**NOTE: will remain draft until dependency PR is merged and this will then be rebased.**

This PR implements "unsupported protocol action" for LoadBalancer services, so that users can specify how Cilium should behave when processing traffic over unsupported L4 protocols towards LoadBalancer VIPs.

The first version of this was submitted under https://github.com/cilium/cilium/pull/42897 but required rework of control plane elements, and at the time of first review was missing test coverage.

The revised change set was getting large, so it's now being split into 2 smaller PRs to reduce review burden.

A personal [dev branch containing the full work](https://github.com/ajmmm/cilium/tree/dev/ipcache-unroutable-db) includes:
* Commits 1-7 (data path; see https://github.com/cilium/cilium/pull/44736)
* Commits 8-13 (control plane; this PR)

https://github.com/cilium/cilium/pull/42897 is superseded by https://github.com/cilium/cilium/pull/44736 and this PR.

---

**This PR**

- Introduces node-level `bpf-lb-unsupported-protocol-action` flag which can be configured as `forward` or `drop`. The default is `forward`.

- Introduces service-level `network.cilium.io/unsupported-protocol-action` annotation which can also be configured as `forward` or `drop`. If specified, this will take precedent over the default action.

- Introduces new "nullroute" sub-package in IPCache, which implements:
  - Watcher on StateDB frontends table
  - Reconciliation logic to update IPCache with `null_route` flags set on candidate LoadBalancer frontend entries.

---

Release Notes

```release-note
Introduces unsupported-protocol-action feature so Cilium can be configured to drop unsupported protocols towards Cilium-managed IPs in the data path.
```