### PR TITLE
fix: HTTP body leak, lost error context, logic inversion, and unchecked type assertions

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -1417,7 +1417,10 @@ func (k *K8sClusterMesh) helmUpgradeClusters(ctx context.Context, client *k8s.Cl
 	var clustersRaw any
 	clustersRaw = clusters
 
-	versionStr := rel.MetadataAsMap()["Version"].(string)
+	versionStr, ok := rel.MetadataAsMap()["Version"].(string)
+	if !ok {
+		return fmt.Errorf("failed to get Helm chart version from release metadata on cluster %s", client.ClusterName())
+	}
 	version, err := versioncheck.Version(versionStr)
 	if err != nil {
 		return fmt.Errorf("Failed to parse Helm chart version %s on cluster %s: %w", versionStr, client.ClusterName(), err)
@@ -1794,11 +1797,10 @@ func getClustersFromValues(values map[string]any) (map[string]any, map[string]an
 		if !ok {
 			return nil, nil, fmt.Errorf("existing clustermesh.config.clusters is invalid")
 		}
-		if _, ok := cluster["name"]; !ok {
+		clusterName, ok := cluster["name"].(string)
+		if !ok {
 			return nil, nil, fmt.Errorf("existing clustermesh.config.clusters is invalid")
 		}
-
-		clusterName := cluster["name"].(string)
 		delete(cluster, "name")
 		clusters[clusterName] = cluster
 	}

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -20,7 +20,7 @@ func (igc *GC) startKVStoreModeGC(ctx context.Context) error {
 	igc.logger.InfoContext(ctx, "Starting kvstore identity garbage collector", logfields.Interval, igc.gcInterval)
 	backend, err := kvstoreallocator.NewKVStoreBackend(igc.logger, kvstoreallocator.KVStoreBackendConfiguration{BasePath: cache.IdentitiesPath, Backend: igc.kvstoreClient})
 	if err != nil {
-		return fmt.Errorf("unable to initialize kvstore backend for identity allocation")
+		return fmt.Errorf("unable to initialize kvstore backend for identity allocation: %w", err)
 	}
 
 	minID := idpool.ID(ciliumIdentity.GetMinimalAllocationIdentity(igc.clusterInfo.ID))

--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -62,12 +62,11 @@ func getMetadata(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("metadata service returned status code %d", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 	respBytes, err := safeio.ReadAllLimit(resp.Body, safeio.MB)
 	if err != nil {
 		return "", err

--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -26,8 +26,12 @@ type FakeRecorder struct {
 func objectString(object runtime.Object, includeObject bool) string {
 	var uid string
 	uo, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
-	if err != nil && uo["metadata"] != nil && uo["metadata"].(map[string]any)["uid"] != nil {
-		uid = uo["metadata"].(map[string]any)["uid"].(string)
+	if err == nil {
+		if meta, ok := uo["metadata"].(map[string]any); ok {
+			if u, ok := meta["uid"].(string); ok {
+				uid = u
+			}
+		}
 	}
 	if !includeObject {
 		return ""


### PR DESCRIPTION
## Summary

Four correctness fixes found via code review:

### 1. HTTP response body leak in Alibaba Cloud metadata client
`defer resp.Body.Close()` was placed after the status code check. On non-200 responses, the function returned without closing the body, leaking the HTTP connection. Moved `defer` immediately after the nil error check.

**File:** `pkg/alibabacloud/metadata/metadata.go`

### 2. Lost error context in kvstore identity GC
`NewKVStoreBackend` error was discarded — `fmt.Errorf` created a new message without `%w` wrapping. When kvstore initialization fails, operators see a generic message with no root cause. Added `%w` wrapping.

**File:** `operator/identitygc/kvstore_gc.go`

### 3. Logic inversion in drop event emitter fake recorder
Condition was `err != nil` (runs on error) but intent is `err == nil` (access result on success). Also added comma-ok guards on nested type assertions to prevent panics on unexpected types.

**File:** `pkg/hubble/dropeventemitter/fake_recorder.go`

### 4. Unchecked type assertions in clustermesh CLI (2 locations)
`.(string)` without comma-ok on Helm metadata values — panics if value is missing or wrong type. Changed to comma-ok pattern with proper error returns.

**File:** `cilium-cli/clustermesh/clustermesh.go`

## Testing

- `go vet` clean on all changed packages
- Each fix is a minimal, isolated change with no behavioral impact on the happy path