### PR TITLE
bpf: host: use `revalidate_data` in l2 announcement handling

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1047,7 +1047,7 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 			if (ret != CTX_ACT_OK)
 				break;
 			/* Verifier invalidates ip6 for some reason.. sigh*/
-			if (!revalidate_data_pull(ctx, &data, &data_end, &ip6)) {
+			if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 				ret = DROP_INVALID;
 				goto drop_err_ingress;
 			}


### PR DESCRIPTION
Right before `handle_l2_announcement()`, `ctx_pull_data()` has already been called to pull the full packet into the linear section. Therefore `revalidate_data()` is sufficient to revalidate the `ip6` pointer. There is no data left to pull, so `revalidate_data_pull()` is not needed.