### PR TITLE
datapath: export enums as Go types

### DIFF
--- a/bpf/lib/clustermesh.h
+++ b/bpf/lib/clustermesh.h
@@ -4,6 +4,7 @@
 
 #include <bpf/config/node.h>
 
+#include "common.h"
 #include "lib/utils.h"
 
 /*

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -118,30 +118,6 @@ __revalidate_data_pull(const struct __ctx_buff *ctx, void **data_, void **data_e
 	return true;
 }
 
-static __always_inline __u32 get_tunnel_id(__u32 identity)
-{
-#if defined ENABLE_IPV4 && defined ENABLE_IPV6
-	if (identity == WORLD_IPV4_ID || identity == WORLD_IPV6_ID)
-		return WORLD_ID;
-#endif
-	return identity;
-}
-
-static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __be16 proto  __maybe_unused)
-{
-#if defined ENABLE_IPV4 && defined ENABLE_IPV6
-	if (tunnel_id == WORLD_ID) {
-		switch (proto) {
-		case bpf_htons(ETH_P_IP):
-			return WORLD_IPV4_ID;
-		case bpf_htons(ETH_P_IPV6):
-			return WORLD_IPV6_ID;
-		}
-	}
-#endif
-	return tunnel_id;
-}
-
 /* revalidate_data_pull() initializes the provided pointers from the ctx and
  * ensures that the data is pulled in for access. Should be used the first
  * time that the ctx data is accessed, subsequent calls can be made to

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -176,7 +176,6 @@ struct debug_capture_msg {
 
 #if defined(DEBUG) || defined(DEBUG_TAGGED)
 #include "events.h"
-#include "common.h"
 #include "utils.h"
 
 #ifdef DEBUG_TAGGED

--- a/bpf/lib/export_type.h
+++ b/bpf/lib/export_type.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+/* Export and generate a Go type definition for this type. Only use this if the
+ * type is not already referenced by a config variable or used as a map
+ * key/value type.
+ *
+ * Force creating a reference to the type by declaring a global variable to
+ * ensure the compiler includes it in BTF.
+ */
+#define EXPORT_TYPE(type) __expand_type(type, __COUNTER__)
+#define __expand_type(type, n) ___expand_type(type, n)
+#define ___expand_type(type, n) type __dpexp_ ## n

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -4,9 +4,36 @@
 #pragma once
 
 #include <bpf/config/node.h>
+#include "export_type.h"
 
 #include "dbg.h"
 #include "clustermesh.h"
