### PR TITLE
.github/renovate: use builder container for generate-k8s-api in all r…

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -112,9 +112,9 @@
     "^make -C Documentation update-helm-values$",
     "^make -C Documentation update-cmdref$",
     "^make -C Documentation update-requirements$",
-    "^make generate-k8s-api$",
     "^make manifests$",
     "^make GO='contrib/scripts/builder.sh go' generate-apis$",
+    "^make GO='contrib/scripts/builder.sh go' generate-k8s-api$",
     "^go mod tidy$",
     "^go mod vendor$"
   ],
@@ -317,7 +317,7 @@
         "commands": [
           "go mod tidy",
           "go mod vendor",
-          "make generate-k8s-api",
+          "make GO='contrib/scripts/builder.sh go' generate-k8s-api",
           "make manifests"
         ],
         "executionMode": "update"
@@ -718,7 +718,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "make generate-k8s-api",
+          "make GO='contrib/scripts/builder.sh go' generate-k8s-api",
           "make manifests"
         ],
         "executionMode": "update"
@@ -758,7 +758,7 @@
       "postUpgradeTasks": {
         "commands": [
           "make GO='contrib/scripts/builder.sh go' generate-apis",
-          "make generate-k8s-api"
+          "make GO='contrib/scripts/builder.sh go' generate-k8s-api"
         ],
         "executionMode": "update"
       }


### PR DESCRIPTION
…ules

The `make generate-k8s-api` target uses `$(GO)` in Makefile variable evaluations (e.g. `NATIVE_ARCH`) which run on the host before delegating to the builder container. In the Renovate executor environment, `go` is not in PATH, causing `go: command not found` errors during these evaluations.

The goswagger rule already used `GO='contrib/scripts/builder.sh go'` for `generate-apis` but not for `generate-k8s-api`. The k8s.io dependency rules also lacked this override. This commit updates all three postUpgradeTasks callsites to use the builder container for `go` invocations, matching the pattern already used by `generate-apis`.