### PR TITLE
cilium-cli: Ignore gobgp tcp close error in log checks

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -54,7 +54,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, knownIssueWireguardCollision, nilDetailsForService}
+		failedToListCRDs, knownIssueWireguardCollision, nilDetailsForService, gobgpFailedCloseTCP}
 
 	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
 	envoyExternalOtherTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalOtherTarget))}
@@ -430,6 +430,7 @@ const (
 	failedToReleaseLock  stringMatcher = "Failed to release lock:"
 	nilDetailsForService stringMatcher = "retrieved nil details for Service"                    // from: https://github.com/cilium/cilium/issues/35595
 	removeInexistentID   stringMatcher = "removing identity not added to the identity manager!" // from https://github.com/cilium/cilium/issues/16419
+	gobgpFailedCloseTCP  stringMatcher = "failed to close existing tcp connection"              // Benign error during BGP peer teardown in ACTIVE state
 
 	// warnings
 	cantEnableJIT                    stringMatcher = "bpf_jit_enable: no such file or directory"                              // Because we run tests in Kind.


### PR DESCRIPTION
Add an error-level log exception for the "failed to close existing tcp connection" message emitted by GoBGP during BGP peer teardown. This connection for a peer in ACTIVE state that is already closed by the remote side or another goroutine. There is no resource leak or functional impact since the peer is being torn down anyway.

sample error:
```
.  ❌ Found 1 logs in kube-system/cilium-n4r9n (cilium-agent) matching list of errors that must be investigated:
time=2026-03-26T03:34:30.320463118Z level=error source=/go/src/github.com/cilium/cilium/pkg/bgp/gobgp/logger.go:86 msg="failed to close existing tcp connection" module=agent.controlplane.bgp-control-plane instance=test-instance Topic=Peer Key=192.168.9.4 State=BGP_FSM_ACTIVE asn=65001 component=gobgp.BgpServerInstance subsys=bgp-control-plane (2 occurrences)
  [.] Action [check-log-errors/no-errors-in-logs:pkg/bgp/gobgp:kube-system/cilium-n4r9n (config)]
.  [.] Action [check-log-errors/no-errors-in-logs:pkg/bgp/gobgp:kube-system/cilium-node-init-59fr7 (node-init)]
.  [.] Action [check-log-errors/no-errors-in-logs:pkg/bgp/gobgp:kube-system/cilium-operator-5dc7988f58-vzbl8 (cilium-operator)]
.
📋 Test Report [cilium-test-1]
[cilium-test-1] 1 tests failed
❌ 1/3 tests failed (2/64 actions), 156 tests skipped, 0 scenarios skipped:
Test [check-log-errors]:
  🟥 check-log-errors/no-errors-in-logs:pkg/bgp/gobgp:kube-system/cilium-7gh88 (cilium-agent): Found 1 logs in kube-system/cilium-7gh88 (cilium-agent) matching list of errors that must be investigated:
time=2026-03-26T03:34:30.325571736Z level=error source=/go/src/github.com/cilium/cilium/pkg/bgp/gobgp/logger.go:86 msg="failed to close existing tcp connection" module=agent.controlplane.bgp-control-plane instance=test-instance State=BGP_FSM_ACTIVE Topic=Peer Key=192.168.9.5 asn=65001 component=gobgp.BgpServerInstance subsys=bgp-control-plane (1 occurrences) 
```
