### PR TITLE
Introduce BPF auxiliary variables

### DIFF
--- a/bpf/lib/aux.h
+++ b/bpf/lib/aux.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+#include <bpf/compiler.h>
+#include <bpf/helpers.h>
+
+#define DEFINE_AUX(typ, name) \
+	__section(".data.aux") typ __aux_##name;
+
+volatile const __section(".rodata.aux") __u64 _aux_stride;
+volatile const __section(".rodata.aux") __u64 _aux_max_off;
+
+#define AUX(name) ({ \
+	__u32 cpuid = get_smp_processor_id(); \
+	void *aux_addr = (void *)&__aux_##name; \
+	__u64 offset = (_aux_stride * cpuid); \
+	if (offset > _aux_max_off) \
+		offset = _aux_max_off; \
+	aux_addr += offset; \
+	(__typeof__(__aux_##name) *)(aux_addr); \
+})

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -23,6 +23,7 @@
 #include "nat_46x64.h"
 #include "stubs.h"
 #include "trace.h"
+#include "aux.h"
 
 /* Nodeport NAT minimum port value */
 #define NODEPORT_PORT_MIN_NAT CONFIG(nodeport_port_max) + 1
@@ -1414,20 +1415,8 @@ out:
 	return ret;
 }
 
-/* Store struct ipv6_nat_entry objects in map to optimize stack usage. */
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__type(value, struct ipv6_nat_entry);
-} ipv6_nat_entry_storage __section_maps_btf;
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__type(value, struct ipv6_ct_tuple);
-} ipv6_ct_tuple_storage __section_maps_btf;
+DEFINE_AUX(struct ipv6_nat_entry, snat_v6_nhm_nat_entry)
+DEFINE_AUX(struct ipv6_ct_tuple, snat_v6_nhm_tuple)
 
 static __always_inline int
 snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
@@ -1440,17 +1429,12 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   __s8 *ext_err)
 {
 	bool needs_ct = target->needs_ct;
-	int zero = 0;
 
 	*state = snat_v6_lookup(tuple);
 
 	if (needs_ct) {
-		struct ipv6_ct_tuple *tuple_snat;
+		struct ipv6_ct_tuple *tuple_snat = AUX(snat_v6_nhm_tuple);
 		int ret;
-
-		tuple_snat = map_lookup_elem(&ipv6_ct_tuple_storage, &zero);
-		if (!tuple_snat)
-			return DROP_INVALID;
 
 		memcpy(tuple_snat, tuple, sizeof(*tuple_snat));
 		/* Lookup with SCOPE_FORWARD. Ports are already in correct layout: */
@@ -1474,11 +1458,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (*state) {
 		int ret;
-		struct ipv6_ct_tuple *rtuple;
-
-		rtuple = map_lookup_elem(&ipv6_ct_tuple_storage, &zero);
-		if (!rtuple)
-			return DROP_INVALID;
+		struct ipv6_ct_tuple *rtuple = AUX(snat_v6_nhm_tuple);
 
 		set_v6_rtuple(tuple, *state, rtuple);
 		if (ipv6_addr_equals(&target->addr, &(*state)->to_saddr) &&
@@ -1486,14 +1466,11 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			/* Check for the reverse SNAT entry. If it is missing (e.g. due to LRU
 			 * eviction), it must be restored before returning.
 			 */
-			struct ipv6_nat_entry *rstate;
 			struct ipv6_nat_entry *lookup_result;
 
 			lookup_result = snat_v6_lookup(rtuple);
 			if (!lookup_result) {
-				rstate = map_lookup_elem(&ipv6_nat_entry_storage, &zero);
-				if (!rstate)
-					return DROP_INVALID;
+				struct ipv6_nat_entry *rstate = AUX(snat_v6_nhm_nat_entry);
 
 				memset(rstate, 0, sizeof(*rstate));
 				rstate->to_daddr = tuple->saddr;
@@ -1522,9 +1499,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			__snat_delete(&cilium_snat_v6_external, rtuple);
 	}
 
-	*state = map_lookup_elem(&ipv6_nat_entry_storage, &zero);
-	if (!*state)
-		return DROP_INVALID;
+	*state = AUX(snat_v6_nhm_nat_entry);
 	return snat_v6_new_mapping(ctx, tuple, *state, target, needs_ct, ext_err);
 }
 
@@ -1801,44 +1776,22 @@ __snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 /* Store struct ipv6_ct_tuple and struct ipv6_nat_target objects in maps to
  * optimize stack usage.
  */
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__type(value, struct ipv6_ct_tuple);
-} ct_tuple_storage __section_maps_btf;
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__type(value, struct ipv6_nat_target);
-} nat_target_storage __section_maps_btf;
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__type(value, struct trace_ctx);
-} trace_ctx_storage __section_maps_btf;
+struct snat_v6_args {
+	struct ipv6_ct_tuple tuple;
+	struct ipv6_nat_target target;
+	struct trace_ctx trace;
+};
+
+DEFINE_AUX(struct snat_v6_args, snat_v6_args);
 
 __noinline __weak int
 snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 			 fraginfo_t fraginfo __maybe_unused,
 			 int l4_off __maybe_unused)
 {
-	struct ipv6_nat_target *target;
-	struct ipv6_ct_tuple *tuple;
-	int ret, zero = 0;
+	struct snat_v6_args *args = AUX(snat_v6_args);
 
-	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
-	if (!tuple)
-		return DROP_INVALID;
-	target = map_lookup_elem(&nat_target_storage, &zero);
-	if (!target)
-		return DROP_INVALID;
-
-	ret = __snat_v6_needs_masquerade(ctx, tuple, fraginfo, l4_off, target);
-
-	return ret;
+	return __snat_v6_needs_masquerade(ctx, &args->tuple, fraginfo, l4_off, &args->target);
 }
 
 static __always_inline __maybe_unused int
