### PR TITLE
bpf,lxc: do not pass non-routed traffic to stack when tbid is explicit

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -791,6 +791,13 @@ ipv6_forward_to_destination(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		__u32 tbid = CONFIG(fib_table_id);
 
 		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, false, ext_err, &oif, tbid);
+		/*
+		 * if the endpoint is configured with an explicit table id,
+		 * be strict and drop the traffic if we are not redirected.
+		 */
+		if (tbid && ret != CTX_ACT_REDIRECT)
+			return ret;
+
 		switch (ret) {
 		case CTX_ACT_REDIRECT:
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
@@ -1350,6 +1357,13 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 		__u32 tbid = CONFIG(fib_table_id);
 
 		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, false, ext_err, &oif, tbid);
+		/*
+		 * if the endpoint is configured with an explicit table id,
+		 * be strict and drop the traffic if we are not redirected.
+		 */
+		if (tbid && ret != CTX_ACT_REDIRECT)
+			return ret;
+
 		switch (ret) {
 		case CTX_ACT_REDIRECT:
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,


### PR DESCRIPTION
Do not drop `BPF_FIB_LKUP_RET_NOT_FWDED` traffic when tbid is explicitly
set.

When tbid is explicitly set, we are forcing the pod's egress routing to
be part of a specific routing domain.

If this routing domain does not have a specific route toward the
destination we must drop it, not push it to stack.

A push to stack here would cause the egress packet to leak into the
stack's routing domain and potentially take an unexpected next hop to
the destination.

```release-note
[bpf] avoid leaking explicit tbid traffic to the host network namespace
```