### PR TITLE
[envoy] Add HTTP CONNECT support

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -411,6 +411,8 @@ jobs:
             CILIUM_INSTALL_MULTIPOOL_IPAM_CLUSTER2="--helm-set=ipMasqAgent.enabled=true \
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.cidrs='{11.10.0.0/16}' \
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.maskSize=24 \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.cidrs='{11.20.0.0/16}' \
+              --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.maskSize=24 \
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{192.168.16.0/24}' \
               --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
           fi

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -83,6 +83,9 @@ var (
 	//go:embed manifests/client-egress-l7-http.yaml
 	clientEgressL7HTTPPolicyYAML string
 
+	//go:embed manifests/client-egress-l7-http-connect.yaml
+	clientEgressL7HTTPConnectPolicyYAML string
+
 	//go:embed manifests/client-egress-l7-http-port-range.yaml
 	clientEgressL7HTTPPolicyPortRangeYAML string
 
@@ -311,6 +314,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientEgressL7Method{},
 		clientEgressL7{},
 		clientEgressL7NamedPort{},
+		clientEgressL7Connect{},
 		clientEgressTlsSni{},
 		clientEgressL7SetHeader{},
 		echoIngressAuthAlwaysFail{},
@@ -371,6 +375,7 @@ func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Par
 		"clientEgressToCIDRGroupExternalDenyLabelPolicyYAML":         clientEgressToCIDRGroupExternalDenyLabelPolicyYAML,
 		"clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML": clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML,
 		"clientEgressL7HTTPPolicyYAML":                               clientEgressL7HTTPPolicyYAML,
+		"clientEgressL7HTTPConnectPolicyYAML":                        clientEgressL7HTTPConnectPolicyYAML,
 		"clientEgressL7HTTPPolicyPortRangeYAML":                      clientEgressL7HTTPPolicyPortRangeYAML,
 		"clientEgressL7HTTPNamedPortPolicyYAML":                      clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                              clientEgressToFQDNsPolicyYAML,

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -83,6 +83,9 @@ var (
 	//go:embed manifests/client-egress-l7-http.yaml
 	clientEgressL7HTTPPolicyYAML string
 
+	//go:embed manifests/client-egress-l7-http-connect.yaml
+	clientEgressL7HTTPConnectPolicyYAML string
+
 	//go:embed manifests/client-egress-l7-http-port-range.yaml
 	clientEgressL7HTTPPolicyPortRangeYAML string
 
@@ -317,6 +320,7 @@ func concurrentTests(connTests []*check.ConnectivityTest) error {
 		clientEgressL7Method{},
 		clientEgressL7{},
 		clientEgressL7NamedPort{},
+		clientEgressL7Connect{},
 		clientEgressTlsSni{},
 		clientEgressL7SetHeader{},
 		echoIngressAuthAlwaysFail{},
@@ -378,6 +382,7 @@ func renderTemplates(clusterNameLocal, clusterNameRemote string, param check.Par
 		"clientEgressToCIDRGroupExternalDenyLabelPolicyYAML":         clientEgressToCIDRGroupExternalDenyLabelPolicyYAML,
 		"clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML": clientEgressToCIDRGroupExternalDenyLabelPolicyV2Alpha1YAML,
 		"clientEgressL7HTTPPolicyYAML":                               clientEgressL7HTTPPolicyYAML,
+		"clientEgressL7HTTPConnectPolicyYAML":                        clientEgressL7HTTPConnectPolicyYAML,
 		"clientEgressL7HTTPPolicyPortRangeYAML":                      clientEgressL7HTTPPolicyPortRangeYAML,
 		"clientEgressL7HTTPNamedPortPolicyYAML":                      clientEgressL7HTTPNamedPortPolicyYAML,
 		"clientEgressToFQDNsPolicyYAML":                              clientEgressToFQDNsPolicyYAML,

--- a/cilium-cli/connectivity/builder/client_egress_l7_connect.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_connect.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressL7Connect struct{}
+
+func (t clientEgressL7Connect) build(ct *check.ConnectivityTest, templates map[string]string) {
+	// Test L7 HTTP CONNECT support using an egress policy on the clients.
+	// This verifies that Envoy correctly forwards CONNECT requests when
+	// L7 HTTP policies are active (issue #24276).
+	newTest("client-egress-l7-http-connect", ct).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithCiliumPolicy(templates["clientEgressL7HTTPConnectPolicyYAML"]).
+		WithScenarios(tests.PodToPodConnect()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") &&
+				a.Destination().Port() == 8080 {
+				egress = check.ResultOK
+				egress.HTTP = check.HTTP{
+					Method: "CONNECT",
+				}
+				return egress, check.ResultNone
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_l7_connect.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_connect.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressL7Connect struct{}
+
+func (t clientEgressL7Connect) build(ct *check.ConnectivityTest, templates map[string]string) {
+	// The upstream HTTP proxy terminates CONNECT. Cilium enforces policy on the
+	// handshake, then passes the upgraded connection through as raw TCP.
+	newTest("client-egress-l7-http-connect", ct).
+		WithCiliumVersion(">=1.21.0").
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithResources(templates["clientEgressL7HTTPConnectPolicyYAML"]).
+		WithSetupFunc(func(ctx context.Context, _ *check.Test, ct *check.ConnectivityTest) error {
+			if err := check.WaitForDeployment(ctx, ct, ct.K8sClient(), ct.Params().TestNamespace, tests.HTTPConnectProxyName); err != nil {
+				return err
+			}
+
+			service, err := check.WaitForServiceRetrieval(ctx, ct, ct.K8sClient(), ct.Params().TestNamespace, tests.HTTPConnectProxyName)
+			if err != nil {
+				return err
+			}
+
+			clientNodes := make(map[string]struct{})
+			for _, client := range ct.ClientPods() {
+				clientNodes[client.NodeName()] = struct{}{}
+			}
+
+			for _, agent := range ct.CiliumPods() {
+				if _, ok := clientNodes[agent.NodeName()]; !ok {
+					continue
+				}
+				if err := check.WaitForServiceEndpoints(ctx, ct, agent, service, 1, ct.Features.IPFamilies()); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}).
+		WithScenarios(tests.PodToPodConnect(
+			tests.WithRetryCondition(tests.WithRetryAll()),
+		)).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") &&
+				a.Destination().HasLabel("kind", tests.HTTPConnectProxyName) &&
+				a.Destination().Port() == 8080 {
+				egress = check.ResultOK
+				egress.HTTP = check.HTTP{
+					Method: "CONNECT",
+				}
+				return egress, check.ResultNone
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/client_egress_l7_connect.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_connect.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+type clientEgressL7Connect struct{}
+
+func (t clientEgressL7Connect) build(ct *check.ConnectivityTest, templates map[string]string) {
+	// The upstream HTTP proxy terminates CONNECT. Cilium enforces policy on the
+	// handshake, then passes the upgraded connection through as raw TCP.
+	newTest("client-egress-l7-http-connect", ct).
+		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
+		WithResources(templates["clientEgressL7HTTPConnectPolicyYAML"]).
+		WithSetupFunc(func(ctx context.Context, _ *check.Test, ct *check.ConnectivityTest) error {
+			return check.WaitForDeployment(ctx, ct, ct.K8sClient(), ct.Params().TestNamespace, tests.HTTPConnectProxyName)
+		}).
+		WithScenarios(tests.PodToPodConnect()).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			if a.Source().HasLabel("other", "client") &&
+				a.Destination().HasLabel("kind", tests.HTTPConnectProxyName) &&
+				a.Destination().Port() == 8080 {
+				egress = check.ResultOK
+				egress.HTTP = check.HTTP{
+					Method: "CONNECT",
+				}
+				return egress, check.ResultNone
+			}
+			return check.ResultDefaultDenyEgressDrop, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-connect.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-connect.yaml
@@ -1,0 +1,26 @@
+---
+# client2 is allowed to make HTTP requests to echo pods, including CONNECT.
+# This policy enables L7 HTTP introspection on the client2 egress path.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-l7-http-connect
+spec:
+  description: "Allow HTTP (including CONNECT) from client2 to echo pods"
+  endpointSelector:
+    matchLabels:
+      other: client
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        kind: echo
+      matchExpressions:
+      - { key: 'io.cilium.k8s.policy.cluster', operator: In, values: [ "{{.ClusterNameLocal}}", "{{.ClusterNameRemote}}" ] }
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "GET"
+        - method: "CONNECT"

--- a/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-connect.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-l7-http-connect.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: http-connect-proxy
+  namespace: cilium-test
+data:
+  proxy.js: |
+    const http = require("http");
+    const net = require("net");
+
+    const server = http.createServer((request, response) => {
+      if (request.url === "/healthz") {
+        response.writeHead(200);
+        response.end("ok");
+        return;
+      }
+      response.writeHead(405);
+      response.end();
+    });
+
+    server.on("connect", (request, downstream, head) => {
+      let target;
+      try {
+        target = new URL(`http://${request.url}`);
+      } catch (_) {
+        downstream.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+        return;
+      }
+
+      const host = target.hostname.replace(/^\[|\]$/g, "");
+      const port = Number(target.port || 80);
+      const upstream = net.connect({ host, port }, () => {
+        downstream.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (head.length > 0) {
+          upstream.write(head);
+        }
+        downstream.pipe(upstream);
+        upstream.pipe(downstream);
+      });
+
+      upstream.on("error", () => {
+        if (!downstream.destroyed) {
+          downstream.end("HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+        }
+      });
+      downstream.on("error", () => upstream.destroy());
+    });
+
+    server.requestTimeout = 0;
+    server.listen(8080);
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http-connect-proxy
+  namespace: cilium-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: http-connect-proxy
+  template:
+    metadata:
+      labels:
+        kind: http-connect-proxy
+        name: http-connect-proxy
+    spec:
+      containers:
+      - name: http-connect-proxy
+        image: "{{.JSONMockImage}}"
+        command: ["node", "/proxy/proxy.js"]
+        ports:
+        - name: http
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+          periodSeconds: 1
+        volumeMounts:
+        - name: proxy-script
+          mountPath: /proxy
+          readOnly: true
+      volumes:
+      - name: proxy-script
+        configMap:
+          name: http-connect-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-connect-proxy
+  namespace: cilium-test
+  labels:
+    kind: http-connect-proxy
+spec:
+  ipFamilyPolicy: PreferDualStack
+  selector:
+    name: http-connect-proxy
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: client-egress-l7-http-connect
+  namespace: cilium-test
+spec:
+  description: "Allow client2 to establish tunnels through the HTTP proxy"
+  endpointSelector:
+    matchLabels:
+      other: client
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        kind: http-connect-proxy
+    toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      rules:
+        http:
+        - method: "CONNECT"

--- a/cilium-cli/connectivity/tests/connect.go
+++ b/cilium-cli/connectivity/tests/connect.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+// PodToPodConnect generates an HTTP CONNECT request from each client pod
+// to each echo (server) pod in the test context. This validates that
+// Envoy correctly forwards CONNECT requests when L7 HTTP policies are active,
+// rather than rejecting them with 400/404 errors.
+func PodToPodConnect() check.Scenario {
+	return &podToPodConnect{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+type podToPodConnect struct {
+	check.ScenarioBase
+}
+
+func (s *podToPodConnect) Name() string {
+	return "pod-to-pod-connect"
+}
+
+func (s *podToPodConnect) Run(ctx context.Context, t *check.Test) {
+	var i int
+	ct := t.Context()
+
+	for _, client := range ct.ClientPods() {
+		if !client.HasLabel("other", "client") {
+			continue
+		}
+		for _, echo := range ct.EchoPods() {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
+					a.ExecInPod(ctx, a.CurlCommand(echo, "-X", "CONNECT"))
+
+					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
+					a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{}))
+				})
+			})
+
+			i++
+		}
+	}
+}

--- a/cilium-cli/connectivity/tests/connect.go
+++ b/cilium-cli/connectivity/tests/connect.go
@@ -6,6 +6,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -40,7 +41,8 @@ func (s *podToPodConnect) Run(ctx context.Context, t *check.Test) {
 		for _, echo := range ct.EchoPods() {
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, echo, ipFam).Run(func(a *check.Action) {
-					a.ExecInPod(ctx, a.CurlCommand(echo, "-X", "CONNECT"))
+					proxyURL := fmt.Sprintf("%s://%s", echo.Scheme(), net.JoinHostPort(echo.Address(ipFam), fmt.Sprint(echo.Port())))
+					a.ExecInPod(ctx, a.CurlCommand(echo, "--proxytunnel", "-x", proxyURL))
 
 					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{}))
 					a.ValidateFlows(ctx, echo, a.GetIngressRequirements(check.FlowParameters{}))

--- a/cilium-cli/connectivity/tests/connect.go
+++ b/cilium-cli/connectivity/tests/connect.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+const HTTPConnectProxyName = "http-connect-proxy"
+
+// PodToPodConnect tunnels an HTTP request to each echo pod through an HTTP
+// proxy. The proxy, rather than Cilium Envoy, terminates CONNECT and establishes
+// the upstream connection.
+func PodToPodConnect() check.Scenario {
+	return &podToPodConnect{
+		ScenarioBase: check.NewScenarioBase(),
+	}
+}
+
+type podToPodConnect struct {
+	check.ScenarioBase
+}
+
+func (s *podToPodConnect) Name() string {
+	return "pod-to-pod-connect"
+}
+
+func (s *podToPodConnect) Run(ctx context.Context, t *check.Test) {
+	var i int
+	ct := t.Context()
+	proxyService, err := ct.K8sClient().GetService(ctx, ct.Params().TestNamespace, HTTPConnectProxyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get HTTP CONNECT proxy service: %s", err)
+		return
+	}
+	proxy := check.Service{Service: proxyService}
+	proxyPods, err := ct.K8sClient().ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{
+		LabelSelector: "kind=" + HTTPConnectProxyName,
+	})
+	if err != nil {
+		t.Fatalf("failed to list HTTP CONNECT proxy pods: %s", err)
+		return
+	}
+	if len(proxyPods.Items) != 1 {
+		t.Fatalf("expected one HTTP CONNECT proxy pod, found %d", len(proxyPods.Items))
+		return
+	}
+	proxyPod := check.Pod{Pod: &proxyPods.Items[0]}
+
+	for _, client := range ct.ClientPods() {
+		if !client.HasLabel("other", "client") {
+			continue
+		}
+		for _, echo := range ct.EchoPods() {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, proxy, ipFam).Run(func(a *check.Action) {
+					proxyURL := fmt.Sprintf("%s://%s", proxy.Scheme(), net.JoinHostPort(proxy.Address(ipFam), fmt.Sprint(proxy.Port())))
+					a.ExecInPod(ctx, a.CurlCommand(echo, "--proxytunnel", "-x", proxyURL))
+
+					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+						AltDstIP: proxyPod.Address(ipFam),
+					}))
+				})
+			})
+
+			i++
+		}
+	}
+}

--- a/cilium-cli/connectivity/tests/connect.go
+++ b/cilium-cli/connectivity/tests/connect.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+const HTTPConnectProxyName = "http-connect-proxy"
+
+// PodToPodConnect tunnels an HTTP request to each echo pod through an HTTP
+// proxy. The proxy, rather than Cilium Envoy, terminates CONNECT and establishes
+// the upstream connection.
+func PodToPodConnect(opts ...Option) check.Scenario {
+	options := &labelsOption{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	rc := &retryCondition{}
+	for _, opt := range options.retryCondition {
+		opt(rc)
+	}
+
+	return &podToPodConnect{
+		ScenarioBase:   check.NewScenarioBase(),
+		retryCondition: rc,
+	}
+}
+
+type podToPodConnect struct {
+	check.ScenarioBase
+
+	retryCondition *retryCondition
+}
+
+func (s *podToPodConnect) Name() string {
+	return "pod-to-pod-connect"
+}
+
+func (s *podToPodConnect) Run(ctx context.Context, t *check.Test) {
+	var i int
+	ct := t.Context()
+	proxyService, err := ct.K8sClient().GetService(ctx, ct.Params().TestNamespace, HTTPConnectProxyName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get HTTP CONNECT proxy service: %s", err)
+		return
+	}
+	proxy := check.Service{Service: proxyService}
+	proxyPods, err := ct.K8sClient().ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{
+		LabelSelector: "kind=" + HTTPConnectProxyName,
+	})
+	if err != nil {
+		t.Fatalf("failed to list HTTP CONNECT proxy pods: %s", err)
+		return
+	}
+	if len(proxyPods.Items) != 1 {
+		t.Fatalf("expected one HTTP CONNECT proxy pod, found %d", len(proxyPods.Items))
+		return
+	}
+	proxyPod := check.Pod{Pod: &proxyPods.Items[0]}
+
+	for _, client := range ct.ClientPods() {
+		if !client.HasLabel("other", "client") {
+			continue
+		}
+		for _, echo := range ct.EchoPods() {
+			t.ForEachIPFamily(func(ipFam features.IPFamily) {
+				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, proxy, ipFam).Run(func(a *check.Action) {
+					proxyURL := fmt.Sprintf("%s://%s", proxy.Scheme(), net.JoinHostPort(proxy.Address(ipFam), fmt.Sprint(proxy.Port())))
+					opts := s.retryCondition.CurlOptions(proxy, ipFam, client, ct.Params(), a.ExpectingSuccess())
+					opts = append(opts, "--proxytunnel", "-x", proxyURL)
+					a.ExecInPod(ctx, a.CurlCommand(echo, opts...))
+
+					a.ValidateFlows(ctx, client, a.GetEgressRequirements(check.FlowParameters{
+						AltDstIP: proxyPod.Address(ipFam),
+					}))
+				})
+			})
+
+			i++
+		}
+	}
+}

--- a/pkg/envoy/model.go
+++ b/pkg/envoy/model.go
@@ -993,6 +993,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 		StatPrefix: "proxy",
 		UpgradeConfigs: []*envoy_config_http.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
+			{UpgradeType: "CONNECT"},
 		},
 		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:     true,
@@ -1017,6 +1018,23 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 					Name:    "default_route",
 					Domains: []string{"*"},
 					Routes: []*envoy_config_route.Route{{
+						Match: &envoy_config_route.RouteMatch{
+							PathSpecifier: &envoy_config_route.RouteMatch_ConnectMatcher_{
+								ConnectMatcher: &envoy_config_route.RouteMatch_ConnectMatcher{},
+							},
+						},
+						Action: &envoy_config_route.Route_Route{
+							Route: &envoy_config_route.RouteAction{
+								ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
+									Cluster: clusterName,
+								},
+								UpgradeConfigs: []*envoy_config_route.RouteAction_UpgradeConfig{{
+									UpgradeType:   "CONNECT",
+									ConnectConfig: &envoy_config_route.RouteAction_UpgradeConfig_ConnectConfig{},
+								}},
+							},
+						},
+					}, {
 						Match: &envoy_config_route.RouteMatch{
 							PathSpecifier: &envoy_config_route.RouteMatch_Prefix{Prefix: "/"},
 							Grpc:          &envoy_config_route.RouteMatch_GrpcRouteMatchOptions{},
@@ -1069,7 +1087,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 
 	// Idle timeout can only be specified if non-zero
 	if idleTimeout > 0 {
-		hcmConfig.GetRouteConfig().VirtualHosts[0].Routes[1].GetRoute().IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
+		hcmConfig.GetRouteConfig().VirtualHosts[0].Routes[2].GetRoute().IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
 	}
 
 	chain := &envoy_config_listener.FilterChain{

--- a/pkg/envoy/model.go
+++ b/pkg/envoy/model.go
@@ -1028,6 +1028,9 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 								ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
 									Cluster: clusterName,
 								},
+								// HCM-level CONNECT support only allows Envoy to parse CONNECT requests.
+								// Route-level ConnectConfig makes the router establish a tunnel instead of
+								// forwarding CONNECT upstream as a normal HTTP request.
 								UpgradeConfigs: []*envoy_config_route.RouteAction_UpgradeConfig{{
 									UpgradeType:   "CONNECT",
 									ConnectConfig: &envoy_config_route.RouteAction_UpgradeConfig_ConnectConfig{},

--- a/pkg/envoy/model.go
+++ b/pkg/envoy/model.go
@@ -985,10 +985,29 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 		xffNumTrustedHops = config.proxyXffNumTrustedHopsIngress
 	}
 
+	newHTTPRouteAction := func() *envoy_config_route.RouteAction {
+		action := &envoy_config_route.RouteAction{
+			ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
+				Cluster: clusterName,
+			},
+			Timeout: &durationpb.Duration{Seconds: requestTimeout},
+			RetryPolicy: &envoy_config_route.RetryPolicy{
+				RetryOn:       "5xx",
+				NumRetries:    &wrapperspb.UInt32Value{Value: numRetries},
+				PerTryTimeout: &durationpb.Duration{Seconds: retryTimeout},
+			},
+		}
+		if idleTimeout > 0 {
+			action.IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
+		}
+		return action
+	}
+
 	hcmConfig := &envoy_config_http.HttpConnectionManager{
 		StatPrefix: "proxy",
 		UpgradeConfigs: []*envoy_config_http.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
+			{UpgradeType: "CONNECT"},
 		},
 		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:     true,
@@ -1013,6 +1032,16 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 					Name:    "default_route",
 					Domains: []string{"*"},
 					Routes: []*envoy_config_route.Route{{
+						// CONNECT requests have no path, so they need a dedicated route matcher.
+						Match: &envoy_config_route.RouteMatch{
+							PathSpecifier: &envoy_config_route.RouteMatch_ConnectMatcher_{
+								ConnectMatcher: &envoy_config_route.RouteMatch_ConnectMatcher{},
+							},
+						},
+						Action: &envoy_config_route.Route_Route{
+							Route: newHTTPRouteAction(),
+						},
+					}, {
 						Match: &envoy_config_route.RouteMatch{
 							PathSpecifier: &envoy_config_route.RouteMatch_Prefix{Prefix: "/"},
 							Grpc:          &envoy_config_route.RouteMatch_GrpcRouteMatchOptions{},
@@ -1038,18 +1067,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 							PathSpecifier: &envoy_config_route.RouteMatch_Prefix{Prefix: "/"},
 						},
 						Action: &envoy_config_route.Route_Route{
-							Route: &envoy_config_route.RouteAction{
-								ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
-									Cluster: clusterName,
-								},
-								Timeout: &durationpb.Duration{Seconds: requestTimeout},
-								// IdleTimeout: &durationpb.Duration{Seconds: idleTimeout},
-								RetryPolicy: &envoy_config_route.RetryPolicy{
-									RetryOn:       "5xx",
-									NumRetries:    &wrapperspb.UInt32Value{Value: numRetries},
-									PerTryTimeout: &durationpb.Duration{Seconds: retryTimeout},
-								},
-							},
+							Route: newHTTPRouteAction(),
 						},
 					}},
 				}},
