### PR TITLE
bpf:tests:lb: add E/W fragment tests to tc_nodeport_lb{4,6}_fragments

### DIFF
--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -33,6 +33,8 @@ lb6_clusterip_post_dnat = (
     Raw("S"*1)
 )
 
+# Packets for testing N/S LB path with fragments.
+
 # Create two TCP fragments over IPv4:
 # 1. Ether(14) + IP(20) + TCP(20) + Raw(1) = 55B
 # 2. Ether(14) + IP(20) + Raw(1)           = 35B.
@@ -40,27 +42,27 @@ lb6_clusterip_post_dnat = (
 # `id` is in big endian.
 # `frag` (offset) is in 8-byte units. The very last fragment in a sequence is
 #        the only one allowed to have a size not divisible by 8.
-lb4_nodeport_fragment1 = (
+lb4_ns_nodeport_fragment1 = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_ext_one, dst=v4_svc_one, flags='MF', frag=0, id=256, proto=6) /
     TCP(sport=tcp_src_one, dport=tcp_svc_one) /
     Raw(load="S" * 1)
 )
 
-lb4_nodeport_fragment1_post_dnat = (
+lb4_ns_nodeport_fragment1_post_dnat = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_ext_one, dst=v4_pod_one, flags='MF', frag=0, id=256, proto=6) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one) /
     Raw(load="S" * 1)
 )
 
-lb4_nodeport_fragment2 = (
+lb4_ns_nodeport_fragment2 = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_ext_one, dst=v4_svc_one, flags='', frag=(20+1)//8, id=256, proto=6) /
     Raw(load="S" * 1)
 )
 
-lb4_nodeport_fragment2_post_dnat = (
+lb4_ns_nodeport_fragment2_post_dnat = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_ext_one, dst=v4_pod_one, flags='', frag=(20+1)//8, id=256, proto=6) /
     Raw(load="S" * 1)
@@ -75,7 +77,7 @@ lb4_nodeport_fragment2_post_dnat = (
 # `id` is in big endian.
 # `offset` is in 8-byte units. The very last fragment in a sequence is
 #        the only one allowed to have a size not divisible by 8.
-lb6_nodeport_fragment1 = (
+lb6_ns_nodeport_fragment1 = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_ext_node_one, dst=v6_svc_one, nh=44) /
     IPv6ExtHdrFragment(offset=0, m=1, id=256, nh=6) /
@@ -83,7 +85,7 @@ lb6_nodeport_fragment1 = (
     Raw(load="S" * 1)
 )
 
-lb6_nodeport_fragment1_post_dnat = (
+lb6_ns_nodeport_fragment1_post_dnat = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=44) /
     IPv6ExtHdrFragment(offset=0, m=1, id=256, nh=6) /
@@ -91,14 +93,14 @@ lb6_nodeport_fragment1_post_dnat = (
     Raw(load="S" * 1)
 )
 
-lb6_nodeport_fragment2 = (
+lb6_ns_nodeport_fragment2 = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_ext_node_one, dst=v6_svc_one, nh=44) /
     IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /
     Raw(load="S" * 1)
 )
 
-lb6_nodeport_fragment2_post_dnat = (
+lb6_ns_nodeport_fragment2_post_dnat = (
     Ether(src=mac_one, dst=mac_two) /
     IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=44) /
     IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /

--- a/bpf/tests/scapy/lb_pkt_defs.py
+++ b/bpf/tests/scapy/lb_pkt_defs.py
@@ -106,3 +106,63 @@ lb6_ns_nodeport_fragment2_post_dnat = (
     IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /
     Raw(load="S" * 1)
 )
+
+# Packets for testing East/West LB path with fragments.
+# Same as before, but with the source IP of a pod instead of an external node.
+
+lb4_ew_nodeport_fragment1 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_two, dst=v4_svc_one, flags='MF', frag=0, id=256, proto=6) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(load="S" * 1)
+)
+
+lb4_ew_nodeport_fragment1_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_two, dst=v4_pod_one, flags='MF', frag=0, id=256, proto=6) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one) /
+    Raw(load="S" * 1)
+)
+
+lb4_ew_nodeport_fragment2 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_two, dst=v4_svc_one, flags='', frag=(20+1)//8, id=256, proto=6) /
+    Raw(load="S" * 1)
+)
+
+lb4_ew_nodeport_fragment2_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_pod_two, dst=v4_pod_one, flags='', frag=(20+1)//8, id=256, proto=6) /
+    Raw(load="S" * 1)
+)
+
+lb6_ew_nodeport_fragment1 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_pod_two, dst=v6_svc_one, nh=44) /
+    IPv6ExtHdrFragment(offset=0, m=1, id=256, nh=6) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one) /
+    Raw(load="S" * 1)
+)
+
+lb6_ew_nodeport_fragment1_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_pod_two, dst=v6_pod_one, nh=44) /
+    IPv6ExtHdrFragment(offset=0, m=1, id=256, nh=6) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one) /
+    Raw(load="S" * 1)
+)
+
+lb6_ew_nodeport_fragment2 = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_pod_two, dst=v6_svc_one, nh=44) /
+    IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /
+    Raw(load="S" * 1)
+)
+
+lb6_ew_nodeport_fragment2_post_dnat = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_pod_two, dst=v6_pod_one, nh=44) /
+    IPv6ExtHdrFragment(offset=(20+1)//8, m=0, id=256, nh=6) /
+    Raw(load="S" * 1)
+)
+

