### PR TITLE
[v1.17] cilium-dbg: don't emit logs on flush

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -378,7 +378,7 @@ func newMap(mapName string, m mapType) *Map {
 	return result
 }
 
-func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func(GCEvent)) error {
+func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func(GCEvent), logResults bool) error {
 	err := m.DeleteLocked(key)
 	if err != nil {
 		return err
@@ -402,7 +402,7 @@ func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func
 
 // doGC6 iterates through a CTv6 map and drops entries based on the given
 // filter.
-func doGC6(m *Map, filter GCFilter, next func(GCEvent)) gcStats {
+func doGC6(m *Map, filter GCFilter, next func(GCEvent), logResults bool) gcStats {
 	var natMap *nat.Map
 
 	if m.clusterID == 0 {
@@ -423,7 +423,7 @@ func doGC6(m *Map, filter GCFilter, next func(GCEvent)) gcStats {
 		}
 	}
 
-	stats := statStartGc(m)
+	stats := statStartGc(m, logResults)
 	defer stats.finish()
 
 	if natMap != nil {
@@ -450,7 +450,7 @@ func doGC6(m *Map, filter GCFilter, next func(GCEvent)) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry6(m, currentKey6Global, entry, natMap, next)
+				err := purgeCtEntry6(m, currentKey6Global, entry, natMap, next, logResults)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey6Global.String()).Error("Unable to delete CT entry")
 				} else {
@@ -470,7 +470,7 @@ func doGC6(m *Map, filter GCFilter, next func(GCEvent)) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry6(m, currentKey6, entry, natMap, next)
+				err := purgeCtEntry6(m, currentKey6, entry, natMap, next, logResults)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey6.String()).Error("Unable to delete CT entry")
 				} else {
@@ -516,7 +516,7 @@ func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map, next func
 
 // doGC4 iterates through a CTv4 map and drops entries based on the given
 // filter.
-func doGC4(m *Map, filter GCFilter, next func(GCEvent)) gcStats {
+func doGC4(m *Map, filter GCFilter, next func(GCEvent), logResults bool) gcStats {
 	var natMap *nat.Map
 
 	if m.clusterID == 0 {
@@ -537,7 +537,7 @@ func doGC4(m *Map, filter GCFilter, next func(GCEvent)) gcStats {
 		}
 	}
 
-	stats := statStartGc(m)
+	stats := statStartGc(m, logResults)
 	defer stats.finish()
 
 	if natMap != nil {
@@ -637,12 +637,12 @@ func (f GCFilter) doFiltering(srcIP, dstIP netip.Addr, srcPort, dstPort uint16, 
 	return noAction
 }
 
-func doGC(m *Map, filter GCFilter, next4 func(GCEvent), next6 func(GCEvent)) (int, error) {
+func doGC(m *Map, filter GCFilter, next4 func(GCEvent), next6 func(GCEvent), logResults bool) (int, error) {
 	if m.mapType.isIPv6() {
-		stats := doGC6(m, filter, next6)
+		stats := doGC6(m, filter, next6, logResults)
 		return int(stats.deleted), stats.dumpError
 	} else if m.mapType.isIPv4() {
-		stats := doGC4(m, filter, next4)
+		stats := doGC4(m, filter, next4, logResults)
 		return int(stats.deleted), stats.dumpError
 	}
 	log.Fatalf("Unsupported ct map type: %s", m.mapType.String())
@@ -657,7 +657,7 @@ func GC(m *Map, filter GCFilter, next4 func(GCEvent), next6 func(GCEvent)) (int,
 		filter.Time = uint32(t)
 	}
 
-	return doGC(m, filter, next4, next6)
+	return doGC(m, filter, next4, next6, false)
 }
 
 // PurgeOrphanNATEntries removes orphan SNAT entries. We call an SNAT entry
@@ -768,7 +768,7 @@ func (m *Map) Flush(next4 func(GCEvent), next6 func(GCEvent)) int {
 	d, _ := doGC(m, GCFilter{
 		RemoveExpired: true,
 		Time:          MaxTime,
-	}, next4, next6)
+	}, next4, next6, false)
 
 	return d
 }

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -222,7 +222,7 @@ func TestCtGcIcmp(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGC4(ctMap, filter, next)
+	stats := doGC4(ctMap, filter, next, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -336,7 +336,7 @@ func TestCtGcTcp(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGC4(ctMap, filter, next)
+	stats := doGC4(ctMap, filter, next, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -430,7 +430,7 @@ func TestCtGcDsr(t *testing.T) {
 	}
 	mcast, next, complete := stream.Multicast[GCEvent]()
 	mcast.Observe(context.Background(), NatMapNext4, func(err error) {})
-	stats := doGC4(ctMap, filter, next)
+	stats := doGC4(ctMap, filter, next, false)
 	complete(nil)
 	require.Equal(t, uint32(0), stats.aliveEntries)
 	require.Equal(t, uint32(1), stats.deleted)
@@ -837,4 +837,81 @@ func populateFakeDataCTMap4(tb testing.TB, m CtMap, size int) map[*CtKey4Global]
 	}
 
 	return cache
+}
+
+func BenchmarkCtGcTcpXL(t *testing.B) {
+	benchmarkCtGc(t, 1<<24) // max size
+}
+
+func BenchmarkCtGcTcpL(t *testing.B) {
+	benchmarkCtGc(t, 1<<22)
+}
+
+func BenchmarkCtGcTcpM(t *testing.B) {
+	benchmarkCtGc(t, 1<<17)
+}
+
+func benchmarkCtGc(t *testing.B, size int) {
+	for t.Loop() {
+		t.StopTimer()
+		setupCTMap(t)
+		// Init maps
+		natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, size)
+		err := natMap.OpenOrCreate()
+		assert.NoError(t, err)
+		defer natMap.Map.Unpin()
+
+		ctMapName := MapNameTCP4Global + "_test"
+		mapInfo[mapTypeIPv4TCPGlobal] = mapAttributes{
+			natMap: natMap, natMapLock: mapInfo[mapTypeIPv4TCPGlobal].natMapLock,
+		}
+
+		prev := option.Config.CTMapEntriesGlobalTCP
+		option.Config.CTMapEntriesGlobalTCP = size
+		defer func() {
+			option.Config.CTMapEntriesGlobalTCP = prev
+		}()
+		ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+		err = ctMap.OpenOrCreate()
+		assert.NoError(t, err)
+		defer ctMap.Map.Unpin()
+
+		t.Logf("populating test map (size=%d)", size)
+		for i := range size {
+			var dest types.IPv4
+			dest[0] = byte(i >> 24)
+			dest[1] = byte(i >> 16)
+			dest[2] = byte(i >> 8)
+			dest[3] = byte(i)
+			ctKey := &CtKey4Global{
+				tuple.TupleKey4Global{
+					TupleKey4: tuple.TupleKey4{
+						SourceAddr: types.IPv4{192, 168, 61, 12},
+						DestAddr:   dest,
+						SourcePort: 0x3195,
+						DestPort:   0x50,
+						NextHeader: u8proto.TCP,
+						Flags:      tuple.TUPLE_F_OUT,
+					},
+				},
+			}
+			ctVal := &CtEntry{
+				Packets:  1,
+				Bytes:    216,
+				Lifetime: 2,
+			}
+			err = ctMap.Map.Update(ctKey, ctVal)
+			assert.NoError(t, err)
+		}
+		// GC and check whether NAT entries have been collected
+		filter := GCFilter{
+			RemoveExpired: true,
+			Time:          1,
+		}
+
+		t.Logf("starting gc")
+		defer t.Logf("done gc pass!")
+		t.StartTimer()
+		doGC4(ctMap, filter, nil, false)
+	}
 }


### PR DESCRIPTION
This was breaking CI as that wasn't emitting the expected output when running commands such as:

```
root@kind-worker:/home/cilium# cilium bpf ct flush global
Flushed 61 entries from /sys/fs/bpf/tc/globals/cilium_ct4_global
Flushed 6 entries from /sys/fs/bpf/tc/globals/cilium_ct_any4_global
Flushed 4 entries from /sys/fs/bpf/tc/globals/cilium_ct6_global
Flushed 6 entries from /sys/fs/bpf/tc/globals/cilium_ct_any6_global
```

This behavior was added in 694213c64ec903c49a1c421e9a32c4741027faa7 to add visibility following the decision to not emit error logs when we had a gc map delete "miss".

Fixes: #38989
