### PR TITLE
metrics: fix operator DumpMetrics to report histogram/summary quantiles

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -374,6 +374,12 @@ Added Metrics
 Changed Metrics
 ###############
 
+* The Cilium Operator REST API endpoint ``/v1/metrics`` (``DumpMetrics``) now
+  returns per-quantile values for histogram and summary metrics instead of a
+  raw sample sum. Histogram metrics now emit three entries with quantile labels
+  ``0.5``, ``0.9``, and ``0.99``. Summary metrics emit one entry per declared
+  quantile. This aligns the operator metrics API output with the behavior of
+  ``cilium-dbg metrics list``.
 * The ``cilium_feature_np_other_l7_policies_total`` metric no longer counts
   Kafka policies, as Kafka-aware network policy support has been removed.
 * The metric ``policy_change_total`` now reports additional ``source`` (directory, k8s, custom, generated)

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -691,6 +691,7 @@ qdisc
 qdiscs
 qede
 qemu
+quantile
 queryable
 queueing
 rST

--- a/operator/metrics/legacy.go
+++ b/operator/metrics/legacy.go
@@ -4,6 +4,9 @@
 package metrics
 
 import (
+	"fmt"
+	"maps"
+
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/cilium/cilium/api/v1/operator/models"
@@ -12,6 +15,11 @@ import (
 
 // DumpMetrics gets the current Cilium operator metrics and dumps all into a
 // Metrics structure. If metrics cannot be retrieved, returns an error.
+//
+// For histogram metrics, three entries are emitted with a "quantile" label set
+// to "0.5", "0.9", and "0.99" respectively, each holding the computed quantile
+// value. For summary metrics, one entry per predefined quantile is emitted with
+// the corresponding "quantile" label.
 func DumpMetrics(reg *metrics.Registry) ([]*models.Metric, error) {
 	result := []*models.Metric{}
 	if reg == nil {
@@ -30,33 +38,63 @@ func DumpMetrics(reg *metrics.Registry) ([]*models.Metric, error) {
 
 		for _, metricLabel := range val.Metric {
 			labelPairs := metricLabel.GetLabel()
-			labels := make(map[string]string, len(labelPairs))
+			baseLabels := make(map[string]string, len(labelPairs))
 			for _, label := range labelPairs {
-				labels[label.GetName()] = label.GetValue()
+				baseLabels[label.GetName()] = label.GetValue()
 			}
 
-			var value float64
 			switch metricType {
 			case dto.MetricType_COUNTER:
-				value = metricLabel.Counter.GetValue()
+				result = append(result, &models.Metric{
+					Name:   metricName,
+					Labels: baseLabels,
+					Value:  metricLabel.Counter.GetValue(),
+				})
 			case dto.MetricType_GAUGE:
-				value = metricLabel.GetGauge().GetValue()
+				result = append(result, &models.Metric{
+					Name:   metricName,
+					Labels: baseLabels,
+					Value:  metricLabel.GetGauge().GetValue(),
+				})
 			case dto.MetricType_UNTYPED:
-				value = metricLabel.GetUntyped().GetValue()
-			case dto.MetricType_SUMMARY:
-				value = metricLabel.GetSummary().GetSampleSum()
+				result = append(result, &models.Metric{
+					Name:   metricName,
+					Labels: baseLabels,
+					Value:  metricLabel.GetUntyped().GetValue(),
+				})
 			case dto.MetricType_HISTOGRAM:
-				value = metricLabel.GetHistogram().GetSampleSum()
+				p50, p90, p99 := metrics.HistogramQuantiles(metricLabel.GetHistogram())
+				for _, qv := range []struct {
+					q string
+					v float64
+				}{
+					{"0.5", p50},
+					{"0.9", p90},
+					{"0.99", p99},
+				} {
+					labels := make(map[string]string, len(baseLabels)+1)
+					maps.Copy(labels, baseLabels)
+					labels["quantile"] = qv.q
+					result = append(result, &models.Metric{
+						Name:   metricName,
+						Labels: labels,
+						Value:  qv.v,
+					})
+				}
+			case dto.MetricType_SUMMARY:
+				for _, q := range metricLabel.GetSummary().GetQuantile() {
+					labels := make(map[string]string, len(baseLabels)+1)
+					maps.Copy(labels, baseLabels)
+					labels["quantile"] = fmt.Sprintf("%g", q.GetQuantile())
+					result = append(result, &models.Metric{
+						Name:   metricName,
+						Labels: labels,
+						Value:  q.GetValue(),
+					})
+				}
 			default:
 				continue
 			}
-
-			metric := &models.Metric{
-				Name:   metricName,
-				Labels: labels,
-				Value:  value,
-			}
-			result = append(result, metric)
 		}
 	}
 

--- a/operator/metrics/legacy_test.go
+++ b/operator/metrics/legacy_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+func newTestRegistry(t *testing.T) *metrics.Registry {
+	t.Helper()
+	reg := metrics.NewRegistry(metrics.RegistryParams{
+		Logger: slog.Default(),
+	})
+	return reg
+}
+
+func TestDumpMetrics_NilRegistry(t *testing.T) {
+	result, err := DumpMetrics(nil)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestDumpMetrics_Counter(t *testing.T) {
+	reg := newTestRegistry(t)
+	c := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_counter_total"})
+	c.Add(42)
+	require.NoError(t, reg.Register(c))
+
+	result, err := DumpMetrics(reg)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "test_counter_total", result[0].Name)
+	assert.InDelta(t, 42.0, result[0].Value, 1e-9)
+}
+
+func TestDumpMetrics_Histogram(t *testing.T) {
+	reg := newTestRegistry(t)
+	h := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "test_histogram_seconds",
+		Buckets: prometheus.DefBuckets,
+	})
+	// Observe values that should place p50 < p90 < p99
+	for range 50 {
+		h.Observe(0.01) // 50 fast samples
+	}
+	for range 40 {
+		h.Observe(0.1) // 40 medium samples
+	}
+	for range 10 {
+		h.Observe(1.0) // 10 slow samples
+	}
+	require.NoError(t, reg.Register(h))
+
+	result, err := DumpMetrics(reg)
+	require.NoError(t, err)
+
+	// One entry per quantile: p50, p90, p99
+	require.Len(t, result, 3)
+
+	quantiles := make(map[string]float64)
+	for _, m := range result {
+		assert.Equal(t, "test_histogram_seconds", m.Name)
+		q, ok := m.Labels["quantile"]
+		require.True(t, ok, "expected 'quantile' label")
+		quantiles[q] = m.Value
+	}
+
+	assert.Contains(t, quantiles, "0.5")
+	assert.Contains(t, quantiles, "0.9")
+	assert.Contains(t, quantiles, "0.99")
+
+	// p50 should be around 0.01, p90 around 0.1, p99 around 1.0
+	assert.Less(t, quantiles["0.5"], quantiles["0.9"])
+	assert.Less(t, quantiles["0.9"], quantiles["0.99"])
+}
+
+func TestDumpMetrics_Histogram_PreservesExistingLabels(t *testing.T) {
+	reg := newTestRegistry(t)
+	hv := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "test_hist_labeled",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"method"})
+	hv.WithLabelValues("GET").Observe(0.05)
+	require.NoError(t, reg.Register(hv))
+
+	result, err := DumpMetrics(reg)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+
+	for _, m := range result {
+		assert.Equal(t, "GET", m.Labels["method"], "existing labels must be preserved")
+		_, ok := m.Labels["quantile"]
+		assert.True(t, ok, "quantile label must be present")
+	}
+}
+
+func TestDumpMetrics_Summary(t *testing.T) {
+	reg := newTestRegistry(t)
+	s := prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "test_summary_seconds",
+		Objectives: map[float64]float64{
+			0.5:  0.05,
+			0.9:  0.01,
+			0.99: 0.001,
+		},
+	})
+	for i := range 100 {
+		s.Observe(float64(i) * 0.01)
+	}
+	require.NoError(t, reg.Register(s))
+
+	result, err := DumpMetrics(reg)
+	require.NoError(t, err)
+
+	// One entry per predefined quantile
+	require.Len(t, result, 3)
+
+	quantiles := make(map[string]float64)
+	for _, m := range result {
+		assert.Equal(t, "test_summary_seconds", m.Name)
+		q, ok := m.Labels["quantile"]
+		require.True(t, ok, "expected 'quantile' label")
+		quantiles[q] = m.Value
+	}
+
+	assert.Contains(t, quantiles, "0.5")
+	assert.Contains(t, quantiles, "0.9")
+	assert.Contains(t, quantiles, "0.99")
+
+	// p50 < p90 < p99 for an ascending distribution
+	assert.Less(t, quantiles["0.5"], quantiles["0.9"])
+	assert.Less(t, quantiles["0.9"], quantiles["0.99"])
+}

