### PR TITLE
ipam: Wire `AllowFirstLastIPs` option into `cidrPool`

### DIFF
--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -601,10 +601,10 @@ func (m *multiPoolManager) upsertPoolLocked(poolName Pool, cidrs []types.IPAMCID
 	if !ok {
 		pool = &poolPair{}
 		if m.ipv4Enabled {
-			pool.v4 = newCIDRPool(m.logger)
+			pool.v4 = newCIDRPool(m.logger, false)
 		}
 		if m.ipv6Enabled {
-			pool.v6 = newCIDRPool(m.logger)
+			pool.v6 = newCIDRPool(m.logger, false)
 		}
 	}
 

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -39,14 +39,19 @@ type cidrPool struct {
 	ipAllocators []*ipallocator.Range
 	released     map[string]struct{} // key is a CIDR string, e.g. 10.20.30.0/24
 	removed      map[string]struct{} // key is a CIDR string, e.g. 10.20.30.0/24
+	// allowFirstLastIPs, when true, makes the pool include the first and last
+	// IPs of each CIDR (normally reserved as network/broadcast). This is used
+	// for delegated prefixes where the entire range is exclusively assigned.
+	allowFirstLastIPs bool
 }
 
 // newCIDRPool creates a new CIDR pool.
-func newCIDRPool(logger *slog.Logger) *cidrPool {
+func newCIDRPool(logger *slog.Logger, allowFirstLastIPs bool) *cidrPool {
 	return &cidrPool{
-		logger:   logger,
-		released: map[string]struct{}{},
-		removed:  map[string]struct{}{},
+		logger:            logger,
+		released:          map[string]struct{}{},
+		removed:           map[string]struct{}{},
+		allowFirstLastIPs: allowFirstLastIPs,
 	}
 }
 
@@ -294,12 +299,16 @@ func (p *cidrPool) updatePool(CIDRs []string) {
 	}
 
 	// Create and add new IP allocators to newIPAllocators.
+	var rangeOpts []ipallocator.CIDRRangeOption
+	if p.allowFirstLastIPs {
+		rangeOpts = append(rangeOpts, ipallocator.WithAllowFirstLastIPs())
+	}
 	for _, cidrNet := range cidrNets {
 		cidrStr := cidrNet.String()
 		if _, ok := existingAllocators[cidrStr]; ok {
 			continue
 		}
-		ipAllocator := ipallocator.NewCIDRRange(cidrNet)
+		ipAllocator := ipallocator.NewCIDRRange(cidrNet, rangeOpts...)
 		if ipAllocator.Free() == 0 {
 			p.logger.Error(
 				"skipping too-small CIDR",

--- a/pkg/ipam/pool_test.go
+++ b/pkg/ipam/pool_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIDRPoolAllowFirstLastIPs(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	t.Run("default excludes first and last", func(t *testing.T) {
+		pool := newCIDRPool(logger, false)
+		pool.updatePool([]string{"10.0.0.0/28"})
+
+		// /28 = 16 IPs, minus first and last = 14 usable
+		require.Equal(t, 14, pool.capacity())
+
+		// First and last IPs should be out of range.
+		require.Error(t, pool.allocate(net.ParseIP("10.0.0.0")))
+		require.Error(t, pool.allocate(net.ParseIP("10.0.0.15")))
+
+		// Interior IPs should work.
+		require.NoError(t, pool.allocate(net.ParseIP("10.0.0.1")))
+		require.NoError(t, pool.allocate(net.ParseIP("10.0.0.14")))
+	})
+
+	t.Run("allowFirstLastIPs includes all IPs", func(t *testing.T) {
+		pool := newCIDRPool(logger, true)
+		pool.updatePool([]string{"10.0.0.0/28"})
+
+		// /28 = 16 IPs, all usable
+		require.Equal(t, 16, pool.capacity())
+
+		// First and last IPs should be allocatable.
+		require.NoError(t, pool.allocate(net.ParseIP("10.0.0.0")))
+		require.NoError(t, pool.allocate(net.ParseIP("10.0.0.15")))
+	})
+
+	t.Run("allowFirstLastIPs with multiple CIDRs", func(t *testing.T) {
+		pool := newCIDRPool(logger, true)
+		pool.updatePool([]string{"10.0.0.0/28", "10.0.0.16/28"})
+
+		require.Equal(t, 32, pool.capacity())
+
+		// First IP of each CIDR should be allocatable.
+		require.NoError(t, pool.allocate(net.ParseIP("10.0.0.0")))
+		require.NoError(t, pool.allocate(net.ParseIP("10.0.0.16")))
+	})
+}


### PR DESCRIPTION
Add an `allowFirstLastIPs` parameter to `cidrPool` that propagates the `WithAllowFirstLastIPs` option to `ipallocator.NewCIDRRange` when creating new CIDR allocators in `updatePool`. This allows pools used for delegated prefixes (e.g. AWS /28 prefix delegation) to allocate all IPs in the range without reserving the first and last addresses.

Existing multi-pool callers pass false to preserve current behavior.

Relates to cilium/design-cfps#87

This is a direct followup to #45025 and a small setup step before the larger migration or ENI IPAM from the CRD allocator to the multipool allocator.