### PR TITLE
.github/workflows: disable cache for go steps

### DIFF
--- a/.github/workflows/lint-ariane-config.yaml
+++ b/.github/workflows/lint-ariane-config.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: 1.26.0
+          cache: false
 
       - name: Install Ariane linter
         shell: bash

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.1
+          cache: false
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,6 +46,7 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.1
+          cache: false
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -66,6 +68,7 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.1
+          cache: false
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -94,6 +97,7 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.1
+          cache: false
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -123,6 +127,7 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.1
+          cache: false
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -146,6 +151,7 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.1
+          cache: false
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
We don't use the golang cache on these steps so we can disable
it to avoid warnings on the action runs.