### PR TITLE
ipam: Add allocator-independent ENI `AllocationResult` builder

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -727,42 +727,8 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 
 	switch a.conf.IPAMMode() {
 
-	// In ENI mode, the Resource points to the ENI so we can derive the
-	// master interface and all CIDRs of the VPC
 	case ipamOption.IPAMENI:
-		for _, eni := range a.store.ownNode.Status.ENI.ENIs {
-			if eni.ID == ipInfo.Resource {
-				result.PrimaryMAC = eni.MAC
-				result.CIDRs = []string{eni.VPC.PrimaryCIDR}
-				result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
-				// Add manually configured Native Routing CIDR
-				if a.conf.IPv4NativeRoutingCIDR != nil {
-					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR.String())
-				}
-				// If the ip-masq-agent is enabled, get the CIDRs that are not masqueraded.
-				// Note that the resulting ip rules will not be dynamically regenerated if the
-				// ip-masq-agent configuration changes.
-				if a.conf.EnableIPMasqAgent {
-					nonMasqCidrs := a.ipMasqAgent.NonMasqCIDRsFromConfig()
-					for _, prefix := range nonMasqCidrs {
-						if ip.To4() != nil && prefix.Addr().Is4() {
-							result.CIDRs = append(result.CIDRs, prefix.String())
-						} else if ip.To4() == nil && prefix.Addr().Is6() {
-							result.CIDRs = append(result.CIDRs, prefix.String())
-						}
-					}
-				}
-				if eni.Subnet.CIDR != "" {
-					// The gateway for a subnet and VPC is always x.x.x.1
-					// Ref: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
-					result.GatewayIP = deriveGatewayIP(a.logger, eni.Subnet.CIDR, 1)
-				}
-				result.InterfaceNumber = strconv.Itoa(eni.Number)
-
-				return
-			}
-		}
-		return nil, fmt.Errorf("unable to find ENI %s", ipInfo.Resource)
+		return buildENIAllocationResult(a.logger, ip, a.store.ownNode, a.conf, a.ipMasqAgent)
 
 	// In Azure mode, the Resource points to the azure interface so we can
 	// derive the master interface

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"slices"
+	"strconv"
 
 	"github.com/cilium/hive/job"
 	"github.com/vishvananda/netlink"
@@ -21,9 +22,11 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/ipmasq"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -326,4 +329,81 @@ func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sy
 	}
 
 	return nil
