### PR TITLE
Fix host L7 policy operation

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -296,8 +296,8 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		if (from_host) {
 			bool is_host_id = from_host_raw & FROM_HOST_FLAG_HOST_ID;
 
-			ret = __ipv6_host_policy_egress(ctx, is_host_id, ip6, ct_buffer, &trace,
-							ext_err);
+			ret = __ipv6_host_policy_egress(ctx, is_host_id, false, ip6, ct_buffer,
+							&trace, ext_err);
 		} else {
 			ret = __ipv6_host_policy_ingress(ctx, ip6, ct_buffer, &remote_id, &trace,
 							 ext_err);
@@ -518,7 +518,7 @@ int tail_handle_ipv6_from_netdev(struct __ctx_buff *ctx)
 
 # ifdef ENABLE_HOST_FIREWALL
 static __always_inline int
-handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 src_sec_identity,
+handle_to_netdev_ipv6(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_sec_identity,
 		      struct trace_ctx *trace, __s8 *ext_err)
 {
 	void *data, *data_end;
@@ -554,7 +554,8 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	srcid = resolve_srcid_ipv6(ctx, ip6, src_sec_identity, &ipcache_srcid);
 
 	/* to-netdev is attached to the egress path of the native device. */
-	return ipv6_host_policy_egress(ctx, srcid, ipcache_srcid, ip6, trace, ext_err);
+	return ipv6_host_policy_egress(ctx, is_from_proxy, srcid, ipcache_srcid, ip6,
+				       trace, ext_err);
 }
 #endif /* ENABLE_HOST_FIREWALL */
 #endif /* ENABLE_IPV6 */
@@ -721,8 +722,8 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		if (from_host) {
 			bool is_host_id = from_host_raw & FROM_HOST_FLAG_HOST_ID;
 
-			ret = __ipv4_host_policy_egress(ctx, is_host_id, ip4, ct_buffer, &trace,
-							ext_err);
+			ret = __ipv4_host_policy_egress(ctx, is_host_id, false, ip4, ct_buffer,
+							&trace, ext_err);
 		} else {
 			ret = __ipv4_host_policy_ingress(ctx, ip4, ct_buffer, &remote_id, &trace,
 							 ext_err);
@@ -979,7 +980,7 @@ int tail_handle_ipv4_from_netdev(struct __ctx_buff *ctx)
 
 #ifdef ENABLE_HOST_FIREWALL
 static __always_inline int
-handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
+handle_to_netdev_ipv4(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_sec_identity,
 		      struct trace_ctx *trace, __s8 *ext_err)
 {
 	void *data, *data_end;
@@ -1002,7 +1003,8 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	/* We need to pass the srcid from ipcache to host firewall. See
 	 * comment in ipv4_host_policy_egress() for details.
 	 */
-	return ipv4_host_policy_egress(ctx, src_id, ipcache_srcid, ip4, trace, ext_err);
+	return ipv4_host_policy_egress(ctx, is_from_proxy, src_id, ipcache_srcid, ip4,
+				       trace, ext_err);
 }
 #endif /* ENABLE_HOST_FIREWALL */
 #endif /* ENABLE_IPV4 */
@@ -1387,14 +1389,14 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 	switch (proto) {
 # ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		ret = handle_to_netdev_ipv6(ctx, src_sec_identity,
-					    &trace, &ext_err);
+		ret = handle_to_netdev_ipv6(ctx, magic == MARK_MAGIC_PROXY_EGRESS,
+					    src_sec_identity, &trace, &ext_err);
 		break;
 # endif
 # ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP): {
-		ret = handle_to_netdev_ipv4(ctx, src_sec_identity,
-					    &trace, &ext_err);
+		ret = handle_to_netdev_ipv4(ctx, magic == MARK_MAGIC_PROXY_EGRESS,
+					    src_sec_identity, &trace, &ext_err);
 		break;
 	}
 	case bpf_htons(ETH_P_ARP):
@@ -1807,7 +1809,7 @@ from_host_to_lxc(struct __ctx_buff *ctx, __be16 proto, __s8 *ext_err)
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
 
-		ret = ipv6_host_policy_egress(ctx, HOST_ID, 0, ip6, &trace, ext_err);
+		ret = ipv6_host_policy_egress(ctx, false, HOST_ID, 0, ip6, &trace, ext_err);
 		break;
 # endif
 # ifdef ENABLE_IPV4
@@ -1821,7 +1823,7 @@ from_host_to_lxc(struct __ctx_buff *ctx, __be16 proto, __s8 *ext_err)
 		 * src_id is HOST_ID. Therefore, we don't need to pass a value
 		 * for the last parameter. That avoids an ipcache lookup.
 		 */
-		ret = ipv4_host_policy_egress(ctx, HOST_ID, 0, ip4, &trace, ext_err);
+		ret = ipv4_host_policy_egress(ctx, false, HOST_ID, 0, ip4, &trace, ext_err);
 		break;
 	case bpf_htons(ETH_P_ARP):
 		ret = CTX_ACT_OK;

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -18,6 +18,34 @@
 #include "proxy.h"
 #include "trace.h"
 
+static __always_inline bool
+need_apply_host_policy_egress(bool is_host_id, bool is_from_proxy)
+{
+	/* Some pod-originating traffic may have a host IP as source IP
+	 * (eg. non-transparent proxy connection, or when using iptables masquerading).
+	 * The response packet will therefore have a host IP as the destination IP.
+	 *
+	 * We don't want to apply egress policy for such packets. But
+	 * to avoid enforcing host policies for response packets to pods, we
+	 * need to create a CT entry for the forward, SNATed packet from the
+	 * pod. Response packets will thus match this CT entry and bypass host
+	 * policies.
+	 * We know the packet is a SNATed packet if the srcid from ipcache is
+	 * HOST_ID, but the actual srcid (derived from the packet mark) isn't.
+	 */
+	if (!is_host_id)
+		return false;
+
+	/* Host packets sent by proxy in response to host requests have had host policy
+	 * already applied to them. We don't want to apply host policy to them again,
+	 * as it creates redirect loops and prevents responses from reaching the proxy.
+	 */
+	if (is_from_proxy)
+		return false;
+
+	return true;
+}
+
 # ifdef ENABLE_IPV6
 static __always_inline bool
 ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
@@ -54,7 +82,7 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 }
 
 static __always_inline int
