### PR TITLE
operator: wrap kvstore backend init error in identity GC

### DIFF
--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -20,7 +20,7 @@ func (igc *GC) startKVStoreModeGC(ctx context.Context) error {
 	igc.logger.InfoContext(ctx, "Starting kvstore identity garbage collector", logfields.Interval, igc.gcInterval)
 	backend, err := kvstoreallocator.NewKVStoreBackend(igc.logger, kvstoreallocator.KVStoreBackendConfiguration{BasePath: cache.IdentitiesPath, Backend: igc.kvstoreClient})
 	if err != nil {
-		return fmt.Errorf("unable to initialize kvstore backend for identity allocation")
+		return fmt.Errorf("unable to initialize kvstore backend for identity allocation: %w", err)
 	}
 
 	minID := idpool.ID(ciliumIdentity.GetMinimalAllocationIdentity(igc.clusterInfo.ID))


### PR DESCRIPTION
The original error from NewKVStoreBackend is discarded — operators just see "unable to initialize kvstore backend" with no root cause. Added %w wrapping.