+
+enum identity {
+	UNKNOWN_ID = 0,
+	HOST_ID = 1,
+	WORLD_ID = 2,
+	UNMANAGED_ID = 3,
+	HEALTH_ID = 4,
+	INIT_ID = 5,
+	LOCAL_NODE_ID = 6,
+	REMOTE_NODE_ID = LOCAL_NODE_ID,
+	KUBE_APISERVER_NODE_ID = 7,
+	INGRESS_ID = 8,
+	WORLD_IPV4_ID = 9,
+	WORLD_IPV6_ID = 10,
+};
+
+EXPORT_TYPE(enum identity);
+
+/* TODO(tb): Replace this with a helper, enable_v4/v6 will be runtime configs at
+ * some point.
+ */
+#if defined ENABLE_IPV4 && defined ENABLE_IPV6
+#else
+# define WORLD_IPV4_ID WORLD_ID
+# define WORLD_IPV6_ID WORLD_ID
+#endif
 
 /**
  * Minimal numeric identity value for a local (CIDR) identity.
@@ -304,6 +331,30 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 static __always_inline bool identity_is_local(__u32 identity)
 {
 	return (identity & IDENTITY_LOCAL_SCOPE_MASK) != 0;
+}
+
+static __always_inline __u32 get_tunnel_id(__u32 identity)
+{
+#if defined ENABLE_IPV4 && defined ENABLE_IPV6
+	if (identity == WORLD_IPV4_ID || identity == WORLD_IPV6_ID)
+		return WORLD_ID;
+#endif
+	return identity;
+}
+
+static __always_inline __u32 get_id_from_tunnel_id(__u32 tunnel_id, __be16 proto  __maybe_unused)
+{
+#if defined ENABLE_IPV4 && defined ENABLE_IPV6
+	if (tunnel_id == WORLD_ID) {
+		switch (proto) {
+		case bpf_htons(ETH_P_IP):
+			return WORLD_IPV4_ID;
+		case bpf_htons(ETH_P_IPV6):
+			return WORLD_IPV6_ID;
+		}
+	}
+#endif
+	return tunnel_id;
 }
 
 /**

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -3,9 +3,8 @@
 
 #pragma once
 
-#include "lib/common.h"
-#include "linux/ip.h"
-
+#include <linux/ip.h>
+#include "identity.h"
 
 static __always_inline __maybe_unused void
 bpf_clear_meta(struct __sk_buff *ctx)

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -5,6 +5,7 @@
 
 #include <linux/udp.h>
 #include <linux/ip.h>
+#include "identity.h"
 
 static __always_inline __maybe_unused void
 bpf_clear_meta(struct xdp_md *ctx __maybe_unused)

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -16,24 +16,6 @@
 
 #define LRU_MEM_FLAVOR 0
 
-#define UNKNOWN_ID 0
-#define HOST_ID 1
-#define WORLD_ID 2
-#if defined ENABLE_IPV4 && defined ENABLE_IPV6
-# define WORLD_IPV4_ID 9
-# define WORLD_IPV6_ID 10
-#else
-# define WORLD_IPV4_ID 2
-# define WORLD_IPV6_ID 2
-#endif
-#define UNMANAGED_ID 3
-#define HEALTH_ID 4
-#define INIT_ID 5
-#define LOCAL_NODE_ID 6
-#define REMOTE_NODE_ID 6
-#define KUBE_APISERVER_NODE_ID 7
-#define INGRESS_ID 8
-
 #define CT_CONNECTION_LIFETIME_TCP	21600
 #define CT_CONNECTION_LIFETIME_NONTCP	60
 #define CT_SERVICE_LIFETIME_TCP		21600

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -29,9 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/kpr"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
@@ -160,24 +158,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 
 	// --- WARNING: THIS CONFIGURATION METHOD IS DEPRECATED, SEE FUNCTION DOC ---
 
-	cDefinesMap["UNKNOWN_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameUnknown))
-	cDefinesMap["HOST_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameHost))
-	cDefinesMap["WORLD_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameWorld))
-	if option.Config.IsDualStack() {
-		cDefinesMap["WORLD_IPV4_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameWorldIPv4))
-		cDefinesMap["WORLD_IPV6_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameWorldIPv6))
-	} else {
-		worldID := identity.GetReservedID(labels.IDNameWorld)
-		cDefinesMap["WORLD_IPV4_ID"] = fmt.Sprintf("%d", worldID)
-		cDefinesMap["WORLD_IPV6_ID"] = fmt.Sprintf("%d", worldID)
-	}
-	cDefinesMap["HEALTH_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameHealth))
-	cDefinesMap["UNMANAGED_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameUnmanaged))
-	cDefinesMap["INIT_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameInit))
-	cDefinesMap["LOCAL_NODE_ID"] = fmt.Sprintf("%d", identity.ReservedIdentityRemoteNode)
-	cDefinesMap["REMOTE_NODE_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameRemoteNode))
-	cDefinesMap["KUBE_APISERVER_NODE_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameKubeAPIServer))
-	cDefinesMap["INGRESS_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameIngress))
 	cDefinesMap["CILIUM_LB_SERVICE_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", cfg.LBConfig.LBServiceMapEntries)
 	cDefinesMap["CILIUM_LB_BACKENDS_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", cfg.LBConfig.LBBackendMapEntries)
 	cDefinesMap["CILIUM_LB_REV_NAT_MAP_MAX_ENTRIES"] = fmt.Sprintf("%d", cfg.LBConfig.LBRevNatEntries)

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -238,6 +238,24 @@ type EndpointKey struct {
 	ClusterID uint16
 }
 
+// Identity is generated from the BPF C type identity.
+type Identity uint32
+
+const (
+	IdentityUnknownID           Identity = 0
+	IdentityHostID              Identity = 1
+	IdentityWorldID             Identity = 2
+	IdentityUnmanagedID         Identity = 3
+	IdentityHealthID            Identity = 4
+	IdentityInitID              Identity = 5
+	IdentityLocalNodeID         Identity = 6
+	IdentityRemoteNodeID        Identity = 6
+	IdentityKubeAPIServerNodeID Identity = 7
+	IdentityIngressID           Identity = 8
+	IdentityWorldIPv4ID         Identity = 9
+	IdentityWorldIPv6ID         Identity = 10
+)
+
 // IPCacheKey is generated from the BPF C type ipcache_key.
 type IPCacheKey struct {
 	_      structs.HostLayout

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -99,43 +100,43 @@ var (
 
 const (
 	// IdentityUnknown represents an unknown identity
-	IdentityUnknown NumericIdentity = iota
+	IdentityUnknown = NumericIdentity(datapath.IdentityUnknownID)
 
 	// ReservedIdentityHost represents the local host
-	ReservedIdentityHost
+	ReservedIdentityHost = NumericIdentity(datapath.IdentityHostID)
 
 	// ReservedIdentityWorld represents any endpoint outside of the cluster
-	ReservedIdentityWorld
+	ReservedIdentityWorld = NumericIdentity(datapath.IdentityWorldID)
 
 	// ReservedIdentityUnmanaged represents unmanaged endpoints.
-	ReservedIdentityUnmanaged
+	ReservedIdentityUnmanaged = NumericIdentity(datapath.IdentityUnmanagedID)
 
 	// ReservedIdentityHealth represents the local cilium-health endpoint
-	ReservedIdentityHealth
+	ReservedIdentityHealth = NumericIdentity(datapath.IdentityHealthID)
 
 	// ReservedIdentityInit is the identity given to endpoints that have not
 	// received any labels yet.
-	ReservedIdentityInit
+	ReservedIdentityInit = NumericIdentity(datapath.IdentityInitID)
 
 	// ReservedIdentityRemoteNode is the identity given to all nodes in
 	// local and remote clusters except for the local node.
-	ReservedIdentityRemoteNode
+	ReservedIdentityRemoteNode = NumericIdentity(datapath.IdentityRemoteNodeID)
 
 	// ReservedIdentityKubeAPIServer is the identity given to remote node(s) which
 	// have backend(s) serving the kube-apiserver running.
-	ReservedIdentityKubeAPIServer
+	ReservedIdentityKubeAPIServer = NumericIdentity(datapath.IdentityKubeAPIServerNodeID)
 
 	// ReservedIdentityIngress is the identity given to the IP used as the source
 	// address for connections from Ingress proxies.
-	ReservedIdentityIngress
+	ReservedIdentityIngress = NumericIdentity(datapath.IdentityIngressID)
 
 	// ReservedIdentityWorldIPv4 represents any endpoint outside of the cluster
 	// for IPv4 address only.
-	ReservedIdentityWorldIPv4
+	ReservedIdentityWorldIPv4 = NumericIdentity(datapath.IdentityWorldIPv4ID)
 
 	// ReservedIdentityWorldIPv6 represents any endpoint outside of the cluster
 	// for IPv6 address only.
-	ReservedIdentityWorldIPv6
+	ReservedIdentityWorldIPv6 = NumericIdentity(datapath.IdentityWorldIPv6ID)
 )
 
 // Special identities for well-known cluster components

--- a/tools/dpgen/acronyms.txt
+++ b/tools/dpgen/acronyms.txt
@@ -6,6 +6,7 @@
 // perform the lookup.
 
 ACT
+APIServer
 ARP
 BPF
 CIDR

--- a/tools/dpgen/types.go
+++ b/tools/dpgen/types.go
@@ -90,11 +90,11 @@ func runTypes(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("getting BTF type %v: %w", t, err)
 		}
 
-		// Only include structs, unions and typedefs.
+		// Only include certain types of interest.
 		switch typ.(type) {
 		default:
 			continue
-		case *btf.Struct, *btf.Union, *btf.Typedef:
+		case *btf.Struct, *btf.Union, *btf.Typedef, *btf.Enum:
 		}
 
 		cName := typ.TypeName()

--- a/tools/dpgen/util.go
+++ b/tools/dpgen/util.go
@@ -73,10 +73,15 @@ func stylize(s string) string {
 	return s
 }
 
-// camelCase converts a string like "foo_bar" to "FooBar". It capitalizes the
-// acronyms defined in acronyms.txt.
+// camelCase converts strings like "foo_bar" and "FOO_BAR" to "FooBar". It
+// capitalizes the acronyms defined in acronyms.txt.
 func camelCase(s string) string {
 	var b strings.Builder
+
+	// Ignore existing capitalization. Typically, identifiers are all upper or all
+	// lower; apply our own capitalization rules on them.
+	s = strings.ToLower(s)
+
 	for w := range strings.SplitSeq(s, "_") {
 		w = stylize(w)
 		b.WriteString(cases.Title(language.English, cases.NoLower).String(w))


### PR DESCRIPTION
This PR adds an EXPORT_TYPE macro to explicitly flag a type for exporting by dpgen. Only needed in case a type doesn't appear as a variable value or as a map k/v type, which should be the case for most enums. Therefore, an extra mechanism is needed.