--- a/pkg/metrics/histogram.go
+++ b/pkg/metrics/histogram.go
@@ -49,6 +49,15 @@ func histogramSampleCount(histogram []histogramBucket) uint64 {
 	return histogram[len(histogram)-1].cumulativeCount
 }
 
+// HistogramQuantiles calculates p50, p90, and p99 quantiles from a Prometheus
+// Histogram proto message. These values are suitable for display and API output.
+func HistogramQuantiles(h *dto.Histogram) (p50, p90, p99 float64) {
+	b := convertHistogram(h)
+	return getHistogramQuantile(b, 0.50),
+		getHistogramQuantile(b, 0.90),
+		getHistogramQuantile(b, 0.99)
+}
+
 // getHistogramQuantile calculates quantile from the Prometheus Histogram message.
 // For example: getHistogramQuantile(h, 0.95) returns the 95th quantile.
 func getHistogramQuantile(histogram []histogramBucket, quantile float64) float64 {


### PR DESCRIPTION
This is a continuation of #44858, which was accidentally closed. I squashed the commits and force-pushed before reopening, which caused GitHub to block the reopen. Apologies for the confusion — opening a new PR to retain the ability to merge.

@joestringer

---

Previously, `DumpMetrics` in `operator/metrics/legacy.go` returned `GetSampleSum()` for both histogram and summary metric types. This value is meaningless in isolation because it grows with the number of samples, making it impossible to distinguish e.g. one slow operation from many fast ones.

This commit aligns the operator metrics API with the behaviour already implemented in `cilium-dbg` (`pkg/metrics/cmd.go`):

- Histogram metrics now emit three separate `Metric` entries, each carrying a `"quantile"` label (`"0.5"`, `"0.9"`, `"0.99"`) and the corresponding interpolated quantile value computed from the histogram buckets.
- Summary metrics now emit one `Metric` entry per predefined quantile declared on the summary, with the `"quantile"` label set to the quantile value (e.g. `"0.5"`, `"0.9"`, `"0.99"`).

To share the quantile calculation logic a new exported helper `HistogramQuantiles()` is added to `pkg/metrics/histogram.go`, wrapping the existing unexported `convertHistogram` / `getHistogramQuantile` pair.

Fixes: https://github.com/cilium/cilium/issues/34521