### PR TITLE
CI: conformance {aws-cni, aks, eks, gke}: improve use of intermediate environment variables

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -148,6 +148,8 @@ jobs:
           yq -o=json "${work_dir}/k8s-versions.yaml" | jq . > "${destination_directory}/azure.json"
 
       - name: Generate Matrix
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
         run: |
           cd /tmp/generated/azure
 
@@ -155,7 +157,7 @@ jobs:
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
           # shellcheck disable=SC2193
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
+          if [[ "${{ github.event_name }}" == "schedule" || "${PR_NUMBER}" == v* ]];then
             jq '{ "include": [ .include[] | select(.disabled==null) ] }' azure.json > /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' azure.json > /tmp/matrix.json
@@ -241,9 +243,11 @@ jobs:
         uses: ./.github/actions/set-env-variables
 
       - name: Override cluster name
+        env:
+          INDEX: ${{ matrix.index }}
         run: |
           # Extend default name with matrix index to avoid cluster name conflicts
-          NAME=${{ env.name }}-${{ matrix.index }}
+          NAME="${{ env.name }}-${INDEX}"
           echo "name=${NAME}" >> "$GITHUB_ENV"
 
       - name: Get Cilium's default values
@@ -255,12 +259,15 @@ jobs:
 
       - name: Set up job variables
         id: vars
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
+          REF_NAME: ${{ github.ref_name }}
+          EXTRA_ARGS: ${{ inputs.extra-args }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            OWNER="${{ inputs.PR-number }}"
+            OWNER="${PR_NUMBER}"
           else
-            OWNER="${{ github.ref_name }}"
-            OWNER="${OWNER//[.\/]/-}"
+            OWNER="${REF_NAME//[.\/]/-}"
           fi
 
           # We explicity set the cluster-pool Pod CIDR here to not clash with the AKS default Service CIDRs
@@ -276,7 +283,7 @@ jobs:
             --helm-set ipam.operator.clusterPoolIPv6PodCIDRList=fd00::/104"
 
           # Check if ipsec is requested via extra-args
-          IPSEC=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
+          IPSEC=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
           if [[ "$IPSEC" == "true" ]]; then
             echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true \
@@ -284,13 +291,13 @@ jobs:
           fi
 
           # Check if KPR is requested via extra-args
-          KPR=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["kpr"] // false')
+          KPR=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["kpr"] // false')
           if [[ "$KPR" == "true" ]]; then
             echo "::notice::KPR enabled - setting kpr=true for all matrix entries"
             CILIUM_INSTALL_DEFAULTS+=" --helm-set=kubeProxyReplacement=true"
           fi
 
-          ADV_FEAT=$(echo '${{ inputs.extra-args }}' | jq -r '.["advanced-features"] // false')
+          ADV_FEAT=$(echo "${EXTRA_ARGS}" | jq -r '.["advanced-features"] // false')
           if [[ "$ADV_FEAT" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
               --helm-set enableIPv4Masquerade=true \
@@ -298,7 +305,7 @@ jobs:
               --helm-set egressGateway.enabled=true"
           fi
 
-          WG=$(echo '${{ inputs.extra-args }}' | jq -r '.["wireguard"] // false')
+          WG=$(echo "${EXTRA_ARGS}" | jq -r '.["wireguard"] // false')
           if [[ "$WG" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=wireguard"
           fi

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -105,6 +105,8 @@ jobs:
           yq -o=json "${work_dir}/k8s-versions.yaml" | jq . > "${destination_directory}/aws-cni.json"
 
       - name: Generate Matrix
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
         run: |
           cd /tmp/generated/aws-cni
 
@@ -112,7 +114,7 @@ jobs:
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
           # shellcheck disable=SC2193
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
+          if [[ "${{ github.event_name }}" == "schedule" || "${PR_NUMBER}" == v* ]];then
             cp aws-cni.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' aws-cni.json > /tmp/matrix.json
@@ -226,24 +228,28 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.PR-number }}
+          CONTEXT_REF: ${{ inputs.context-ref }}
         run: |
           # If PR-number isn't an integer then we use context-ref because branch isn't associated with a PR
-          if [[ "${{ inputs.PR-number }}" =~ ^[0-9]+$ ]]; then
-            BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          if [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            BASE_BRANCH=$(gh pr view ${PR_NUMBER} --json baseRefName -q .baseRefName)
           else
-            BASE_BRANCH="${{ inputs.context-ref }}"
+            BASE_BRANCH="${CONTEXT_REF}"
           fi
           echo "base-branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "Base branch for PR #${{ inputs.PR-number }}: $BASE_BRANCH"
 
       - name: Set up job variables
         id: vars
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            OWNER="${{ inputs.PR-number }}"
+            OWNER="${PR_NUMBER}"
           else
-            OWNER="${{ github.ref_name }}"
-            OWNER="${OWNER//[.\/]/-}"
+            OWNER="${REF_NAME//[.\/]/-}"
           fi
 
           # Create unique cluster name including version to avoid conflicts
@@ -398,16 +404,19 @@ jobs:
       - name: Trigger cluster deletion workflow
         if: ${{ always() && steps.setup-cluster.outputs.cluster_name != '' }}
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+          REGION: ${{ matrix.region }}
         run: |
           CLUSTER_NAME="${{ steps.setup-cluster.outputs.cluster_name }}"
-          REGION="${{ matrix.region }}"
 
           # Use base branch from PR if available, otherwise fall back to
           # context-ref or current branch
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             REF="${{ steps.get-base-branch.outputs.base-branch }}"
           else
-            REF="${{ github.ref_name }}"
+            REF="${REF_NAME}"
           fi
 
           echo "Triggering delete-eks-clusters workflow with:"
@@ -418,8 +427,6 @@ jobs:
           gh workflow run eks-cluster-delete.yaml \
             --field cluster_name="$CLUSTER_NAME" \
             --field region="$REGION"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
   merge-upload-and-status:
     name: Merge Upload and Status

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -176,6 +176,8 @@ jobs:
           yq -o=json "${work_dir}/k8s-versions.yaml" | jq . > "${destination_directory}/eks.json"
 
       - name: Generate Matrix
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
         run: |
           cd /tmp/generated/eks
 
@@ -183,7 +185,7 @@ jobs:
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
           # shellcheck disable=SC2193
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* ]];then
+          if [[ "${{ github.event_name }}" == "schedule" || "${PR_NUMBER}" == v* ]];then
             cp eks.json /tmp/matrix.json
           else
             jq '{ "include": [ .include[] | select(.default) ] }' eks.json > /tmp/matrix.json
@@ -200,11 +202,13 @@ jobs:
 
       - name: Filter Matrix
         id: set-matrix
+        env:
+          EXTRA_ARGS: ${{ inputs.extra-args }}
         run: |
           cp /tmp/matrix.json /tmp/result.json
 
           # Check if ipsec is requested via extra-args
-          IPSEC=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
+          IPSEC=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
           if [[ "$IPSEC" == "true" ]]; then
             echo "::notice::IPsec enabled - setting ipsec=true for all matrix entries"
             jq '.include |= map(. + {"ipsec": true})' /tmp/result.json > /tmp/result.json.tmp
@@ -212,7 +216,7 @@ jobs:
           fi
 
           # Check if KPR is requested via extra-args
-          KPR=$(echo '${{ inputs.extra-args }}' | jq -r '.["kpr"] // false')
+          KPR=$(echo "${EXTRA_ARGS}" | jq -r '.["kpr"] // false')
           if [[ "$KPR" == "true" ]]; then
             echo "::notice::KPR enabled - setting kpr=true for all matrix entries"
             jq '.include |= map(. + {"kpr": true})' /tmp/result.json > /tmp/result.json.tmp
@@ -300,29 +304,34 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.PR-number }}
+          CONTEXT_REF: ${{ inputs.context-ref }}
         run: |
           # If PR-number isn't an integer then we use context-ref because branch isn't associated with a PR
