### PR TITLE
bpf: Move edt_set_aggregate() above proto switch in cil_from_container

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1796,6 +1796,8 @@ int cil_from_container(struct __ctx_buff *ctx)
 	 */
 	ctx->queue_mapping = 0;
 
+	edt_set_aggregate(ctx, LXC_ID);
+
 	send_trace_notify(ctx, TRACE_FROM_LXC, sec_label, UNKNOWN_ID,
 			  TRACE_EP_ID_UNKNOWN, TRACE_IFINDEX_UNKNOWN,
 			  TRACE_REASON_UNKNOWN, TRACE_PAYLOAD_LEN, proto);
@@ -1808,14 +1810,12 @@ int cil_from_container(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		edt_set_aggregate(ctx, LXC_ID);
 		ret = tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_LXC, &ext_err);
 		sec_label = SECLABEL_IPV6;
 		break;
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		edt_set_aggregate(ctx, LXC_ID);
 		ret = tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_LXC, &ext_err);
 		sec_label = SECLABEL_IPV4;
 		break;


### PR DESCRIPTION
This commit moves the edt_set_aggregate() call from the individual IPv4/6 switch case to the before of that switch statement.

This makes it consistent with other places in the code which call the helper function. Also, it makes adding a new tailcall before those proto switch statements less brittle, as edt_set_aggregate() will be called before the tailcall.

Just for posterity, edt_sched_departure() checks for IPv4/6 protocols, so calling edt_set_aggregate() for other protos is no-op.