### PR TITLE
hubble: fix nil pointer dereference in Peer.Equal() when one Address is nil

### DIFF
--- a/pkg/hubble/peer/types/peer.go
+++ b/pkg/hubble/peer/types/peer.go
@@ -101,8 +101,15 @@ func (p Peer) String() string {
 
 // Equal reports whether the Peer is equal to the provided Peer
 func (p Peer) Equal(o Peer) bool {
-	addrEq := (p.Address == nil && o.Address == nil) ||
-		(p.Address.String() == o.Address.String() && p.Address.Network() == o.Address.Network())
+	var addrEq bool
+	switch {
+	case p.Address == nil && o.Address == nil:
+		addrEq = true
+	case p.Address == nil || o.Address == nil:
+		addrEq = false
+	default:
+		addrEq = p.Address.String() == o.Address.String() && p.Address.Network() == o.Address.Network()
+	}
 	return p.Name == o.Name &&
 		p.TLSEnabled == o.TLSEnabled &&
 		p.TLSServerName == o.TLSServerName &&

--- a/pkg/hubble/peer/types/peer_test.go
+++ b/pkg/hubble/peer/types/peer_test.go
@@ -382,6 +382,21 @@ func TestEqual(t *testing.T) {
 			equal: false,
 		},
 		{
+			name: "one address nil other non-nil",
+			a: Peer{
+				Name:    "name",
+				Address: nil,
+			},
+			b: Peer{
+				Name: "name",
+				Address: &net.TCPAddr{
+					IP:   net.ParseIP("192.0.2.1"),
+					Port: 4000,
+				},
+			},
+			equal: false,
+		},
+		{
 			name: "TLS enabled and not enabled",
 			a: Peer{
 				Name: "name",


### PR DESCRIPTION
## Summary

`Peer.Equal()` in `pkg/hubble/peer/types/peer.go` panics with a nil pointer dereference when one peer has a nil `Address` and the other does not. This causes **hubble-relay to crash loop** (exit code 2) in environments with dynamic node pools.

### Root cause

The original expression:

```go
addrEq := (p.Address == nil && o.Address == nil) ||
    (p.Address.String() == o.Address.String() && p.Address.Network() == o.Address.Network())
```

When only one `Address` is nil, the first condition evaluates to `false`, so Go evaluates the second branch and calls `.String()` / `.Network()` on the nil `net.Addr` interface — **panic**.

### Fix

Replace the single boolean expression with a switch statement that explicitly handles three cases: both nil, one nil (mixed), and both non-nil.

### Trigger scenario

In GKE with Node Auto-Provisioning (or any environment with node churn — autoscaling, spot/preemptible nodes), the hubble peer service fires multiple rapid `PEER_ADDED` notifications for the same peer. When the peer address is unresolvable (e.g. `connection refused`), `FromChangeNotification()` returns a `Peer` with `Address: nil`. This nil-address `Peer` is then passed to `Peer.Equal()` during `PeerManager.upsert()` in `watchNotifications()`, triggering the panic.

### Panic stack trace

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1e7380e]

goroutine 37 [running]:
github.com/cilium/cilium/pkg/hubble/peer/types.Peer.Equal(
    {{0xc00005ae40, 0x33}, {0x0, 0x0}, 0x1, {0xc000dac060, 0x51}},
    {{0xc00005b540, 0x33}, {0x29b9368, ...}, ...}
    /go/src/github.com/cilium/cilium/pkg/hubble/peer/types/peer.go:105 +0x6e
github.com/cilium/cilium/pkg/hubble/relay/pool.(*PeerManager).upsert(...)
    /go/src/github.com/cilium/cilium/pkg/hubble/relay/pool/manager.go:281 +0x16a
github.com/cilium/cilium/pkg/hubble/relay/pool.(*PeerManager).watchNotifications(...)
    /go/src/github.com/cilium/cilium/pkg/hubble/relay/pool/manager.go:152 +0x935
```

### Impact

- hubble-relay enters a permanent crash loop (exit code 2)
- All Hubble observability is lost
- Any environment with node churn is affected
- Bug is present in all released versions (verified up to v1.19.2)

## Test plan

- [x] Added test case `"one address nil other non-nil"` to `TestEqual` — verifies no panic and correct `false` result
- [x] All 15 existing + new tests pass: `go test ./pkg/hubble/peer/types/ -v`
- [x] Verified the fix resolves the crash on a live GKE cluster with NAP (retina-hubble chart v1.1.0)

```release-note
Fix panic in Hubble Relay when new peer address is unresolvable
```