@@ -1962,31 +1915,18 @@ __noinline __weak int
 snat_v6_nat(struct __ctx_buff *ctx, fraginfo_t fraginfo, int off, __s8 *ext_err)
 {
 	struct ipv6_nat_entry *state = NULL;
-	struct ipv6_nat_target *target;
-	struct ipv6_ct_tuple *tuple;
-	struct trace_ctx *trace;
+	struct snat_v6_args *args = AUX(snat_v6_args);
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	__u16 port_off = 0;
-	int zero = 0;
 	int ret;
-
-	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
-	if (!tuple)
-		return DROP_INVALID;
-	target = map_lookup_elem(&nat_target_storage, &zero);
-	if (!target)
-		return DROP_INVALID;
-	trace = map_lookup_elem(&trace_ctx_storage, &zero);
-	if (!trace)
-		return DROP_INVALID;
 
 	build_bug_on(sizeof(struct ipv6_nat_entry) > 64);
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	switch (tuple->nexthdr) {
+	switch (args->tuple.nexthdr) {
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
 #ifdef ENABLE_SCTP
@@ -2001,14 +1941,14 @@ snat_v6_nat(struct __ctx_buff *ctx, fraginfo_t fraginfo, int off, __s8 *ext_err)
 			return DROP_FRAG_NOSUPPORT;
 
 		ret = ipv6_load_l4_ports(ctx, ip6, fraginfo, off,
-					 CT_EGRESS, &tuple->dport);
+					 CT_EGRESS, &args->tuple.dport);
 		if (ret < 0)
 			return ret;
 
-		ipv6_ct_tuple_swap_ports(tuple);
+		ipv6_ct_tuple_swap_ports(&args->tuple);
 		port_off = TCP_SPORT_OFF;
 
-		if (snat_v6_nat_can_skip(target, tuple))
+		if (snat_v6_nat_can_skip(&args->target, &args->tuple))
 			return NAT_PUNT_TO_STACK;
 
 		break;
@@ -2028,13 +1968,13 @@ snat_v6_nat(struct __ctx_buff *ctx, fraginfo_t fraginfo, int off, __s8 *ext_err)
 		case ICMP6_NA_MSG_TYPE:
 			return NAT_PUNT_TO_STACK;
 		case ICMPV6_ECHO_REQUEST:
-			tuple->dport = 0;
-			tuple->sport = icmp6hdr.icmp6_dataun.u_echo.identifier;
+			args->tuple.dport = 0;
+			args->tuple.sport = icmp6hdr.icmp6_dataun.u_echo.identifier;
 			port_off = offsetof(struct icmp6hdr,
 					    icmp6_dataun.u_echo.identifier);
 			/* Don't clamp the ID field: */
-			target->min_port = 0;
-			target->max_port = UINT16_MAX;
+			args->target.min_port = 0;
+			args->target.max_port = UINT16_MAX;
 
 			break;
 		case ICMPV6_DEST_UNREACH:
@@ -2068,8 +2008,8 @@ nat_icmp_v6:
 		return NAT_PUNT_TO_STACK;
 	};
 
-	return __snat_v6_nat(ctx, tuple, state, fraginfo, off, false, target,
-			     port_off, trace, ext_err);
+	return __snat_v6_nat(ctx, &args->tuple, state, fraginfo, off, false, &args->target,
+			     port_off, &args->trace, ext_err);
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -5,6 +5,7 @@
 
 #include "drop.h"
 #include "nodeport.h"
+#include "aux.h"
 
 #ifdef ENABLE_NODEPORT
 
@@ -56,40 +57,29 @@ nodeport_has_nat_conflict_ipv6(const struct __ctx_buff *ctx __maybe_unused,
 
 static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  union v6addr *saddr,
-						  __s8 *ext_err)
+						  __s8 *ext_err, struct snat_v6_args *args)
 {
 	int hdrlen, l4_off, ret = NAT_PUNT_TO_STACK;
-	struct ipv6_nat_target *target;
-	struct ipv6_ct_tuple *tuple;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	fraginfo_t fraginfo;
-	int zero = 0;
 
-	tuple = map_lookup_elem(&ct_tuple_storage, &zero);
-	if (!tuple)
-		return DROP_INVALID;
-	target = map_lookup_elem(&nat_target_storage, &zero);
-	if (!target)
-		return DROP_INVALID;
-
-	memset(target, 0, sizeof(*target));
-	target->min_port = NODEPORT_PORT_MIN_NAT;
-	target->max_port = NODEPORT_PORT_MAX_NAT;
+	args->target.min_port = NODEPORT_PORT_MIN_NAT;
+	args->target.max_port = NODEPORT_PORT_MAX_NAT;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	tuple->nexthdr = ip6->nexthdr;
-	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &tuple->nexthdr, &fraginfo);
+	args->tuple.nexthdr = ip6->nexthdr;
+	hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &args->tuple.nexthdr, &fraginfo);
 	if (hdrlen < 0)
 		return hdrlen;
 
