### PR TITLE
bgp: Use logger with BGP instance name in registerBGPInstance

### DIFF
--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -600,7 +600,7 @@ func (m *BGPRouterManager) registerBGPInstance(ctx context.Context,
 		return fmt.Errorf("failed initial reconciliation of BGP instance: %w", err)
 	}
 
-	m.logger.Info(
+	l.Info(
 		"Successfully registered BGP instance",
 		types.LocalASNLogField, localASN,
 		types.ListenPortLogField, localPort,


### PR DESCRIPTION
Use logger with BGP instance name in registerBGPInstance because current BGP implementation uses instance name as the identifier in the CRD API.