### PR TITLE
ipam: Operator dual-write `Spec.IPAM.Pools.Allocated` for ENI mode

### DIFF
--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/netip"
 	"slices"
 	"sync/atomic"
 
@@ -550,6 +551,77 @@ func (n *Node) Pool() (pool ipamTypes.AllocationMap) {
 	maps.Copy(pool, n.ipv4Alloc.available)
 	n.mutex.RUnlock()
 	return
+}
+
+// buildPoolAllocated constructs Spec.IPAM.Pools.Allocated from the ENI state
+// on the CiliumNode.
+//
+// Secondary IPs are represented as /32 CIDRs and delegated prefixes as /28 CIDRs
+// Addresses that are covered by a prefix are omitted to avoid overlap, only addresses
+// outside any prefix (e.g. the ENI primary IP with UsePrimaryAddress) are
+// written as /32 CIDRs.
+//
+// Returns nil if the node has no ENI status (non-ENI IPAM modes).
+func (n *Node) buildPoolAllocated(node *v2.CiliumNode) []ipamTypes.IPAMPoolAllocation {
+	if len(node.Status.ENI.ENIs) == 0 {
+		return nil
+	}
+
+	var cidrs []ipamTypes.IPAMCIDR
+	for _, eni := range node.Status.ENI.ENIs {
+		if eni.IsExcludedBySpec(node.Spec.ENI) {
+			continue
+		}
+
+		var prefixes []netip.Prefix
+		for _, p := range eni.Prefixes {
+			cidrs = append(cidrs, ipamTypes.IPAMCIDR(p))
+			if parsed, err := netip.ParsePrefix(p); err == nil {
+				prefixes = append(prefixes, parsed)
+			}
+		}
+
+		// In parseENI (pkg/aws/ec2), we currently use PrefixToIps to flatten each prefixes
+		// into 16 individual IPs and append those IPs to the ENI Addresses field.
+		// Here we need to apply a reverse logic to only advertise as /32 CIDRs in the pool
+		// regular secondary addresses (or the ENI primary IP when using UsePrimaryAddress)
+		// and not addresses that are already being advertised through a /28 CIDR.
+		for _, addr := range eni.Addresses {
+			if addressCoveredByPrefix(addr, prefixes) {
+				continue
+			}
+			cidrs = append(cidrs, ipamTypes.IPAMCIDR(addr+"/32"))
+		}
+	}
+
+	if len(cidrs) == 0 {
+		return nil
+	}
+
+	return []ipamTypes.IPAMPoolAllocation{
+		{
+			Pool:  defaults.IPAMDefaultIPPool,
+			CIDRs: cidrs,
+		},
+	}
+}
+
+// addressCoveredByPrefix returns true if the given IP address string falls
+// within any of the provided prefixes.
+func addressCoveredByPrefix(addr string, prefixes []netip.Prefix) bool {
+	if len(prefixes) == 0 {
+		return false
+	}
+	ip, err := netip.ParseAddr(addr)
+	if err != nil {
+		return false
+	}
+	for _, p := range prefixes {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // ResourceCopy returns a deep copy of the CiliumNode custom resource
@@ -1173,6 +1245,15 @@ func (n *Node) syncToAPIServer() error {
 	for retry := range maxRetries {
 		node.Spec.IPAM.Pool = pool
 		n.logger.Load().Debug("Updating node in apiserver", logfields.PoolSize, len(node.Spec.IPAM.Pool))
+
+		// Dual-write: populate Spec.IPAM.Pools.Allocated alongside
+		// Spec.IPAM.Pool for the ENI multi-pool migration
+		// (https://github.com/cilium/design-cfps/pull/87).
+		// 1.20 agents read CIDRs from Pools.Allocated; 1.19 agents continue
+		// to use Pool. This dual-write will be removed in 1.21
+		if allocated := n.buildPoolAllocated(node); allocated != nil {
+			node.Spec.IPAM.Pools.Allocated = allocated
+		}
 
 		// The PreAllocate value is added here rather than where the CiliumNode
 		// resource is created ((*NodeDiscovery).mutateNodeResource() inside

--- a/pkg/ipam/node_test.go
+++ b/pkg/ipam/node_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/defaults"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/time"
@@ -109,4 +112,86 @@ func TestSyncToAPIServerForNonExistingNode(t *testing.T) {
 	node.updateLogger()
 
 	require.NoError(t, node.syncToAPIServer())
+}
+
+type prefixDelegationMock struct {
+	nodeOperationsMock
+	prefixDelegated bool
+}
+
+func (p *prefixDelegationMock) IsPrefixDelegated() bool {
+	return p.prefixDelegated
+}
+
+func TestBuildPoolAllocated(t *testing.T) {
+	t.Run("no ENIs returns nil", func(t *testing.T) {
+		n := &Node{ops: &nodeOperationsMock{}}
+		node := &v2.CiliumNode{}
+		require.Nil(t, n.buildPoolAllocated(node))
+	})
+
+	t.Run("secondary IPs as /32 CIDRs", func(t *testing.T) {
+		n := &Node{ops: &prefixDelegationMock{prefixDelegated: false}}
+		node := &v2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1", "10.0.0.2"},
+			},
+		}
+
+		result := n.buildPoolAllocated(node)
+		require.Len(t, result, 1)
+		require.Equal(t, defaults.IPAMDefaultIPPool, result[0].Pool)
+		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.1/32"))
+		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
+	})
+
+	t.Run("prefix delegation writes prefixes and excludes covered addresses", func(t *testing.T) {
+		n := &Node{ops: &prefixDelegationMock{prefixDelegated: true}}
+		node := &v2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				// Mimics the pkg/aws/ec2.parseENI behavior: Addresses contains the ENI secondary
+				// IPs, the ENI primary if UsePrimaryAddress annd the 16 IPs expanded from the /28 prefix.
+				// Prefixes contains the raw /28.
+				Addresses: []string{
+					"10.0.0.1", // ENI primary IP (UsePrimaryAddress)
+					"10.0.0.16", "10.0.0.17", "10.0.0.18", "10.0.0.19",
+					"10.0.0.20", "10.0.0.21", "10.0.0.22", "10.0.0.23",
+					"10.0.0.24", "10.0.0.25", "10.0.0.26", "10.0.0.27",
+					"10.0.0.28", "10.0.0.29", "10.0.0.30", "10.0.0.31",
+				},
+				Prefixes: []string{"10.0.0.16/28"},
+			},
+		}
+
+		result := n.buildPoolAllocated(node)
+		require.Len(t, result, 1)
+		require.Equal(t, defaults.IPAMDefaultIPPool, result[0].Pool)
+		// Should contain the /28 prefix and the primary IP as /32,
+		// but not the 16 expanded prefix IPs.
+		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.16/28"))
+		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.1/32"))
+		require.Len(t, result[0].CIDRs, 2) // 1 prefix + 1 primary IP
+	})
+
+	t.Run("excluded ENIs are skipped", func(t *testing.T) {
+		n := &Node{ops: &prefixDelegationMock{prefixDelegated: false}}
+		node := &v2.CiliumNode{}
+		node.Spec.ENI.ExcludeInterfaceTags = map[string]string{"skip": "true"}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Tags:      map[string]string{"skip": "true"},
+			},
+			"eni-2": {
+				Addresses: []string{"10.0.0.2"},
+			},
+		}
+
+		result := n.buildPoolAllocated(node)
+		require.Len(t, result, 1)
+		require.Len(t, result[0].CIDRs, 1)
+		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
+	})
 }


