### PR TITLE
k8s/synced: allow multiple subsystems to register CRDs to wait for

### DIFF
--- a/clustermesh-apiserver/clustermesh/cells.go
+++ b/clustermesh-apiserver/clustermesh/cells.go
@@ -45,7 +45,9 @@ var Cell = cell.Module(
 	synced.Cell,
 
 	// Provide CRD resource names for 'synced.CRDSyncCell' below.
-	cell.Provide(func() synced.CRDSyncResourceNames { return synced.ClusterMeshAPIServerResourceNames() }),
+	cell.Provide(func() synced.CRDSyncResourceNamesOut {
+		return synced.NewCRDSyncResourceNamesOut(synced.ClusterMeshAPIServerResourceNames()...)
+	}),
 
 	// CRDSyncCell provides a promise that is resolved as soon as CRDs used by the
 	// clustermesh-apiserver have synced.

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -153,7 +153,9 @@ var (
 		store.Cell,
 
 		// Provide CRD resource names for 'k8sSynced.CRDSyncCell' below.
-		cell.Provide(func() k8sSynced.CRDSyncResourceNames { return k8sSynced.AgentCRDResourceNames() }),
+		cell.Provide(func() k8sSynced.CRDSyncResourceNamesOut {
+			return k8sSynced.NewCRDSyncResourceNamesOut(k8sSynced.AgentCRDResourceNames()...)
+		}),
 
 		// CRDSyncCell provides a promise that is resolved as soon as CRDs used by the
 		// agent have k8sSynced.

--- a/pkg/k8s/synced/cell.go
+++ b/pkg/k8s/synced/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -69,8 +70,24 @@ func (def CRDSyncConfig) Flags(flags *pflag.FlagSet) {
 // promise Reject to the result of the promise Await() call.
 type CRDSync struct{}
 
-// CRDSyncResourceNames is a slice of CRD resource names CRDSync promise waits for
-type CRDSyncResourceNames []string
+// CRDSyncResourceName represents a CRD resource name CRDSync promise waits for
+type CRDSyncResourceName string
+
+// CRDSyncResourceNamesOut is a utility struct for providing a list of [CRDSyncResourceName] to the hive.
+type CRDSyncResourceNamesOut struct {
+	cell.Out
+
+	Names []CRDSyncResourceName `group:"crd-sync-resource-names,flatten"`
+}
+
+func NewCRDSyncResourceNamesOut(names ...string) (out CRDSyncResourceNamesOut) {
+	out.Names = slices.Map(names,
+		func(name string) CRDSyncResourceName {
+			return CRDSyncResourceName(name)
+		},
+	)
+	return out
+}
 
 var ErrCRDSyncDisabled = errors.New("CRDSync promise is disabled")
 
@@ -90,7 +107,7 @@ type syncCRDsPromiseParams struct {
 	Clientset     client.Clientset
 	Resources     *Resources
 	APIGroups     *APIGroups
-	ResourceNames CRDSyncResourceNames
+	ResourceNames []CRDSyncResourceName `group:"crd-sync-resource-names"`
 	Config        CRDSyncConfig
 }
 
@@ -102,7 +119,8 @@ func newCRDSyncPromise(params syncCRDsPromiseParams) promise.Promise[CRDSync] {
 	}
 
 	params.JobGroup.Add(job.OneShot("sync-crds", func(ctx context.Context, health cell.Health) error {
-		err := SyncCRDs(ctx, params.Logger, params.Clientset, params.ResourceNames, params.Resources, params.APIGroups, params.Config)
+		names := slices.Map(params.ResourceNames, func(in CRDSyncResourceName) string { return string(in) })
+		err := SyncCRDs(ctx, params.Logger, params.Clientset, names, params.Resources, params.APIGroups, params.Config)
 		if err != nil {
 			crdSyncResolver.Reject(err)
 		} else {


### PR DESCRIPTION
Currently, the logic constructing the [CRDSync] promise expects a single list of resource names to wait for. Let's relax this constraint, and allow multiple subsystems to register the set of resource names that should be waited for, to allow for additional flexibility.
