### PR TITLE
cilium-cli: add connectivity test for toFQDNs on host

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -133,6 +133,9 @@ var (
 
 	//go:embed manifests/allow-egress-specific-ns-ccnp.yaml
 	egresstoSpecificNSYAML string
+
+	//go:embed manifests/host-firewall-egress-to-fqdns.yaml
+	hostFirewallEgressToFQDNsPolicyYAML string
 )
 
 var (
@@ -344,6 +347,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{
 		hostFirewallIngress{},
 		hostFirewallEgress{},
+		hostFirewallEgressToFqdns{},
 		clientEgressL7TlsDenyWithoutHeaders{},
 		clientEgressL7TlsHeaders{},
 		egresstoSpecificNamespace{},
@@ -396,6 +400,7 @@ func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Par
 		"ingressfromSpecificNSYAML":                                  ingressfromSpecificNSYAML,
 		"egresstoSpecificNSYAML":                                     egresstoSpecificNSYAML,
 		"echoIngressFromClientTieredWildcardPassL7YAML":              echoIngressFromClientTieredWildcardPassL7PolicyYAML,
+		"hostFirewallEgressToFQDNsPolicyYAML":                        hostFirewallEgressToFQDNsPolicyYAML,
 	}
 	if param.K8sLocalHostTest {
 		templates["clientEgressToCIDRCPHostPolicyYAML"] = clientEgressToCIDRCPHostPolicyYAML

--- a/cilium-cli/connectivity/builder/host_firewall_egress_to_fqdns.go
+++ b/cilium-cli/connectivity/builder/host_firewall_egress_to_fqdns.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type hostFirewallEgressToFqdns struct{}
+
+func (t hostFirewallEgressToFqdns) build(ct *check.ConnectivityTest, templates map[string]string) {
+	// This test does only half the job unless external targets differ
+	differentExternalTargets := func() bool {
+		return ct.Params().ExternalTarget != ct.Params().ExternalOtherTarget
+	}
+	// This policy only allows port 80 to domain-name, default one.one.one.one., DNS proxy enabled.
+	newTest("host-firewall-egress-to-fqdns", ct).
+		WithCiliumVersion(">=1.19.6").
+		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithCondition(differentExternalTargets).
+		WithFeatureRequirements(
+			features.RequireDisabled(features.EndpointRoutes), // currently broken when proxying to in-cluster endpoints, see #45957
+			features.RequireEnabled(features.L7Proxy),
+			features.RequireEnabled(features.HostFirewall)).
+		WithCiliumClusterwidePolicy(templates["hostFirewallEgressToFQDNsPolicyYAML"]).
+		WithScenarios(
+			tests.HostToWorld()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			extTarget := ct.Params().ExternalTarget
+			if a.Destination().Address(features.GetIPFamily(extTarget)) == extTarget {
+				return check.ResultOK, check.ResultNone
+			}
+
+			return check.ResultDNSOKDropCurlTimeout, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/host-firewall-egress-to-fqdns.yaml
+++ b/cilium-cli/connectivity/builder/manifests/host-firewall-egress-to-fqdns.yaml
@@ -1,0 +1,28 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: host-firewall-egress-to-fqdns-{{trimSuffix .ExternalTarget "."}}
+spec:
+  nodeSelector: {}
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: TCP
+    toFQDNs:
+    - matchName: "{{.ExternalTarget}}"
+  - toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
+      rules:
+        dns:
+        - matchPattern: "*"
+    toEntities:
+    - all
+  - toEntities:
+    - cluster
+    - kube-apiserver
+    - remote-node

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -254,6 +254,10 @@ func newDeployment(p deploymentParameters) *appsv1.Deployment {
 
 	maps.Copy(dep.Spec.Template.ObjectMeta.Labels, p.Labels)
 
+	if p.HostNetwork {
+		dep.Spec.Template.Spec.DNSPolicy = "ClusterFirstWithHostNet"
+	}
+
 	return dep
 }
 
@@ -369,6 +373,10 @@ func newDaemonSet(p daemonSetParameters) *appsv1.DaemonSet {
 
 	if p.NodeSelector != nil {
 		ds.Spec.Template.Spec.NodeSelector = p.NodeSelector
+	}
+
+	if p.HostNetwork {
+		ds.Spec.Template.Spec.DNSPolicy = "ClusterFirstWithHostNet"
 	}
 
 	return ds

--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -206,3 +206,50 @@ func (s *hostToPod) Run(ctx context.Context, t *check.Test) {
 		}
 	}
 }
+
+// HostToWorld sends multiple HTTP requests to ExternalTarget
+// from each node inside the cluster.
+func HostToWorld() check.Scenario {
+	return &hostToWorld{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+// hostToWorld implements a Scenario.
+type hostToWorld struct {
+	check.ScenarioBase
+}
+
+func (s *hostToWorld) Name() string {
+	return "host-to-world"
+}
+
+func (s *hostToWorld) Run(ctx context.Context, t *check.Test) {
+	extTarget := t.Context().Params().ExternalTarget
+	extOtherTarget := t.Context().Params().ExternalOtherTarget
+	http := check.HTTPEndpoint(extTarget+"-http", "http://"+extTarget)
+	httpOther := check.HTTPEndpoint(extOtherTarget+"-http", "http://"+extOtherTarget)
+
+	var i int
+	ct := t.Context()
+
+	for _, src := range ct.HostNetNSPodsByNode() {
+		if src.Outside {
+			continue
+		}
+
+		t.ForEachIPFamily(func(ipFam features.IPFamily) {
+			// With http, over port 80.
+			t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extTarget, i), &src, http, ipFam).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(http, ipFam, true, nil))
+			})
+
+			// With http, over port 80.
+			t.NewAction(s, fmt.Sprintf("http-to-%s-%d", extOtherTarget, i), &src, httpOther, ipFam).Run(func(a *check.Action) {
+				a.ExecInPod(ctx, ct.CurlCommand(httpOther, ipFam, true, nil))
+			})
+
+			i++
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a long missing connectivity test for host L7 DNS egress policy, i.e. `toFQDNs` for nodes. The new test creates a CCNP with an L7 DNS rule for the host redirecting its DNS requests to the DNS proxy, and a `toFQDNs` rule allowing egress to `extTarget`.

~**IMPORTANT**: the new test is currently broken (the host does not receive proxied DNS responses) due to commit 7fb6f4105c. The companion PR https://github.com/cilium/cilium/pull/45030 fixes the problem.~