### PR TITLE
Add restore-aware logic to datapath connector

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -123,7 +123,7 @@ Datapath Mode Value     Description
 ``veth`` (default)      Use veth devices operating at Layer2.
 ``netkit``              Use netkit in Layer3 mode. Cilium will error on startup if unsupported.
 ``netkit-l2``           Use netkit in Layer2 mode. Cilium will error on startup if unsupported.
-``auto``                Auto-detect at runtime: use netkit (Layer3) if kernel support is present, fallback to veth.
+``auto``                Auto-detect at runtime: prefer datapath mode of existing workloads; otherwise use netkit (Layer3) if kernel support is present, fallback to veth.
 ======================= =======================================================================================
 
 .. note::
@@ -131,14 +131,20 @@ Datapath Mode Value     Description
     possible since the CNI plugin cannot simply replace veth with netkit after
     Pod creation. Also, running both flavors in parallel is currently not supported.
 
-    This restriction also applies to auto-detection: if you have existing
-    Pods using veth, then switch to ``bpf.datapathMode=auto`` and netkit support
-    is detected when restarting, Cilium will error.
+    When ``bpf.datapathMode=auto`` is used, Cilium will continue operating with
+    the datapath mode of any existing workloads that are restored on agent restart.
+    For example, if a node restarts with existing Pods using veth, Cilium will
+    retain veth mode, it will not switch those workloads to netkit. This prevents
+    Cilium from failing to start during configuration updates.
+
+    If restored workloads require a concrete datapath mode that is no longer
+    supported by the current node configuration, Cilium will error on startup.
 
     The best way to consume this for an existing cluster is to utilize per-node
-    configuration for enabling netkit on newly spawned nodes which join the
-    cluster. Alternatively, cordon and drain existing nodes before modifying
-    the configuration. See the :ref:`per-node-configuration` page for more details.
+    configuration for enabling netkit or auto-detect mode on newly spawned nodes
+    which join the cluster. Alternatively, cordon and drain existing nodes before
+    modifying the configuration. See the :ref:`per-node-configuration` page for
+    more details.
 
 **Requirements:**
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -320,8 +320,10 @@ The following options have been introduced in this version of Cilium:
   the underlying host for netkit support and, if found, netkit mode will be selected at
   runtime. Otherwise, Cilium will default back to the standard veth mode. This has the
   side effect of splitting the datapath-mode into "configured mode" and "operational mode"
-  in status outputs, where they differ. The default remains ``bpf.datapathMode=veth``
-  but may change in future releases.
+  in status outputs, where they differ. 
+  When restarting a node with existing workloads, Cilium will attempt to retain the
+  existing datapath mode. See :ref:`datapath_config` for further details.
+  The default remains ``bpf.datapathMode=veth`` but may change in future releases.
 
 Changed Options
 ###############
@@ -331,7 +333,9 @@ differently than in prior releases:
 
 * ``bpf.tproxy=true`` is incompatible with netkit datapath mode. If netkit is also enabled,
   Cilium will fail to start. If auto-detect datapath mode is used, Cilium will revert to
-  veth mode, even if netkit support is present.
+  veth mode when probing on a fresh start, even if netkit support is present. If restored
+  workloads require netkit, Cilium will fail to start instead of switching those workloads
+  to veth in place.
 
 Deprecated Options
 ##################

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -226,9 +226,10 @@ func (r *endpointRestorer) WaitForInitialPolicy(ctx context.Context) error {
 }
 
 type endpointRestoreState struct {
-	possible map[uint16]*endpoint.Endpoint
-	restored []*endpoint.Endpoint
-	toClean  []*endpoint.Endpoint
+	inventory endpoint.RestoreInventory
+	possible  map[uint16]*endpoint.Endpoint
+	restored  []*endpoint.Endpoint
+	toClean   []*endpoint.Endpoint
 }
 
 // checkLink returns an error if a link with linkName does not exist.
