### PR TITLE
ci: fix PR branch pull step on stable pushes

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -228,7 +228,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          if [[ "${{ inputs.PR-number }}" == "${{ inputs.context-ref }}" ]]; then
+            BASE_BRANCH="${{ inputs.context-ref }}"
+          else
+            BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          fi
           echo "base-branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "Base branch for PR #${{ inputs.PR-number }}: $BASE_BRANCH"
 

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -302,7 +302,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          if [[ "${{ inputs.PR-number }}" == "${{ inputs.context-ref }}" ]]; then
+            BASE_BRANCH="${{ inputs.context-ref }}"
+          else
+            BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          fi
           echo "base-branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "Base branch for PR #${{ inputs.PR-number }}: $BASE_BRANCH"
 


### PR DESCRIPTION
On workflow_dispatch event, pr-number also carry the name of the branch instead of the PR number when the branch isn't associated with any PR. Such example can be found on stable branch workflow-dispatch : https://github.com/cilium/cilium/actions/runs/23629031538/job/68824091132

In order to avoid error on the PR research with git CLI, we check when the context-ref equals the pr-number. Knowing it's a case where the branch isn't associated with any PR, we then use the context-ref as a base branch to carry on the workflow.

Fixes: https://github.com/cilium/cilium/actions/runs/23629031538/job/68824124379