--- a/bpf/tests/tc_nodeport_lb4_fragments.h
+++ b/bpf/tests/tc_nodeport_lb4_fragments.h
@@ -14,14 +14,21 @@
 # define HOOK		netdev_receive_packet
 
 # include "lib/bpf_host.h"
+#elif defined(EAST_WEST_TEST)
+# define ENABLE_SOCKET_LB_HOST_ONLY 1
+# define CLIENT_IP	v4_pod_two
+# define HOOK		pod_send_packet
+
+# include "lib/bpf_lxc.h"
 #else
-# error "Needs to be included with NORTH_SOUTH_TEST defined"
+# error "Needs to be included with either NORTH_SOUTH_TEST or EAST_WEST_TEST defined"
 #endif
 
 ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
 ASSIGN_CONFIG(bool, enable_ipv4_fragments, true)
 
 #include "lib/endpoint.h"
+#include "lib/policy.h"
 #include "lib/lb.h"
 #include "scapy.h"
 
@@ -59,7 +66,7 @@ ASSIGN_CONFIG(bool, enable_ipv4_fragments, true)
 	.reason = REASON_FRAG_PACKET, \
 	.dir = METRIC_SERVICE }
 
-/* Test that the 1st fragment of an external-to-nodeport request is handled correctly */
+/* Test that the 1st fragment is handled correctly */
 PKTGEN("tc", "tc_nodeport_lb4_fragments_1")
 int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
 {
@@ -70,6 +77,9 @@ int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
 #ifdef NORTH_SOUTH_TEST
 	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT1, lb4_ns_nodeport_fragment1);
 	BUILDER_PUSH_BUF(builder, LB4_NS_NODEPORT_FRAGMENT1);
+#else
+	BUF_DECL(LB4_EW_NODEPORT_FRAGMENT1, lb4_ew_nodeport_fragment1);
+	BUILDER_PUSH_BUF(builder, LB4_EW_NODEPORT_FRAGMENT1);
 #endif
 
 	pktgen__finish(&builder);
@@ -80,6 +90,8 @@ int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_lb4_fragments_1")
 int nodeport_lb4_fragments_1_setup(struct __ctx_buff *ctx)
 {
+	policy_add_egress_allow_all_entry();
+
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
 			      (__u8 *)mac_one, (__u8 *)mac_two);
 	lb_v4_add_service_with_flags(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, BACKEND_COUNT,
@@ -132,6 +144,12 @@ int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 			   LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT,
 			   sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT)));
 	bytes = sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT));
+#else
+	BUF_DECL(LB4_EW_NODEPORT_FRAGMENT1_POST_DNAT, lb4_ew_nodeport_fragment1_post_dnat);
+	ASSERT_CTX_BUF_OFF("lb4_ew_nodeport_fragment1_post_dnat", "Ether", ctx, sizeof(__u32),
+			   LB4_EW_NODEPORT_FRAGMENT1_POST_DNAT,
+			   sizeof(BUF(LB4_EW_NODEPORT_FRAGMENT1_POST_DNAT)));
+	bytes = sizeof(BUF(LB4_EW_NODEPORT_FRAGMENT1_POST_DNAT));
 #endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */
