### PR TITLE
bpf: tests: add and use various BPF unit test helpers

### DIFF
--- a/bpf/tests/decrypt_overlay_wireguard.c
+++ b/bpf/tests/decrypt_overlay_wireguard.c
@@ -155,6 +155,8 @@ int ipv4_wireguard_mark_from_overlay_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_two);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -145,6 +145,8 @@ int eni_nlb_symetric_routing_egress_v4_setup_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_one);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 
@@ -255,6 +257,8 @@ int eni_nlb_symetric_routing_egress_v4_setup_icmp_check(const struct __ctx_buff 
 	__u32 *redirect_ifindex;
 
 	test_init();
+
+	endpoint_v4_del_entry(v4_pod_one);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -98,6 +98,8 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_one);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 
@@ -234,6 +236,8 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	struct iphdr *l3;
 	struct sctphdr *l4;
 
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
+
 	/* Init packet builder */
 	pktgen__init(&builder, ctx);
 
@@ -267,6 +271,8 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	struct sctphdr *l4;
 
 	test_init();
+
+	endpoint_v4_del_entry(v4_pod_one);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/host_bpf_masq.h
+++ b/bpf/tests/host_bpf_masq.h
@@ -82,6 +82,8 @@ int host_bpf_masq_v4_1_udp_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(NODE_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -570,6 +572,8 @@ int host_bpf_masq_v4_5_no_snat_ep_udp_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_one);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 	if (data + sizeof(__u32) > data_end)
@@ -694,6 +698,8 @@ int host_bpf_masq_v4_6_snat_ep_udp_check(const struct __ctx_buff *ctx)
 	__u32 *status_code;
 
 	test_init();
+
+	endpoint_v4_del_entry(v4_pod_one);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/host_bpf_masq.h
+++ b/bpf/tests/host_bpf_masq.h
@@ -156,6 +156,8 @@ int host_bpf_masq_v6_1_udp_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)NODE_IP_V6);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -637,6 +639,8 @@ int host_bpf_masq_v6_5_no_snat_ep_udp_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)v6_pod_one);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 	if (data + sizeof(__u32) > data_end)
@@ -756,6 +760,8 @@ int host_bpf_masq_v6_6_snat_ep_udp_check(const struct __ctx_buff *ctx)
 	__u32 *status_code;
 
 	test_init();
+
+	endpoint_v6_del_entry((union v6addr *)v6_pod_one);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/hostfw_bpf_masq.c
+++ b/bpf/tests/hostfw_bpf_masq.c
@@ -80,6 +80,8 @@ int hostfw_ipv4_bpf_masq_proxy_01_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(NODE_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -81,6 +81,8 @@ int hostfw_iptables_host_ipv4_01_pod_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(NODE_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -78,6 +78,8 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(NODE_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -232,6 +234,8 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 	__u32 *status_code;
 
 	test_init();
+
+	endpoint_v4_del_entry(NODE_IP2);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -186,6 +186,8 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -341,6 +343,9 @@ int from_overlay_ack_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "03_from_overlay_ack")
 int from_overlay_ack_setup(struct __ctx_buff *ctx)
 {
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
+			      (__u8 *)BACKEND_MAC, (__u8 *)BACKEND_ROUTER_MAC);
+
 	return overlay_receive_packet(ctx);
 }
 
@@ -355,6 +360,8 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 	__u32 meta;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -284,6 +284,8 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(CLIENT_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -95,6 +95,8 @@ int ipv6_from_netdev_ns_pod_check(const struct __ctx_buff *ctx)
 {
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)v6_pod_three);
+
 	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
 	BUF_DECL(V6_NDP_POD_NA_LLOPT, v6_ndp_pod_na_llopt);
@@ -132,6 +134,8 @@ CHECK("tc", "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_check_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
+
+	endpoint_v6_del_entry((union v6addr *)v6_pod_three);
 
 	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
@@ -182,6 +186,8 @@ int ipv6_from_netdev_ns_pod_check_mcast(const struct __ctx_buff *ctx)
 {
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)v6_pod_three);
+
 	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
 	/* Note we always return NA with llopt */
@@ -219,6 +225,8 @@ CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
+
+	endpoint_v6_del_entry((union v6addr *)v6_pod_three);
 
 	assert(__check_ret_code(ctx, CTX_ACT_REDIRECT));
 
@@ -275,6 +283,8 @@ int ipv6_from_netdev_ns_node_ip_check(const struct __ctx_buff *ctx)
 {
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)v6_node_one);
+
 	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
 	/* Packet should not be modified */
