### PR TITLE
Fix endpoints for static pods stuck in init identity

### DIFF
--- a/pkg/endpoint/metadata/k8s_metadatafetcher.go
+++ b/pkg/endpoint/metadata/k8s_metadatafetcher.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/cilium/statedb"
+	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -52,12 +53,22 @@ func (cemf *cachedEndpointMetadataFetcher) FetchK8sMetadataForEndpoint(nsName, p
 		return nil, nil, err
 	}
 
-	if uid != "" && uid != string(p.GetUID()) {
+	if isPodStoreOutdatedForUID(uid, p) {
 		return nil, nil, ErrPodStoreOutdated
 	}
 
 	metadata, err := cemf.FetchK8sMetadataForEndpointFromPod(p)
 	return p, metadata, err
+}
+
+// isPodStoreOutdatedForUID returns true when CNI uid disagrees with the store pod uid such
+// that ErrPodStoreOutdated applies. Mirror pods (static pods; corev1.MirrorPodAnnotationKey) are exempt.
+func isPodStoreOutdatedForUID(uid string, pod *slim_corev1.Pod) bool {
+	if uid == "" || uid == string(pod.GetUID()) {
+		return false
+	}
+	_, mirrorPod := pod.GetAnnotations()[corev1.MirrorPodAnnotationKey]
+	return !mirrorPod
 }
 
 func (cemf *cachedEndpointMetadataFetcher) FetchK8sMetadataForEndpointFromPod(p *slim_corev1.Pod) (*endpoint.K8sMetadata, error) {

--- a/pkg/endpoint/metadata/k8s_metadatafetcher_test.go
+++ b/pkg/endpoint/metadata/k8s_metadatafetcher_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+func TestIsPodStoreOutdatedForUID(t *testing.T) {
+	storeUID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	otherUID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	tests := []struct {
+		name string
+		uid  string
+		pod  *slim_corev1.Pod
+		want bool
+	}{
+		{
+			name: "empty uid never outdated",
+			uid:  "",
+			pod:  &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{UID: types.UID(storeUID)}},
+			want: false,
+		},
+		{
+			name: "uid match not outdated",
+			uid:  storeUID,
+			pod:  &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{UID: types.UID(storeUID)}},
+			want: false,
+		},
+		{
+			name: "uid mismatch without mirror annotation is outdated",
+			uid:  otherUID,
+			pod: &slim_corev1.Pod{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					UID: types.UID(storeUID),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "uid mismatch mirror pod not outdated",
+			uid:  otherUID,
+			pod: &slim_corev1.Pod{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					UID: types.UID(storeUID),
+					Annotations: map[string]string{
+						corev1.MirrorPodAnnotationKey: otherUID,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPodStoreOutdatedForUID(tt.uid, tt.pod)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Static pods are represented in the API as mirror pods. The pod UID passed to CNI (K8S_POD_UID) can differ from the UID of the mirror pod in the local API-backed pod store, so the strict UID check caused FetchK8sMetadataForEndpoint to return ErrPodStoreOutdated repeatedly and left endpoints on reserved:init.

Skip the outdated-store error when the pod has the mirror pod annotation (kubernetes.io/config.mirror / corev1.MirrorPodAnnotationKey).

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #34197

```release-note
Fix endpoints for static pods stuck in init identity
```
