### PR TITLE
GHA: Node without Cilium for AKS workflows

### DIFF
--- a/.github/actions/generic-external-targets/action.sh
+++ b/.github/actions/generic-external-targets/action.sh
@@ -27,19 +27,21 @@ openssl req -newkey rsa:2048 -nodes \
     -out external-service.cilium.req.pem
 
 # Figure out the addresses of the external nodes.
-IP4TARGET="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
-IP4OTHERTARGET="$(kubectl get nodes -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')"
+mapfile -d ' ' -t IPTARGET < <(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+mapfile -d ' ' -t IPOTHERTARGET < <(kubectl get nodes -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')
 
 # Create a config file to tell openssl how to turn the signing request into a certificate
 # Make sure the key usage is such that we can use the cert for HTTPS traffic.
 # Also make sure both domain names are in the subjectAltName so the certificate works for
 # both external services and the IP addresses without domain name.
+(IFS=''
 cat > v3.ext << EOF
 subjectKeyIdentifier   = hash
 authorityKeyIdentifier = keyid:always,issuer:always
 keyUsage               = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment, keyAgreement, keyCertSign
-subjectAltName         = DNS:$OTHERTARGETNAME, DNS:$TARGETNAME, DNS:fake.external.first.target, DNS:fake.external.second.target, IP:$IP4TARGET, IP:$IP4OTHERTARGET
+subjectAltName         = DNS:$OTHERTARGETNAME, DNS:$TARGETNAME, DNS:fake.external.first.target, DNS:fake.external.second.target${IPTARGET[*]/#/, IP:}${IPOTHERTARGET[*]/#/, IP:}
 EOF
+)
 
 # Turn the certificate signing request into a certificate, signed by our CA
 openssl x509 -req -days 365 -set_serial 01 \
@@ -67,7 +69,11 @@ envsubst '$NGINX_CERT_BASE64 $NGINX_KEY_BASE64 $EXTERNAL_NODE' < "$(dirname "$0"
 kubectl -n external rollout status daemonset nginx --timeout 60s
 kubectl -n external-other rollout status daemonset nginx --timeout 60s
 
-echo "ipv4_external_target=$IP4TARGET" >> $GITHUB_OUTPUT
-echo "ipv4_other_external_target=$IP4OTHERTARGET" >> $GITHUB_OUTPUT
+echo "ipv4_external_target=${IPTARGET[0]}" >> $GITHUB_OUTPUT
+echo "ipv4_other_external_target=${IPOTHERTARGET[0]}" >> $GITHUB_OUTPUT
+if [ "${#IPTARGET[@]}" -ge 2 ] && [ "${#IPOTHERTARGET[@]}" -ge 2 ]; then
+	echo "ipv6_external_target=${IPTARGET[1]}" >> $GITHUB_OUTPUT
+	echo "ipv6_other_external_target=${IPOTHERTARGET[1]}" >> $GITHUB_OUTPUT
+fi
 echo "external_target_name=$TARGETNAME" >> $GITHUB_OUTPUT
 echo "other_external_target_name=$OTHERTARGETNAME" >> $GITHUB_OUTPUT

--- a/.github/actions/generic-external-targets/action.sh
+++ b/.github/actions/generic-external-targets/action.sh
@@ -69,6 +69,11 @@ envsubst '$NGINX_CERT_BASE64 $NGINX_KEY_BASE64 $EXTERNAL_NODE' < "$(dirname "$0"
 kubectl -n external rollout status daemonset nginx --timeout 60s
 kubectl -n external-other rollout status daemonset nginx --timeout 60s
 
+# Explicitly check that pods have been deployed to avoid a situation where the
+# above command succeeds with 0 desired pods if tolerations aren't met.
+kubectl -n external wait --for=jsonpath='{.status.numberReady}=1' daemonset/nginx --timeout=60s
+kubectl -n external-other wait --for=jsonpath='{.status.numberReady}=1' daemonset/nginx --timeout=60s
+
 echo "ipv4_external_target=${IPTARGET[0]}" >> $GITHUB_OUTPUT
 echo "ipv4_other_external_target=${IPOTHERTARGET[0]}" >> $GITHUB_OUTPUT
 if [ "${#IPTARGET[@]}" -ge 2 ] && [ "${#IPOTHERTARGET[@]}" -ge 2 ]; then

--- a/.github/actions/generic-external-targets/action.yaml
+++ b/.github/actions/generic-external-targets/action.yaml
@@ -9,6 +9,12 @@ outputs:
   ipv4_other_external_target:
     description: "IPv4 address of the second external target"
     value: ${{ steps.add_targets.outputs.ipv4_other_external_target }}
+  ipv6_external_target:
+    description: "IPv6 address of the first external target"
+    value: ${{ steps.add_targets.outputs.ipv6_external_target }}
+  ipv6_other_external_target:
+    description: "IPv6 address of the second external target"
+    value: ${{ steps.add_targets.outputs.ipv6_other_external_target }}
   external_target_name:
     description: "Domain name of the first external target"
     value: ${{ steps.add_targets.outputs.external_target_name }}

--- a/.github/actions/generic-external-targets/nginx-external.yaml
+++ b/.github/actions/generic-external-targets/nginx-external.yaml
@@ -81,6 +81,12 @@ spec:
         operator: "Equal"
         value: "true"
         effect: "NoExecute"
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: nginx

--- a/.github/actions/nodes-without-cilium/action.yml
+++ b/.github/actions/nodes-without-cilium/action.yml
@@ -1,0 +1,10 @@
+name: Patch nodes without Cilium
+description: Add no-schedule labels to nodes without Cilium
+runs:
+  using: composite
+  steps:
+    - name: Add no-schedule labels to nodes without Cilium
+      shell: bash
+      run: |
+        mapfile -t nodes_without_cilium < <(kubectl get nodes -o name | head -n 2)
+        kubectl patch "${nodes_without_cilium[@]}" --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'

--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -67,3 +67,9 @@ runs:
           --generate-ssh-keys \
           --api-server-authorized-ip-ranges ${{ steps.get-runner-ip.outputs.cidr }}
 
+    - name: Get cluster credentials
+      shell: bash
+      run: |
+        az aks get-credentials \
+          --resource-group ${{ inputs.cluster_name }} \
+          --name ${{ inputs.cluster_name }}

--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -61,7 +61,7 @@ runs:
           --location ${{ inputs.location }} \
           $VERSION \
           --network-plugin none \
-          --node-count ${{ inputs.node_count }} \
+          --node-count "$(( ${{ inputs.node_count }} + 2 ))" \
           --ip-families ipv4,ipv6 \
           ${{ inputs.taints }} \
           --generate-ssh-keys \
@@ -73,3 +73,6 @@ runs:
         az aks get-credentials \
           --resource-group ${{ inputs.cluster_name }} \
           --name ${{ inputs.cluster_name }}
+
+    - name: Patch nodes without Cilium
+      uses: ./.github/actions/nodes-without-cilium

--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -82,5 +82,5 @@ runs:
         native_cidr=$(gcloud container clusters describe "${{ inputs.cluster-name }}" --zone "${{ inputs.zone }}" --format 'value(clusterIpv4Cidr)')
         echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
 
-        mapfile -t nodes_without_cilium < <(kubectl get nodes -o name | head -n 2)
-        kubectl patch "${nodes_without_cilium[@]}" --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+    - name: Patch nodes without Cilium
+      uses: ./.github/actions/nodes-without-cilium

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -253,12 +253,6 @@ jobs:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
-      - name: Get connectivity test flags
-        id: e2e_config
-        uses: ./.github/actions/cli-test-config
-        with:
-          hubble: false
-
       - name: Set up job variables
         id: vars
         run: |
@@ -309,10 +303,7 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=wireguard"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
-
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
           echo ipsec=${IPSEC} >> $GITHUB_OUTPUT
@@ -347,6 +338,12 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
           kubeconfig: ${{ steps.gen-kubeconfig.outputs.kubeconfig_path }}
 
+      - name: Copy scripts to trusted directory
+        run: |
+          mkdir -p ../cilium-base-branch/.github/actions
+          cp -a .github/actions/generic-external-targets ../cilium-base-branch/.github/actions/
+          cp -a .github/actions/cli-test-config ../cilium-base-branch/.github/actions/
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -377,6 +374,53 @@ jobs:
         run: |
           cilium status --wait --interactive=false --wait-duration=10m
 
+      - name: Add external targets to the cluster
+        uses: ./../cilium-base-branch/.github/actions/generic-external-targets
+        id: external_targets
+
+      - name: Determine the CIDR of fake external targets
+        id: external_cidr
+        run: |
+          NODERG=$(az aks show \
+            --resource-group ${{ env.name }} \
+            --name ${{ env.name }} \
+            --query 'nodeResourceGroup' \
+            -o tsv)
+          CIDRV4=$(az network vnet list \
+            --resource-group "$NODERG" \
+            --query '[].addressSpace.addressPrefixes[0]' \
+            -o tsv)
+          CIDRV6=$(az network vnet list \
+            --resource-group "$NODERG" \
+            --query '[].addressSpace.addressPrefixes[1]' \
+            -o tsv)
+          echo "ipv4_external_cidr=$CIDRV4" >> $GITHUB_OUTPUT
+          echo "ipv6_external_cidr=$CIDRV6" >> $GITHUB_OUTPUT
+
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./../cilium-base-branch/.github/actions/cli-test-config
+        with:
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-cidr: ${{ steps.external_cidr.outputs.ipv4_external_cidr }}
+          external-cidrv6: ${{ steps.external_cidr.outputs.ipv6_external_cidr }}
+          external-ip: ${{ steps.external_targets.outputs.ipv4_external_target }}
+          external-other-ip: ${{ steps.external_targets.outputs.ipv4_other_external_target }}
+          external-ipv6: ${{ steps.external_targets.outputs.ipv6_external_target }}
+          external-other-ipv6: ${{ steps.external_targets.outputs.ipv6_other_external_target }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
+          external-target-fake-dns: true
+          hubble: false
+
+      - name: Set up job variables for connectivity tests
+        id: vars-conn
+        run: |
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits
@@ -384,14 +428,14 @@ jobs:
       - name: Run sequential connectivity test (${{ join(matrix.*, ', ') }})
         id: run-tests
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --test "seq-.*" \
           --junit-file "cilium-junits/${{ env.job_name }}-sequential-clear (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       - name: Run concurrent connectivity test (${{ join(matrix.*, ', ') }})
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --test-concurrency=${{ env.test_concurrency }} \
           --test "!seq-.*" \
           --junit-file "cilium-junits/${{ env.job_name }}-concurrent-clear (${{ join(matrix.*, ', ') }}).xml" \

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -366,7 +366,8 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --nodes-without-cilium
 
       - name: Enable Relay
         run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -331,12 +331,6 @@ jobs:
           tags: "usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}"
           taints: ${{ env.cost_reduction }}
 
-      - name: Get cluster credentials
-        run: |
-          az aks get-credentials \
-            --resource-group ${{ env.name }} \
-            --name ${{ env.name }}
-
       - name: Generate cilium-cli kubeconfig
         id: gen-kubeconfig
         uses: ./.github/actions/get-cloud-kubeconfig

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -450,7 +450,7 @@ jobs:
           cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
-      - name: Add external targets to kind cluster
+      - name: Add external targets to the cluster
         uses: ./../cilium-base-branch/.github/actions/generic-external-targets
         id: external_targets
 


### PR DESCRIPTION
```release-note
Use fake external targets on nodes without Cilium in AKS CI workflows for better stability.
```