### PR TITLE
fix(gateway-api): fix hardcoded HTTPRoute refs in non-HTTP reconcilers

### DIFF
--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -90,7 +90,7 @@ func (r *gammaReconciler) enqueueRequestForOwningHTTPRoute(logger *slog.Logger) 
 	})
 }
 
-// enqueueRequestForOwningGRPCRoute returns an event handler for any changes with HTTP Routes
+// enqueueRequestForOwningGRPCRoute returns an event handler for any changes with GRPC Routes
 // belonging to the given Service
 func (r *gammaReconciler) enqueueRequestForOwningGRPCRoute(logger *slog.Logger) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
@@ -136,7 +136,7 @@ func (r *gammaReconciler) enqueueAll() handler.MapFunc {
 	}
 }
 
-// getGammaReconcileRequestsForRoute returns a list of GAMMA services to be reconciled based on the supplied HTTPRoute.
+// getGammaReconcileRequestsForRoute returns a list of GAMMA services to be reconciled based on the supplied route.
 func getGammaReconcileRequestsForRoute(ctx context.Context, c client.Client, object metav1.Object, route gatewayv1.CommonRouteSpec, logger *slog.Logger, objKind string) []reconcile.Request {
 	var reqs []reconcile.Request
 

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -195,7 +195,7 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 				Type:    string(gatewayv1.RouteConditionAccepted),
 				Status:  metav1.ConditionTrue,
 				Reason:  string(gatewayv1.RouteReasonAccepted),
-				Message: "Accepted HTTPRoute",
+				Message: fmt.Sprintf("Accepted %s", i.GetGVK().Kind),
 			})
 
 			// set status to okay, this wil be overwritten in checks if needed

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -142,7 +142,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		ReferenceGrants: grants.Items,
 	})
 
