### PR TITLE
[network-driver] CODEOWNERS: Add sig-network-driver team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -207,6 +207,15 @@
 #   configurations within the agent control plane, including Services,
 #   ClusterIP, NodePorts, Maglev, local redirect policies, and
 #   NAT46/NAT64.
+# - @cilium/network-driver:
+#   Maintain the Cilium Network Driver feature, that allows to request and share
+#   networking resources, like SR-IOV devices, among workloads. Responsible for all
+#   interactions between the driver and the Kubelet via the Dynamic Resource
+#   Allocation (DRA) API as well as between the driver and the Container Runtime
+#   via the Node Resource Interface (NRI) API. Ensure the consistency of the
+#   dedicated IPAM modes with the Network Driver resources management.
+#   This code owner is not related to the low level interactions with the Linux
+#   network drivers.
 # - @cilium/sig-policy:
 #   Ensure consistency of semantics for all network policy representations.
 #   Responsible for all policy logic from Kubernetes down to eBPF policymap
@@ -524,6 +533,7 @@ Makefile* @cilium/build
 /operator/pkg/model @cilium/sig-servicemesh
 /operator/pkg/multipool @cilium/sig-ipam
 /operator/pkg/networkpolicy @cilium/sig-policy
+/operator/pkg/networkdriver @cilium/network-driver
 /operator/pkg/nodeipam @cilium/sig-lb
 /operator/pkg/secretsync @cilium/envoy @cilium/sig-servicemesh
 /operator/pkg/workqueuemetrics @cilium/metrics
@@ -653,6 +663,7 @@ Makefile* @cilium/build
 /pkg/multicast @cilium/sig-datapath
 /pkg/murmur3/ @cilium/sig-datapath
 /pkg/netns/ @cilium/sig-datapath @cilium/sig-k8s
+/pkg/networkdriver/ @cilium/network-driver
 /pkg/node @cilium/sig-agent
 /pkg/node/neighbordiscovery @cilium/sig-agent @cilium/sig-datapath
 /pkg/nodediscovery/ @cilium/sig-agent

--- a/Documentation/codeowners.rst
+++ b/Documentation/codeowners.rst
@@ -210,6 +210,15 @@ external software and protocols:
   configurations within the agent control plane, including Services,
   ClusterIP, NodePorts, Maglev, local redirect policies, and
   NAT46/NAT64.
+- `@cilium/network-driver <https://github.com/orgs/cilium/teams/network-driver>`__:
+  Maintain the Cilium Network Driver feature, that allows to request and share
+  networking resources, like SR-IOV devices, among workloads. Responsible for all
+  interactions between the driver and the Kubelet via the Dynamic Resource
+  Allocation (DRA) API as well as between the driver and the Container Runtime
+  via the Node Resource Interface (NRI) API. Ensure the consistency of the
+  dedicated IPAM modes with the Network Driver resources management.
+  This code owner is not related to the low level interactions with the Linux
+  network drivers.
 - `@cilium/sig-policy <https://github.com/orgs/cilium/teams/sig-policy>`__:
   Ensure consistency of semantics for all network policy representations.
   Responsible for all policy logic from Kubernetes down to eBPF policymap


### PR DESCRIPTION
Add a new team responsible to maintain the Cilium Network Driver feature and assign the related agent and operator files.

This should improve the reviewers selection algorithm when opening PRs against `feature/dra-driver` branch.

Related: https://github.com/cilium/cilium/pull/44213#issuecomment-4127347041