### PR TITLE
refactor(bpf): return the original drop verdict in `tail_policy_denied_ipv4`

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2678,7 +2678,7 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 
 	ret = generate_icmp4_reply(ctx, ICMP_DEST_UNREACH, ICMP_PKT_FILTERED);
 	if (!ret) {
-		cilium_dbg_capture(ctx, DBG_CAPTURE_DELIVERY, ctx_get_ifindex(ctx));
+		cilium_dbg(ctx, DBG_LOCAL_DELIVERY, LXC_ID, SECLABEL_IPV4);
 		ret = redirect_self(ctx);
 
 		if (!IS_ERR(ret)) {
@@ -2687,7 +2687,7 @@ int tail_policy_denied_ipv4(struct __ctx_buff *ctx)
 		}
 	}
 
-	return send_drop_notify_error(ctx, SECLABEL_IPV4, ret, METRIC_EGRESS);
+	return send_drop_notify_error(ctx, SECLABEL_IPV4, verdict, METRIC_EGRESS);
 }
 #endif /* ENABLE_IPV4 */
 


### PR DESCRIPTION
As previously discussed here https://github.com/cilium/cilium/pull/44234#discussion_r2837602603

As we do in IPv6, we want to return the original verdict as an error if we are not able to generate the return ICMP packet. Moreover, we prefer to use `cilium_dbg` as we do in `tail_policy_denied_ipv6`.

@joestringer, tagging you since you are the one who initially suggested the change