@@ -314,6 +324,8 @@ CHECK("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_check_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
+
+	endpoint_v6_del_entry((union v6addr *)v6_node_one);
 
 	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
@@ -364,6 +376,8 @@ int ipv6_from_netdev_ns_node_ip_check_mcast(const struct __ctx_buff *ctx)
 {
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)v6_node_one);
+
 	assert(__check_ret_code(ctx, CTX_ACT_OK));
 
 	/* Packet should not be modified */
@@ -402,6 +416,8 @@ CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
+
+	endpoint_v6_del_entry((union v6addr *)v6_node_one);
 
 	assert(__check_ret_code(ctx, CTX_ACT_OK));
 

--- a/bpf/tests/lib/endpoint.h
+++ b/bpf/tests/lib/endpoint.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#pragma once
+
 static __always_inline void
 endpoint_add_entry(struct endpoint_key *key, __u32 ifindex, __u16 lxc_id, __u32 flags, __u32 sec_id,
 		   __u32 parent_ifindex, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
@@ -58,4 +60,16 @@ endpoint_v6_add_entry(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
 
 	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, 0,
 			   ep_mac_addr, node_mac_addr);
+}
+
+static __always_inline void
+endpoint_v6_del_entry(const union v6addr *addr)
+{
+	struct endpoint_key key = {
+		.family = ENDPOINT_KEY_IPV6,
+	};
+
+	memcpy(&key.ip6, addr, sizeof(*addr));
+
+	map_delete_elem(&cilium_lxc, &key);
 }

--- a/bpf/tests/lib/metrics.h
+++ b/bpf/tests/lib/metrics.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#pragma once
+
+static __always_inline void
+metrics_del_entry(__u8 reason, enum metric_dir dir)
+{
+	struct metrics_key key = {
+		.reason = reason,
+		.dir = dir,
+	};
+
+	map_delete_elem(&cilium_metrics, &key);
+}

--- a/bpf/tests/lib/network_device.h
+++ b/bpf/tests/lib/network_device.h
@@ -13,3 +13,9 @@ cilium_device_add_entry(__u32 ifindex, const __u8 *mac, __u8 l3)
 
 	map_update_elem(&cilium_devices, &ifindex, &state, BPF_ANY);
 }
+
+static __always_inline void
+cilium_device_del_entry(__u32 ifindex)
+{
+	map_delete_elem(&cilium_devices, &ifindex);
+}

