### PR TITLE
[v1.17] ci: fix setup-eks-cluster action

### DIFF
--- a/.github/actions/setup-eks-cluster/action.yml
+++ b/.github/actions/setup-eks-cluster/action.yml
@@ -42,7 +42,9 @@ runs:
           tags:
            usage: "${{ github.repository_owner }}-${{ github.event.repository.name }}"
            owner: "${{ inputs.owner }}"
-        clusterEndpoints:
+
+        vpc:
+          clusterEndpoints:
             publicAccess: true
             privateAccess: true
           publicAccessCIDRs: [ "${{ steps.get-runner-ip.outputs.cidr }}" ]


### PR DESCRIPTION
The generated eks-config.yaml was missing the vpc key which the referenced commit forgot to add, leading to the following error when using the action:

    Run ./.github/actions/get-runner-ip
    Run actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
    Run cat <<EOF > eks-config.yaml
    Error: loading config file "./eks-config.yaml": error converting YAML to JSON: yaml: line 13: did not find expected key

Fixes: 330882c1b523 ("fix: k8s apiserver should be restricted to runner")