### PR TITLE
k8s: Validate empty (C)CNPs at admission

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -293,7 +293,13 @@ notes carefully below to understand what to do during upgrade.
 Informational Notes
 ~~~~~~~~~~~~~~~~~~~
 
-* TODO
+* CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy resources that specify
+  neither ``spec`` nor ``specs`` are now rejected at admission time by the
+  Kubernetes API server via a CEL validation rule. Previously, such empty
+  policies were accepted and only flagged later by the Cilium agent with a
+  warning log. Existing empty policies already present in the cluster are not
+  affected, but any create or update that results in an empty policy will be
+  rejected.
 
 Changes to Features
 ~~~~~~~~~~~~~~~~~~~

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -6411,6 +6411,9 @@ spec:
         required:
         - metadata
         type: object
+        x-kubernetes-validations:
+        - message: spec or specs must be provided
+          rule: has(self.spec) || has(self.specs)
     served: true
     storage: true
     subresources:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -6409,6 +6409,9 @@ spec:
         required:
         - metadata
         type: object
+        x-kubernetes-validations:
+        - message: spec or specs must be provided
+          rule: has(self.spec) || has(self.specs)
     served: true
     storage: true
     subresources:

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.2"
+	CustomResourceDefinitionSchemaVersion = "1.33.3"
 )

--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -21,6 +21,7 @@ import (
 // +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='Valid')].status",name="Valid",type=string
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:validation:XValidation:rule="has(self.spec) || has(self.specs)",message="spec or specs must be provided"
 
 // CiliumClusterwideNetworkPolicy is a Kubernetes third-party resource with an
 // modified version of CiliumNetworkPolicy which is cluster scoped rather than

--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -26,6 +26,7 @@ import (
 // +kubebuilder:printcolumn:JSONPath=".status.conditions[?(@.type=='Valid')].status",name="Valid",type=string
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:validation:XValidation:rule="has(self.spec) || has(self.specs)",message="spec or specs must be provided"
 
 // CiliumNetworkPolicy is a Kubernetes third-party resource with an extended
 // version of NetworkPolicy.


### PR DESCRIPTION
Update the CCNP/CNP CRD to add admission time validation preventing CCNP/CNP with neither `specs` nor `spec`. These resources could previously be created and would only lead agents to emit an `Invalid CiliumNetworkPolicy spec(s): empty policy` warning log on parse. Now the API server will reject the creation or update of such resources.

This relies on [CRD Validation Rules](https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/) which have been GA since kubernetes 1.29.

Existing empty policies already present in the cluster are not affected, but any create or update that results in an empty policy will be rejected.