### PR TITLE
bgp: Disable MPTCP in the MD5 probing in the test

### DIFF
--- a/pkg/bgp/test/probe.go
+++ b/pkg/bgp/test/probe.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -15,7 +16,13 @@ import (
 // TCPMD5SigAvailable probes whether TCP_MD5SIG option can be set on a server socket.
 // Requires CONFIG_TCP_MD5SIG enabled in the kernel.
 func TCPMD5SigAvailable() (bool, error) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	var lc net.ListenConfig
+
+	// Disable Multipath TCP to avoid "protocol not available" error on
+	// kernels without MPTCP support.
+	lc.SetMultipathTCP(false)
+
+	listener, err := lc.Listen(context.Background(), "tcp", "localhost:0")
 	if err != nil {
 		return false, fmt.Errorf("listen failed: %w", err)
 	}


### PR DESCRIPTION
In the https://github.com/osrg/gobgp/pull/3021, we fixed the GoBGP side to diable MPTCP, but didn't fix our MD5 support probing code in the script test. As a result, the peering-auth.txtar has been skipped for a while. Fix it by disabling MPTCP in the probing code as well.

Fortunately, disabling and executing the test didn't produce any error.

```release-note
bgp: Disable MPTCP in the MD5 probing in the test
```
