### PR TITLE
Allow ServiceMatcher LRPs to fallback to service backends

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -383,7 +383,6 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 	switch lrp.FrontendType {
 	case svcFrontendAll, svcFrontendSinglePort, addrFrontendSinglePort:
 		portNameMatches = nil
-
 	}
 
 	// Function to compare whether the new Backend produced in the loop below
@@ -397,19 +396,51 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 
 	// Construct the Backend from matching pods.
 	beps := make([]lb.Backend, 0, len(pods))
-	lrpServiceName := lrp.RedirectServiceName()
+
+	portNumberMatches := func(addr lb.L3n4Addr) bool {
+		return slices.ContainsFunc(lrp.BackendPorts, func(p bePortInfo) bool {
+			return p.l4Addr.Port == addr.Port() && p.l4Addr.Protocol == addr.Protocol()
+		})
+	}
+
+	appendBackend := func(be lb.Backend) {
+		if portNameMatches != nil && !slices.ContainsFunc(be.PortNames, portNameMatches) {
+			return
+		}
+		if !portNumberMatches(be.Address) {
+			return
+		}
+		beps = append(beps, lb.Backend{
+			Address:   be.Address,
+			State:     be.State,
+			PortNames: slices.Clone(be.PortNames),
+			// NOTE: Update [compareBackendParams] if more fields are added here.
+		})
+	}
+
+	serviceBackendsByAddr := map[cmtypes.AddrCluster][]*lb.Backend{}
+	if lrp.LRPType == lrpConfigTypeSvc {
+		serviceBackends, _ := lb.ListBackendsByServiceName(wtxn, c.p.Writer.Backends(), lrp.ServiceID)
+		preferred := lb.PreferredBackendsByAddress(serviceBackends)
+		for be := range preferred {
+			addrCluster := be.Address.AddrCluster()
+			serviceBackendsByAddr[addrCluster] = append(serviceBackendsByAddr[addrCluster], be)
+		}
+	}
+
+	hasServiceBackendFallback := len(serviceBackendsByAddr) != 0
 	for _, podInfo := range pods {
+		if len(podInfo.addrs) == 0 && hasServiceBackendFallback {
+			for _, podIP := range podInfo.ips {
+				for _, be := range serviceBackendsByAddr[podIP] {
+					appendBackend(*be)
+				}
+			}
+			continue
+		}
+
 		for _, addr := range podInfo.addrs {
-			if portNameMatches != nil && !portNameMatches(addr.portName) {
-				continue
-			}
-			portNumberMatches := slices.ContainsFunc(lrp.BackendPorts, func(p bePortInfo) bool {
-				return p.l4Addr.Port == addr.Port() && p.l4Addr.Protocol == addr.Protocol()
-			})
-			if !portNumberMatches {
-				continue
-			}
-			beps = append(beps, lb.Backend{
+			appendBackend(lb.Backend{
 				Address: addr.L3n4Addr,
 				State:   lb.BackendStateActive,
 				PortNames: func() []string {
@@ -418,7 +449,6 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 					}
 					return []string{}
 				}(),
-				// NOTE: Update [compareBackendParams] if more fields are added here.
 			})
 		}
 	}
@@ -426,6 +456,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 	// Validate whether an update is actually needed to avoid no-op changes to the tables.
 	newCount := len(beps)
 	orphanCount := 0
+	lrpServiceName := lrp.RedirectServiceName()
 	bes, _ := lb.ListBackendsByServiceName(wtxn, c.p.Writer.Backends(), lrpServiceName)
 	preferred := lb.PreferredBackendsByAddress(bes)
 	for be := range preferred {
@@ -616,17 +647,20 @@ type podAddr struct {
 	portName string
 }
 
-func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
+func podAddrs(pod *slim_corev1.Pod) (ips []cmtypes.AddrCluster, addrs []podAddr) {
 	podIPs := k8sUtils.ValidIPs(pod.Status)
 	if len(podIPs) == 0 {
 		// IPs not available yet.
-		return nil
+		return nil, nil
 	}
 	for _, podIP := range podIPs {
 		addrCluster, err := cmtypes.ParseAddrCluster(podIP)
 		if err != nil {
 			continue
 		}
+		ips = append(ips, addrCluster)
+	}
+	for _, addrCluster := range ips {
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				l4addr := lb.NewL4Addr(lb.L4Type(port.Protocol), uint16(port.ContainerPort))
@@ -643,22 +677,31 @@ func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
 			}
 		}
 	}
-	return
+	return ips, addrs
 }
 
 // podInfo is the condensed data from the pod relevant for the LRP processing.
 type podInfo struct {
 	namespace      string
 	namespacedName string
-	addrs          []podAddr
-	labels         map[string]string
+	// ips identify the selected pod independently of declared container
+	// ports. ServiceMatcher LRPs use these to match selected pods back to
+	// reflected service backends when the pod spec does not declare ports.
+	ips []cmtypes.AddrCluster
+	// addrs are the concrete backend addresses derived from the pod spec.
+	// Address-based LRPs rely on these directly, and ServiceMatcher LRPs use
+	// them when container ports are declared.
+	addrs  []podAddr
+	labels map[string]string
 }
 
 func getPodInfo(pod daemonk8s.LocalPod) podInfo {
+	ips, addrs := podAddrs(pod.Pod)
 	return podInfo{
 		namespace:      pod.Namespace,
 		namespacedName: pod.Namespace + "/" + pod.Name,
-		addrs:          podAddrs(pod.Pod),
+		ips:            ips,
+		addrs:          addrs,
 		labels:         pod.Labels,
 	}
 }