-          if [[ "${{ inputs.PR-number }}" =~ ^[0-9]+$ ]]; then
-            BASE_BRANCH=$(gh pr view ${{ inputs.PR-number }} --json baseRefName -q .baseRefName)
+          if [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            BASE_BRANCH=$(gh pr view ${PR_NUMBER} --json baseRefName -q .baseRefName)
           else
-            BASE_BRANCH="${{ inputs.context-ref }}"
+            BASE_BRANCH="${CONTEXT_REF}"
           fi
           echo "base-branch=$BASE_BRANCH" >> $GITHUB_OUTPUT
-          echo "Base branch for PR #${{ inputs.PR-number }}: $BASE_BRANCH"
+          echo "Base branch for PR #${PR_NUMBER}: $BASE_BRANCH"
 
       - name: Set up job variables
         id: vars
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
+          REF_NAME: ${{ github.ref_name }}
+          VERSION_SANITIZED: ${{ matrix.version }}
+          EXTRA_ARGS: ${{ inputs.extra-args }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            OWNER="${{ inputs.PR-number }}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            OWNER="${PR_NUMBER}"
           else
-            OWNER="${{ github.ref_name }}"
-            OWNER="${OWNER//[.\/]/-}"
+            OWNER="${REF_NAME//[.\/]/-}"
           fi
 
           # Create unique cluster name including version to avoid conflicts
           # when multiple versions use same region
-          VERSION_SANITIZED="${{ matrix.version }}"
           VERSION_SANITIZED="${VERSION_SANITIZED//[.]/-}"
 
           CLUSTER_NAME="${{ env.clusterNamePrefix }}-${VERSION_SANITIZED}"
@@ -344,7 +353,7 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set eni.awsEnablePrefixDelegation=true"
           fi
 
-          ADV_FEAT=$(echo '${{ inputs.extra-args }}' | jq -r '.["advanced-features"] // false')
+          ADV_FEAT=$(echo "${EXTRA_ARGS}" | jq -r '.["advanced-features"] // false')
           if [[ "$ADV_FEAT" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
               --helm-set enableIPv4Masquerade=true \
@@ -352,7 +361,7 @@ jobs:
               --helm-set egressGateway.enabled=true"
           fi
 
-          WG=$(echo '${{ inputs.extra-args }}' | jq -r '.["wireguard"] // false')
+          WG=$(echo "${EXTRA_ARGS}" | jq -r '.["wireguard"] // false')
           if [[ "$WG" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=wireguard"
           fi
@@ -509,15 +518,18 @@ jobs:
       - name: Trigger cluster deletion workflow
         if: ${{ always() && steps.setup-cluster.outputs.cluster_name != '' }}
         continue-on-error: true
+        env:
+          REGION: ${{ matrix.region }}
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           CLUSTER_NAME="${{ steps.setup-cluster.outputs.cluster_name }}"
-          REGION="${{ matrix.region }}"
 
           # Use base branch from PR if available, otherwise fall back to current branch
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
             REF="${{ steps.get-base-branch.outputs.base-branch }}"
           else
-            REF="${{ github.ref_name }}"
+            REF="${REF_NAME}"
           fi
 
           echo "Triggering delete-eks-clusters workflow with:"
@@ -528,8 +540,6 @@ jobs:
           gh workflow run eks-cluster-delete.yaml \
             --field cluster_name="$CLUSTER_NAME" \
             --field region="$REGION"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
   merge-upload-and-status:
     name: Merge Upload and Status

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -157,20 +157,23 @@ jobs:
           jq -s "add" ${destination_directory}/*.json > "${destination_directory}/gke.json"
 
       - name: Generate Matrix
+        env:
+          PR_NUMBER: ${{ inputs.PR-number }}
+          EXTRA_ARGS: ${{ inputs.extra-args }}
         run: |
           cd /tmp/generated/gke
 
           # Use complete matrix in case of scheduled run
           # main -> event_name = schedule
           # other stable branches -> PR-number starting with v (e.g. v1.14)
-          VERSIONS=$(echo ${{ inputs.extra-args }} | awk -F'=' '{print $2}')
-          IPSEC=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
-          WG=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["wireguard"] // false')
-          KPR=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["kpr"] // false')
-          ADV_FEAT=$(echo '${{ inputs.extra-args }}' | sed 's/^""$/{}/' | jq -r '.["advanced-features"] // false')
+          VERSIONS=$(echo "${EXTRA_ARGS}" | awk -F'=' '{print $2}')
+          IPSEC=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
+          WG=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["wireguard"] // false')
+          KPR=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["kpr"] // false')
+          ADV_FEAT=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["advanced-features"] // false')
 
           # shellcheck disable=SC2193
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.PR-number }}" == v* || "$VERSIONS" == "all" ]];then
+          if [[ "${{ github.event_name }}" == "schedule" || "${PR_NUMBER}" == v* || "$VERSIONS" == "all" ]];then
             cp gke.json /tmp/matrix.json
           else
             jq '{ "k8s": [ .k8s[] | select(.default) ], "config": .config}' gke.json > /tmp/matrix.json
@@ -223,8 +226,10 @@ jobs:
 
       - name: Filter Matrix
         id: set-matrix
+        env:
+          EXTRA_ARGS: ${{ inputs.extra-args }}
         run: |
-          CHANNEL=$(echo ${{ inputs.extra-args }} | grep "channel" | awk -F'=' '{print $2}' | tr '[:lower:]' '[:upper:]')
+          CHANNEL=$(echo "${EXTRA_ARGS}" | grep "channel" | awk -F'=' '{print $2}' | tr '[:lower:]' '[:upper:]')
           if [ "$CHANNEL" == "" ];then
             FILTER="channels.channel=REGULAR"
           elif [ "$CHANNEL" == "NONE" ];then


### PR DESCRIPTION
In preparation for introducing conformance testing on AKS, EKS and GKE with `bpf.datapathMode=netkit` I noticed a lot of the conformance workflows embed input data directly into scripts. This [can be dangerous](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks) so this PR moves some to intermediate variables.