### PR TITLE
ztunnel: add Prometheus metrics with conditional enablement

### DIFF
--- a/pkg/ztunnel/xds/cell.go
+++ b/pkg/ztunnel/xds/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/ztunnel/config"
 	"github.com/cilium/cilium/pkg/ztunnel/table"
 )
@@ -26,6 +27,7 @@ var Cell = cell.Module(
 		}
 		return x.endpointEventChan
 	}),
+	metrics.Metric(NewMetrics),
 )
 
 type xdsServerParams struct {
@@ -38,12 +40,14 @@ type xdsServerParams struct {
 	K8sWatcher             *watchers.K8sWatcher
 	Config                 config.Config
 	EnrolledNamespaceTable statedb.RWTable[*table.EnrolledNamespace]
+	Metrics                *Metrics
 }
 
 func NewServer(params xdsServerParams) *Server {
 	if !params.Config.EnableZTunnel {
 		return nil
 	}
+	params.Metrics.Enable()
 
 	server := newServer(
 		params.Logger,
@@ -52,6 +56,7 @@ func NewServer(params xdsServerParams) *Server {
 		params.K8sWatcher.GetK8sCiliumEndpointsWatcher(),
 		params.EnrolledNamespaceTable,
 		params.Config.EndpointEventChannelBufferSize,
+		params.Metrics,
 	)
 
 	params.Lifecycle.Append(cell.Hook{

--- a/pkg/ztunnel/xds/metrics.go
+++ b/pkg/ztunnel/xds/metrics.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xds
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	// subsystem is the metrics subsystem for ztunnel XDS
+	subsystem = "ztunnel_xds"
+
+	// Label names
+	labelStatus = "status"
+)
+
+// Metrics holds XDS-related metrics for ztunnel workload discovery
+type Metrics struct {
+	// EnrollmentFailures tracks workload enrollment failures to Z-tunnel via XDS
+	// Status values: send_failed, nack_received
+	EnrollmentFailures metric.Vec[metric.Counter]
+}
+
+// Enable enables XDS metrics for Prometheus scraping.
+func (m *Metrics) Enable() {
+	if m == nil {
+		return
+	}
+	m.EnrollmentFailures.SetEnabled(true)
+}
+
+// NewMetrics creates a new Metrics instance for XDS enrollment failures
+func NewMetrics() *Metrics {
+	return &Metrics{
+		EnrollmentFailures: metric.NewCounterVec(
+			metric.CounterOpts{
+				Disabled:  true,
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "enrollment_failures_total",
+				Help:      "Total number of workload enrollment failures to ztunnel via XDS by status (send_failed, nack_received)",
+			},
+			[]string{labelStatus},
+		),
+	}
+}

--- a/pkg/ztunnel/xds/metrics_test.go
+++ b/pkg/ztunnel/xds/metrics_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package xds
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+func TestMetricsDisabledByDefault(t *testing.T) {
+	m := NewMetrics()
+
+	require.NotNil(t, m.EnrollmentFailures, "EnrollmentFailures should be initialized")
+
+	// Verify operations on disabled metrics don't panic
+	m.EnrollmentFailures.WithLabelValues("send_failed").Inc()
+	m.EnrollmentFailures.WithLabelValues("nack_received").Inc()
+}
+
+func TestMetricsEnabled(t *testing.T) {
+	m := NewMetrics()
+	m.Enable()
+
+	// Verify operations on enabled metrics don't panic
+	m.EnrollmentFailures.WithLabelValues("send_failed").Inc()
+	m.EnrollmentFailures.WithLabelValues("nack_received").Inc()
+}
+
+// TestEnrollmentFailuresActuallyEmit verifies enrollment failure metrics are actually emitted to Prometheus
+func TestEnrollmentFailuresActuallyEmit(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	enrollmentFailures := metric.NewCounterVec(
+		metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "enrollment_failures_total",
+			Help:      "Total number of workload enrollment failures to ztunnel via XDS by status",
+		},
+		[]string{labelStatus},
+	)
+	registry.MustRegister(enrollmentFailures)
+
+	enrollmentFailures.WithLabelValues("send_failed").Inc()
+	enrollmentFailures.WithLabelValues("nack_received").Inc()
+	enrollmentFailures.WithLabelValues("nack_received").Inc()
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 1, "Expected exactly 1 metric family")
+
+	assert.Equal(t, "cilium_ztunnel_xds_enrollment_failures_total", *metricFamilies[0].Name)
+	require.Len(t, metricFamilies[0].Metric, 2, "Expected 2 metrics for 2 different status labels")
+
+	statusCounts := make(map[string]float64)
+	for _, m := range metricFamilies[0].Metric {
+		require.Len(t, m.Label, 1, "Expected exactly 1 label")
+		assert.Equal(t, "status", *m.Label[0].Name)
+		statusCounts[*m.Label[0].Value] = *m.Counter.Value
+	}
+
+	assert.Equal(t, float64(1), statusCounts["send_failed"], "send_failed should be incremented once")
+	assert.Equal(t, float64(2), statusCounts["nack_received"], "nack_received should be incremented twice")
+}

--- a/pkg/ztunnel/xds/stream_processor.go
+++ b/pkg/ztunnel/xds/stream_processor.go
@@ -37,6 +37,7 @@ type StreamProcessorParams struct {
 	DB                        *statedb.DB
 	EnrolledNamespaceTable    statedb.RWTable[*table.EnrolledNamespace]
 	Log                       *slog.Logger
+	Metrics                   *Metrics
 }
 
 // StreamProcessor implements the logic for handling xDS streams to zTunnel.
@@ -52,6 +53,7 @@ type StreamProcessor struct {
 	endpointSource         EndpointEventSource
 	db                     *statedb.DB
 	enrolledNamespaceTable statedb.RWTable[*table.EnrolledNamespace]
+	metrics                *Metrics
 }
 
 // CiliumEndpointsWatcher defines the interface for watching CiliumEndpoints and CiliumEndpointSlices.
@@ -94,6 +96,10 @@ type EndpointEventSource interface {
 }
 
 func NewStreamProcessor(params *StreamProcessorParams) *StreamProcessor {
+	metrics := params.Metrics
+	if metrics == nil {
+		metrics = NewMetrics()
+	}
 	sp := &StreamProcessor{
 		stream:                 params.Stream,
 		streamRecv:             params.StreamRecv,
@@ -102,6 +108,7 @@ func NewStreamProcessor(params *StreamProcessorParams) *StreamProcessor {
 		expectedNonce:          make(map[string]struct{}),
 		db:                     params.DB,
 		enrolledNamespaceTable: params.EnrolledNamespaceTable,
+		metrics:                metrics,
 	}
 	sp.endpointSource = NewEndpointSource(params.K8sCiliumEndpointsWatcher, sp)
 	return sp
@@ -328,6 +335,7 @@ func (sp *StreamProcessor) handleAddressTypeURL(req *v3.DeltaDiscoveryRequest) e
 	sp.expectedNonce[resp.Nonce] = struct{}{}
 
 	if err := sp.stream.SendMsg(resp); err != nil {
+		sp.metrics.EnrollmentFailures.WithLabelValues("send_failed").Inc()
 		return err
 	}
 
@@ -365,6 +373,7 @@ func (sp *StreamProcessor) handleDeltaDiscoveryReq(req *v3.DeltaDiscoveryRequest
 		delete(sp.expectedNonce, req.ResponseNonce)
 
 		if req.ErrorDetail != nil {
+			sp.metrics.EnrollmentFailures.WithLabelValues("nack_received").Inc()
 			sp.log.Error("Nack received from ztunnel",
 				logfields.Error,
 				req.ErrorDetail.Message,

--- a/pkg/ztunnel/xds/stream_processor_test.go
+++ b/pkg/ztunnel/xds/stream_processor_test.go
@@ -240,6 +240,7 @@ func TestStreamProcessorEndpointEvents(t *testing.T) {
 
 		// Create StreamProcessor with the populated channel
 		sp := &StreamProcessor{
+			metrics:       NewMetrics(),
 			stream:        mockStream,
 			endpointRecv:  endpointEventChan,
 			expectedNonce: make(map[string]struct{}),
@@ -295,6 +296,7 @@ func TestStreamProcessorEndpointEvents(t *testing.T) {
 func TestStreamProcessorDeltaDiscoveryRequest(t *testing.T) {
 	t.Run("Ack", func(t *testing.T) {
 		sp := &StreamProcessor{
+			metrics: NewMetrics(),
 			expectedNonce: map[string]struct{}{
 				"x": {},
 			},
@@ -316,6 +318,7 @@ func TestStreamProcessorDeltaDiscoveryRequest(t *testing.T) {
 
 	t.Run("Unexpected Nonce", func(t *testing.T) {
 		sp := &StreamProcessor{
+			metrics: NewMetrics(),
 			// no Nonce recorded
 			expectedNonce: map[string]struct{}{},
 			log:           slog.New(slog.DiscardHandler),
@@ -337,6 +340,7 @@ func TestStreamProcessorDeltaDiscoveryRequest(t *testing.T) {
 
 	t.Run("Nack logs error but does not return error", func(t *testing.T) {
 		sp := &StreamProcessor{
+			metrics: NewMetrics(),
 			expectedNonce: map[string]struct{}{
 				"nack-nonce": {},
 			},
@@ -362,6 +366,7 @@ func TestStreamProcessorDeltaDiscoveryRequest(t *testing.T) {
 
 	t.Run("Unexpected TypeURL returns error", func(t *testing.T) {
 		sp := &StreamProcessor{
+			metrics:       NewMetrics(),
 			expectedNonce: make(map[string]struct{}),
 			log:           slog.New(slog.DiscardHandler),
 		}
@@ -386,6 +391,7 @@ func TestHandleAuthorizationTypeURL(t *testing.T) {
 		}
 
 		sp := &StreamProcessor{
+			metrics:       NewMetrics(),
 			stream:        mockStream,
 			expectedNonce: make(map[string]struct{}),
 			log:           slog.New(slog.DiscardHandler),
@@ -419,6 +425,7 @@ func TestHandleAddressTypeURL(t *testing.T) {
 		}
 
 		sp := &StreamProcessor{
+			metrics:       NewMetrics(),
 			stream:        mockStream,
 			expectedNonce: make(map[string]struct{}),
 			log:           slog.New(slog.DiscardHandler),
@@ -453,6 +460,7 @@ func TestHandleAddressTypeURL(t *testing.T) {
 
 		mockEpSource := &MockEndpointEventSource{}
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			stream:                 mockStream,
 			expectedNonce:          make(map[string]struct{}),
 			log:                    slog.New(slog.DiscardHandler),
@@ -792,6 +800,7 @@ func TestSubscribeToEndpointEvents_CEP(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -826,6 +835,7 @@ func TestSubscribeToEndpointEvents_CEP(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -875,6 +885,7 @@ func TestSubscribeToEndpointEvents_CEP(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -930,6 +941,7 @@ func TestSubscribeToEndpointEvents_CEP(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -969,6 +981,7 @@ func TestSubscribeToEndpointEvents_CEP(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1013,6 +1026,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1047,6 +1061,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1095,6 +1110,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1150,6 +1166,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1231,6 +1248,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1294,6 +1312,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,
@@ -1332,6 +1351,7 @@ func TestSubscribeToEndpointEvents_CES(t *testing.T) {
 
 		endpointRecv := make(chan *EndpointEvent, 10)
 		sp := &StreamProcessor{
+			metrics:                NewMetrics(),
 			endpointRecv:           endpointRecv,
 			db:                     db,
 			enrolledNamespaceTable: tbl,

--- a/pkg/ztunnel/xds/xds_server.go
+++ b/pkg/ztunnel/xds/xds_server.go
@@ -79,6 +79,7 @@ type Server struct {
 	// endpointEventChan is shared across streams. Overlapping sends during
 	// ztunnel reconnect are safe since xDS upserts are idempotent.
 	endpointEventChan chan *EndpointEvent
+	metrics           *Metrics
 	// cache the PEM encoded certificate, we return this as the trust anchor
 	// on zTunnel certificate creation requests.
 	caCertPEM string
@@ -94,6 +95,7 @@ func newServer(
 	k8sCiliumEndpointsWatcher *watchers.K8sCiliumEndpointsWatcher,
 	enrolledNamespaceTable statedb.RWTable[*table.EnrolledNamespace],
 	endpointEventChanBufferSize int,
+	metrics *Metrics,
 ) *Server {
 	return &Server{
 		log:                       log,
@@ -102,6 +104,7 @@ func newServer(
 		endpointEventChan:         make(chan *EndpointEvent, endpointEventChanBufferSize),
 		db:                        db,
 		enrolledNamespaceTable:    enrolledNamespaceTable,
+		metrics:                   metrics,
 	}
 }
 
@@ -398,6 +401,7 @@ func (x *Server) DeltaAggregatedResources(stream v3.AggregatedDiscoveryService_D
 		Log:                       x.log,
 		DB:                        x.db,
 		EnrolledNamespaceTable:    x.enrolledNamespaceTable,
+		Metrics:                   x.metrics,
 	}
 
 	x.log.Debug("begin processing DeltaAggregatedResources stream")

--- a/pkg/ztunnel/xds/xds_server_test.go
+++ b/pkg/ztunnel/xds/xds_server_test.go
@@ -251,7 +251,8 @@ func TestCreateCertificate(t *testing.T) {
 				return []*endpoint.Endpoint{{}}
 			},
 		},
-		log: slog.Default(),
+		log:     slog.Default(),
+		metrics: NewMetrics(),
 	}
 
 	// we'll generate a CSR using the simple CSR we see in a default ztunnel

--- a/pkg/ztunnel/zds/cell.go
+++ b/pkg/ztunnel/zds/cell.go
@@ -5,6 +5,8 @@ package zds
 
 import (
 	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 // Cell implements the ztunnel server.
@@ -12,4 +14,5 @@ var Cell = cell.Module(
 	"cilium-zds-server",
 	"Workload discovery server for ztunnel",
 	cell.Provide(newZDSServer),
+	metrics.Metric(NewMetrics),
 )

--- a/pkg/ztunnel/zds/metrics.go
+++ b/pkg/ztunnel/zds/metrics.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package zds
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	// Subsystem is the metrics subsystem for ztunnel
+	subsystem = "ztunnel_zds"
+
+	// Label names
+	labelStatus = "status"
+)
+
+// Metrics holds the core ztunnel metrics
+type Metrics struct {
+	// EnrollmentTotal tracks the total number of endpoint enrollment attempts to ztunnel
+	EnrollmentTotal metric.Counter
+
+	// EnrollmentFailures tracks endpoint enrollment failures to ztunnel
+	// Status values: netns_failed, iptables_failed, send_failed, conversion_failed
+	EnrollmentFailures metric.Vec[metric.Counter]
+
+	// ConnectionActive tracks whether ztunnel is connected (1) or not (0)
+	ConnectionActive metric.Gauge
+}
+
+// NewMetrics creates a new Metrics instance with the core ztunnel metrics
+func NewMetrics() *Metrics {
+	return &Metrics{
+		EnrollmentTotal: metric.NewCounter(
+			metric.CounterOpts{
+				Disabled:  true,
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "enrollment_total",
+				Help:      "Total number of endpoint enrollment attempts to ztunnel",
+			},
+		),
+
+		EnrollmentFailures: metric.NewCounterVec(
+			metric.CounterOpts{
+				Disabled:  true,
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "enrollment_failures_total",
+				Help:      "Total number of endpoint enrollment failures to ztunnel by status (netns_failed, iptables_failed, send_failed, conversion_failed)",
+			},
+			[]string{labelStatus},
+		),
+
+		ConnectionActive: metric.NewGauge(
+			metric.GaugeOpts{
+				Disabled:  true,
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "connection_active",
+				Help:      "Whether ztunnel connection is active (1) or not (0)",
+			},
+		),
+	}
+}
+
+// Enable enables ZDS metrics for Prometheus scraping.
+func (m *Metrics) Enable() {
+	if m == nil {
+		return
+	}
+	m.EnrollmentTotal.SetEnabled(true)
+	m.EnrollmentFailures.SetEnabled(true)
+	m.ConnectionActive.SetEnabled(true)
+}

--- a/pkg/ztunnel/zds/metrics_test.go
+++ b/pkg/ztunnel/zds/metrics_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package zds
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+func TestMetricsDisabledByDefault(t *testing.T) {
+	m := NewMetrics()
+
+	// Verify all metrics are initialized but disabled
+	require.NotNil(t, m.EnrollmentTotal, "EnrollmentTotal should be initialized")
+	require.NotNil(t, m.EnrollmentFailures, "EnrollmentFailures should be initialized")
+	require.NotNil(t, m.ConnectionActive, "ConnectionActive should be initialized")
+
+	assert.False(t, m.EnrollmentTotal.IsEnabled(), "EnrollmentTotal should be disabled by default")
+	assert.False(t, m.ConnectionActive.IsEnabled(), "ConnectionActive should be disabled by default")
+
+	// Verify operations on disabled metrics don't panic
+	m.EnrollmentTotal.Inc()
+	m.EnrollmentFailures.WithLabelValues("netns_failed").Inc()
+	m.ConnectionActive.Inc()
+	m.ConnectionActive.Dec()
+}
+
+func TestMetricsEnabled(t *testing.T) {
+	m := NewMetrics()
+	m.Enable()
+
+	assert.True(t, m.EnrollmentTotal.IsEnabled(), "EnrollmentTotal should be enabled after Enable()")
+	assert.True(t, m.ConnectionActive.IsEnabled(), "ConnectionActive should be enabled after Enable()")
+}
+
+// TestEnrollmentFailuresActuallyEmit verifies enrollment failure metrics are actually emitted to Prometheus
+func TestEnrollmentFailuresActuallyEmit(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	enrollmentFailures := metric.NewCounterVec(
+		metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "enrollment_failures_total",
+			Help:      "Total number of endpoint enrollment failures to ztunnel by status",
+		},
+		[]string{labelStatus},
+	)
+	registry.MustRegister(enrollmentFailures)
+
+	enrollmentFailures.WithLabelValues("netns_failed").Inc()
+	enrollmentFailures.WithLabelValues("iptables_failed").Inc()
+	enrollmentFailures.WithLabelValues("iptables_failed").Inc()
+	enrollmentFailures.WithLabelValues("send_failed").Inc()
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 1, "Expected exactly 1 metric family")
+
+	assert.Equal(t, "cilium_ztunnel_zds_enrollment_failures_total", *metricFamilies[0].Name)
+	require.Len(t, metricFamilies[0].Metric, 3, "Expected 3 metrics for 3 different status labels")
+
+	statusCounts := make(map[string]float64)
+	for _, m := range metricFamilies[0].Metric {
+		require.Len(t, m.Label, 1, "Expected exactly 1 label")
+		assert.Equal(t, "status", *m.Label[0].Name)
+		statusCounts[*m.Label[0].Value] = *m.Counter.Value
+	}
+
+	assert.Equal(t, float64(1), statusCounts["netns_failed"], "netns_failed should be incremented once")
+	assert.Equal(t, float64(2), statusCounts["iptables_failed"], "iptables_failed should be incremented twice")
+	assert.Equal(t, float64(1), statusCounts["send_failed"], "send_failed should be incremented once")
+}
+
+// TestConnectionActiveActuallyEmit verifies connection active gauge is actually emitted to Prometheus
+func TestConnectionActiveActuallyEmit(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	connectionActive := metric.NewGauge(
+		metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "connection_active",
+			Help:      "Whether ztunnel connection is active (1) or not (0)",
+		},
+	)
+	registry.MustRegister(connectionActive)
+
+	connectionActive.Set(1)
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 1, "Expected exactly 1 metric family")
+
+	assert.Equal(t, "cilium_ztunnel_zds_connection_active", *metricFamilies[0].Name)
+	require.Len(t, metricFamilies[0].Metric, 1, "Expected exactly 1 metric")
+	assert.Equal(t, float64(1), *metricFamilies[0].Metric[0].Gauge.Value, "Connection should be active (1)")
+
+	connectionActive.Set(0)
+
+	metricFamilies, err = registry.Gather()
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), *metricFamilies[0].Metric[0].Gauge.Value, "Connection should be inactive (0)")
+}
+
+// TestAllMetricsEmitTogether verifies all metrics can coexist in the same registry
+func TestAllMetricsEmitTogether(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	enrollmentTotal := metric.NewCounter(
+		metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "enrollment_total",
+			Help:      "Total number of endpoint enrollment attempts to ztunnel",
+		},
+	)
+	enrollmentFailures := metric.NewCounterVec(
+		metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "enrollment_failures_total",
+			Help:      "Total number of endpoint enrollment failures to ztunnel by status",
+		},
+		[]string{labelStatus},
+	)
+	connectionActive := metric.NewGauge(
+		metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystem,
+			Name:      "connection_active",
+			Help:      "Whether ztunnel connection is active (1) or not (0)",
+		},
+	)
+
+	registry.MustRegister(enrollmentTotal)
+	registry.MustRegister(enrollmentFailures)
+	registry.MustRegister(connectionActive)
+
+	enrollmentTotal.Inc()
+	enrollmentTotal.Inc()
+	enrollmentFailures.WithLabelValues("netns_failed").Inc()
+	enrollmentFailures.WithLabelValues("send_failed").Inc()
+	connectionActive.Set(1)
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 3, "Expected 3 metric families")
+
+	metricNames := make(map[string]bool)
+	for _, mf := range metricFamilies {
+		metricNames[*mf.Name] = true
+	}
+	assert.True(t, metricNames["cilium_ztunnel_zds_connection_active"], "connection_active metric should be present")
+	assert.True(t, metricNames["cilium_ztunnel_zds_enrollment_total"], "enrollment_total metric should be present")
+	assert.True(t, metricNames["cilium_ztunnel_zds_enrollment_failures_total"], "enrollment_failures_total metric should be present")
+}

--- a/pkg/ztunnel/zds/server.go
+++ b/pkg/ztunnel/zds/server.go
@@ -140,6 +140,7 @@ type serverParams struct {
 	Lifecycle cell.Lifecycle
 	Logger    *slog.Logger
 	Config    config.Config
+	Metrics   *Metrics
 
 	EndpointManager endpointmanager.EndpointManager
 
@@ -173,6 +174,7 @@ type Server struct {
 
 	updates               chan zdsUpdate // updates to send to ztunnel
 	initialSnapshotSeeded chan struct{}
+	metrics               *Metrics
 }
 
 type zdsUpdate struct {
@@ -188,11 +190,16 @@ func newZDSServer(p serverParams) serverOut {
 	if !p.Config.EnableZTunnel {
 		return serverOut{}
 	}
+	if p.Metrics == nil {
+		p.Metrics = NewMetrics()
+	}
+	p.Metrics.Enable()
 	server := &Server{
 		logger:                p.Logger,
 		updates:               make(chan zdsUpdate, 100),
 		endpointCache:         make(map[uint16]*endpoint.Endpoint),
 		initialSnapshotSeeded: make(chan struct{}),
+		metrics:               p.Metrics,
 	}
 
 	zdsUnixAddr := defaultZDSUnixAddress
@@ -290,6 +297,8 @@ func (s *Server) Serve(ctx context.Context) {
 
 func (s *Server) handleConn(ctx context.Context, zc *ztunnelConn) error {
 	defer zc.Close()
+	s.metrics.ConnectionActive.Inc()
+	defer s.metrics.ConnectionActive.Dec()
 
 	s.logger.Info("new ztunnel connection")
 
@@ -331,6 +340,7 @@ func (s *Server) handleConn(ctx context.Context, zc *ztunnelConn) error {
 
 func (s *Server) EnrollEndpoint(ep *endpoint.Endpoint) error {
 	s.logger.Info("enrolling endpoint to ztunnel", logfields.EndpointID, ep.GetID16())
+	s.metrics.EnrollmentTotal.Inc()
 
 	// Check if endpoint is already enrolled
 	s.endpointCacheMutex.Lock()
@@ -343,6 +353,7 @@ func (s *Server) EnrollEndpoint(ep *endpoint.Endpoint) error {
 
 	ns, err := netns.OpenPinned(ep.GetContainerNetnsPath())
 	if err != nil {
+		s.metrics.EnrollmentFailures.WithLabelValues("netns_failed").Inc()
 		s.logger.Error("failed to open netns file",
 			logfields.EndpointID, ep.GetID16(),
 			logfields.Error, err,
@@ -354,11 +365,13 @@ func (s *Server) EnrollEndpoint(ep *endpoint.Endpoint) error {
 	if err = ns.Do(func() error {
 		return iptables.CreateInPodRules(s.logger, option.Config.EnableIPv4, option.Config.EnableIPv6)
 	}); err != nil {
+		s.metrics.EnrollmentFailures.WithLabelValues("iptables_failed").Inc()
 		return fmt.Errorf("unable to setup iptable rules for ztunnel inpod mode: %w", err)
 	}
 
 	workload, err := endpointToWorkload(ep)
 	if err != nil {
+		s.metrics.EnrollmentFailures.WithLabelValues("conversion_failed").Inc()
 		s.logger.Error("failed to convert endpoint to workload",
 			logfields.EndpointID, ep.GetID16(),
 			logfields.Error, err,
@@ -380,6 +393,7 @@ func (s *Server) EnrollEndpoint(ep *endpoint.Endpoint) error {
 
 	s.updates <- update
 	if err := <-update.errCh; err != nil {
+		s.metrics.EnrollmentFailures.WithLabelValues("send_failed").Inc()
 		return fmt.Errorf("sending update failed: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Add Prometheus metrics for ztunnel monitoring:
  - `cilium_ztunnel_enrollment_total` (counter) — tracks total endpoint enrollment attempts
  - `cilium_ztunnel_enrollment_failures_total` (counter) — tracks ZDS enrollment failures by type (netns_failed, iptables_failed, conversion_failed, send_failed)
  - `cilium_ztunnel_xds_enrollment_failures_total` (counter) — tracks XDS enrollment failures (send_failed, nack_received)
  - `cilium_ztunnel_connection_active` (gauge) — whether ztunnel is connected (1) or disconnected (0)
- Metrics are disabled by default and only enabled when `--enable-ztunnel` is true, preventing false alerts on non-ztunnel clusters
- Metrics are registered via hive cells using `metrics.Metric()` and injected through dependency injection into the ZDS and XDS servers

## Test plan
- [x] Unit tests pass for ZDS metrics (`pkg/ztunnel/zds/metrics_test.go`)
- [x] Unit tests pass for XDS metrics (`pkg/ztunnel/xds/metrics_test.go`)
- [x] Verified metrics emit correctly on a kind cluster with ztunnel enabled
- [x] Verified metrics are not emitted when ztunnel is disabled