--- a/pkg/loadbalancer/redirectpolicy/testdata/service-no-pod-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service-no-pod-ports.txtar
@@ -1,0 +1,137 @@
+hive start
+
+# Add the service backend pod, service and EndpointSlice. The pod does not
+# declare any container ports, but the EndpointSlice still carries the
+# resolved backend ports.
+k8s/add pod.yaml service.yaml endpointslice.yaml
+db/cmp services services-before.table
+
+# Add a service-based local redirect policy that selects the same pod.
+k8s/add lrp-svc.yaml
+db/cmp localredirectpolicies lrp.table
+db/cmp services services-after.table
+db/cmp frontends frontends-after.table
+db/cmp backends backends-after.table
+
+-- lrp.table --
+Name           Type     FrontendType                Frontends
+test/lrp-svc   service  all
+
+-- services-before.table --
+Name       Source
+test/echo  k8s
+
+-- services-after.table --
+Name                          Source
+test/echo                     k8s
+test/lrp-svc:local-redirect   k8s
+
+-- frontends-after.table --
+Address                    Type        ServiceName   PortName   Backends              RedirectTo                    Status
+169.254.169.254:7070/UDP   ClusterIP   test/echo     udp        10.244.2.1:70/UDP     test/lrp-svc:local-redirect   Done
+169.254.169.254:8080/TCP   ClusterIP   test/echo     tcp        10.244.2.1:80/TCP     test/lrp-svc:local-redirect   Done
+
+-- backends-after.table --
+Service                      Address            NodeName
+test/echo                    10.244.2.1:70/UDP  testnode
+test/echo                    10.244.2.1:80/TCP  testnode
+test/lrp-svc:local-redirect  10.244.2.1:70/UDP
+test/lrp-svc:local-redirect  10.244.2.1:80/TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: echo
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2019-07-08T09:41:59Z"
+    status: "True"
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 169.254.169.254
+  ports:
+  - name: udp
+    port: 7070
+    protocol: UDP
+    targetPort: 70
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: echo
+  type: ClusterIP
+
+-- endpointslice.yaml --
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-1
+  namespace: test
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: udp
+  port: 70
+  protocol: UDP
+- name: tcp
+  port: 80
+  protocol: TCP
+
+-- lrp-svc.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-svc
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: echo
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: echo
+    toPorts:
+      - port: "80"
+        name: "tcp"
+        protocol: TCP
+      - port: "70"
+        name: "udp"
+        protocol: UDP


### PR DESCRIPTION
This PR updates the LRP Controller logic to provide a fall-back mechanism for ServiceMatcher LRPs that map backend pods that don't have container ports in their spec. This is achieved by:

1. Bubbling up a Pods range of `AddrCluster` entries (pure L3) as well as `L3n4Addr` entries (L3 + L4 tuple) when an LRP is being matched to backend pods.
2. Caching existing service backend entries for ServiceMatcher LRPs
3. Where a matched pod has no `L3n4Addr` entries, we instead map to the cached backends, if available.

This maintains the existing logic for backend pods that _do_ specify container ports, but allows mapping to succeed if container ports are not specified.

Fixes: #43929 

```release-note
LocalRedirectPolicies with a ServiceMatcher that maps to pods with unspecified container ports will now fallback to ports from the redirected service.
```
