### PR TITLE
workflows/gke: Shorten cluster name

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -103,7 +103,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  clusterName: ${{ github.event.repository.name }}-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
+  clusterName: cilium-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 561.0.0


### PR DESCRIPTION
As of 4b79591 we include UID in the cluster name. Given this, it can sometimes extend the [32-character cluster name limit](https://github.com/cilium/cilium/blob/7894d69cca9106803fd4256b08b3d1fcd5d5a46d/install/kubernetes/cilium/templates/validate.yaml#L155-L157). Shorten it a bit to only contain "cilium-" prefix instead of full repository name.

