### PR TITLE
cilium-dbg: add bpf subnet list command

### DIFF
--- a/cilium-dbg/cmd/bpf_subnet.go
+++ b/cilium-dbg/cmd/bpf_subnet.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// BPFSubnetCmd represents the bpf subnet command
+var BPFSubnetCmd = &cobra.Command{
+	Use:   "subnet",
+	Short: "Manage the subnet identity mappings for hybrid routing",
+}
+
+func init() {
+	BPFCmd.AddCommand(BPFSubnetCmd)
+}

--- a/cilium-dbg/cmd/bpf_subnet_list.go
+++ b/cilium-dbg/cmd/bpf_subnet_list.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/pkg/command"
+	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/maps/subnet"
+)
+
+const (
+	subnetPrefixTitle   = "SUBNET PREFIX"
+	subnetIdentityTitle = "IDENTITY"
+)
+
+var bpfSubnetListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List subnet CIDR to identity mappings",
+	Long:    "List the contents of the subnet BPF map used for hybrid routing.\n",
+	Run: func(cmd *cobra.Command, args []string) {
+		common.RequireRootPrivilege("cilium bpf subnet list")
+
+		bpfSubnetList := make(map[string][]string)
+		if err := subnet.SubnetMap().DumpIfExists(bpfSubnetList); err != nil {
+			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
+			os.Exit(1)
+		}
+
+		if command.OutputOption() {
+			if err := command.PrintOutput(bpfSubnetList); err != nil {
+				fmt.Fprintf(os.Stderr, "error getting output of map in %s: %s\n", command.OutputOptionString(), err)
+				os.Exit(1)
+			}
+			return
+		}
+
+		if len(bpfSubnetList) == 0 {
+			fmt.Fprintf(os.Stderr, "No entries found.\n")
+		} else {
+			TablePrinter(subnetPrefixTitle, subnetIdentityTitle, bpfSubnetList)
+		}
+	},
+}
+
+func init() {
+	BPFSubnetCmd.AddCommand(bpfSubnetListCmd)
+	command.AddOutputOption(bpfSubnetListCmd)
+}


### PR DESCRIPTION
Add a 'cilium-dbg bpf subnet list' subcommand to inspect the subnet BPF map used for hybrid routing mode. This allows operators to verify the CIDR-to-identity mappings that drive per-packet routing decisions.

Follows the same pattern as 'cilium-dbg bpf vtep list'.

Related: #44129

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!
