### PR TITLE
operator/identitygc: fix nil pointer dereference on shutdown

### DIFF
--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -147,7 +147,9 @@ func registerGC(p params) {
 				gc.allocationMode == option.IdentityAllocationModeDoubleWriteReadCRD ||
 				gc.allocationMode == option.IdentityAllocationModeDoubleWriteReadKVstore {
 				// CRD mode GC runs in an additional goroutine
-				gc.mgr.RemoveAllAndWait()
+				if gc.mgr != nil {
+					gc.mgr.RemoveAllAndWait()
+				}
 			}
 			// Close the worker pool first to ensure all goroutines complete
 			// before stopping the rate limiter they depend on

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -147,6 +147,50 @@ func TestIdentitiesGC(t *testing.T) {
 	}
 }
 
+func TestIdentitiesGC_Disabled(t *testing.T) {
+	defer testutils.GoleakVerifyNone(
+		t,
+		testutils.GoleakIgnoreTopFunction("time.Sleep"),
+	)
+
+	hive := hive.New(
+		cell.Config(cmtypes.DefaultClusterInfo),
+		metrics.Metric(NewMetrics),
+
+		k8sFakeClient.FakeClientCell(),
+		kvstore.Cell(kvstore.DisabledBackendName),
+		spire.FakeCellClient,
+		k8s.ResourcesCell,
+
+		cell.Provide(func() Config {
+			return Config{
+				Interval: 0,
+
+				RateInterval: time.Minute,
+				RateLimit:    2500,
+			}
+		}),
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				IdentityAllocationMode: option.IdentityAllocationModeCRD,
+			}
+		}),
+
+		cell.Invoke(registerGC),
+	)
+
+	ctx := t.Context()
+	tlog := hivetest.Logger(t)
+
+	if err := hive.Start(tlog, ctx); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if err := hive.Stop(tlog, ctx); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
 func setupK8sNodes(t *testing.T, clientset k8sClient.Clientset) error {
 	nodes := []*corev1.Node{
 		{


### PR DESCRIPTION
When DisableCiliumEndpointCRD is set (e.g. via --disable-endpoint-crd=true) and the CiliumEndpoint CRD is missing from the cluster, the startCRDModeGC startup function returns early to skip running the Garbage Collector.

However, the OnStop lifecycle hook unconditionally attempts to call RemoveAllAndWait() on the internal controller manager (gc.mgr). Since it remains uninitialized (nil) due to the early return, this causes a panic when the operator shuts down.

Fix this by adding a defensive nil check for gc.mgr in OnStop.

Fixes: #45087