@@ -143,7 +161,7 @@ int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-/* Test that the 2nd fragment of an external-to-nodeport request is handled correctly */
+/* Test that the 2nd fragment is handled correctly */
 PKTGEN("tc", "tc_nodeport_lb4_fragments_2")
 int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
 {
@@ -154,6 +172,9 @@ int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
 #ifdef NORTH_SOUTH_TEST
 	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT2, lb4_ns_nodeport_fragment2);
 	BUILDER_PUSH_BUF(builder, LB4_NS_NODEPORT_FRAGMENT2);
+#else
+	BUF_DECL(LB4_EW_NODEPORT_FRAGMENT2, lb4_ew_nodeport_fragment2);
+	BUILDER_PUSH_BUF(builder, LB4_EW_NODEPORT_FRAGMENT2);
 #endif
 
 	pktgen__finish(&builder);
@@ -206,6 +227,14 @@ int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
 			   sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT2_POST_DNAT)));
 	bytes = sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT)) +
 		sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT2_POST_DNAT));
+#else
+	BUF_DECL(LB4_EW_NODEPORT_FRAGMENT1_POST_DNAT, lb4_ew_nodeport_fragment1_post_dnat);
+	BUF_DECL(LB4_EW_NODEPORT_FRAGMENT2_POST_DNAT, lb4_ew_nodeport_fragment2_post_dnat);
+	ASSERT_CTX_BUF_OFF("lb4_ew_nodeport_fragment2_post_dnat", "Ether", ctx, sizeof(__u32),
+			   LB4_EW_NODEPORT_FRAGMENT2_POST_DNAT,
+			   sizeof(BUF(LB4_EW_NODEPORT_FRAGMENT2_POST_DNAT)));
+	bytes = sizeof(BUF(LB4_EW_NODEPORT_FRAGMENT1_POST_DNAT)) +
+		sizeof(BUF(LB4_EW_NODEPORT_FRAGMENT2_POST_DNAT));
 #endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */

--- a/bpf/tests/tc_nodeport_lb4_fragments.h
+++ b/bpf/tests/tc_nodeport_lb4_fragments.h
@@ -1,14 +1,22 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+ * Copyright Authors of Cilium
+ */
 
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
 
-#define ENABLE_IPV4
-#define ENABLE_NODEPORT
+#define ENABLE_IPV4 1
+#define ENABLE_NODEPORT 1
 
-#include "lib/bpf_host.h"
+#ifdef NORTH_SOUTH_TEST
+# define CLIENT_IP	v4_ext_one
+# define HOOK		netdev_receive_packet
+
+# include "lib/bpf_host.h"
+#else
+# error "Needs to be included with NORTH_SOUTH_TEST defined"
+#endif
 
 ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
 ASSIGN_CONFIG(bool, enable_ipv4_fragments, true)
@@ -17,7 +25,6 @@ ASSIGN_CONFIG(bool, enable_ipv4_fragments, true)
 #include "lib/lb.h"
 #include "scapy.h"
 
-#define CLIENT_IP	v4_ext_one
 #define CLIENT_PORT	tcp_src_one
 
 #define FRONTEND_IP	v4_svc_one
@@ -60,8 +67,10 @@ int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
 
 	pktgen__init(&builder, ctx);
 
-	BUF_DECL(LB4_NODEPORT_FRAGMENT1, lb4_nodeport_fragment1);
-	BUILDER_PUSH_BUF(builder, LB4_NODEPORT_FRAGMENT1);
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT1, lb4_ns_nodeport_fragment1);
+	BUILDER_PUSH_BUF(builder, LB4_NS_NODEPORT_FRAGMENT1);
+#endif
 
 	pktgen__finish(&builder);
 
@@ -78,7 +87,7 @@ int nodeport_lb4_fragments_1_setup(struct __ctx_buff *ctx)
 	lb_v4_add_backend(FRONTEND_IP, FRONTEND_PORT, BACKEND_COUNT, BACKEND_ID,
 			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
-	return netdev_receive_packet(ctx);
+	return HOOK(ctx);
 }
 
 CHECK("tc", "tc_nodeport_lb4_fragments_1")
@@ -93,6 +102,7 @@ int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 	struct ipv4_frag_id expected_frag_id = EXPECTED_FRAG_ID;
 	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
 	__u64 count = 1;
+	__u64 bytes = 0;
 
 	test_init();
 
@@ -116,16 +126,19 @@ int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 	assert_metrics_count(metric_key, count);
 
 	/* Ensure packet has been DNAT correctly. */
