### PR TITLE
ipam: Decouple ENI device configuration from CRD allocator

### DIFF
--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -31,6 +31,8 @@ func (o *ownerMock) UpdateCiliumNodeResource() {}
 type resourceMock struct{}
 
 func (rm *resourceMock) Observe(ctx context.Context, next func(resource.Event[*ciliumv2.CiliumNode]), complete func(error)) {
+	<-ctx.Done()
+	complete(ctx.Err())
 }
 
 func (rm *resourceMock) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[*ciliumv2.CiliumNode] {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -11,7 +11,6 @@ import (
 	"maps"
 	"net"
 	"reflect"
-	"slices"
 	"strconv"
 	"sync"
 
@@ -366,64 +365,12 @@ func (n *nodeStore) deleteLocalNodeResource() {
 	n.mutex.Unlock()
 }
 
-// validateENIConfig validates the ENI configuration in the CiliumNode resource
-// and returns an error if the configuration is not fully set.
-func validateENIConfig(node *ciliumv2.CiliumNode) error {
-	// Check if the VPC CIDR is set for all ENIs
-	for _, eni := range node.Status.ENI.ENIs {
-		if len(eni.VPC.PrimaryCIDR) == 0 {
-			return fmt.Errorf("VPC Primary CIDR not set for ENI %s", eni.ID)
-		}
-
-		for _, c := range eni.VPC.CIDRs {
-			if len(c) == 0 {
-				return fmt.Errorf("VPC CIDR not set for ENI %s", eni.ID)
-			}
-		}
-	}
-
-	// Check if all pool resource IPs are present in the status
-	eniIPMap := map[string][]string{}
-	for k, v := range node.Spec.IPAM.Pool {
-		eniIPMap[v.Resource] = append(eniIPMap[v.Resource], k)
-	}
-
-	for eni, addresses := range eniIPMap {
-		eniFound := false
-		for _, sENI := range node.Status.ENI.ENIs {
-			if eni == sENI.ID {
-				for _, addr := range addresses {
-					if !slices.Contains(sENI.Addresses, addr) {
-						return fmt.Errorf("ENI %s does not have address %s", eni, addr)
-					}
-				}
-				eniFound = true
-			}
-		}
-
-		if !eniFound {
-			return fmt.Errorf("ENI %s not found in status", eni)
-		}
-	}
-
-	return nil
-}
-
 // updateLocalNodeResource is called when the CiliumNode resource representing
 // the local node has been added or updated. It updates the available IPs based
 // on the custom resource passed into the function.
 func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-
-	if n.conf.IPAMMode() == ipamOption.IPAMENI {
-		if err := validateENIConfig(node); err != nil {
-			n.logger.Info("ENI state is not consistent yet", logfields.Error, err)
-			return
-		}
-
-		configureENIDevices(n.logger, n.ownNode, node, n.mtuConfig, n.sysctl)
-	}
 
 	n.ownNode = node
 	n.allocationPoolSize[IPv4] = 0

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -4,24 +4,28 @@
 package ipam
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"testing"
 	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -182,6 +186,14 @@ func TestIPMasq(t *testing.T) {
 	sharedNodeStore = newFakeNodeStore(conf, t)
 	sharedNodeStore.ownNode = cn
 
+	var jg job.Group
+	h := hive.New(
+		cell.Invoke(func(jg_ job.Group) { jg = jg_ }),
+	)
+	tlog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	require.NoError(t, h.Start(tlog, t.Context()))
+	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
+
 	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
 	ipam := NewIPAM(NewIPAMParams{
 		Logger:         hivetest.Logger(t),
@@ -193,6 +205,7 @@ func TestIPMasq(t *testing.T) {
 		NodeResource:   &resourceMock{},
 		MTUConfig:      &mtuMock,
 		IPMasqAgent:    ipMasqAgent,
+		JobGroup:       jg,
 	})
 	ipam.ConfigureAllocator()
 
@@ -296,213 +309,4 @@ func TestAzureIPMasq(t *testing.T) {
 	)
 
 	ipMasqAgent.Stop()
-}
-
-func Test_validateENIConfig(t *testing.T) {
-	type args struct {
-		node *ciliumv2.CiliumNode
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-		want    string
-	}{
-		{
-			name: "Consistent ENI config",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.226": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: eniTypes.ENIStatus{
-							ENIs: map[string]eniTypes.ENI{
-								"eni-1": {
-									ID: "eni-1",
-									Addresses: []string{
-										"10.1.1.226",
-										"10.1.1.229",
-									},
-									VPC: eniTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: "10.1.0.0/16",
-										CIDRs: []string{
-											"10.1.0.0/16",
-											"10.2.0.0/16",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Missing VPC Primary CIDR",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.226": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: eniTypes.ENIStatus{
-							ENIs: map[string]eniTypes.ENI{
-								"eni-1": {
-									ID: "eni-1",
-									Addresses: []string{
-										"10.1.1.226",
-										"10.1.1.229",
-									},
-									VPC: eniTypes.AwsVPC{
-										ID: "vpc-1",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-			want:    "VPC Primary CIDR not set for ENI eni-1",
-		},
-		{
-			name: "VPC CIDRs contain invalid value",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.226": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: eniTypes.ENIStatus{
-							ENIs: map[string]eniTypes.ENI{
-								"eni-1": {
-									ID: "eni-1",
-									Addresses: []string{
-										"10.1.1.226",
-										"10.1.1.229",
-									},
-									VPC: eniTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: "10.1.0.0/16",
-										CIDRs: []string{
-											"",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-			want:    "VPC CIDR not set for ENI eni-1",
-		},
-		{
-			name: "ENI not found in status",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.226": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: eniTypes.ENIStatus{
-							ENIs: map[string]eniTypes.ENI{
-								"eni-2": {
-									ID: "eni-2",
-									Addresses: []string{
-										"10.1.1.226",
-										"10.1.1.229",
-									},
-									VPC: eniTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: "10.1.0.0/16",
-										CIDRs: []string{
-											"10.1.0.0/16",
-											"10.2.0.0/16",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-			want:    "ENI eni-1 not found in status",
-		},
-		{
-			name: "ENI IP not found in status",
-			args: args{
-				node: &ciliumv2.CiliumNode{
-					Spec: ciliumv2.NodeSpec{
-						IPAM: ipamTypes.IPAMSpec{
-							Pool: ipamTypes.AllocationMap{
-								"10.1.1.227": ipamTypes.AllocationIP{
-									Resource: "eni-1",
-								},
-							},
-						},
-					},
-					Status: ciliumv2.NodeStatus{
-						ENI: eniTypes.ENIStatus{
-							ENIs: map[string]eniTypes.ENI{
-								"eni-1": {
-									ID: "eni-1",
-									Addresses: []string{
-										"10.1.1.226",
-										"10.1.1.229",
-									},
-									VPC: eniTypes.AwsVPC{
-										ID:          "vpc-1",
-										PrimaryCIDR: "10.1.0.0/16",
-										CIDRs: []string{
-											"10.1.0.0/16",
-											"10.2.0.0/16",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: true,
-			want:    "ENI eni-1 does not have address 10.1.1.227",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := validateENIConfig(tt.args.node)
-			require.Equal(t, tt.wantErr, got != nil, "error: %v", got)
-			if tt.wantErr {
-				require.Equal(t, tt.want, got.Error())
-			}
-		})
-	}
 }

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -4,23 +4,106 @@
 package ipam
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"slices"
 
+	"github.com/cilium/hive/job"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/defaults"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
+
+// startENIDeviceConfigurator starts a CiliumNode observer that configures ENI
+// network devices independently of the IPAM allocator. This decouples ENI
+// device setup from the allocator implementation.
+func startENIDeviceConfigurator(
+	logger *slog.Logger,
+	jg job.Group,
+	nodeResource agentK8s.LocalCiliumNodeResource,
+	mtuConfig MtuConfiguration,
+	sysctl sysctl.Sysctl,
+) {
+	var prevNode *ciliumv2.CiliumNode
+	jg.Add(
+		job.Observer(
+			"eni-device-configurator",
+			func(ctx context.Context, ev resource.Event[*ciliumv2.CiliumNode]) error {
+				defer ev.Done(nil)
+
+				if ev.Kind != resource.Upsert {
+					return nil
+				}
+
+				if err := validateENIConfig(ev.Object); err != nil {
+					logger.Info("ENI state is not consistent yet", logfields.Error, err)
+					return nil
+				}
+
+				configureENIDevices(logger, prevNode, ev.Object, mtuConfig, sysctl)
+				prevNode = ev.Object
+				return nil
+			},
+			nodeResource,
+		),
+	)
+}
+
+// validateENIConfig validates the ENI configuration in the CiliumNode resource
+// and returns an error if the configuration is not fully set.
+func validateENIConfig(node *ciliumv2.CiliumNode) error {
+	// Check if the VPC CIDR is set for all ENIs
+	for _, eni := range node.Status.ENI.ENIs {
+		if len(eni.VPC.PrimaryCIDR) == 0 {
+			return fmt.Errorf("VPC Primary CIDR not set for ENI %s", eni.ID)
+		}
+
+		for _, c := range eni.VPC.CIDRs {
+			if len(c) == 0 {
+				return fmt.Errorf("VPC CIDR not set for ENI %s", eni.ID)
+			}
+		}
+	}
+
+	// Check if all pool resource IPs are present in the status
+	eniIPMap := map[string][]string{}
+	for k, v := range node.Spec.IPAM.Pool {
+		eniIPMap[v.Resource] = append(eniIPMap[v.Resource], k)
+	}
+
+	for eni, addresses := range eniIPMap {
+		eniFound := false
+		for _, sENI := range node.Status.ENI.ENIs {
+			if eni == sENI.ID {
+				for _, addr := range addresses {
+					if !slices.Contains(sENI.Addresses, addr) {
+						return fmt.Errorf("ENI %s does not have address %s", eni, addr)
+					}
+				}
+				eniFound = true
+			}
+		}
+
+		if !eniFound {
+			return fmt.Errorf("ENI %s not found in status", eni)
+		}
+	}
+
+	return nil
+}
 
 type eniDeviceConfig struct {
 	name         string

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func Test_validateENIConfig(t *testing.T) {
+	type args struct {
+		node *ciliumv2.CiliumNode
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}{
+		{
+			name: "Consistent ENI config",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"10.1.0.0/16",
+											"10.2.0.0/16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Missing VPC Primary CIDR",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID: "vpc-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "VPC Primary CIDR not set for ENI eni-1",
+		},
+		{
+			name: "VPC CIDRs contain invalid value",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "VPC CIDR not set for ENI eni-1",
+		},
+		{
+			name: "ENI not found in status",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.226": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-2": {
+									ID: "eni-2",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"10.1.0.0/16",
+											"10.2.0.0/16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "ENI eni-1 not found in status",
+		},
+		{
+			name: "ENI IP not found in status",
+			args: args{
+				node: &ciliumv2.CiliumNode{
+					Spec: ciliumv2.NodeSpec{
+						IPAM: ipamTypes.IPAMSpec{
+							Pool: ipamTypes.AllocationMap{
+								"10.1.1.227": ipamTypes.AllocationIP{
+									Resource: "eni-1",
+								},
+							},
+						},
+					},
+					Status: ciliumv2.NodeStatus{
+						ENI: eniTypes.ENIStatus{
+							ENIs: map[string]eniTypes.ENI{
+								"eni-1": {
+									ID: "eni-1",
+									Addresses: []string{
+										"10.1.1.226",
+										"10.1.1.229",
+									},
+									VPC: eniTypes.AwsVPC{
+										ID:          "vpc-1",
+										PrimaryCIDR: "10.1.0.0/16",
+										CIDRs: []string{
+											"10.1.0.0/16",
+											"10.2.0.0/16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			want:    "ENI eni-1 does not have address 10.1.1.227",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validateENIConfig(tt.args.node)
+			require.Equal(t, tt.wantErr, got != nil, "error: %v", got)
+			if tt.wantErr {
+				require.Equal(t, tt.want, got.Error())
+			}
+		})
+	}
+}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -162,6 +162,9 @@ func (ipam *IPAM) ConfigureAllocator() {
 		}
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		ipam.logger.Info("Initializing CRD-based IPAM")
+		if ipam.config.IPAMMode() == ipamOption.IPAMENI {
+			startENIDeviceConfigurator(ipam.logger, ipam.jg, ipam.nodeResource, ipam.mtuConfig, ipam.sysctl)
+		}
 		if ipam.config.IPv6Enabled() {
 			ipam.ipv6Allocator = newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
 		}


### PR DESCRIPTION
Extract ENI device configuration into a standalone CiliumNode observer that runs independently of the IPAM allocator. Previously, `configureENIDevices` was called from `nodeStore.updateLocalNodeResource`, coupling ENI network device setup to the CRD allocator code path.

The new observer follows the same `job.Observer` pattern used by `startLocalNodeAllocCIDRsSync` in the multi-pool allocator. It watches CiliumNode updates and configures newly attached ENI devices regardless of which allocator is active.

Relates to [cilium/design-cfps#87](https://github.com/cilium/design-cfps/pull/87)