### PR TITLE
pkg/datapath: require scrub attributes with netkit and endpoint routes

### DIFF
--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -119,6 +119,27 @@ func canUseNetkit(p connectorParams) error {
 		return fmt.Errorf("netkit devices cannot be used with --%s=true", option.EnableHostLegacyRouting)
 	}
 
+	// early versions of netkit would scrub skb metadata before execution of BPF
+	// programs, meaning identity data stored in skb metadata would not be available
+	// to BPF programs. When using per-endpoint-routes, this can result in network
+	// policy mis-classification.
+	//
+	// A fix in the netkit driver landed in kernel 6.13 [0]. This fix was backported
+	// to stable branches. Cilium was also updated to configure netkit devices with
+	// an appropriate scrubbing attribute [1].
+	//
+	// [0] https://lore.kernel.org/bpf/20241004101335.117711-1-daniel@iogearbox.net
+	// [1] https://github.com/cilium/cilium/pull/35306
+	//
+	// To avoid issues, if we're running with per-endpoint-routes, we probe the host
+	// for scrub attribute support and raise errors if it's missing.
+	if p.DaemonConfig.EnableEndpointRoutes {
+		if err := probes.HaveNetkitScrub(); err != nil {
+			return fmt.Errorf("netkit driver missing scrub attributes, required with --%s=true",
+				option.EnableEndpointRoutes)
+		}
+	}
+
 	// bpf.tproxy requires use of bpf_sk_assign() helper, which at the time of
 	// writing can only be called from TC ingress. However, netkit programs
 	// run at TC egress, so the helper returns -ENOTSUPP and tproxy cannot