--- a/bpf/tests/lxc_extended_protocols.c
+++ b/bpf/tests/lxc_extended_protocols.c
@@ -103,6 +103,8 @@ int lxc_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(CLIENT_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -184,6 +186,8 @@ int lxc_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(CLIENT_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -262,6 +266,8 @@ int lxc_igmp_egress_policy_deny_check(const struct __ctx_buff *ctx)
 	__u32 *status_code;
 
 	test_init();
+
+	endpoint_v4_del_entry(CLIENT_IP);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -146,6 +146,8 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_check(const struct __ctx_buff *ctx
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -88,6 +88,9 @@ int v4_local_backend_to_service_check(__maybe_unused const struct __ctx_buff *ct
 	struct tcphdr *l4;
 
 	test_init();
+
+	endpoint_v4_del_entry(V4_BACKEND_IP);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 	if (data + sizeof(__u32) > data_end)

--- a/bpf/tests/skip_tunnel_from_host.c
+++ b/bpf/tests/skip_tunnel_from_host.c
@@ -68,6 +68,7 @@ ASSIGN_CONFIG(union macaddr, cilium_net_mac, cilium_net_mac)
  * Include test helpers
  */
 #include "lib/ipcache.h"
+#include "lib/metrics.h"
 #include "lib/subnet.h"
 
 ASSIGN_CONFIG(bool, hybrid_routing_enabled, true)
@@ -112,12 +113,7 @@ setup(struct __ctx_buff *ctx, bool flag_skip_tunnel, bool v4)
 	 * Otherwise, the metric we want to check would increase by one
 	 * after each test.
 	 */
-	struct metrics_key key = {};
-
-	key.reason = REASON_FORWARDED;
-	key.dir = METRIC_EGRESS;
-
-	map_delete_elem(&cilium_metrics, &key);
+	metrics_del_entry(REASON_FORWARDED, METRIC_EGRESS);
 
 	if (v4)
 		ipcache_v4_add_entry_with_flags(DST_IPV4,

--- a/bpf/tests/skip_tunnel_from_lxc.c
+++ b/bpf/tests/skip_tunnel_from_lxc.c
@@ -35,6 +35,7 @@
  * Include test helpers
  */
 #include "lib/ipcache.h"
+#include "lib/metrics.h"
 #include "lib/policy.h"
 #include "lib/subnet.h"
 
@@ -80,12 +81,7 @@ setup(struct __ctx_buff *ctx, bool flag_skip_tunnel, bool v4)
 	 * Otherwise, the metric we want to check would increase by one
 	 * after each test.
 	 */
-	struct metrics_key key = {};
-
-	key.reason = REASON_FORWARDED;
-	key.dir = METRIC_EGRESS;
-
-	map_delete_elem(&cilium_metrics, &key);
+	metrics_del_entry(REASON_FORWARDED, METRIC_EGRESS);
 
 	policy_add_egress_allow_all_entry();
 

--- a/bpf/tests/skip_tunnel_nodeport_masq.c
+++ b/bpf/tests/skip_tunnel_nodeport_masq.c
@@ -138,6 +138,11 @@ check_ctx(const struct __ctx_buff *ctx, bool v4, bool snat)
 
 	test_init();
 
+	if (v4)
+		endpoint_v4_del_entry(SRC_IPV4);
+	else
+		endpoint_v6_del_entry((union v6addr *)SRC_IPV6);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -20,6 +20,7 @@
 #include "lib/egressgw.h"
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
+#include "lib/metrics.h"
 
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program gets redirected to the gateway node.
@@ -108,12 +109,7 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
-	struct metrics_key key = {
-		.reason = (__u8)-DROP_NO_EGRESS_GATEWAY,
-		.dir = METRIC_EGRESS,
-	};
-
-	map_delete_elem(&cilium_metrics, &key);
+	metrics_del_entry((__u8)-DROP_NO_EGRESS_GATEWAY, METRIC_EGRESS);
 	ipcache_v4_add_world_entry();
 	create_ct_entry(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY,
@@ -165,12 +161,7 @@ int egressgw_drop_no_egress_ip_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_drop_no_egress_ip")
 int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 {
-	struct metrics_key key = {
-		.reason = (__u8)-DROP_NO_EGRESS_IP,
-		.dir = METRIC_EGRESS,
-	};
-
-	map_delete_elem(&cilium_metrics, &key);
+	metrics_del_entry((__u8)-DROP_NO_EGRESS_IP, METRIC_EGRESS);
 	ipcache_v4_add_world_entry();
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 
@@ -312,15 +303,11 @@ int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
 int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 {
-	struct metrics_key key = {
-		.reason = (__u8)-DROP_NO_EGRESS_GATEWAY,
-		.dir = METRIC_EGRESS,
-	};
-
-	map_delete_elem(&cilium_metrics, &key);
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
+
+	metrics_del_entry((__u8)-DROP_NO_EGRESS_GATEWAY, METRIC_EGRESS);
 
 	ipcache_v6_add_world_entry();
 	create_ct_entry_v6(ctx, client_port(TEST_REDIRECT_SKIP_NO_GATEWAY));
@@ -375,15 +362,10 @@ int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_drop_no_egress_ip_v6")
 int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 {
-	struct metrics_key key = {
-		.reason = (__u8)-DROP_NO_EGRESS_IP,
-		.dir = METRIC_EGRESS,
-	};
-
-	map_delete_elem(&cilium_metrics, &key);
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 
+	metrics_del_entry((__u8)-DROP_NO_EGRESS_IP, METRIC_EGRESS);
 	ipcache_v6_add_world_entry();
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST, 0, 0, NULL, NULL);
 

--- a/bpf/tests/tc_geneve_dsr_v4_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_v4_legacy.c
@@ -106,6 +106,8 @@ int tc_geneve_dsr_v4_legacy_check(struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_lb6_clusterip.c
+++ b/bpf/tests/tc_lb6_clusterip.c
@@ -146,6 +146,8 @@ int lb6_routable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v6_del_entry((union v6addr *)BACKEND_IP);
+
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
 	status_code = data;

--- a/bpf/tests/tc_lxc_lb4_nodeport.c
+++ b/bpf/tests/tc_lxc_lb4_nodeport.c
@@ -134,6 +134,8 @@ int lxc_v4_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -242,6 +244,8 @@ int lxc_v4_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ct
 
 	test_init();
 
+	endpoint_v4_del_entry(CLIENT_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -343,6 +347,8 @@ int lxc_v4_remote_nodeport_dsr_local_backend_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
@@ -452,6 +458,8 @@ int lxc_v4_remote_nodeport_dsr_local_backend_reply_check(const struct __ctx_buff
 
 	test_init();
 
+	endpoint_v4_del_entry(CLIENT_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -551,6 +559,8 @@ int lxc_v4_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(CLIENT_IP);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
@@ -656,6 +666,8 @@ int lxc_v4_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(CLIENT_IP);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
@@ -858,6 +870,8 @@ int lxc_v4_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -961,6 +975,8 @@ int lxc_v4_host_nodeport_local_backend_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_nodeport_l3_dev.h
+++ b/bpf/tests/tc_nodeport_l3_dev.h
@@ -249,6 +249,13 @@ ingress_l3_to_l2_fast_redirect_check(__maybe_unused const struct __ctx_buff *ctx
 
 	test_init();
 
+	if (is_ipv4) {
+		if (is_host)
+			endpoint_v4_del_entry(TEST_IP_NODE_LOCAL);
+		else
+			endpoint_v4_del_entry(TEST_IP_LOCAL);
+	}
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_nodeport_l3_dev.h
+++ b/bpf/tests/tc_nodeport_l3_dev.h
@@ -77,6 +77,8 @@ ASSIGN_CONFIG(union macaddr, interface_mac, router_mac)
 # include "lib/endpoint.h"
 #endif
 
+#include "lib/metrics.h"
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(key_size, sizeof(__u32));
@@ -183,17 +185,13 @@ l3_to_l2_fast_redirect_setup(struct __ctx_buff *ctx, bool is_ingress, bool is_ip
 	void *data = (void *)(long)ctx->data;
 	void *data_end = (void *)(long)ctx->data_end;
 	__u64 flags = BPF_F_ADJ_ROOM_FIXED_GSO;
-	struct metrics_key key = {
-#if defined(IS_BPF_HOST)
-		.reason = is_ingress ? REASON_PLAINTEXT : REASON_FORWARDED,
-#endif
-#if defined(IS_BPF_WIREGUARD)
-		.reason = is_ingress ? REASON_DECRYPTING : REASON_ENCRYPTING,
-#endif
-		.dir = is_ingress ? METRIC_INGRESS : METRIC_EGRESS,
-	};
 
-	map_delete_elem(&cilium_metrics, &key);
+	if (is_defined(IS_BPF_HOST))
+		metrics_del_entry(is_ingress ? REASON_PLAINTEXT : REASON_FORWARDED,
+				  is_ingress ? METRIC_INGRESS : METRIC_EGRESS);
+	if (is_defined(IS_BPF_WIREGUARD))
+		metrics_del_entry(is_ingress ? REASON_DECRYPTING : REASON_ENCRYPTING,
+				  is_ingress ? METRIC_INGRESS : METRIC_EGRESS);
 
 	if (is_ipv4)
 		if (is_host)

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -188,6 +188,8 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -435,6 +437,9 @@ int nodeport_dsr_backend_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_dsr_backend_redirect")
 int nodeport_dsr_backend_redirect_setup(struct __ctx_buff *ctx)
 {
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)backend_mac, (__u8 *)node_mac);
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -449,6 +454,8 @@ int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_nodeport_lb4_fragments.c
+++ b/bpf/tests/tc_nodeport_lb4_fragments.c
@@ -96,6 +96,8 @@ int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP);
+
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);
 	status_code = data;
@@ -147,6 +149,9 @@ int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_lb4_fragments_2")
 int nodeport_lb4_fragments_2_setup(struct __ctx_buff *ctx)
 {
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
+			      (__u8 *)mac_one, (__u8 *)mac_two);
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -162,6 +167,8 @@ int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
 	__u64 count = 2;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP);
 
 	data = ctx_data(ctx);
 	data_end = ctx_data_end(ctx);

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -117,6 +117,8 @@ int nodeport_nat_backend_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -215,6 +215,8 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -389,6 +391,9 @@ int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
 {
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -402,6 +407,8 @@ int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
@@ -582,6 +589,9 @@ int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
 
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
+
 	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, IPPROTO_UDP, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 125,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
@@ -599,6 +609,8 @@ int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -148,6 +148,8 @@ int tc_nodeport_lb_terminating_backend_0_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -231,6 +233,9 @@ int tc_nodeport_lb_terminating_backend_1_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = SVC_REV_NAT_ID;
 
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
+			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
+
 	/* Remove the service's last backend, and flip the backend to
 	 * 'terminating' state.
 	 */
@@ -251,6 +256,8 @@ int tc_nodeport_lb_terminating_backend_1_check(const struct __ctx_buff *ctx)
 	struct iphdr *l3;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_nodeport_snat_conflict.c
+++ b/bpf/tests/tc_nodeport_snat_conflict.c
@@ -147,6 +147,9 @@ CHECK("tc", "tc_nodeport_snat_conflict_host_ipv4")
 int tc_nodeport_snat_conflict_host_ipv4_check(struct __ctx_buff *ctx)
 {
 	test_init();
+
+	endpoint_v4_del_entry(NODE_IP);
+
 	assert(tc_nodeport_snat_conflict_assert_status(ctx));
 	assert(tc_nodeport_snat_conflict_assert_ipv4());
 	test_finish();
@@ -245,6 +248,9 @@ CHECK("tc", "tc_nodeport_snat_conflict_egressproxy_ipv4")
 int tc_nodeport_snat_conflict_egressproxy_ipv4_check(struct __ctx_buff *ctx)
 {
 	test_init();
+
+	endpoint_v4_del_entry(NODE_IP);
+
 	assert(tc_nodeport_snat_conflict_assert_status(ctx));
 	assert(tc_nodeport_snat_conflict_assert_ipv4());
 	test_finish();
@@ -354,6 +360,9 @@ int tc_nodeport_snat_conflict_pod_ipv4_check(struct __ctx_buff *ctx)
 	};
 
 	test_init();
+
+	endpoint_v4_del_entry(POD_IP);
+
 	assert(tc_nodeport_snat_conflict_assert_status(ctx));
 
 	/* Pod traffic should NOT create a conntrack entry */

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -110,6 +110,8 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_one);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 
@@ -332,6 +334,8 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hairpin_flow_3_reverse_v4")
 int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
+
 	return pod_send_packet(ctx);
 }
 
@@ -345,6 +349,8 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	struct tcphdr *l4;
 
 	test_init();
+
+	endpoint_v4_del_entry(v4_pod_one);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_policy_reject_response_test.c
+++ b/bpf/tests/tc_policy_reject_response_test.c
@@ -74,6 +74,8 @@ int policy_reject_response_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(CLIENT_IP);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -193,6 +193,8 @@ int tc_redirect_host_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_one);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -288,11 +288,14 @@ int tc_redirect_host_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 #else
 	const unsigned int expected[RECORD__MAX] = {1, 1, 0};
 #endif
+	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
 	void *data;
 	void *data_end;
 	__u32 *status_code;
 
 	test_init();
+
+	endpoint_v6_del_entry(&pod_ip);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_redirect_lxc.h
+++ b/bpf/tests/tc_redirect_lxc.h
@@ -281,11 +281,14 @@ int tc_redirect_lxc_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 #else
 	const unsigned int expected[RECORD__MAX] = {1, 0, 1};
 #endif
+	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
 	void *data;
 	void *data_end;
 	__u32 *status_code;
 
 	test_init();
+
+	endpoint_v6_del_entry(&pod_ip);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_redirect_lxc.h
+++ b/bpf/tests/tc_redirect_lxc.h
@@ -187,6 +187,8 @@ int tc_redirect_lxc_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(v4_pod_one);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -268,6 +268,8 @@ int srv6_decap_to_pod_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
 
 	test_init();
 
+	endpoint_v6_del_entry((const union v6addr *)POD_IPV6);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 
@@ -551,6 +553,8 @@ int srv6_decap_to_service_ipv6_check(const struct __ctx_buff *ctx __maybe_unused
 	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
 
 	test_init();
+
+	endpoint_v6_del_entry((const union v6addr *)POD_IPV6);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -130,6 +130,8 @@ int srv6_decap_to_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 
 	test_init();
 
+	endpoint_v4_del_entry(POD_IPV4);
+
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;
 
@@ -406,6 +408,8 @@ int srv6_decap_to_service_ipv4_check(const struct __ctx_buff *ctx __maybe_unused
 	memcpy(sid.addr, (const void *)SID, sizeof(sid.addr));
 
 	test_init();
+
+	endpoint_v4_del_entry(POD_IPV4);
 
 	data = (void *)(long)ctx->data;
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -92,6 +92,8 @@ int nodeport_nat_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -151,6 +151,8 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -613,6 +615,8 @@ int nodeport_l7delegate_local_check(const struct __ctx_buff *ctx)
 	__u32 *meta;
 
 	test_init();
+
+	endpoint_v4_del_entry(BACKEND_IP_LOCAL);
 
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -553,6 +553,8 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 CHECK("xdp", "xdp_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *ctx)
 {
+	cilium_device_del_entry(DEFAULT_IFACE);
+
 	return check_reply(ctx);
 }
 


### PR DESCRIPTION
Add an use helpers to delete entries from the following maps in BPF unit tests:

- `cilium_metrics`
- `cilium_lxc` (IPv6 entries)
- `cilium_devices`

See commits for details.