@@ -400,13 +401,13 @@ func (r *endpointRestorer) readOldEndpointsFromDisk(ctx context.Context) error {
 
 	r.logger.Info("Reading old endpoints...")
 
-	dirFiles, err := os.ReadDir(r.stateDir)
+	inventory, err := endpoint.ReadRestoreInventory(ctx, r.logger, r.stateDir)
 	if err != nil {
 		return err
 	}
-	eptsID := endpoint.FilterEPDir(dirFiles)
-
-	r.restoreState.possible, failed = endpoint.ReadEPsFromDirNames(ctx, r.logger, r.endpointCreator, r.stateDir, eptsID)
+	r.restoreState.inventory = inventory
+	r.restoreState.possible, failed = endpoint.ReadEPsFromRestoreInventory(ctx, r.logger, r.endpointCreator, r.stateDir, inventory)
+	r.restoreState.inventory = endpoint.RestoreInventory{}
 
 	if len(r.restoreState.possible) == 0 {
 		r.logger.Info("No old endpoints found.")

--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -4,6 +4,8 @@
 package connector
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -15,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -121,6 +124,56 @@ func getLinkMode(ifName string) (Mode, error) {
 	return linkMode, nil
 }
 
+func deriveRestorationMode(inv endpoint.RestoreInventory) (Mode, error) {
+	var restorationMode Mode
+
+	for _, item := range inv.Items {
+		if !isRelevantRestoreInventoryItem(item) {
+			continue
+		}
+
+		linkMode, err := getLinkMode(item.HostIfName)
+		if err != nil {
+			if errors.As(err, &netlink.LinkNotFoundError{}) {
+				continue
+			}
+			return ModeUnspec, fmt.Errorf("inspect restored endpoint %d link %q: %w",
+				item.EndpointID, item.HostIfName, err)
+		}
+		if linkMode == ModeUnspec {
+			return ModeUnspec, fmt.Errorf("restored endpoint %d link %q uses an unknown datapath mode",
+				item.EndpointID, item.HostIfName)
+		}
+
+		if restorationMode == ModeUnspec {
+			restorationMode = linkMode
+			continue
+		}
+		if restorationMode != linkMode {
+			return ModeUnspec, fmt.Errorf("restored endpoints use multiple datapath modes: %s and %s",
+				restorationMode, linkMode)
+		}
+	}
+
+	return restorationMode, nil
+}
+
+func isRelevantRestoreInventoryItem(item endpoint.RestoreInventoryItem) bool {
+	return item.K8sNamespace != "" &&
+		item.K8sPodName != "" &&
+		item.HostIfName != "" &&
+		!item.IsFake
+}
+
+func validateOperationalMode(mode Mode, p connectorParams) error {
+	switch mode {
+	case ModeNetkit, ModeNetkitL2:
+		return canUseNetkit(p)
+	default:
+		return nil
+	}
+}
+
 type connectorParams struct {
 	cell.In
 
@@ -180,6 +233,7 @@ func canUseNetkit(p connectorParams) error {
 // newConnectorConfig initialises a new ConnectorConfig object with default parameters.
 func newConfig(p connectorParams) (*config, error) {
 	var configuredMode, operationalMode Mode
+	var restorationMode Mode
 
 	configuredMode = ModeByName(p.DaemonConfig.DatapathMode)
 	switch configuredMode {
@@ -187,6 +241,35 @@ func newConfig(p connectorParams) (*config, error) {
 		return nil, fmt.Errorf("invalid datapath mode: %s", p.DaemonConfig.DatapathMode)
 
 	case ModeAuto:
+		// We need to probe into the Cilium state dir and see if we have existing
+		// endpoints to restore. If we do, we take the operational mode from said
+		// endpoints to avoid datapath incompatibility.
+		if p.DaemonConfig.StateDir != "" {
+			inventory, err := endpoint.ReadRestoreInventory(context.Background(), p.Log, p.DaemonConfig.StateDir)
+			if err != nil {
+				return nil, fmt.Errorf("read restore inventory: %w", err)
+			}
+
+			restorationMode, err = deriveRestorationMode(inventory)
+			if err != nil {
+				return nil, fmt.Errorf("derive restoration mode: %w", err)
+			}
+		}
+
+		// If we detect a restorationMode, we validate it and implement it as our
+		// operational mode if everything checks out.
+		if restorationMode != ModeUnspec {
+			if err := validateOperationalMode(restorationMode, p); err != nil {
+				return nil, fmt.Errorf("cannot restore datapath mode %s: %w",
+					restorationMode, err)
+			}
+
+			operationalMode = restorationMode
+			break
+		}
+
+		// With no existing restore mode we can proceed to probe for netkit support
+		// and enable it if present, falling bath to veth mode otherwise.
 		if err := canUseNetkit(p); err != nil {
 			p.Log.Warn("datapath autodiscovery failed, reverting from netkit to veth",
 				logfields.Error, err)
@@ -211,6 +294,7 @@ func newConfig(p connectorParams) (*config, error) {
 		wgAgent:         p.WgAgent,
 		tunnelConfig:    p.TunnelConfig,
 		configuredMode:  configuredMode,
+		restorationMode: restorationMode,
 		operationalMode: operationalMode,
 	}
 
@@ -222,7 +306,22 @@ func newConfig(p connectorParams) (*config, error) {
 		p.DaemonConfig.EnableTCX = true
 	}
 
-	p.Log.Info("Datapath connector ready", logfields.DatapathMode, cc.operationalMode)
+	var sourceMsg string
+	switch {
+	case cc.operationalMode == cc.restorationMode:
+		// Must have been restored from endpoint inventory,
+		// must also be auto-discovery!
+		sourceMsg = "auto-discovery-restored"
+	case cc.operationalMode != cc.configuredMode:
+		// Must be auto-discovery
+		sourceMsg = "auto-discovery"
+	default:
+		// Must be explicit configuration
+		sourceMsg = "configuration"
+	}
+	p.Log.Info("Datapath connector ready",
+		logfields.DatapathMode, cc.operationalMode,
+		logfields.Source, sourceMsg)
 
 	return cc, nil
 }

--- a/pkg/datapath/connector/config.go
+++ b/pkg/datapath/connector/config.go
@@ -50,6 +50,11 @@ type config struct {
 	// as specified by runtime configuration.
 	configuredMode Mode
 
+	// restorationMode tracks the datapath mode inferred from endpoint restore
+	// state. This is used with configuredMode=auto to calibrate the operationalMode
+	// to the underlying datapath of any endpoints being restored.
+	restorationMode Mode
+
 	// operationalMode tracks the operational datapath mode of Cilium,
 	// which may differ from the configured datapath mode.
 	operationalMode Mode
@@ -80,9 +85,25 @@ func (cc *config) NewLinkPair(cfg LinkConfig, sysctl sysctl.Sysctl) (LinkPair, e
 }
 
 func (cc *config) GetLinkCompatibility(ifName string) (Mode, bool, error) {
-	link, err := safenetlink.LinkByName(ifName)
+	linkMode, err := getLinkMode(ifName)
 	if err != nil {
 		return ModeUnspec, false, err
+	}
+	linkCompatible := cc.operationalMode == linkMode
+
+	return linkMode, linkCompatible, nil
+}
+
+// Returns true if we should actively try and align the connector's netdev buffer
+// margins with that of the host's egress interfaces (e.g. tunnel, wireguard).
+func (cc *config) useTunedBufferMargins() bool {
+	return cc.operationalMode.IsNetkit()
+}
+
+func getLinkMode(ifName string) (Mode, error) {
+	link, err := safenetlink.LinkByName(ifName)
+	if err != nil {
+		return ModeUnspec, err
 	}
 
 	linkMode := ModeByName(link.Type())
@@ -97,15 +118,7 @@ func (cc *config) GetLinkCompatibility(ifName string) (Mode, bool, error) {
 		}
 	}
 
-	linkCompatible := cc.operationalMode == linkMode
-
-	return linkMode, linkCompatible, nil
-}
-
-// Returns true if we should actively try and align the connector's netdev buffer
-// margins with that of the host's egress interfaces (e.g. tunnel, wireguard).
-func (cc *config) useTunedBufferMargins() bool {
-	return cc.operationalMode.IsNetkit()
+	return linkMode, nil
 }
 
 type connectorParams struct {

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -446,6 +448,44 @@ func TestUseTunedBufferMargins(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func TestPrivilegedGetLinkMode(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	logger := hivetest.Logger(t)
+
+	ns := netns.NewNetNS(t)
+	require.NoError(t, ns.Do(func() error {
+		h, err := netlink.NewHandle()
+		require.NoError(t, err)
+		defer h.Close()
+
+		createFakePair(t, h, TestHostIfName, TestPeerIfName)
+
+		mode, err := getLinkMode(TestHostIfName)
+		require.NoError(t, err)
+		require.Equal(t, types.ConnectorModeVeth, mode)
+
+		if hostSupportsNetkit() {
+			ctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+			linkConfig := types.LinkConfig{
+				HostIfName: TestEndpointFinalIfName,
+				PeerIfName: TestPeerIfName,
+				DeviceMTU:  TestStandardMTU,
+			}
+
+			linkPair, err := NewLinkPair(logger, types.ConnectorModeNetkitL2, linkConfig, ctl)
+			require.NoError(t, err)
+			defer linkPair.Delete()
+
+			// Netkit L2 exercises the extra mode disambiguation in getLinkMode().
+			mode, err = getLinkMode(TestEndpointFinalIfName)
+			require.NoError(t, err)
+			require.Equal(t, types.ConnectorModeNetkitL2, mode)
+		}
+
+		return nil
+	}))
 }
 
 type ifBufferMargin struct {

--- a/pkg/datapath/connector/config_test.go
+++ b/pkg/datapath/connector/config_test.go
@@ -4,7 +4,11 @@
 package connector
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cilium/hive/cell"
@@ -14,12 +18,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
@@ -161,11 +167,129 @@ var (
 	}
 	connectorConfigAuto_Veth = config{
 		configuredMode:  ModeAuto,
+		restorationMode: ModeUnspec,
 		operationalMode: ModeVeth,
 	}
 	connectorConfigAuto_Netkit = config{
 		configuredMode:  ModeAuto,
+		restorationMode: ModeUnspec,
 		operationalMode: ModeNetkit,
+	}
+
+	restoreInventoryItemMissingLink = endpoint.RestoreInventoryItem{
+		Directory:    "123",
+		EndpointID:   123,
+		HostIfName:   "missing-link",
+		K8sNamespace: "default",
+		K8sPodName:   "missing-link",
+	}
+	restoreInventoryItemFake = endpoint.RestoreInventoryItem{
+		Directory:  "123",
+		EndpointID: 123,
+		HostIfName: "missing-link",
+		IsFake:     true,
+	}
+	restoreInventoryItemHostIfOnly = endpoint.RestoreInventoryItem{
+		Directory:  "124",
+		EndpointID: 124,
+		HostIfName: "missing-link",
+	}
+	restoreInventoryItemPodWithoutHostLink = endpoint.RestoreInventoryItem{
+		Directory:    "125",
+		EndpointID:   125,
+		K8sNamespace: "default",
+		K8sPodName:   "pod-a",
+	}
+	restoreInventoryItemVethA = endpoint.RestoreInventoryItem{
+		Directory:    "123",
+		EndpointID:   123,
+		HostIfName:   "lxc-veth-a",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-a",
+	}
+	restoreInventoryItemMissingPodB = endpoint.RestoreInventoryItem{
+		Directory:    "124",
+		EndpointID:   124,
+		HostIfName:   "missing-link",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-b",
+	}
+	restoreInventoryItemFakeVethC = endpoint.RestoreInventoryItem{
+		Directory:    "125",
+		EndpointID:   125,
+		HostIfName:   "lxc-veth-a",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-c",
+		IsFake:       true,
+	}
+	restoreInventoryItemNetkitL2 = endpoint.RestoreInventoryItem{
+		Directory:    "126",
+		EndpointID:   126,
+		HostIfName:   "lxc-netkit-l2",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-d",
+	}
+	restoreInventoryItemMixedVeth = endpoint.RestoreInventoryItem{
+		Directory:    "127",
+		EndpointID:   127,
+		HostIfName:   "lxc-veth-mixed",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-e",
+	}
+	restoreInventoryItemMixedNetkit = endpoint.RestoreInventoryItem{
+		Directory:    "128",
+		EndpointID:   128,
+		HostIfName:   "lxc-nk-mixed",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-f",
+	}
+	restoreInventoryItemAutoVeth = endpoint.RestoreInventoryItem{
+		Directory:    "123",
+		EndpointID:   123,
+		HostIfName:   "lxc-auto-veth",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-a",
+	}
+	restoreInventoryItemAutoNetkitL2 = endpoint.RestoreInventoryItem{
+		Directory:    "124",
+		EndpointID:   124,
+		HostIfName:   "lxc-auto-nkl2",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-b",
+	}
+	restoreInventoryItemAutoMissing = endpoint.RestoreInventoryItem{
+		Directory:    "125",
+		EndpointID:   125,
+		HostIfName:   "missing-link",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-c",
+	}
+	restoreInventoryItemAutoIgnoredFake = endpoint.RestoreInventoryItem{
+		Directory:  "126",
+		EndpointID: 126,
+		HostIfName: "lxc-ignored",
+		IsFake:     true,
+	}
+	restoreInventoryItemAutoMixedVeth = endpoint.RestoreInventoryItem{
+		Directory:    "127",
+		EndpointID:   127,
+		HostIfName:   "lxc-auto-mvth",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-d",
+	}
+	restoreInventoryItemAutoMixedNetkit = endpoint.RestoreInventoryItem{
+		Directory:    "128",
+		EndpointID:   128,
+		HostIfName:   "lxc-auto-mnkt",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-e",
+	}
+	restoreInventoryItemAutoUnsupportedNetkit = endpoint.RestoreInventoryItem{
+		Directory:    "129",
+		EndpointID:   129,
+		HostIfName:   "lxc-auto-nkbad",
+		K8sNamespace: "default",
+		K8sPodName:   "pod-f",
 	}
 )
 
@@ -394,6 +518,7 @@ func TestNewConfig(t *testing.T) {
 				assert.Equal(t, tt.expectedConfig.podDeviceHeadroom, connector.podDeviceHeadroom)
 				assert.Equal(t, tt.expectedConfig.podDeviceTailroom, connector.podDeviceTailroom)
 				assert.Equal(t, tt.expectedConfig.configuredMode, connector.configuredMode)
+				assert.Equal(t, tt.expectedConfig.restorationMode, connector.restorationMode)
 				assert.Equal(t, tt.expectedConfig.operationalMode, connector.operationalMode)
 			}
 		})
@@ -464,28 +589,313 @@ func TestPrivilegedGetLinkMode(t *testing.T) {
 
 		mode, err := getLinkMode(TestHostIfName)
 		require.NoError(t, err)
-		require.Equal(t, types.ConnectorModeVeth, mode)
+		require.Equal(t, ModeVeth, mode)
 
 		if hostSupportsNetkit() {
 			ctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
-			linkConfig := types.LinkConfig{
+			linkConfig := LinkConfig{
 				HostIfName: TestEndpointFinalIfName,
-				PeerIfName: TestPeerIfName,
+				PeerIfName: "tmp-nk-peer",
 				DeviceMTU:  TestStandardMTU,
 			}
 
-			linkPair, err := NewLinkPair(logger, types.ConnectorModeNetkitL2, linkConfig, ctl)
+			// Create a netkit-L2 link pair so we can exercise the netkit
+			// mode checking in getLinkMode(), which is embedded in the
+			// underlying netkit structure in netlink.
+			linkPair, err := NewLinkPair(logger, ModeNetkitL2, linkConfig, ctl)
 			require.NoError(t, err)
 			defer linkPair.Delete()
 
-			// Netkit L2 exercises the extra mode disambiguation in getLinkMode().
 			mode, err = getLinkMode(TestEndpointFinalIfName)
 			require.NoError(t, err)
-			require.Equal(t, types.ConnectorModeNetkitL2, mode)
+			require.Equal(t, ModeNetkitL2, mode)
 		}
 
 		return nil
 	}))
+}
+
+func TestPrivilegedDeriveRestorationMode(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	logger := hivetest.Logger(t)
+
+	tests := []struct {
+		name           string
+		shouldSkip     bool
+		inventoryItems []endpoint.RestoreInventoryItem
+		linkSetups     []testConnectorLink
+		expectedMode   Mode
+		shouldError    bool
+	}{
+		{
+			name:           "missing-link-only",
+			inventoryItems: []endpoint.RestoreInventoryItem{restoreInventoryItemMissingLink},
+			expectedMode:   ModeUnspec,
+		},
+		{
+			name: "non-relevant-items-only",
+			inventoryItems: []endpoint.RestoreInventoryItem{
+				restoreInventoryItemFake,
+				restoreInventoryItemHostIfOnly,
+				restoreInventoryItemPodWithoutHostLink,
+			},
+			expectedMode: ModeUnspec,
+		},
+		{
+			name: "veth-with-ignored-items",
+			inventoryItems: []endpoint.RestoreInventoryItem{
+				restoreInventoryItemVethA,
+				restoreInventoryItemMissingPodB,
+				restoreInventoryItemFakeVethC,
+			},
+			linkSetups: []testConnectorLink{
+				{mode: ModeVeth, hostIfName: "lxc-veth-a", peerIfName: "tmp-veth-a"},
+			},
+			expectedMode: ModeVeth,
+		},
+		{
+			name:           "netkit-l2",
+			shouldSkip:     !hostSupportsNetkit(),
+			inventoryItems: []endpoint.RestoreInventoryItem{restoreInventoryItemNetkitL2},
+			linkSetups: []testConnectorLink{
+				{mode: ModeNetkitL2, hostIfName: "lxc-netkit-l2", peerIfName: "tmp-netkit-l2"},
+			},
+			expectedMode: ModeNetkitL2,
+		},
+		{
+			name:       "mixed-modes",
+			shouldSkip: !hostSupportsNetkit(),
+			inventoryItems: []endpoint.RestoreInventoryItem{
+				restoreInventoryItemMixedVeth,
+				restoreInventoryItemMixedNetkit,
+			},
+			linkSetups: []testConnectorLink{
+				{mode: ModeVeth, hostIfName: "lxc-veth-mixed", peerIfName: "tmp-veth-mixed"},
+				{mode: ModeNetkitL2, hostIfName: "lxc-nk-mixed", peerIfName: "tmp-nk-mixed"},
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
+			ns := netns.NewNetNS(t)
+			require.NoError(t, ns.Do(func() error {
+				for _, link := range tt.linkSetups {
+					if err := createTestConnectorLink(t, logger, link); err != nil {
+						return err
+					}
+				}
+
+				mode, err := deriveRestorationMode(endpoint.RestoreInventory{
+					Items: tt.inventoryItems,
+				})
+				if tt.shouldError {
+					require.Error(t, err)
+					require.Equal(t, ModeUnspec, mode)
+					return nil
+				}
+
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedMode, mode)
+				return nil
+			}))
+		})
+	}
+}
+
+func TestPrivilegedNewConfigAutoRestorationMode(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	logger := hivetest.Logger(t)
+
+	tests := []struct {
+		name                string
+		shouldSkip          bool
+		daemonConfig        *option.DaemonConfig
+		inventoryItems      []endpoint.RestoreInventoryItem
+		linkSetups          []testConnectorLink
+		expectedRestoreMode Mode
+		expectedOperMode    Mode
+		shouldError         bool
+	}{
+		{
+			name:           "restored-veth-overrides-netkit-probe",
+			shouldSkip:     !hostSupportsNetkit(),
+			daemonConfig:   &daemonConfigAuto,
+			inventoryItems: []endpoint.RestoreInventoryItem{restoreInventoryItemAutoVeth},
+			linkSetups: []testConnectorLink{
+				{mode: ModeVeth, hostIfName: "lxc-auto-veth", peerIfName: "tmp-auto-veth"},
+			},
+			expectedRestoreMode: ModeVeth,
+			expectedOperMode:    ModeVeth,
+		},
+		{
+			name:           "restored-netkit-l2-is-selected",
+			shouldSkip:     !hostSupportsNetkit(),
+			daemonConfig:   &daemonConfigAuto,
+			inventoryItems: []endpoint.RestoreInventoryItem{restoreInventoryItemAutoNetkitL2},
+			linkSetups: []testConnectorLink{
+				{mode: ModeNetkitL2, hostIfName: "lxc-auto-nkl2", peerIfName: "tmp-auto-nkl2"},
+			},
+			expectedRestoreMode: ModeNetkitL2,
+			expectedOperMode:    ModeNetkitL2,
+		},
+		{
+			name:                "missing-link-falls-back-to-probe",
+			shouldSkip:          !hostSupportsNetkit(),
+			daemonConfig:        &daemonConfigAuto,
+			inventoryItems:      []endpoint.RestoreInventoryItem{restoreInventoryItemAutoMissing},
+			expectedRestoreMode: ModeUnspec,
+			expectedOperMode:    ModeNetkit,
+		},
+		{
+			name:           "non-relevant-inventory-falls-back-to-probe",
+			shouldSkip:     !hostSupportsNetkit(),
+			daemonConfig:   &daemonConfigAuto,
+			inventoryItems: []endpoint.RestoreInventoryItem{restoreInventoryItemAutoIgnoredFake},
+			linkSetups: []testConnectorLink{
+				{mode: ModeVeth, hostIfName: "lxc-ignored", peerIfName: "tmp-ignored"},
+			},
+			expectedRestoreMode: ModeUnspec,
+			expectedOperMode:    ModeNetkit,
+		},
+		{
+			name:         "mixed-restored-modes-error",
+			shouldSkip:   !hostSupportsNetkit(),
+			daemonConfig: &daemonConfigAuto,
+			inventoryItems: []endpoint.RestoreInventoryItem{
+				restoreInventoryItemAutoMixedVeth,
+				restoreInventoryItemAutoMixedNetkit,
+			},
+			linkSetups: []testConnectorLink{
+				{mode: ModeVeth, hostIfName: "lxc-auto-mvth", peerIfName: "tmp-auto-mvth"},
+				{mode: ModeNetkitL2, hostIfName: "lxc-auto-mnkt", peerIfName: "tmp-auto-mnkt"},
+			},
+			shouldError: true,
+		},
+		{
+			name:       "unsupported-restored-netkit-errors",
+			shouldSkip: !hostSupportsNetkit(),
+			// Use TProxy to force an invalid netkit configuration.
+			daemonConfig:   &daemonConfigAutoTproxy,
+			inventoryItems: []endpoint.RestoreInventoryItem{restoreInventoryItemAutoUnsupportedNetkit},
+			linkSetups: []testConnectorLink{
+				{mode: ModeNetkitL2, hostIfName: "lxc-auto-nkbad", peerIfName: "tmp-auto-nkbad"},
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
+			tmpDir := t.TempDir()
+			daemonConfig := *tt.daemonConfig
+			daemonConfig.StateDir = tmpDir
+
+			ns := netns.NewNetNS(t)
+			require.NoError(t, ns.Do(func() error {
+				for _, link := range tt.linkSetups {
+					if err := createTestConnectorLink(t, logger, link); err != nil {
+						return err
+					}
+				}
+				for _, item := range tt.inventoryItems {
+					require.NoError(t, writeRestoreInventoryState(tmpDir, item.Directory, item))
+				}
+
+				p := connectorParams{
+					Lifecycle:    &cell.DefaultLifecycle{},
+					Log:          logger,
+					DaemonConfig: &daemonConfig,
+					WgAgent:      fakewireguard.NewTestAgent(wgConfigDisabled),
+					TunnelConfig: tunnelConfigNative,
+				}
+
+				connector, err := newConfig(p)
+				if tt.shouldError {
+					require.Error(t, err)
+					require.Nil(t, connector)
+					return nil
+				}
+
+				require.NoError(t, err)
+				require.NotNil(t, connector)
+				require.Equal(t, tt.expectedRestoreMode, connector.restorationMode)
+				require.Equal(t, tt.expectedOperMode, connector.operationalMode)
+				return nil
+			}))
+		})
+	}
+}
+
+func writeRestoreInventoryState(basePath, directory string, item endpoint.RestoreInventoryItem) error {
+	stateDir := filepath.Join(basePath, directory)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+
+	state, err := json.Marshal(map[string]any{
+		"ID":           item.EndpointID,
+		"IfName":       item.HostIfName,
+		"K8sNamespace": item.K8sNamespace,
+		"K8sPodName":   item.K8sPodName,
+		"Properties": map[string]any{
+			endpoint.PropertyFakeEndpoint: item.IsFake,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(stateDir, common.EndpointStateFileName), state, 0o644)
+}
+
+type testConnectorLink struct {
+	mode       Mode
+	hostIfName string
+	peerIfName string
+}
+
+func createTestConnectorLink(tb testing.TB, logger *slog.Logger, link testConnectorLink) error {
+	tb.Helper()
+
+	switch link.mode {
+	case ModeVeth:
+		h, err := netlink.NewHandle()
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+
+		createFakePair(tb, h, link.hostIfName, link.peerIfName)
+		return nil
+	case ModeNetkit, ModeNetkitL2:
+		ctl := sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
+		linkConfig := LinkConfig{
+			HostIfName: link.hostIfName,
+			PeerIfName: link.peerIfName,
+			DeviceMTU:  TestStandardMTU,
+		}
+
+		linkPair, err := NewLinkPair(logger, link.mode, linkConfig, ctl)
+		if err != nil {
+			return err
+		}
+		_ = linkPair
+		return nil
+	default:
+		return fmt.Errorf("unsupported test link mode: %s", link.mode)
+	}
 }
 
 type ifBufferMargin struct {

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -75,6 +75,13 @@ type restoreInventoryEndpoint struct {
 	Properties   map[string]any
 }
 
+// restoreParseEntry identifies a discovered restore candidate that should be
+// instantiated into a full Endpoint.
+type restoreParseEntry struct {
+	Directory  string
+	EndpointID uint16
+}
+
 func (rie restoreInventoryEndpoint) toRestoreInventoryItem(directory string) RestoreInventoryItem {
 	return RestoreInventoryItem{
 		Directory:    directory,
@@ -169,47 +176,26 @@ func ReadEPsFromDirNames(ctx context.Context, logger *slog.Logger, parser Endpoi
 		}
 	}
 
-	possibleEPs := map[uint16]*Endpoint{}
-	failed := 0
+	parseEntries := make([]restoreParseEntry, 0, len(completeEPDirNames))
 	for _, epDirName := range completeEPDirNames {
-		epDir := filepath.Join(basePath, epDirName)
-
-		scopedLogger := logger.With(
-			logfields.EndpointID, epDirName,
-			logfields.Path, epDir,
-		)
-
-		state, err := findEndpointState(scopedLogger, epDir)
-		if err != nil {
-			scopedLogger.Warn("Couldn't find state, ignoring endpoint", logfields.Error, err)
-			failed++
-			continue
-		}
-
-		ep, err := parser.ParseEndpoint(state)
-		if err != nil {
-			scopedLogger.Warn("Unable to parse the C header file", logfields.Error, err)
-			failed++
-			continue
-		}
-		if _, ok := possibleEPs[ep.ID]; ok {
-			// If the endpoint already exists then give priority to the directory
-			// that contains an endpoint that didn't fail to be build.
-			if strings.HasSuffix(ep.DirectoryPath(), epDirName) {
-				possibleEPs[ep.ID] = ep
-			}
-		} else {
-			possibleEPs[ep.ID] = ep
-		}
-
-		// We need to save the host endpoint ID as we'll need it to regenerate
-		// other endpoints.
-		if ep.IsHost() {
-			node.SetEndpointID(ep.GetID())
-		}
+		parseEntries = append(parseEntries, restoreParseEntry{Directory: epDirName})
 	}
 
-	return possibleEPs, failed
+	return readEPsFromEntries(ctx, logger, parser, basePath, parseEntries)
+}
+
+// ReadEPsFromRestoreInventory returns a mapping of endpoint ID to endpoint
+// from the previously discovered restore inventory.
+func ReadEPsFromRestoreInventory(ctx context.Context, logger *slog.Logger, parser EndpointParser, basePath string, inventory RestoreInventory) (map[uint16]*Endpoint, int) {
+	parseEntries := make([]restoreParseEntry, 0, len(inventory.Items))
+	for _, item := range inventory.Items {
+		parseEntries = append(parseEntries, restoreParseEntry{
+			Directory:  item.Directory,
+			EndpointID: item.EndpointID,
+		})
+	}
+
+	return readEPsFromEntries(ctx, logger, parser, basePath, parseEntries)
 }
 
 // findEndpointState finds the JSON representation of an endpoint's state in
@@ -292,6 +278,55 @@ func partitionEPDirNamesByRestoreStatus(eptsDirNames []string) (complete []strin
 	}
 
 	return
+}
+
+func readEPsFromEntries(ctx context.Context, logger *slog.Logger, parser EndpointParser, basePath string, entries []restoreParseEntry) (map[uint16]*Endpoint, int) {
+	possibleEPs := map[uint16]*Endpoint{}
+	failed := 0
+
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+
+		epDir := filepath.Join(basePath, entry.Directory)
+
+		scopedLogger := logger.With(logfields.Path, epDir)
+		if entry.EndpointID != 0 {
+			scopedLogger = scopedLogger.With(logfields.EndpointID, entry.EndpointID)
+		}
+
+		state, err := findEndpointState(scopedLogger, epDir)
+		if err != nil {
+			scopedLogger.Warn("Couldn't find state, ignoring endpoint", logfields.Error, err)
+			failed++
+			continue
+		}
+
+		ep, err := parser.ParseEndpoint(state)
+		if err != nil {
+			scopedLogger.Warn("Unable to parse the C header file", logfields.Error, err)
+			failed++
+			continue
+		}
+		if _, ok := possibleEPs[ep.ID]; ok {
+			// If the endpoint already exists then give priority to the directory
+			// that contains an endpoint that didn't fail to be built.
+			if strings.HasSuffix(ep.DirectoryPath(), entry.Directory) {
+				possibleEPs[ep.ID] = ep
+			}
+		} else {
+			possibleEPs[ep.ID] = ep
+		}
+
+		// We need to save the host endpoint ID as we'll need it to regenerate
+		// other endpoints.
+		if ep.IsHost() {
+			node.SetEndpointID(ep.GetID())
+		}
+	}
+
+	return possibleEPs, failed
 }
 
 func isRestoreInventoryEndpointFake(properties map[string]any) bool {

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -46,6 +46,107 @@ type EndpointParser interface {
 	ParseEndpoint(epJSON []byte) (*Endpoint, error)
 }
 
+// RestoreInventory contains the lightweight set of restore candidates
+// discovered from persisted endpoint state directories.
+type RestoreInventory struct {
+	Items []RestoreInventoryItem
+}
+
+// RestoreInventoryItem contains the persisted fields needed to reason about a
+// restore candidate without constructing a full Endpoint.
+type RestoreInventoryItem struct {
+	Directory    string
+	EndpointID   uint16
+	HostIfName   string
+	K8sNamespace string
+	K8sPodName   string
+	IsFake       bool
+}
+
+// restoreInventoryEndpoint is a lightweight view of the persisted endpoint
+// state used for restore inventory scanning. Its fields are intentionally
+// aligned with the on-disk serialized endpoint fields so we can decode only
+// the data needed for inventory construction without full Endpoint parsing.
+type restoreInventoryEndpoint struct {
+	ID           uint16
+	IfName       string
+	K8sNamespace string
+	K8sPodName   string
+	Properties   map[string]any
+}
+
+func (rie restoreInventoryEndpoint) toRestoreInventoryItem(directory string) RestoreInventoryItem {
+	return RestoreInventoryItem{
+		Directory:    directory,
+		EndpointID:   rie.ID,
+		HostIfName:   rie.IfName,
+		K8sNamespace: rie.K8sNamespace,
+		K8sPodName:   rie.K8sPodName,
+		IsFake:       isRestoreInventoryEndpointFake(rie.Properties),
+	}
+}
+
+// ReadRestoreInventory returns lightweight restore inventory entries for the
+// endpoint state directories discovered under basePath.
+func ReadRestoreInventory(ctx context.Context, logger *slog.Logger, basePath string) (RestoreInventory, error) {
+	dirFiles, err := os.ReadDir(basePath)
+	if err != nil {
+		return RestoreInventory{}, err
+	}
+
+	eptsDirNames := FilterEPDir(dirFiles)
+	completeEPDirNames, incompleteEPDirNames := partitionEPDirNamesByRestoreStatus(eptsDirNames)
+
+	if len(incompleteEPDirNames) > 0 {
+		for _, epDirName := range incompleteEPDirNames {
+			fullDirName := filepath.Join(basePath, epDirName)
+			logger.Info(
+				fmt.Sprintf("Found incomplete restore directory %s. Removing it...", fullDirName),
+				logfields.EndpointID, epDirName,
+			)
+			if err := os.RemoveAll(epDirName); err != nil {
+				logger.Warn(
+					fmt.Sprintf("Error while removing directory %s. Ignoring it...", fullDirName),
+					logfields.Error, err,
+					logfields.EndpointID, epDirName,
+				)
+			}
+		}
+	}
+
+	inventory := RestoreInventory{
+		Items: make([]RestoreInventoryItem, 0, len(completeEPDirNames)),
+	}
+
+	for _, epDirName := range completeEPDirNames {
+		if err := ctx.Err(); err != nil {
+			return RestoreInventory{}, err
+		}
+
+		epDir := filepath.Join(basePath, epDirName)
+		scopedLogger := logger.With(
+			logfields.EndpointID, epDirName,
+			logfields.Path, epDir,
+		)
+
+		state, err := findEndpointState(scopedLogger, epDir)
+		if err != nil {
+			scopedLogger.Warn("Couldn't find state, ignoring endpoint", logfields.Error, err)
+			continue
+		}
+
+		var restored restoreInventoryEndpoint
+		if err := json.Unmarshal(state, &restored); err != nil {
+			scopedLogger.Warn("Unable to parse the endpoint state", logfields.Error, err)
+			continue
+		}
+
+		inventory.Items = append(inventory.Items, restored.toRestoreInventoryItem(epDirName))
+	}
+
+	return inventory, nil
+}
+
 // ReadEPsFromDirNames returns a mapping of endpoint ID to endpoint of endpoints
 // from a list of directory names that can possible contain an endpoint.
 func ReadEPsFromDirNames(ctx context.Context, logger *slog.Logger, parser EndpointParser, basePath string, eptsDirNames []string) (map[uint16]*Endpoint, int) {
@@ -191,6 +292,20 @@ func partitionEPDirNamesByRestoreStatus(eptsDirNames []string) (complete []strin
 	}
 
 	return
+}
+
+func isRestoreInventoryEndpointFake(properties map[string]any) bool {
+	if len(properties) == 0 {
+		return false
+	}
+
+	value, ok := properties[PropertyFakeEndpoint]
+	if !ok {
+		return false
+	}
+
+	fake, ok := value.(bool)
+	return ok && fake
 }
 
 // RegenerateAfterRestore performs the following operations on the specified

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -4,7 +4,6 @@
 package endpoint
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -88,6 +87,7 @@ func (s *EndpointSuite) endpointCreator(t testing.TB, id uint16, secID identity.
 
 func TestReadEPsFromDirNames(t *testing.T) {
 	logger := hivetest.Logger(t)
+	ctx := t.Context()
 	s := setupEndpointSuite(t)
 	epsWanted, _ := s.createEndpoints(t)
 	tmpDir := t.TempDir()
@@ -141,7 +141,7 @@ func TestReadEPsFromDirNames(t *testing.T) {
 	p.Logger = logger
 	p.Orchestrator = s.orchestrator
 	p.PolicyRepo = s.repo
-	eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epsNames)
+	eps, _ := ReadEPsFromDirNames(ctx, logger, &fakeParser{p: p}, tmpDir, epsNames)
 	require.Len(t, eps, len(epsWanted))
 
 	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
@@ -185,9 +185,7 @@ func TestReadRestoreInventory(t *testing.T) {
 		fullDirName := filepath.Join(tmpDir, ep.DirectoryPath())
 		require.NoError(t, os.MkdirAll(fullDirName, 0o777))
 
-		if i == 0 {
-			ep.properties[PropertyFakeEndpoint] = true
-		}
+		ep.properties[PropertyFakeEndpoint] = i == 0
 
 		require.NoError(t, ep.writeHeaderfile(fullDirName))
 
@@ -246,8 +244,58 @@ func TestReadRestoreInventoryRemovesIncompleteRestoreDirs(t *testing.T) {
 	require.NoDirExists(t, nextDir)
 }
 
+func TestReadEPsFromRestoreInventory(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx := t.Context()
+	s := setupEndpointSuite(t)
+	epsWanted, _ := s.createEndpoints(t)
+	tmpDir := t.TempDir()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	for _, ep := range epsWanted {
+		require.NotNil(t, ep)
+
+		fullDirName := filepath.Join(tmpDir, ep.DirectoryPath())
+		require.NoError(t, os.MkdirAll(fullDirName, 0o777))
+		require.NoError(t, ep.writeHeaderfile(fullDirName))
+	}
+
+	inventory, err := ReadRestoreInventory(ctx, logger, tmpDir)
+	require.NoError(t, err)
+
+	p := s.createEndpointParams(t)
+	p.Logger = logger
+	p.Orchestrator = s.orchestrator
+	p.PolicyRepo = s.repo
+
+	eps, failed := ReadEPsFromRestoreInventory(ctx, logger, &fakeParser{p: p}, tmpDir, inventory)
+	require.Zero(t, failed)
+	require.Len(t, eps, len(epsWanted))
+
+	sort.Slice(epsWanted, func(i, j int) bool { return epsWanted[i].ID < epsWanted[j].ID })
+	restoredEPs := make([]*Endpoint, 0, len(eps))
+	for _, ep := range eps {
+		restoredEPs = append(restoredEPs, ep)
+	}
+	sort.Slice(restoredEPs, func(i, j int) bool { return restoredEPs[i].ID < restoredEPs[j].ID })
+
+	for i, restoredEP := range restoredEPs {
+		restoredEP.status = nil
+		wanted := epsWanted[i]
+		wanted.status = nil
+		require.Equal(t, wanted.String(), restoredEP.String())
+	}
+}
+
 func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
+	ctx := t.Context()
 	s := setupEndpointSuite(t)
 
 	eps, _ := s.createEndpoints(t)
@@ -290,7 +338,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 	p.Logger = logger
 	p.Orchestrator = s.orchestrator
 	p.PolicyRepo = s.repo
-	epResult, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epNames)
+	epResult, _ := ReadEPsFromDirNames(ctx, logger, &fakeParser{p: p}, tmpDir, epNames)
 	require.Len(t, epResult, 1)
 
 	restoredEP := epResult[ep.ID]
@@ -313,6 +361,7 @@ func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 
 func BenchmarkReadEPsFromDirNames(b *testing.B) {
 	logger := hivetest.Logger(b)
+	ctx := b.Context()
 	s := setupEndpointSuite(b)
 
 	// For this benchmark, the real linux datapath is necessary to properly
@@ -347,7 +396,7 @@ func BenchmarkReadEPsFromDirNames(b *testing.B) {
 		p.Logger = logger
 		p.Orchestrator = s.orchestrator
 		p.PolicyRepo = s.repo
-		eps, _ := ReadEPsFromDirNames(context.TODO(), logger, &fakeParser{p: p}, tmpDir, epsNames)
+		eps, _ := ReadEPsFromDirNames(ctx, logger, &fakeParser{p: p}, tmpDir, epsNames)
 		require.Len(b, eps, len(epsWanted))
 	}
 }

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -164,6 +164,88 @@ func TestReadEPsFromDirNames(t *testing.T) {
 	}
 }
 
+func TestReadRestoreInventory(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx := t.Context()
+	s := setupEndpointSuite(t)
+	epsWanted, _ := s.createEndpoints(t)
+	tmpDir := t.TempDir()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	var wanted []RestoreInventoryItem
+	for i, ep := range epsWanted {
+		require.NotNil(t, ep)
+
+		fullDirName := filepath.Join(tmpDir, ep.DirectoryPath())
+		require.NoError(t, os.MkdirAll(fullDirName, 0o777))
+
+		if i == 0 {
+			ep.properties[PropertyFakeEndpoint] = true
+		}
+
+		require.NoError(t, ep.writeHeaderfile(fullDirName))
+
+		wanted = append(wanted, RestoreInventoryItem{
+			Directory:    ep.DirectoryPath(),
+			EndpointID:   ep.ID,
+			HostIfName:   ep.ifName,
+			K8sNamespace: ep.K8sNamespace,
+			K8sPodName:   ep.K8sPodName,
+			IsFake:       i == 0,
+		})
+	}
+
+	inventory, err := ReadRestoreInventory(ctx, logger, tmpDir)
+	require.NoError(t, err)
+	require.Len(t, inventory.Items, len(wanted))
+
+	sort.Slice(inventory.Items, func(i, j int) bool {
+		return inventory.Items[i].EndpointID < inventory.Items[j].EndpointID
+	})
+	sort.Slice(wanted, func(i, j int) bool {
+		return wanted[i].EndpointID < wanted[j].EndpointID
+	})
+
+	require.Equal(t, wanted, inventory.Items)
+}
+
+func TestReadRestoreInventoryRemovesIncompleteRestoreDirs(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx := t.Context()
+	s := setupEndpointSuite(t)
+	eps, _ := s.createEndpoints(t)
+	ep := eps[0]
+	require.NotNil(t, ep)
+	tmpDir := t.TempDir()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	fullDirName := filepath.Join(tmpDir, ep.DirectoryPath())
+	require.NoError(t, os.MkdirAll(fullDirName, 0o777))
+	require.NoError(t, ep.writeHeaderfile(fullDirName))
+
+	nextDir := filepath.Join(tmpDir, ep.NextDirectoryPath())
+	require.NoError(t, os.MkdirAll(nextDir, 0o777))
+	require.NoError(t, ep.writeHeaderfile(nextDir))
+
+	inventory, err := ReadRestoreInventory(ctx, logger, tmpDir)
+	require.NoError(t, err)
+	require.Len(t, inventory.Items, 1)
+	require.Equal(t, ep.DirectoryPath(), inventory.Items[0].Directory)
+	require.NoDirExists(t, nextDir)
+}
+
 func TestReadEPsFromDirNamesWithRestoreFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
 	s := setupEndpointSuite(t)


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/43062 introduced `bpf.datapathMode=auto` which enables Cilium to choose the right device mode at runtime. On hosts that support netkit, it will use netkit, otherwise it will use veth.

Auto-discovery can fail if modifying `bpf.datapathMode` of an existing node (from `veth` to `auto`) if there are existing workloads. In this scenario, Cilium may successfully probe for (and so enable) netkit, to then find it has to restore pods that use veth. In this scenario, Cilium fails to start with an error and the user has to revert the change.

This PR introduces logic that aims to improve the U/X of modifying the configuration. At a high level:

- `pkg/endpoint` gains the ability to provide "restore inventory" which is a sub-set of state for existing workloads that can be shared:
   - The datapath connector consumes this to inspect and detect existing datapath link pairs and associated modes
  - The endpoint restore logic consumes this to implement the restore of workloads
- `pkg/datapath/connector` gains a `restoreMode` that sits between `configuredMode` and `operationalMode`. In auto-discovery mode:
    - the connector will inspects the endpoint restore inventory and iterates over it to derive the `restoreMode`
    - if all all is equal, the `restoreMode` is checked for compatibility with the host, before transitioning into the `operationalMode`
    - if no `restoreMode` is detected, the existing auto-detect logic applies

```release-note
BPF datapath auto-discovery will now revert to a compatible mode if restoring existing workloads.
```