+}
+
+// buildENIAllocationResult derives ENI-specific AllocationResult metadata
+// (PrimaryMAC, GatewayIP, VPC CIDRs, InterfaceNumber) by finding which ENI
+// owns the given IP.
+func buildENIAllocationResult(
+	logger *slog.Logger,
+	allocatedIP net.IP,
+	node *ciliumv2.CiliumNode,
+	conf *option.DaemonConfig,
+	ipMasqAgent *ipmasq.IPMasqAgent,
+) (*AllocationResult, error) {
+	for _, eni := range node.Status.ENI.ENIs {
+		if !eniContainsIP(eni, allocatedIP) {
+			continue
+		}
+
+		result := &AllocationResult{
+			IP:         allocatedIP,
+			PrimaryMAC: eni.MAC,
+			CIDRs:      []string{eni.VPC.PrimaryCIDR},
+		}
+		result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
+
+		// Add manually configured Native Routing CIDR
+		if conf.IPv4NativeRoutingCIDR != nil {
+			result.CIDRs = append(result.CIDRs, conf.IPv4NativeRoutingCIDR.String())
+		}
+
+		// If the ip-masq-agent is enabled, get the CIDRs that are not masqueraded.
+		// Note that the resulting ip rules will not be dynamically regenerated if the
+		// ip-masq-agent configuration changes.
+		if conf.EnableIPMasqAgent {
+			for _, prefix := range ipMasqAgent.NonMasqCIDRsFromConfig() {
+				if allocatedIP.To4() != nil && prefix.Addr().Is4() {
+					result.CIDRs = append(result.CIDRs, prefix.String())
+				} else if allocatedIP.To4() == nil && prefix.Addr().Is6() {
+					result.CIDRs = append(result.CIDRs, prefix.String())
+				}
+			}
+		}
+
+		if eni.Subnet.CIDR != "" {
+			// The gateway for a subnet and VPC is always x.x.x.1
+			// Ref: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
+			result.GatewayIP = deriveGatewayIP(logger, eni.Subnet.CIDR, 1)
+		}
+		result.InterfaceNumber = strconv.Itoa(eni.Number)
+
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("unable to find ENI for IP %s", allocatedIP)
+}
+
+// eniContainsIP returns true if the given IP belongs to the ENI: either as the
+// primary IP, a secondary address, or within one of its delegated prefixes.
+func eniContainsIP(eni eniTypes.ENI, ip net.IP) bool {
+	ipStr := ip.String()
+	if eni.IP == ipStr {
+		return true
+	}
+	if slices.Contains(eni.Addresses, ipStr) {
+		return true
+	}
+
+	for _, prefix := range eni.Prefixes {
+		_, cidr, err := net.ParseCIDR(prefix)
+		if err != nil {
+			continue
+		}
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -4,13 +4,17 @@
 package ipam
 
 import (
+	"net"
 	"testing"
 
+	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/cidr"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func Test_validateENIConfig(t *testing.T) {
@@ -220,4 +224,143 @@ func Test_validateENIConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildENIAllocationResult(t *testing.T) {
+	node := &ciliumv2.CiliumNode{}
+	node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+		"eni-1": {
+			ID:  "eni-1",
+			MAC: "aa:bb:cc:dd:ee:01",
+			Addresses: []string{
+				"10.1.1.10",
+				"10.1.1.11",
+			},
+			Number: 1,
+			Subnet: eniTypes.AwsSubnet{
+				CIDR: "10.1.1.0/24",
+			},
+			VPC: eniTypes.AwsVPC{
+				PrimaryCIDR: "10.1.0.0/16",
+				CIDRs:       []string{"10.2.0.0/16"},
+			},
+		},
+		"eni-2": {
+			ID:  "eni-2",
+			MAC: "aa:bb:cc:dd:ee:02",
+			Addresses: []string{
+				"10.3.1.20",
+			},
+			Number: 2,
+			Subnet: eniTypes.AwsSubnet{
+				CIDR: "10.3.1.0/24",
+			},
+			VPC: eniTypes.AwsVPC{
+				PrimaryCIDR: "10.1.0.0/16",
+				CIDRs:       []string{"10.2.0.0/16"},
+			},
+		},
+	}
+
+	conf := &option.DaemonConfig{}
+	logger := hivetest.Logger(t)
+
+	t.Run("secondary IP on eni-1", func(t *testing.T) {
+		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.10"), node, conf, nil)
+		require.NoError(t, err)
+		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
+		require.Equal(t, "1", result.InterfaceNumber)
+		require.Equal(t, "10.1.1.1", result.GatewayIP)
+		require.Contains(t, result.CIDRs, "10.1.0.0/16")
+		require.Contains(t, result.CIDRs, "10.2.0.0/16")
+	})
+
+	t.Run("secondary IP on eni-2", func(t *testing.T) {
+		result, err := buildENIAllocationResult(logger, net.ParseIP("10.3.1.20"), node, conf, nil)
+		require.NoError(t, err)
+		require.Equal(t, "aa:bb:cc:dd:ee:02", result.PrimaryMAC)
+		require.Equal(t, "2", result.InterfaceNumber)
+		require.Equal(t, "10.3.1.1", result.GatewayIP)
+	})
+
+	t.Run("unknown IP returns error", func(t *testing.T) {
+		_, err := buildENIAllocationResult(logger, net.ParseIP("10.99.99.99"), node, conf, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to find ENI for IP")
+	})
+
+	t.Run("native routing CIDR is appended", func(t *testing.T) {
+		confWithNative := &option.DaemonConfig{
+			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.0.0.0/8"),
+		}
+		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.10"), node, confWithNative, nil)
+		require.NoError(t, err)
+		require.Contains(t, result.CIDRs, "10.0.0.0/8")
+	})
+}
+
+func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
+	node := &ciliumv2.CiliumNode{}
+	node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+		"eni-1": {
+			ID:  "eni-1",
+			MAC: "aa:bb:cc:dd:ee:01",
+			Prefixes: []string{
+				"10.1.1.0/28",
+				"10.1.1.16/28",
+			},
+			Number: 1,
+			Subnet: eniTypes.AwsSubnet{
+				CIDR: "10.1.1.0/24",
+			},
+			VPC: eniTypes.AwsVPC{
+				PrimaryCIDR: "10.1.0.0/16",
+			},
+		},
+	}
+
+	conf := &option.DaemonConfig{}
+	logger := hivetest.Logger(t)
+
+	t.Run("IP in first prefix", func(t *testing.T) {
+		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.5"), node, conf, nil)
+		require.NoError(t, err)
+		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
+		require.Equal(t, "1", result.InterfaceNumber)
+	})
+
+	t.Run("IP in second prefix", func(t *testing.T) {
+		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.20"), node, conf, nil)
+		require.NoError(t, err)
+		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
+	})
+
+	t.Run("IP outside all prefixes", func(t *testing.T) {
+		_, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.32"), node, conf, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestEniContainsIP(t *testing.T) {
+	eni := eniTypes.ENI{
+		IP:        "10.0.0.100",
+		Addresses: []string{"10.0.0.1", "10.0.0.2"},
+		Prefixes:  []string{"10.0.1.0/28"},
+	}
+
+	// Primary IP match
+	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.0.100")))
+
+	// Secondary address match
+	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.0.1")))
+	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.0.2")))
+	require.False(t, eniContainsIP(eni, net.ParseIP("10.0.0.3")))
+
+	// Prefix match
+	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.1.0")))
+	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.1.15")))
+	require.False(t, eniContainsIP(eni, net.ParseIP("10.0.1.16")))
+
+	// Empty ENI
+	require.False(t, eniContainsIP(eniTypes.ENI{}, net.ParseIP("10.0.0.1")))
 }


### PR DESCRIPTION
Add `buildENIAllocationResult` which derives ENI-specific metadata by matching an allocated IP against each ENI's Addresses and Prefixes lists. This replaces the CRD allocator's inline ENI branch in `buildAllocationResult`, which looked up the ENI by `AllocationIP.Resource` (ENI ID).

The IP-based lookup is needed for the multi-pool allocator, as it allocates IPs from CIDRs without tracking per-IP resource metadata. The `eniContainsIP` helper covers all cases:
* IP is a secondary ENI IP: under `eni.Addresses`
* IP belongs to a delegated prefix: under `eni.Prefixes`
* IP is ENI primary IP (necessary for when `UsePrimaryAddress` is enabled): under `eni.IP`

Relates to cilium/design-cfps#87