-__ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
+__ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_proxy,
 			  struct ipv6hdr *ip6, struct ct_buffer6 *ct_buffer,
 			  struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -67,6 +95,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 	__u32 dst_sec_identity = 0;
 	__u16 proxy_port = 0;
 	__u32 cookie = 0;
+	bool apply_policy;
 
 	trace->monitor = ct_buffer->monitor;
 	trace->reason = (enum trace_reason)ret;
@@ -75,7 +104,8 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 	if (ret == CT_REPLY || ret == CT_RELATED)
 		return CTX_ACT_OK;
 
-	if (is_host_id) {
+	apply_policy = need_apply_host_policy_egress(is_host_id, is_from_proxy);
+	if (apply_policy) {
 		const struct remote_endpoint_info *info;
 		__u32 tunnel_endpoint = 0;
 
@@ -118,7 +148,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 			return ret;
 	}
 
-	if (is_host_id) {
+	if (apply_policy) {
 		/* Emit verdict if drop or if allow for CT_NEW. */
 		if (verdict != CTX_ACT_OK || ret != CT_ESTABLISHED)
 			send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
@@ -139,7 +169,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 }
 
 static __always_inline int
-ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
+ipv6_host_policy_egress(struct __ctx_buff *ctx,  bool is_from_proxy, __u32 src_id,
 			__u32 ipcache_srcid, struct ipv6hdr *ip6,
 			struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -150,7 +180,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	if (ct_buffer.ret < 0)
 		return ct_buffer.ret;
 
-	return __ipv6_host_policy_egress(ctx, src_id == HOST_ID,
+	return __ipv6_host_policy_egress(ctx, src_id == HOST_ID, is_from_proxy,
 					ip6, &ct_buffer, trace, ext_err);
 }
 
@@ -324,7 +354,7 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 }
 
 static __always_inline int
-__ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
+__ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_proxy,
 			  struct iphdr *ip4, struct ct_buffer4 *ct_buffer,
 			  struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -337,6 +367,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 	__u32 dst_sec_identity = 0;
 	__u16 proxy_port = 0;
 	__u32 cookie = 0;
+	bool apply_policy;
 
 	trace->monitor = ct_buffer->monitor;
 	trace->reason = (enum trace_reason)ret;
@@ -345,20 +376,8 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 	if (ret == CT_REPLY || ret == CT_RELATED)
 		return CTX_ACT_OK;
 
-	/* Some pod-originating traffic may have a host IP as source IP
-	 * (eg. non-transparent proxy connection, or when using iptables masquerading).
-	 * The response packet will therefore have a host IP as the destination IP.
-	 *
-	 * We don't want to apply egress policy for such packets. But
-	 * to avoid enforcing host policies for response packets to pods, we
-	 * need to create a CT entry for the forward, SNATed packet from the
-	 * pod. Response packets will thus match this CT entry and bypass host
-	 * policies.
-	 * We know the packet is a SNATed packet if the srcid from ipcache is
-	 * HOST_ID, but the actual srcid (derived from the packet mark) isn't.
-	 */
-
-	if (is_host_id) {
+	apply_policy = need_apply_host_policy_egress(is_host_id, is_from_proxy);
+	if (apply_policy) {
 		const struct remote_endpoint_info *info;
 		__u32 tunnel_endpoint = 0;
 
@@ -401,7 +420,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 			return ret;
 	}
 
-	if (is_host_id) {
+	if (apply_policy) {
 		/* Emit verdict if drop or if allow for CT_NEW. */
 		if (verdict != CTX_ACT_OK || ret != CT_ESTABLISHED)
 			send_policy_verdict_notify(ctx, dst_sec_identity, tuple->dport,
@@ -422,7 +441,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id,
 }
 
 static __always_inline int
-ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
+ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_id,
 			__u32 ipcache_srcid, struct iphdr *ip4,
 			struct trace_ctx *trace, __s8 *ext_err)
 {
@@ -433,7 +452,8 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	if (ct_buffer.ret < 0)
 		return ct_buffer.ret;
 
-	return __ipv4_host_policy_egress(ctx, src_id == HOST_ID, ip4, &ct_buffer, trace, ext_err);
+	return __ipv4_host_policy_egress(ctx, src_id == HOST_ID, is_from_proxy,
+					ip4, &ct_buffer, trace, ext_err);
 }
 
 static __always_inline bool

--- a/bpf/tests/host_proxy.c
+++ b/bpf/tests/host_proxy.c
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_HOST_FIREWALL		1
+#define ENABLE_IPV4			1
+
+#define NODE_IP				v4_node_one
+#define NODE_PORT			bpf_htons(50000)
+#define NODE_PROXY_PORT			bpf_htons(50001)
+
+#define TPROXY_PORT			bpf_htons(11111)
+
+#define SERVER_IP			v4_ext_one
+#define SERVER_PORT			bpf_htons(53)
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *server_mac = mac_two;
+
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+static __always_inline
+int host_proxy_v4_udp_pktgen(struct __ctx_buff *ctx, __be16 node_port)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)node_mac, (__u8 *)server_mac,
+					   NODE_IP, SERVER_IP,
+					   node_port, SERVER_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+PKTGEN("tc", "host_proxy_v4_1_udp")
+int host_proxy_v4_1_udp_pktgen(struct __ctx_buff *ctx)
+{
+	return host_proxy_v4_udp_pktgen(ctx, NODE_PORT);
+}
+
+SETUP("tc", "host_proxy_v4_1_udp")
+int host_proxy_v4_1_udp_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+	policy_add_entry(true, WORLD_ID, IPPROTO_UDP, SERVER_PORT, 0, false, TPROXY_PORT);
+
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "host_proxy_v4_1_udp")
+int host_proxy_v4_1_udp_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	/* Check whether BPF created a CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+	assert(ct_entry->proxy_redirect);
+
+	test_finish();
+}
+
+PKTGEN("tc", "host_proxy_v4_2_udp")
+int host_proxy_v4_2_udp_pktgen(struct __ctx_buff *ctx)
+{
+	return host_proxy_v4_udp_pktgen(ctx, NODE_PROXY_PORT);
+}
+
+SETUP("tc", "host_proxy_v4_2_udp")
+int host_proxy_v4_2_udp_setup(struct __ctx_buff *ctx)
+{
+	set_identity_mark(ctx, HOST_ID, MARK_MAGIC_PROXY_EGRESS);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "host_proxy_v4_2_udp")
+int host_proxy_v4_2_udp_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check whether BPF created a CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_PROXY_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+	assert(!ct_entry->proxy_redirect);
+
+	/* Check that the original CT entry was not hit */
+	tuple.sport = NODE_PORT;
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+
+	policy_delete_entry(true, WORLD_ID, IPPROTO_UDP, SERVER_PORT, 0);
+
+	test_finish();
+}

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -42,7 +42,7 @@ policy_delete_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
 
 static __always_inline void
 policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
-		 __u8 port_range, bool deny)
+		 __u8 port_range, bool deny, __be16 proxy_port)
 {
 	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport, port_range);
 	/* Start with an exact L3/L4 policy, and wildcard it as determined above: */