@@ -1061,11 +1079,6 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 		hcmConfig.NormalizePath = &wrapperspb.BoolValue{Value: true}
 		hcmConfig.MergeSlashes = true
 		hcmConfig.PathWithEscapedSlashesAction = envoy_config_http.HttpConnectionManager_UNESCAPE_AND_REDIRECT
-	}
-
-	// Idle timeout can only be specified if non-zero
-	if idleTimeout > 0 {
-		hcmConfig.GetRouteConfig().VirtualHosts[0].Routes[1].GetRoute().IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
 	}
 
 	chain := &envoy_config_listener.FilterChain{

--- a/pkg/envoy/model.go
+++ b/pkg/envoy/model.go
@@ -993,6 +993,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 		StatPrefix: "proxy",
 		UpgradeConfigs: []*envoy_config_http.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
+			{UpgradeType: "CONNECT"},
 		},
 		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:     true,
@@ -1017,6 +1018,19 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 					Name:    "default_route",
 					Domains: []string{"*"},
 					Routes: []*envoy_config_route.Route{{
+						Match: &envoy_config_route.RouteMatch{
+							PathSpecifier: &envoy_config_route.RouteMatch_ConnectMatcher_{
+								ConnectMatcher: &envoy_config_route.RouteMatch_ConnectMatcher{},
+							},
+						},
+						Action: &envoy_config_route.Route_Route{
+							Route: &envoy_config_route.RouteAction{
+								ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
+									Cluster: clusterName,
+								},
+							},
+						},
+					}, {
 						Match: &envoy_config_route.RouteMatch{
 							PathSpecifier: &envoy_config_route.RouteMatch_Prefix{Prefix: "/"},
 							Grpc:          &envoy_config_route.RouteMatch_GrpcRouteMatchOptions{},
@@ -1069,7 +1083,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 
 	// Idle timeout can only be specified if non-zero
 	if idleTimeout > 0 {
-		hcmConfig.GetRouteConfig().VirtualHosts[0].Routes[1].GetRoute().IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
+		hcmConfig.GetRouteConfig().VirtualHosts[0].Routes[2].GetRoute().IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
 	}
 
 	chain := &envoy_config_listener.FilterChain{

--- a/pkg/envoy/model_test.go
+++ b/pkg/envoy/model_test.go
@@ -8,11 +8,34 @@ import (
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	config "github.com/cilium/cilium/pkg/envoy/config"
 )
+
+func TestGetHttpFilterChainProtoCONNECTPassThrough(t *testing.T) {
+	chain := GetHttpFilterChainProto("test-cluster", false, false, "", xdsServerConfig{})
+	require.Len(t, chain.Filters, 2)
+
+	msg, err := chain.Filters[1].GetTypedConfig().UnmarshalNew()
+	require.NoError(t, err)
+	hcm, ok := msg.(*envoy_config_http.HttpConnectionManager)
+	require.True(t, ok)
+
+	require.Len(t, hcm.UpgradeConfigs, 2)
+	assert.Equal(t, "CONNECT", hcm.UpgradeConfigs[1].UpgradeType)
+
+	virtualHosts := hcm.GetRouteConfig().GetVirtualHosts()
+	require.Len(t, virtualHosts, 1)
+	routes := virtualHosts[0].GetRoutes()
+	require.Len(t, routes, 3)
+	connectRoute := routes[0]
+	require.NotNil(t, connectRoute.GetMatch().GetConnectMatcher())
+	assert.Equal(t, "test-cluster", connectRoute.GetRoute().GetCluster())
+	assert.Empty(t, connectRoute.GetRoute().GetUpgradeConfigs(), "the upstream HTTP proxy must terminate CONNECT")
+}
 
 func TestGetListenerFilterADSMode(t *testing.T) {
 	t.Run("ADS disabled: UseNphds not set", func(t *testing.T) {

--- a/pkg/envoy/model_test.go
+++ b/pkg/envoy/model_test.go
@@ -8,11 +8,48 @@ import (
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	config "github.com/cilium/cilium/pkg/envoy/config"
 )
+
+func TestGetHttpFilterChainProtoCONNECTPassThrough(t *testing.T) {
+	serverConfig := xdsServerConfig{
+		httpRequestTimeout: 10,
+		httpIdleTimeout:    20,
+		httpRetryCount:     3,
+		httpRetryTimeout:   5,
+	}
+	chain := GetHttpFilterChainProto("test-cluster", false, false, "", serverConfig)
+	require.Len(t, chain.Filters, 2)
+
+	msg, err := chain.Filters[1].GetTypedConfig().UnmarshalNew()
+	require.NoError(t, err)
+	hcm, ok := msg.(*envoy_config_http.HttpConnectionManager)
+	require.True(t, ok)
+
+	require.Len(t, hcm.UpgradeConfigs, 2)
+	assert.Equal(t, "CONNECT", hcm.UpgradeConfigs[1].UpgradeType)
+
+	virtualHosts := hcm.GetRouteConfig().GetVirtualHosts()
+	require.Len(t, virtualHosts, 1)
+	routes := virtualHosts[0].GetRoutes()
+	require.Len(t, routes, 3)
+	connectRoute := routes[0]
+	require.NotNil(t, connectRoute.GetMatch().GetConnectMatcher())
+	connectAction := connectRoute.GetRoute()
+	require.NotNil(t, connectAction)
+	assert.Equal(t, "test-cluster", connectAction.GetCluster())
+	assert.Empty(t, connectAction.GetUpgradeConfigs(), "the upstream HTTP proxy must terminate CONNECT")
+
+	defaultAction := routes[2].GetRoute()
+	require.NotNil(t, defaultAction)
+	assert.Equal(t, defaultAction.GetTimeout(), connectAction.GetTimeout())
+	assert.Equal(t, defaultAction.GetIdleTimeout(), connectAction.GetIdleTimeout())
+	assert.Equal(t, defaultAction.GetRetryPolicy(), connectAction.GetRetryPolicy())
+}
 
 func TestGetListenerFilterADSMode(t *testing.T) {
 	t.Run("ADS disabled: UseNphds not set", func(t *testing.T) {


### PR DESCRIPTION

<!-- Description of change -->
Add support of HTTP CONNECT method for L7 policies.

Fixes: #24276

```release-note
envoy: Add support for HTTP CONNECT
```
AI disclosure: testing code was developed with LLM assistance, but i fully understand and stand by the code.