### PR TITLE
Fix CLI --namespace-labels option to be applied to all spawned namespaces

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -65,6 +65,9 @@ const (
 	client3DeploymentName = "client3"
 	clientCPDeployment    = "client-cp"
 
+	ccnpTestNamespace1 = "cilium-test-ccnp1"
+	ccnpTestNamespace2 = "cilium-test-ccnp2"
+
 	DNSTestServerContainerName = "dns-test-server"
 
 	echoSameNodeDeploymentName                 = "echo-same-node"
@@ -951,18 +954,18 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 		obj  *corev1.Namespace
 	}{
 		{
-			name: "cilium-test-ccnp1",
+			name: ccnpTestNamespace1,
 			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cilium-test-ccnp1",
+					Name: ccnpTestNamespace1,
 				},
 			},
 		},
 		{
-			name: "cilium-test-ccnp2",
+			name: ccnpTestNamespace2,
 			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cilium-test-ccnp2",
+					Name: ccnpTestNamespace2,
 				},
 			},
 		},
@@ -1782,7 +1785,8 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 }
 
 func (ct *ConnectivityTest) DeleteCCNPTestEnv(ctx context.Context, client *k8s.Client) error {
-	namespaces := []string{"cilium-test-ccnp1", "cilium-test-ccnp2"}
+
+	namespaces := []string{ccnpTestNamespace1, ccnpTestNamespace2}
 
 	for _, ns := range namespaces {
 		_, err := client.GetDeployment(ctx, ns, ccnpDeploymentName, metav1.GetOptions{})
@@ -2752,7 +2756,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 
 	if ct.Features[features.CCNP].Enabled {
 
-		namespaces := []string{"cilium-test-ccnp1", "cilium-test-ccnp2"}
+		namespaces := []string{ccnpTestNamespace1, ccnpTestNamespace2}
 		for _, ns := range namespaces {
 			if err := WaitForDeployment(ctx, ct, ct.clients.src, ns, ccnpDeploymentName); err != nil {
 				return err

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -714,40 +714,38 @@ func (ct *ConnectivityTest) forceDeploy(ctx context.Context) error {
 	return nil
 }
 
-// deployNamespace sets up the test namespace.
-func (ct *ConnectivityTest) deployNamespace(ctx context.Context) error {
-	for _, client := range ct.Clients() {
+// deployNamespace sets up the specified test namespace.
+func (ct *ConnectivityTest) deployNamespace(ctx context.Context, client *k8s.Client, namespaceName string) error {
 
-		namespace, err := client.GetNamespace(ctx, ct.params.TestNamespace, metav1.GetOptions{})
+	namespace, err := client.GetNamespace(ctx, namespaceName, metav1.GetOptions{})
+	if err != nil {
+		ct.Logf("✨ [%s] Creating namespace %s for connectivity check...", client.ClusterName(), namespaceName)
+		namespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        namespaceName,
+				Annotations: ct.params.NamespaceAnnotations,
+				Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
+			},
+		}
+	}
+	if !ct.Features[features.DefaultGlobalNamespace].Enabled {
+		// Mark the namespace as global to ensure resources under this
+		// namespace are treated as global. This is required for
+		// multi-cluster tests.
+		if namespace.Annotations == nil {
+			namespace.Annotations = make(map[string]string)
+		}
+		namespace.Annotations[annotation.GlobalNamespace] = "true"
+	}
+	if err == nil { // Namespace already exists.
+		_, err = client.UpdateNamespace(ctx, namespace, metav1.UpdateOptions{})
 		if err != nil {
-			ct.Logf("✨ [%s] Creating namespace %s for connectivity check...", client.ClusterName(), ct.params.TestNamespace)
-			namespace = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        ct.params.TestNamespace,
-					Annotations: ct.params.NamespaceAnnotations,
-					Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
-				},
-			}
+			return fmt.Errorf("unable to update namespace %s: %w", namespaceName, err)
 		}
-		if !ct.Features[features.DefaultGlobalNamespace].Enabled {
-			// Mark the namespace as global to ensure resources under this
-			// namespace are treated as global. This is required for
-			// multi-cluster tests.
-			if namespace.Annotations == nil {
-				namespace.Annotations = make(map[string]string)
-			}
-			namespace.Annotations[annotation.GlobalNamespace] = "true"
-		}
-		if err == nil { // Namespace already exists.
-			_, err = client.UpdateNamespace(ctx, namespace, metav1.UpdateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to update namespace %s: %w", ct.params.TestNamespace, err)
-			}
-		} else {
-			_, err = client.CreateNamespace(ctx, namespace, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create namespace %s: %w", ct.params.TestNamespace, err)
-			}
+	} else {
+		_, err = client.CreateNamespace(ctx, namespace, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create namespace %s: %w", namespaceName, err)
 		}
 	}
 	return nil
@@ -957,42 +955,17 @@ func DeployZtunnelTestEnv(ctx context.Context, t *Test, ct *ConnectivityTest) er
 }
 
 func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
-	namespaceConfigs := []struct {
-		name string
-		obj  *corev1.Namespace
-	}{
-		{
-			name: ccnpTestNamespace1,
-			obj: &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: ccnpTestNamespace1,
-				},
-			},
-		},
-		{
-			name: ccnpTestNamespace2,
-			obj: &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: ccnpTestNamespace2,
-				},
-			},
-		},
-	}
 
