### PR TITLE
sockets: Ensure bpffs is mounted in TestPrivilegedSocketDestroyers

### DIFF
--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -418,6 +418,8 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	log := hivetest.Logger(t)
 
+	bpf.CheckOrMountFS(log, "")
+
 	socketDestroyers := makeSocketDestroyers(t)
 	servers := map[string][]string{
 		"127.0.0.1:8888": {"udp", "tcp"},


### PR DESCRIPTION
The test pins BPF maps but never calls bpf.CheckOrMountFS(), unlike
every other privileged test that pins maps. It only passes when a
test from another package has already mounted bpffs in the same
process (CheckOrMountFS uses sync.Once). This makes it flaky
depending on test execution order.

Fixes: #44976