### PR TITLE
bpf: fix flaky nat4_port_allocation_tcp/udp tests

### DIFF
--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -1421,7 +1421,7 @@ int test_nat4_port_allocation_tcp_check(struct __ctx_buff *ctx)
 	assert(cb_ctx.fail_thres >= SNAT_TEST_ITERATIONS * 7 / 10);
 
 	/* Only occasional failures at 50% of the test. */
-	assert(retries_50percent[SNAT_COLLISION_RETRIES] < 15);
+	assert(retries_50percent[SNAT_COLLISION_RETRIES] < 25);
 
 	/* Less than 7% of failures at 75% of the test. */
 	assert(retries_75percent[SNAT_COLLISION_RETRIES] < SNAT_TEST_ITERATIONS * 75 * 7 / 10000);
@@ -1548,7 +1548,7 @@ int test_nat4_port_allocation_udp_check(struct __ctx_buff *ctx)
 	assert(cb_ctx.fail_thres >= SNAT_TEST_ITERATIONS * 7 / 10);
 
 	/* Only occasional failures at 50% of the test. */
-	assert(retries_50percent[SNAT_COLLISION_RETRIES] < 15);
+	assert(retries_50percent[SNAT_COLLISION_RETRIES] < 25);
 
 	/* Less than 7% of failures at 75% of the test. */
 	assert(retries_75percent[SNAT_COLLISION_RETRIES] < SNAT_TEST_ITERATIONS * 75 * 7 / 10000);


### PR DESCRIPTION
The SNAT port allocation stress tests were occasionally failing in CI on the 50% checkpoint assertion. 
The bound of 15 was too tight. The port allocation algorithm internally uses `get_prandom_u32()` to pick source ports on collision, so the retry count at any given fill level is a random variable with a long right tail. Across 1000 runs, the median retry count at the 50% checkpoint was 0 and the mean ~2,but the distribution extends out to a max of 26, about 1% of runs hit ≥ 15 (p99 ≈ 14) which is enough to make the test flake regularly in CI even though the typical-case behavior is healthy.

Relax the threshold from 15 to 25. This is still negligible in absolute terms (25 retries across 131K iterations at the 50% mark = 0.019% of operations),and based on the 1000-run distribution only ~0.2% of runs (p99.9) would now hit the bound. imo a much more reasonable noise floor for a stress test. The assertion still catches any meaningful regression in the algorithm.

Fixes: #42599

```release-note
bpf: fix flaky nat4_port_allocation_tcp/udp tests
```
