### PR TITLE
alibabacloud: close HTTP response body on non-200 status codes

### DIFF
--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -62,12 +62,11 @@ func getMetadata(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("metadata service returned status code %d", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 	respBytes, err := safeio.ReadAllLimit(resp.Body, safeio.MB)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
defer resp.Body.Close() is placed after the status check, so the body leaks on non-200 responses. Moved it before the check.

Found while reviewing the metadata client for a related timeout issue.