-	setGammaServiceAccepted(svc, true, "Gamma Service has HTTPRoutes attached", CiliumGammaReasonAccepted)
+	setGammaServiceAccepted(svc, true, "Gamma Service has routes attached", CiliumGammaReasonAccepted)
 
 	cec, _, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
 	if err != nil {
@@ -380,7 +380,7 @@ func (r *gammaReconciler) updateHTTPRouteStatus(ctx context.Context, original *g
 	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
 		return nil
 	}
-	r.logger.DebugContext(ctx, "Updating HTTRRoute status", httpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	r.logger.DebugContext(ctx, "Updating HTTPRoute status", httpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -163,7 +163,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Run the TLSRoute route checks here and update the status accordingly.
 	if helpers.HasTLSRouteSupport(r.Client.Scheme()) {
 		if err := r.setTLSRouteStatuses(scopedLog, ctx, tlsRouteList, grants); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to update HTTPRoute Status", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Unable to update TLSRoute Status", logfields.Error, err)
 			return controllerruntime.Fail(err)
 		}
 	}
@@ -912,7 +912,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 		tlsr := original.DeepCopy()
 
 		// input for the validators
-		// The validators will mutate the HTTPRoute as required, setting its status correctly.
+		// The validators will mutate the TLSRoute as required, setting its status correctly.
 		i := &routechecks.TLSRouteInput{
 			Ctx:      ctx,
 			Logger:   scopedLog.With(logfields.TLSRoute, tlsr),
@@ -929,7 +929,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateTLSRouteStatus(ctx, scopedLog, &original, tlsr); err != nil {
-			return fmt.Errorf("failed to update HTTPRoute status: %w", err)
+			return fmt.Errorf("failed to update TLSRoute status: %w", err)
 		}
 
 		// Update the cached copy with the same status changes to prevent re-fetching from client cache.
@@ -946,7 +946,7 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 		grpcr := original.DeepCopy()
 
 		// input for the validators
-		// The validators will mutate the HTTPRoute as required, setting its status correctly.
+		// The validators will mutate the GRPCRoute as required, setting its status correctly.
 		i := &routechecks.GRPCRouteInput{
 			Ctx:       ctx,
 			Logger:    scopedLog.With(logfields.GRPCRoute, grpcr),
@@ -963,7 +963,7 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateGRPCRouteStatus(ctx, scopedLog, &original, grpcr); err != nil {
-			return fmt.Errorf("failed to update HTTPRoute status: %w", err)
+			return fmt.Errorf("failed to update GRPCRoute status: %w", err)
 		}
 
 		// Update the cached copy with the same status changes to prevent re-fetching from client cache.
@@ -1271,7 +1271,7 @@ func (r *gatewayReconciler) updateGRPCRouteStatus(ctx context.Context, scopedLog
 	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
 		return nil
 	}
-	scopedLog.Debug("Updating GRPCRoute status", tlsRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	scopedLog.Debug("Updating GRPCRoute status", grpcRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -798,7 +798,7 @@ func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parent
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionTrue,
 			Reason:  string(gatewayv1.RouteReasonAccepted),
-			Message: "Accepted HTTPRoute",
+			Message: fmt.Sprintf("Accepted %s", input.GetGVK().Kind),
 		})
 
 		// set ResolvedRefs to okay, this wil be overwritten in checks if needed

--- a/operator/pkg/gateway-api/indexers/grpcroute_test.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute_test.go
@@ -206,7 +206,7 @@ func Test_IndexGRPCRouteByGammaService(t *testing.T) {
 			},
 		},
 		{
-			name: "not a HTTPRoute",
+			name: "not a GRPCRoute",
 			args: args{
 				obj: &corev1.Service{},
 			},
@@ -218,7 +218,7 @@ func Test_IndexGRPCRouteByGammaService(t *testing.T) {
 			parentIndexFunc := IndexGRPCRouteByGammaService
 
 			if got := parentIndexFunc(tt.args.obj); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getGammaHTTPRouteParentIndexFunc() = %#v, want %#v", got, tt.want)
+				t.Errorf("IndexGRPCRouteByGammaService() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -169,7 +169,7 @@ func (h *HTTPRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
 	return []gatewayv1.ProtocolType{gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType}
 }
 
-// HTTPRouteRule is used to implement the GenericRule interface for TLSRoute
+// HTTPRouteRule is used to implement the GenericRule interface for HTTPRoute
 type HTTPRouteRule struct {
 	Rule gatewayv1.HTTPRouteRule
 }

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-basic/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-basic/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:48:45Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-frontend/output/service-echo-v2.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-frontend/output/service-echo-v2.yaml
@@ -31,7 +31,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:07:33Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-grpc-weight/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-grpc-weight/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
     - lastTransitionTime: "2025-06-19T03:46:56Z"
-      message: Gamma Service has HTTPRoutes attached
+      message: Gamma Service has routes attached
       reason: Accepted
       status: "True"
       type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-matching/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-matching/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:43:28Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-ports/output/service-echo-v1.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-ports/output/service-echo-v1.yaml
@@ -31,7 +31,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:21:44Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-ports/output/service-echo-v2.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-ports/output/service-echo-v2.yaml
@@ -31,7 +31,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:21:44Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-query-param-matching/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-query-param-matching/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:39:58Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-host-and-status/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-host-and-status/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:24:06Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-path/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-path/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:25:28Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-port/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-port/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:26:58Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-scheme/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-scheme/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:28:01Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-request-header-modifier/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:31:18Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-rewrite-path/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-rewrite-path/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:32:48Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-split/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-split/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:19:50Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-weighted-backends/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-weighted-backends/output/service-echo.yaml
@@ -30,7 +30,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-06-19T03:46:56Z"
-    message: Gamma Service has HTTPRoutes attached
+    message: Gamma Service has routes attached
     reason: Accepted
     status: "True"
     type: gamma.cilium.io/GammaRoutesAttached

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-exact-method-matching/output/grpcroute-exact-matching.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-exact-method-matching/output/grpcroute-exact-matching.yaml
@@ -25,7 +25,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-07-01T14:19:43Z"
-          message: Accepted HTTPRoute
+          message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-header-matching/output/grpcroute-grpc-header-matching.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-header-matching/output/grpcroute-grpc-header-matching.yaml
@@ -59,7 +59,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-08-15T08:36:54Z"
-          message: Accepted HTTPRoute
+          message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/grpcroute-backend-v1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/grpcroute-backend-v1.yaml
@@ -17,7 +17,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-07-01T14:19:43Z"
-          message: Accepted HTTPRoute
+          message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/grpcroute-backend-v2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/grpcroute-backend-v2.yaml
@@ -17,7 +17,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-07-01T14:19:43Z"
-          message: Accepted HTTPRoute
+          message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/grpcroute-backend-v3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/grpcroute-listener-hostname-matching/output/grpcroute-backend-v3.yaml
@@ -20,7 +20,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-07-01T14:19:43Z"
-          message: Accepted HTTPRoute
+          message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted
@@ -36,7 +36,7 @@ status:
         sectionName: listener-3
     - conditions:
         - lastTransitionTime: "2025-07-01T14:19:43Z"
-          message: Accepted HTTPRoute
+          message: Accepted GRPCRoute
           reason: Accepted
           status: "True"
           type: Accepted


### PR DESCRIPTION
It's easiest to review commit-by-commit.

This PR uses the existing `GetGVK().Kind` interface method to derive the correct route kind dynamically. Also did some minor cleaning up of stray mentions of HTTPRoute in TLSRoute and GRPCRoute implementations. Verified in this [test repo](https://github.com/eufriction/k8s-cilium-gapi/commit/7166b5bdda5f5838f21724fb6b842bae79f6eac0) to work with operator built off this branch.

Fixes: #43881

```release-note
Fixed Gateway API reconciler incorrectly reporting "Accepted HTTPRoute" in the status condition message for GRPCRoute and TLSRoute resources.
```
