### PR TITLE
maps/nat: add GC metrics for removed NAT entries

### DIFF
--- a/pkg/maps/ctmap/metrics.go
+++ b/pkg/maps/ctmap/metrics.go
@@ -156,4 +156,6 @@ func (s *NatGCStats) finish() {
 	metrics.NatGCSize.WithLabelValues(family, metricsIngress, metricsDeleted).Set(float64(s.IngressDeleted))
 	metrics.NatGCSize.WithLabelValues(family, metricsEgress, metricsAlive).Set(float64(s.EgressAlive))
 	metrics.NatGCSize.WithLabelValues(family, metricsEgress, metricsDeleted).Set(float64(s.EgressDeleted))
+	metrics.NatGCDeletedTotal.WithLabelValues(family, metricsIngress).Add(float64(s.IngressDeleted))
+	metrics.NatGCDeletedTotal.WithLabelValues(family, metricsEgress).Add(float64(s.EgressDeleted))
 }

--- a/pkg/maps/ctmap/metrics_test.go
+++ b/pkg/maps/ctmap/metrics_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ctmap
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+// initTestMetrics initializes NatGCSize and NatGCDeletedTotal metrics for
+// testing, replacing the package-level NoOp vars with real Prometheus
+// metrics so that gauge/counter values can be read back via testutil.
+func initTestMetrics(t *testing.T) *metrics.LegacyMetrics {
+	t.Helper()
+	lm := metrics.NewLegacyMetrics()
+	lm.NatGCSize.SetEnabled(true)
+	lm.NatGCDeletedTotal.SetEnabled(true)
+	metrics.NatGCSize = lm.NatGCSize
+	metrics.NatGCDeletedTotal = lm.NatGCDeletedTotal
+	t.Cleanup(func() {
+		metrics.NatGCSize = metrics.NoOpGaugeVec
+		metrics.NatGCDeletedTotal = metrics.NoOpCounterVec
+	})
+	return lm
+}
+
+func TestNatGCStatsFinish(t *testing.T) {
+	t.Run("counter increment", func(t *testing.T) {
+		lm := initTestMetrics(t)
+
+		s := &NatGCStats{
+			Family:         gcFamilyIPv4,
+			IngressDeleted: 3,
+			EgressDeleted:  5,
+			IngressAlive:   10,
+			EgressAlive:    8,
+		}
+		s.finish()
+
+		assert.Equal(t, 3.0, testutil.ToFloat64(lm.NatGCDeletedTotal.WithLabelValues("ipv4", metricsIngress)))
+		assert.Equal(t, 5.0, testutil.ToFloat64(lm.NatGCDeletedTotal.WithLabelValues("ipv4", metricsEgress)))
+	})
+
+	t.Run("gauge set", func(t *testing.T) {
+		lm := initTestMetrics(t)
+
+		s := &NatGCStats{
+			Family:         gcFamilyIPv4,
+			IngressDeleted: 3,
+			EgressDeleted:  5,
+			IngressAlive:   10,
+			EgressAlive:    8,
+		}
+		s.finish()
+
+		assert.Equal(t, 3.0, testutil.ToFloat64(lm.NatGCSize.WithLabelValues("ipv4", metricsIngress, metricsDeleted)))
+		assert.Equal(t, 8.0, testutil.ToFloat64(lm.NatGCSize.WithLabelValues("ipv4", metricsEgress, metricsAlive)))
+		assert.Equal(t, 10.0, testutil.ToFloat64(lm.NatGCSize.WithLabelValues("ipv4", metricsIngress, metricsAlive)))
+		assert.Equal(t, 5.0, testutil.ToFloat64(lm.NatGCSize.WithLabelValues("ipv4", metricsEgress, metricsDeleted)))
+	})
+
+	t.Run("cumulative counter", func(t *testing.T) {
+		lm := initTestMetrics(t)
+
+		s := &NatGCStats{
+			Family:         gcFamilyIPv4,
+			IngressDeleted: 3,
+			EgressDeleted:  5,
+		}
+		s.finish()
+		s.finish()
+
+		assert.Equal(t, 6.0, testutil.ToFloat64(lm.NatGCDeletedTotal.WithLabelValues("ipv4", metricsIngress)))
+		assert.Equal(t, 10.0, testutil.ToFloat64(lm.NatGCDeletedTotal.WithLabelValues("ipv4", metricsEgress)))
+	})
+
+	t.Run("ipv6 family", func(t *testing.T) {
+		lm := initTestMetrics(t)
+
+		s := &NatGCStats{
+			Family:         gcFamilyIPv6,
+			IngressDeleted: 7,
+			EgressDeleted:  2,
+			IngressAlive:   1,
+			EgressAlive:    4,
+		}
+		s.finish()
+
+		assert.Equal(t, 7.0, testutil.ToFloat64(lm.NatGCDeletedTotal.WithLabelValues("ipv6", metricsIngress)))
+		assert.Equal(t, 2.0, testutil.ToFloat64(lm.NatGCDeletedTotal.WithLabelValues("ipv6", metricsEgress)))
+		assert.Equal(t, 7.0, testutil.ToFloat64(lm.NatGCSize.WithLabelValues("ipv6", metricsIngress, metricsDeleted)))
+		assert.Equal(t, 4.0, testutil.ToFloat64(lm.NatGCSize.WithLabelValues("ipv6", metricsEgress, metricsAlive)))
+	})
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -397,6 +397,9 @@ var (
 	// NatGCSize the number of entries in the nat table
 	NatGCSize = NoOpGaugeVec
 
+	// NatGCDeletedTotal is the number of NAT entries deleted during GC
+	NatGCDeletedTotal = NoOpCounterVec
+
 	// ConntrackGCDuration the duration of the conntrack GC process in milliseconds.
 	ConntrackGCDuration = NoOpObserverVec
 
@@ -663,6 +666,7 @@ type LegacyMetrics struct {
 	ConntrackGCKeyFallbacks                 metric.Vec[metric.Counter]
 	ConntrackGCSize                         metric.Vec[metric.Gauge]
 	NatGCSize                               metric.Vec[metric.Gauge]
+	NatGCDeletedTotal                       metric.Vec[metric.Counter]
 	ConntrackGCDuration                     metric.Vec[metric.Observer]
 	ConntrackInterval                       metric.Vec[metric.Gauge]
 	ConntrackDumpResets                     metric.Vec[metric.Counter]
@@ -948,6 +952,14 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help: "The number of alive and deleted nat entries at the end " +
 				"of a garbage collector run labeled by datapath family.",
 		}, []string{LabelDatapathFamily, LabelDirection, LabelStatus}),
+
+		NatGCDeletedTotal: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: Namespace + "_" + SubsystemDatapath + "_nat_gc_removed_total",
+			Namespace:  Namespace,
+			Subsystem:  SubsystemDatapath,
+			Name:       "nat_gc_removed_total",
+			Help:       "Number of NAT entries removed during garbage collection, labeled by address family and direction.",
+		}, []string{LabelDatapathFamily, LabelDirection}),
 
 		ConntrackGCDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_" + SubsystemDatapath + "_conntrack_gc_duration_seconds",
