### PR TITLE
ci: add fail-fast false to ci image builds

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -43,6 +43,9 @@ jobs:
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-latest' }}
     needs: wait-for-base-images
     strategy:
+      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
+      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
+      fail-fast: ${{ github.event_name != 'pull_request_target' }}
       matrix:
         include:
           - name: cilium

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -45,6 +45,9 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
+      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
+      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
+      fail-fast: ${{ github.event_name != 'pull_request_target' }}
       matrix:
         include:
           - name: cilium

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -45,6 +45,9 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
+      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
+      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
+      fail-fast: ${{ github.event_name != 'pull_request_target' }}
       matrix:
         include:
           - name: cilium

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -53,6 +53,9 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
+      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
+      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
+      fail-fast: ${{ github.event_name != 'pull_request_target' }}
       matrix:
         include:
           - name: cilium


### PR DESCRIPTION
Sometimes CI image build has failures due to transient issues (e.g. network issues, cosign failures, rate limits, etc.). Github workflow strategy for matrix jobs uses fail-fast option to true per default, cancelling all jobs when one fails.

Allowing fail-fast false to the image CI build will permit to just retry the build of failed images instead of running the whole workflow again.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast