### PR TITLE
bpf: sock: remove orig_key in LB path

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -144,7 +144,7 @@ bool sock_proto_enabled(__u8 proto)
 
 static __always_inline int sock4_update_revnat(struct bpf_sock_addr *ctx,
 					       const struct lb4_backend *backend,
-					       const struct lb4_key *orig_key,
+					       __be32 dst_ip, __be16 dst_port,
 					       __u16 rev_nat_id)
 {
 	struct ipv4_revnat_entry val = {}, *tmp;
@@ -159,8 +159,8 @@ static __always_inline int sock4_update_revnat(struct bpf_sock_addr *ctx,
 	key.address = backend->address;
 	key.port = backend->port;
 
-	val.address = orig_key->address;
-	val.port = orig_key->dport;
+	val.address = dst_ip;
+	val.port = dst_port;
 	val.rev_nat_index = rev_nat_id;
 
 	tmp = map_lookup_elem(&cilium_lb4_reverse_sk, &key);
@@ -272,14 +272,14 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	const bool in_hostns = ctx_in_hostns(ctx_full, &id.client_cookie);
 	const struct lb4_backend *backend;
 	const struct lb4_service *svc;
-	__u16 dst_port = ctx_dst_port(ctx);
+	__be16 dst_port = ctx_dst_port(ctx);
 	__u8 protocol = ctx_protocol(ctx);
-	__u32 dst_ip = ctx->user_ip4;
+	__be32 dst_ip = ctx->user_ip4;
 	struct lb4_key key = {
 		.address	= dst_ip,
 		.dport		= dst_port,
 		.proto		= protocol,
-	}, orig_key = key;
+	};
 	const struct lb4_service *backend_slot;
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;
@@ -327,13 +327,13 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 	 * IP address. But do the service translation if the IP
 	 * is from the host.
 	 */
-	if (sock4_skip_xlate(svc, orig_key.address))
+	if (sock4_skip_xlate(svc, dst_ip))
 		return -EPERM;
 
 	if (CONFIG(enable_lrp) &&
 	    lb4_svc_is_localredirect(svc) &&
 	    lrp_v4_skip_xlate_from_ctx_to_svc(get_netns_cookie(ctx_full),
-					      orig_key.address, orig_key.dport))
+					      dst_ip, dst_port))
 		return -ENXIO;
 
 #ifdef ENABLE_L7_LB
@@ -419,7 +419,7 @@ static __always_inline int __sock4_xlate_fwd(struct bpf_sock_addr *ctx,
 #ifdef ENABLE_L7_LB
 out:
 #endif
-	if (sock4_update_revnat(ctx_full, backend, &orig_key,
+	if (sock4_update_revnat(ctx_full, backend, dst_ip, dst_port,
 				svc->rev_nat_index) < 0) {
 		update_metrics(0, METRIC_EGRESS, REASON_LB_REVNAT_UPDATE);
 		return -ENOMEM;
@@ -636,7 +636,8 @@ int cil_sock4_getpeername(struct bpf_sock_addr *ctx)
 
 static __always_inline int sock6_update_revnat(struct bpf_sock_addr *ctx,
 					       const struct lb6_backend *backend,
-					       const struct lb6_key *orig_key,
+					       const union v6addr *dst_ip,
+					       __be16 dst_port,
 					       __u16 rev_nat_index)
 {
 	struct ipv6_revnat_entry val = {}, *tmp;
@@ -647,8 +648,8 @@ static __always_inline int sock6_update_revnat(struct bpf_sock_addr *ctx,
 	key.address = backend->address;
 	key.port = backend->port;
 
-	val.address = orig_key->address;
-	val.port = orig_key->dport;
+	val.address = *dst_ip;
+	val.port = dst_port;
 	val.rev_nat_index = rev_nat_index;
 
 	tmp = map_lookup_elem(&cilium_lb6_reverse_sk, &key);
@@ -988,12 +989,13 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 	const bool in_hostns = ctx_in_hostns(ctx, &id.client_cookie);
 	const struct lb6_backend *backend;
 	const struct lb6_service *svc;
-	__u16 dst_port = ctx_dst_port(ctx);
+	__be16 dst_port = ctx_dst_port(ctx);
 	__u8 protocol = ctx_protocol(ctx);
+	union v6addr dst_ip __align_stack_8;
 	struct lb6_key key __align_stack_8 = {
 		.dport		= dst_port,
 		.proto		= protocol,
-	}, orig_key __align_stack_8;
+	};
 	const struct lb6_service *backend_slot;
 	bool backend_from_affinity = false;
 	__u32 backend_id = 0;
@@ -1008,7 +1010,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 		return -ENOTSUP;
 
 	ctx_get_v6_address(ctx, &key.address);
-	memcpy(&orig_key, &key, sizeof(key));
+	ipv6_addr_copy(&dst_ip, &key.address);
 
 	svc = lb6_lookup_service(&key, true);
 	if (!svc)
@@ -1029,13 +1031,13 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 
 	if (lb6_svc_is_l7_punt_proxy(svc))
 		return SYS_PROCEED;
-	if (sock6_skip_xlate(svc, &orig_key.address))
+	if (sock6_skip_xlate(svc, &dst_ip))
 		return -EPERM;
 
 	if (CONFIG(enable_lrp) &&
 	    lb6_svc_is_localredirect(svc) &&
 	    lrp_v6_skip_xlate_from_ctx_to_svc(get_netns_cookie(ctx),
-					      orig_key.address, orig_key.dport))
+					      dst_ip, dst_port))
 		return -ENXIO;
 
 #ifdef ENABLE_L7_LB
@@ -1096,7 +1098,7 @@ static __always_inline int __sock6_xlate_fwd(struct bpf_sock_addr *ctx,
 #ifdef ENABLE_L7_LB
 out:
 #endif
-	if (sock6_update_revnat(ctx, backend, &orig_key,
+	if (sock6_update_revnat(ctx, backend, &dst_ip, dst_port,
 				svc->rev_nat_index) < 0) {
 		update_metrics(0, METRIC_EGRESS, REASON_LB_REVNAT_UPDATE);
 		return -ENOMEM;


### PR DESCRIPTION
The LB paths currently maintain a copy of the LB lookup key, in case the initial key gets mangled during wildcard lookups.

But we're then not using this copy consistently, and some paths have already switched to individual dst_* variables. Let's just use these variables everywhere, and get rid of the orig_key.