### PR TITLE
dpgen: fix duplicate BTF type lookup for identical structs

### DIFF
--- a/tools/dpgen/types.go
+++ b/tools/dpgen/types.go
@@ -78,12 +78,13 @@ func runTypes(cmd *cobra.Command, args []string) error {
 	for t := range sortedSeq(added.Members()) {
 		// Look up all added root types by name to: 1. avoid emitting type decls for
 		// embedded types, and 2. ensure all types with the same name deduplicated
-		// into one concrete type. This lookup will fail if there are multiple
-		// incompatible candidate types with the same name across objects.
-		typ, err := spec.AnyTypeByName(t)
+		// into one concrete type. Use AnyTypesByName and take the first match, since
+		// the builder's deduplication ensures equivalent types are interchangeable.
+		types, err := spec.AnyTypesByName(t)
 		if err != nil {
 			return fmt.Errorf("getting BTF type %v: %w", t, err)
 		}
+		typ := types[0]
 
 		// Only include structs, unions and typedefs.
 		switch typ.(type) {


### PR DESCRIPTION
AnyTypeByName returns an error when multiple BTF types share the same name, even if they are structurally identical. This happens for types like endpoint_key that are defined in a shared header and included in multiple BPF object files. Despite the BTF builder's deduplication, identical copies can survive as separate entries in the resulting spec.

Switch to AnyTypesByName (plural) and select the first match. This is safe because the builder is configured with Deduplicate: true, ensuring any surviving duplicates are equivalent.

```
Error: getting BTF type endpoint_key: found multiple types: [Struct:"endpoint_key"[fields=4] Struct:"endpoint_key"[fields=4]]
Usage:
  dpgen types [pattern(s) ...] [flags]

Flags:
  -h, --help             help for types
  -p, --package string   name of the Go package dpgen was invoked for/from (default $GOPACKAGE) (default "types")

../pkg/datapath/types/gen.go:6: running "go": exit status 1
```
