### PR TITLE
bgp: Make BGP Hive Shell command overridable

### DIFF
--- a/pkg/bgp/commands/cell.go
+++ b/pkg/bgp/commands/cell.go
@@ -11,11 +11,22 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/agent"
 )
 
-var Cell = cell.Provide(BGPCommands)
+var Cell = cell.Provide(
+	// Provide command map then provide it as a a script.CmdsOut. This
+	// indirection gives us the ability to override the bgp/ commands with
+	// DecorateAll. This is useful for switching to a different command
+	// implementation with some custom logic.
+	NewBGPCommands,
+	func(cmds BGPCommands) hive.ScriptCmdsOut {
+		return hive.NewScriptCmds(cmds)
+	},
+)
 
-func BGPCommands(bgpMgr agent.BGPRouterManager) hive.ScriptCmdsOut {
-	return hive.NewScriptCmds(map[string]script.Cmd{
+type BGPCommands map[string]script.Cmd
+
+func NewBGPCommands(bgpMgr agent.BGPRouterManager) BGPCommands {
+	return map[string]script.Cmd{
 		"bgp/peers":  BGPPeersCmd(bgpMgr),
 		"bgp/routes": BGPRoutesCmd(bgpMgr),
-	})
+	}
 }


### PR DESCRIPTION
Instead of directly provide the Hive Shell command from BGPCommands(), put one level of indirection and provide the map of command name => Cmd object to the Hive. So that we can later override the command instance using cell.DecolateAll which is useful for overriding command with some extension.

```release-note
bgp: Make BGP Hive Shell command overridable
```
