### PR TITLE
network driver: allow user to specify a custom interface name (and fix ns switching + dummy discovery)

### DIFF
--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -322,7 +322,12 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 			Conditions: []metav1.Condition{conditionReady(claim)},
 			Data:       &runtime.RawExtension{Raw: dev},
 			NetworkData: &resourceapi.NetworkDeviceData{
-				InterfaceName: thisAlloc.Device.IfName(),
+				InterfaceName: func() string {
+					if thisAlloc.Config.PodIfName != "" {
+						return thisAlloc.Config.PodIfName
+					}
+					return thisAlloc.Device.IfName()
+				}(),
 				IPs: []string{
 					thisAlloc.Config.IPv4Addr.String(),
 					thisAlloc.Config.IPv6Addr.String(),

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -227,6 +227,16 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 		return kubeletplugin.PrepareResult{Err: err}
 	}
 
+	// Validate podIfName in all configs before proceeding
+	for request, cfg := range deviceClaimConfigs {
+		if err := types.ValidateInterfaceName(cfg.PodIfName); err != nil {
+			return kubeletplugin.PrepareResult{
+				Err: fmt.Errorf("invalid podIfName in request %s for claim %s: %w",
+					request, path.Join(claim.Namespace, claim.Name), err),
+			}
+		}
+	}
+
 	var (
 		alloc         []allocation
 		devicesStatus []resourceapi.AllocatedDeviceStatus

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"slices"
 	"strings"
 
@@ -55,11 +54,6 @@ func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
 
 	for _, link := range links {
 		if link.Type() != "dummy" {
-			continue
-		}
-
-		// Skip down interfaces
-		if link.Attrs().Flags&net.FlagUp == 0 {
 			continue
 		}
 

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -75,30 +75,13 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 
 		// Check for interface name collisions with existing interfaces in pod netns
 		if err := podNs.Do(func() error {
-			existingLinks, err := safenetlink.LinkList()
-			if err != nil {
-				return fmt.Errorf("failed to list existing interfaces in pod netns: %w", err)
-			}
-
-			existingNames := make(map[string]bool)
-			for _, link := range existingLinks {
-				existingNames[link.Attrs().Name] = true
-			}
-
-			// Check if any of our planned renames would collide with existing interfaces
-			for _, devices := range alloc {
-				for _, a := range devices {
-					if a.Config.PodIfName != "" && existingNames[a.Config.PodIfName] {
-						return fmt.Errorf(
-							"interface name collision: %q already exists in pod namespace (possibly from CNI)",
-							a.Config.PodIfName)
-					}
-				}
+			if err := validateInterfaceNames(alloc); err != nil {
+				return err
 			}
 
 			return nil
 		}); err != nil {
-			return fmt.Errorf("pre-flight collision check failed: %w", err)
+			return fmt.Errorf("pod interface allocations is invalid: %w", err)
 		}
 
 		for _, devices := range alloc {
@@ -290,6 +273,33 @@ func configureIfName(l netlink.Link, newIfName string) (netlink.Link, error) {
 	}
 
 	return l, nil
+}
+
+// validateInterfaceNames checks if a pod's set of allocated devices
+// contain valid interface names, that dont collide with interfaces in the pod namespace.
+func validateInterfaceNames(alloc map[kube_types.UID][]allocation) error {
+	existingLinks, err := safenetlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("failed to list existing interfaces in pod netns: %w", err)
+	}
+
+	existingNames := make(map[string]bool)
+	for _, link := range existingLinks {
+		existingNames[link.Attrs().Name] = true
+	}
+
+	// Check if any of our planned renames would collide with existing interfaces
+	for _, devices := range alloc {
+		for _, a := range devices {
+			if a.Config.PodIfName != "" && existingNames[a.Config.PodIfName] {
+				return fmt.Errorf(
+					"interface name collision: %q already exists in pod namespace (possibly from CNI)",
+					a.Config.PodIfName)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (driver *Driver) startNRI(ctx context.Context) error {

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -113,22 +113,10 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 				}
 
 				if err := podNs.Do(func() error {
-					// Rename interface to custom name if specified
-					if a.Config.PodIfName != "" && a.Config.PodIfName != a.Device.KernelIfName() {
-						link, err := safenetlink.LinkByName(a.Device.KernelIfName())
-						if err != nil {
-							return fmt.Errorf("failed to get link by kernel name %s: %w", a.Device.KernelIfName(), err)
-						}
-
-						if err := netlink.LinkSetName(link, a.Config.PodIfName); err != nil {
-							return fmt.Errorf("failed to rename interface from %s to %s: %w", a.Device.KernelIfName(), a.Config.PodIfName, err)
-						}
-
-						// Refresh link reference after rename
-						l, err = safenetlink.LinkByName(a.Config.PodIfName)
-						if err != nil {
-							return fmt.Errorf("failed to get link after rename: %w", err)
-						}
+					// Rename interface to custom name
+					l, err = configureIfName(l, a.Config.PodIfName)
+					if err != nil {
+						return fmt.Errorf("failed to set interface name: %w", err)
 					}
 
 					if err := driver.configureIPs(l, addrAdd, a.Config.IPv4Addr, a.Config.IPv6Addr); err != nil {
@@ -218,30 +206,15 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 					}
 
 					// Rename back to original kernel name before moving to root namespace
-					if a.Config.PodIfName != "" && a.Config.PodIfName != a.Device.KernelIfName() {
-						if err := netlink.LinkSetName(l, a.Device.KernelIfName()); err != nil {
-							// Log error but continue cleanup - don't fail the entire cleanup
-							driver.logger.WarnContext(ctx, "Failed to restore interface name, continuing cleanup",
-								logfields.Error, err,
-								logfields.Interface, a.Config.PodIfName,
-								logfields.Device, a.Device.KernelIfName())
+					l, err = configureIfName(l, a.Device.KernelIfName())
+					if err != nil {
+						driver.logger.ErrorContext(
+							ctx, "failed to restore interface name",
+							logfields.Error, err,
+						)
 
-							// Try to get link by current name for namespace move
-							if newLink, err := safenetlink.LinkByName(a.Config.PodIfName); err == nil {
-								l = newLink
-							}
-							// Continue with move to root netns even if rename failed
-						} else {
-							// Refresh link reference after successful rename
-							var err error
-							l, err = safenetlink.LinkByName(a.Device.KernelIfName())
-							if err != nil {
-								driver.logger.WarnContext(ctx, "Failed to get link after restoring name, continuing cleanup",
-									logfields.Error, err,
-									logfields.Device, a.Device.KernelIfName())
-								continue // Skip this device but continue with others
-							}
-						}
+						// we want to continue here to clean up the remaining, even if this one failed
+						continue
 					}
 
 					// Always try to move back to root netns
@@ -296,6 +269,27 @@ func (driver *Driver) configureIPs(l netlink.Link, action ipamAction, ipv4, ipv6
 	}
 
 	return errors.Join(errs...)
+}
+
+// configureIfName renames an interface to newIfName if the current link name differs from the
+// newIfName and newIfName is not empty.
+func configureIfName(l netlink.Link, newIfName string) (netlink.Link, error) {
+	if newIfName == "" || l.Attrs().Name == newIfName {
+		// no changes needed
+		return l, nil
+	}
+
+	if err := netlink.LinkSetName(l, newIfName); err != nil {
+		return nil, fmt.Errorf("failed to rename interface from %s to %s: %w", l.Attrs().Name, newIfName, err)
+	}
+
+	// Refresh link reference after rename
+	l, err := safenetlink.LinkByName(newIfName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get link after rename: %w", err)
+	}
+
+	return l, nil
 }
 
 func (driver *Driver) startNRI(ctx context.Context) error {

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -91,9 +91,11 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 						if err != nil {
 							return fmt.Errorf("failed to get link by kernel name %s: %w", a.Device.KernelIfName(), err)
 						}
+
 						if err := netlink.LinkSetName(link, a.Config.PodIfName); err != nil {
 							return fmt.Errorf("failed to rename interface from %s to %s: %w", a.Device.KernelIfName(), a.Config.PodIfName, err)
 						}
+
 						// Refresh link reference after rename
 						l, err = safenetlink.LinkByName(a.Config.PodIfName)
 						if err != nil {
@@ -158,6 +160,13 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 
 		defer podNs.Close()
 
+		// Get the root network namespace to move interfaces back to it
+		rootNs, err := netns.OpenPinned("/proc/1/ns/net")
+		if err != nil {
+			return fmt.Errorf("failed to open root netns: %w", err)
+		}
+		defer rootNs.Close()
+
 		for _, devices := range alloc {
 			if err := podNs.Do(func() error {
 				for _, a := range devices {
@@ -185,6 +194,7 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 						if err := netlink.LinkSetName(l, a.Device.KernelIfName()); err != nil {
 							return fmt.Errorf("failed to restore interface name from %s to %s: %w", a.Config.PodIfName, a.Device.KernelIfName(), err)
 						}
+
 						// Refresh link reference after rename
 						l, err = safenetlink.LinkByName(a.Device.KernelIfName())
 						if err != nil {
@@ -192,7 +202,7 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 						}
 					}
 
-					if err := netlink.LinkSetNsFd(l, 1); err != nil {
+					if err := netlink.LinkSetNsFd(l, rootNs.FD()); err != nil {
 						return err
 					}
 				}

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -85,6 +85,22 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 				}
 
 				if err := podNs.Do(func() error {
+					// Rename interface to custom name if specified
+					if a.Config.PodIfName != "" && a.Config.PodIfName != a.Device.KernelIfName() {
+						link, err := safenetlink.LinkByName(a.Device.KernelIfName())
+						if err != nil {
+							return fmt.Errorf("failed to get link by kernel name %s: %w", a.Device.KernelIfName(), err)
+						}
+						if err := netlink.LinkSetName(link, a.Config.PodIfName); err != nil {
+							return fmt.Errorf("failed to rename interface from %s to %s: %w", a.Device.KernelIfName(), a.Config.PodIfName, err)
+						}
+						// Refresh link reference after rename
+						l, err = safenetlink.LinkByName(a.Config.PodIfName)
+						if err != nil {
+							return fmt.Errorf("failed to get link after rename: %w", err)
+						}
+					}
+
 					if err := driver.configureIPs(l, addrAdd, a.Config.IPv4Addr, a.Config.IPv6Addr); err != nil {
 						return err
 					}
@@ -145,7 +161,13 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 		for _, devices := range alloc {
 			if err := podNs.Do(func() error {
 				for _, a := range devices {
-					l, err := safenetlink.LinkByName(a.Device.KernelIfName())
+					// Determine the interface name in the pod namespace
+					ifName := a.Device.KernelIfName()
+					if a.Config.PodIfName != "" {
+						ifName = a.Config.PodIfName
+					}
+
+					l, err := safenetlink.LinkByName(ifName)
 					if err != nil {
 						return err
 					}
@@ -156,6 +178,18 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 
 					if err := netlink.LinkSetDown(l); err != nil {
 						return err
+					}
+
+					// Rename back to original kernel name before moving to root namespace
+					if a.Config.PodIfName != "" && a.Config.PodIfName != a.Device.KernelIfName() {
+						if err := netlink.LinkSetName(l, a.Device.KernelIfName()); err != nil {
+							return fmt.Errorf("failed to restore interface name from %s to %s: %w", a.Config.PodIfName, a.Device.KernelIfName(), err)
+						}
+						// Refresh link reference after rename
+						l, err = safenetlink.LinkByName(a.Device.KernelIfName())
+						if err != nil {
+							return fmt.Errorf("failed to get link after restoring name: %w", err)
+						}
 					}
 
 					if err := netlink.LinkSetNsFd(l, 1); err != nil {

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -73,6 +73,34 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 
 		defer podNs.Close()
 
+		// Check for interface name collisions with existing interfaces in pod netns
+		if err := podNs.Do(func() error {
+			existingLinks, err := safenetlink.LinkList()
+			if err != nil {
+				return fmt.Errorf("failed to list existing interfaces in pod netns: %w", err)
+			}
+
+			existingNames := make(map[string]bool)
+			for _, link := range existingLinks {
+				existingNames[link.Attrs().Name] = true
+			}
+
+			// Check if any of our planned renames would collide with existing interfaces
+			for _, devices := range alloc {
+				for _, a := range devices {
+					if a.Config.PodIfName != "" && existingNames[a.Config.PodIfName] {
+						return fmt.Errorf(
+							"interface name collision: %q already exists in pod namespace (possibly from CNI)",
+							a.Config.PodIfName)
+					}
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("pre-flight collision check failed: %w", err)
+		}
+
 		for _, devices := range alloc {
 			for _, a := range devices {
 				l, err := safenetlink.LinkByName(a.Device.KernelIfName())
@@ -192,18 +220,36 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 					// Rename back to original kernel name before moving to root namespace
 					if a.Config.PodIfName != "" && a.Config.PodIfName != a.Device.KernelIfName() {
 						if err := netlink.LinkSetName(l, a.Device.KernelIfName()); err != nil {
-							return fmt.Errorf("failed to restore interface name from %s to %s: %w", a.Config.PodIfName, a.Device.KernelIfName(), err)
-						}
+							// Log error but continue cleanup - don't fail the entire cleanup
+							driver.logger.WarnContext(ctx, "Failed to restore interface name, continuing cleanup",
+								logfields.Error, err,
+								logfields.Interface, a.Config.PodIfName,
+								logfields.Device, a.Device.KernelIfName())
 
-						// Refresh link reference after rename
-						l, err = safenetlink.LinkByName(a.Device.KernelIfName())
-						if err != nil {
-							return fmt.Errorf("failed to get link after restoring name: %w", err)
+							// Try to get link by current name for namespace move
+							if newLink, err := safenetlink.LinkByName(a.Config.PodIfName); err == nil {
+								l = newLink
+							}
+							// Continue with move to root netns even if rename failed
+						} else {
+							// Refresh link reference after successful rename
+							var err error
+							l, err = safenetlink.LinkByName(a.Device.KernelIfName())
+							if err != nil {
+								driver.logger.WarnContext(ctx, "Failed to get link after restoring name, continuing cleanup",
+									logfields.Error, err,
+									logfields.Device, a.Device.KernelIfName())
+								continue // Skip this device but continue with others
+							}
 						}
 					}
 
+					// Always try to move back to root netns
 					if err := netlink.LinkSetNsFd(l, rootNs.FD()); err != nil {
-						return err
+						driver.logger.WarnContext(ctx, "Failed to move interface to root namespace",
+							logfields.Error, err,
+							logfields.Device, a.Device.KernelIfName())
+						// Log but don't return - continue with other devices
 					}
 				}
 

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -7,7 +7,9 @@ import (
 	"encoding"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/netip"
+	"regexp"
 	"strings"
 
 	resourceapi "k8s.io/api/resource/v1"
@@ -58,6 +60,50 @@ const (
 var (
 	errUnknownDeviceManagerType = errors.New("unknown device manager type")
 )
+
+// Interface name validation constants
+const (
+	// MaxInterfaceNameLength is the maximum length for a Linux interface name (IFNAMSIZ - 1)
+	MaxInterfaceNameLength = 15
+)
+
+var (
+	// validIfNameRegex matches valid interface name characters (alphanumeric, dot, underscore, dash)
+	validIfNameRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+)
+
+// ValidateInterfaceName validates an interface name according to Linux rules
+func ValidateInterfaceName(name string) error {
+	// Empty name is valid (means no custom rename)
+	if name == "" {
+		return nil
+	}
+
+	// Check length limit (Linux IFNAMSIZ - 1)
+	if len(name) > MaxInterfaceNameLength {
+		return fmt.Errorf(
+			"interface name too long: %q (%d chars, max %d)",
+			name, len(name), MaxInterfaceNameLength)
+	}
+
+	// Check for valid characters
+	if !validIfNameRegex.MatchString(name) {
+		return fmt.Errorf(
+			"interface name contains invalid characters: %q (allowed: a-z A-Z 0-9 . _ -)",
+			name)
+	}
+
+	// Check for reserved names
+	if name == "lo" {
+		return fmt.Errorf("interface name %q is reserved (loopback)", name)
+	}
+
+	if len(name) >= 7 && name[:7] == "cilium_" {
+		return fmt.Errorf("interface name %q is reserved (cilium_ prefix)", name)
+	}
+
+	return nil
+}
 
 type DeviceManagerType int
 

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -141,11 +141,12 @@ type RouteSet map[netip.Prefix]AddrSet
 type AddrSet map[netip.Prefix]struct{}
 
 type DeviceConfig struct {
-	IPv4Addr netip.Prefix `json:"ipv4Addr"`
-	IPv6Addr netip.Prefix `json:"ipv6Addr"`
-	IPPool   string       `json:"ip-pool"`
-	Routes   RouteSet
-	Vlan     uint16
+	IPv4Addr  netip.Prefix `json:"ipv4Addr"`
+	IPv6Addr  netip.Prefix `json:"ipv6Addr"`
+	IPPool    string       `json:"ip-pool"`
+	Routes    RouteSet
+	Vlan      uint16
+	PodIfName string `json:"podIfName,omitempty"` // Custom interface name for the pod namespace
 }
 
 func (d *DeviceConfig) Empty() bool {
@@ -153,7 +154,8 @@ func (d *DeviceConfig) Empty() bool {
 		d.IPv6Addr == (netip.Prefix{}) &&
 		d.IPPool == "" &&
 		d.Routes == nil &&
-		d.Vlan == 0
+		d.Vlan == 0 &&
+		d.PodIfName == ""
 }
 
 type SerializedDevice struct {

--- a/pkg/networkdriver/types/validation_test.go
+++ b/pkg/networkdriver/types/validation_test.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateInterfaceNameLength tests the 15-character length limit
+func TestValidateInterfaceNameLength(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifName    string
+		shouldErr bool
+	}{
+		{
+			name:      "empty name is valid",
+			ifName:    "",
+			shouldErr: false,
+		},
+		{
+			name:      "1 char name",
+			ifName:    "a",
+			shouldErr: false,
+		},
+		{
+			name:      "exactly 15 chars (max)",
+			ifName:    "abcdefghijklmno",
+			shouldErr: false,
+		},
+		{
+			name:      "16 chars (too long)",
+			ifName:    "abcdefghijklmnop",
+			shouldErr: true,
+		},
+		{
+			name:      "way too long",
+			ifName:    "this-interface-name-is-way-too-long",
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateInterfaceName(tt.ifName)
+			if tt.shouldErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "too long")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateInterfaceNameCharacters tests character validation
+func TestValidateInterfaceNameCharacters(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifName    string
+		shouldErr bool
+	}{
+		// Valid characters
+		{
+			name:      "alphanumeric",
+			ifName:    "eth0",
+			shouldErr: false,
+		},
+		{
+			name:      "with dash",
+			ifName:    "my-net-0",
+			shouldErr: false,
+		},
+		{
+			name:      "with underscore",
+			ifName:    "my_net_0",
+			shouldErr: false,
+		},
+		{
+			name:      "with dot",
+			ifName:    "my.net.0",
+			shouldErr: false,
+		},
+		{
+			name:      "mixed valid chars",
+			ifName:    "a1-b2_c3.d4",
+			shouldErr: false,
+		},
+		// Invalid characters
+		{
+			name:      "with colon",
+			ifName:    "eth:0",
+			shouldErr: true,
+		},
+		{
+			name:      "with slash",
+			ifName:    "eth/0",
+			shouldErr: true,
+		},
+		{
+			name:      "with space",
+			ifName:    "my net",
+			shouldErr: true,
+		},
+		{
+			name:      "with tab",
+			ifName:    "my\tnet",
+			shouldErr: true,
+		},
+		{
+			name:      "with special char",
+			ifName:    "eth@0",
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateInterfaceName(tt.ifName)
+			if tt.shouldErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid characters")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateInterfaceNameReserved tests reserved name detection
+func TestValidateInterfaceNameReserved(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifName    string
+		shouldErr bool
+	}{
+		{
+			name:      "loopback",
+			ifName:    "lo",
+			shouldErr: true,
+		},
+		{
+			name:      "cilium_host",
+			ifName:    "cilium_host",
+			shouldErr: true,
+		},
+		{
+			name:      "cilium_net",
+			ifName:    "cilium_net",
+			shouldErr: true,
+		},
+		{
+			name:      "cilium without underscore is ok",
+			ifName:    "ciliumnet",
+			shouldErr: false,
+		},
+		{
+			name:      "normal eth",
+			ifName:    "eth0",
+			shouldErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateInterfaceName(tt.ifName)
+			if tt.shouldErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "reserved")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateInterfaceNameRealWorld tests real-world interface names
+func TestValidateInterfaceNameRealWorld(t *testing.T) {
+	validNames := []string{
+		"eth0", "eth1", "net0", "net1",
+		"mynet0", "app-net", "app_net",
+		"sriov0", "dpdk0", "vf0",
+		"veth0", "macvlan0", "bond0",
+		"enp1s0f0", // SR-IOV style
+		"eth0.100", // VLAN
+	}
+
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateInterfaceName(name)
+			assert.NoError(t, err, "Valid name %q should pass validation", name)
+		})
+	}
+
+	invalidNames := map[string]string{
+		"eth:0":                       "colon",
+		"eth 0":                       "space",
+		"verylonginterfacename":       "too long",
+		"lo":                          "reserved",
+		"cilium_host":                 "reserved",
+		"eth0\n":                      "newline",
+		"interface-name-way-too-long": "too long",
+	}
+
+	for name, reason := range invalidNames {
+		t.Run(name+"_"+reason, func(t *testing.T) {
+			err := ValidateInterfaceName(name)
+			assert.Error(t, err, "Invalid name %q should fail validation (reason: %s)", name, reason)
+		})
+	}
+}
+
+// TestDeviceConfigEmpty tests Empty() method considers PodIfName
+func TestDeviceConfigEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   DeviceConfig
+		expected bool
+	}{
+		{
+			name:     "completely empty",
+			config:   DeviceConfig{},
+			expected: true,
+		},
+		{
+			name: "only podIfName set",
+			config: DeviceConfig{
+				PodIfName: "eth1",
+			},
+			expected: false,
+		},
+		{
+			name: "all fields set",
+			config: DeviceConfig{
+				PodIfName: "custom-if",
+				Vlan:      100,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.config.Empty()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestValidateInterfaceNameEdgeCases tests edge cases
+func TestValidateInterfaceNameEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		ifName    string
+		shouldErr bool
+	}{
+		{
+			name:      "just numbers",
+			ifName:    "123",
+			shouldErr: false,
+		},
+		{
+			name:      "starts with number",
+			ifName:    "0eth",
+			shouldErr: false,
+		},
+		{
+			name:      "starts with dash",
+			ifName:    "-eth0",
+			shouldErr: false,
+		},
+		{
+			name:      "exactly 15 valid chars",
+			ifName:    "123456789012345",
+			shouldErr: false,
+		},
+		{
+			name:      "unicode not allowed",
+			ifName:    "ethñ",
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateInterfaceName(tt.ifName)
+			if tt.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
adds a new optional config parameter (podIfName) that lets a customer choose the ifname exposed to the pod.

fixed the namespace switch back to the root namespace, as it wasn't working - it needs an actual FD, not a ns id
lastly, changed dummy driver so it can discover dummy devices in "down" state. since we're bringing interfaces down on StopPodSandbox, dummy devices weren't returned back to the pool and couldn't be reused.

```release-note
network driver: allow custom ifnames, and fix code that moves interfaces back to the root namespace
```
