### PR TITLE
feat(operator): add option to set forward_client_cert_details

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -241,6 +241,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			GRPCWebTranslation: &model.GRPCWebTranslationConfig{
 				Enabled: gatewayClassConfig.GRPCWebTranslationEnabled(),
 			},
+			ForwardClientCertDetails: gatewayClassConfig.GetForwardClientCertDetails(),
 		},
 	})
 	if err != nil {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -492,6 +492,52 @@ func Test_grpcWebTranslationEnabled(t *testing.T) {
 	}
 }
 
+func Test_forwardClientCertDetails(t *testing.T) {
+	appendForward := "APPEND_FORWARD"
+
+	tests := []struct {
+		name   string
+		config *v2alpha1.CiliumGatewayClassConfig
+		want   *string
+	}{
+		{
+			name: "nil config",
+			want: nil,
+		},
+		{
+			name:   "empty config",
+			config: &v2alpha1.CiliumGatewayClassConfig{},
+			want:   nil,
+		},
+		{
+			name: "nil value in options",
+			config: &v2alpha1.CiliumGatewayClassConfig{
+				Spec: v2alpha1.CiliumGatewayClassConfigSpec{
+					HTTPOptions: &v2alpha1.HTTPOptions{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "value set in options",
+			config: &v2alpha1.CiliumGatewayClassConfig{
+				Spec: v2alpha1.CiliumGatewayClassConfigSpec{
+					HTTPOptions: &v2alpha1.HTTPOptions{
+						ForwardClientCertDetails: &appendForward,
+					},
+				},
+			},
+			want: &appendForward,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.config.GetForwardClientCertDetails())
+		})
+	}
+}
+
 func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 	t.Parallel()
 

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -22,7 +22,8 @@ type Model struct {
 }
 
 type HTTPOptions struct {
-	GRPCWebTranslation *GRPCWebTranslationConfig `json:"grpc_web_translation,omitempty"`
+	GRPCWebTranslation       *GRPCWebTranslationConfig `json:"grpc_web_translation,omitempty"`
+	ForwardClientCertDetails *string                   `json:"forward_client_cert_details,omitempty"`
 }
 
 type GRPCWebTranslationConfig struct {
@@ -48,6 +49,13 @@ func (m *Model) GRPCWebTranslationEnabled() bool {
 		m.HTTPOptions == nil ||
 		m.HTTPOptions.GRPCWebTranslation == nil ||
 		m.HTTPOptions.GRPCWebTranslation.Enabled
+}
+
+func (m *Model) GetForwardClientCertDetails() *string {
+	if m == nil || m.HTTPOptions == nil {
+		return nil
+	}
+	return m.HTTPOptions.ForwardClientCertDetails
 }
 
 type Listener interface {

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -191,3 +191,48 @@ func TestModel_GRPCWebTranslationEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_GetForwardClientCertDetails(t *testing.T) {
+	appendForward := "APPEND_FORWARD"
+
+	tests := []struct {
+		name  string
+		model *Model
+		want  *string
+	}{
+		{
+			name: "nil model",
+			want: nil,
+		},
+		{
+			name:  "empty model",
+			model: &Model{},
+			want:  nil,
+		},
+		{
+			name: "nil value in options",
+			model: &Model{
+				HTTPOptions: &HTTPOptions{},
+			},
+			want: nil,
+		},
+		{
+			name: "value set in options",
+			model: &Model{
+				HTTPOptions: &HTTPOptions{
+					ForwardClientCertDetails: &appendForward,
+				},
+			},
+			want: &appendForward,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.model.GetForwardClientCertDetails()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Model.GetForwardClientCertDetails() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -181,6 +181,38 @@ func WithStreamIdleTimeout(streamIdleTimeoutSeconds int) ListenerMutator {
 	}
 }
 
+func withForwardClientCertDetails(forwardClientCertDetailsString string) ListenerMutator {
+	return func(listener *envoy_config_listener.Listener) *envoy_config_listener.Listener {
+		forwardClientCertDetails, ok := httpConnectionManagerv3.HttpConnectionManager_ForwardClientCertDetails_value[forwardClientCertDetailsString]
+		if !ok {
+			return listener
+		}
+		for _, filterChain := range listener.FilterChains {
+			for _, filter := range filterChain.Filters {
+				if filter.Name == httpConnectionManagerType {
+					tc := filter.GetTypedConfig()
+					switch tc.GetTypeUrl() {
+					case envoy.HttpConnectionManagerTypeURL:
+						hcm, err := tc.UnmarshalNew()
+						if err != nil {
+							continue
+						}
+						hcmConfig, ok := hcm.(*httpConnectionManagerv3.HttpConnectionManager)
+						if !ok {
+							continue
+						}
+						hcmConfig.ForwardClientCertDetails = httpConnectionManagerv3.HttpConnectionManager_ForwardClientCertDetails(forwardClientCertDetails)
+						filter.ConfigType = &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(hcmConfig),
+						}
+					}
+				}
+			}
+		}
+		return listener
+	}
+}
+
 func withHostNetworkPort(m *model.Model, ipv4Enabled bool, ipv6Enabled bool) ListenerMutator {
 	return func(listener *envoy_config_listener.Listener) *envoy_config_listener.Listener {
 		listener.Address, listener.AdditionalAddresses = getHostNetworkListenerAddresses(m.AllPorts(), ipv4Enabled, ipv6Enabled)
@@ -323,6 +355,10 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 
 	if i.Config.OriginalIPDetectionConfig.XFFNumTrustedHops > 0 {
 		res = append(res, withXffNumTrustedHops(i.Config.OriginalIPDetectionConfig.XFFNumTrustedHops))
+	}
+
+	if m.GetForwardClientCertDetails() != nil {
+		res = append(res, withForwardClientCertDetails(*m.GetForwardClientCertDetails()))
 	}
 	return res
 }

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -602,6 +602,65 @@ func Test_desiredEnvoyListener_UseRemoteAddressFalse(t *testing.T) {
 	assert.False(t, hcm.UseRemoteAddress.GetValue(), "generated listener should honor UseRemoteAddress=false from config")
 }
 
+func Test_withForwardClientCertDetails(t *testing.T) {
+	tests := []struct {
+		name                          string
+		forwardClientCertDetailsValue string
+		want                          envoy_extensions_filters_network_hcm_v3.HttpConnectionManager_ForwardClientCertDetails
+	}{
+		{
+			name:                          "append_forward",
+			forwardClientCertDetailsValue: "APPEND_FORWARD",
+			want:                          envoy_extensions_filters_network_hcm_v3.HttpConnectionManager_APPEND_FORWARD,
+		},
+		{
+			name:                          "forward_only",
+			forwardClientCertDetailsValue: "FORWARD_ONLY",
+			want:                          envoy_extensions_filters_network_hcm_v3.HttpConnectionManager_FORWARD_ONLY,
+		},
+		{
+			name:                          "invalid_enum",
+			forwardClientCertDetailsValue: "INVALID",
+			want:                          envoy_extensions_filters_network_hcm_v3.HttpConnectionManager_SANITIZE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hcmAny := toAny(&envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{})
+			listener := &envoy_config_listener.Listener{
+				Name: "listener",
+				FilterChains: []*envoy_config_listener.FilterChain{
+					{
+						Filters: []*envoy_config_listener.Filter{
+							{
+								Name: httpConnectionManagerType,
+								ConfigType: &envoy_config_listener.Filter_TypedConfig{
+									TypedConfig: hcmAny,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			mutator := withForwardClientCertDetails(tt.forwardClientCertDetailsValue)
+			listener = mutator(listener)
+
+			require.Len(t, listener.FilterChains, 1)
+			require.Len(t, listener.FilterChains[0].Filters, 1)
+
+			filter := listener.FilterChains[0].Filters[0]
+			typedConfig := filter.GetTypedConfig()
+			hcm, err := typedConfig.UnmarshalNew()
+			require.NoError(t, err)
+			hcmConfig, ok := hcm.(*envoy_extensions_filters_network_hcm_v3.HttpConnectionManager)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, hcmConfig.ForwardClientCertDetails)
+		})
+	}
+}
+
 func Test_withUseRemoteAddress_NoHCMFilter(t *testing.T) {
 	listener := &envoy_config_listener.Listener{
 		Name: "listener",

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumgatewayclassconfigs.yaml
@@ -64,6 +64,17 @@ spec:
               httpOptions:
                 description: HTTPOptions specifies HTTP connection manager options.
                 properties:
+                  forwardClientCertDetails:
+                    description: |-
+                      Sets the forward_client_cert_details property in generated CiliumEnvoyConfig listener objects to the given value.
+                      Allowed values are "SANITIZE", "SANITIZE_SET", "APPEND_FORWARD", "FORWARD_ONLY" and "ALWAYS_FORWARD_ONLY".
+                    enum:
+                    - SANITIZE
+                    - SANITIZE_SET
+                    - APPEND_FORWARD
+                    - FORWARD_ONLY
+                    - ALWAYS_FORWARD_ONLY
+                    type: string
                   grpcWebTranslation:
                     description: GRPCWebTranslation controls Envoy's gRPC-web to gRPC
                       request translation.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/gatewayclassconfig_types.go
@@ -134,6 +134,12 @@ type HTTPOptions struct {
 	//
 	// +kubebuilder:validation:Optional
 	GRPCWebTranslation *GRPCWebTranslationConfig `json:"grpcWebTranslation,omitempty"`
+	// Sets the forward_client_cert_details property in generated CiliumEnvoyConfig listener objects to the given value.
+	// Allowed values are "SANITIZE", "SANITIZE_SET", "APPEND_FORWARD", "FORWARD_ONLY" and "ALWAYS_FORWARD_ONLY".
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=SANITIZE;SANITIZE_SET;APPEND_FORWARD;FORWARD_ONLY;ALWAYS_FORWARD_ONLY
+	ForwardClientCertDetails *string `json:"forwardClientCertDetails,omitempty"`
 }
 
 // CiliumGatewayClassConfigSpec specifies all the configuration options for a
@@ -178,4 +184,11 @@ func (c *CiliumGatewayClassConfig) GRPCWebTranslationEnabled() bool {
 		c.Spec.HTTPOptions.GRPCWebTranslation == nil ||
 		c.Spec.HTTPOptions.GRPCWebTranslation.Enabled == nil ||
 		*c.Spec.HTTPOptions.GRPCWebTranslation.Enabled
+}
+
+func (c *CiliumGatewayClassConfig) GetForwardClientCertDetails() *string {
+	if c == nil || c.Spec.HTTPOptions == nil {
+		return nil
+	}
+	return c.Spec.HTTPOptions.ForwardClientCertDetails
 }

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -1829,6 +1829,11 @@ func (in *HTTPOptions) DeepCopyInto(out *HTTPOptions) {
 		*out = new(GRPCWebTranslationConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ForwardClientCertDetails != nil {
+		in, out := &in.ForwardClientCertDetails, &out.ForwardClientCertDetails
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1423,6 +1423,14 @@ func (in *HTTPOptions) DeepEqual(other *HTTPOptions) bool {
 		}
 	}
 
+	if (in.ForwardClientCertDetails == nil) != (other.ForwardClientCertDetails == nil) {
+		return false
+	} else if in.ForwardClientCertDetails != nil {
+		if *in.ForwardClientCertDetails != *other.ForwardClientCertDetails {
+			return false
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
<!-- Description of change -->
Add option to set forward_client_cert_details using CiliumGatewayClassConfig.

This allows forwarding the X-Forwarded-Client-Cert header downstream for MTLS authentication.

Configuration is added into HTTPOptions object of CRD

Fixes: #45063