### PR TITLE
[41867] [Part4] Core Hybrid routing 

### DIFF
--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -74,10 +74,10 @@ type podToPodEncryptionV2 struct {
 	// pod on server's node providing access to host network namespace
 	serverHostNS *check.Pod
 
-	tunnelMode  features.Status
-	encryptMode features.Status
-	ipv4Enabled features.Status
-	ipv6Enabled features.Status
+	encryptMode       features.Status
+	ipv4Enabled       features.Status
+	ipv6Enabled       features.Status
+	usesTunnelRouting bool
 
 	// the egress device, on the client node, that client->server traffic will
 	// leave on.
@@ -120,10 +120,10 @@ func (s *podToPodEncryptionV2) resolveEgressDevice(ctx context.Context, srcHostN
 	// leaving the host, thus, use the tunnel endpoint IP rather then the
 	// pod IP for route lookup.
 	var srcIP, dstIP string
-	if s.tunnelMode.Enabled {
+	if s.usesTunnelRouting {
 		srcIP = src.Pod.Status.HostIP
 		dstIP = dst.Pod.Status.HostIP
-	} else {
+	} else { // If native or hybrid, pod to pod traffic is natively routed.
 		srcIP = src.Pod.Status.PodIP
 		dstIP = dst.Pod.Status.PodIP
 	}
@@ -305,7 +305,7 @@ func (s *podToPodEncryptionV2) resolveTCPDumpFilters4(ctx context.Context) (clie
 	}
 
 	// handle tunneling mode.
-	if s.tunnelMode.Enabled {
+	if s.usesTunnelRouting {
 		return s.tunnelTCPDumpFilters4(ctx)
 	}
 
@@ -416,7 +416,7 @@ func (s *podToPodEncryptionV2) resolveTCPDumpFilters6(ctx context.Context) (clie
 		return "", "", fmt.Errorf("Context already cancelled")
 	}
 
-	if s.tunnelMode.Enabled {
+	if s.usesTunnelRouting {
 		clientFilter, serverFilter, err = s.tunnelTCPDumpFilters6(ctx)
 	} else {
 		clientFilter, serverFilter, err = s.nativeTCPDumpFilters6(ctx)
@@ -581,7 +581,11 @@ func (s *podToPodEncryptionV2) Run(ctx context.Context, t *check.Test) {
 	if !ok {
 		t.Fatalf("Failed to detect IPv6 feature")
 	}
-	s.tunnelMode, ok = s.ct.Feature(features.Tunnel)
+	subnetTopology, ok := s.ct.Feature(features.SubnetTopology)
+	if !ok {
+		t.Fatalf("Failed to detect subnet topology")
+	}
+	tunnelMode, ok := s.ct.Feature(features.Tunnel)
 	if !ok {
 		t.Fatalf("Failed to detect tunnel mode")
 	}
@@ -609,6 +613,14 @@ func (s *podToPodEncryptionV2) Run(ctx context.Context, t *check.Test) {
 	if s.server == nil {
 		t.Fatalf("Failed to acquire a server pod\n")
 	}
+
+	// usesTunnelRouting determines if pod-to-pod traffic between s.client and s.server
+	// will be tunnel encap'd.
+	// This is true when tunnel mode is enabled and the client and server pods are
+	// not in the same subnet, as determined by the cluster's subnet topology.
+	// The subnet check is needed in case of hybrid routing mode,
+	// where pod-to-pod traffic in the same subnet is natively routed.
+	s.usesTunnelRouting = tunnelMode.Enabled && !features.SameSubnet(s.client.Pod.Status.PodIP, s.server.Pod.Status.PodIP, subnetTopology.Mode)
 
 	// grab host namespace pods for accessing the network namespaces of client
 	// and server pods.

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -128,6 +128,8 @@ const (
 	Ztunnel Feature = "enable-ztunnel"
 
 	DefaultGlobalNamespace Feature = "clustermesh-default-global-namespace"
+
+	SubnetTopology Feature = "subnet-topology"
 )
 
 // Feature is the name of a Cilium Feature (e.g. l7-proxy, cni chaining mode etc)
@@ -425,6 +427,12 @@ func (fs Set) ExtractFromConfigMap(cm *v1.ConfigMap) {
 
 	fs[L7LoadBalancer] = Status{
 		Enabled: cm.Data[string(L7LoadBalancer)] == "envoy",
+	}
+
+	st, ok := cm.Data[string(SubnetTopology)]
+	fs[SubnetTopology] = Status{
+		Enabled: ok,
+		Mode:    st,
 	}
 
 	fs[Tunnel], fs[TunnelPort] = ExtractTunnelFeatureFromConfigMap(cm)

--- a/cilium-cli/utils/features/utils.go
+++ b/cilium-cli/utils/features/utils.go
@@ -3,7 +3,12 @@
 
 package features
 
-import "net"
+import (
+	"net"
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/subnet/topology"
+)
 
 type IPFamily int
 
@@ -103,4 +108,40 @@ func ComputeFailureExceptions(defaultExceptions, inputExceptions []string) []str
 		}
 	}
 	return exceptionList
+}
+
+// SameSubnet returns true if given two IP addresses belong to the same subnet, based on the subnet-topology.
+func SameSubnet(ip1, ip2, topologyStr string) bool {
+	if topologyStr == "" {
+		return false
+	}
+
+	parsedIP1, err := netip.ParseAddr(ip1)
+	if err != nil {
+		return false
+	}
+	parsedIP2, err := netip.ParseAddr(ip2)
+	if err != nil {
+		return false
+	}
+
+	entries, err := topology.Decode(topologyStr)
+	if err != nil {
+		return false
+	}
+
+	var group1, group2 uint32
+	for _, entry := range entries {
+		if entry.Key.Contains(parsedIP1) {
+			group1 = entry.Value
+		}
+		if entry.Key.Contains(parsedIP2) {
+			group2 = entry.Value
+		}
+		if group1 != 0 && group1 == group2 {
+			return true
+		}
+	}
+
+	return false
 }

--- a/cilium-cli/utils/features/utils_test.go
+++ b/cilium-cli/utils/features/utils_test.go
@@ -56,3 +56,129 @@ func TestComputeFailureExceptions(t *testing.T) {
 		})
 	}
 }
+
+func TestSameSubnet(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip1      string
+		ip2      string
+		topology string
+		expected bool
+	}{
+		{
+			name:     "empty topology",
+			ip1:      "10.0.0.1",
+			ip2:      "10.0.0.2",
+			topology: "",
+			expected: false,
+		},
+		{
+			name:     "same subnet single CIDR",
+			ip1:      "10.0.0.1",
+			ip2:      "10.0.0.2",
+			topology: "10.0.0.0/24",
+			expected: true,
+		},
+		{
+			name:     "different subnets single CIDR",
+			ip1:      "10.0.0.1",
+			ip2:      "10.1.0.1",
+			topology: "10.0.0.0/24",
+			expected: false,
+		},
+		{
+			name:     "same group multiple CIDRs",
+			ip1:      "10.0.0.1",
+			ip2:      "10.10.0.1",
+			topology: "10.0.0.0/24,10.10.0.0/24",
+			expected: true,
+		},
+		{
+			name:     "different groups",
+			ip1:      "10.0.0.1",
+			ip2:      "10.20.0.1",
+			topology: "10.0.0.0/24,10.10.0.0/24;10.20.0.0/24",
+			expected: false,
+		},
+		{
+			name:     "same group second group",
+			ip1:      "10.20.0.1",
+			ip2:      "10.20.0.2",
+			topology: "10.0.0.0/24,10.10.0.0/24;10.20.0.0/24",
+			expected: true,
+		},
+		{
+			name:     "ipv6 same subnet",
+			ip1:      "2001:db8:85a3::1",
+			ip2:      "2001:db8:85a3::2",
+			topology: "2001:db8:85a3::/64",
+			expected: true,
+		},
+		{
+			name:     "ipv6 different subnets",
+			ip1:      "2001:db8:85a3::1",
+			ip2:      "2001:db8:85a4::1",
+			topology: "2001:db8:85a3::/64",
+			expected: false,
+		},
+		{
+			name:     "mixed ipv4 and ipv6 in same group",
+			ip1:      "10.0.0.1",
+			ip2:      "2001:db8:85a3::1",
+			topology: "10.0.0.0/24,2001:db8:85a3::/64",
+			expected: true, // both IPs are in CIDRs within the same group
+		},
+		{
+			name:     "invalid ip1",
+			ip1:      "invalid",
+			ip2:      "10.0.0.2",
+			topology: "10.0.0.0/24",
+			expected: false,
+		},
+		{
+			name:     "invalid ip2",
+			ip1:      "10.0.0.1",
+			ip2:      "invalid",
+			topology: "10.0.0.0/24",
+			expected: false,
+		},
+		{
+			name:     "complex topology with three groups",
+			ip1:      "10.0.0.1",
+			ip2:      "10.10.0.1",
+			topology: "10.0.0.0/24,10.10.0.0/24;10.20.0.0/24;2001:db8:85a3::/64",
+			expected: true,
+		},
+		{
+			name:     "ip1 in group but ip2 not in any group",
+			ip1:      "10.0.0.1",
+			ip2:      "192.168.1.1",
+			topology: "10.0.0.0/24,10.10.0.0/24;10.20.0.0/24",
+			expected: false,
+		},
+		{
+			name:     "both IPs in different CIDRs within same group",
+			ip1:      "10.0.0.5",
+			ip2:      "10.10.0.5",
+			topology: "10.0.0.0/24,10.10.0.0/24",
+			expected: true,
+		},
+		{
+			name:     "topology with spaces",
+			ip1:      "10.0.0.1",
+			ip2:      "10.10.0.1",
+			topology: "10.0.0.0/24 , 10.10.0.0/24 ; 10.20.0.0/24",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SameSubnet(tt.ip1, tt.ip2, tt.topology)
+			if result != tt.expected {
+				t.Errorf("SameSubnet(%q, %q, %q) = %v, want %v",
+					tt.ip1, tt.ip2, tt.topology, result, tt.expected)
+			}
+		})
+	}
+}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1062,8 +1062,8 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 		logging.Fatal(logger, "Option "+option.EnableRemoteNodeMasquerade+" requires BPF masquerade to be enabled ("+option.EnableBPFMasquerade+")")
 	}
 
