### PR TITLE
Allow cilium-envoy 1.36.x for 1.17,1.18,1.19

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -825,28 +825,12 @@
         "quay.io/cilium/cilium-envoy"
       ],
       "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
-      "allowedVersions": "/^v1\\.35\\.([0-9]+)-([0-9]+)-.*$/",
-      "matchBaseBranches": [
-        "v1.19",
-        "v1.18",
-        "v1.17"
-      ]
-    },
-    {
-      // cilium-envoy is referenced in both images/cilium/Dockerfile and
-      // install/kubernetes/Makefile.values. Without explicit grouping,
-      // Renovate creates separate PRs for each manager. The groupSlug ensures
-      // both updates use the same branch name and get combined into a single
-      // PR.
-      "groupName": "cilium-envoy",
-      "groupSlug": "cilium-envoy",
-      "matchDepNames": [
-        "quay.io/cilium/cilium-envoy"
-      ],
-      "versioning": "regex:v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+).*$",
       "allowedVersions": "/^v1\\.36\\.([0-9]+)-([0-9]+)-.*$/",
       "matchBaseBranches": [
         "main",
+        "v1.19",
+        "v1.18",
+        "v1.17"
       ]
     },
     {


### PR DESCRIPTION
Envoy 1.35 will be EOL in July, we should gradually perform the upgrade.