### PR TITLE
k8s: Propagate context through `ListerWatcher` chain

### DIFF
--- a/pkg/k8s/utils/listwatcher.go
+++ b/pkg/k8s/utils/listwatcher.go
@@ -13,24 +13,40 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// Compile-time interface assertions.
+var (
+	_ cache.ListerWatcher            = (*genListWatcher[k8sRuntime.Object])(nil)
+	_ cache.ListerWatcherWithContext = (*genListWatcher[k8sRuntime.Object])(nil)
+	_ cache.ListerWatcher            = (*listWatcherWithModifier)(nil)
+	_ cache.ListerWatcherWithContext = (*listWatcherWithModifier)(nil)
+)
+
 // typedListWatcher is a generic interface that all the typed k8s clients match.
 type typedListWatcher[T k8sRuntime.Object] interface {
 	List(ctx context.Context, opts metav1.ListOptions) (T, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 }
 
-// genListWatcher takes a typed list watcher and implements cache.ListWatch
-// using it.
+// genListWatcher takes a typed list watcher and implements cache.ListerWatcher
+// and cache.ListerWatcherWithContext using it.
 type genListWatcher[T k8sRuntime.Object] struct {
 	lw typedListWatcher[T]
 }
 
+func (g *genListWatcher[T]) ListWithContext(ctx context.Context, opts metav1.ListOptions) (k8sRuntime.Object, error) {
+	return g.lw.List(ctx, opts)
+}
+
+func (g *genListWatcher[T]) WatchWithContext(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	return g.lw.Watch(ctx, opts)
+}
+
 func (g *genListWatcher[T]) List(opts metav1.ListOptions) (k8sRuntime.Object, error) {
-	return g.lw.List(context.Background(), opts)
+	return g.ListWithContext(context.Background(), opts)
 }
 
 func (g *genListWatcher[T]) Watch(opts metav1.ListOptions) (watch.Interface, error) {
-	return g.lw.Watch(context.Background(), opts)
+	return g.WatchWithContext(context.Background(), opts)
 }
 
 // ListerWatcherFromTyped adapts a typed k8s client to cache.ListerWatcher so it can be used
@@ -41,18 +57,26 @@ func ListerWatcherFromTyped[T k8sRuntime.Object](lw typedListWatcher[T]) cache.L
 }
 
 type listWatcherWithModifier struct {
-	inner        cache.ListerWatcher
+	inner        cache.ListerWatcherWithContext
 	optsModifier func(*metav1.ListOptions)
 }
 
-func (lw *listWatcherWithModifier) List(opts metav1.ListOptions) (k8sRuntime.Object, error) {
+func (lw *listWatcherWithModifier) ListWithContext(ctx context.Context, opts metav1.ListOptions) (k8sRuntime.Object, error) {
 	lw.optsModifier(&opts)
-	return lw.inner.List(opts)
+	return lw.inner.ListWithContext(ctx, opts)
+}
+
+func (lw *listWatcherWithModifier) WatchWithContext(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	lw.optsModifier(&opts)
+	return lw.inner.WatchWithContext(ctx, opts)
+}
+
+func (lw *listWatcherWithModifier) List(opts metav1.ListOptions) (k8sRuntime.Object, error) {
+	return lw.ListWithContext(context.Background(), opts)
 }
 
 func (lw *listWatcherWithModifier) Watch(opts metav1.ListOptions) (watch.Interface, error) {
-	lw.optsModifier(&opts)
-	return lw.inner.Watch(opts)
+	return lw.WatchWithContext(context.Background(), opts)
 }
 
 func ListerWatcherWithFields(lw cache.ListerWatcher, fieldSelector fields.Selector) cache.ListerWatcher {
@@ -63,7 +87,7 @@ func ListerWatcherWithFields(lw cache.ListerWatcher, fieldSelector fields.Select
 
 func ListerWatcherWithModifier(lw cache.ListerWatcher, optsModifier func(*metav1.ListOptions)) cache.ListerWatcher {
 	return &listWatcherWithModifier{
-		inner:        lw,
+		inner:        cache.ToListerWatcherWithContext(lw),
 		optsModifier: optsModifier,
 	}
 }


### PR DESCRIPTION
The k8s client-go [reflector](https://github.com/kubernetes/client-go/blob/v0.35.2/tools/cache/reflector.go) relies on type assertion to find if the `ListerWatcher` implements the `ListerWatcherWithContext` interface. If it does, the reflector passes its own context to `List/WatchWithContext` so that in-flight HTTP requests are cancelled when the reflector stops. If that interface is not implemented, it falls back to the regular `List/Watch` methods, silently discarding its context, and preventing proper context cancellation propagation.

This PR updates `genListWatcher[T]` and `listWatcherWithModifier` to implement the `ListerWatcherWithContext` interface in addition to the existing `ListerWatcher` one. This allows the reflector's `ToListerWatcherWithContext` type assertion to work and keep full context propagation through the whole chain.