### PR TITLE
ci: fix pr number check for base branch retrieval

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -228,10 +228,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "${{ inputs.PR-number }}" == "${{ inputs.context-ref }}" ]]; then
-            BASE_BRANCH="${{ inputs.context-ref }}"
-          else
+          # If PR-number isn't an integer then we use context-ref because branch isn't associated with a PR
+          if [[ "${{ inputs.PR-number }}" =~ ^[0-9]+$ ]]; then
             BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          else
+            BASE_BRANCH="${{ inputs.context-ref }}"
           fi
           echo "base-branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "Base branch for PR #${{ inputs.PR-number }}: $BASE_BRANCH"

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -302,10 +302,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "${{ inputs.PR-number }}" == "${{ inputs.context-ref }}" ]]; then
-            BASE_BRANCH="${{ inputs.context-ref }}"
-          else
+          # If PR-number isn't an integer then we use context-ref because branch isn't associated with a PR
+          if [[ "${{ inputs.PR-number }}" =~ ^[0-9]+$ ]]; then
             BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          else
+            BASE_BRANCH="${{ inputs.context-ref }}"
           fi
           echo "base-branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "Base branch for PR #${{ inputs.PR-number }}: $BASE_BRANCH"


### PR DESCRIPTION
Fixing bad changes in https://github.com/cilium/cilium/pull/45019 pr-number doesn't have the value of the stable branch but a replacement using hyphens instead of the standard dot.

Instead of comparing pr-number and context-ref, verify that pr-number is an actual pr-number, if it isn't, assuming the dispatch isn't coming from a PR but Ariane's dispatch, so use the context-ref instead.

Fixes https://github.com/cilium/cilium/issues/44914