### PR TITLE
cilium-dbg: show "unknown" entry count for maps without cache

### DIFF
--- a/cilium-dbg/cmd/map_list.go
+++ b/cilium-dbg/cmd/map_list.go
@@ -5,8 +5,10 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
+	"strconv"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -39,7 +41,7 @@ var mapListCmd = &cobra.Command{
 			if verbose {
 				printMapListVerbose(mapList)
 			} else {
-				printMapList(mapList)
+				printMapList(os.Stdout, mapList)
 			}
 		}
 	},
@@ -53,23 +55,30 @@ func printMapListVerbose(mapList *models.BPFMapList) {
 	}
 }
 
-func printMapList(mapList *models.BPFMapList) {
-	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+func printMapList(out io.Writer, mapList *models.BPFMapList) {
+	w := tabwriter.NewWriter(out, 5, 0, 3, ' ', 0)
 	fmt.Fprintf(w, "Name\tNum entries\tNum errors\tCache enabled\n")
 	for _, m := range mapList.Maps {
-		entries, errors := 0, 0
+		entries := "unknown"
+		var errorCount int
 		cacheEnabled := m.Cache != nil
 
-		for _, e := range m.Cache {
-			if e != nil {
-				if e.LastError != "" {
-					errors++
+		if cacheEnabled {
+			var entryCount int
+			for _, e := range m.Cache {
+				if e == nil {
+					continue
 				}
-				entries++
+				entryCount++
+				if e.LastError != "" {
+					errorCount++
+				}
 			}
+			entries = strconv.Itoa(entryCount)
 		}
-		fmt.Fprintf(w, "%s\t%d\t%d\t%t\n",
-			path.Base(m.Path), entries, errors, cacheEnabled)
+
+		fmt.Fprintf(w, "%s\t%s\t%d\t%t\n",
+			path.Base(m.Path), entries, errorCount, cacheEnabled)
 	}
 	w.Flush()
 }

--- a/cilium-dbg/cmd/map_list_test.go
+++ b/cilium-dbg/cmd/map_list_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+func TestPrintMapList(t *testing.T) {
+	tests := []struct {
+		name     string
+		maps     []*models.BPFMap
+		expected []string
+	}{
+		{
+			name: "map with cache entries shows count",
+			maps: []*models.BPFMap{
+				{
+					Path: "/sys/fs/bpf/tc/globals/cilium_ipcache",
+					Cache: []*models.BPFMapEntry{
+						{Key: "key1", Value: "val1"},
+						{Key: "key2", Value: "val2"},
+					},
+				},
+			},
+			expected: []string{"cilium_ipcache", "2", "0", "true"},
+		},
+		{
+			name: "map with nil cache shows unknown",
+			maps: []*models.BPFMap{
+				{
+					Path: "/sys/fs/bpf/tc/globals/cilium_node_map_v2",
+				},
+			},
+			expected: []string{"cilium_node_map_v2", "unknown", "0", "false"},
+		},
+		{
+			name: "map with empty cache shows zero",
+			maps: []*models.BPFMap{
+				{
+					Path:  "/sys/fs/bpf/tc/globals/cilium_empty_map",
+					Cache: []*models.BPFMapEntry{},
+				},
+			},
+			expected: []string{"cilium_empty_map", "0", "0", "true"},
+		},
+		{
+			name: "map with cache errors counts them",
+			maps: []*models.BPFMap{
+				{
+					Path: "/sys/fs/bpf/tc/globals/cilium_test",
+					Cache: []*models.BPFMapEntry{
+						{Key: "key1", Value: "val1"},
+						{Key: "key2", Value: "val2", LastError: "sync failed"},
+					},
+				},
+			},
+			expected: []string{"cilium_test", "2", "1", "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printMapList(&buf, &models.BPFMapList{Maps: tt.maps})
+			output := buf.String()
+
+			for _, exp := range tt.expected {
+				require.Contains(t, output, exp,
+					"expected output to contain %q, got:\n%s", exp, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `cilium map list` incorrectly reports **0 entries** for BPF maps backed
  by `pkg/ebpf` (e.g. `cilium_node_map_v2`, `cilium_auth_map`), even when
  those maps contain data.
- Root cause: `pkg/ebpf.Map.GetModel()` does not populate `BPFMap.Cache`,
  and the CLI counts `len(Cache)` to derive the entry count.
- Display **"unknown"** instead of **0** when `Cache` is nil, so users can
  distinguish "entry count unavailable" from "map is genuinely empty".

## How was this tested?

Unit tests added in `cilium-dbg/cmd/map_list_test.go` covering:

| Scenario | Expected |
|---|---|
| Map with cache entries | Shows actual count |
| Map with nil cache (`pkg/ebpf`) | Shows "unknown" |
| Map with empty cache | Shows 0 |
| Map with cache errors | Counts errors correctly |

```
=== RUN   TestPrintMapList
=== RUN   TestPrintMapList/map_with_cache_entries_shows_count
=== RUN   TestPrintMapList/map_with_nil_cache_shows_unknown
=== RUN   TestPrintMapList/map_with_empty_cache_shows_zero
=== RUN   TestPrintMapList/map_with_cache_errors_counts_them
--- PASS: TestPrintMapList (0.00s)
PASS
```

Fixes: #41087

```release-note
cilium-dbg: `cilium map list` now displays "unknown" instead of 0 for
maps that do not support cache-based entry counting.
```