### PR TITLE
codeql: Add on.push trigger for main branch

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,6 +1,9 @@
 name: CodeQL
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Add push event trigger for the main branch so that CodeQL can analyze code and display scanning alerts on the Security tab.