### PR TITLE
bpf: Reduce scope of large variables

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -916,7 +916,6 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	    int off, struct ipv4_nat_target *target,
 	    struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct icmphdr icmphdr __align_stack_8;
 	struct ipv4_nat_entry *state = NULL;
 	__u16 port_off = 0;
 	int ret;
@@ -949,7 +948,9 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 			return NAT_PUNT_TO_STACK;
 
 		break;
-	case IPPROTO_ICMP:
+	case IPPROTO_ICMP: {
+		struct icmphdr icmphdr __align_stack_8;
+
 		/* Fragmented ECHO packets are not supported currently. Drop all
 		 * fragments, because letting the first fragment pass would be
 		 * useless anyway.
@@ -997,6 +998,7 @@ nat_icmp_v4:
 			return DROP_NAT_UNSUPP_PROTO;
 		}
 		break;
+	}
 	default:
 		return NAT_PUNT_TO_STACK;
 	};
@@ -1120,7 +1122,6 @@ static __always_inline __maybe_unused int
 snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
-	struct icmphdr icmphdr __align_stack_8;
 	struct ipv4_nat_entry *state = NULL;
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
@@ -1160,7 +1161,9 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 			return NAT_PUNT_TO_STACK;
 
 		break;
-	case IPPROTO_ICMP:
+	case IPPROTO_ICMP: {
+		struct icmphdr icmphdr __align_stack_8;
+
 		/* Fragmented ECHOREPLY packets are not supported currently.
 		 * Drop all fragments, because letting the first fragment pass
 		 * would be useless anyway.
@@ -1204,6 +1207,7 @@ rev_nat_icmp_v4:
 			return NAT_PUNT_TO_STACK;
 		}
 		break;
+	}
 	default:
 		return NAT_PUNT_TO_STACK;
 	};
@@ -1954,7 +1958,6 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	    int off, struct ipv6_nat_target *target,
 	    struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct icmp6hdr icmp6hdr __align_stack_8;
 	struct ipv6_nat_entry *state = NULL;
 	__u16 port_off = 0;
 	int ret;
@@ -1987,9 +1990,12 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 			return NAT_PUNT_TO_STACK;
 
 		break;
-	case IPPROTO_ICMPV6:
+	case IPPROTO_ICMPV6: {
+		struct icmp6hdr icmp6hdr __align_stack_8;
+
 		if (ipfrag_is_fragment(fraginfo))
 			return DROP_INVALID;
+
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
 			return DROP_INVALID;
 
@@ -2035,6 +2041,7 @@ nat_icmp_v6:
 			return DROP_NAT_UNSUPP_PROTO;
 		}
 		break;
+	}
 	default:
 		return NAT_PUNT_TO_STACK;
 	};
@@ -2134,7 +2141,6 @@ static __always_inline __maybe_unused int
 snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		struct trace_ctx *trace, __s8 *ext_err __maybe_unused)
 {
-	struct icmp6hdr icmp6hdr __align_stack_8;
 	struct ipv6_nat_entry *state = NULL;
 	struct ipv6_ct_tuple tuple = {};
 	__u32 off, inner_l3_off;
@@ -2176,7 +2182,9 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 			return NAT_PUNT_TO_STACK;
 
 		break;
-	case IPPROTO_ICMPV6:
+	case IPPROTO_ICMPV6: {
+		struct icmp6hdr icmp6hdr __align_stack_8;
+
 		if (ipfrag_is_fragment(fraginfo))
 			return DROP_INVALID;
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
@@ -2208,6 +2216,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 			return NAT_PUNT_TO_STACK;
 		}
 		break;
+	}
 	default:
 		return NAT_PUNT_TO_STACK;
 	};


### PR DESCRIPTION
We are currently very close to the stack size limit for a number of BPF programs, including `tail_handle_snat_fwd_ipv6`, and it's sometimes causing issues in pull requests. This commit attempts to proactively reduce the stack sizes.

Dylan recently noticed that LLVM might be using the variables' scope to determine when it can reuse stack slots. That creates an incentive for us to reduce the scope of large variables, typically by moving their definition at the top of functions closer to the code using them.

We can do that for some of the big ICMP headers we keep on the stack. The impact can be a bit hard to predict as LLVM reshuffle things around, but overall, it helps reduce the stack size by 8 to 24 bytes in some of our largest stack users.

Marking for backport to v1.19 because we've had this issue during backports there as well.