-	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
-		logging.Fatal(logger, fmt.Sprintf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName))
+	if !option.Config.RequiresNativeRouting() && option.Config.EnableAutoDirectRouting {
+		logging.Fatal(logger, fmt.Sprintf("%s requires native or hybrid routing mode.", option.EnableAutoDirectRoutingName))
 	}
 
 	initClockSourceOption(logger)
@@ -1087,8 +1087,9 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 	}
 
 	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
-		if option.Config.TunnelingEnabled() {
-			logging.Fatal(logger, fmt.Sprintf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6))
+		// TODO(weil0ng): add a proper check for ipam in PR# 15429.
+		if !option.Config.RequiresNativeRouting() {
+			logging.Fatal(logger, fmt.Sprintf("%s and %s require native or hybrid routing mode.", option.LocalRouterIPv4, option.LocalRouterIPv6))
 		}
 	}
 

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -163,6 +163,9 @@ type Config struct {
 	// subsequent calls to NodeConfigurationChanged().
 	EnableEncapsulation bool
 
+	// RequiresNativeRouting returns true if the node requires native routing to setup.
+	RequiresNativeRouting bool
+
 	// TunnelProtocol is the datapath ID of the encapsulation protocol
 	// (0 if disabled, 1 for VXLAN, 2 for Geneve).
 	//

--- a/pkg/datapath/config/endpoint.go
+++ b/pkg/datapath/config/endpoint.go
@@ -68,5 +68,7 @@ func Endpoint(ep endpoint.Config, lnc *Config) any {
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
 
+	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
+
 	return cfg
 }

--- a/pkg/datapath/config/host.go
+++ b/pkg/datapath/config/host.go
@@ -61,6 +61,8 @@ func CiliumHost(ep endpoint.Config, lnc *Config) any {
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
 
+	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
+
 	return cfg
 }
 
@@ -107,6 +109,8 @@ func CiliumNet(ep endpoint.Config, lnc *Config, link netlink.Link) any {
 
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
+
+	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
 
 	return cfg
 }
@@ -174,6 +178,8 @@ func Netdev(ep endpoint.Config, lnc *Config, link netlink.Link, masq4, masq6 net
 
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
+
+	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
 
 	switch link.(type) {
 	case *netlink.Bridge:

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -170,6 +170,9 @@ func (in *Config) deepEqual(other *Config) bool {
 	if in.EnableEncapsulation != other.EnableEncapsulation {
 		return false
 	}
+	if in.RequiresNativeRouting != other.RequiresNativeRouting {
+		return false
+	}
 	if in.TunnelProtocol != other.TunnelProtocol {
 		return false
 	}

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -183,6 +183,7 @@ func newLocalNodeConfig(
 		EnableIPv4:                   daemon.EnableIPv4,
 		EnableIPv6:                   daemon.EnableIPv6,
 		EnableEncapsulation:          daemon.TunnelingEnabled(),
+		RequiresNativeRouting:        daemon.RequiresNativeRouting(),
 		TunnelProtocol:               tunnelCfg.EncapProtocol().ToDpID(),
 		TunnelPort:                   tunnelCfg.Port(),
 		EnableAutoDirectRouting:      daemon.EnableAutoDirectRouting,

--- a/pkg/maps/subnet/table.go
+++ b/pkg/maps/subnet/table.go
@@ -6,6 +6,7 @@ package subnet
 import (
 	"encoding"
 	"fmt"
+	"iter"
 	"net/netip"
 
 	"github.com/cilium/statedb"
@@ -17,6 +18,18 @@ import (
 )
 
 const TableName = "subnet-identities"
+
+var (
+	SubnetPrimaryIndex = statedb.Index[SubnetTableEntry, netip.Prefix]{
+		Name: "key",
+		FromObject: func(t SubnetTableEntry) index.KeySet {
+			return index.NewKeySet(index.NetIPPrefix(t.Key))
+		},
+		FromKey:    index.NetIPPrefix,
+		FromString: index.NetIPPrefixString,
+		Unique:     true,
+	}
+)
 
 type SubnetTableEntry struct {
 	Key netip.Prefix
@@ -66,6 +79,26 @@ func (s SubnetTableEntry) getStatus() reconciler.Status {
 	return s.Status
 }
 
+// SubnetLPMIndex is the secondary index for SubnetEntry
+// Primary index is exact prefix index and secondary is LPM.
+var SubnetLPMIndex = statedb.NetIPPrefixIndex[SubnetTableEntry]{
+	Name: "prefix",
+	FromObject: func(s SubnetTableEntry) iter.Seq[netip.Prefix] {
+		return statedb.Just(s.Key)
+	},
+	Unique: true,
+}
+
+// newSubnetEntryTable creates and registers the subnet entry table in stateDB.
+func newSubnetEntryTable(db *statedb.DB) (statedb.RWTable[SubnetTableEntry], error) {
+	return statedb.NewTable(
+		db,
+		TableName,
+		SubnetPrimaryIndex,
+		SubnetLPMIndex,
+	)
+}
+
 // BinaryKey returns the binary representation of the subnet prefix for the eBPF map key.
 func (s SubnetTableEntry) BinaryKey() encoding.BinaryMarshaler {
 	var ip types.IPv6
@@ -101,24 +134,4 @@ func (s SubnetTableEntry) BinaryValue() encoding.BinaryMarshaler {
 		Identity: s.Value,
 	}
 	return bpf.StructBinaryMarshaler{Target: &v}
-}
-
-// SubnetIndex is the primary index for SubnetEntry, indexing by Prefix.
-var SubnetIndex = statedb.Index[SubnetTableEntry, netip.Prefix]{
-	Name: "prefix",
-	FromObject: func(s SubnetTableEntry) index.KeySet {
-		return index.NewKeySet(index.NetIPPrefix(s.Key))
-	},
-	FromKey:    index.NetIPPrefix,
-	FromString: index.NetIPPrefixString,
-	Unique:     true,
-}
-
-// newSubnetEntryTable creates and registers the subnet entry table in stateDB.
-func newSubnetEntryTable(db *statedb.DB) (statedb.RWTable[SubnetTableEntry], error) {
-	return statedb.NewTable(
-		db,
-		TableName,
-		SubnetIndex,
-	)
 }

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -131,7 +131,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 	c := &Configuration{}
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			tunnelOverIPv6 := option.Config.RoutingMode == option.RoutingModeTunnel &&
+			tunnelOverIPv6 := option.Config.TunnelingEnabled() &&
 				p.TunnelConfig.UnderlayProtocol() == tunnel.IPv6
 			*c = NewConfiguration(
 				p.IPsec.AuthKeySize(),

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2005,6 +2005,11 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.RoutingMode != RoutingModeNative
 }
 
+// RequiresNativeRouting returns true if the agent needs to use native routing to implement some features.
+func (c *DaemonConfig) RequiresNativeRouting() bool {
+	return c.RoutingMode == RoutingModeNative || c.RoutingMode == RoutingModeHybrid
+}
+
 // AreDevicesRequired returns true if the agent needs to attach to the native
 // devices to implement some features.
 func (c *DaemonConfig) AreDevicesRequired(kprCfg kpr.KPRConfig, wireguardEnabled, ipsecEnabled bool) bool {
@@ -2020,7 +2025,7 @@ func (c *DaemonConfig) NeedEgressOnWireGuardDevice(kprCfg kpr.KPRConfig, wiregua
 	}
 
 	// No need to handle rev-NAT xlations in wireguard with tunneling enabled.
-	if c.TunnelingEnabled() {
+	if !c.RequiresNativeRouting() {
 		return false
 	}
 
@@ -2242,10 +2247,10 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	}
 
 	switch c.RoutingMode {
-	case RoutingModeNative, RoutingModeTunnel:
+	case RoutingModeNative, RoutingModeTunnel, RoutingModeHybrid:
 	default:
-		return fmt.Errorf("invalid routing mode %q, valid modes = {%q, %q}",
-			c.RoutingMode, RoutingModeTunnel, RoutingModeNative)
+		return fmt.Errorf("invalid routing mode %q, valid modes = {%q, %q, %q}",
+			c.RoutingMode, RoutingModeTunnel, RoutingModeNative, RoutingModeHybrid)
 	}
 
 	cinfo := clustermeshTypes.ClusterInfo{
@@ -2985,7 +2990,7 @@ func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
 	if c.EnableIPMasqAgent {
 		return nil
 	}
-	if c.TunnelingEnabled() {
+	if !c.RequiresNativeRouting() {
 		return nil
 	}
 	if c.IPAMMode() == ipamOption.IPAMENI || c.IPAMMode() == ipamOption.IPAMAlibabaCloud {
@@ -3012,7 +3017,7 @@ func (c *DaemonConfig) checkIPv6NativeRoutingCIDR() error {
 	if c.EnableIPMasqAgent {
 		return nil
 	}
-	if c.TunnelingEnabled() {
+	if !c.RequiresNativeRouting() {
 		return nil
 	}
 	return fmt.Errorf(

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -249,6 +249,42 @@ func TestEnabledFunctions(t *testing.T) {
 	require.Equal(t, ipamOption.IPAMENI, d.IPAMMode())
 }
 
+func TestRoutingModeHelpers(t *testing.T) {
+	tests := []struct {
+		name           string
+		routingMode    string
+		expectedTunnel bool
+		expectedNative bool
+	}{
+		{
+			name:           "native mode - tunneling disabled and native routing required",
+			routingMode:    RoutingModeNative,
+			expectedTunnel: false,
+			expectedNative: true,
+		},
+		{
+			name:           "tunnel mode - tunneling enabled and native routing not required",
+			routingMode:    RoutingModeTunnel,
+			expectedTunnel: true,
+			expectedNative: false,
+		},
+		{
+			name:           "hybrid mode - tunneling enabled and native routing required",
+			routingMode:    RoutingModeHybrid,
+			expectedTunnel: true,
+			expectedNative: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &DaemonConfig{RoutingMode: tt.routingMode}
+			assert.Equal(t, tt.expectedTunnel, d.TunnelingEnabled())
+			assert.Equal(t, tt.expectedNative, d.RequiresNativeRouting())
+		})
+	}
+}
+
 func TestLocalAddressExclusion(t *testing.T) {
 	d := &DaemonConfig{}
 	err := d.parseExcludedLocalAddresses([]string{"1.1.1.1/32", "3.3.3.0/24", "f00d::1/128"})
@@ -546,6 +582,29 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "hybrid mode with native routing cidr",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade:  true,
+				EnableIPv6Masquerade:  true,
+				RoutingMode:           RoutingModeHybrid,
+				IPAM:                  ipamOption.IPAMAzure,
+				IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.127.64.0/18"),
+				EnableIPv4:            true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "hybrid mode without native routing cidr requires cidr",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				RoutingMode:          RoutingModeHybrid,
+				IPAM:                 ipamOption.IPAMAzure,
+				EnableIPv4:           true,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -618,6 +677,27 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 				EnableIPMasqAgent:    true,
 			},
 			wantErr: false,
+		},
+		{
+			name: "hybrid mode with native routing cidr",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade:  true,
+				EnableIPv6Masquerade:  true,
+				RoutingMode:           RoutingModeHybrid,
+				IPv6NativeRoutingCIDR: cidr.MustParseCIDR("fd00::/120"),
+				EnableIPv6:            true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "hybrid mode without native routing cidr requires cidr",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				RoutingMode:          RoutingModeHybrid,
+				EnableIPv6:           true,
+			},
+			wantErr: true,
 		},
 	}
 

--- a/pkg/subnet/cell.go
+++ b/pkg/subnet/cell.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -30,11 +31,25 @@ var Cell = cell.Module(
 	),
 )
 
-func registerSubnetWatcher(cfg *option.DaemonConfig, sw *SubnetWatcher) {
+func registerSubnetWatcher(cfg *option.DaemonConfig, fence regeneration.Fence, sw *SubnetWatcher) {
 	if cfg.RoutingMode != option.RoutingModeHybrid {
 		sw.logger.Debug("Routing mode is not hybrid, skipping subnet watcher")
 		return
 	}
+
+	synced := make(chan struct{})
+
+	// Add a fence to ensure that subnet map is ready before starting endpoint regeneration.
+	fence.Add("subnet-map", func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-synced:
+			sw.logger.Info("Subnet topology dynamic config synced")
+			return nil
+		}
+	})
+
 	sw.jobGroup.Add(job.OneShot("subnet-watcher", func(ctx context.Context, health cell.Health) error {
 		sw.logger.Info("Starting subnet topology dynamic config watcher")
 		for {
@@ -48,6 +63,14 @@ func registerSubnetWatcher(cfg *option.DaemonConfig, sw *SubnetWatcher) {
 					health.OK("subnet-topology dynamic config processed successfully")
 				}
 			}
+
+			// Signal initial sync is complete.
+			select {
+			case <-synced:
+			default:
+				close(synced)
+			}
+
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/pkg/subnet/topology/topology.go
+++ b/pkg/subnet/topology/topology.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package topology provides parsing of the subnet-topology configuration
+// string into platform-neutral entries.
+//
+// It is intentionally free of statedb, BPF, and other Linux-only
+// dependencies so it can be imported by tools (e.g. cilium-cli) that need
+// to interpret the topology string on any platform.
+package topology
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// Entry is a single subnet/identity mapping decoded from a topology string.
+type Entry struct {
+	// Key is the subnet prefix.
+	Key netip.Prefix
+
+	// Value is the identity (group ID) associated with the subnet.
+	Value uint32
+}
+
+// Decode parses a subnet-topology string into a slice of Entry.
+//
+// Subnets within a group are separated by commas; groups are separated by
+// semicolons. Each group is assigned a 1-based identity matching its
+// position in the input.
+//
+// Example: data=10.0.0.1/24,10.10.0.1/24;10.20.0.1/24;2001:0db8:85a3::/64
+// would decode into four entries:
+//
+//	| Key                 | Value |
+//	|---------------------|-------|
+//	| 10.0.0.1/24         | 1     |
+//	| 10.10.0.1/24        | 1     |
+//	| 10.20.0.1/24        | 2     |
+//	| 2001:0db8:85a3::/64 | 3     |
+func Decode(data string) ([]Entry, error) {
+	data = strings.TrimSpace(data)
+	if data == "" {
+		return []Entry{}, nil
+	}
+
+	var entries []Entry
+
+	groups := strings.Split(data, ";")
+
+	for groupID, group := range groups {
+		group = strings.TrimSpace(group)
+		if group == "" {
+			continue
+		}
+
+		subnets := strings.SplitSeq(group, ",")
+
+		for subnet := range subnets {
+			subnet = strings.TrimSpace(subnet)
+			if subnet == "" {
+				continue
+			}
+
+			// Validate CIDR format
+			prefix, err := netip.ParsePrefix(subnet)
+			if err != nil {
+				return nil, fmt.Errorf("invalid CIDR %q: %w", subnet, err)
+			}
+
+			// Identity is groupID + 1 to avoid using identity 0.
+			entries = append(entries, Entry{
+				Key:   prefix,
+				Value: uint32(groupID + 1),
+			})
+		}
+	}
+
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no valid subnets found in data")
+	}
+
+	return entries, nil
+}

--- a/pkg/subnet/topology/topology_test.go
+++ b/pkg/subnet/topology/topology_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package topology
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []Entry
+		wantErr  bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []Entry{},
+			wantErr:  false,
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			expected: []Entry{},
+			wantErr:  false,
+		},
+		{
+			name:  "single CIDR",
+			input: "10.0.0.0/24",
+			expected: []Entry{
+				{Key: netip.MustParsePrefix("10.0.0.0/24"), Value: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "two CIDRs in same group",
+			input: "10.0.0.0/24,10.10.0.0/24",
+			expected: []Entry{
+				{Key: netip.MustParsePrefix("10.0.0.0/24"), Value: 1},
+				{Key: netip.MustParsePrefix("10.10.0.0/24"), Value: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "two groups with semicolon separator",
+			input: "10.0.0.0/24;10.20.0.0/24",
+			expected: []Entry{
+				{Key: netip.MustParsePrefix("10.0.0.0/24"), Value: 1},
+				{Key: netip.MustParsePrefix("10.20.0.0/24"), Value: 2},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "complex topology from CFP example",
+			input: "10.0.0.1/24,10.10.0.1/24;10.20.0.1/24;2001:0db8:85a3::/64",
+			expected: []Entry{
+				{Key: netip.MustParsePrefix("10.0.0.1/24"), Value: 1},
+				{Key: netip.MustParsePrefix("10.10.0.1/24"), Value: 1},
+				{Key: netip.MustParsePrefix("10.20.0.1/24"), Value: 2},
+				{Key: netip.MustParsePrefix("2001:db8:85a3::/64"), Value: 3},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "topology with whitespace",
+			input: " 10.0.0.0/24 , 10.10.0.0/24 ; 10.20.0.0/24 ",
+			expected: []Entry{
+				{Key: netip.MustParsePrefix("10.0.0.0/24"), Value: 1},
+				{Key: netip.MustParsePrefix("10.10.0.0/24"), Value: 1},
+				{Key: netip.MustParsePrefix("10.20.0.0/24"), Value: 2},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid CIDR",
+			input:   "not-a-cidr",
+			wantErr: true,
+		},
+		{
+			name:    "partially invalid - one bad CIDR",
+			input:   "10.0.0.0/24,invalid",
+			wantErr: true,
+		},
+		{
+			name:  "ipv6 only",
+			input: "2001:db8::/32,fd00::/8",
+			expected: []Entry{
+				{Key: netip.MustParsePrefix("2001:db8::/32"), Value: 1},
+				{Key: netip.MustParsePrefix("fd00::/8"), Value: 1},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Decode(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, result, len(tt.expected))
+			for i, entry := range result {
+				assert.Equal(t, tt.expected[i].Key, entry.Key, "entry %d key mismatch", i)
+				assert.Equal(t, tt.expected[i].Value, entry.Value, "entry %d value (group ID) mismatch", i)
+			}
+		})
+	}
+}

--- a/pkg/subnet/watcher.go
+++ b/pkg/subnet/watcher.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
 	subnetTable "github.com/cilium/cilium/pkg/maps/subnet"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/subnet/topology"
 )
 
@@ -24,6 +25,7 @@ type watcherParams struct {
 	SubnetTable        statedb.RWTable[subnetTable.SubnetTableEntry]
 	DB                 *statedb.DB
 	JobGroup           job.Group
+	NodeHandler        node.Handler `optional:"true"`
 }
 
 type SubnetWatcher struct {
@@ -32,6 +34,7 @@ type SubnetWatcher struct {
 	subnetTable        statedb.RWTable[subnetTable.SubnetTableEntry]
 	db                 *statedb.DB
 	jobGroup           job.Group
+	nodeHandler        node.Handler
 }
 
 func newSubnetWatcher(params watcherParams) *SubnetWatcher {
@@ -41,6 +44,7 @@ func newSubnetWatcher(params watcherParams) *SubnetWatcher {
 		subnetTable:        params.SubnetTable,
 		db:                 params.DB,
 		jobGroup:           params.JobGroup,
+		nodeHandler:        params.NodeHandler,
 	}
 }
 
@@ -65,5 +69,11 @@ func (w *SubnetWatcher) processSubnetConfigEntry(entry dynamicconfig.DynamicConf
 		}
 	}
 	wTx.Commit()
+
+	// Trigger re-evaluation of all node routes based on new topology
+	if w.nodeHandler != nil {
+		w.nodeHandler.AllNodeValidateImplementation()
+	}
+
 	return nil
 }

--- a/pkg/subnet/watcher.go
+++ b/pkg/subnet/watcher.go
@@ -6,8 +6,6 @@ package subnet
 import (
 	"fmt"
 	"log/slog"
-	"net/netip"
-	"strings"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -15,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/dynamicconfig"
 	subnetTable "github.com/cilium/cilium/pkg/maps/subnet"
+	"github.com/cilium/cilium/pkg/subnet/topology"
 )
 
 type watcherParams struct {
@@ -46,7 +45,7 @@ func newSubnetWatcher(params watcherParams) *SubnetWatcher {
 }
 
 func (w *SubnetWatcher) processSubnetConfigEntry(entry dynamicconfig.DynamicConfig) error {
-	subnetEntries, err := decodeJson(entry.Value)
+	decoded, err := topology.Decode(entry.Value)
 	if err != nil {
 		return fmt.Errorf("failed to decode subnet-topology dynamic config value: %w", err)
 	}
@@ -59,64 +58,12 @@ func (w *SubnetWatcher) processSubnetConfigEntry(entry dynamicconfig.DynamicConf
 	if err := w.subnetTable.DeleteAll(wTx); err != nil {
 		return fmt.Errorf("failed to reset subnet table: %w", err)
 	}
-	for _, entry := range subnetEntries {
+	for _, e := range decoded {
+		entry := subnetTable.NewSubnetEntry(e.Key, e.Value)
 		if _, _, err := w.subnetTable.Insert(wTx, entry); err != nil {
 			return fmt.Errorf("failed to upsert subnet entry %v: %w", entry, err)
 		}
 	}
 	wTx.Commit()
 	return nil
-}
-
-// decodeJson decodes a JSON string into a slice of SubnetTableEntry.
-// Ex: data=10.0.0.1/24,10.10.0.1/24;10.20.0.1/24;2001:0db8:85a3::/64
-// would decode into four SubnetTableEntry objects.
-// | Key | Value |
-// |------|-----------|
-// | 10.0.0.1/24 | 1  |
-// | 10.10.0.1/24 | 1 |
-// | 10.20.0.1/24 | 2 |
-// | 2001:0db8:85a3::/64 | 3 |
-func decodeJson(data string) ([]subnetTable.SubnetTableEntry, error) {
-	data = strings.TrimSpace(data)
-	if data == "" {
-		return []subnetTable.SubnetTableEntry{}, nil
-	}
-
-	var entries []subnetTable.SubnetTableEntry
-
-	// Split by semicolons to get groups
-	groups := strings.Split(data, ";")
-
-	for groupID, group := range groups {
-		group = strings.TrimSpace(group)
-		if group == "" {
-			continue
-		}
-
-		// Split by commas to get individual subnets within a group
-		subnets := strings.SplitSeq(group, ",")
-
-		for subnet := range subnets {
-			subnet = strings.TrimSpace(subnet)
-			if subnet == "" {
-				continue
-			}
-
-			// Validate CIDR format
-			prefix, err := netip.ParsePrefix(subnet)
-			if err != nil {
-				return nil, fmt.Errorf("invalid CIDR %q: %w", subnet, err)
-			}
-
-			// Identity is groupID + 1 to avoid using identity 0.
-			entries = append(entries, subnetTable.NewSubnetEntry(prefix, uint32(groupID+1)))
-		}
-	}
-
-	if len(entries) == 0 {
-		return nil, fmt.Errorf("no valid subnets found in data")
-	}
-
-	return entries, nil
 }


### PR DESCRIPTION

This PR picks up the work from #44292 to enable the hybrid routing mode
introduced in [CFP-32810.](https://github.com/cilium/design-cfps/blob/main/cilium/CFP-32810-hybrid-routing-mode.md)

The hybrid routing mode allows Cilium's datapath to dynamically choose
between native routing and tunnel encapsulation on a per-packet basis,
based on the subnet topology configuration. Packets between pods in
directly connected subnets are routed natively (avoiding encapsulation
overhead), while packets destined for pods in non-directly-connected
subnets are encapsulated as in tunnel mode.


Update 4/23
This PR has been further split to simplify review. It now contains only the core control-plane support:

Core hybrid routing infrastructure (RoutingModeHybrid constant, RequiresNativeRouting() method, validation, native routing CIDR checks, BPF HybridRoutingEnabled flag)
Helm chart support for routingMode: hybrid and subnetTopology
Connectivity test updates for hybrid routing encryption tests
Subnet fence to ensure subnet map is ready before endpoint regeneration

Split-out follow-up PRs:
[[41867][Part6] Hybrid Routing Route Installation](https://github.com/cilium/cilium/pull/45579)
[[41867][Part7] Hybrid Routing WireGuard
](https://github.com/cilium/cilium/pull/45580)


Future enablements
L7 Proxy Routes
KPR: DSR Warning
IPTables: xt_socket Fallback
NodeIpsetNeeded: Masquerade Exemption

## Prior PRs (merged)

- Part 1: #41868 — BPF datapath: LPM trie map, `lookup_subnet_id()`, tunnel skip logic
- Part 2: #43631 — BPF tests for skip_tunnel flag and subnet-based routing
- Part 3: #43438 — Control plane: SubnetWatcher, dynamic config, StateDB-to-BPF reconciler
- Please ensure your pull request adheres to the following guidelines:
- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #44129
Fixes: #43705

Old release note:
Add support for `hybrid` routing mode (`routing-mode: hybrid`), allowing
Cilium to dynamically choose between native routing and tunnel
encapsulation based on subnet topology. Traffic between pods in directly
connected subnets is routed natively for improved throughput, while
cross-subnet traffic is tunneled.
```release-note
Add new `hybrid` routing mode that supports routing based on subnet topology
```