-	BUF_DECL(LB4_NODEPORT_FRAGMENT1_POST_DNAT, lb4_nodeport_fragment1_post_dnat);
-	ASSERT_CTX_BUF_OFF("tcp4_first_fragment_ok", "Ether", ctx, sizeof(__u32),
-			   LB4_NODEPORT_FRAGMENT1_POST_DNAT,
-			   sizeof(BUF(LB4_NODEPORT_FRAGMENT1_POST_DNAT)));
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT, lb4_ns_nodeport_fragment1_post_dnat);
+	ASSERT_CTX_BUF_OFF("lb4_ns_nodeport_fragment1_post_dnat", "Ether", ctx, sizeof(__u32),
+			   LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT,
+			   sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT)));
+	bytes = sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT));
+#endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */
 	ct_entry = map_lookup_elem(get_ct_map4(&expected_ct_tuple), &expected_ct_tuple);
 	assert(ct_entry);
 	assert(ct_entry->packets == count);
-	assert(ct_entry->bytes == sizeof(BUF(LB4_NODEPORT_FRAGMENT1_POST_DNAT)));
+	assert(ct_entry->bytes == bytes);
 
 	test_finish();
 }
@@ -138,8 +151,10 @@ int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
 
 	pktgen__init(&builder, ctx);
 
-	BUF_DECL(LB4_NODEPORT_FRAGMENT2, lb4_nodeport_fragment2);
-	BUILDER_PUSH_BUF(builder, LB4_NODEPORT_FRAGMENT2);
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT2, lb4_ns_nodeport_fragment2);
+	BUILDER_PUSH_BUF(builder, LB4_NS_NODEPORT_FRAGMENT2);
+#endif
 
 	pktgen__finish(&builder);
 
@@ -152,7 +167,7 @@ int nodeport_lb4_fragments_2_setup(struct __ctx_buff *ctx)
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
 			      (__u8 *)mac_one, (__u8 *)mac_two);
 
-	return netdev_receive_packet(ctx);
+	return HOOK(ctx);
 }
 
 CHECK("tc", "tc_nodeport_lb4_fragments_2")
@@ -165,6 +180,7 @@ int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
 	struct ipv4_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
 	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
 	__u64 count = 2;
+	__u64 bytes = 0;
 
 	test_init();
 
@@ -182,18 +198,21 @@ int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
 	assert_metrics_count(metric_key, count);
 
 	/* Ensure packet has been DNAT correctly. */
-	BUF_DECL(LB4_NODEPORT_FRAGMENT1_POST_DNAT, lb4_nodeport_fragment1_post_dnat);
-	BUF_DECL(LB4_NODEPORT_FRAGMENT2_POST_DNAT, lb4_nodeport_fragment2_post_dnat);
-	ASSERT_CTX_BUF_OFF("tcp4_second_fragment_ok", "Ether", ctx, sizeof(__u32),
-			   LB4_NODEPORT_FRAGMENT2_POST_DNAT,
-			   sizeof(BUF(LB4_NODEPORT_FRAGMENT2_POST_DNAT)));
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT, lb4_ns_nodeport_fragment1_post_dnat);
+	BUF_DECL(LB4_NS_NODEPORT_FRAGMENT2_POST_DNAT, lb4_ns_nodeport_fragment2_post_dnat);
+	ASSERT_CTX_BUF_OFF("lb4_ns_nodeport_fragment2_post_dnat", "Ether", ctx, sizeof(__u32),
+			   LB4_NS_NODEPORT_FRAGMENT2_POST_DNAT,
+			   sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT2_POST_DNAT)));
+	bytes = sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT1_POST_DNAT)) +
+		sizeof(BUF(LB4_NS_NODEPORT_FRAGMENT2_POST_DNAT));
+#endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */
 	ct_entry = map_lookup_elem(get_ct_map4(&expected_ct_tuple), &expected_ct_tuple);
 	assert(ct_entry);
 	assert(ct_entry->packets == count);
-	assert(ct_entry->bytes == sizeof(BUF(LB4_NODEPORT_FRAGMENT1_POST_DNAT)) +
-				  sizeof(BUF(LB4_NODEPORT_FRAGMENT2_POST_DNAT)));
+	assert(ct_entry->bytes == bytes);
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_fragments_ew.c
+++ b/bpf/tests/tc_nodeport_lb4_fragments_ew.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define EAST_WEST_TEST 1
+
+#include "tc_nodeport_lb4_fragments.h"

