### PR TITLE
ipam: Remove obsolete fields from cloud provider IPAM types

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -390,6 +390,17 @@ Removed Metrics
 
 * ``cilium_agent_bootstrap_seconds`` has been removed. Please use ``cilium_hive_jobs_oneshot_last_run_duration_seconds`` of respective job instead.
 
+Removed CRD Fields
+~~~~~~~~~~~~~~~~~~~
+
+The following obsolete fields have been removed from the ``CiliumNode`` CRD:
+
+* ``spec.eni.instance-id``: Use ``spec.instance-id`` instead. Deprecated since v1.8.
+* ``spec.eni.min-allocate``: Use ``spec.ipam.min-allocate`` instead. Deprecated since v1.8.
+* ``spec.eni.pre-allocate``: Use ``spec.ipam.pre-allocate`` instead. Deprecated since v1.8.
+* ``spec.eni.max-above-watermark``: Use ``spec.ipam.max-above-watermark`` instead. Deprecated since v1.8.
+* ``status.azure.interfaces[].GatewayIP``: Use ``status.azure.interfaces[].gateway`` instead. Deprecated since v1.10.
+
 Advanced
 ========
 

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -16,54 +16,10 @@ import (
 // custom resource along with an ENI specification when the node registers
 // itself to the Kubernetes cluster.
 type ENISpec struct {
-	// InstanceID is the AWS InstanceId of the node. The InstanceID is used
-	// to retrieve AWS metadata for the node.
-	//
-	// OBSOLETE: This field is obsolete, please use Spec.InstanceID
-	//
-	// +kubebuilder:validation:Optional
-	InstanceID string `json:"instance-id,omitempty"`
-
 	// InstanceType is the AWS EC2 instance type, e.g. "m5.large"
 	//
 	// +kubebuilder:validation:Optional
 	InstanceType string `json:"instance-type,omitempty"`
-
-	// MinAllocate is the minimum number of IPs that must be allocated when
-	// the node is first bootstrapped. It defines the minimum base socket
-	// of addresses that must be available. After reaching this watermark,
-	// the PreAllocate and MaxAboveWatermark logic takes over to continue
-	// allocating IPs.
-	//
-	// OBSOLETE: This field is obsolete, please use Spec.IPAM.MinAllocate
-	//
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Optional
-	MinAllocate int `json:"min-allocate,omitempty"`
-
-	// PreAllocate defines the number of IP addresses that must be
-	// available for allocation in the IPAMspec. It defines the buffer of
-	// addresses available immediately without requiring cilium-operator to
-	// get involved.
-	//
-	// OBSOLETE: This field is obsolete, please use Spec.IPAM.PreAllocate
-	//
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Optional
-	PreAllocate int `json:"pre-allocate,omitempty"`
-
-	// MaxAboveWatermark is the maximum number of addresses to allocate
-	// beyond the addresses needed to reach the PreAllocate watermark.
-	// Going above the watermark can help reduce the number of API calls to
-	// allocate IPs, e.g. when a new ENI is allocated, as many secondary
-	// IPs as possible are allocated. Limiting the amount can help reduce
-	// waste of IPs.
-	//
-	// OBSOLETE: This field is obsolete, please use Spec.IPAM.MaxAboveWatermark
-	//
-	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Optional
-	MaxAboveWatermark int `json:"max-above-watermark,omitempty"`
 
 	// FirstInterfaceIndex is the index of the first ENI to use for IP
 	// allocation, e.g. if the node has eth0, eth1, eth2 and

--- a/pkg/aws/eni/types/zz_generated.deepequal.go
+++ b/pkg/aws/eni/types/zz_generated.deepequal.go
@@ -177,19 +177,7 @@ func (in *ENISpec) DeepEqual(other *ENISpec) bool {
 		return false
 	}
 
-	if in.InstanceID != other.InstanceID {
-		return false
-	}
 	if in.InstanceType != other.InstanceType {
-		return false
-	}
-	if in.MinAllocate != other.MinAllocate {
-		return false
-	}
-	if in.PreAllocate != other.PreAllocate {
-		return false
-	}
-	if in.MaxAboveWatermark != other.MaxAboveWatermark {
 		return false
 	}
 	if (in.FirstInterfaceIndex == nil) != (other.FirstInterfaceIndex == nil) {

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -347,10 +347,7 @@ func parseInterface(iface *armnetwork.Interface, subnets ipamTypes.SubnetMap, us
 						if subnet.CIDR.IsValid() {
 							i.CIDR = subnet.CIDR.String()
 						}
-						if gateway := deriveGatewayIP(subnet.CIDR.Addr()); gateway != "" {
-							i.GatewayIP = gateway
-							i.Gateway = gateway
-						}
+						i.Gateway = deriveGatewayIP(subnet.CIDR.Addr())
 					}
 				}
 

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -104,13 +104,6 @@ type AzureInterface struct {
 	// SecurityGroup is the security group associated with the interface
 	SecurityGroup string `json:"security-group,omitempty"`
 
-	// GatewayIP is the interface's subnet's default route
-	//
-	// OBSOLETE: This field is obsolete, please use Gateway field instead.
-	//
-	// +optional
-	GatewayIP string `json:"GatewayIP"`
-
 	// Gateway is the interface's subnet's default route
 	//
 	// +optional

--- a/pkg/azure/types/zz_generated.deepequal.go
+++ b/pkg/azure/types/zz_generated.deepequal.go
@@ -67,9 +67,6 @@ func (in *AzureInterface) DeepEqual(other *AzureInterface) bool {
 	if in.SecurityGroup != other.SecurityGroup {
 		return false
 	}
-	if in.GatewayIP != other.GatewayIP {
-		return false
-	}
 	if in.Gateway != other.Gateway {
 		return false
 	}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -174,54 +174,14 @@ spec:
                       used for IP allocation, eth0 will be ignored for PodIP allocation.
                     minimum: 0
                     type: integer
-                  instance-id:
-                    description: |-
-                      InstanceID is the AWS InstanceId of the node. The InstanceID is used
-                      to retrieve AWS metadata for the node.
-
-                      OBSOLETE: This field is obsolete, please use Spec.InstanceID
-                    type: string
                   instance-type:
                     description: InstanceType is the AWS EC2 instance type, e.g. "m5.large"
                     type: string
-                  max-above-watermark:
-                    description: |-
-                      MaxAboveWatermark is the maximum number of addresses to allocate
-                      beyond the addresses needed to reach the PreAllocate watermark.
-                      Going above the watermark can help reduce the number of API calls to
-                      allocate IPs, e.g. when a new ENI is allocated, as many secondary
-                      IPs as possible are allocated. Limiting the amount can help reduce
-                      waste of IPs.
-
-                      OBSOLETE: This field is obsolete, please use Spec.IPAM.MaxAboveWatermark
-                    minimum: 0
-                    type: integer
-                  min-allocate:
-                    description: |-
-                      MinAllocate is the minimum number of IPs that must be allocated when
-                      the node is first bootstrapped. It defines the minimum base socket
-                      of addresses that must be available. After reaching this watermark,
-                      the PreAllocate and MaxAboveWatermark logic takes over to continue
-                      allocating IPs.
-
-                      OBSOLETE: This field is obsolete, please use Spec.IPAM.MinAllocate
-                    minimum: 0
-                    type: integer
                   node-subnet-id:
                     description: |-
                       NodeSubnetID is the subnet of the primary ENI the instance was brought up
                       with. It is used as a sensible default subnet to create ENIs in.
                     type: string
-                  pre-allocate:
-                    description: |-
-                      PreAllocate defines the number of IP addresses that must be
-                      available for allocation in the IPAMspec. It defines the buffer of
-                      addresses available immediately without requiring cilium-operator to
-                      get involved.
-
-                      OBSOLETE: This field is obsolete, please use Spec.IPAM.PreAllocate
-                    minimum: 0
-                    type: integer
                   security-group-tags:
                     additionalProperties:
                       type: string
@@ -570,12 +530,6 @@ spec:
                     items:
                       description: AzureInterface represents an Azure Interface
                       properties:
-                        GatewayIP:
-                          description: |-
-                            GatewayIP is the interface's subnet's default route
-
-                            OBSOLETE: This field is obsolete, please use Gateway field instead.
-                          type: string
                         addresses:
                           description: |-
                             Addresses is the list of all IPs associated with the interface,

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.2"
+	CustomResourceDefinitionSchemaVersion = "1.33.3"
 )

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -527,10 +527,6 @@ type CiliumNodeList struct {
 func (n *CiliumNode) InstanceID() (instanceID string) {
 	if n != nil {
 		instanceID = n.Spec.InstanceID
-		// OBSOLETE: This fallback can be removed in Cilium 1.9
-		if instanceID == "" {
-			instanceID = n.Spec.ENI.InstanceID
-		}
 	}
 	return
 }

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
@@ -579,8 +578,6 @@ func TestCiliumNodeInstanceID(t *testing.T) {
 	require.Empty(t, (*CiliumNode)(nil).InstanceID())
 	require.Empty(t, (&CiliumNode{}).InstanceID())
 	require.Equal(t, "foo", (&CiliumNode{Spec: NodeSpec{InstanceID: "foo"}}).InstanceID())
-	require.Equal(t, "foo", (&CiliumNode{Spec: NodeSpec{InstanceID: "foo", ENI: eniTypes.ENISpec{InstanceID: "bar"}}}).InstanceID())
-	require.Equal(t, "bar", (&CiliumNode{Spec: NodeSpec{ENI: eniTypes.ENISpec{InstanceID: "bar"}}}).InstanceID())
 }
 
 func BenchmarkSpecEquals(b *testing.B) {


### PR DESCRIPTION
Remove deprecated fields that have been unused for 5+ years:
* Azure `AzureInterface.GatewayIP` (obsolete since v1.10, see #15182)
* AWS `ENISpec.InstanceID` (obsolete since v1.8, see #10569)
* AWS `ENISpec.{MinAllocate,PreAllocate,MaxAboveWatermark}` (obsolete since v1.8, see #10089)

```release-note
Remove long deprecated cloud provider IPAM fields `spec.eni.instance-id`, `spec.eni.min-allocate`, `spec.eni.pre-allocate`, `spec.eni.max-above-watermark` and `status.azure.interfaces[].GatewayIP`.
```
