### PR TITLE
cilium-dbg: Fix json logging on failure

### DIFF
--- a/cilium-dbg/cmd/build-config.go
+++ b/cilium-dbg/cmd/build-config.go
@@ -17,6 +17,8 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sConsts "github.com/cilium/cilium/pkg/k8s/constants"
 	"github.com/cilium/cilium/pkg/k8s/hostfirewallbypass"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option/resolver"
 )
 
@@ -41,7 +43,7 @@ var buildConfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Info("Running")
 		if err := buildConfigHive.Run(log); err != nil {
-			Fatalf("Build config failed: %v\n", err)
+			logging.Fatal(log, "Build config failed", logfields.Error, err)
 		}
 	},
 }


### PR DESCRIPTION
When `cilium-dbg build-config` is configured to output JSON-formatted logs with the `--log-opt=format=json-ts` flag, all logs are properly JSON-formatted except for the one emmited on crash with `Fatalf`. This PR fixes that by properly wriring in the appropriate logging function that goes through the slog handler chain and respects the `log-opt` flag.

Before:
```json
{"time":"2026-03-23T12:25:16.50792884Z","level":"info","msg":"Running","subsys":"cilium-dbg"}
{"time":"2026-03-23T12:25:16.512698937Z","level":"info","msg":"Starting hive","subsys":"cilium-dbg"}
{"time":"2026-03-23T12:25:16.512792958Z","level":"info","msg":"Establishing connection to apiserver","subsys":"cilium-dbg","module":"k8s-client","ipAddr":"https://REDACTED"}
{"time":"2026-03-23T12:25:16.52705306Z","level":"info","msg":"Connected to apiserver","subsys":"cilium-dbg","module":"k8s-client"}
{"time":"2026-03-23T12:25:16.528834212Z","level":"info","msg":"Reading configuration from source","subsys":"cilium-dbg","module":"build-config","configSource":{"kind":"config-map","namespace":"cilium-ns","name":"cilium-config"}}
{"time":"2026-03-23T12:25:16.534083273Z","level":"info","msg":"Got configuration source","subsys":"cilium-dbg","module":"build-config","lenConfigPairs":50,"configSource":{"kind":"config-map","namespace":"cilium-ns","name":"cilium-config"}}
{"time":"2026-03-23T12:25:16.534132322Z","level":"info","msg":"Reading configuration from source","subsys":"cilium-dbg","module":"build-config","configSource":{"kind":"cilium-node-config","namespace":"cilium-ns","name":""}}
{"time":"2026-03-23T12:25:16.536128863Z","level":"error","msg":"CiliumNodeConfig v2 not found","subsys":"cilium-dbg","module":"build-config","error":"could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"","node":"ip-REDACTED.ec2.internal"}
{"time":"2026-03-23T12:25:16.538005308Z","level":"error","msg":"CiliumNodeConfig v2alpha1 not found","subsys":"cilium-dbg","module":"build-config","error":"could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"","node":"ip-REDACTED.ec2.internal"}
{"time":"2026-03-23T12:25:16.538051247Z","level":"error","msg":"Start hook failed","subsys":"cilium-dbg","function":"cmd.(*buildConfig).onStart (build-config)","error":"failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"\n"}
{"time":"2026-03-23T12:25:16.538071612Z","level":"error","msg":"Failed to start hive","subsys":"cilium-dbg","error":"failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"\n","duration":25330838}
{"time":"2026-03-23T12:25:16.538103119Z","level":"info","msg":"Stopping hive","subsys":"cilium-dbg"}
Error: Build config failed: failed to start: failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User "system:serviceaccount:cilium-ns:cilium-agent" cannot list resource "ciliumnodeconfigs" in API group "cilium.io" in the namespace "cilium-ns" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User "system:serviceaccount:cilium-ns:cilium-agent" cannot list resource "ciliumnodeconfigs" in API group "cilium.io" in the namespace "cilium-ns"

{"time":"2026-03-23T12:25:16.538154925Z","level":"info","msg":"Stopped hive","subsys":"cilium-dbg","duration":43453}
```

After
```json
{"time":"2026-03-23T12:45:08.492284434Z","level":"info","msg":"Running","subsys":"cilium-dbg"}
{"time":"2026-03-23T12:45:08.494684518Z","level":"info","msg":"Starting hive","subsys":"cilium-dbg"}
{"time":"2026-03-23T12:45:08.494749132Z","level":"info","msg":"Establishing connection to apiserver","subsys":"cilium-dbg","module":"k8s-client","ipAddr":"https://REDACTED"}
{"time":"2026-03-23T12:45:08.508667237Z","level":"info","msg":"Connected to apiserver","subsys":"cilium-dbg","module":"k8s-client"}
{"time":"2026-03-23T12:45:08.51074202Z","level":"info","msg":"Reading configuration from source","subsys":"cilium-dbg","module":"build-config","configSource":{"kind":"config-map","namespace":"cilium-ns","name":"cilium-config"}}
{"time":"2026-03-23T12:45:08.515521849Z","level":"info","msg":"Got configuration source","subsys":"cilium-dbg","module":"build-config","lenConfigPairs":50,"configSource":{"kind":"config-map","namespace":"cilium-ns","name":"cilium-config"}}
{"time":"2026-03-23T12:45:08.515633953Z","level":"info","msg":"Reading configuration from source","subsys":"cilium-dbg","module":"build-config","configSource":{"kind":"cilium-node-config","namespace":"cilium-ns","name":""}}
{"time":"2026-03-23T12:45:08.51826165Z","level":"error","msg":"CiliumNodeConfig v2 not found","subsys":"cilium-dbg","module":"build-config","error":"could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"","node":"ip-REDACTED.ec2.internal"}
{"time":"2026-03-23T12:45:08.52058236Z","level":"error","msg":"CiliumNodeConfig v2alpha1 not found","subsys":"cilium-dbg","module":"build-config","error":"could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"","node":"ip-REDACTED.ec2.internal"}
{"time":"2026-03-23T12:45:08.520681238Z","level":"error","msg":"Start hook failed","subsys":"cilium-dbg","function":"cmd.(*buildConfig).onStart (build-config)","error":"failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"\n"}
{"time":"2026-03-23T12:45:08.52083019Z","level":"error","msg":"Failed to start hive","subsys":"cilium-dbg","error":"failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"\n","duration":26122806}
{"time":"2026-03-23T12:45:08.521015655Z","level":"info","msg":"Stopping hive","subsys":"cilium-dbg"}
{"time":"2026-03-23T12:45:08.521187762Z","level":"info","msg":"Stopped hive","subsys":"cilium-dbg","duration":84897}
{"time":"2026-03-23T12:45:08.521330577Z","level":"fatal","msg":"Build config failed","subsys":"cilium-dbg","error":"failed to start: failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"\n"}
```

When not using JSON logging, the log line produced is the same before and after this PR:
```
time=2026-03-23T13:05:05.316543491Z level=fatal msg="Build config failed" subsys=cilium-dbg error="failed to start: failed to resolve configurations: failed to read config source cilium-node-config:cilium-ns/: CiliumNodeConfig v2 and v2alpha1 not found: could not list CiliumNodeConfig objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\" and could not list CiliumNodeConfig v2alpha1 objects: ciliumnodeconfigs.cilium.io is forbidden: User \"system:serviceaccount:cilium-ns:cilium-agent\" cannot list resource \"ciliumnodeconfigs\" in API group \"cilium.io\" in the namespace \"cilium-ns\"\n"
```

Followup to #36802