@@ -59,6 +59,7 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
 	struct policy_entry value = {
 		.deny = deny,
 		.lpm_prefix_length = value_prefix_len,
+		.proxy_port = proxy_port,
 	};
 
 	map_update_elem(&cilium_policy_v2, &key, &value, BPF_ANY);
@@ -68,26 +69,26 @@ static __always_inline void
 policy_add_ingress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport,
 				     __u8 port_range)
 {
-	policy_add_entry(false, sec_label, protocol, dport, port_range, false);
+	policy_add_entry(false, sec_label, protocol, dport, port_range, false, 0);
 }
 
 static __always_inline void
 policy_add_ingress_deny_l4_entry(__u8 protocol, __u16 dport, __u8 port_range)
 {
-	policy_add_entry(false, 0, protocol, dport, port_range, true);
+	policy_add_entry(false, 0, protocol, dport, port_range, true, 0);
 }
 
 static __always_inline void
 policy_add_ingress_deny_all_entry(void)
 {
-	policy_add_entry(false, 0, 0, 0, 0, true);
+	policy_add_entry(false, 0, 0, 0, 0, true, 0);
 }
 
 static __always_inline void
 policy_add_egress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport,
 				    __u8 port_range)
 {
-	policy_add_entry(true, sec_label, protocol, dport, port_range, false);
+	policy_add_entry(true, sec_label, protocol, dport, port_range, false, 0);
 }
 
 static __always_inline void
