### PR TITLE
hubble-relay: fix TLS config variable shadowing preventing cleanup on shutdown

### DIFF
--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -228,7 +228,8 @@ func runServe(vp *viper.Viper) error {
 	if vp.GetBool(keyTLSClientDisabled) {
 		opts = append(opts, server.WithInsecureClient())
 	} else {
-		tlsClientConfig, err := certloader.NewWatchedClientConfig(
+		var err error
+		tlsClientConfig, err = certloader.NewWatchedClientConfig(
 			logger.With(logfields.Config, "tls-to-hubble"),
 			vp.GetStringSlice(keyTLSHubbleServerCAFiles),
 			hubbleClientCertFile(vp),
@@ -245,7 +246,8 @@ func runServe(vp *viper.Viper) error {
 	if vp.GetBool(keyTLSServerDisabled) {
 		opts = append(opts, server.WithInsecureServer())
 	} else {
-		tlsServerConfig, err := certloader.NewWatchedServerConfig(
+		var err error
+		tlsServerConfig, err = certloader.NewWatchedServerConfig(
 			logger.With(logfields.Config, "tls-server"),
 			vp.GetStringSlice(keyTLSRelayClientCAFiles),
 			relayServerCertFile(vp),


### PR DESCRIPTION
## Summary

The TLS config variables (`tlsClientConfig` and `tlsServerConfig`) in the hubble-relay serve command are shadowed by short variable declarations (`:=`) inside `else` blocks. The shutdown goroutine references the outer variables which remain `nil`, so `WatchedClientConfig.Stop()` and `WatchedServerConfig.Stop()` are never called on SIGINT/SIGTERM.

This means TLS certificate file watchers and their internal goroutines continue running during graceful shutdown, preventing clean process exit.

## Fix

Change `:=` to `=` (with pre-declared `err`) so the outer variables are assigned, and the shutdown goroutine can properly stop them.

## Testing

- `go vet ./hubble-relay/cmd/serve/...` — clean
- The fix is a pure variable assignment change with no behavioral change to the happy path