### PR TITLE
 bpf: redirect proxy hairpin traffic to cilium_net ingress

### DIFF
--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -55,7 +55,7 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
 	 * ctx_redirect_to_proxy_first().
 	 */
 
-	return ctx_redirect(ctx, CONFIG(cilium_net_ifindex), 0);
+	return ctx_redirect(ctx, CONFIG(cilium_net_ifindex), BPF_F_INGRESS);
 }
 
 #ifdef ENABLE_IPV4

--- a/bpf/tests/l7_lb_hairpin_netdev.c
+++ b/bpf/tests/l7_lb_hairpin_netdev.c
@@ -30,6 +30,7 @@ static volatile const __u8 *lb_mac = mac_host;
 
 /* Track ctx_redirect calls */
 static volatile __u32 redirect_ifindex;
+static volatile __u32 redirect_flags;
 
 #define fib_lookup mock_fib_lookup
 
@@ -44,9 +45,10 @@ long mock_fib_lookup(const __maybe_unused void *ctx,
 
 static __always_inline __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
-		  int ifindex, __u32 flags __maybe_unused)
+		  int ifindex, __u32 flags)
 {
 	redirect_ifindex = (__u32)ifindex;
+	redirect_flags = flags;
 	return CTX_ACT_REDIRECT;
 }
 
@@ -98,6 +100,7 @@ int l7_lb_hairpin_v4_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(FRONTEND_IP, 0, 112233, 0, 0);
 
 	redirect_ifindex = 0;
+	redirect_flags = 0;
 
 	return netdev_receive_packet(ctx);
 }
@@ -123,6 +126,10 @@ int l7_lb_hairpin_v4_check(const struct __ctx_buff *ctx)
 	if (redirect_ifindex != CONFIG(cilium_net_ifindex))
 		test_fatal("expected redirect to cilium_net (ifindex %d), got ifindex %d",
 			   CONFIG(cilium_net_ifindex), redirect_ifindex);
+
+	if (redirect_flags != BPF_F_INGRESS)
+		test_fatal("expected redirect with BPF_F_INGRESS, got flags %u",
+			   redirect_flags);
 
 	test_finish();
 }
@@ -160,6 +167,7 @@ int l7_lb_hairpin_v6_setup(struct __ctx_buff *ctx)
 	ipcache_v6_add_entry((union v6addr *)v6_svc_one, 0, 112233, 0, 0);
 
 	redirect_ifindex = 0;
+	redirect_flags = 0;
 
 	return netdev_receive_packet(ctx);
 }
@@ -185,6 +193,10 @@ int l7_lb_hairpin_v6_check(const struct __ctx_buff *ctx)
 	if (redirect_ifindex != CONFIG(cilium_net_ifindex))
 		test_fatal("expected redirect to cilium_net (ifindex %d), got ifindex %d",
 			   CONFIG(cilium_net_ifindex), redirect_ifindex);
+
+	if (redirect_flags != BPF_F_INGRESS)
+		test_fatal("expected redirect with BPF_F_INGRESS, got flags %u",
+			   redirect_flags);
 
 	test_finish();
 }


### PR DESCRIPTION
  - [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
  - [x] All code is covered by unit and/or runtime tests where feasible.
  - [x] All commits contain a well written commit description including a title,
        description and a `Fixes: #XXX` line if the commit addresses a particular
        GitHub issue.
  - [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
        please add the commit author[s] as reviewer[s] to this issue.
  - [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
  - [x] Provide a title or release-note blurb suitable for the release notes.
  - [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
  - [x] Thanks for contributing!

  <!-- Description of change -->

  ## Summary

  Fix the L7 proxy hairpin redirect to `cilium_net` by redirecting to the device ingress hook explicitly.

  In the WireGuard + Gateway API L7 LoadBalancer + `enable-bpf-tproxy=true` path, `cil_from_netdev` hairpins traffic to `cilium_net`, but `cilium_net` only has `cil_to_host` attached on ingress. Redirecting
  without `BPF_F_INGRESS` can blackhole traffic before it reaches the local proxy listener.

  This change updates the hairpin redirect to use `ctx_redirect(..., BPF_F_INGRESS)` and extends the BPF test to assert the redirect flags.

  ## Testing

  - Added test assertions in `bpf/tests/l7_lb_hairpin_netdev.c`
  - Verified the fix logically against the affected datapath
  - Not run locally in this environment

  Fixes: #44982 

  ```release-note
  Fix a bug where L7 proxy hairpin traffic could be blackholed before reaching Envoy when BPF TPROXY redirects traffic to cilium_net.