--- a/bpf/tests/tc_nodeport_lb4_fragments_ns.c
+++ b/bpf/tests/tc_nodeport_lb4_fragments_ns.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define NORTH_SOUTH_TEST 1
+
+#include "tc_nodeport_lb4_fragments.h"

--- a/bpf/tests/tc_nodeport_lb6_fragments.h
+++ b/bpf/tests/tc_nodeport_lb6_fragments.h
@@ -1,14 +1,22 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+ * Copyright Authors of Cilium
+ */
 
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
 
-#define ENABLE_IPV6
-#define ENABLE_NODEPORT
+#define ENABLE_IPV6 1
+#define ENABLE_NODEPORT 1
 
-#include "lib/bpf_host.h"
+#ifdef NORTH_SOUTH_TEST
+# define CLIENT_IP	v6_ext_node_one
+# define HOOK		netdev_receive_packet
+
+# include "lib/bpf_host.h"
+#else
+# error "Needs to be included with NORTH_SOUTH_TEST defined"
+#endif
 
 ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
 ASSIGN_CONFIG(bool, enable_ipv6_fragments, true)
@@ -17,7 +25,6 @@ ASSIGN_CONFIG(bool, enable_ipv6_fragments, true)
 #include "lib/lb.h"
 #include "scapy.h"
 
-#define CLIENT_IP	v6_ext_node_one
 #define CLIENT_PORT	tcp_src_one
 
 #define FRONTEND_IP	v6_svc_one
@@ -60,8 +67,10 @@ int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
 
 	pktgen__init(&builder, ctx);
 
-	BUF_DECL(LB6_NODEPORT_FRAGMENT1, lb6_nodeport_fragment1);
-	BUILDER_PUSH_BUF(builder, LB6_NODEPORT_FRAGMENT1);
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT1, lb6_ns_nodeport_fragment1);
+	BUILDER_PUSH_BUF(builder, LB6_NS_NODEPORT_FRAGMENT1);
+#endif
 
 	pktgen__finish(&builder);
 
@@ -79,7 +88,7 @@ int nodeport_lb6_fragment1_setup(struct __ctx_buff *ctx)
 	lb_v6_add_backend((union v6addr *)FRONTEND_IP, FRONTEND_PORT, BACKEND_COUNT, BACKEND_ID,
 			  (union v6addr *)BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
 
-	return netdev_receive_packet(ctx);
+	return HOOK(ctx);
 }
 
 CHECK("tc", "tc_nodeport_lb6_fragment1")
@@ -94,6 +103,7 @@ int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
 	struct ipv6_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
 	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
 	__u64 count = 1;
+	__u64 bytes = 0;
 
 	test_init();
 
@@ -115,16 +125,19 @@ int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
 	assert_metrics_count(metric_key, count);
 
 	/* Ensure packet has been DNAT correctly. */
-	BUF_DECL(LB6_NODEPORT_FRAGMENT1_POST_DNAT, lb6_nodeport_fragment1_post_dnat);
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT, lb6_ns_nodeport_fragment1_post_dnat);
 	ASSERT_CTX_BUF_OFF("tcp6_first_fragment_ok", "Ether", ctx, sizeof(__u32),
-			   LB6_NODEPORT_FRAGMENT1_POST_DNAT,
-			   sizeof(BUF(LB6_NODEPORT_FRAGMENT1_POST_DNAT)));
+			   LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT,
+			   sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT)));
+	bytes = sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT));
+#endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */
 	ct_entry = map_lookup_elem(get_ct_map6(&expected_ct_tuple), &expected_ct_tuple);
 	assert(ct_entry);
 	assert(ct_entry->packets == count);
-	assert(ct_entry->bytes == sizeof(BUF(LB6_NODEPORT_FRAGMENT1_POST_DNAT)));
+	assert(ct_entry->bytes == bytes);
 
 	test_finish();
 }
@@ -137,8 +150,10 @@ int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
 
 	pktgen__init(&builder, ctx);
 
-	BUF_DECL(LB6_NODEPORT_FRAGMENT2, lb6_nodeport_fragment2);
-	BUILDER_PUSH_BUF(builder, LB6_NODEPORT_FRAGMENT2);
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT2, lb6_ns_nodeport_fragment2);
+	BUILDER_PUSH_BUF(builder, LB6_NS_NODEPORT_FRAGMENT2);
+#endif
 
 	pktgen__finish(&builder);
 
