### PR TITLE
datapath/loader: Move BPFFS paths to LocalNodeConfiguration

### DIFF
--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func listAllMaps(logger *slog.Logger) {
-	mapRootPrefixPath := bpffs.TCGlobalsPath()
+	mapRootPrefixPath := bpffs.TCGlobalsPath(bpffs.BPFFSRoot())
 	mapMatchExpr := filepath.Join(mapRootPrefixPath, "cilium_policy_*")
 
 	matchFiles, err := filepath.Glob(mapMatchExpr)

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func listAllMaps(logger *slog.Logger) {
-	mapRootPrefixPath := bpffs.TCGlobalsPath(bpffs.BPFFSRoot())
+	mapRootPrefixPath := bpffs.TCGlobalsPath(bpffs.Root())
 	mapMatchExpr := filepath.Join(mapRootPrefixPath, "cilium_policy_*")
 
 	matchFiles, err := filepath.Glob(mapMatchExpr)

--- a/cilium-dbg/cmd/bpf_policy_get.go
+++ b/cilium-dbg/cmd/bpf_policy_get.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/identity"
@@ -54,7 +54,7 @@ func init() {
 }
 
 func listAllMaps(logger *slog.Logger) {
-	mapRootPrefixPath := bpf.TCGlobalsPath()
+	mapRootPrefixPath := bpffs.TCGlobalsPath()
 	mapMatchExpr := filepath.Join(mapRootPrefixPath, "cilium_policy_*")
 
 	matchFiles, err := filepath.Glob(mapMatchExpr)

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -14,7 +14,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader"
@@ -115,8 +115,8 @@ type bpfCleanup struct{}
 
 func (c bpfCleanup) whatWillBeRemoved() []string {
 	return []string{
-		fmt.Sprintf("all BPF maps in %s containing '%s'", bpf.TCGlobalsPath(), ciliumLinkPrefix),
-		fmt.Sprintf("mounted bpffs at %s", bpf.BPFFSRoot()),
+		fmt.Sprintf("all BPF maps in %s containing '%s'", bpffs.TCGlobalsPath(), ciliumLinkPrefix),
+		fmt.Sprintf("mounted bpffs at %s", bpffs.BPFFSRoot()),
 	}
 }
 
@@ -425,7 +425,7 @@ func removeDirs() error {
 }
 
 func removeAllMaps() error {
-	mapDir := bpf.TCGlobalsPath()
+	mapDir := bpffs.TCGlobalsPath()
 	maps, err := os.ReadDir(mapDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -550,7 +550,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 
 func removeXDPAttachments(links []netlink.Link) error {
 	for _, link := range links {
-		if err := loader.DetachXDP(link.Attrs().Name, bpf.CiliumPath(), "cil_xdp_entry"); err != nil {
+		if err := loader.DetachXDP(link.Attrs().Name, bpffs.CiliumPath(), "cil_xdp_entry"); err != nil {
 			return err
 		}
 		fmt.Printf("removed cilium xdp of %s\n", link.Attrs().Name)
@@ -592,9 +592,9 @@ func isCiliumXDP(progId uint32) (bool, error) {
 }
 
 func removeCiliumBPFFS() error {
-	path := bpf.CiliumPath()
+	path := bpffs.CiliumPath()
 
-	if err := bpf.Remove(path); err != nil {
+	if err := bpffs.Remove(path); err != nil {
 		return err
 	}
 

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -116,8 +116,8 @@ type bpfCleanup struct{}
 
 func (c bpfCleanup) whatWillBeRemoved() []string {
 	return []string{
-		fmt.Sprintf("all BPF maps in %s containing '%s'", bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), ciliumLinkPrefix),
-		fmt.Sprintf("mounted bpffs at %s", bpffs.BPFFSRoot()),
+		fmt.Sprintf("all BPF maps in %s containing '%s'", bpffs.TCGlobalsPath(bpffs.Root()), ciliumLinkPrefix),
+		fmt.Sprintf("mounted bpffs at %s", bpffs.Root()),
 	}
 }
 
@@ -426,7 +426,7 @@ func removeDirs() error {
 }
 
 func removeAllMaps() error {
-	mapDir := bpffs.TCGlobalsPath(bpffs.BPFFSRoot())
+	mapDir := bpffs.TCGlobalsPath(bpffs.Root())
 	maps, err := os.ReadDir(mapDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -551,7 +551,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 
 func removeXDPAttachments(links []netlink.Link) error {
 	for _, link := range links {
-		if err := loader.DetachXDP(link.Attrs().Name, &config.BPFFS{Root: bpffs.BPFFSRoot()}, "cil_xdp_entry"); err != nil {
+		if err := loader.DetachXDP(link.Attrs().Name, &config.BPFFS{Root: bpffs.Root()}, "cil_xdp_entry"); err != nil {
 			return err
 		}
 		fmt.Printf("removed cilium xdp of %s\n", link.Attrs().Name)
@@ -593,7 +593,7 @@ func isCiliumXDP(progId uint32) (bool, error) {
 }
 
 func removeCiliumBPFFS() error {
-	path := bpffs.CiliumPath(bpffs.BPFFSRoot())
+	path := bpffs.CiliumPath(bpffs.Root())
 
 	if err := bpffs.Remove(path); err != nil {
 		return err

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -16,6 +16,7 @@ import (
 
 	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -550,7 +551,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 
 func removeXDPAttachments(links []netlink.Link) error {
 	for _, link := range links {
-		if err := loader.DetachXDP(link.Attrs().Name, bpffs.CiliumPath(bpffs.BPFFSRoot()), "cil_xdp_entry"); err != nil {
+		if err := loader.DetachXDP(link.Attrs().Name, &config.BPFFS{Root: bpffs.BPFFSRoot()}, "cil_xdp_entry"); err != nil {
 			return err
 		}
 		fmt.Printf("removed cilium xdp of %s\n", link.Attrs().Name)

--- a/cilium-dbg/cmd/post_uninstall_cleanup.go
+++ b/cilium-dbg/cmd/post_uninstall_cleanup.go
@@ -115,7 +115,7 @@ type bpfCleanup struct{}
 
 func (c bpfCleanup) whatWillBeRemoved() []string {
 	return []string{
-		fmt.Sprintf("all BPF maps in %s containing '%s'", bpffs.TCGlobalsPath(), ciliumLinkPrefix),
+		fmt.Sprintf("all BPF maps in %s containing '%s'", bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), ciliumLinkPrefix),
 		fmt.Sprintf("mounted bpffs at %s", bpffs.BPFFSRoot()),
 	}
 }
@@ -425,7 +425,7 @@ func removeDirs() error {
 }
 
 func removeAllMaps() error {
-	mapDir := bpffs.TCGlobalsPath()
+	mapDir := bpffs.TCGlobalsPath(bpffs.BPFFSRoot())
 	maps, err := os.ReadDir(mapDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -550,7 +550,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 
 func removeXDPAttachments(links []netlink.Link) error {
 	for _, link := range links {
-		if err := loader.DetachXDP(link.Attrs().Name, bpffs.CiliumPath(), "cil_xdp_entry"); err != nil {
+		if err := loader.DetachXDP(link.Attrs().Name, bpffs.CiliumPath(bpffs.BPFFSRoot()), "cil_xdp_entry"); err != nil {
 			return err
 		}
 		fmt.Printf("removed cilium xdp of %s\n", link.Attrs().Name)
@@ -592,7 +592,7 @@ func isCiliumXDP(progId uint32) (bool, error) {
 }
 
 func removeCiliumBPFFS() error {
-	path := bpffs.CiliumPath()
+	path := bpffs.CiliumPath(bpffs.BPFFSRoot())
 
 	if err := bpffs.Remove(path); err != nil {
 		return err

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/legacy"
 	"github.com/cilium/cilium/daemon/infraendpoints"
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/common"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
@@ -1028,7 +1029,7 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 	// the path to an already mounted filesystem instead. This is
 	// useful if the daemon is being round inside a namespace and the
 	// BPF filesystem is mapped into the slave namespace.
-	bpf.CheckOrMountFS(logger, option.Config.BPFRoot)
+	bpffs.CheckOrMountFS(logger, option.Config.BPFRoot)
 	cgroups.CheckOrMountCgrpFS(logger, option.Config.CGroupRoot)
 
 	option.Config.Opts.SetBool(option.Debug, debugDatapath)

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/spanstat"
@@ -55,7 +56,7 @@ func OpenOrCreateMap(logger *slog.Logger, spec *ebpf.MapSpec, pinDir string) (*e
 			return nil, errors.New("cannot load unnamed map from pin")
 		}
 
-		if err := MkdirBPF(pinDir); err != nil {
+		if err := bpffs.MkdirBPF(pinDir); err != nil {
 			return nil, fmt.Errorf("creating map base pinning directory: %w", err)
 		}
 

--- a/pkg/bpf/fs/bpffs_linux.go
+++ b/pkg/bpf/fs/bpffs_linux.go
@@ -50,14 +50,12 @@ func BPFFSRoot() string {
 
 // TCGlobalsPath returns the absolute path to <bpffs>/tc/globals, used for
 // legacy map pin paths.
-func TCGlobalsPath() string {
-	once.Do(lockDown)
+func TCGlobalsPath(bpffsRoot string) string {
 	return filepath.Join(bpffsRoot, defaults.TCGlobalsPath)
 }
 
 // CiliumPath returns the bpffs path to be used for Cilium object pins.
-func CiliumPath() string {
-	once.Do(lockDown)
+func CiliumPath(bpffsRoot string) string {
 	return filepath.Join(bpffsRoot, "cilium")
 }
 

--- a/pkg/bpf/fs/bpffs_linux.go
+++ b/pkg/bpf/fs/bpffs_linux.go
@@ -43,7 +43,7 @@ func setBPFFSRoot(path string) {
 	bpffsRoot = path
 }
 
-func BPFFSRoot() string {
+func Root() string {
 	once.Do(lockDown)
 	return bpffsRoot
 }

--- a/pkg/bpf/fs/bpffs_linux.go
+++ b/pkg/bpf/fs/bpffs_linux.go
@@ -3,7 +3,7 @@
 
 //go:build linux
 
-package bpf
+package fs
 
 import (
 	"errors"
@@ -15,7 +15,6 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -77,7 +76,7 @@ func Remove(path string) error {
 	return err
 }
 
-func tcPathFromMountInfo(logger *slog.Logger, name string) string {
+func TCPathFromMountInfo(logger *slog.Logger, name string) string {
 	readMountInfo.Do(func() {
 		mountInfos, err := mountinfo.GetMountInfo()
 		if err != nil {
@@ -95,25 +94,6 @@ func tcPathFromMountInfo(logger *slog.Logger, name string) string {
 	})
 
 	return filepath.Join(mountInfoPrefix, name)
-}
-
-// MapPath returns a path for a BPF map with a given name.
-func MapPath(logger *slog.Logger, name string) string {
-	if components.IsCiliumAgent() {
-		once.Do(lockDown)
-		return filepath.Join(TCGlobalsPath(), name)
-	}
-	return tcPathFromMountInfo(logger, name)
-}
-
-// LocalMapName returns the name for a BPF map that is local to the specified ID.
-func LocalMapName(name string, id uint16) string {
-	return fmt.Sprintf("%s%05d", name, id)
-}
-
-// LocalMapPath returns the path for a BPF map that is local to the specified ID.
-func LocalMapPath(logger *slog.Logger, name string, id uint16) string {
-	return MapPath(logger, LocalMapName(name, id))
 }
 
 var (

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1676,7 +1676,7 @@ func (m *Map) exist() (bool, error) {
 // MapPath returns a path for a BPF map with a given name.
 func MapPath(logger *slog.Logger, name string) string {
 	if components.IsCiliumAgent() {
-		return filepath.Join(bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), name)
+		return filepath.Join(bpffs.TCGlobalsPath(bpffs.Root()), name)
 	}
 	return bpffs.TCPathFromMountInfo(logger, name)
 }

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -15,6 +15,7 @@ import (
 	"math"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -22,6 +23,8 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
+	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -1668,4 +1671,22 @@ func (m *Map) exist() (bool, error) {
 	}
 
 	return false, nil
+}
+
+// MapPath returns a path for a BPF map with a given name.
+func MapPath(logger *slog.Logger, name string) string {
+	if components.IsCiliumAgent() {
+		return filepath.Join(bpffs.TCGlobalsPath(), name)
+	}
+	return bpffs.TCPathFromMountInfo(logger, name)
+}
+
+// LocalMapName returns the name for a BPF map that is local to the specified ID.
+func LocalMapName(name string, id uint16) string {
+	return fmt.Sprintf("%s%05d", name, id)
+}
+
+// LocalMapPath returns the path for a BPF map that is local to the specified ID.
+func LocalMapPath(logger *slog.Logger, name string, id uint16) string {
+	return MapPath(logger, LocalMapName(name, id))
 }

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1676,7 +1676,7 @@ func (m *Map) exist() (bool, error) {
 // MapPath returns a path for a BPF map with a given name.
 func MapPath(logger *slog.Logger, name string) string {
 	if components.IsCiliumAgent() {
-		return filepath.Join(bpffs.TCGlobalsPath(), name)
+		return filepath.Join(bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), name)
 	}
 	return bpffs.TCPathFromMountInfo(logger, name)
 }

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -57,7 +58,7 @@ func (k *TestValue) NewSlice() any  { return &TestValues{} }
 func setup(tb testing.TB) *Map {
 	testutils.PrivilegedTest(tb)
 
-	CheckOrMountFS(hivetest.Logger(tb), "")
+	bpffs.CheckOrMountFS(hivetest.Logger(tb), "")
 
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
@@ -83,7 +84,7 @@ func setup(tb testing.TB) *Map {
 func setupPerCPU(tb testing.TB) *Map {
 	testutils.PrivilegedTest(tb)
 
-	CheckOrMountFS(hivetest.Logger(tb), "")
+	bpffs.CheckOrMountFS(hivetest.Logger(tb), "")
 
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
@@ -891,7 +892,7 @@ func BenchmarkMapLookup(b *testing.B) {
 func TestPrivilegedErrorResolver(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
-	CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	require.NoError(t, rlimit.RemoveMemlock())
 
 	var (

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/envoy"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -576,7 +576,7 @@ func (r *CECResourceParser) getBPFMetadataListenerFilter(useOriginalSourceAddr b
 	conf := &cilium.BpfMetadata{
 		IsIngress:                false,
 		UseOriginalSourceAddress: useOriginalSourceAddr,
-		BpfRoot:                  bpf.BPFFSRoot(),
+		BpfRoot:                  bpffs.BPFFSRoot(),
 		IsL7Lb:                   l7lb,
 		ProxyId:                  uint32(proxyPort),
 		IpcacheName:              ipcache.Name,

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -576,7 +576,7 @@ func (r *CECResourceParser) getBPFMetadataListenerFilter(useOriginalSourceAddr b
 	conf := &cilium.BpfMetadata{
 		IsIngress:                false,
 		UseOriginalSourceAddress: useOriginalSourceAddr,
-		BpfRoot:                  bpffs.BPFFSRoot(),
+		BpfRoot:                  bpffs.Root(),
 		IsL7Lb:                   l7lb,
 		ProxyId:                  uint32(proxyPort),
 		IpcacheName:              ipcache.Name,

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -912,7 +912,7 @@ func TestCiliumEnvoyConfigTCPProxy(t *testing.T) {
 	assert.NotNil(t, lf)
 	assert.False(t, lf.IsIngress)
 	assert.True(t, lf.UseOriginalSourceAddress)
-	assert.Equal(t, bpffs.BPFFSRoot(), lf.BpfRoot)
+	assert.Equal(t, bpffs.Root(), lf.BpfRoot)
 	assert.False(t, lf.IsL7Lb)
 
 	// TCP listener has no SO_LINGER config
@@ -1055,7 +1055,7 @@ func TestCiliumEnvoyConfigTCPProxyTermination(t *testing.T) {
 	assert.NotNil(t, lf)
 	assert.False(t, lf.IsIngress)
 	assert.False(t, lf.UseOriginalSourceAddress)
-	assert.Equal(t, bpffs.BPFFSRoot(), lf.BpfRoot)
+	assert.Equal(t, bpffs.Root(), lf.BpfRoot)
 	assert.True(t, lf.IsL7Lb)
 
 	// HTTP listener has zero SO_LINGER config

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/pkg/annotation"
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/envoy"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -912,7 +912,7 @@ func TestCiliumEnvoyConfigTCPProxy(t *testing.T) {
 	assert.NotNil(t, lf)
 	assert.False(t, lf.IsIngress)
 	assert.True(t, lf.UseOriginalSourceAddress)
-	assert.Equal(t, bpf.BPFFSRoot(), lf.BpfRoot)
+	assert.Equal(t, bpffs.BPFFSRoot(), lf.BpfRoot)
 	assert.False(t, lf.IsL7Lb)
 
 	// TCP listener has no SO_LINGER config
@@ -1055,7 +1055,7 @@ func TestCiliumEnvoyConfigTCPProxyTermination(t *testing.T) {
 	assert.NotNil(t, lf)
 	assert.False(t, lf.IsIngress)
 	assert.False(t, lf.UseOriginalSourceAddress)
-	assert.Equal(t, bpf.BPFFSRoot(), lf.BpfRoot)
+	assert.Equal(t, bpffs.BPFFSRoot(), lf.BpfRoot)
 	assert.True(t, lf.IsL7Lb)
 
 	// HTTP listener has zero SO_LINGER config

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -259,6 +259,9 @@ type Config struct {
 	SvcRouteConfig svcrouteconfig.RoutesConfig
 
 	Plugins plugin.Plugins
+
+	// Cilium BPFFS paths
+	BPFFS BPFFS
 }
 
 // DeepEqual compares two LocalNodeConfiguration structs for equality.

--- a/pkg/datapath/config/paths.go
+++ b/pkg/datapath/config/paths.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
+	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
+
+	"github.com/vishvananda/netlink"
+)
+
+type BPFFS struct {
+	Root string
+}
+
+func (p *BPFFS) CiliumPath() string {
+	return bpffs.CiliumPath(p.Root)
+}
+
+func (p *BPFFS) TCGlobalsPath() string {
+	return bpffs.TCGlobalsPath(p.Root)
+}
+
+// devicesDir returns the path to the 'devices' directory on bpffs, usually
+// /sys/fs/bpf/cilium/devices. It does not ensure the directory exists.
+func (p *BPFFS) devicesDir() string {
+	return filepath.Join(p.CiliumPath(), "devices")
+}
+
+// DeviceDir returns the path to the per-device directory on bpffs, usually
+// /sys/fs/bpf/cilium/devices/<device>. It does not ensure the directory exists.
+func (p *BPFFS) DeviceDir(device netlink.Link) string {
+	// If a device name contains a "." we must sanitize the string to satisfy bpffs directory path
+	// requirements. The string of a directory path on bpffs is not allowed to contain any "." characters.
+	// By replacing "." with "-", we circurmvent this limitation. This also introduces a small
+	// risk of naming collisions, e.g "eth-0" and "eth.0" would translate to the same bpffs directory.
+	// The probability of this happening in practice should be very small.
+	return filepath.Join(p.devicesDir(), strings.ReplaceAll(device.Attrs().Name, ".", "-"))
+}
+
+// DeviceLinksDir returns the bpffs path to the per-device links directory,
+// usually /sys/fs/bpf/cilium/devices/<device>/links. It does not ensure the
+// directory exists.
+func (p *BPFFS) DeviceLinksDir(device netlink.Link) string {
+	return filepath.Join(p.DeviceDir(device), "links")
+}
+
+// endpointsDir returns the path to the 'endpoints' directory on bpffs, usually
+// /sys/fs/bpf/cilium/endpoints. It does not ensure the directory exists.
+func (p *BPFFS) endpointsDir() string {
+	return filepath.Join(p.CiliumPath(), "endpoints")
+}
+
+// EndpointDir returns the path to the per-endpoint directory on bpffs,
+// usually /sys/fs/bpf/cilium/endpoints/<endpoint-id>. It does not ensure the
+// directory exists.
+func (p *BPFFS) EndpointDir(ep endpoint.Endpoint) string {
+	return filepath.Join(p.endpointsDir(), ep.StringID())
+}
+
+// EndpointLinksDir returns the bpffs path to the per-endpoint links directory,
+// usually /sys/fs/bpf/cilium/endpoints/<endpoint-id>/links. It does not ensure the
+// directory exists.
+func (p *BPFFS) EndpointLinksDir(ep endpoint.Endpoint) string {
+	return filepath.Join(p.EndpointDir(ep), "links")
+}

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -273,5 +273,9 @@ func (in *Config) deepEqual(other *Config) bool {
 		}
 	}
 
+	if in.BPFFS != other.BPFFS {
+		return false
+	}
+
 	return true
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -165,9 +165,9 @@ func cleanIngressQdisc(logger *slog.Logger, devices []string) error {
 	return nil
 }
 
-// cleanCallsMaps is used to remove any pinned map matching mapNamePattern from bpffs.TCGlobalsPath().
-func cleanCallsMaps(mapNamePattern string) error {
-	matches, err := filepath.Glob(filepath.Join(bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), mapNamePattern))
+// cleanCallsMaps is used to remove any pinned map matching mapNamePattern from tcGlobalsPath.
+func cleanCallsMaps(mapNamePattern string, tcGlobalsPath string) error {
+	matches, err := filepath.Glob(filepath.Join(tcGlobalsPath, mapNamePattern))
 	if err != nil {
 		return fmt.Errorf("failed to list maps with mapNamePattern %s: %w", mapNamePattern, err)
 	}
@@ -184,7 +184,7 @@ func reinitializeOverlay(ctx context.Context, logger *slog.Logger, reg *registry
 	// tunnelConfig.EncapProtocol() can be one of tunnel.[Disabled, VXLAN, Geneve]
 	// if it is disabled, the overlay network programs don't have to be (re)initialized
 	if tunnelConfig.EncapProtocol() == tunnel.Disabled {
-		cleanCallsMaps("cilium_calls_overlay*")
+		cleanCallsMaps("cilium_calls_overlay*", lnc.BPFFS.TCGlobalsPath())
 
 		os.RemoveAll(bpfStateDeviceDir(defaults.VxlanDevice))
 		os.RemoveAll(bpfStateDeviceDir(defaults.GeneveDevice))
@@ -207,7 +207,7 @@ func reinitializeOverlay(ctx context.Context, logger *slog.Logger, reg *registry
 
 func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry, lnc *config.Config) (err error) {
 	if !lnc.EnableWireguard {
-		cleanCallsMaps("cilium_calls_wireguard*")
+		cleanCallsMaps("cilium_calls_wireguard*", lnc.BPFFS.TCGlobalsPath())
 
 		os.RemoveAll(bpfStateDeviceDir(wgTypes.IfaceName))
 
@@ -228,7 +228,7 @@ func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *regist
 func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 	lnc *config.Config, devices []string) error {
 	xdpConfig := lnc.XDPConfig
-	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpffs.CiliumPath(bpffs.BPFFSRoot()))
+	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), &lnc.BPFFS)
 	if xdpConfig.Disabled() {
 		return nil
 	}
@@ -300,7 +300,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 	}
 
 	// BPF file system setup.
-	if err := bpffs.MkdirBPF(bpffs.TCGlobalsPath(bpffs.BPFFSRoot())); err != nil {
+	if err := bpffs.MkdirBPF(lnc.BPFFS.TCGlobalsPath()); err != nil {
 		return fmt.Errorf("failed to create bpffs directory: %w", err)
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -167,7 +167,7 @@ func cleanIngressQdisc(logger *slog.Logger, devices []string) error {
 
 // cleanCallsMaps is used to remove any pinned map matching mapNamePattern from bpffs.TCGlobalsPath().
 func cleanCallsMaps(mapNamePattern string) error {
-	matches, err := filepath.Glob(filepath.Join(bpffs.TCGlobalsPath(), mapNamePattern))
+	matches, err := filepath.Glob(filepath.Join(bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), mapNamePattern))
 	if err != nil {
 		return fmt.Errorf("failed to list maps with mapNamePattern %s: %w", mapNamePattern, err)
 	}
@@ -228,7 +228,7 @@ func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *regist
 func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 	lnc *config.Config, devices []string) error {
 	xdpConfig := lnc.XDPConfig
-	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpffs.CiliumPath())
+	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpffs.CiliumPath(bpffs.BPFFSRoot()))
 	if xdpConfig.Disabled() {
 		return nil
 	}
@@ -300,7 +300,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 	}
 
 	// BPF file system setup.
-	if err := bpffs.MkdirBPF(bpffs.TCGlobalsPath()); err != nil {
+	if err := bpffs.MkdirBPF(bpffs.TCGlobalsPath(bpffs.BPFFSRoot())); err != nil {
 		return fmt.Errorf("failed to create bpffs directory: %w", err)
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
@@ -165,9 +165,9 @@ func cleanIngressQdisc(logger *slog.Logger, devices []string) error {
 	return nil
 }
 
-// cleanCallsMaps is used to remove any pinned map matching mapNamePattern from bpf.TCGlobalsPath().
+// cleanCallsMaps is used to remove any pinned map matching mapNamePattern from bpffs.TCGlobalsPath().
 func cleanCallsMaps(mapNamePattern string) error {
-	matches, err := filepath.Glob(filepath.Join(bpf.TCGlobalsPath(), mapNamePattern))
+	matches, err := filepath.Glob(filepath.Join(bpffs.TCGlobalsPath(), mapNamePattern))
 	if err != nil {
 		return fmt.Errorf("failed to list maps with mapNamePattern %s: %w", mapNamePattern, err)
 	}
@@ -228,7 +228,7 @@ func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *regist
 func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
 	lnc *config.Config, devices []string) error {
 	xdpConfig := lnc.XDPConfig
-	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpf.CiliumPath())
+	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpffs.CiliumPath())
 	if xdpConfig.Disabled() {
 		return nil
 	}
@@ -300,7 +300,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 	}
 
 	// BPF file system setup.
-	if err := bpf.MkdirBPF(bpf.TCGlobalsPath()); err != nil {
+	if err := bpffs.MkdirBPF(bpffs.TCGlobalsPath()); err != nil {
 		return fmt.Errorf("failed to create bpffs directory: %w", err)
 	}
 

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	routeReconciler "github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
@@ -154,17 +155,17 @@ func (l *loader) Unload(ep endpoint.Endpoint) {
 
 	// Remove the links directory first to avoid removing program arrays before
 	// the entrypoints are detached.
-	if err := bpf.Remove(bpffsEndpointLinksDir(bpf.CiliumPath(), ep)); err != nil {
+	if err := bpffs.Remove(bpffsEndpointLinksDir(bpffs.CiliumPath(), ep)); err != nil {
 		log.Error("Failed to remove bpffs entry",
 			logfields.Error, err,
-			logfields.BPFFSEndpointLinksDir, bpffsEndpointLinksDir(bpf.CiliumPath(), ep),
+			logfields.BPFFSEndpointLinksDir, bpffsEndpointLinksDir(bpffs.CiliumPath(), ep),
 		)
 	}
 	// Finally, remove the endpoint's top-level directory.
-	if err := bpf.Remove(bpffsEndpointDir(bpf.CiliumPath(), ep)); err != nil {
+	if err := bpffs.Remove(bpffsEndpointDir(bpffs.CiliumPath(), ep)); err != nil {
 		log.Error("Failed to remove bpffs entry",
 			logfields.Error, err,
-			logfields.BPFFSEndpointDir, bpffsEndpointDir(bpf.CiliumPath(), ep),
+			logfields.BPFFSEndpointDir, bpffsEndpointDir(bpffs.CiliumPath(), ep),
 		)
 	}
 }
@@ -200,7 +201,7 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 	commit, err := bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		Constants:      endpointConfiguration(ep, lnc),
 		MapRenames:     endpointMapRenames(ep, lnc),
@@ -231,7 +232,7 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 		return fmt.Errorf("retrieving device %s: %w", device, err)
 	}
 
-	linkDir := bpffsEndpointLinksDir(bpf.CiliumPath(), ep)
+	linkDir := bpffsEndpointLinksDir(bpffs.CiliumPath(), ep)
 	if err := attachSKBProgram(logger, iface, obj.FromContainer, symbolFromEndpoint,
 		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", device, err)

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -155,17 +155,17 @@ func (l *loader) Unload(ep endpoint.Endpoint) {
 
 	// Remove the links directory first to avoid removing program arrays before
 	// the entrypoints are detached.
-	if err := bpffs.Remove(bpffsEndpointLinksDir(bpffs.CiliumPath(), ep)); err != nil {
+	if err := bpffs.Remove(bpffsEndpointLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep)); err != nil {
 		log.Error("Failed to remove bpffs entry",
 			logfields.Error, err,
-			logfields.BPFFSEndpointLinksDir, bpffsEndpointLinksDir(bpffs.CiliumPath(), ep),
+			logfields.BPFFSEndpointLinksDir, bpffsEndpointLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep),
 		)
 	}
 	// Finally, remove the endpoint's top-level directory.
-	if err := bpffs.Remove(bpffsEndpointDir(bpffs.CiliumPath(), ep)); err != nil {
+	if err := bpffs.Remove(bpffsEndpointDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep)); err != nil {
 		log.Error("Failed to remove bpffs entry",
 			logfields.Error, err,
-			logfields.BPFFSEndpointDir, bpffsEndpointDir(bpffs.CiliumPath(), ep),
+			logfields.BPFFSEndpointDir, bpffsEndpointDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep),
 		)
 	}
 }
@@ -201,7 +201,7 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 	commit, err := bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		Constants:      endpointConfiguration(ep, lnc),
 		MapRenames:     endpointMapRenames(ep, lnc),
@@ -232,7 +232,7 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 		return fmt.Errorf("retrieving device %s: %w", device, err)
 	}
 
-	linkDir := bpffsEndpointLinksDir(bpffs.CiliumPath(), ep)
+	linkDir := bpffsEndpointLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep)
 	if err := attachSKBProgram(logger, iface, obj.FromContainer, symbolFromEndpoint,
 		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", device, err)

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -116,7 +116,7 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep endpoint.Endpoint, lnc *
 }
 
 // Unload removes the datapath specific program aspects
-func (l *loader) Unload(ep endpoint.Endpoint) {
+func (l *loader) Unload(ep endpoint.Endpoint, lnc *config.Config) {
 	if ep.RequireEndpointRoute() {
 		if ip := ep.IPv4Address(); ip.IsValid() {
 			removeEndpointRoute(ep, l.routeManager)
@@ -155,17 +155,17 @@ func (l *loader) Unload(ep endpoint.Endpoint) {
 
 	// Remove the links directory first to avoid removing program arrays before
 	// the entrypoints are detached.
-	if err := bpffs.Remove(bpffsEndpointLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep)); err != nil {
+	if err := bpffs.Remove(lnc.BPFFS.EndpointLinksDir(ep)); err != nil {
 		log.Error("Failed to remove bpffs entry",
 			logfields.Error, err,
-			logfields.BPFFSEndpointLinksDir, bpffsEndpointLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep),
+			logfields.BPFFSEndpointLinksDir, lnc.BPFFS.EndpointLinksDir(ep),
 		)
 	}
 	// Finally, remove the endpoint's top-level directory.
-	if err := bpffs.Remove(bpffsEndpointDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep)); err != nil {
+	if err := bpffs.Remove(lnc.BPFFS.EndpointDir(ep)); err != nil {
 		log.Error("Failed to remove bpffs entry",
 			logfields.Error, err,
-			logfields.BPFFSEndpointDir, bpffsEndpointDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep),
+			logfields.BPFFSEndpointDir, lnc.BPFFS.EndpointDir(ep),
 		)
 	}
 }
@@ -201,7 +201,7 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 	commit, err := bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+			Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 		},
 		Constants:      endpointConfiguration(ep, lnc),
 		MapRenames:     endpointMapRenames(ep, lnc),
@@ -232,7 +232,7 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 		return fmt.Errorf("retrieving device %s: %w", device, err)
 	}
 
-	linkDir := bpffsEndpointLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), ep)
+	linkDir := lnc.BPFFS.EndpointLinksDir(ep)
 	if err := attachSKBProgram(logger, iface, obj.FromContainer, symbolFromEndpoint,
 		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", device, err)

--- a/pkg/datapath/loader/fake/loader.go
+++ b/pkg/datapath/loader/fake/loader.go
@@ -31,7 +31,7 @@ func (f *Loader) EndpointHash(cfg endpoint.Config, _ *config.Config) (string, er
 	panic("implement me")
 }
 
-func (f *Loader) Unload(ep endpoint.Endpoint) {
+func (f *Loader) Unload(ep endpoint.Endpoint, _ *config.Config) {
 }
 
 func (f *Loader) CallsMapPath(id uint16) string {

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -45,19 +45,20 @@ func TestHashEndpoint(t *testing.T) {
 	var base datapathHash
 	ep := testutils.NewTestEndpoint(t)
 	cfg := configWriterForTest(t)
+	lnc := localNodeConfig(nil)
 
 	// Error from ConfigWriter is forwarded.
 	_, err := base.hashEndpoint(fakeConfigWriter{}, nil, nil)
 	require.Error(t, err)
 
 	// Hashing the endpoint gives a hash distinct from the base.
-	a, err := base.hashEndpoint(cfg, &localNodeConfig, &ep)
+	a, err := base.hashEndpoint(cfg, lnc, &ep)
 	require.NoError(t, err)
 	require.NotEqual(t, base.String(), a)
 
 	// When we configure the endpoint differently, it's different
 	ep.Opts.SetBool("foo", true)
-	b, err := base.hashEndpoint(cfg, &localNodeConfig, &ep)
+	b, err := base.hashEndpoint(cfg, lnc, &ep)
 	require.NoError(t, err)
 	require.NotEqual(t, a, b)
 }

--- a/pkg/datapath/loader/host.go
+++ b/pkg/datapath/loader/host.go
@@ -107,7 +107,7 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 	commit, err := bpf.LoadAndAssign(logger, &hostObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		Constants:      ciliumHostConfiguration(ep, lnc),
 		MapRenames:     ciliumHostMapRenames(ep, lnc),
@@ -125,12 +125,12 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 
 	// Attach cil_to_host to cilium_host ingress.
 	if err := attachSKBProgram(logger, host, hostObj.ToHost, symbolToHostEp,
-		bpffsDeviceLinksDir(bpffs.CiliumPath(), host), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), host), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", ep.InterfaceName(), err)
 	}
 	// Attach cil_from_host to cilium_host egress.
 	if err := attachSKBProgram(logger, host, hostObj.FromHost, symbolFromHostEp,
-		bpffsDeviceLinksDir(bpffs.CiliumPath(), host), netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
+		bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), host), netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s egress: %w", ep.InterfaceName(), err)
 	}
 
@@ -186,7 +186,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 	commit, err := bpf.LoadAndAssign(logger, &netObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		Constants:      ciliumNetConfiguration(ep, lnc, net),
 		MapRenames:     ciliumNetMapRenames(ep, lnc, net),
@@ -199,7 +199,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 
 	// Attach cil_to_host to cilium_net.
 	if err := attachSKBProgram(logger, net, netObj.ToHost, symbolToHostEp,
-		bpffsDeviceLinksDir(bpffs.CiliumPath(), net), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), net), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", defaults.SecondHostDevice, err)
 	}
 
@@ -276,7 +276,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 			continue
 		}
 
-		linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(), iface)
+		linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), iface)
 		masq4, masq6 := bpfMasqAddrs(iface.Attrs().Name, lnc,
 			option.Config.EnableIPv4Masquerade, option.Config.EnableIPv6Masquerade)
 
@@ -284,7 +284,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 		commit, err := bpf.LoadAndAssign(logger, &netdevObj, spec, &bpf.CollectionOptions{
 			MapRegistry: reg,
 			CollectionOptions: ebpf.CollectionOptions{
-				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 			},
 			Constants:      netdevConfiguration(ep, lnc, iface, masq4, masq6),
 			MapRenames:     netdevMapRenames(ep, lnc, iface),

--- a/pkg/datapath/loader/host.go
+++ b/pkg/datapath/loader/host.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -106,7 +107,7 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 	commit, err := bpf.LoadAndAssign(logger, &hostObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		Constants:      ciliumHostConfiguration(ep, lnc),
 		MapRenames:     ciliumHostMapRenames(ep, lnc),
@@ -124,12 +125,12 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 
 	// Attach cil_to_host to cilium_host ingress.
 	if err := attachSKBProgram(logger, host, hostObj.ToHost, symbolToHostEp,
-		bpffsDeviceLinksDir(bpf.CiliumPath(), host), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		bpffsDeviceLinksDir(bpffs.CiliumPath(), host), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", ep.InterfaceName(), err)
 	}
 	// Attach cil_from_host to cilium_host egress.
 	if err := attachSKBProgram(logger, host, hostObj.FromHost, symbolFromHostEp,
-		bpffsDeviceLinksDir(bpf.CiliumPath(), host), netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
+		bpffsDeviceLinksDir(bpffs.CiliumPath(), host), netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s egress: %w", ep.InterfaceName(), err)
 	}
 
@@ -185,7 +186,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 	commit, err := bpf.LoadAndAssign(logger, &netObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		Constants:      ciliumNetConfiguration(ep, lnc, net),
 		MapRenames:     ciliumNetMapRenames(ep, lnc, net),
@@ -198,7 +199,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 
 	// Attach cil_to_host to cilium_net.
 	if err := attachSKBProgram(logger, net, netObj.ToHost, symbolToHostEp,
-		bpffsDeviceLinksDir(bpf.CiliumPath(), net), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		bpffsDeviceLinksDir(bpffs.CiliumPath(), net), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", defaults.SecondHostDevice, err)
 	}
 
@@ -275,7 +276,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 			continue
 		}
 
-		linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), iface)
+		linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(), iface)
 		masq4, masq6 := bpfMasqAddrs(iface.Attrs().Name, lnc,
 			option.Config.EnableIPv4Masquerade, option.Config.EnableIPv6Masquerade)
 
@@ -283,7 +284,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 		commit, err := bpf.LoadAndAssign(logger, &netdevObj, spec, &bpf.CollectionOptions{
 			MapRegistry: reg,
 			CollectionOptions: ebpf.CollectionOptions{
-				Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 			},
 			Constants:      netdevConfiguration(ep, lnc, iface, masq4, masq6),
 			MapRenames:     netdevMapRenames(ep, lnc, iface),

--- a/pkg/datapath/loader/host.go
+++ b/pkg/datapath/loader/host.go
@@ -13,7 +13,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -107,7 +106,7 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 	commit, err := bpf.LoadAndAssign(logger, &hostObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+			Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 		},
 		Constants:      ciliumHostConfiguration(ep, lnc),
 		MapRenames:     ciliumHostMapRenames(ep, lnc),
@@ -125,12 +124,12 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 
 	// Attach cil_to_host to cilium_host ingress.
 	if err := attachSKBProgram(logger, host, hostObj.ToHost, symbolToHostEp,
-		bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), host), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		lnc.BPFFS.DeviceLinksDir(host), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", ep.InterfaceName(), err)
 	}
 	// Attach cil_from_host to cilium_host egress.
 	if err := attachSKBProgram(logger, host, hostObj.FromHost, symbolFromHostEp,
-		bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), host), netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
+		lnc.BPFFS.DeviceLinksDir(host), netlink.HANDLE_MIN_EGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s egress: %w", ep.InterfaceName(), err)
 	}
 
@@ -186,7 +185,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 	commit, err := bpf.LoadAndAssign(logger, &netObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+			Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 		},
 		Constants:      ciliumNetConfiguration(ep, lnc, net),
 		MapRenames:     ciliumNetMapRenames(ep, lnc, net),
@@ -199,7 +198,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 
 	// Attach cil_to_host to cilium_net.
 	if err := attachSKBProgram(logger, net, netObj.ToHost, symbolToHostEp,
-		bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), net), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
+		lnc.BPFFS.DeviceLinksDir(net), netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", defaults.SecondHostDevice, err)
 	}
 
@@ -276,7 +275,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 			continue
 		}
 
-		linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), iface)
+		linkDir := lnc.BPFFS.DeviceLinksDir(iface)
 		masq4, masq6 := bpfMasqAddrs(iface.Attrs().Name, lnc,
 			option.Config.EnableIPv4Masquerade, option.Config.EnableIPv6Masquerade)
 
@@ -284,7 +283,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 		commit, err := bpf.LoadAndAssign(logger, &netdevObj, spec, &bpf.CollectionOptions{
 			MapRegistry: reg,
 			CollectionOptions: ebpf.CollectionOptions{
-				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+				Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 			},
 			Constants:      netdevConfiguration(ep, lnc, iface, masq4, masq6),
 			MapRenames:     netdevMapRenames(ep, lnc, iface),
@@ -326,7 +325,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 
 	// Call immediately after attaching programs to make it obvious that a
 	// program was wrongfully detached due to a bug or misconfiguration.
-	if err := removeObsoleteNetdevPrograms(logger, devices); err != nil {
+	if err := removeObsoleteNetdevPrograms(logger, devices, lnc); err != nil {
 		logger.Error("Failed to remove obsolete netdev programs", logfields.Error, err)
 	}
 

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
+	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -58,18 +59,15 @@ func initEndpoint(tb testing.TB, ep *testutils.TestEndpoint) {
 	}
 }
 
-func initBpffs(tb testing.TB) {
+func initBpffs(tb testing.TB) *config.BPFFS {
 	testutils.PrivilegedTest(tb)
 
 	tb.Helper()
 
-	require.NoError(tb, bpf.MkdirBPF(bpffs.TCGlobalsPath(bpffs.BPFFSRoot())))
-	require.NoError(tb, bpf.MkdirBPF(bpffs.CiliumPath(bpffs.BPFFSRoot())))
-
-	tb.Cleanup(func() {
-		require.NoError(tb, os.RemoveAll(bpffs.TCGlobalsPath(bpffs.BPFFSRoot())))
-		require.NoError(tb, os.RemoveAll(bpffs.CiliumPath(bpffs.BPFFSRoot())))
-	})
+	b := &config.BPFFS{Root: testutils.TempBPFFS(tb)}
+	require.NoError(tb, bpffs.MkdirBPF(b.TCGlobalsPath()))
+	require.NoError(tb, bpffs.MkdirBPF(b.CiliumPath()))
+	return b
 }
 
 func getDirs(tb testing.TB) *directoryInfo {
@@ -91,13 +89,12 @@ func getEpDirs(ep *testutils.TestEndpoint) *directoryInfo {
 }
 
 func testReloadDatapath(t *testing.T, ep *testutils.TestEndpoint) {
-	initBpffs(t)
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 	stats := &metrics.SpanStat{}
 
 	l := newTestLoader(t)
-	_, err := l.ReloadDatapath(ctx, ep, &localNodeConfig, stats)
+	_, err := l.ReloadDatapath(ctx, ep, localNodeConfig(initBpffs(t)), stats)
 	require.NoError(t, err)
 }
 
@@ -173,11 +170,12 @@ func testCompileFailure(t *testing.T, ep *testutils.TestEndpoint) {
 	}()
 
 	l := newTestLoader(t)
+	lnc := localNodeConfig(initBpffs(t))
 	timeout := time.Now().Add(contextTimeout)
 	var err error
 	stats := &metrics.SpanStat{}
 	for err == nil && time.Now().Before(timeout) {
-		_, err = l.ReloadDatapath(ctx, ep, &localNodeConfig, stats)
+		_, err = l.ReloadDatapath(ctx, ep, lnc, stats)
 	}
 	require.Error(t, err)
 }

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -62,12 +63,12 @@ func initBpffs(tb testing.TB) {
 
 	tb.Helper()
 
-	require.NoError(tb, bpf.MkdirBPF(bpf.TCGlobalsPath()))
-	require.NoError(tb, bpf.MkdirBPF(bpf.CiliumPath()))
+	require.NoError(tb, bpffs.MkdirBPF(bpffs.TCGlobalsPath()))
+	require.NoError(tb, bpffs.MkdirBPF(bpffs.CiliumPath()))
 
 	tb.Cleanup(func() {
-		require.NoError(tb, os.RemoveAll(bpf.TCGlobalsPath()))
-		require.NoError(tb, os.RemoveAll(bpf.CiliumPath()))
+		require.NoError(tb, os.RemoveAll(bpffs.TCGlobalsPath()))
+		require.NoError(tb, os.RemoveAll(bpffs.CiliumPath()))
 	})
 }
 

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -63,12 +63,12 @@ func initBpffs(tb testing.TB) {
 
 	tb.Helper()
 
-	require.NoError(tb, bpffs.MkdirBPF(bpffs.TCGlobalsPath()))
-	require.NoError(tb, bpffs.MkdirBPF(bpffs.CiliumPath()))
+	require.NoError(tb, bpf.MkdirBPF(bpffs.TCGlobalsPath(bpffs.BPFFSRoot())))
+	require.NoError(tb, bpf.MkdirBPF(bpffs.CiliumPath(bpffs.BPFFSRoot())))
 
 	tb.Cleanup(func() {
-		require.NoError(tb, os.RemoveAll(bpffs.TCGlobalsPath()))
-		require.NoError(tb, os.RemoveAll(bpffs.CiliumPath()))
+		require.NoError(tb, os.RemoveAll(bpffs.TCGlobalsPath(bpffs.BPFFSRoot())))
+		require.NoError(tb, os.RemoveAll(bpffs.CiliumPath(bpffs.BPFFSRoot())))
 	})
 }
 
@@ -92,7 +92,6 @@ func getEpDirs(ep *testutils.TestEndpoint) *directoryInfo {
 
 func testReloadDatapath(t *testing.T, ep *testutils.TestEndpoint) {
 	initBpffs(t)
-
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 	stats := &metrics.SpanStat{}

--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -94,7 +94,7 @@ func isObsoleteDev(dev string, devices []string) bool {
 // before 1.13, most filters were named e.g. bpf_host.o:[to-host], to be changed to
 // cilium-<device> in 1.13, then to cil_to_host-<device> in 1.14. As a result, this
 // function only cleans up filters following the current naming scheme.
-func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
+func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string, lnc *config.Config) error {
 	links, err := safenetlink.LinkList()
 	if err != nil {
 		return fmt.Errorf("retrieving all netlink devices: %w", err)
@@ -110,7 +110,7 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 
 		// Remove the per-device bpffs directory containing pinned links and
 		// per-endpoint maps.
-		bpffsPath := bpffsDeviceDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), l)
+		bpffsPath := lnc.BPFFS.DeviceDir(l)
 		if err := bpffs.Remove(bpffsPath); err != nil {
 			logger.Error("Failed to remove bpffs entry",
 				logfields.Error, err,

--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -110,7 +110,7 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 
 		// Remove the per-device bpffs directory containing pinned links and
 		// per-endpoint maps.
-		bpffsPath := bpffsDeviceDir(bpffs.CiliumPath(), l)
+		bpffsPath := bpffsDeviceDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), l)
 		if err := bpffs.Remove(bpffsPath); err != nil {
 			logger.Error("Failed to remove bpffs entry",
 				logfields.Error, err,

--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -110,8 +110,8 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 
 		// Remove the per-device bpffs directory containing pinned links and
 		// per-endpoint maps.
-		bpffsPath := bpffsDeviceDir(bpf.CiliumPath(), l)
-		if err := bpf.Remove(bpffsPath); err != nil {
+		bpffsPath := bpffsDeviceDir(bpffs.CiliumPath(), l)
+		if err := bpffs.Remove(bpffsPath); err != nil {
 			logger.Error("Failed to remove bpffs entry",
 				logfields.Error, err,
 				logfields.BPFFSPath, bpffsPath,

--- a/pkg/datapath/loader/netdev_test.go
+++ b/pkg/datapath/loader/netdev_test.go
@@ -13,11 +13,12 @@ import (
 )
 
 func TestBPFMasqAddrs(t *testing.T) {
-	masq4, masq6 := bpfMasqAddrs("test", &localNodeConfig, true, true)
+	lnc := localNodeConfig(nil)
+	masq4, masq6 := bpfMasqAddrs("test", lnc, true, true)
 	require.False(t, masq4.IsValid())
 	require.False(t, masq6.IsValid())
 
-	newConfig := localNodeConfig
+	newConfig := *lnc
 	newConfig.NodeAddresses = []tables.NodeAddress{
 		{
 			Addr:       netip.MustParseAddr("1.0.0.1"),

--- a/pkg/datapath/loader/netkit.go
+++ b/pkg/datapath/loader/netkit.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -61,7 +62,7 @@ func upsertNetkitProgram(logger *slog.Logger, device netlink.Link, prog *ebpf.Pr
 // attach is either ebpf.AttachNetkitPrimary or ebpf.AttachNetkitPeer and
 // will attach the program to the xmit of either the primary or peer device.
 func attachNetkit(logger *slog.Logger, device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, attach ebpf.AttachType) error {
-	if err := bpf.MkdirBPF(bpffsDir); err != nil {
+	if err := bpffs.MkdirBPF(bpffsDir); err != nil {
 		return fmt.Errorf("creating bpffs link dir for netkit attachment to device %s: %w", device.Attrs().Name, err)
 	}
 

--- a/pkg/datapath/loader/overlay.go
+++ b/pkg/datapath/loader/overlay.go
@@ -78,7 +78,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 		Constants:   overlayConfiguration(lnc, link),
 		MapRenames:  overlayMapRenames(lnc, link),
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(link.Attrs().Name), overlayConfig),
 	})
@@ -87,7 +87,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 	}
 	defer obj.Close()
 
-	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(), link)
+	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), link)
 	if err := attachSKBProgram(logger, link, obj.FromOverlay, symbolFromOverlay,
 		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", link, err)

--- a/pkg/datapath/loader/overlay.go
+++ b/pkg/datapath/loader/overlay.go
@@ -13,7 +13,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/registry"
@@ -78,7 +77,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 		Constants:   overlayConfiguration(lnc, link),
 		MapRenames:  overlayMapRenames(lnc, link),
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+			Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(link.Attrs().Name), overlayConfig),
 	})
@@ -87,7 +86,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 	}
 	defer obj.Close()
 
-	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), link)
+	linkDir := lnc.BPFFS.DeviceLinksDir(link)
 	if err := attachSKBProgram(logger, link, obj.FromOverlay, symbolFromOverlay,
 		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", link, err)

--- a/pkg/datapath/loader/overlay.go
+++ b/pkg/datapath/loader/overlay.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/registry"
@@ -77,7 +78,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 		Constants:   overlayConfiguration(lnc, link),
 		MapRenames:  overlayMapRenames(lnc, link),
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(link.Attrs().Name), overlayConfig),
 	})
@@ -86,7 +87,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 	}
 	defer obj.Close()
 
-	linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), link)
+	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(), link)
 	if err := attachSKBProgram(logger, link, obj.FromOverlay, symbolFromOverlay,
 		linkDir, netlink.HANDLE_MIN_INGRESS, option.Config.EnableTCX); err != nil {
 		return fmt.Errorf("interface %s ingress: %w", link, err)

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -5,75 +5,9 @@ package loader
 
 import (
 	"path/filepath"
-	"strings"
 
-	"github.com/vishvananda/netlink"
-
-	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/option"
 )
-
-// bpffsDevicesDir returns the path to the 'devices' directory on bpffs, usually
-// /sys/fs/bpf/cilium/devices. It does not ensure the directory exists.
-//
-// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
-// during tests.
-func bpffsDevicesDir(base string) string {
-	return filepath.Join(base, "devices")
-}
-
-// bpffsDeviceDir returns the path to the per-device directory on bpffs, usually
-// /sys/fs/bpf/cilium/devices/<device>. It does not ensure the directory exists.
-//
-// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
-// during tests.
-func bpffsDeviceDir(base string, device netlink.Link) string {
-	// If a device name contains a "." we must sanitize the string to satisfy bpffs directory path
-	// requirements. The string of a directory path on bpffs is not allowed to contain any "." characters.
-	// By replacing "." with "-", we circurmvent this limitation. This also introduces a small
-	// risk of naming collisions, e.g "eth-0" and "eth.0" would translate to the same bpffs directory.
-	// The probability of this happening in practice should be very small.
-	return filepath.Join(bpffsDevicesDir(base), strings.ReplaceAll(device.Attrs().Name, ".", "-"))
-}
-
-// bpffsDeviceLinksDir returns the bpffs path to the per-device links directory,
-// usually /sys/fs/bpf/cilium/devices/<device>/links. It does not ensure the
-// directory exists.
-//
-// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
-// during tests.
-func bpffsDeviceLinksDir(base string, device netlink.Link) string {
-	return filepath.Join(bpffsDeviceDir(base, device), "links")
-}
-
-// bpffsEndpointsDir returns the path to the 'endpoints' directory on bpffs, usually
-// /sys/fs/bpf/cilium/endpoints. It does not ensure the directory exists.
-//
-// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
-// during tests.
-func bpffsEndpointsDir(base string) string {
-	return filepath.Join(base, "endpoints")
-}
-
-// bpffsEndpointDir returns the path to the per-endpoint directory on bpffs,
-// usually /sys/fs/bpf/cilium/endpoints/<endpoint-id>. It does not ensure the
-// directory exists.
-//
-// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
-// during tests.
-func bpffsEndpointDir(base string, ep endpoint.Endpoint) string {
-	return filepath.Join(bpffsEndpointsDir(base), ep.StringID())
-}
-
-// bpffsEndpointLinksDir returns the bpffs path to the per-endpoint links directory,
-// usually /sys/fs/bpf/cilium/endpoints/<endpoint-id>/links. It does not ensure the
-// directory exists.
-//
-// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
-// during tests.
-func bpffsEndpointLinksDir(base string, ep endpoint.Endpoint) string {
-	return filepath.Join(bpffsEndpointDir(base, ep), "links")
-}
 
 // bpfStateDeviceDir returns the path to the per-device directory in the Cilium
 // state directory, usually /var/run/cilium/bpf/<device>. It does not ensure the

--- a/pkg/datapath/loader/sock.go
+++ b/pkg/datapath/loader/sock.go
@@ -9,11 +9,9 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	bpfgen "github.com/cilium/cilium/pkg/datapath/bpf"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
 
-	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
 )
 
@@ -74,9 +72,6 @@ func LoadSockTerm(l *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Map) (*bpfgen.So
 	// We can't assign directly to a sock_termObjects, since some maps and
 	// programs may be missing.
 	coll, commit, err := bpf.LoadCollection(l, spec, &bpf.CollectionOptions{
-		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
-		},
 		MapReplacements: mapReplacements,
 	})
 

--- a/pkg/datapath/loader/sock.go
+++ b/pkg/datapath/loader/sock.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	bpfgen "github.com/cilium/cilium/pkg/datapath/bpf"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
 
@@ -74,7 +75,7 @@ func LoadSockTerm(l *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Map) (*bpfgen.So
 	// programs may be missing.
 	coll, commit, err := bpf.LoadCollection(l, spec, &bpf.CollectionOptions{
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		MapReplacements: mapReplacements,
 	})

--- a/pkg/datapath/loader/sock.go
+++ b/pkg/datapath/loader/sock.go
@@ -75,7 +75,7 @@ func LoadSockTerm(l *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Map) (*bpfgen.So
 	// programs may be missing.
 	coll, commit, err := bpf.LoadCollection(l, spec, &bpf.CollectionOptions{
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		MapReplacements: mapReplacements,
 	})

--- a/pkg/datapath/loader/tcx.go
+++ b/pkg/datapath/loader/tcx.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/ebpf/link"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -52,7 +53,7 @@ func upsertTCXProgram(logger *slog.Logger, device netlink.Link, prog *ebpf.Progr
 //
 // progName is typically the Program's key in CollectionSpec.Programs.
 func attachTCX(logger *slog.Logger, device netlink.Link, prog *ebpf.Program, progName, bpffsDir string, attach ebpf.AttachType) error {
-	if err := bpf.MkdirBPF(bpffsDir); err != nil {
+	if err := bpffs.MkdirBPF(bpffsDir); err != nil {
 		return fmt.Errorf("creating bpffs link dir for tcx attachment to device %s: %w", device.Attrs().Name, err)
 	}
 

--- a/pkg/datapath/loader/types/loader.go
+++ b/pkg/datapath/loader/types/loader.go
@@ -19,7 +19,7 @@ import (
 // Loader is an interface to abstract out loading of datapath programs.
 type Loader interface {
 	CallsMapPath(id uint16) string
-	Unload(ep endpoint.Endpoint)
+	Unload(ep endpoint.Endpoint, cfg *config.Config)
 	HostDatapathInitialized() <-chan struct{}
 
 	ReloadDatapath(ctx context.Context, ep endpoint.Endpoint, cfg *config.Config, stats *metrics.SpanStat) (string, error)

--- a/pkg/datapath/loader/util_test.go
+++ b/pkg/datapath/loader/util_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 )
 
-var (
-	localNodeConfig = config.Config{
+func localNodeConfig(paths *config.BPFFS) *config.Config {
+	lnc := &config.Config{
 		NodeIPv4:            netip.AddrFrom4([4]byte(templateIPv4)),
 		CiliumInternalIPv4:  netip.AddrFrom4([4]byte(templateIPv4)),
 		AllocCIDRIPv4:       cidr.MustParseCIDR("10.147.0.0/16"),
@@ -46,7 +46,13 @@ var (
 		HostEndpointID:      1,
 		EnableIPv4:          true,
 	}
-)
+
+	if paths != nil {
+		lnc.BPFFS = *paths
+	}
+
+	return lnc
+}
 
 func setupCompilationDirectories(tb testing.TB) {
 	option.Config.DryMode = true

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -228,7 +229,7 @@ func loadAndRecordComplexity(
 			coll, _, err = bpf.LoadCollection(log, spec, &bpf.CollectionOptions{
 				Constants: constants,
 				CollectionOptions: ebpf.CollectionOptions{
-					Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+					Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 					Programs: ebpf.ProgramOptions{
 						LogLevel: logLevel,
 					},

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -229,7 +229,7 @@ func loadAndRecordComplexity(
 			coll, _, err = bpf.LoadCollection(log, spec, &bpf.CollectionOptions{
 				Constants: constants,
 				CollectionOptions: ebpf.CollectionOptions{
-					Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+					Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.Root())},
 					Programs: ebpf.ProgramOptions{
 						LogLevel: logLevel,
 					},

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -229,7 +229,7 @@ func loadAndRecordComplexity(
 			coll, _, err = bpf.LoadCollection(log, spec, &bpf.CollectionOptions{
 				Constants: constants,
 				CollectionOptions: ebpf.CollectionOptions{
-					Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+					Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 					Programs: ebpf.ProgramOptions{
 						LogLevel: logLevel,
 					},

--- a/pkg/datapath/loader/wireguard.go
+++ b/pkg/datapath/loader/wireguard.go
@@ -13,7 +13,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/registry"
@@ -78,7 +77,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 		Constants:   wireguardConfiguration(lnc, device),
 		MapRenames:  wireguardMapRenames(lnc, device),
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+			Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(device.Attrs().Name), wireguardConfig),
 	})
@@ -87,7 +86,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 	}
 	defer obj.Close()
 
-	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), device)
+	linkDir := lnc.BPFFS.DeviceLinksDir(device)
 	// Attach/detach cil_to_wireguard to/from egress.
 	if option.Config.NeedEgressOnWireGuardDevice(lnc.KPRConfig, lnc.EnableWireguard) {
 		if err := attachSKBProgram(logger, device, obj.ToWireguard, symbolToWireguard,

--- a/pkg/datapath/loader/wireguard.go
+++ b/pkg/datapath/loader/wireguard.go
@@ -78,7 +78,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 		Constants:   wireguardConfiguration(lnc, device),
 		MapRenames:  wireguardMapRenames(lnc, device),
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(device.Attrs().Name), wireguardConfig),
 	})
@@ -87,7 +87,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 	}
 	defer obj.Close()
 
-	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(), device)
+	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), device)
 	// Attach/detach cil_to_wireguard to/from egress.
 	if option.Config.NeedEgressOnWireGuardDevice(lnc.KPRConfig, lnc.EnableWireguard) {
 		if err := attachSKBProgram(logger, device, obj.ToWireguard, symbolToWireguard,

--- a/pkg/datapath/loader/wireguard.go
+++ b/pkg/datapath/loader/wireguard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/registry"
@@ -77,7 +78,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 		Constants:   wireguardConfiguration(lnc, device),
 		MapRenames:  wireguardMapRenames(lnc, device),
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(device.Attrs().Name), wireguardConfig),
 	})
@@ -86,7 +87,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 	}
 	defer obj.Close()
 
-	linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), device)
+	linkDir := bpffsDeviceLinksDir(bpffs.CiliumPath(), device)
 	// Attach/detach cil_to_wireguard to/from egress.
 	if option.Config.NeedEgressOnWireGuardDevice(lnc.KPRConfig, lnc.EnableWireguard) {
 		if err := attachSKBProgram(logger, device, obj.ToWireguard, symbolToWireguard,

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/xdp"
@@ -242,7 +243,7 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 			Constants:   xdpConfiguration(lnc, iface),
 			MapRenames:  xdpMapRenames(lnc, iface),
 			CollectionOptions: ebpf.CollectionOptions{
-				Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 			},
 			ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), xdpConfig),
 		})
@@ -252,7 +253,7 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 		defer obj.Close()
 
 		err = attachXDPProgram(logger, iface, obj.Entrypoint, symbolFromHostNetdevXDP,
-			bpffsDeviceLinksDir(bpf.CiliumPath(), iface), xdpConfigModeToFlag(xdpMode))
+			bpffsDeviceLinksDir(bpffs.CiliumPath(), iface), xdpConfigModeToFlag(xdpMode))
 		if errors.Is(err, unix.EINVAL) {
 			// EINVAL during attachment can have multiple causes. There are two common
 			// cases we can handle:
@@ -336,7 +337,7 @@ func attachXDPProgram(logger *slog.Logger, iface netlink.Link, prog *ebpf.Progra
 		return fmt.Errorf("updating link %s for program %s: %w", pin, progName, err)
 	}
 
-	if err := bpf.MkdirBPF(bpffsDir); err != nil {
+	if err := bpffs.MkdirBPF(bpffsDir); err != nil {
 		return fmt.Errorf("creating bpffs link dir for xdp attachment to device %s: %w", iface.Attrs().Name, err)
 	}
 

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -105,7 +105,7 @@ func xdpAttachedModeToFlag(mode uint32) link.XDPAttachFlags {
 //
 // bpffsBase is typically set to /sys/fs/bpf/cilium, but can be a temp directory
 // during tests.
-func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, keep []string, xdpMode xdp.Mode, bpffsBase string) {
+func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, keep []string, xdpMode xdp.Mode, paths *config.BPFFS) {
 	links, err := safenetlink.LinkList()
 	if err != nil {
 		logger.Warn("Failed to list links for XDP unload",
@@ -135,7 +135,7 @@ func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, keep []string, xdpMode 
 			}
 		}
 		if !used {
-			if err := DetachXDP(link.Attrs().Name, bpffsBase, symbolFromHostNetdevXDP); err != nil {
+			if err := DetachXDP(link.Attrs().Name, paths, symbolFromHostNetdevXDP); err != nil {
 				logger.Warn("Failed to detach obsolete XDP program",
 					logfields.Error, err,
 				)
@@ -243,7 +243,7 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 			Constants:   xdpConfiguration(lnc, iface),
 			MapRenames:  xdpMapRenames(lnc, iface),
 			CollectionOptions: ebpf.CollectionOptions{
-				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+				Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 			},
 			ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), xdpConfig),
 		})
@@ -253,7 +253,7 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 		defer obj.Close()
 
 		err = attachXDPProgram(logger, iface, obj.Entrypoint, symbolFromHostNetdevXDP,
-			bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), iface), xdpConfigModeToFlag(xdpMode))
+			lnc.BPFFS.DeviceLinksDir(iface), xdpConfigModeToFlag(xdpMode))
 		if errors.Is(err, unix.EINVAL) {
 			// EINVAL during attachment can have multiple causes. There are two common
 			// cases we can handle:
@@ -406,13 +406,13 @@ func attachXDPProgram(logger *slog.Logger, iface netlink.Link, prog *ebpf.Progra
 //
 // bpffsBase is typically /sys/fs/bpf/cilium, but can be overridden to a tempdir
 // during tests.
-func DetachXDP(ifaceName string, bpffsBase, progName string) error {
+func DetachXDP(ifaceName string, paths *config.BPFFS, progName string) error {
 	iface, err := safenetlink.LinkByName(ifaceName)
 	if err != nil {
 		return fmt.Errorf("getting link '%s' by name: %w", ifaceName, err)
 	}
 
-	pin := filepath.Join(bpffsDeviceLinksDir(bpffsBase, iface), progName)
+	pin := filepath.Join(paths.DeviceLinksDir(iface), progName)
 	err = bpf.UnpinLink(pin)
 	if err == nil {
 		return nil

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -243,7 +243,7 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 			Constants:   xdpConfiguration(lnc, iface),
 			MapRenames:  xdpMapRenames(lnc, iface),
 			CollectionOptions: ebpf.CollectionOptions{
-				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+				Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 			},
 			ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), xdpConfig),
 		})
@@ -253,7 +253,7 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 		defer obj.Close()
 
 		err = attachXDPProgram(logger, iface, obj.Entrypoint, symbolFromHostNetdevXDP,
-			bpffsDeviceLinksDir(bpffs.CiliumPath(), iface), xdpConfigModeToFlag(xdpMode))
+			bpffsDeviceLinksDir(bpffs.CiliumPath(bpffs.BPFFSRoot()), iface), xdpConfigModeToFlag(xdpMode))
 		if errors.Is(err, unix.EINVAL) {
 			// EINVAL during attachment can have multiple causes. There are two common
 			// cases we can handle:

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
@@ -40,9 +40,9 @@ func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 		require.NoError(t, netlink.LinkAdd(veth))
 
 		loLinkPath := bpffsDeviceLinksDir(basePath, lo)
-		require.NoError(t, bpf.MkdirBPF(loLinkPath))
+		require.NoError(t, bpffs.MkdirBPF(loLinkPath))
 		vethLinkPath := bpffsDeviceLinksDir(basePath, veth)
-		require.NoError(t, bpf.MkdirBPF(vethLinkPath))
+		require.NoError(t, bpffs.MkdirBPF(vethLinkPath))
 
 		// need to use symbolFromHostNetdevXDP as progName here as maybeUnloadObsoleteXDPPrograms explicitly uses that name.
 		require.NoError(t, attachXDPProgram(logger, lo, prog, symbolFromHostNetdevXDP, loLinkPath, link.XDPGenericMode))
@@ -127,7 +127,7 @@ func TestPrivilegedAttachXDPWithExistingLink(t *testing.T) {
 
 		basePath := testutils.TempBPFFS(t)
 		pinDir := bpffsDeviceLinksDir(basePath, lo)
-		require.NoError(t, bpf.MkdirBPF(pinDir))
+		require.NoError(t, bpffs.MkdirBPF(pinDir))
 
 		// At this point, we know bpf_link is supported, so attachXDPProgram should
 		// use it.

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
+	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
@@ -28,7 +29,7 @@ func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
-	basePath := testutils.TempBPFFS(t)
+	paths := config.BPFFS{Root: testutils.TempBPFFS(t)}
 	prog := mustXDPProgram(t, symbolFromHostNetdevXDP)
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{Name: "veth"},
@@ -39,9 +40,9 @@ func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	ns.Do(func() error {
 		require.NoError(t, netlink.LinkAdd(veth))
 
-		loLinkPath := bpffsDeviceLinksDir(basePath, lo)
+		loLinkPath := paths.DeviceLinksDir(lo)
 		require.NoError(t, bpffs.MkdirBPF(loLinkPath))
-		vethLinkPath := bpffsDeviceLinksDir(basePath, veth)
+		vethLinkPath := paths.DeviceLinksDir(veth)
 		require.NoError(t, bpffs.MkdirBPF(vethLinkPath))
 
 		// need to use symbolFromHostNetdevXDP as progName here as maybeUnloadObsoleteXDPPrograms explicitly uses that name.
@@ -49,7 +50,7 @@ func TestPrivilegedMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 		require.NoError(t, attachXDPProgram(logger, veth, prog, symbolFromHostNetdevXDP, vethLinkPath, link.XDPGenericMode))
 
 		// Clean up all interfaces except lo.
-		maybeUnloadObsoleteXDPPrograms(logger, []string{lo.Attrs().Name}, option.XDPModeLinkGeneric, basePath)
+		maybeUnloadObsoleteXDPPrograms(logger, []string{lo.Attrs().Name}, option.XDPModeLinkGeneric, &paths)
 
 		// Wait for veth to be detached.
 		require.NoError(t, testutils.WaitUntil(func() bool {
@@ -125,8 +126,8 @@ func TestPrivilegedAttachXDPWithExistingLink(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, l.Close())
 
-		basePath := testutils.TempBPFFS(t)
-		pinDir := bpffsDeviceLinksDir(basePath, lo)
+		paths := config.BPFFS{Root: testutils.TempBPFFS(t)}
+		pinDir := paths.DeviceLinksDir(lo)
 		require.NoError(t, bpffs.MkdirBPF(pinDir))
 
 		// At this point, we know bpf_link is supported, so attachXDPProgram should
@@ -137,7 +138,7 @@ func TestPrivilegedAttachXDPWithExistingLink(t *testing.T) {
 		require.NoError(t, attachXDPProgram(logger, lo, prog, "test", pinDir, link.XDPGenericMode))
 
 		// Detach the program.
-		require.NoError(t, DetachXDP(lo.Attrs().Name, basePath, "test"))
+		require.NoError(t, DetachXDP(lo.Attrs().Name, &paths, "test"))
 
 		return nil
 	})
@@ -150,16 +151,16 @@ func TestPrivilegedDetachXDPWithPreviousAttach(t *testing.T) {
 	ns := netns.NewNetNS(t)
 	ns.Do(func() error {
 		prog := mustXDPProgram(t, "test")
-		basePath := testutils.TempBPFFS(t)
+		paths := config.BPFFS{Root: testutils.TempBPFFS(t)}
 
 		require.NoError(t, netlink.LinkSetXdpFdWithFlags(lo, prog.FD(), int(link.XDPGenericMode)))
 		require.True(t, getLink(t, lo).Attrs().Xdp.Attached)
 
 		// Detach with the wrong name, leaving the program attached.
-		require.NoError(t, DetachXDP(lo.Attrs().Name, basePath, "foo"))
+		require.NoError(t, DetachXDP(lo.Attrs().Name, &paths, "foo"))
 		require.True(t, getLink(t, lo).Attrs().Xdp.Attached)
 
-		require.NoError(t, DetachXDP(lo.Attrs().Name, basePath, "test"))
+		require.NoError(t, DetachXDP(lo.Attrs().Name, &paths, "test"))
 		require.False(t, getLink(t, lo).Attrs().Xdp.Attached)
 
 		return nil

--- a/pkg/datapath/mapsweeper/map.go
+++ b/pkg/datapath/mapsweeper/map.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
@@ -107,7 +108,7 @@ func (ms *MapSweeper) walk(path string, _ os.FileInfo, _ error) error {
 // CollectStaleMapGarbage cleans up stale content in the BPF maps from the
 // datapath.
 func (ms *MapSweeper) CollectStaleMapGarbage() {
-	if err := filepath.Walk(bpf.TCGlobalsPath(), ms.walk); err != nil {
+	if err := filepath.Walk(bpffs.TCGlobalsPath(), ms.walk); err != nil {
 		ms.logger.Warn("Error while scanning for stale maps", logfields.Error, err)
 	}
 }
@@ -117,7 +118,7 @@ func (ms *MapSweeper) CollectStaleMapGarbage() {
 // to live until the BPF program using them is being replaced.
 func (ms *MapSweeper) RemoveDisabledMaps() {
 	var (
-		mapsDir = bpf.TCGlobalsPath()
+		mapsDir = bpffs.TCGlobalsPath()
 		maps    = []string{
 			// maps we unconditionally remove, because they no longer exist in modern versions of Cilium at all
 			"cilium_proxy4",

--- a/pkg/datapath/mapsweeper/map.go
+++ b/pkg/datapath/mapsweeper/map.go
@@ -108,7 +108,7 @@ func (ms *MapSweeper) walk(path string, _ os.FileInfo, _ error) error {
 // CollectStaleMapGarbage cleans up stale content in the BPF maps from the
 // datapath.
 func (ms *MapSweeper) CollectStaleMapGarbage() {
-	if err := filepath.Walk(bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), ms.walk); err != nil {
+	if err := filepath.Walk(bpffs.TCGlobalsPath(bpffs.Root()), ms.walk); err != nil {
 		ms.logger.Warn("Error while scanning for stale maps", logfields.Error, err)
 	}
 }
@@ -118,7 +118,7 @@ func (ms *MapSweeper) CollectStaleMapGarbage() {
 // to live until the BPF program using them is being replaced.
 func (ms *MapSweeper) RemoveDisabledMaps() {
 	var (
-		mapsDir = bpffs.TCGlobalsPath(bpffs.BPFFSRoot())
+		mapsDir = bpffs.TCGlobalsPath(bpffs.Root())
 		maps    = []string{
 			// maps we unconditionally remove, because they no longer exist in modern versions of Cilium at all
 			"cilium_proxy4",

--- a/pkg/datapath/mapsweeper/map.go
+++ b/pkg/datapath/mapsweeper/map.go
@@ -108,7 +108,7 @@ func (ms *MapSweeper) walk(path string, _ os.FileInfo, _ error) error {
 // CollectStaleMapGarbage cleans up stale content in the BPF maps from the
 // datapath.
 func (ms *MapSweeper) CollectStaleMapGarbage() {
-	if err := filepath.Walk(bpffs.TCGlobalsPath(), ms.walk); err != nil {
+	if err := filepath.Walk(bpffs.TCGlobalsPath(bpffs.BPFFSRoot()), ms.walk); err != nil {
 		ms.logger.Warn("Error while scanning for stale maps", logfields.Error, err)
 	}
 }
@@ -118,7 +118,7 @@ func (ms *MapSweeper) CollectStaleMapGarbage() {
 // to live until the BPF program using them is being replaced.
 func (ms *MapSweeper) RemoveDisabledMaps() {
 	var (
-		mapsDir = bpffs.TCGlobalsPath()
+		mapsDir = bpffs.TCGlobalsPath(bpffs.BPFFSRoot())
 		maps    = []string{
 			// maps we unconditionally remove, because they no longer exist in modern versions of Cilium at all
 			"cilium_proxy4",

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -198,7 +198,7 @@ func newLocalNodeConfig(
 		DatapathIsLayer2:             connectorConfig.GetOperationalMode().IsLayer2(),
 		DatapathIsNetkit:             connectorConfig.GetOperationalMode().IsNetkit(),
 		Plugins:                      plugins,
-		BPFFS:                        config.BPFFS{Root: bpffs.BPFFSRoot()},
+		BPFFS:                        config.BPFFS{Root: bpffs.Root()},
 	}, common.MergeChannels(watchChans...), nil
 }
 

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/statedb"
 
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/config"
@@ -197,6 +198,7 @@ func newLocalNodeConfig(
 		DatapathIsLayer2:             connectorConfig.GetOperationalMode().IsLayer2(),
 		DatapathIsNetkit:             connectorConfig.GetOperationalMode().IsNetkit(),
 		Plugins:                      plugins,
+		BPFFS:                        config.BPFFS{Root: bpffs.BPFFSRoot()},
 	}, common.MergeChannels(watchChans...), nil
 }
 

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -384,7 +384,7 @@ func (o *orchestrator) EndpointHash(cfg endpoint.Config) (string, error) {
 
 func (o *orchestrator) Unload(ep endpoint.Endpoint) {
 	<-o.dpInitialized
-	o.params.Loader.Unload(ep)
+	o.params.Loader.Unload(ep, o.latestLocalNodeConfig.Load())
 }
 
 func (o *orchestrator) WriteEndpointConfig(w io.Writer, cfg endpoint.Config) error {

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
@@ -418,7 +419,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	log := hivetest.Logger(t)
 
-	bpf.CheckOrMountFS(log, "")
+	bpffs.CheckOrMountFS(log, "")
 
 	socketDestroyers := makeSocketDestroyers(t)
 	servers := map[string][]string{

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -121,7 +122,7 @@ func (m *Map) OpenOrCreate() error {
 	}
 
 	opts := ciliumebpf.MapOptions{
-		PinPath: bpf.TCGlobalsPath(),
+		PinPath: bpffs.TCGlobalsPath(),
 	}
 
 	memoryFlags := bpf.GetMapMemoryFlags(m.spec.Type)

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -122,7 +122,7 @@ func (m *Map) OpenOrCreate() error {
 	}
 
 	opts := ciliumebpf.MapOptions{
-		PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot()),
+		PinPath: bpffs.TCGlobalsPath(bpffs.Root()),
 	}
 
 	memoryFlags := bpf.GetMapMemoryFlags(m.spec.Type)

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -122,7 +122,7 @@ func (m *Map) OpenOrCreate() error {
 	}
 
 	opts := ciliumebpf.MapOptions{
-		PinPath: bpffs.TCGlobalsPath(),
+		PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot()),
 	}
 
 	memoryFlags := bpf.GetMapMemoryFlags(m.spec.Type)

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/hive"
@@ -146,7 +146,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 
 	err := rlimit.RemoveMemlock()
 	require.NoError(t, err)

--- a/pkg/envoy/utils.go
+++ b/pkg/envoy/utils.go
@@ -84,7 +84,7 @@ func listenerRequiresNPDS(listener *envoy_config_listener.Listener) bool {
 		var bpfMeta cilium.BpfMetadata
 		err := lf.GetTypedConfig().UnmarshalTo(&bpfMeta)
 
-		if err == nil && bpfMeta.GetBpfRoot() == bpffs.BPFFSRoot() {
+		if err == nil && bpfMeta.GetBpfRoot() == bpffs.Root() {
 			return true
 		}
 	}

--- a/pkg/envoy/utils.go
+++ b/pkg/envoy/utils.go
@@ -10,7 +10,7 @@ import (
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 )
 
 const (
@@ -84,7 +84,7 @@ func listenerRequiresNPDS(listener *envoy_config_listener.Listener) bool {
 		var bpfMeta cilium.BpfMetadata
 		err := lf.GetTypedConfig().UnmarshalTo(&bpfMeta)
 
-		if err == nil && bpfMeta.GetBpfRoot() == bpf.BPFFSRoot() {
+		if err == nil && bpfMeta.GetBpfRoot() == bpffs.BPFFSRoot() {
 			return true
 		}
 	}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
@@ -983,7 +983,7 @@ func getListenerFilter(isIngress bool, useOriginalSourceAddr bool, proxyPort uin
 	conf := &cilium.BpfMetadata{
 		IsIngress:                isIngress,
 		UseOriginalSourceAddress: useOriginalSourceAddr,
-		BpfRoot:                  bpf.BPFFSRoot(),
+		BpfRoot:                  bpffs.BPFFSRoot(),
 		IsL7Lb:                   false,
 		ProxyId:                  uint32(proxyPort),
 		IpcacheName:              ipcache.Name,

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -983,7 +983,7 @@ func getListenerFilter(isIngress bool, useOriginalSourceAddr bool, proxyPort uin
 	conf := &cilium.BpfMetadata{
 		IsIngress:                isIngress,
 		UseOriginalSourceAddress: useOriginalSourceAddr,
-		BpfRoot:                  bpffs.BPFFSRoot(),
+		BpfRoot:                  bpffs.Root(),
 		IsL7Lb:                   false,
 		ProxyId:                  uint32(proxyPort),
 		IpcacheName:              ipcache.Name,

--- a/pkg/maps/authmap/auth_map_privileged_test.go
+++ b/pkg/maps/authmap/auth_map_privileged_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/hive"
@@ -23,7 +23,7 @@ import (
 func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 
-	bpf.CheckOrMountFS(hivetest.Logger(tb), "")
+	bpffs.CheckOrMountFS(hivetest.Logger(tb), "")
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
 }

--- a/pkg/maps/bwmap/cell.go
+++ b/pkg/maps/bwmap/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	bandwidth "github.com/cilium/cilium/pkg/datapath/linux/bandwidth/types"
 	"github.com/cilium/cilium/pkg/maps/registry"
 )
@@ -45,7 +46,7 @@ func provide(lc cell.Lifecycle, reg *registry.MapRegistry, log *slog.Logger,
 	out bpf.MaybeMapOut[*throttleMap], err error) {
 	if !cfg.EnableBandwidthManager {
 		// Remove map pin if the map is disabled.
-		bpf.Remove(bpf.MapPath(log, MapName))
+		bpffs.Remove(bpf.MapPath(log, MapName))
 
 		return bpf.NoneMap[*throttleMap](), nil
 	}

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -34,7 +35,7 @@ func setupCTMap(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 	logger := hivetest.Logger(tb)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
 }

--- a/pkg/maps/ctmap/per_cluster_ctmap_test.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -19,7 +20,7 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 	logger := hivetest.Logger(tb)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to set memlock rlimit")
 
 	// Override the map names to avoid clashing with the real ones.

--- a/pkg/maps/egressmap/policy_test.go
+++ b/pkg/maps/egressmap/policy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -20,7 +20,7 @@ func TestPrivilegedPolicyMap(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	logger := hivetest.Logger(t)
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	assert.NoError(t, rlimit.RemoveMemlock())
 
 	t.Run("IPv4 policies", func(t *testing.T) {

--- a/pkg/maps/iptrace/iptrace_map_test.go
+++ b/pkg/maps/iptrace/iptrace_map_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -19,7 +20,7 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 	logger := hivetest.Logger(tb)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to set memlock rlimit")
 }
 

--- a/pkg/maps/multicast/subscribermap_test.go
+++ b/pkg/maps/multicast/subscribermap_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -23,7 +23,7 @@ func TestPrivilegedSubscriberMap(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	logger := hivetest.Logger(t)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	assert.NoError(t, rlimit.RemoveMemlock())
 
 	groupMapEBPF := NewGroupV4OuterMap(logger, TestGroupV4OuterMapName)

--- a/pkg/maps/nat/per_cluster_nat_test.go
+++ b/pkg/maps/nat/per_cluster_nat_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -20,7 +21,7 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 	logger := hivetest.Logger(tb)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to set memlock rlimit")
 
 	// Override the map names to avoid clashing with the real ones.

--- a/pkg/maps/netdev/netdev_test.go
+++ b/pkg/maps/netdev/netdev_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -21,7 +21,7 @@ func setup(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 	logger := hivetest.Logger(tb)
 
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to set memlock rlimit")
 }
 

--- a/pkg/maps/nodemap/node_map_v2.go
+++ b/pkg/maps/nodemap/node_map_v2.go
@@ -50,6 +50,7 @@ type MapV2 interface {
 type nodeMapV2 struct {
 	logger *slog.Logger
 	conf   Config
+	name   string
 	bpfMap *ebpf.Map
 }
 
@@ -57,6 +58,7 @@ func newMapV2(logger *slog.Logger, mapName string, conf Config) *nodeMapV2 {
 	return &nodeMapV2{
 		logger: logger,
 		conf:   conf,
+		name:   mapName,
 		bpfMap: ebpf.NewMap(logger, &ebpf.MapSpec{
 			Name:       mapName,
 			Type:       ebpf.Hash,
@@ -175,7 +177,7 @@ func LoadNodeMapV2(logger *slog.Logger) (MapV2, error) {
 }
 
 func (m *nodeMapV2) init() error {
-	if existing, err := ebpf.LoadRegisterMap(m.logger, MapNameV2); err == nil {
+	if existing, err := ebpf.LoadRegisterMap(m.logger, m.name); err == nil {
 		m.bpfMap = existing
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {

--- a/pkg/maps/nodemap/node_map_v2_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_v2_privileged_test.go
@@ -12,13 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func setupNodeMapV2TestSuite(tb testing.TB) {
 	testutils.PrivilegedTest(tb)
 
-	bpf.CheckOrMountFS(hivetest.Logger(tb), "")
+	bpffs.CheckOrMountFS(hivetest.Logger(tb), "")
 	err := rlimit.RemoveMemlock()
 	require.NoError(tb, err)
 }

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -33,7 +34,7 @@ func setupPolicyMapPrivilegedTestSuite(tb testing.TB) PolicyMap {
 	testutils.PrivilegedTest(tb)
 
 	logger := hivetest.Logger(tb)
-	bpf.CheckOrMountFS(logger, "")
+	bpffs.CheckOrMountFS(logger, "")
 
 	if err := rlimit.RemoveMemlock(); err != nil {
 		tb.Fatal(err)

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/ebpf"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	bpffs "github.com/cilium/cilium/pkg/bpf/fs"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
@@ -52,7 +53,7 @@ var (
 
 // TODO: Clean up bpffs root logic and make this a var.
 func cgroupLinkPath() string {
-	return filepath.Join(bpf.CiliumPath(), Subsystem, "links/cgroup")
+	return filepath.Join(bpffs.CiliumPath(), Subsystem, "links/cgroup")
 }
 
 // File to dump the socketlb BPF configuration to.
@@ -86,7 +87,7 @@ func Enable(logger *slog.Logger, reg *registry.MapRegistry,
 		MapRegistry: reg,
 		Constants:   cfg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
 		},
 		ConfigDumpPath: configDumpPath,
 	})

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -53,7 +53,7 @@ var (
 
 // TODO: Clean up bpffs root logic and make this a var.
 func cgroupLinkPath() string {
-	return filepath.Join(bpffs.CiliumPath(), Subsystem, "links/cgroup")
+	return filepath.Join(bpffs.CiliumPath(bpffs.BPFFSRoot()), Subsystem, "links/cgroup")
 }
 
 // File to dump the socketlb BPF configuration to.
@@ -87,7 +87,7 @@ func Enable(logger *slog.Logger, reg *registry.MapRegistry,
 		MapRegistry: reg,
 		Constants:   cfg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath()},
+			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
 		},
 		ConfigDumpPath: configDumpPath,
 	})

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -53,7 +53,7 @@ var (
 
 // TODO: Clean up bpffs root logic and make this a var.
 func cgroupLinkPath() string {
-	return filepath.Join(bpffs.CiliumPath(bpffs.BPFFSRoot()), Subsystem, "links/cgroup")
+	return filepath.Join(bpffs.CiliumPath(bpffs.Root()), Subsystem, "links/cgroup")
 }
 
 // File to dump the socketlb BPF configuration to.

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -87,7 +87,7 @@ func Enable(logger *slog.Logger, reg *registry.MapRegistry,
 		MapRegistry: reg,
 		Constants:   cfg,
 		CollectionOptions: ebpf.CollectionOptions{
-			Maps: ebpf.MapOptions{PinPath: bpffs.TCGlobalsPath(bpffs.BPFFSRoot())},
+			Maps: ebpf.MapOptions{PinPath: lnc.BPFFS.TCGlobalsPath()},
 		},
 		ConfigDumpPath: configDumpPath,
 	})


### PR DESCRIPTION
Make BPFFS directory paths part of LocalNodeConfiguration as BPFFS and derive other paths from there. This avoids issues like GH-44417 where parallel tests can step on each others' toes as they try to share the same global directories. Instead, loader tests now each get their own dedicated set of directories for state.

Fixes: #44417