### PR DESCRIPTION
In `syncToAPIServer`, populate `Spec.IPAM.Pools.Allocated` alongside `Spec.IPAM.Pool` for nodes with ENI status. This enables the ENI multi-pool migration (cilium/design-cfps#87): new agents (1.20) will read CIDRs from `Pools.Allocated` (with the multipool allocator) while old agents (1.19) will continue reading from `Pool` (with the CRD allocator).

Note: this PR only includes the double write logic on the operator side, a followup PR will change the read path on the agent side.

For secondary IP mode, each IP is written as a /32 CIDR. For prefix delegation mode, each /28 prefix is written directly alongside the secondary IP /32s. All CIDRs are placed under the "default" pool.

The dual-write is low-frequency (fires on ENI capacity changes, not on every pod event) and will be removed in 1.21. The dual write is also atomic, both `Pool` and `Pools.Allocated` get written in the same CilimNode update operation so they are garanteed to always be in sync and consistent.

Relates to cilium/design-cfps#87

## Testing

Here's what this looks like (with `kubectl get ciliumnode $node -ojson | jq '.spec.ipam'`):
* On a node without prefix delegation:
```json
{
  "min-allocate": 3,
  "pool": {
    "100.120.134.75": {
      "resource": "eni-0e979576c285fd4d5"
    },
    "100.120.137.182": {
      "resource": "eni-0e979576c285fd4d5"
    },
    "100.120.248.50": {
      "resource": "eni-0e979576c285fd4d5"
    }
  },
  "pools": {
    "allocated": [
      {
        "cidrs": [
          "100.120.134.75/32",
          "100.120.248.50/32",
          "100.120.137.182/32"
        ],
        "pool": "default"
      }
    ]
  },
  "pre-allocate": 1
}
```
* On a node with prefix delegation:
```json
{
  "min-allocate": 3,
  "pool": {
    "100.121.95.100": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.101": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.102": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.103": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.104": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.105": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.106": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.107": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.108": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.109": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.110": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.111": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.96": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.97": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.98": {
      "resource": "eni-0f05f2edf01f99001"
    },
    "100.121.95.99": {
      "resource": "eni-0f05f2edf01f99001"
    }
  },
  "pools": {
    "allocated": [
      {
        "cidrs": [
          "100.121.95.96/28"
        ],
        "pool": "default"
      }
    ]
  },
  "pre-allocate": 1
}
```