@@ -1338,6 +1350,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	ConntrackGCKeyFallbacks = lm.ConntrackGCKeyFallbacks
 	ConntrackGCSize = lm.ConntrackGCSize
 	NatGCSize = lm.NatGCSize
+	NatGCDeletedTotal = lm.NatGCDeletedTotal
 	ConntrackGCDuration = lm.ConntrackGCDuration
 	ConntrackInterval = lm.ConntrackInterval
 	ConntrackDumpResets = lm.ConntrackDumpResets


### PR DESCRIPTION
## Summary

Add a new `cilium_datapath_nat_gc_removed_total` counter to track NAT entries
removed during garbage collection, labeled by address family and direction.

Fixes: #17239

## Changes

- `pkg/metrics/metrics.go`: Add `NatGCDeletedTotal` counter following the
  `ConntrackGCRuns` registration pattern
- `pkg/maps/ctmap/metrics.go`: Emit `NatGCDeletedTotal` counter from
  `NatGCStats.finish()` (existing method, already called after both GC paths)
- `pkg/maps/ctmap/metrics_test.go`: Unit test verifying `finish()` increments
  the counter with expected label values

## Testing

- `go test ./pkg/maps/ctmap/... -run TestNatGCStats -v` — new unit test passes
- All ctmap package tests pass
- `golangci-lint run ./pkg/maps/ctmap/... ./pkg/metrics/...` — 0 issues