### PR TITLE
ipam: add `AllowFirstLastIPs` option to `ipallocator.NewCIDRRange`

### DIFF
--- a/pkg/ipam/service/ipallocator/allocator.go
+++ b/pkg/ipam/service/ipallocator/allocator.go
@@ -38,6 +38,23 @@ func (e *ErrNotInRange) Error() string {
 	return fmt.Sprintf("provided IP is not in the valid range. The range of valid IPs is %s", e.ValidRange)
 }
 
+// CIDRRangeOption is a functional option for NewCIDRRange.
+type CIDRRangeOption func(*cidrRangeOptions)
+
+type cidrRangeOptions struct {
+	allowFirstLastIPs bool
+}
+
+// WithAllowFirstLastIPs configures the Range to include the first and last IPs
+// of the CIDR (normally reserved as network and broadcast addresses). This is
+// useful for delegated prefixes (e.g. AWS /28 prefix delegation) where the
+// entire range is exclusively assigned and there is no shared network segment.
+func WithAllowFirstLastIPs() CIDRRangeOption {
+	return func(o *cidrRangeOptions) {
+		o.allowFirstLastIPs = true
+	}
+}
+
 // Range is a contiguous block of IPs that can be allocated atomically.
 //
 // The internal structure of the range is:
@@ -64,15 +81,21 @@ type Range struct {
 	alloc allocator.Interface
 }
 
