### PR TITLE
k8s/testutils: surface parse error for CRDs

### DIFF
--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -86,6 +86,10 @@ func DecodeObjectGVK(bytes []byte) (runtime.Object, *schema.GroupVersionKind, er
 	obj, gvk, err := Decoder().Decode(bytes, nil, nil)
 	if err == nil {
 		return obj, gvk, err
+	} else if !runtime.IsNotRegisteredError(err) {
+		// If we get a legitimate parse error in a CRD, surface that instead of a generic "unknown
+		// kind" from the fallback below.
+		return nil, nil, err
 	}
 	return DecodeKubernetesObject(bytes)
 }


### PR DESCRIPTION
Without this you just get an unhelpful/misleading error such as `no kind "XXX" is registered for version "YYY" in scheme "pkg/k8s/testutils/decoder.go:33"` when you have a typo in a manifest in a script test, for example.

I've tested that this does the right thing by running `go test ./pkg/ciliumenvoyconfig/ -v 'TestScript/anyport.txtar' -count=1 | less` and inserting something which doesn't parse into the `cec.yaml` manifest inside `anyport.txtar`. Without this change you get the error above, with it you get an error saying that the resource can't be parsed.

On the [AI involvement scale](https://danielmiessler.com/blog/ai-influence-level-ail) I'm not super sure where to put it. Maybe AIL 3? 4? I came up with the idea that we should fix this after having diagnosed an issue as mentioned above (also using AI). It suggested something, I changed it. 