-	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, tuple);
+	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, &args->tuple);
 	l4_off = ETH_HLEN + hdrlen;
 
-	if (lb_is_svc_proto(tuple->nexthdr) &&
-	    nodeport_has_nat_conflict_ipv6(ctx, ip6, target))
+	if (lb_is_svc_proto(args->tuple.nexthdr) &&
+	    nodeport_has_nat_conflict_ipv6(ctx, ip6, &args->target))
 		goto apply_snat;
 
 #if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
@@ -99,25 +89,22 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		goto out;
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
-	if (target->egress_gateway) {
+	if (args->target.egress_gateway) {
 		/* Stay on the desired egress interface: */
-		if (target->ifindex && target->ifindex == CONFIG(interface_ifindex))
+		if (args->target.ifindex && args->target.ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
 
 		/* Send packet to the correct egress interface, and SNAT it there. */
-		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &target->addr,
-							   &tuple->daddr, target->ifindex,
+		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &args->target.addr,
+							   &args->tuple.daddr, args->target.ifindex,
 							   ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
-
-		if (!revalidate_data(ctx, &data, &data_end, &ip6))
-			return DROP_INVALID;
 	}
 #endif
 
 apply_snat:
-	ipv6_addr_copy(saddr, &tuple->saddr);
+	ipv6_addr_copy(saddr, &args->tuple.saddr);
 	ret = snat_v6_nat(ctx, fraginfo, l4_off, ext_err);
 	if (IS_ERR(ret))
 		goto out;
@@ -137,22 +124,18 @@ __declare_tail(CILIUM_CALL_IPV6_NODEPORT_SNAT_FWD)
 int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	__u32 src_id = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
-	struct trace_ctx *trace;
 	union v6addr saddr = {};
 	int ret;
 	__s8 ext_err = 0;
-	__u32 zero = 0;
+	struct snat_v6_args *args = AUX(snat_v6_args);
 
-	trace = map_lookup_elem(&trace_ctx_storage, &zero);
-	if (!trace)
-		return DROP_INVALID;
-
-	*trace = (struct trace_ctx){
+	memset(args, 0, sizeof(*args));
+	args->trace = (struct trace_ctx){
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = 0,
 	};
 
-	ret = nodeport_snat_fwd_ipv6(ctx, &saddr, &ext_err);
+	ret = nodeport_snat_fwd_ipv6(ctx, &saddr, &ext_err, args);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, METRIC_EGRESS);
 
@@ -164,7 +147,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	if (ret == CTX_ACT_OK)
 		send_trace_notify6(ctx, NODEPORT_OBS_POINT_EGRESS, src_id, UNKNOWN_ID,
 				   &saddr, TRACE_EP_ID_UNKNOWN, CONFIG(interface_ifindex),
-				   trace->reason, trace->monitor);
+				   args->trace.reason, args->trace.monitor);
 
 	return ret;
 }

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -11,6 +11,9 @@ import (
 	"os"
 	"path"
 	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/cpu"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
@@ -252,6 +255,10 @@ func LoadCollection(logger *slog.Logger, spec *ebpf.CollectionSpec, opts *Collec
 		return nil, nil, fmt.Errorf("writing constants: %w", err)
 	}
 
+	if err := modifyAuxData(spec); err != nil {
+		return nil, nil, fmt.Errorf("loading auxiliary data: %w", err)
+	}
+
 	// Find and strip all CILIUM_PIN_REPLACE pinning flags before creating the
 	// Collection. ebpf-go will reject maps with pins it doesn't recognize.
 	toReplace := consumePinReplace(spec)
@@ -423,4 +430,48 @@ func logFreedMaps(logger *slog.Logger, coll *ebpf.Collection, fixed *set.Set[str
 	}
 
 	logger.Debug("No freed maps found after loading Collection")
+}
+
+func modifyAuxData(spec *ebpf.CollectionSpec) error {
+	auxData, found := spec.Maps[".data.aux"]
+	if !found {
+		return nil
+	}
+
+	// Make collections of per-CPU values cache line aligned to prevent false sharing between CPUs.
+	cacheLineSize := uint64(unsafe.Sizeof(cpu.CacheLinePad{}))
+	stride := uint64(auxData.ValueSize)
+	if stride%cacheLineSize != 0 {
+		stride += cacheLineSize - (stride % cacheLineSize)
+	}
+
+	// Communicate the stride to the BPF programs so it can calculate the offset from any variable in the map
+	// to the value for the current CPU.
+	auxStride, found := spec.Variables["_aux_stride"]
+	if !found {
+		return fmt.Errorf("missing _aux_stride variable for .data.aux map")
+	}
+	err := auxStride.Set(stride)
+	if err != nil {
+		return fmt.Errorf("setting _aux_stride: %w", err)
+	}
+
+	// Resize the map so it has a copy of the values for each possible CPU.
+	cpus := ebpf.MustPossibleCPU()
+	valueSize := uint32(cpus) * uint32(stride)
+	auxData.Contents[0] = ebpf.MapKV{Key: uint32(0), Value: make([]byte, valueSize)}
+	auxData.ValueSize = valueSize
+
+	// Communicate the maximum offset of any variable in the map, used to make the verifier happy that we will never
+	// read or write past the end of the map value.
+	auxMaxOff, found := spec.Variables["_aux_max_off"]
+	if !found {
+		return fmt.Errorf("missing _aux_max_off variable for .data.aux map")
+	}
+	err = auxMaxOff.Set(uint64(valueSize) - stride)
+	if err != nil {
+		return fmt.Errorf("setting _aux_max_off: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -856,6 +856,47 @@ type SkipLB6Key struct {
 	Pad2 uint16
 }
 
+// SNATV6Args is generated from the BPF C type snat_v6_args.
+type SNATV6Args struct {
+	_     structs.HostLayout
+	Tuple struct {
+		_     structs.HostLayout
+		DAddr struct {
+			_    structs.HostLayout
+			Addr [16]uint8
+		}
+		SAddr struct {
+			_    structs.HostLayout
+			Addr [16]uint8
+		}
+		DPort   uint16
+		SPort   uint16
+		Nexthdr uint8
+		Flags   uint8
+	}
+	_      [2]byte
+	Target struct {
+		_    structs.HostLayout
+		Addr struct {
+			_    structs.HostLayout
+			Addr [16]uint8
+		}
+		MinPort           uint16
+		MaxPort           uint16
+		FromLocalEndpoint bool
+		NeedsCT           bool
+		EgressGateway     bool
+		_                 [1]byte
+		IfIndex           uint32
+	}
+	Trace struct {
+		_       structs.HostLayout
+		Reason  uint8
+		_       [3]byte
+		Monitor uint32
+	}
+}
+
 // SRv6PolicyKey4 is generated from the BPF C type srv6_policy_key4.
 type SRv6PolicyKey4 struct {
 	_   structs.HostLayout


### PR DESCRIPTION
This PR introduces what I have dubbed "auxiliary variables". Stack usage is becoming a limitation we have to deal with more and more. One of the primary tools we have to combat stack usage is to relocate variables from the stack to a map value. Typically you would do this with a per-CPU map per variable, but this has downsides.

* Using a per-CPU map requires a lookup helper, which can fail according to the verifier (even if it never does).
* The lookup helper requires an additional stack slot of 8 bytes for the zeroed key, a waste.
* We are limited to 64 maps total, so we want to limit single item maps, but creating combined maps creates difficulties in terms of include ordering and type definition locations.

So, auxiliary variables are meant to be an easier to use alternative. You define variable you would like to have in a per CPU map value with `DEFINE_AUX({type}, {name})`. This can happen anywhere in global scope (as long as its after the type definition). And you can then obtain a pointer to the per-CPU map value with `{type} *value = AUX({name})`.

Under the hood the compiler will collect all defined aux variables in a single ELF section, which becomes a global variable map. The loader turns this global map value into a per-CPU map value, and the `AUX` macro ensures we do the correct pointer math to get the variable associated with the current CPU.

This mechanism has the same properties of normal per-CPU map values, so they persist between program calls, and across tail calls. Users need to manually zero the value if a known starting value is desired. Users also need to be careful about using variables in multiple functions if there is a chance of them calling each other. When in doubt, creating multiple aux variables of the same type is safer, and not as costly as doing so with per-CPU maps.

But benefits are that all variables are packed into a single map and due to how global variables work, there is no helper call nor a null check needed to satisfy the verifier. We also save on having to create a "zero" key on the stack, the pointer math all happens with registers on the initial map pointer, so we only pay the stack usage for the returned pointer value.

This PR also converts the per-CPU map used in the NAT logic to AUX data to give some context on its usage.

Fixes: #44650