### PR TITLE
ci: Run KCNP tests via conformance-kind-proxy-embedded

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -87,6 +87,7 @@ jobs:
           extra-helm-set: "--helm-set=envoy.xdsMode=split"
     env:
       job_name: "Installation and Connectivity Test (${{ matrix.name }})"
+      ENABLE_CLUSTERNETWORKPOLICY: "true"
     steps:
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0
@@ -160,6 +161,7 @@ jobs:
             --helm-set=hubble.relay.enabled=true
             --helm-set=cni.chainingMode=portmap \
             --helm-set-string=kubeProxyReplacement=true \
+            --helm-set=k8sClusterNetworkPolicy.enabled=${ENABLE_CLUSTERNETWORKPOLICY} \
             --helm-set=loadBalancer.l7.backend=envoy \
             --helm-set=tls.readSecretsOnlyFromSecretsNamespace=true \
             --helm-set=tls.secretSync.enabled=true \
@@ -218,6 +220,10 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
 
+      - name: Install KCNP CRD
+        run: |
+          make kind-install-kcnp-crd ENABLE_CLUSTERNETWORKPOLICY=${ENABLE_CLUSTERNETWORKPOLICY}
+
       - name: Install Cilium
         id: install-cilium
         run: |
@@ -251,6 +257,7 @@ jobs:
           helm upgrade cilium untrusted/install/kubernetes/cilium \
             --namespace kube-system \
             --reuse-values \
+            --set=k8sClusterNetworkPolicy.enabled=${ENABLE_CLUSTERNETWORKPOLICY} \
             --set=tls.readSecretsOnlyFromSecretsNamespace=false \
             --set=tls.secretSync.enabled=false
 

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -232,6 +232,18 @@ ifdef ADDITIONAL_KIND_VALUES_FILE
 	KIND_VALUES_FAST_FILES := $(KIND_VALUES_FAST_FILES) --helm-values=$(ROOT_DIR)/$(ADDITIONAL_KIND_VALUES_FILE)
 endif
 
+ENABLE_CLUSTERNETWORKPOLICY ?= false
+
+# Macro for installing k8s ClusterNetworkPolicy CRD.
+# - $(1): argument to kubectl, used for specifying --context when needed
+define KIND_INSTALL_KCNP_CRD
+if [ "$(ENABLE_CLUSTERNETWORKPOLICY)" = "true" ]; then $(KUBECTL) $(1) get crd clusternetworkpolicies.policy.networking.k8s.io >/dev/null 2>&1 || $(KUBECTL) $(1) apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/refs/heads/release-0.2/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml; fi
+endef
+
+.PHONY: kind-install-kcnp-crd
+kind-install-kcnp-crd:
+	$(QUIET)$(call KIND_INSTALL_KCNP_CRD,$(if $(KIND_CLUSTER_NAME),--context=kind-$(KIND_CLUSTER_NAME)))
+
 .PHONY: kind-install-cilium-fast
 kind-install-cilium-fast: .SHELLFLAGS=-c
 kind-install-cilium-fast: check_deps kind-ready kind-load-base-images ## "Fast" Install a local Cilium version using volume-mounted binaries into all clusters.
@@ -239,9 +251,11 @@ kind-install-cilium-fast: check_deps kind-ready kind-load-base-images ## "Fast" 
 	$(QUIET)for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
 		$(CILIUM_CLI) --context=kind-$$cluster_name uninstall >/dev/null 2>&1 || true; \
 		sleep 5; \
+		$(call KIND_INSTALL_KCNP_CRD,--context=kind-$$cluster_name); \
 		$(CILIUM_CLI) install --context=kind-$$cluster_name \
 			--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 			$(KIND_VALUES_FAST_FILES) \
+			--set=k8sClusterNetworkPolicy.enabled=$(ENABLE_CLUSTERNETWORKPOLICY) \
 			--version= >/dev/null ; \
 	done
 
@@ -353,13 +367,13 @@ ifneq ("$(wildcard $(ROOT_DIR)/contrib/testing/kind-custom.yaml)","")
 endif
 
 .PHONY: kind-install-cilium
-ENABLE_CLUSTERNETWORKPOLICY ?= false
 kind-install-cilium: check_deps kind-ready ## Install a local Cilium version into the cluster.
 	@echo "  INSTALL cilium"
 	# cilium-cli doesn't support idempotent installs, so we uninstall and
 	# reinstall here. https://github.com/cilium/cilium-cli/issues/205
 	-@$(CILIUM_CLI) uninstall >/dev/null 2>&1 || true
 
+	$(QUIET)$(call KIND_INSTALL_KCNP_CRD)
 	$(CILIUM_CLI) install \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		$(KIND_VALUES_FILES) \


### PR DESCRIPTION
Enable k8s ClusterNetworkPolicy tests in Conformance Kind Envoy Embedded workflow.

CI ran the k8s CNP test successfully:
```
[=] [cilium-test-5] Test [echo-ingress-from-client-tiered-wildcard-pass-l7] [14/32]
........
```