-	for _, nsConfig := range namespaceConfigs {
+	for _, namespaceName := range []string{ccnpTestNamespace1, ccnpTestNamespace2} {
 
 		clientccnp := ct.clients.src
 		var err error
 
-		_, err = clientccnp.GetNamespace(ctx, nsConfig.name, metav1.GetOptions{})
-		if err != nil {
-			_, err = clientccnp.CreateNamespace(ctx, nsConfig.obj, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("unable to create namespace %s: %w", nsConfig.name, err)
-			}
+		if err := ct.deployNamespace(ctx, clientccnp, namespaceName); err != nil {
+			return err
 		}
 
-		_, err = clientccnp.GetDeployment(ctx, nsConfig.name, ccnpDeploymentName, metav1.GetOptions{})
+		_, err = clientccnp.GetDeployment(ctx, namespaceName, ccnpDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			clientDeployment := newDeployment(deploymentParameters{
 				Name:         ccnpDeploymentName,
@@ -1003,13 +976,13 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 				Affinity:     &corev1.Affinity{NodeAffinity: ct.maybeNodeToNodeEncryptionAffinity()},
 				NodeSelector: ct.params.NodeSelector,
 			})
-			_, err = clientccnp.CreateServiceAccount(ctx, nsConfig.name, k8s.NewServiceAccount(ccnpDeploymentName), metav1.CreateOptions{})
+			_, err = clientccnp.CreateServiceAccount(ctx, namespaceName, k8s.NewServiceAccount(ccnpDeploymentName), metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("unable to create service account %s in namespace %s: %w", ccnpDeploymentName, nsConfig.name, err)
+				return fmt.Errorf("unable to create service account %s in namespace %s: %w", ccnpDeploymentName, namespaceName, err)
 			}
-			_, err = clientccnp.CreateDeployment(ctx, nsConfig.name, clientDeployment, metav1.CreateOptions{})
+			_, err = clientccnp.CreateDeployment(ctx, namespaceName, clientDeployment, metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("unable to create deployment %s in namespace %s: %w", ccnpDeploymentName, nsConfig.name, err)
+				return fmt.Errorf("unable to create deployment %s in namespace %s: %w", ccnpDeploymentName, namespaceName, err)
 			}
 		}
 
@@ -1024,8 +997,10 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		ct.forceDeploy(ctx)
 	}
 
-	if err := ct.deployNamespace(ctx); err != nil {
-		return err
+	for _, client := range ct.Clients() {
+		if err := ct.deployNamespace(ctx, client, ct.params.TestNamespace); err != nil {
+			return err
+		}
 	}
 
 	// Deploy test-conn-disrupt actors (only in the first
@@ -2311,8 +2286,10 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 		ct.forceDeploy(ctx)
 	}
 
-	if err := ct.deployNamespace(ctx); err != nil {
-		return err
+	for _, client := range ct.Clients() {
+		if err := ct.deployNamespace(ctx, client, ct.params.TestNamespace); err != nil {
+			return err
+		}
 	}
 
 	nodeSelectorServer := labels.SelectorFromSet(ct.params.PerfParameters.NodeSelectorServer).String()

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -695,20 +695,28 @@ func (ct *ConnectivityTest) maybeNodeToNodeEncryptionAffinity() *corev1.NodeAffi
 	}
 }
 
+// forceDeploy cleans up connectivity test artifacts before deployment.
+// Note: deploy() and deployPerf() currently ignore its returned error.
+func (ct *ConnectivityTest) forceDeploy(ctx context.Context) error {
+	for _, client := range ct.Clients() {
+
+		if err := ct.deleteDeployments(ctx, client); err != nil {
+			return err
+		}
+		if err := ct.DeleteConnDisruptTestDeployment(ctx, client); err != nil {
+			return err
+		}
+		if err := ct.DeleteCCNPTestEnv(ctx, client); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // deployNamespace sets up the test namespace.
 func (ct *ConnectivityTest) deployNamespace(ctx context.Context) error {
 	for _, client := range ct.Clients() {
-		if ct.params.ForceDeploy {
-			if err := ct.deleteDeployments(ctx, client); err != nil {
-				return err
-			}
-			if err := ct.DeleteConnDisruptTestDeployment(ctx, client); err != nil {
-				return err
-			}
-			if err := ct.DeleteCCNPTestEnv(ctx, client); err != nil {
-				return err
-			}
-		}
 
 		namespace, err := client.GetNamespace(ctx, ct.params.TestNamespace, metav1.GetOptions{})
 		if err != nil {
@@ -1012,6 +1020,10 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 
 // deploy ensures the test Namespace, Services and Deployments are running on the cluster.
 func (ct *ConnectivityTest) deploy(ctx context.Context) error {
+	if ct.params.ForceDeploy {
+		ct.forceDeploy(ctx)
+	}
+
 	if err := ct.deployNamespace(ctx); err != nil {
 		return err
 	}
@@ -2295,6 +2307,10 @@ func (ct *ConnectivityTest) createProfilingPerfDeployment(ctx context.Context, n
 }
 
 func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
+	if ct.params.ForceDeploy {
+		ct.forceDeploy(ctx)
+	}
+
 	if err := ct.deployNamespace(ctx); err != nil {
 		return err
 	}

--- a/cilium-cli/connectivity/check/deployment_test.go
+++ b/cilium-cli/connectivity/check/deployment_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/cilium/cilium/cilium-cli/k8s"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+	"github.com/cilium/cilium/pkg/annotation"
+)
+
+func newFakeConnectivityTest(t *testing.T, objects ...runtime.Object) (*ConnectivityTest, *k8s.Client) {
+	t.Helper()
+
+	client := &k8s.Client{
+		Clientset: fake.NewSimpleClientset(objects...),
+	}
+
+	ct := &ConnectivityTest{
+		params: Parameters{
+			TestNamespace:        "default-test-namespace",
+			Writer:               &bytes.Buffer{},
+			NamespaceLabels:      map[string]string{"suite": "connectivity"},
+			NamespaceAnnotations: map[string]string{"owner": "test"},
+			CurlImage:            "quay.io/cilium/alpine-curl:latest",
+		},
+		Features: features.Set{
+			features.DefaultGlobalNamespace: {Enabled: false},
+		},
+		clients: &deploymentClients{
+			src: client,
+			dst: client,
+		},
+	}
+
+	return ct, client
+}
+
+func TestDeployNamespaceCreatesMissingNamespace(t *testing.T) {
+	ct, client := newFakeConnectivityTest(t)
+
+	err := ct.deployNamespace(context.Background(), client, "created-ns")
+	require.NoError(t, err)
+
+	namespace, err := client.GetNamespace(context.Background(), "created-ns", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "created-ns", namespace.Name)
+	assert.Equal(t, "connectivity", namespace.Labels["suite"])
+	assert.Equal(t, "cilium-cli", namespace.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, "test", namespace.Annotations["owner"])
+	assert.Equal(t, "true", namespace.Annotations[annotation.GlobalNamespace])
+}
+
+func TestDeployNamespaceUpdatesExistingNamespace(t *testing.T) {
+	existing := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "existing-ns",
+			Annotations: map[string]string{"existing": "annotation"},
+			Labels:      map[string]string{"existing": "label"},
+		},
+	}
+	ct, client := newFakeConnectivityTest(t, existing)
+
+	err := ct.deployNamespace(context.Background(), client, "existing-ns")
+	require.NoError(t, err)
+
+	namespace, err := client.GetNamespace(context.Background(), "existing-ns", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "annotation", namespace.Annotations["existing"])
+	assert.Equal(t, "true", namespace.Annotations[annotation.GlobalNamespace])
+	assert.Equal(t, "label", namespace.Labels["existing"])
+}
+
+func TestDeployNamespaceUsesProvidedNamespaceName(t *testing.T) {
+	ct, client := newFakeConnectivityTest(t)
+	ct.params.TestNamespace = "wrong-ns"
+
+	err := ct.deployNamespace(context.Background(), client, "actual-ns")
+	require.NoError(t, err)
+
+	_, err = client.GetNamespace(context.Background(), "actual-ns", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	_, err = client.GetNamespace(context.Background(), "wrong-ns", metav1.GetOptions{})
+	assert.Error(t, err)
+}
+
+func TestDeployCCNPTestEnvCreatesNamespacesAndDeployments(t *testing.T) {
+	ct, client := newFakeConnectivityTest(t)
+
+	err := ct.deployCCNPTestEnv(context.Background())
+	require.NoError(t, err)
+
+	for _, namespaceName := range []string{ccnpTestNamespace1, ccnpTestNamespace2} {
+		namespace, err := client.GetNamespace(context.Background(), namespaceName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "true", namespace.Annotations[annotation.GlobalNamespace])
+
+		serviceAccount, err := client.GetServiceAccount(context.Background(), namespaceName, ccnpDeploymentName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, ccnpDeploymentName, serviceAccount.Name)
+
+		deployment, err := client.GetDeployment(context.Background(), namespaceName, ccnpDeploymentName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, ccnpDeploymentName, deployment.Name)
+		assert.Equal(t, kindCCNPName, deployment.Labels["kind"])
+	}
+}


### PR DESCRIPTION
- [x] All code is covered by unit and/or runtime tests where feasible.

Refactor `deployNamespace` so namespace setup can be reused for all connectivity-test namespaces, including the CCNP test namespaces, while preserving labels passed through the `--namespace-labels` CLI option.

This branch picks up @BroderPeters' refactoring and adds tests for the refactored deployment logic.

Added unit tests for the following cases:
- creating a missing namespace with the expected labels and annotations
- updating an existing namespace without losing existing configuration
- using the explicit namespace argument passed to `deployNamespace`
- creating the CCNP test namespaces and `client-ccnp` deployments through the refactored path

Fixes cilium/cilium-cli#3173

```release-note
Fix cilium connectivity test namespace setup so configured namespace labels also apply to CCNP test namespaces.
```