### PR TITLE
fix : switch from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/build-images-docs-builder-v1.17.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.17.yaml
@@ -2,7 +2,7 @@ name: Docs-builder Image Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - v1.17
     types:

--- a/.github/workflows/build-images-docs-builder-v1.18.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.18.yaml
@@ -2,7 +2,7 @@ name: Docs-builder Image Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - v1.18
     types:

--- a/.github/workflows/build-images-docs-builder-v1.19.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.19.yaml
@@ -2,7 +2,7 @@ name: Docs-builder Image Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - v1.19
     types:

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -2,7 +2,7 @@ name: Docs-builder Image Build
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
Updated the GitHub Actions workflow trigger from pull_request_target to pull_request to enhance security by ensuring the workflow runs in the context of the pull request branch rather than the base branch.

Reported-by: SeungMyung Lee <smlee.gl@gmail.com>
