### PR TITLE
ci: add cilium-debugtools image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,7 @@
     "test/packet/scripts/install.sh",
     "images/builder/install-protoc.sh",
     "images/builder/install-protoplugins.sh",
+    "images/cilium-debugtools/install-tools.sh",
     "install/kubernetes/cilium/templates/spire/**",
     "install/kubernetes/cilium/values.yaml.tmpl",
     "install/kubernetes/Makefile.values",
@@ -963,6 +964,7 @@
       "managerFilePatterns": [
         "/images/builder/install-protoc.sh/",
         "/images/builder/install-protoplugins.sh/",
+        "/images/cilium-debugtools/install-tools.sh/",
         "/images/runtime/build-gops.sh/"
       ],
       // These regexes manage version and digest strings in shell scripts,

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -95,6 +95,10 @@ jobs:
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
             platforms: linux/amd64,linux/arm64
 
+          - name: cilium-debugtools
+            dockerfile: ./images/cilium-debugtools/Dockerfile
+            platforms: linux/amd64,linux/arm64
+
     steps:
       - name: Checkout base or default branch (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/images/cilium-debugtools/Dockerfile
+++ b/images/cilium-debugtools/Dockerfile
@@ -1,0 +1,69 @@
+# check=error=true
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+# renovate: datasource=docker
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:7fdeaeec57c8e59cdcef4014ae34c7fdf5be2ef6@sha256:d21b12a3bb16d3bfcf49518fcb8218ff03b163e91d7ae7cbc39b558cf4aa2b10
+ARG CILIUM_BPFTOOL_IMAGE=quay.io/cilium/cilium-bpftool:7.6.0-1772622536-65b121f@sha256:7bd6330b1d92eb1e923cd7d1ad44808ac7598b4661a6726fabf24407a95f5bde
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
+
+FROM ${CILIUM_BPFTOOL_IMAGE} AS bpftool-dist
+
+FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG MODIFIERS
+
+WORKDIR /go/src/github.com/cilium/cilium
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
+    --mount=type=cache,target=/root/.cache \
+    --mount=type=cache,target=/go/pkg \
+    make GOARCH=${TARGETARCH} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} PKG_BUILD=1 $(echo $MODIFIERS | tr -d '"') \
+    build-container install-container-binary
+
+FROM ${UBUNTU_IMAGE} AS release
+
+ARG TARGETOS
+ARG TARGETARCH
+
+LABEL maintainer="maintainer@cilium.io"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      bash \
+      curl \
+      dnsutils \
+      netcat-openbsd \
+      iperf3 \
+      iputils-ping \
+      tcpdump \
+      iproute2 \
+      iptables \
+      nftables \
+      conntrack \
+      net-tools \
+      ethtool \
+      jq \
+      tree \
+      procps \
+      lsof \
+      less \
+      strace \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /go/src/github.com/cilium/cilium/images/cilium-debugtools
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/cilium-debugtools \
+    ./install-tools.sh
+
+COPY --from=bpftool-dist /usr/local/bin/bpftool /usr/local/bin/bpftool
+
+COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-dbg /usr/local/bin/cilium-dbg
+COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/cilium-bugtool /usr/local/bin/cilium-bugtool
+COPY --from=builder /tmp/install/${TARGETOS}/${TARGETARCH}/usr/bin/hubble /usr/local/bin/hubble
+
+# cilium-dbg as primary entry point  drop to a shell by default
+CMD ["/bin/bash"]

--- a/images/cilium-debugtools/install-tools.sh
+++ b/images/cilium-debugtools/install-tools.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+kubectl_version="v1.35.3"
+# renovate: datasource=github-releases depName=helm/helm
+helm_version="v3.17.3"
+# renovate: datasource=github-releases depName=mikefarah/yq
+yq_version="v4.45.1"
+
+ARCH=$(uname -m)
+case "${ARCH}" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
+esac
+
+curl --fail --show-error --silent --location \
+  "https://dl.k8s.io/release/${kubectl_version}/bin/linux/${ARCH}/kubectl" \
+  --output /usr/local/bin/kubectl
+chmod +x /usr/local/bin/kubectl
+
+curl --fail --show-error --silent --location \
+  "https://get.helm.sh/helm-${helm_version}-linux-${ARCH}.tar.gz" | \
+  tar xz --strip-components=1 -C /usr/local/bin "linux-${ARCH}/helm"
+
+curl --fail --show-error --silent --location \
+  "https://github.com/mikefarah/yq/releases/download/${yq_version}/yq_linux_${ARCH}" \
+  --output /usr/local/bin/yq
+chmod +x /usr/local/bin/yq


### PR DESCRIPTION
New ephemeral debugging image for usage alongside cilium containers.

This image isn't intended to be run as a regular container, but to be launched on-demand as an ephemeral container to help debugging Cilium pods.

It bundles the Cilium binaries(cilium-dbg, cilium-bugtool & hubble), alongside a full set of system and network debugging tools.