### PR TITLE
node/health: sync node IP changes to health responder at runtime

### DIFF
--- a/pkg/health/health_connectivity_node.go
+++ b/pkg/health/health_connectivity_node.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/models"
@@ -20,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/health/server"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -73,8 +75,36 @@ func (h *ciliumHealthManager) launchCiliumNodeHealth(ctx context.Context, spec *
 	}
 
 	go ch.runServer(initialized)
+	go h.observeNodeIPChangesForHealth(ctx, ch)
 
 	return ch, nil
+}
+
+// observeNodeIPChangesForHealth watches the LocalNodeStore for IP address
+// changes and rebinds the health HTTP path server when the node IP changes
+// at runtime (e.g. KubeVirt VM migration).
+func (h *ciliumHealthManager) observeNodeIPChangesForHealth(ctx context.Context, ch *CiliumHealth) {
+	var lastAddrs []string
+	var seeded bool
+	h.localNodeStore.Observe(ctx,
+		func(ln node.LocalNode) {
+			addrs := server.GetAddresses(ln)
+			if seeded && !slices.Equal(addrs, lastAddrs) {
+				h.logger.Info("Node IP changed, rebinding health responder",
+					"oldAddresses", lastAddrs,
+					"newAddresses", addrs,
+				)
+				ch.server.RebindHTTPPathServer(addrs)
+			}
+			lastAddrs = addrs
+			seeded = true
+		},
+		func(err error) {
+			if err != nil && ctx.Err() == nil {
+				h.logger.Error("LocalNodeStore observation ended unexpectedly", logfields.Error, err)
+			}
+		},
+	)
 }
 
 func (ch *CiliumHealth) runServer(initialized <-chan struct{}) {
@@ -149,3 +179,4 @@ func (ch *CiliumHealth) setStatus(status *models.Status) {
 	ch.status = status
 	ch.mutex.Unlock()
 }
+

--- a/pkg/health/probe/responder/responder.go
+++ b/pkg/health/probe/responder/responder.go
@@ -8,9 +8,10 @@ package responder
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
+	"strconv"
+	"sync"
 	"time"
 )
 
