### PR TITLE
policy/api: remove unused {Egress,Ingress}CommonRule.IsL3 methods

### DIFF
--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -227,18 +227,6 @@ func (e *EgressCommonRule) RequiresDerivative() bool {
 	return len(e.ToGroups) > 0
 }
 
-func (e *EgressCommonRule) IsL3() bool {
-	if e == nil {
-		return false
-	}
-	return len(e.ToEndpoints) > 0 ||
-		len(e.ToCIDR) > 0 ||
-		len(e.ToCIDRSet) > 0 ||
-		len(e.ToEntities) > 0 ||
-		len(e.ToGroups) > 0 ||
-		len(e.ToNodes) > 0
-}
-
 // CreateDerivative will return a new rule based on the data gathered by the
 // rules that creates a new derivative policy.
 // In the case of ToGroups will call outside using the groups callback and this

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -207,20 +207,6 @@ func (e *IngressCommonRule) RequiresDerivative() bool {
 	return len(e.FromGroups) > 0
 }
 
-// IsL3 returns true if the IngressCommonRule contains at least a rule that
-// affects L3 policy enforcement.
-func (in *IngressCommonRule) IsL3() bool {
-	if in == nil {
-		return false
-	}
-	return len(in.FromEndpoints) > 0 ||
-		len(in.FromCIDR) > 0 ||
-		len(in.FromCIDRSet) > 0 ||
-		len(in.FromEntities) > 0 ||
-		len(in.FromGroups) > 0 ||
-		len(in.FromNodes) > 0
-}
-
 // CreateDerivative will return a new rule based on the data gathered by the
 // rules that creates a new derivative policy.
 // In the case of FromGroups will call outside using the groups callback and this


### PR DESCRIPTION
They are unused since commit 461100f9e5f4 ("Replace api.Rule with types.PolicyEntry").
