### PR TITLE
feat: Limit the logs checked to the time of the tests

### DIFF
--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -59,6 +59,7 @@ cilium connectivity test [flags]
       --junit-file string                                          Generate junit report and write to file
       --junit-property map                                         Add key=value properties to the generated junit file
       --k8s-version string                                         Kubernetes server version in case auto-detection fails
+      --log-check-only-test-time                                   Whether logs should only get checked for the duration of the tests
       --multi-cluster string                                       Test across clusters to given context
       --namespace-labels map                                       Add labels to the connectivity test namespace
       --node-cidr strings                                          one or more CIDRs that cover all nodes in the cluster

--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -220,6 +220,7 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().MarkHidden("exclude-code-owners")
 	cmd.Flags().StringSliceVar(&params.LogCheckLevels, "log-check-levels", defaults.LogCheckLevels, "Log levels to check for in log messages")
 	cmd.Flags().MarkHidden("log-check-levels")
+	cmd.Flags().BoolVar(&params.LogCheckOnlyTestTime, "log-check-only-test-time", false, "Whether logs should only get checked for the duration of the tests")
 
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")
 	cmd.Flags().MarkHidden("flush-ct")

--- a/cilium-cli/connectivity/builder/check_log_errors.go
+++ b/cilium-cli/connectivity/builder/check_log_errors.go
@@ -4,6 +4,8 @@
 package builder
 
 import (
+	"time"
+
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
 )
@@ -11,8 +13,12 @@ import (
 type checkLogErrors struct{}
 
 func (t checkLogErrors) build(ct *check.ConnectivityTest, _ map[string]string) {
+	var startTime time.Time
+	if ct.Params().LogCheckOnlyTestTime {
+		startTime = time.Now()
+	}
 	newTest("check-log-errors", ct).
 		WithSysdumpPolicy(check.SysdumpPolicyOnce).
 		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels, ct.Params().ExternalTarget,
-			ct.Params().ExternalOtherTarget))
+			ct.Params().ExternalOtherTarget, startTime))
 }

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -127,10 +127,11 @@ type Parameters struct {
 	ExpectedDropReasons []string
 	ExpectedXFRMErrors  []string
 
-	CodeOwners        []string
-	LogCodeOwners     bool
-	ExcludeCodeOwners []string
-	LogCheckLevels    []string
+	CodeOwners           []string
+	LogCodeOwners        bool
+	ExcludeCodeOwners    []string
+	LogCheckLevels       []string
+	LogCheckOnlyTestTime bool
 
 	FlushCT               bool
 	SecondaryNetworkIface string

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ func (r regexMatcher) IsMatch(log string) bool {
 // NoErrorsInLogs checks whether there are no error messages in cilium-agent
 // logs. The error messages are defined in badLogMsgsWithExceptions, which key
 // is an error message, while values is a list of ignored messages.
-func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, externalTarget string, externalOtherTarget string) check.Scenario {
+func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, externalTarget string, externalOtherTarget string, startTime time.Time) check.Scenario {
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
 	errorLogExceptions := []logMatcher{
@@ -104,6 +105,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 		errorMsgsWithExceptions: errorMsgsWithExceptions,
 		ScenarioBase:            check.NewScenarioBase(),
 		ciliumVersion:           ciliumVersion,
+		startTime:               startTime,
 	}
 }
 
@@ -114,6 +116,7 @@ type noErrorsInLogs struct {
 	ciliumVersion           semver.Version
 	mostCommonFailureLog    string
 	mostCommonFailureCount  int
+	startTime               time.Time
 }
 
 func (n *noErrorsInLogs) FilePath() string {
@@ -150,6 +153,9 @@ func (n *noErrorsInLogs) Run(ctx context.Context, t *check.Test) {
 	}
 
 	opts := corev1.PodLogOptions{LimitBytes: ptr.To[int64](sysdump.DefaultLogsLimitBytes)}
+	st := metav1.NewTime(n.startTime)
+	t.Infof("Start time for the check: %s", st.UTC().String())
+	opts.SinceTime = &st
 	prevOpts := opts
 	prevOpts.Previous = true
 	for pod, info := range pods {

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
@@ -93,7 +94,8 @@ time=2025-04-08T14:27:09Z level=error msg="bar" serviceID=2 source=/go/src/githu
 			wantFilePath: "cilium-cli/connectivity/tests/errors.go",
 		},
 	} {
-		s := NoErrorsInLogs(tt.version, tt.levels, "one.one.one.one", "k8s.io").(*noErrorsInLogs)
+		var zt time.Time
+		s := NoErrorsInLogs(tt.version, tt.levels, "one.one.one.one", "k8s.io", zt).(*noErrorsInLogs)
 		fails, example := s.findUniqueFailures([]byte(errs))
 		assert.Len(t, fails, tt.wantLen)
 		for wantMsg, wantCount := range tt.wantLogsCount {


### PR DESCRIPTION
Add a parameter --log-check-only-test-time. When set to true only the logs from the time the tests started are checked. Checking the complete logs creates false positive. Failures reported in the logs may be due to cluster components outside of Cilium being in the installation or upgrade phase. The default behavior of checking all the logs is unchanged.

fixes #37762

```release-note
A new parameter, `--log-check-only-test-time`, has been added to Cilium CLI connectivity tests. When set to true, only the logs written after the point in time where the tests have been started get checked. This aims at avoiding false positive.
```