### PR TITLE
workflows/aks: Use static Helm cluster name

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -274,7 +274,7 @@ jobs:
           # which are 10.0.0.0/16 and fd12:3456:789a:1::/108
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --datapath-mode=aks-byocni \
-            --helm-set=cluster.name=${{ env.name }} \
+            --helm-set=cluster.name=cilium \
             --helm-set=loadBalancer.l7.backend=envoy \
             --helm-set=azure.resourceGroup=${{ env.name }} \
             --helm-set=ipv4.enabled=true \


### PR DESCRIPTION
As of f073063, the UID is part of the cluster name, which can generate cluster names longer than 32 character limit and break the cilium installation.

As the Helm cluster name does not really need to be dynamic here, let's change it to static "cilium" which is simpler to reason about and avoids similar issues in the future.