@@ -127,7 +148,6 @@ func canUseNetkit(p connectorParams) error {
 	// Until this is resolved we don't tolerate tproxy and netkit.
 	//
 	// GH issue: https://github.com/cilium/cilium/issues/39892
-
 	if p.DaemonConfig.EnableBPFTProxy {
 		return fmt.Errorf("netkit devices cannot be used with --%s=true", option.EnableBPFTProxy)
 	}

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -81,6 +81,12 @@ var (
 		EnableIPv6:               true,
 		UnsafeDaemonConfigOption: option.UnsafeDaemonConfig{EnableHostLegacyRouting: true},
 	}
+	daemonConfigNetkitEndpointRoutes = option.DaemonConfig{
+		DatapathMode:         datapathOption.DatapathModeNetkit,
+		EnableIPv4:           true,
+		EnableIPv6:           true,
+		EnableEndpointRoutes: true,
+	}
 	daemonConfigNetkitL2 = option.DaemonConfig{
 		DatapathMode:    datapathOption.DatapathModeNetkitL2,
 		EnableIPv4:      true,
@@ -99,6 +105,12 @@ var (
 		EnableIPv6:               true,
 		UnsafeDaemonConfigOption: option.UnsafeDaemonConfig{EnableHostLegacyRouting: true},
 	}
+	daemonConfigNetkitL2EndpointRoutes = option.DaemonConfig{
+		DatapathMode:         datapathOption.DatapathModeNetkitL2,
+		EnableIPv4:           true,
+		EnableIPv6:           true,
+		EnableEndpointRoutes: true,
+	}
 	daemonConfigAuto = option.DaemonConfig{
 		DatapathMode:    datapathOption.DatapathModeAuto,
 		EnableIPv4:      true,
@@ -116,6 +128,12 @@ var (
 		EnableIPv4:               true,
 		EnableIPv6:               true,
 		UnsafeDaemonConfigOption: option.UnsafeDaemonConfig{EnableHostLegacyRouting: true},
+	}
+	daemonConfigAutoEndpointRoutes = option.DaemonConfig{
+		DatapathMode:         datapathOption.DatapathModeAuto,
+		EnableIPv4:           true,
+		EnableIPv6:           true,
+		EnableEndpointRoutes: true,
 	}
 
 	// WireguardConfigs
@@ -152,6 +170,11 @@ var (
 
 func hostSupportsNetkit() bool {
 	err := probes.HaveNetkit()
+	return err == nil
+}
+
+func hostSupportsNetkitScrub() bool {
+	err := probes.HaveNetkitScrub()
 	return err == nil
 }
 
@@ -227,6 +250,15 @@ func TestNewConfig(t *testing.T) {
 			shouldSkip:     false,
 		},
 		{
+			name:           "datapath-netkit+endpoint-routes",
+			daemonConfig:   &daemonConfigNetkitEndpointRoutes,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkit,
+			shouldError:    !hostSupportsNetkitScrub(),
+			shouldSkip:     false,
+		},
+		{
 			name:           "datapath-netkit-l2",
 			daemonConfig:   &daemonConfigNetkitL2,
 			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
@@ -251,6 +283,15 @@ func TestNewConfig(t *testing.T) {
 			tunnelConfig:   tunnelConfigNative,
 			expectedConfig: &connectorConfigNetkitL2,
 			shouldError:    true,
+			shouldSkip:     false,
+		},
+		{
+			name:           "datapath-netkit-l2+endpoint-routes",
+			daemonConfig:   &daemonConfigNetkitL2EndpointRoutes,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigNetkitL2,
+			shouldError:    !hostSupportsNetkitScrub(),
 			shouldSkip:     false,
 		},
 		{
@@ -306,6 +347,24 @@ func TestNewConfig(t *testing.T) {
 			expectedConfig: &connectorConfigAuto_Veth,
 			shouldError:    false,
 			shouldSkip:     !hostSupportsNetkit(),
+		},
+		{
+			name:           "datapath-auto(netkit,scrub)+endpoint-routes+oper-netkit",
+			daemonConfig:   &daemonConfigAutoEndpointRoutes,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigAuto_Netkit,
+			shouldError:    false,
+			shouldSkip:     !hostSupportsNetkitScrub(),
+		},
+		{
+			name:           "datapath-auto(netkit,!scrub)+endpoint-routes+oper-veth",
+			daemonConfig:   &daemonConfigAutoEndpointRoutes,
+			wgAgent:        fakeTypes.NewTestAgent(wgConfigDisabled),
+			tunnelConfig:   tunnelConfigNative,
+			expectedConfig: &connectorConfigAuto_Veth,
+			shouldError:    false,
+			shouldSkip:     hostSupportsNetkitScrub(),
 		},
 	}
 

--- a/pkg/datapath/connector/netkit.go
+++ b/pkg/datapath/connector/netkit.go
@@ -136,12 +136,6 @@ func validateNetkitPair(logger *slog.Logger, cfg types.LinkConfig) (netlink.Link
 		return nil, fmt.Errorf("peer link does not appear to be a Netkit device")
 	}
 
-	// Validate the kernel supports Scrub functionality.
-	if !hostDevice.SupportsScrub() || !peerDevice.SupportsScrub() {
-		logger.Warn("kernel does not support IFLA_NETKIT_SCRUB, some features may not work with netkit",
-			logfields.NetkitPair, []string{hostDevice.Name, peerDevice.Name})
-	}
-
 	// Verify we have the correct buffer margins configured. We accept a margin that
 	// is greater than what we requested, just in case it's ever rounded or aligned
 	// within the kernel.

--- a/pkg/datapath/connector/netkit_test.go
+++ b/pkg/datapath/connector/netkit_test.go
@@ -29,6 +29,7 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 		cfg               types.LinkConfig
 		expectedMode      netlink.NetkitMode
 		expectedHwAddrLen int
+		shouldAssertScrub bool
 		shouldSkip        bool
 	}{
 		{
@@ -38,6 +39,7 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 			expectedMode:      netlink.NETKIT_MODE_L3,
 			expectedHwAddrLen: 0,
 			shouldSkip:        !hostSupportsNetkit(),
+			shouldAssertScrub: hostSupportsNetkitScrub(),
 		},
 		{
 			name:              "netkit+tbm",
@@ -46,6 +48,7 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 			expectedMode:      netlink.NETKIT_MODE_L3,
 			expectedHwAddrLen: 0,
 			shouldSkip:        !hostSupportsNetkitTunedBufferMargins(),
+			shouldAssertScrub: hostSupportsNetkitScrub(),
 		},
 		{
 			name:              "netkit-l2",
@@ -54,6 +57,7 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 			expectedMode:      netlink.NETKIT_MODE_L2,
 			expectedHwAddrLen: 6,
 			shouldSkip:        !hostSupportsNetkit(),
+			shouldAssertScrub: hostSupportsNetkitScrub(),
 		},
 		{
 			name:              "netkit-l2+tbm",
@@ -62,6 +66,7 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 			expectedMode:      netlink.NETKIT_MODE_L2,
 			expectedHwAddrLen: 6,
 			shouldSkip:        !hostSupportsNetkitTunedBufferMargins(),
+			shouldAssertScrub: hostSupportsNetkitScrub(),
 		},
 	}
 
@@ -99,7 +104,9 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 			require.NotNil(t, hostNetkit)
 			assert.Equal(t, tt.expectedMode, hostNetkit.Mode)
 			assert.Equal(t, netlink.NETKIT_POLICY_FORWARD, hostNetkit.Policy)
-			assert.Equal(t, netlink.NETKIT_SCRUB_NONE, hostNetkit.Scrub)
+			if tt.shouldAssertScrub {
+				assert.Equal(t, netlink.NETKIT_SCRUB_NONE, hostNetkit.Scrub)
+			}
 			assert.Equal(t, tt.cfg.DeviceHeadroom, hostNetkit.Headroom)
 			assert.Equal(t, tt.cfg.DeviceTailroom, hostNetkit.Tailroom)
 			assert.Len(t, hostLink2.Attrs().HardwareAddr, tt.expectedHwAddrLen)
@@ -110,7 +117,9 @@ func TestPrivilegedSetupNetkitPair(t *testing.T) {
 			require.NotNil(t, peerNetkit)
 			assert.Equal(t, tt.expectedMode, peerNetkit.Mode)
 			assert.Equal(t, netlink.NETKIT_POLICY_BLACKHOLE, peerNetkit.Policy)
-			assert.Equal(t, netlink.NETKIT_SCRUB_DEFAULT, peerNetkit.Scrub)
+			if tt.shouldAssertScrub {
+				assert.Equal(t, netlink.NETKIT_SCRUB_DEFAULT, peerNetkit.Scrub)
+			}
 			assert.Equal(t, tt.cfg.DeviceHeadroom, peerNetkit.Headroom)
 			assert.Equal(t, tt.cfg.DeviceTailroom, peerNetkit.Tailroom)
 			assert.Len(t, peerLink2.Attrs().HardwareAddr, tt.expectedHwAddrLen)

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -322,6 +322,62 @@ var HaveNetkit = sync.OnceValue(func() error {
 	})
 })
 
+// HaveNetkitScrub returns nil if the running kernel supports netkit scrub
+// attribute.
+var HaveNetkitScrub = sync.OnceValue(func() error {
+	ns, err := netns.New()
+	if err != nil {
+		return fmt.Errorf("create netns: %w", err)
+	}
+	defer ns.Close()
+
+	return ns.Do(func() error {
+		hostIfName := "tmpnkscr0"
+		peerIfName := "tmpnkscr1"
+
+		var hostMac, peerMac mac.MAC
+		netkit := &netlink.Netkit{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         hostIfName,
+				TxQLen:       1000,
+				HardwareAddr: net.HardwareAddr(hostMac),
+			},
+			Mode:       netlink.NETKIT_MODE_L3,
+			Policy:     netlink.NETKIT_POLICY_FORWARD,
+			PeerPolicy: netlink.NETKIT_POLICY_BLACKHOLE,
+			Scrub:      netlink.NETKIT_SCRUB_NONE,
+			PeerScrub:  netlink.NETKIT_SCRUB_DEFAULT,
+		}
+		netkit.SetPeerAttrs(&netlink.LinkAttrs{
+			Name:         peerIfName,
+			HardwareAddr: net.HardwareAddr(peerMac),
+		})
+
+		err = netlink.LinkAdd(netkit)
+		if err != nil {
+			return fmt.Errorf("create link: %w", err)
+		}
+		hostLink, err := safenetlink.LinkByName(hostIfName)
+		if err != nil {
+			return fmt.Errorf("query link: %w", err)
+		}
+		defer func() {
+			netlink.LinkDel(hostLink)
+		}()
+
+		hostNetkit, ok := hostLink.(*netlink.Netkit)
+		if !ok || hostNetkit == nil {
+			return fmt.Errorf("expected link of type *netlink.Netkit")
+		}
+
+		if !hostNetkit.SupportsScrub() {
+			return fmt.Errorf("netkit scrub attribute not supported")
+		}
+
+		return nil
+	})
+})
+
 // HaveNetkitTunableBufferMargins returns nil if the running kernel supports
 // configuring tuned buffer margins on netkit devices.
 var HaveNetkitTunableBufferMargins = sync.OnceValue(func() error {

--- a/pkg/datapath/linux/probes/probes_test.go
+++ b/pkg/datapath/linux/probes/probes_test.go
@@ -106,6 +106,12 @@ func TestPrivilegedHaveNetkit(t *testing.T) {
 	assert.NoError(t, HaveNetkit())
 }
 
+func TestPrivilegedHaveNetkitScrub(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	testutils.SkipOnOldKernel(t, "6.13", "netkit scrub")
+	assert.NoError(t, HaveNetkitScrub())
+}
+
 func TestPrivilegedHaveNetkitTunableBufferMargins(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	testutils.SkipOnOldKernel(t, "6.18", "netkit tbm")


### PR DESCRIPTION
Early versions of the netkit driver scrubbed skb metadata before BPF programs are run, meaning identity metadata is not available in BPF. This can cause network policy mis-classification if per-endpoint routes are enabled.

A kernel patch landed in the driver [0] which adds new scrub attributes to manage this, and a subsequent change was made in the Cilium datapath connector [1] to make use of these new attributes. However, it's still possible to run Cilium with netkit on a kernel that doesn't support them, which is confusing [2] and may still result in strange behavior.

This commit introduces a runtime probe that will actively probe the underlying host for netkit scrub attributes, if running with per-endpoint routes. If the probe fails, we error out.

- With `bpf.datapathMode={netkit,netkit-l2}` this will error and the agent will fail to start.

- with `bpf.datapathMode=auto`, this will log a warning and fall-back to veth connector.

This commit also introduces additional test permutations to cover this.

[0] https://lore.kernel.org/bpf/20241004101335.117711-1-daniel@iogearbox.net
[1] https://github.com/cilium/cilium/pull/35306
[2] https://github.com/cilium/cilium/issues/40021

```release-note
Do not run with netkit and per-endpoint routes if kernel does not support netkit scrub attributes.
```