@@ -148,7 +163,7 @@ int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_lb6_fragment2")
 int nodeport_lb6_fragment2_setup(struct __ctx_buff *ctx)
 {
-	return netdev_receive_packet(ctx);
+	return HOOK(ctx);
 }
 
 CHECK("tc", "tc_nodeport_lb6_fragment2")
@@ -161,6 +176,7 @@ int nodeport_lb6_fragment2_check(struct __ctx_buff *ctx)
 	struct ipv6_ct_tuple expected_ct_tuple = EXPECTED_CT_TUPLE;
 	struct metrics_key metric_key = EXPECTED_METRIC_KEY;
 	__u64 count = 2;
+	__u64 bytes = 0;
 
 	test_init();
 
@@ -176,18 +192,21 @@ int nodeport_lb6_fragment2_check(struct __ctx_buff *ctx)
 	assert_metrics_count(metric_key, count);
 
 	/* Ensure packet has been DNAT correctly. */
-	BUF_DECL(LB6_NODEPORT_FRAGMENT1_POST_DNAT, lb6_nodeport_fragment1_post_dnat);
-	BUF_DECL(LB6_NODEPORT_FRAGMENT2_POST_DNAT, lb6_nodeport_fragment2_post_dnat);
+#ifdef NORTH_SOUTH_TEST
+	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT, lb6_ns_nodeport_fragment1_post_dnat);
+	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT2_POST_DNAT, lb6_ns_nodeport_fragment2_post_dnat);
 	ASSERT_CTX_BUF_OFF("tcp6_second_fragment_ok", "Ether", ctx, sizeof(__u32),
-			   LB6_NODEPORT_FRAGMENT2_POST_DNAT,
-			   sizeof(BUF(LB6_NODEPORT_FRAGMENT2_POST_DNAT)));
+			   LB6_NS_NODEPORT_FRAGMENT2_POST_DNAT,
+			   sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT2_POST_DNAT)));
+	bytes = sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT)) +
+		sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT2_POST_DNAT));
+#endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */
 	ct_entry = map_lookup_elem(get_ct_map6(&expected_ct_tuple), &expected_ct_tuple);
 	assert(ct_entry);
 	assert(ct_entry->packets == count);
-	assert(ct_entry->bytes == sizeof(BUF(LB6_NODEPORT_FRAGMENT1_POST_DNAT)) +
-				  sizeof(BUF(LB6_NODEPORT_FRAGMENT2_POST_DNAT)));
+	assert(ct_entry->bytes == bytes);
 
 	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb6_fragments.h
+++ b/bpf/tests/tc_nodeport_lb6_fragments.h
@@ -14,14 +14,21 @@
 # define HOOK		netdev_receive_packet
 
 # include "lib/bpf_host.h"
+#elif defined(EAST_WEST_TEST)
+# define ENABLE_SOCKET_LB_HOST_ONLY 1
+# define CLIENT_IP	v6_pod_two
+# define HOOK		pod_send_packet
+
+# include "lib/bpf_lxc.h"
 #else
-# error "Needs to be included with NORTH_SOUTH_TEST defined"
+# error "Needs to be included with either NORTH_SOUTH_TEST or EAST_WEST_TEST defined"
 #endif
 
 ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
 ASSIGN_CONFIG(bool, enable_ipv6_fragments, true)
 
 #include "lib/endpoint.h"
+#include "lib/policy.h"
 #include "lib/lb.h"
 #include "scapy.h"
 
@@ -59,7 +66,7 @@ ASSIGN_CONFIG(bool, enable_ipv6_fragments, true)
 	.reason = REASON_FRAG_PACKET, \
 	.dir = METRIC_SERVICE }
 
-/* Test that the 1st fragment of an external-to-nodeport request is handled correctly */
+/* Test that the 1st fragment is handled correctly */
 PKTGEN("tc", "tc_nodeport_lb6_fragment1")
 int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
 {
@@ -70,6 +77,9 @@ int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
 #ifdef NORTH_SOUTH_TEST
 	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT1, lb6_ns_nodeport_fragment1);
 	BUILDER_PUSH_BUF(builder, LB6_NS_NODEPORT_FRAGMENT1);
+#else
+	BUF_DECL(LB6_EW_NODEPORT_FRAGMENT1, lb6_ew_nodeport_fragment1);
+	BUILDER_PUSH_BUF(builder, LB6_EW_NODEPORT_FRAGMENT1);
 #endif
 
 	pktgen__finish(&builder);