-// NewCIDRRange creates a Range over a net.IPNet, calling allocator.NewAllocationMap to construct
-// the backing store. Returned Range excludes first (base) and last addresses (max) if provided cidr
-// has more than 2 addresses.
-func NewCIDRRange(cidr *net.IPNet) *Range {
+// NewCIDRRange creates a Range over a net.IPNet, calling allocator.NewAllocationMap
+// to construct the backing store. By default, the first (network) and last
+// (broadcast) addresses are excluded for CIDRs with more than 2 addresses.
+// Pass functional options (e.g. WithAllowFirstLastIPs) to alter this behavior.
+func NewCIDRRange(cidr *net.IPNet, opts ...CIDRRangeOption) *Range {
+	var o cidrRangeOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	base := bigForIP(cidr.IP)
 	size := RangeSize(cidr)
 
 	// for any CIDR other than /32 or /128:
-	if size > 2 {
+	if size > 2 && !o.allowFirstLastIPs {
 		// don't use the network broadcast
 		size = max(0, size-2)
 		// don't use the network base
@@ -142,8 +165,7 @@ func (r *Range) Release(ip net.IP) {
 // ForEach calls the provided function for each allocated IP.
 func (r *Range) ForEach(fn func(net.IP)) {
 	r.alloc.ForEach(func(offset int) {
-		ip, _ := GetIndexedIP(r.net, offset+1) // +1 because Range doesn't store IP 0
-		fn(ip)
+		fn(addIPOffset(r.base, offset))
 	})
 }
 
@@ -185,7 +207,7 @@ func (r *Range) Restore(net *net.IPNet, data []byte) error {
 }
 
 // contains returns true and the offset if the ip is in the range, and false
-// and nil otherwise. The first and last addresses of the CIDR are omitted.
+// and 0 otherwise.
 func (r *Range) contains(ip net.IP) (bool, int) {
 	if !r.net.Contains(ip) {
 		return false, 0
@@ -234,13 +256,4 @@ func RangeSize(subnet *net.IPNet) int64 {
 	} else {
 		return int64(1) << uint(bits-ones)
 	}
-}
-
-// GetIndexedIP returns a net.IP that is subnet.IP + index in the contiguous IP space.
-func GetIndexedIP(subnet *net.IPNet, index int) (net.IP, error) {
-	ip := addIPOffset(bigForIP(subnet.IP), index)
-	if !subnet.Contains(ip) {
-		return nil, fmt.Errorf("can't generate IP with index %d from subnet. subnet too small. subnet: %q", index, subnet)
-	}
-	return ip, nil
 }

--- a/pkg/ipam/service/ipallocator/allocator_test.go
+++ b/pkg/ipam/service/ipallocator/allocator_test.go
@@ -32,7 +32,7 @@ func TestNewCIDRRange(t *testing.T) {
 			name:     "IPv4 /27",
 			ipNet:    mustParseCidr("192.168.0.1/27"),
 			wantBase: net.ParseIP("192.168.0.1"),
-			wantMax:  30, // (2^(32-27) - 2
+			wantMax:  30, // (2^(32-27)) - 2
 		},
 		{
 			name:     "IPv4 /31",
@@ -79,6 +79,111 @@ func TestNewCIDRRange(t *testing.T) {
 			require.Equal(t, tc.wantMax, actual.max)
 		})
 	}
+}
+
+func TestNewCIDRRangeWithAllowFirstLastIPs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ipNet    *net.IPNet
+		wantBase net.IP
+		wantMax  int
+	}{
+		{
+			name:     "IPv4 /28 prefix delegation",
+			ipNet:    mustParseCidr("10.0.0.0/28"),
+			wantBase: net.ParseIP("10.0.0.0"),
+			wantMax:  16, // all 16 IPs usable
+		},
+		{
+			name:     "IPv4 /24",
+			ipNet:    mustParseCidr("10.0.0.0/24"),
+			wantBase: net.ParseIP("10.0.0.0"),
+			wantMax:  256, // all 256 IPs usable
+		},
+		{
+			name:     "IPv6 /80 prefix delegation",
+			ipNet:    mustParseCidr("2001:db8::/80"),
+			wantBase: net.ParseIP("2001:db8::"),
+			wantMax:  65536, // all 65536 IPs usable
+		},
+		{
+			name:     "IPv4 /32 unchanged",
+			ipNet:    mustParseCidr("10.0.0.1/32"),
+			wantBase: net.ParseIP("10.0.0.1"),
+			wantMax:  1, // /32 is unaffected by the option
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCIDRRange(tc.ipNet, WithAllowFirstLastIPs())
+			baseIP := ipForBig(r.base)
+			require.Equal(t, tc.wantBase.String(), baseIP.String())
+			require.Equal(t, tc.wantMax, r.max)
+		})
+	}
+}
+
+func TestAllowFirstLastIPsAllocateAll(t *testing.T) {
+	// Verify all 16 IPs in a /28 are allocatable with WithAllowFirstLastIPs.
+	cidr := mustParseCidr("10.0.0.0/28")
+	r := NewCIDRRange(cidr, WithAllowFirstLastIPs())
+
+	require.Equal(t, 16, r.Free())
+
+	allocatedSet := map[string]struct{}{}
+	for range 16 {
+		ip, err := r.AllocateNext()
+		require.NoError(t, err)
+		allocatedSet[ip.String()] = struct{}{}
+	}
+
+	// Should be full now.
+	_, err := r.AllocateNext()
+	require.ErrorIs(t, err, ErrFull)
+	require.Equal(t, 0, r.Free())
+
+	// First and last IPs of the /28 should have been allocated.
+	require.Contains(t, allocatedSet, "10.0.0.0")
+	require.Contains(t, allocatedSet, "10.0.0.15")
+
+	// Verify ForEach returns all allocated IPs.
+	forEachSet := map[string]struct{}{}
+	r.ForEach(func(ip net.IP) {
+		forEachSet[ip.String()] = struct{}{}
+	})
+	require.Len(t, forEachSet, 16)
+	require.Contains(t, forEachSet, "10.0.0.0")
+	require.Contains(t, forEachSet, "10.0.0.15")
+}
+
+func TestAllowFirstLastIPsAllocateSpecific(t *testing.T) {
+	cidr := mustParseCidr("10.0.0.0/28")
+	r := NewCIDRRange(cidr, WithAllowFirstLastIPs())
+
+	// Allocate the first IP (network address).
+	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.0")))
+	require.True(t, r.Has(net.ParseIP("10.0.0.0")))
+
+	// Allocate the last IP (broadcast address).
+	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.15")))
+	require.True(t, r.Has(net.ParseIP("10.0.0.15")))
+
+	require.Equal(t, 14, r.Free())
+}
+
+func TestDefaultRangeExcludesFirstLastIPs(t *testing.T) {
+	cidr := mustParseCidr("10.0.0.0/28")
+	r := NewCIDRRange(cidr)
+
+	require.Equal(t, 14, r.Free())
+
+	// .0 and .15 should be out of range.
+	require.ErrorContains(t, r.Allocate(net.ParseIP("10.0.0.0")), "not in the valid range")
+	require.ErrorContains(t, r.Allocate(net.ParseIP("10.0.0.15")), "not in the valid range")
+
+	// .1 and .14 should be allocatable (first and last usable IPs).
+	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.1")))
+	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.14")))
 }
 
 func TestRangeSize(t *testing.T) {


### PR DESCRIPTION
Extend `NewCIDRRange` with a `WithAllowFirstLastIPs` functional option that includes the first and last IPs of a CIDR in the allocatable range. This is needed for AWS ENI prefix delegation where /28 prefixes are exclusively assigned to a node and all 16 IPs are usable as there is no shared network segment requiring base/broadcast reservation.

Also refactor `ForEach` to use `r.base` directly instead of assuming a +1 offset from the CIDR base, making it correct for both default and `AllowFirstLastIPs` ranges.

Relates to [cilium/design-cfps#87](https://github.com/cilium/design-cfps/pull/87)

Followup to #34618

See https://github.com/cilium/cilium/issues/28637#issuecomment-2337426529