### PR TITLE
bgp: Ensure ServerLogger uses BGP instance name

### DIFF
--- a/pkg/bgp/gobgp/logger.go
+++ b/pkg/bgp/gobgp/logger.go
@@ -16,12 +16,14 @@ import (
 type ServerLogger struct {
 	l         *slog.Logger
 	asn       uint32
+	name      string
 	component string
 	subsys    string
 }
 
 type LogParams struct {
 	AS        uint32
+	Name      string
 	Component string
 	SubSys    string
 }
@@ -30,13 +32,14 @@ func NewServerLogger(l *slog.Logger, params LogParams) *ServerLogger {
 	return &ServerLogger{
 		l:         l,
 		asn:       params.AS,
+		name:      params.Name,
 		component: params.Component,
 		subsys:    params.SubSys,
 	}
 }
 
 func (l *ServerLogger) Panic(msg string, fields gobgpLog.Fields) {
-	logAttrs := make([]any, 0, len(fields)+3)
+	logAttrs := make([]any, 0, len(fields)+4)
 	for k, v := range fields {
 		logAttrs = append(
 			logAttrs,
@@ -45,6 +48,7 @@ func (l *ServerLogger) Panic(msg string, fields gobgpLog.Fields) {
 	}
 	logAttrs = append(
 		logAttrs,
+		types.InstanceLogField, l.name,
 		types.LocalASNLogField, l.asn,
 		types.ComponentLogField, l.component,
 		types.SubsysLogField, l.subsys,
@@ -53,7 +57,7 @@ func (l *ServerLogger) Panic(msg string, fields gobgpLog.Fields) {
 }
 
 func (l *ServerLogger) Fatal(msg string, fields gobgpLog.Fields) {
-	logAttrs := make([]any, 0, len(fields)+3)
+	logAttrs := make([]any, 0, len(fields)+4)
 	for k, v := range fields {
 		logAttrs = append(
 			logAttrs,
@@ -62,6 +66,7 @@ func (l *ServerLogger) Fatal(msg string, fields gobgpLog.Fields) {
 	}
 	logAttrs = append(
 		logAttrs,
+		types.InstanceLogField, l.name,
 		types.LocalASNLogField, l.asn,
 		types.ComponentLogField, l.component,
 		types.SubsysLogField, l.subsys,
@@ -70,7 +75,7 @@ func (l *ServerLogger) Fatal(msg string, fields gobgpLog.Fields) {
 }
 
 func (l *ServerLogger) Error(msg string, fields gobgpLog.Fields) {
-	logAttrs := make([]any, 0, len(fields)+3)
+	logAttrs := make([]any, 0, len(fields)+4)
 	for k, v := range fields {
 		logAttrs = append(
 			logAttrs,
@@ -79,6 +84,7 @@ func (l *ServerLogger) Error(msg string, fields gobgpLog.Fields) {
 	}
 	logAttrs = append(
 		logAttrs,
+		types.InstanceLogField, l.name,
 		types.LocalASNLogField, l.asn,
 		types.ComponentLogField, l.component,
 		types.SubsysLogField, l.subsys,
@@ -87,7 +93,7 @@ func (l *ServerLogger) Error(msg string, fields gobgpLog.Fields) {
 }
 
 func (l *ServerLogger) Warn(msg string, fields gobgpLog.Fields) {
-	logAttrs := make([]any, 0, len(fields)+3)
+	logAttrs := make([]any, 0, len(fields)+4)
 	for k, v := range fields {
 		logAttrs = append(
 			logAttrs,
@@ -96,6 +102,7 @@ func (l *ServerLogger) Warn(msg string, fields gobgpLog.Fields) {
 	}
 	logAttrs = append(
 		logAttrs,
+		types.InstanceLogField, l.name,
 		types.LocalASNLogField, l.asn,
 		types.ComponentLogField, l.component,
 		types.SubsysLogField, l.subsys,
@@ -104,7 +111,7 @@ func (l *ServerLogger) Warn(msg string, fields gobgpLog.Fields) {
 }
 
 func (l *ServerLogger) Info(msg string, fields gobgpLog.Fields) {
-	logAttrs := make([]any, 0, len(fields)+3)
+	logAttrs := make([]any, 0, len(fields)+4)
 	for k, v := range fields {
 		logAttrs = append(
 			logAttrs,
@@ -113,6 +120,7 @@ func (l *ServerLogger) Info(msg string, fields gobgpLog.Fields) {
 	}
 	logAttrs = append(
 		logAttrs,
+		types.InstanceLogField, l.name,
 		types.LocalASNLogField, l.asn,
 		types.ComponentLogField, l.component,
 		types.SubsysLogField, l.subsys,
@@ -121,7 +129,7 @@ func (l *ServerLogger) Info(msg string, fields gobgpLog.Fields) {
 }
 
 func (l *ServerLogger) Debug(msg string, fields gobgpLog.Fields) {
-	logAttrs := make([]any, 0, len(fields)+3)
+	logAttrs := make([]any, 0, len(fields)+4)
 	for k, v := range fields {
 		logAttrs = append(
 			logAttrs,
@@ -130,6 +138,7 @@ func (l *ServerLogger) Debug(msg string, fields gobgpLog.Fields) {
 	}
 	logAttrs = append(
 		logAttrs,
+		types.InstanceLogField, l.name,
 		types.LocalASNLogField, l.asn,
 		types.ComponentLogField, l.component,
 		types.SubsysLogField, l.subsys,

--- a/pkg/bgp/gobgp/server.go
+++ b/pkg/bgp/gobgp/server.go
@@ -93,6 +93,7 @@ type GoBGPServer struct {
 func NewGoBGPServer(ctx context.Context, log *slog.Logger, params types.ServerParameters) (types.Router, error) {
 	logger := NewServerLogger(log, LogParams{
 		AS:        params.Global.ASN,
+		Name:      params.Name,
 		Component: "gobgp.BgpServerInstance",
 		SubSys:    "bgp-control-plane",
 	})

--- a/pkg/bgp/gobgp/server_test.go
+++ b/pkg/bgp/gobgp/server_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var testServerParameters = types.ServerParameters{
+	Name: "test-instance",
 	Global: types.BGPGlobal{
 		ASN:        65000,
 		RouterID:   "127.0.0.1",

--- a/pkg/bgp/gobgp/state_test.go
+++ b/pkg/bgp/gobgp/state_test.go
@@ -296,6 +296,7 @@ func TestGetPeerState(t *testing.T) {
 	}
 	for _, tt := range table {
 		srvParams := types.ServerParameters{
+			Name: "test-instance",
 			Global: types.BGPGlobal{
 				ASN:        tt.localASN,
 				RouterID:   "127.0.0.1",
@@ -395,6 +396,7 @@ func findMatchingPeer(peers []*models.BgpPeer, n *types.Neighbor) *models.BgpPee
 
 func TestGetRoutes(t *testing.T) {
 	testSC, err := NewGoBGPServer(context.Background(), hivetest.Logger(t), types.ServerParameters{
+		Name: "test-instance",
 		Global: types.BGPGlobal{
 			ASN:        65000,
 			RouterID:   "127.0.0.1",

--- a/pkg/bgp/manager/instance/instance.go
+++ b/pkg/bgp/manager/instance/instance.go
@@ -36,7 +36,7 @@ func (i *BGPInstance) NotifyStateChange() {
 //
 // Canceling the provided context will kill the BGP instance along with calling the
 // underlying Router's Stop() method.
-func NewBGPInstance(ctx context.Context, routerProvider types.RouterProvider, log *slog.Logger, name string, params types.ServerParameters) (*BGPInstance, error) {
+func NewBGPInstance(ctx context.Context, routerProvider types.RouterProvider, log *slog.Logger, params types.ServerParameters) (*BGPInstance, error) {
 	routerCtx, cancel := context.WithCancel(ctx)
 	s, err := routerProvider.NewRouter(routerCtx, log, params)
 	if err != nil {
@@ -45,7 +45,7 @@ func NewBGPInstance(ctx context.Context, routerProvider types.RouterProvider, lo
 	}
 
 	return &BGPInstance{
-		Name:                name,
+		Name:                params.Name,
 		Global:              params.Global,
 		CancelCtx:           cancel,
 		Config:              nil,

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -565,6 +565,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 	}
 
 	globalConfig := types.ServerParameters{
+		Name: c.Name,
 		Global: types.BGPGlobal{
 			ASN:        uint32(localASN),
 			RouterID:   routerID,
@@ -576,7 +577,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 		StateNotification: make(types.StateNotificationCh, 1),
 	}
 
-	i, err := instance.NewBGPInstance(ctx, m.routerProvider, l, c.Name, globalConfig)
+	i, err := instance.NewBGPInstance(ctx, m.routerProvider, l, globalConfig)
 	if err != nil {
 		return fmt.Errorf("failed to start BGP instance: %w", err)
 	}
@@ -602,6 +603,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 
 	m.logger.Info(
 		"Successfully registered BGP instance",
+		types.InstanceLogField, c.Name,
 		types.LocalASNLogField, localASN,
 		types.ListenPortLogField, localPort,
 		types.RouterIDLogField, routerID,

--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -160,13 +160,14 @@ func TestGetRoutesLegacy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// set up BGPRouterManager with one BGP server
 			srvParams := types.ServerParameters{
+				Name: "test-instance",
 				Global: types.BGPGlobal{
 					ASN:        uint32(testRouterASN),
 					RouterID:   "127.0.0.1",
 					ListenPort: -1,
 				},
 			}
-			testInstance, err := instance.NewBGPInstance(context.Background(), gobgp.NewRouterProvider(), hivetest.Logger(t), "test-instance", srvParams)
+			testInstance, err := instance.NewBGPInstance(context.Background(), gobgp.NewRouterProvider(), hivetest.Logger(t), srvParams)
 			require.NoError(t, err)
 
 			testInstance.Config = &v2.CiliumBGPNodeInstance{

--- a/pkg/bgp/manager/reconciler/default_gateway_test.go
+++ b/pkg/bgp/manager/reconciler/default_gateway_test.go
@@ -513,6 +513,7 @@ func TestDeviceChangeTrackerObserver(t *testing.T) {
 func setupBGPInstance(logger *slog.Logger) (*instance.BGPInstance, error) {
 	// our test BgpServer with our original router ID and local port
 	srvParams := types.ServerParameters{
+		Name: "test-instance",
 		Global: types.BGPGlobal{
 			ASN:        64125,
 			RouterID:   "127.0.0.1",
@@ -520,7 +521,7 @@ func setupBGPInstance(logger *slog.Logger) (*instance.BGPInstance, error) {
 		},
 	}
 
-	testInstance, err := instance.NewBGPInstance(context.Background(), gobgp.NewRouterProvider(), logger, "test-instance", srvParams)
+	testInstance, err := instance.NewBGPInstance(context.Background(), gobgp.NewRouterProvider(), logger, srvParams)
 	return testInstance, err
 }
 

--- a/pkg/bgp/test/commands/gobgp.go
+++ b/pkg/bgp/test/commands/gobgp.go
@@ -147,6 +147,7 @@ func GoBGPAddServerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 			// start new GoBGP server
 			gobgpServer := server.NewBgpServer(server.LoggerOption(gobgp.NewServerLogger(slog.Default(), gobgp.LogParams{
 				AS:        uint32(asn),
+				Name:      args[0],
 				Component: "test",
 				SubSys:    "gobgp",
 			})))

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -465,6 +465,7 @@ type GetBGPResponse struct {
 
 // ServerParameters contains information for underlying bgp implementation layer to initializing BGP process.
 type ServerParameters struct {
+	Name              string
 	Global            BGPGlobal
 	StateNotification StateNotificationCh
 }


### PR DESCRIPTION
Changed ServerLogger, LogParams, ServerParameters to contain BGP instance name because current BGP implementation uses instance name as the identifier in the CRD API.
Deleted the name parameter from NewBGPInstance because it is part of ServerParameters.
