### PR TITLE
.github/renovate: update k8s generate files when swagger is updated

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -743,11 +743,22 @@
       "matchPackageNames": [
         "protocolbuffers/protobuf",
         "protocolbuffers/protobuf-go",
-        "quay.io/goswagger/swagger"
       ],
       "postUpgradeTasks": {
         "commands": [
           "make GO='contrib/scripts/builder.sh go' generate-apis"
+        ],
+        "executionMode": "update"
+      }
+    },
+    {
+      "matchPackageNames": [
+        "quay.io/goswagger/swagger"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "make GO='contrib/scripts/builder.sh go' generate-apis",
+          "make generate-k8s-api"
         ],
         "executionMode": "update"
       }


### PR DESCRIPTION
When swagger is updated and its files are modified, the k8s generated files also need to be updated otherwise the files might be out of sync.