### PR TITLE
bpf: tests: simplify __lb_v4_upsert_service()

### DIFF
--- a/bpf/tests/lib/lb.h
+++ b/bpf/tests/lib/lb.h
@@ -18,7 +18,7 @@ lb_v4_delete_service(__be32 addr, __be16 port, __u8 proto)
 }
 
 static __always_inline void
-__lb_v4_upsert_service(__be32 addr, __be16 port, __u8 proto, __u8 proto_int,
+__lb_v4_upsert_service(__be32 addr, __be16 port, __u8 proto,
 		       __u16 backend_count, __u16 rev_nat_index, __u8 flags, __u8 flags2,
 		       bool session_affinity, __u32 affinity_timeout)
 {
@@ -44,7 +44,7 @@ __lb_v4_upsert_service(__be32 addr, __be16 port, __u8 proto, __u8 proto_int,
 
 	if (lb4_svc_is_two_scopes(&svc_value)) {
 		/* Register with both scopes: */
-		svc_key.proto = proto_int;
+		svc_key.proto = proto;
 		svc_key.scope = LB_LOOKUP_SCOPE_INT;
 		map_update_elem(&cilium_lb4_services_v2, &svc_key, &svc_value, BPF_ANY);
 	}
@@ -54,17 +54,17 @@ static __always_inline void
 lb_v4_upsert_service(__be32 addr, __be16 port, __u8 proto, __u16 backend_count,
 		     __u16 rev_nat_index)
 {
-	__lb_v4_upsert_service(addr, port, proto, proto, backend_count, rev_nat_index,
+	__lb_v4_upsert_service(addr, port, proto, backend_count, rev_nat_index,
 			       SVC_FLAG_ROUTABLE, 0, false, 0);
 }
 
 static __always_inline void
-__lb_v4_add_service(__be32 addr, __be16 port, __u8 proto, __u8 proto_int,
+__lb_v4_add_service(__be32 addr, __be16 port, __u8 proto,
 		    __u16 backend_count, __u16 rev_nat_index, __u8 flags,
 		    __u8 flags2, bool session_affinity, __u32 affinity_timeout)
 {
 	/* Register with both scopes: */
-	__lb_v4_upsert_service(addr, port, proto, proto_int, backend_count, rev_nat_index,
+	__lb_v4_upsert_service(addr, port, proto, backend_count, rev_nat_index,
 			       flags, flags2, session_affinity, affinity_timeout);
 
 	/* Insert a reverse NAT entry for the above service */
@@ -79,7 +79,7 @@ static __always_inline void
 lb_v4_add_service(__be32 addr, __be16 port, __u8 proto, __u16 backend_count,
 		  __u16 rev_nat_index)
 {
-	__lb_v4_add_service(addr, port, proto, proto, backend_count, rev_nat_index,
+	__lb_v4_add_service(addr, port, proto, backend_count, rev_nat_index,
 			    SVC_FLAG_ROUTABLE, 0, false, 0);
 }
 
@@ -87,7 +87,7 @@ static __always_inline void
 lb_v4_add_service_with_flags(__be32 addr, __be16 port, __u8 proto, __u16 backend_count,
 			     __u16 rev_nat_index, __u8 flags, __u8 flags2)
 {
-	__lb_v4_add_service(addr, port, proto, proto, backend_count, rev_nat_index,
+	__lb_v4_add_service(addr, port, proto, backend_count, rev_nat_index,
 			    flags, flags2, false, 0);
 }
 
@@ -96,7 +96,7 @@ lb_v4_add_nodeport_service(__be32 addr, __be16 port, __u8 proto,
 			   __u16 backend_count, __u16 rev_nat_index,
 			   __u8 flags2)
 {
-	__lb_v4_add_service(addr, port, proto, proto, backend_count, rev_nat_index,
+	__lb_v4_add_service(addr, port, proto, backend_count, rev_nat_index,
 			    SVC_FLAG_ROUTABLE | SVC_FLAG_NODEPORT, flags2, false, 0);
 }
 

--- a/bpf/tests/session_affinity_maglev_test.c
+++ b/bpf/tests/session_affinity_maglev_test.c
@@ -184,7 +184,7 @@ static __always_inline void setup_test(void)
 	 */
 	__u32 affinity_timeout = 0x2000064;
 
-	__lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, IPPROTO_TCP,
+	__lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP,
 			    LB_MAGLEV_LUT_SIZE, TEST_REVNAT, SVC_FLAG_ROUTABLE, 0,
 			    true, affinity_timeout);
 


### PR DESCRIPTION
12065b5eac7d ("bpf: test: support service definition with mixed L4 proto values") added support for configuring a dual-scope SVC with mixed L4 proto values (the actual proto, and ANY).

But we now always have L4 service differentiation, and 3091b2e406af ("bpf: tests: Remove redundant function") removed the helper for services with mixed L4 protos. Clean up the redundant `proto_int` parameter as well.