@@ -19,53 +20,118 @@ var defaultTimeout = 30 * time.Second
 
 // Server wraps a minimal http server for the /hello endpoint
 type Server struct {
+	mu          sync.Mutex
+	port        int
 	httpServers []*http.Server
+	errCh       chan error
+	closed      bool
 }
 
 // NewServer creates a new server listening on the given port
 func NewServers(address []string, port int) *Server {
-	if len(address) == 0 {
-		address = []string{""}
+	server := &Server{
+		port:  port,
+		errCh: make(chan error, 1),
+	}
+	server.httpServers = newHTTPServers(address, port)
+	return server
+}
+
+func newHTTPServers(addresses []string, port int) []*http.Server {
+	if len(addresses) == 0 {
+		addresses = []string{""}
 	}
 
-	server := &Server{}
-	for _, ip := range address {
-		addr := net.JoinHostPort(ip, fmt.Sprintf("%v", port))
-		hs := http.Server{
+	servers := make([]*http.Server, 0, len(addresses))
+	for _, ip := range addresses {
+		addr := net.JoinHostPort(ip, strconv.Itoa(port))
+		servers = append(servers, &http.Server{
 			Addr:    addr,
 			Handler: http.HandlerFunc(serverRequests),
-		}
-		server.httpServers = append(server.httpServers, &hs)
+		})
 	}
-
-	return server
+	return servers
 }
 
 // Serve http requests until shut down
 func (s *Server) Serve() error {
-	errors := make(chan error)
-	for _, hs := range s.httpServers {
-		tmpHttpServer := hs
-		go func() {
-			errors <- tmpHttpServer.ListenAndServe()
-		}()
-	}
+	s.serveHTTPServers()
 
-	// Block for the first error, then return.
-	err := <-errors
+	// Block for the first real error, then return.
+	err := <-s.errCh
 	return err
+}
+
+func (s *Server) serveHTTPServers() {
+	s.mu.Lock()
+	servers := s.httpServers
+	s.mu.Unlock()
+
+	for _, hs := range servers {
+		go func(srv *http.Server) {
+			// Bind errors are intentionally not propagated: a transient error
+			// during Rebind (e.g. TIME_WAIT) must not cause Serve() to return.
+			srv.ListenAndServe()
+		}(hs)
+	}
+}
+
+// swapServers atomically replaces the server list and reports whether the
+// server is already closed. Returns (nil, true) if already shut down.
+func (s *Server) swapServers(addresses []string) (old []*http.Server, closed bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, true
+	}
+	old = s.httpServers
+	s.httpServers = newHTTPServers(addresses, s.port)
+	return old, false
+}
+
+// Rebind shuts down the current HTTP servers and starts new ones on the
+// given addresses. Serve() continues to block transparently.
+func (s *Server) Rebind(addresses []string) {
+	old, closed := s.swapServers(addresses)
+	if closed {
+		return
+	}
+	shutdownServers(old)
+	// Re-check closed: Shutdown() may have raced while we were draining.
+	s.mu.Lock()
+	closed = s.closed
+	s.mu.Unlock()
+	if closed {
+		return
+	}
+	s.serveHTTPServers()
 }
 
 // Shutdown server gracefully
 func (s *Server) Shutdown() error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-	errs := make([]error, 0, len(s.httpServers))
-	for _, hs := range s.httpServers {
-		errs = append(errs, hs.Shutdown(ctx))
+	s.mu.Lock()
+	servers := s.httpServers
+	alreadyClosed := s.closed
+	s.closed = true
+	s.mu.Unlock()
+
+	errs := shutdownServers(servers)
+
+	if !alreadyClosed {
+		s.errCh <- http.ErrServerClosed
 	}
 
 	return errors.Join(errs...)
+}
+
+func shutdownServers(servers []*http.Server) []error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	errs := make([]error, 0, len(servers))
+	for _, hs := range servers {
+		errs = append(errs, hs.Shutdown(ctx))
+	}
+	return errs
 }
 
 func serverRequests(w http.ResponseWriter, r *http.Request) {

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -392,6 +392,12 @@ func (s *Server) Shutdown() {
 	s.Server.Shutdown()
 }
 
+// RebindHTTPPathServer rebinds the health HTTP responder to the given
+// addresses. This is used when the node IP changes at runtime.
+func (s *Server) RebindHTTPPathServer(addresses []string) {
+	s.httpPathServer.Rebind(addresses)
+}
+
 // newServer instantiates a new instance of the health API server on the
 // defaults unix socket.
 func (s *Server) newServer(logger *slog.Logger, spec *healthApi.Spec) *healthApi.Server {
@@ -433,14 +439,14 @@ func NewServer(logger *slog.Logger, config Config, enableActiveChecks bool, loca
 	server.Client = cl
 	server.Server = *server.newServer(logger, config.HealthAPISpec)
 
-	server.httpPathServer = responder.NewServers(getAddresses(localNode), config.HTTPPathPort)
+	server.httpPathServer = responder.NewServers(GetAddresses(localNode), config.HTTPPathPort)
 
 	return server, nil
 }
 
-// Get internal node ipv4/ipv6 addresses based on config enabled.
-// If it fails to get either of internal node address, it returns "0.0.0.0" if ipv4 or "::" if ipv6.
-func getAddresses(localNode node.LocalNode) []string {
+// GetAddresses returns internal node ipv4/ipv6 addresses based on config enabled.
+// If it fails to get either of internal node address, it returns nil to listen on all addresses.
+func GetAddresses(localNode node.LocalNode) []string {
 	addresses := make([]string, 0, 2)
 
 	if option.Config.EnableIPv4 {

--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"slices"
 
 	"github.com/cilium/hive/cell"
 
@@ -100,6 +101,7 @@ func (ini *localNodeSynchronizer) SyncLocalNode(ctx context.Context, store *node
 			if !ini.mutableFieldsEqual(new) {
 				store.Update(func(ln *node.LocalNode) {
 					ini.syncFromK8s(ln, new)
+					ini.syncIPAddresses(ln, new)
 				})
 			}
 		} else if ev.Kind == resource.Delete {
@@ -213,6 +215,7 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			node.SetNodeExternalIP(addr.IP)
 		}
 	}
+	ini.old.IPAddresses = parsedNode.IPAddresses
 	ini.syncFromK8s(node, parsedNode)
 
 	// In cases where no local CiliumNode exists (such as on a fresh node) we skip restoring
@@ -241,10 +244,13 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 	return nil
 }
 
+func nodeAddressEqual(a, b nodeTypes.Address) bool { return a.DeepEqual(&b) }
+
 func (ini *localNodeSynchronizer) mutableFieldsEqual(new *node.LocalNode) bool {
 	return maps.Equal(ini.old.Labels, new.Labels) &&
 		maps.Equal(ini.old.Annotations, new.Annotations) &&
-		ini.old.Local.UID == new.Local.UID && ini.old.Local.ProviderID == new.Local.ProviderID
+		ini.old.Local.UID == new.Local.UID && ini.old.Local.ProviderID == new.Local.ProviderID &&
+		slices.EqualFunc(ini.old.IPAddresses, new.IPAddresses, nodeAddressEqual)
 }
 
 // syncFromK8s synchronizes the fields that can be mutated at runtime
@@ -291,6 +297,29 @@ func (ini *localNodeSynchronizer) syncFromK8s(ln, new *node.LocalNode) {
 		logfields.UID, ln.Local.UID,
 		logfields.ProviderID, ln.Local.ProviderID,
 	)
+}
+
+// syncIPAddresses syncs node IP addresses if they changed at runtime.
+// This is separate from syncFromK8s because initFromK8s handles the initial
+// IP setup directly — only runtime changes need the Info-level log.
+func (ini *localNodeSynchronizer) syncIPAddresses(ln, new *node.LocalNode) {
+	if slices.EqualFunc(ini.old.IPAddresses, new.IPAddresses, nodeAddressEqual) {
+		return
+	}
+
+	ini.Logger.Info(
+		"Node IP addresses changed, syncing to local node",
+		"oldAddresses", ini.old.IPAddresses,
+		"newAddresses", new.IPAddresses,
+	)
+	for _, addr := range new.IPAddresses {
+		if addr.Type == addressing.NodeInternalIP {
+			ln.SetNodeInternalIP(addr.IP)
+		} else if addr.Type == addressing.NodeExternalIP {
+			ln.SetNodeExternalIP(addr.IP)
+		}
+	}
+	ini.old.IPAddresses = new.IPAddresses
 }
 
 func parseNode(logger *slog.Logger, k8sNode *slim_corev1.Node) *node.LocalNode {

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -6,6 +6,7 @@ package sync
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 	"time"
 
@@ -358,4 +359,91 @@ func testNodeDeletion(t *testing.T, nodeEvent resource.Event[*slim_corev1.Node])
 		}
 	}
 	assert.True(t, foundDeleted, "Node should be marked as being deleted")
+}
+
+// TestLocalNodeSync_IPAddressChange verifies that when a node's IP address
+// changes at runtime (e.g. KubeVirt VM migration), the change is detected
+// by mutableFieldsEqual and propagated through syncFromK8s to the LocalNodeStore.
+// This is a regression test for https://github.com/cilium/cilium/issues/15406.
+func TestLocalNodeSync_IPAddressChange(t *testing.T) {
+	oldIP := "134.209.112.214"
+	newIP := "10.116.0.7"
+
+	eventWithIP := func(ip string) resource.Event[*slim_corev1.Node] {
+		return resource.Event[*slim_corev1.Node]{
+			Kind: resource.Upsert,
+			Key:  resource.Key{Name: "test-node"},
+			Object: &slim_corev1.Node{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:   "test-node",
+					UID:    k8stypes.UID("uid1"),
+					Labels: map[string]string{"env": "test"},
+				},
+				Spec: slim_corev1.NodeSpec{ProviderID: "provider://test"},
+				Status: slim_corev1.NodeStatus{
+					Addresses: []slim_corev1.NodeAddress{
+						{Type: slim_corev1.NodeInternalIP, Address: ip},
+					},
+				},
+			},
+			Done: func(err error) {},
+		}
+	}
+
+	fakeNode := &mockResource[*slim_corev1.Node]{
+		items: []resource.Event[*slim_corev1.Node]{
+			eventWithIP(oldIP), // init event
+			eventWithIP(newIP), // IP change event (same labels/annotations, different IP)
+		},
+	}
+
+	sync := newLocalNodeSynchronizer(localNodeSynchronizerParams{
+		Logger: hivetest.Logger(t),
+		Config: &option.DaemonConfig{
+			IPv4NodeAddr: "auto",
+			IPv6NodeAddr: "auto",
+		},
+		K8sLocalNode: fakeNode,
+		K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+			items: []resource.Event[*v2.CiliumNode]{
+				{Kind: resource.Sync, Done: func(err error) {}},
+			},
+		},
+		IPsecConfig: fakeTypes.IPsecConfig{},
+	})
+
+	// Initialize with the first event (old IP)
+	local := node.LocalNode{
+		Node: types.Node{
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		Local: &node.LocalNodeInfo{},
+	}
+	require.NoError(t, sync.InitLocalNode(t.Context(), &local))
+	require.Equal(t, net.ParseIP(oldIP), local.GetNodeInternalIPv4())
+
+	store := node.NewTestLocalNodeStore(local)
+
+	// SyncLocalNode processes the second event (new IP)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	updates := stream.ToChannel(ctx, store, stream.WithBufferSize(3))
+	go sync.SyncLocalNode(ctx, store)
+
+	// Wait for the update with the new IP
+	var foundNewIP bool
+	for !foundNewIP {
+		select {
+		case updated := <-updates:
+			if updated.GetNodeInternalIPv4().Equal(net.ParseIP(newIP)) {
+				foundNewIP = true
+			}
+		case <-ctx.Done():
+			t.Fatal("Timeout waiting for IP address change to propagate")
+		}
+	}
+
+	require.True(t, foundNewIP, "LocalNodeStore should reflect the new IP address")
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
### Problem: 

Node IP address changes that occur after startup (e.g. cloud provider CCM correction or KubeVirt VM live migration) are not recognized by the cilium-health HTTP path server. The server continues listening on the stale address, breaking connectivity health checks until the agent is restarted, causing it to continue listening on the stale address.

Extend mutableFieldsEqual to include IPAddresses so SyncLocalNode detects IP changes and updates NodeInternalIP in the LocalNodeStore. Add a LocalNodeStore observer that rebinds the health HTTP path server whenever the node's internal IPs change, with Rebind made race-safe against concurrent Shutdown() calls.

### Call flow

K8s Node update
-> localNodeSynchronizer.SyncLocalNode
  -> mutableFieldsEqual (now includes IPAddresses)
  -> LocalNodeStore.Update / syncIPAddresses
  -> LocalNodeStore observer fires
  -> ciliumHealthManager.observeNodeIPChangesForHealth
  -> server.Server.RebindHTTPPathServer
  -> responder.Server.Rebind (swapServers + closed double-check)
  -> new http.Server listening on updated address

### Testing
Tested on a live 4-node RHCOS cluster running Cilium 1.17 with KubeVirt. After a VM live migration the node IP changed, and both SyncLocalNode and the health responder rebind fired within the same second. Node InternalIP and CiliumNode InternalIP remained in sync for the duration of the observation window.

```
time="2026-03-24T09:05:56Z" level=info msg="Node IP addresses changed, syncing to local node" oldAddresses="[{InternalIP 10.131.19.130}]" newAddresses="[{InternalIP 10.131.18.153}]"
time="2026-03-24T09:05:56Z" level=info msg="Node IP changed, rebinding health responder" oldAddresses="[10.131.19.130]" newAddresses="[10.131.18.153]"
```

Fixes: #15406

```release-note
Fix cilium-health HTTP path server not updating when node IP changes at runtime (e.g. KubeVirt VM migration).
```
