### PR TITLE
network driver: use PCI address to name sr-iov vfs

### DIFF
--- a/pkg/networkdriver/sriov/sriov.go
+++ b/pkg/networkdriver/sriov/sriov.go
@@ -57,7 +57,6 @@ func (p PciDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAt
 	result[types.VendorLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(p.Vendor)}
 	result[types.PFNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(p.PfName)}
 	result[types.PCIAddrLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(p.Addr)}
-	result[types.IfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(p.IfName())}
 	result[types.KernelIfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(p.KernelIfName())}
 
 	return result
@@ -65,9 +64,9 @@ func (p PciDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAt
 
 // IfName returns a name for this sr-iov VF. Does not match kernel interface name since it is not
 // guaranteed that we have a kernel interface for this device.
-// constructed with <pfName>vf<vfID>
+// derived from the PCI address.
 func (d PciDevice) IfName() string {
-	return fmt.Sprintf("%svf%d", d.PfName, d.VfID)
+	return strings.ReplaceAll(strings.ReplaceAll(d.Addr, ":", "-"), ".", "-")
 }
 
 func (d PciDevice) KernelIfName() string {


### PR DESCRIPTION
The previous naming scheme (ex: ens1f0np0vf4) was a made up name, which doesn't mean much and may cause confusion since we also have the Kernel IfName and it usually looks similar:
```
      If Name:
        String:  ens1f0np0vf4
      Kernel If Name:
        String:  ens1f0v4
```

change the sr-iov vfs to be named after the pci address so it is more explicit

```release-note
network driver: name sr-iov vf resources after PCI address
```