@@ -109,7 +110,7 @@ static __always_inline void policy_add_egress_allow_all_entry(void)
 
 static __always_inline void policy_add_egress_deny_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, 0, true);
+	policy_add_entry(true, 0, 0, 0, 0, true, 0);
 }
 
 static __always_inline void

--- a/bpf/tests/lxc_extended_protocols.c
+++ b/bpf/tests/lxc_extended_protocols.c
@@ -250,7 +250,7 @@ int lxc_igmp_egress_policy_deny_setup(struct __ctx_buff *ctx)
 			      0, (__u8 *)client_mac, (__u8 *)client_mac);
 	ipcache_v4_add_entry(CLIENT_IP, 0, LXC_ID, 0, 0);
 	ipcache_v4_add_world_entry();
-	policy_add_entry(true, 0, IPPROTO_IGMP, 0, 0, true);
+	policy_add_entry(true, 0, IPPROTO_IGMP, 0, 0, true, 0);
 
 	/* Set identity mark for the source pod */
 	set_identity_mark(ctx, LXC_ID, MARK_MAGIC_IDENTITY);


### PR DESCRIPTION
This PR restores host L7 policy functionality accidentally broken by commit 7fb6f41, which caused the BPF stack to re-apply host egress policy to packets egressing from the proxy, creating redirect loops and preventing remote responses from reaching the proxy due to missing CT table entries. The companion PR https://github.com/cilium/cilium/pull/45026 adds a connectivity test for host L7 policy functionality.