### PR TITLE
bpf: nodeport: remove XDP-accel support for LB of tunnel traffic

### DIFF
--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -97,12 +97,11 @@ bpf_xdp_exit(struct __ctx_buff *ctx, const int verdict)
 __declare_tail(CILIUM_CALL_IPV4_FROM_NETDEV)
 int tail_lb_ipv4(struct __ctx_buff *ctx)
 {
-	bool punt_to_stack = false;
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
 
 	if (!ctx_skip_nodeport(ctx)) {
-		int l3_off = ETH_HLEN;
+		bool punt_to_stack = false;
 		void *data, *data_end;
 		struct iphdr *ip4;
 		bool is_dsr = false;
@@ -112,81 +111,8 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 			goto out;
 		}
 
-#if defined(ENABLE_DSR) && !defined(ENABLE_DSR_BYUSER) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-		{
-			int l4_off, inner_l2_off;
-			struct genevehdr geneve;
-			__sum16	udp_csum;
-			__be16 dport;
-			__be16 proto;
-
-			if (ip4->protocol != IPPROTO_UDP)
-				goto no_encap;
-
-			/* Punt packets with IP options to TC */
-			if (ipv4_hdrlen(ip4) != sizeof(*ip4))
-				goto no_encap;
-
-			l4_off = l3_off + sizeof(*ip4);
-
-			if (l4_load_port(ctx, l4_off + UDP_DPORT_OFF, &dport) < 0) {
-				ret = DROP_INVALID;
-				goto out;
-			}
-
-			if (dport != bpf_htons(CONFIG(tunnel_port)))
-				goto no_encap;
-
-			/* Cilium uses BPF_F_ZERO_CSUM_TX for its tunnel traffic.
-			 *
-			 * Adding LB support for checksummed packets would require
-			 * that we adjust udp->check
-			 * 1.	after DNAT of the inner packet,
-			 * 2.	after re-writing the outer headers and inserting
-			 *	the DSR option
-			 */
-			if (ctx_load_bytes(ctx, l4_off + offsetof(struct udphdr, check),
-					   &udp_csum, sizeof(udp_csum)) < 0) {
-				ret = DROP_INVALID;
-				goto out;
-			}
-
-			if (udp_csum != 0)
-				goto no_encap;
-
-			if (ctx_load_bytes(ctx, l4_off + sizeof(struct udphdr), &geneve,
-					   sizeof(geneve)) < 0) {
-				ret = DROP_INVALID;
-				goto out;
-			}
-
-			if (geneve.protocol_type != bpf_htons(ETH_P_TEB))
-				goto no_encap;
-
-			/* Punt packets with GENEVE options to TC */
-			if (geneve.opt_len)
-				goto no_encap;
-
-			inner_l2_off = l4_off + sizeof(struct udphdr) + sizeof(struct genevehdr);
-
-			/* point at the inner L3 header: */
-			if (!validate_ethertype_l2_off(ctx, inner_l2_off, &proto))
-				goto no_encap;
-
-			if (proto != bpf_htons(ETH_P_IP))
-				goto no_encap;
-
-			l3_off = inner_l2_off + ETH_HLEN;
-
-			if (!revalidate_data_l3_off(ctx, &data, &data_end, &ip4, l3_off)) {
-				ret = DROP_INVALID;
-				goto out;
-			}
-		}
-no_encap:
-#endif /* ENABLE_DSR && !ENABLE_DSR_BYUSER && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE */
-
-		ret = nodeport_lb4(ctx, ip4, l3_off, UNKNOWN_ID, &punt_to_stack, &ext_err, &is_dsr);
+		ret = nodeport_lb4(ctx, ip4, ETH_HLEN, UNKNOWN_ID, &punt_to_stack,
+				   &ext_err, &is_dsr);
 	}
 
 out:

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -69,13 +69,13 @@ union v4addr {
 
 #define THIS_IS_L3_DEV		(ETH_HLEN == 0)
 
-static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
-						      int l2_off, __be16 *proto)
+static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
+					       __be16 *proto)
 {
-	const __u64 tot_len = l2_off + ETH_HLEN;
 	void *data_end = ctx_data_end(ctx);
+	const __u64 tot_len = ETH_HLEN;
 	void *data = ctx_data(ctx);
-	struct ethhdr *eth;
+	struct ethhdr *eth = data;
 
 	if (THIS_IS_L3_DEV) {
 		/* The packet is received on L2-less device. Determine L3
@@ -88,17 +88,9 @@ static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 	if (data + tot_len > data_end)
 		return false;
 
-	eth = data + l2_off;
-
 	*proto = eth->h_proto;
 
 	return eth_is_supported_ethertype(*proto);
-}
-
-static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
-					       __be16 *proto)
-{
-	return validate_ethertype_l2_off(ctx, 0, proto);
 }
 
 static __always_inline __maybe_unused bool
@@ -160,15 +152,12 @@ static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __be16 proto
 #define revalidate_data_pull(ctx, data, data_end, ip)			\
 	__revalidate_data_pull(ctx, data, data_end, (void **)ip, ETH_HLEN, sizeof(**ip), true)
 
-#define revalidate_data_l3_off(ctx, data, data_end, ip, l3_off)		\
-	__revalidate_data_pull(ctx, data, data_end, (void **)ip, l3_off, sizeof(**ip), false)
-
 /* revalidate_data() initializes the provided pointers from the ctx.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.
  */
 #define revalidate_data(ctx, data, data_end, ip)			\
-	revalidate_data_l3_off(ctx, data, data_end, ip, ETH_HLEN)
+	__revalidate_data_pull(ctx, data, data_end, (void **)ip, ETH_HLEN, sizeof(**ip), false)
 
 /* arp is different from the above as we also want to pull in the payload.
  * Returns true if 'ctx' is long enough to be valid ARP packet, false otherwise.
@@ -355,7 +344,6 @@ enum {
 #define	CB_ADDR_V6_3		CB_3		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_3		/* Alias, non-overlapping */
 #define CB_SRV6_SID_4		CB_3		/* Alias, non-overlapping */
-#define CB_DSR_L3_OFF		CB_3		/* Alias, non-overlapping */
 	CB_CT_STATE,
 #define	CB_ADDR_V6_4		CB_CT_STATE	/* Alias, non-overlapping */
 #define	CB_ENCRYPT_IDENTITY	CB_CT_STATE	/* Alias, non-overlapping,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1809,58 +1809,41 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 	return 0;
 }
 # elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_off __maybe_unused,
-						 struct iphdr *ip4, __be32 svc_addr,
-						 __be16 svc_port, int *ifindex, __be16 *ohead)
+static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct iphdr *ip4,
+						 __be32 svc_addr, __be16 svc_port,
+						 int *ifindex, __be16 *ohead)
 {
-	const struct remote_endpoint_info *info __maybe_unused;
-	struct geneve_dsr_opt4 gopt __align_stack_8;
+	const struct remote_endpoint_info *info;
+	struct geneve_dsr_opt4 gopt __align_stack_8 = { };
 	bool need_opt = true;
 	__u16 encap_len = sizeof(struct iphdr) + sizeof(struct udphdr) +
 		sizeof(struct genevehdr) + ETH_HLEN;
 	__u16 total_len = bpf_ntohs(ip4->tot_len);
 	__u32 src_sec_identity = WORLD_IPV4_ID;
-	__be32 tunnel_endpoint __maybe_unused;
 	__be16 src_port = 0;
+	int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 #  if __ctx_is == __ctx_xdp
-	bool has_encap = l3_off > ETH_HLEN;
-	struct iphdr *outer_ip4 = ip4;
-	void *data, *data_end;
+	fraginfo_t fraginfo = ipfrag_encode_ipv4(ip4);
+	struct ipv4_ct_tuple tuple = {};
+	int ret;
 
 	build_bug_on((sizeof(gopt) % 4) != 0);
 
-	if (has_encap) {
-		/* point at the inner IPv4 header */
-		if (!revalidate_data_l3_off(ctx, &data, &data_end, &ip4, encap_len + ETH_HLEN))
-			return DROP_INVALID;
+	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
+	if (IS_ERR(ret))
+		return ret;
 
-		encap_len = 0;
-	} else {
-		struct ipv4_ct_tuple tuple = {};
-		fraginfo_t fraginfo;
-		int l4_off, ret;
-
-		fraginfo = ipfrag_encode_ipv4(ip4);
-		l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
-
-		ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
-		if (IS_ERR(ret))
-			return ret;
-
-		src_port = tunnel_gen_src_port_v4(&tuple);
-	}
+	src_port = tunnel_gen_src_port_v4(&tuple);
 #  endif
 
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (!info || !info->flag_has_tunnel_ep)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-	tunnel_endpoint = info->tunnel_endpoint.ip4.be32;
-
 	if (ip4->protocol == IPPROTO_TCP) {
 		union tcp_flags tcp_flags = { .value = 0 };
 
-		if (l4_load_tcp_flags(ctx, l3_off + ipv4_hdrlen(ip4), &tcp_flags) < 0)
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
 		/* The GENEVE option is required only for the first packet
@@ -1881,63 +1864,6 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_
 		*ohead = encap_len;
 		return DROP_FRAG_NEEDED;
 	}
-
-#  if __ctx_is == __ctx_xdp
-	if (has_encap) {
-		int outer_l4_off = ETH_HLEN + ipv4_hdrlen(outer_ip4);
-		__be32 lb_ip = IPV4_DIRECT_ROUTING;
-		__wsum sum = 0;
-
-		/* update outer_ip4 daddr and saddr: */
-		sum = csum_diff(&outer_ip4->daddr, 4, &tunnel_endpoint, 4, 0);
-		if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
-				    &tunnel_endpoint, 4, 0) < 0)
-			return DROP_WRITE_ERROR;
-
-		sum = csum_diff(&outer_ip4->saddr, 4, &lb_ip, 4, sum);
-		if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, saddr),
-				    &lb_ip, 4, 0) < 0)
-			return DROP_WRITE_ERROR;
-
-		/* adjust outer_ip4->csum: */
-		if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0)
-			return DROP_CSUM_L3;
-
-		/* insert the GENEVE-DSR option: */
-		if (need_opt) {
-			__be16 new_length;
-			int ret;
-
-			/* update udp->len */
-			if (ctx_load_bytes(ctx, outer_l4_off + offsetof(struct udphdr, len),
-					   &new_length, sizeof(new_length)) < 0)
-				return DROP_INVALID;
-
-			new_length = bpf_htons(bpf_ntohs(new_length) + sizeof(gopt));
-
-			if (ctx_store_bytes(ctx, outer_l4_off + offsetof(struct udphdr, len),
-					    &new_length, sizeof(new_length), 0) < 0)
-				return DROP_WRITE_ERROR;
-
-			/* update outer_ip4->tot_len */
-			new_length = bpf_htons(total_len + sizeof(gopt));
-
-			if (ipv4_csum_update_by_value(ctx, ETH_HLEN, outer_ip4->tot_len,
-						      new_length, sizeof(new_length)) < 0)
-				return DROP_CSUM_L3;
-
-			if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, tot_len),
-					    &new_length, sizeof(new_length), 0) < 0)
-				return DROP_WRITE_ERROR;
-
-			ret = ctx_set_tunnel_opt(ctx, (__u8 *)&gopt, sizeof(gopt));
-			if (ret)
-				return ret;
-		}
-
-		return CTX_ACT_REDIRECT;
-	}
-#  endif
 
 	if (need_opt)
 		return nodeport_add_tunnel_encap_opt(ctx,
@@ -2187,8 +2113,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 			   addr,
 			   port, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt4(ctx, ctx_load_meta(ctx, CB_DSR_L3_OFF),
-				    ip4, addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, &oif, &ohead);
 #else
 # error "Invalid load balancer DSR encapsulation mode!"
 #endif
@@ -2963,7 +2888,6 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
 		ctx_store_meta(ctx, CB_PORT, key->dport);
 		ctx_store_meta(ctx, CB_ADDR_V4, key->address);
-		ctx_store_meta(ctx, CB_DSR_L3_OFF, l3_off);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR, ext_err);
 	}


### PR DESCRIPTION
This code was initially introduced as part of the hs-ipcache feature (https://github.com/cilium/cilium/pull/25745,
 https://github.com/cilium/cilium/pull/25854). It allowed for the XDP path
to peek into GENEVE-encapsulated traffic, LB it in-place (using DSR-GENEVE mode), and redirect the packet straight out to the backend.

But with HS-ipcache gone, this code path is pretty much unused. It *might* have seen some unintentional usage for E/W NodePort access when SocketLB is disabled - but with https://github.com/cilium/cilium/pull/41963, we now also LB at the source in such configurations. Either way, it's perfectly fine to remove this optimization.