@@ -80,6 +90,8 @@ int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_lb6_fragment1")
 int nodeport_lb6_fragment1_setup(struct __ctx_buff *ctx)
 {
+	policy_add_egress_allow_all_entry();
+
 	endpoint_v6_add_entry((union v6addr *)BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0,
 			      (__u8 *)mac_one, (__u8 *)mac_two);
 	lb_v6_add_service_with_flags((union v6addr *)FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP,
@@ -131,6 +143,12 @@ int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
 			   LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT,
 			   sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT)));
 	bytes = sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT));
+#else
+	BUF_DECL(LB6_EW_NODEPORT_FRAGMENT1_POST_DNAT, lb6_ew_nodeport_fragment1_post_dnat);
+	ASSERT_CTX_BUF_OFF("tcp6_first_fragment_ok", "Ether", ctx, sizeof(__u32),
+			   LB6_EW_NODEPORT_FRAGMENT1_POST_DNAT,
+			   sizeof(BUF(LB6_EW_NODEPORT_FRAGMENT1_POST_DNAT)));
+	bytes = sizeof(BUF(LB6_EW_NODEPORT_FRAGMENT1_POST_DNAT));
 #endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */
@@ -142,7 +160,7 @@ int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-/* Test that the 2nd fragment of an external-to-nodeport request is handled correctly */
+/* Test that the 2nd fragment is handled correctly */
 PKTGEN("tc", "tc_nodeport_lb6_fragment2")
 int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
 {
@@ -153,6 +171,9 @@ int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
 #ifdef NORTH_SOUTH_TEST
 	BUF_DECL(LB6_NS_NODEPORT_FRAGMENT2, lb6_ns_nodeport_fragment2);
 	BUILDER_PUSH_BUF(builder, LB6_NS_NODEPORT_FRAGMENT2);
+#else
+	BUF_DECL(LB6_EW_NODEPORT_FRAGMENT2, lb6_ew_nodeport_fragment2);
+	BUILDER_PUSH_BUF(builder, LB6_EW_NODEPORT_FRAGMENT2);
 #endif
 
 	pktgen__finish(&builder);
@@ -200,6 +221,14 @@ int nodeport_lb6_fragment2_check(struct __ctx_buff *ctx)
 			   sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT2_POST_DNAT)));
 	bytes = sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT1_POST_DNAT)) +
 		sizeof(BUF(LB6_NS_NODEPORT_FRAGMENT2_POST_DNAT));
+#else
+	BUF_DECL(LB6_EW_NODEPORT_FRAGMENT1_POST_DNAT, lb6_ew_nodeport_fragment1_post_dnat);
+	BUF_DECL(LB6_EW_NODEPORT_FRAGMENT2_POST_DNAT, lb6_ew_nodeport_fragment2_post_dnat);
+	ASSERT_CTX_BUF_OFF("tcp6_second_fragment_ok", "Ether", ctx, sizeof(__u32),
+			   LB6_EW_NODEPORT_FRAGMENT2_POST_DNAT,
+			   sizeof(BUF(LB6_EW_NODEPORT_FRAGMENT2_POST_DNAT)));
+	bytes = sizeof(BUF(LB6_EW_NODEPORT_FRAGMENT1_POST_DNAT)) +
+		sizeof(BUF(LB6_EW_NODEPORT_FRAGMENT2_POST_DNAT));
 #endif
 
 	/* Ensure CT entry is updated accordingly (SVC). */

--- a/bpf/tests/tc_nodeport_lb6_fragments_ew.c
+++ b/bpf/tests/tc_nodeport_lb6_fragments_ew.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define EAST_WEST_TEST 1
+
+#include "tc_nodeport_lb6_fragments.h"

--- a/bpf/tests/tc_nodeport_lb6_fragments_ns.c
+++ b/bpf/tests/tc_nodeport_lb6_fragments_ns.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define NORTH_SOUTH_TEST 1
+
+#include "tc_nodeport_lb6_fragments.h"


### PR DESCRIPTION
In https://github.com/cilium/cilium/pull/44271, we moved the Ginkgo tests into BPF unit tests.
However, we tested only the North/South path (netdev).
This PR adds the East/West LB case when ENABLE_PER_PACKET_LB is defined (bpf_lxc).