### PR TITLE
hubble: fix inverted error check and unsafe type assertions in fake recorder

### DIFF
--- a/pkg/hubble/dropeventemitter/fake_recorder.go
+++ b/pkg/hubble/dropeventemitter/fake_recorder.go
@@ -26,8 +26,12 @@ type FakeRecorder struct {
 func objectString(object runtime.Object, includeObject bool) string {
 	var uid string
 	uo, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
-	if err != nil && uo["metadata"] != nil && uo["metadata"].(map[string]any)["uid"] != nil {
-		uid = uo["metadata"].(map[string]any)["uid"].(string)
+	if err == nil {
+		if meta, ok := uo["metadata"].(map[string]any); ok {
+			if u, ok := meta["uid"].(string); ok {
+				uid = u
+			}
+		}
 	}
 	if !includeObject {
 		return ""


### PR DESCRIPTION
The condition checks err != nil but should be err == nil — uid extraction only makes sense when ToUnstructured succeeds. Also switched to comma-ok type assertions to avoid panics on unexpected types.

Noticed while looking at drop event handling in hubble.