### PR TITLE
ipam: Return error from instance (re)sync instead of sentinel time.Time

### DIFF
--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -5,6 +5,7 @@ package eni
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"maps"
 
@@ -86,8 +87,8 @@ func (m *InstancesManager) GetPoolQuota() ipamTypes.PoolQuotaMap {
 
 // Resync fetches the list of ECS instances and vSwitches and updates the local
 // cache in the instanceManager. It returns the time when the resync has
-// started or time.Time{} if it did not complete.
-func (m *InstancesManager) Resync(ctx context.Context) time.Time {
+// started or an error if it did not complete.
+func (m *InstancesManager) Resync(ctx context.Context) (time.Time, error) {
 	// Full API resync should block the instance incremental resync from all nodes.
 	m.resyncLock.Lock()
 	defer m.resyncLock.Unlock()
@@ -97,8 +98,8 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 
 // InstanceSync fetches the ECS instance by the given ID and vSwitches and updates the local
 // cache in the instanceManager. It returns the time when the resync has
-// started or time.Time{} if it did not complete.
-func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) time.Time {
+// started or an error if it did not complete.
+func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) (time.Time, error) {
 	// Instance incremental resync from different nodes should be executed in parallel,
 	// but must block the full API resync.
 	m.resyncLock.RLock()
@@ -106,25 +107,22 @@ func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) 
 	return m.resync(ctx, instanceID)
 }
 
-func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.Time {
+func (m *InstancesManager) resync(ctx context.Context, instanceID string) (time.Time, error) {
 	resyncStart := time.Now()
 
 	vpcs, err := m.api.GetVPCs(ctx)
 	if err != nil {
-		m.logger.Warn("Unable to synchronize VPC list", logfields.Error, err)
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("synchronize VPC list: %w", err)
 	}
 
 	vSwitches, err := m.api.GetVSwitches(ctx)
 	if err != nil {
-		m.logger.Warn("Unable to retrieve VPC vSwitches list", logfields.Error, err)
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("retrieve VPC vSwitches list: %w", err)
 	}
 
 	securityGroups, err := m.api.GetSecurityGroups(ctx)
 	if err != nil {
-		m.logger.Warn("Unable to retrieve ECS security group list", logfields.Error, err)
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("retrieve ECS security group list: %w", err)
 	}
 
 	// An empty instanceID indicates that this is full resync, ENIs from all instances
@@ -133,8 +131,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	if instanceID == "" {
 		instances, err := m.api.GetInstances(ctx, vpcs, vSwitches)
 		if err != nil {
-			m.logger.Warn("Unable to synchronize ECS interface list", logfields.Error, err)
-			return time.Time{}
+			return time.Time{}, fmt.Errorf("synchronize ECS interface list: %w", err)
 		}
 
 		m.logger.Info(
@@ -151,8 +148,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	} else {
 		instance, err := m.api.GetInstance(ctx, vpcs, vSwitches, instanceID)
 		if err != nil {
-			m.logger.Warn("Unable to synchronize ECS interface list", logfields.Error, err)
-			return time.Time{}
+			return time.Time{}, fmt.Errorf("synchronize ECS interface list for instance %s: %w", instanceID, err)
 		}
 
 		m.logger.Info(
@@ -172,7 +168,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	m.vpcs = vpcs
 	m.securityGroups = securityGroups
 
-	return resyncStart
+	return resyncStart, nil
 }
 
 // GetVSwitches returns all the tracked vSwitches

--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -66,7 +66,8 @@ func TestCreateInterface(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	alibabaAPI.UpdateENIs(primaryENIs)
-	instances.Resync(t.Context())
+	_, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 
 	mngr, err := ipam.NewNodeManager(logger, instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
@@ -120,7 +121,8 @@ func TestCandidateAndEmptyInterfaces(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	alibabaAPI.UpdateENIs(primaryENIs)
-	instances.Resync(t.Context())
+	_, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 
 	mngr, err := ipam.NewNodeManager(logger, instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
@@ -152,7 +154,8 @@ func TestPrepareIPAllocation(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	alibabaAPI.UpdateENIs(primaryENIs)
-	instances.Resync(t.Context())
+	_, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 
 	mngr, err := ipam.NewNodeManager(logger, instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -7,6 +7,7 @@ package eni
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
@@ -210,8 +211,8 @@ func (m *InstancesManager) FindSecurityGroupByTags(vpcID string, required ipamTy
 
 // Resync fetches the list of EC2 instances and subnets and updates the local
 // cache in the instanceManager. It returns the time when the resync has
-// started or time.Time{} if it did not complete.
-func (m *InstancesManager) Resync(ctx context.Context) time.Time {
+// started or an error if it did not complete.
+func (m *InstancesManager) Resync(ctx context.Context) (time.Time, error) {
 	// Full API resync should block the instance incremental resync from all nodes.
 	m.resyncLock.Lock()
 	defer m.resyncLock.Unlock()
@@ -219,7 +220,7 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 	return m.resync(ctx, "")
 }
 
-func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.Time {
+func (m *InstancesManager) resync(ctx context.Context, instanceID string) (time.Time, error) {
 	resyncStart := time.Now()
 
 	// An empty instanceID indicates that this is full resync, ENIs from all instances
@@ -228,8 +229,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 	if instanceID == "" {
 		// Only sync infrastructure in full resync.
 		if err := m.syncInfrastructure(ctx); err != nil {
-			m.logger.Warn("Unable to synchronize infrastructure", logfields.Error, err)
-			return time.Time{}
+			return time.Time{}, fmt.Errorf("synchronize infrastructure: %w", err)
 		}
 		m.mutex.RLock()
 		vpcs := m.vpcs
@@ -239,8 +239,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 		m.mutex.RUnlock()
 		instances, err := m.ec2api.GetInstances(ctx, vpcs, subnets)
 		if err != nil {
-			m.logger.Warn("Unable to synchronize EC2 interface list", logfields.Error, err)
-			return time.Time{}
+			return time.Time{}, fmt.Errorf("synchronize EC2 interface list: %w", err)
 		}
 
 		m.logger.Info(
@@ -261,8 +260,7 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 		m.mutex.RUnlock()
 		instance, err := m.ec2api.GetInstance(ctx, vpcs, subnets, instanceID)
 		if err != nil {
-			m.logger.Warn("Unable to synchronize EC2 interface list", logfields.Error, err)
-			return time.Time{}
+			return time.Time{}, fmt.Errorf("synchronize EC2 interface list for instance %s: %w", instanceID, err)
 		}
 
 		m.logger.Info(
@@ -275,10 +273,10 @@ func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.T
 		m.instances.UpdateInstance(instanceID, instance)
 	}
 
-	return resyncStart
+	return resyncStart, nil
 }
 
-func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) time.Time {
+func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) (time.Time, error) {
 	// Instance incremental resync from different nodes should be executed in parallel,
 	// but must block the full API resync.
 	m.resyncLock.RLock()

--- a/pkg/aws/eni/instances_test.go
+++ b/pkg/aws/eni/instances_test.go
@@ -195,14 +195,16 @@ var (
 
 func iteration1(t *testing.T, api *ec2mock.API, mngr *InstancesManager) {
 	api.UpdateENIs(enis)
-	mngr.Resync(t.Context())
+	_, err := mngr.Resync(t.Context())
+	require.NoError(t, err)
 }
 
 func iteration2(t *testing.T, api *ec2mock.API, mngr *InstancesManager) {
 	api.UpdateSubnets(subnets2)
 	api.UpdateSecurityGroups(securityGroups2)
 	api.UpdateENIs(enis2)
-	mngr.Resync(t.Context())
+	_, err := mngr.Resync(t.Context())
+	require.NoError(t, err)
 }
 
 func TestGetSubnet(t *testing.T) {
@@ -352,7 +354,8 @@ func TestGetSecurityGroupByTags(t *testing.T) {
 	require.Equal(t, reqTags, sgGroups[0].Tags)
 
 	// iteration 3
-	mngr.Resync(t.Context())
+	_, err = mngr.Resync(t.Context())
+	require.NoError(t, err)
 	reqTags = ipamTypes.Tags{
 		"k3": "v3",
 	}

--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -153,7 +153,8 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -199,7 +200,8 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, true)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -270,7 +272,8 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -332,7 +335,8 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -390,7 +394,8 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -416,7 +421,8 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 
 	// Use 10 out of 10 IPs, PreAllocate 1 must kick in and allocate an additional IP
 	mngr.Upsert(updateCiliumNode(cn, 10, 10))
-	syncTime := instances.Resync(t.Context())
+	syncTime, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr.Resync(t.Context(), syncTime)
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second))
 	node = mngr.Get("node2")
@@ -456,7 +462,8 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, true, 2, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -512,14 +519,16 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	node.UpdatedResource(obj)
 
 	// Excess timestamps should be registered after this
-	syncTime := instances.Resync(t.Context())
+	syncTime, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr.Resync(t.Context(), syncTime)
 
 	// Acknowledge release IPs after 3 secs
 	time.AfterFunc(3*time.Second, func() {
 		// Excess delay duration should have elapsed by now, trigger resync again.
 		// IPs should be marked as excess
-		syncTime := instances.Resync(t.Context())
+		syncTime, err := instances.Resync(t.Context())
+		require.NoError(t, err)
 		mngr.Resync(t.Context(), syncTime)
 		time.Sleep(1 * time.Second)
 		node.PopulateIPReleaseStatus(obj)
@@ -527,7 +536,8 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 		testipam.FakeAcknowledgeReleaseIps(obj)
 		node.UpdatedResource(obj)
 		// Resync one more time to process acknowledgements.
-		syncTime = instances.Resync(t.Context())
+		syncTime, err = instances.Resync(t.Context())
+		require.NoError(t, err)
 		mngr.Resync(t.Context(), syncTime)
 	})
 
@@ -565,7 +575,8 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -593,7 +604,9 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 
 	// Use 7 out of 8 IPs
 	mngr.Upsert(updateCiliumNode(cn, 8, 7))
-	mngr.Resync(t.Context(), instances.Resync(t.Context()))
+	syncTime, err := instances.Resync(t.Context())
+	require.NoError(t, err)
+	mngr.Resync(t.Context(), syncTime)
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
 
 	node = mngr.Get("node1")
@@ -630,7 +643,8 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -650,7 +664,8 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	// assigned the remaining 3 that the t2.xlarge instance type supports
 	// (3x15 - 3 = 42 max)
 	mngr.Upsert(updateCiliumNode(cn, 42, 40))
-	syncTime := instances.Resync(t.Context())
+	syncTime, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr.Resync(t.Context(), syncTime)
 	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node2", 0) }, 5*time.Second))
 
@@ -690,7 +705,8 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -762,7 +778,8 @@ func TestNodeManagerManyNodes(t *testing.T) {
 		require.NoError(t, err)
 		_, err = ec2api.AttachNetworkInterface(t.Context(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID)
 		require.NoError(t, err)
-		instancesManager.Resync(t.Context())
+		_, err = instancesManager.Resync(t.Context())
+		require.NoError(t, err)
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-testNodeManagerManyNodes-%d", i)}
 		s.cn = newCiliumNode(s.name, withTestDefaults(), withInstanceID(s.instanceName), withInstanceType("c3.xlarge"),
 			withFirstInterfaceIndex(1), withIPAMPreAllocate(1), withIPAMMinAllocate(minAllocate))
@@ -827,7 +844,8 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	ec2api.SetMockError(ec2mock.AttachNetworkInterface, errors.New("foo is not 'running' foo"))
 	require.NoError(t, err)
@@ -878,7 +896,8 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, eniID2)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -903,7 +922,8 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	err = ec2api.DeleteNetworkInterface(t.Context(), eniID2)
 	require.NoError(t, err)
 	// Resync instances from mocked AWS
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	// Use 2 out of 9 IPs
 	mngr.Upsert(updateCiliumNode(cn, 9, 2))
 
@@ -935,7 +955,8 @@ func TestNodeManagerStaticIP(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -983,7 +1004,8 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	require.NoError(t, err)
 	staticIP, err := ec2api.AssociateEIP(t.Context(), eniID1, make(ipamTypes.Tags))
 	require.NoError(t, err)
-	instances.Resync(t.Context())
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
 	require.NoError(t, err)
 	require.NotNil(t, mngr)
@@ -1023,7 +1045,8 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 		require.NoError(b, err)
 		_, err = ec2api.AttachNetworkInterface(b.Context(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID)
 		require.NoError(b, err)
-		instances.Resync(b.Context())
+		_, err = instances.Resync(b.Context())
+		require.NoError(b, err)
 		s := &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("i-benchmarkAllocWorker-%d", i)}
 		s.cn = newCiliumNode(s.name, withTestDefaults(), withInstanceID(s.instanceName), withInstanceType("m4.large"),
 			withIPAMPreAllocate(1), withIPAMMinAllocate(10))

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -5,6 +5,7 @@ package ipam
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
@@ -86,8 +87,8 @@ func (m *InstancesManager) GetPoolQuota() (quota ipamTypes.PoolQuotaMap) {
 
 // Resync fetches the list of instances and subnets and updates the local
 // cache in the instanceManager. It returns the time when the resync has
-// started or time.Time{} if it did not complete.
-func (m *InstancesManager) Resync(ctx context.Context) time.Time {
+// started or an error if it did not complete.
+func (m *InstancesManager) Resync(ctx context.Context) (time.Time, error) {
 	// Full API resync should block the instance incremental resync from all nodes.
 	m.resyncLock.Lock()
 	defer m.resyncLock.Unlock()
@@ -97,17 +98,13 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 // resyncInstance only resyncs a given instance
 // Note: This function uses GetInstance directly (not optimized with separate fetch/parse)
 // because it already queries per-instance APIs which are relatively lightweight
-func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string) time.Time {
+func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string) (time.Time, error) {
 	resyncStart := time.Now()
 
 	// First get the instance with empty subnet map to extract subnet IDs
 	instance, err := m.api.GetInstance(ctx, ipamTypes.SubnetMap{}, instanceID)
 	if err != nil {
-		m.logger.Warn("Unable to synchronize Azure instance interface list",
-			logfields.Error, err,
-			logfields.InstanceID, instanceID,
-		)
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("synchronize Azure instance %s interface list: %w", instanceID, err)
 	}
 
 	// Extract subnet IDs from this instance
@@ -130,11 +127,7 @@ func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string
 	if len(subnets) > 0 {
 		instance, err = m.api.GetInstance(ctx, subnets, instanceID)
 		if err != nil {
-			m.logger.Warn("Unable to re-synchronize Azure instance with subnet details",
-				logfields.Error, err,
-				logfields.InstanceID, instanceID,
-			)
-			return time.Time{}
+			return time.Time{}, fmt.Errorf("re-synchronize Azure instance %s with subnet details: %w", instanceID, err)
 		}
 	}
 
@@ -150,7 +143,7 @@ func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string
 	m.instances.UpdateInstance(instanceID, instance)
 	m.subnets = subnets
 
-	return resyncStart
+	return resyncStart, nil
 }
 
 // extractSubnetIDs extracts unique subnet IDs from node network interfaces
@@ -170,14 +163,13 @@ func (m *InstancesManager) extractSubnetIDs(instances *ipamTypes.InstanceMap) []
 
 // resyncInstances performs a full sync of all instances using three-phase strategy
 // Optimization: Fetches network interfaces once from Azure, then parses them twice
-func (m *InstancesManager) resyncInstances(ctx context.Context) time.Time {
+func (m *InstancesManager) resyncInstances(ctx context.Context) (time.Time, error) {
 	resyncStart := time.Now()
 
 	// Phase 1: Fetch network interfaces once from Azure API
 	networkInterfaces, err := m.api.ListAllNetworkInterfaces(ctx)
 	if err != nil {
-		m.logger.Warn("Unable to fetch Azure network interfaces", logfields.Error, err)
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("fetch Azure network interfaces: %w", err)
 	}
 
 	// Phase 2: Parse with empty subnets to discover which subnets are actually in use
@@ -213,10 +205,10 @@ func (m *InstancesManager) resyncInstances(ctx context.Context) time.Time {
 	m.instances = instances
 	m.subnets = subnets
 
-	return resyncStart
+	return resyncStart, nil
 }
 
-func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) time.Time {
+func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) (time.Time, error) {
 	// Instance incremental resync from different nodes should be executed in parallel,
 	// but must block the full API resync.
 	m.resyncLock.RLock()

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -105,7 +105,8 @@ func iteration1(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 	})
 
 	api.UpdateInstances(instances)
-	mngr.Resync(t.Context())
+	_, err := mngr.Resync(t.Context())
+	require.NoError(t, err)
 }
 
 func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
@@ -162,7 +163,8 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 	})
 
 	api.UpdateInstances(instances)
-	mngr.Resync(t.Context())
+	_, err := mngr.Resync(t.Context())
+	require.NoError(t, err)
 }
 
 func TestSubnetDiscovery(t *testing.T) {

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -171,7 +171,8 @@ func TestIpamPreAllocate8(t *testing.T) {
 	})
 	api.UpdateInstances(m)
 
-	instances.Resync(t.Context())
+	_, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 
 	k8sapi := newK8sMock()
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, 0, false)
@@ -234,7 +235,8 @@ func TestIpamMinAllocate10(t *testing.T) {
 	})
 	api.UpdateInstances(m)
 
-	instances.Resync(t.Context())
+	_, err := instances.Resync(t.Context())
+	require.NoError(t, err)
 
 	k8sapi := newK8sMock()
 	mngr, err := ipam.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsmock.NewMockMetrics(), 10, false, 0, false)
@@ -327,7 +329,8 @@ func TestIpamManyNodes(t *testing.T) {
 			}
 
 			api.UpdateInstances(allInstances)
-			instances.Resync(t.Context())
+			_, err = instances.Resync(t.Context())
+			require.NoError(t, err)
 
 			for i := range state {
 				state[i] = &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i)}
@@ -404,7 +407,8 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	}
 
 	api.UpdateInstances(allInstances)
-	instances.Resync(b.Context())
+	_, err = instances.Resync(b.Context())
+	require.NoError(b, err)
 
 	for i := range state {
 		state[i] = &nodeState{name: fmt.Sprintf("node%d", i), instanceName: fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i)}

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -409,12 +409,6 @@ func (n *Node) InstanceID() (id string) {
 	return
 }
 
-func (n *Node) instanceAPISync(ctx context.Context, instanceID string) (time.Time, bool) {
-	syncTime := n.manager.instancesAPI.InstanceSync(ctx, instanceID)
-	success := !syncTime.IsZero()
-	return syncTime, success
-}
-
 // UpdatedResource is called when an update to the CiliumNode has been
 // received. The IPAM layer will attempt to immediately resolve any IP deficits
 // and also trigger the background sync to continue working in the background

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -122,11 +122,11 @@ type AllocationImplementation interface {
 	// Resync is called periodically to give the IPAM implementation a
 	// chance to resync its own state with external APIs or systems. It is
 	// also called when the IPAM layer detects that state got out of sync.
-	Resync(ctx context.Context) time.Time
+	Resync(ctx context.Context) (time.Time, error)
 
 	// InstanceSync is called to sync the state of the specified instance with
 	// external APIs or systems.
-	InstanceSync(ctx context.Context, instanceID string) time.Time
+	InstanceSync(ctx context.Context, instanceID string) (time.Time, error)
 
 	// HasInstance returns whether the instance is in instances
 	HasInstance(instanceID string) bool
@@ -216,19 +216,18 @@ func NewNodeManager(logger *slog.Logger, instancesAPI AllocationImplementation, 
 	return mngr, nil
 }
 
-func (n *NodeManager) instancesAPIResync(ctx context.Context) (time.Time, bool) {
-	syncTime := n.instancesAPI.Resync(ctx)
-	success := !syncTime.IsZero()
-	n.SetInstancesAPIReadiness(success)
-	return syncTime, success
+func (n *NodeManager) instancesAPIResync(ctx context.Context) (time.Time, error) {
+	syncTime, err := n.instancesAPI.Resync(ctx)
+	n.SetInstancesAPIReadiness(err == nil)
+	return syncTime, err
 }
 
 // Start kicks of the NodeManager by performing the initial state
 // synchronization and starting the background sync goroutine
 func (n *NodeManager) Start(ctx context.Context) error {
 	// Trigger the initial resync in a blocking manner
-	if _, ok := n.instancesAPIResync(ctx); !ok {
-		return fmt.Errorf("Initial synchronization with instances API failed")
+	if _, err := n.instancesAPIResync(ctx); err != nil {
+		return fmt.Errorf("initial synchronization with instances API failed: %w", err)
 	}
 
 	// Start an interval based  background resync for safety, it will
@@ -243,13 +242,13 @@ func (n *NodeManager) Start(ctx context.Context) error {
 				RunInterval: time.Minute,
 				DoFunc: func(ctx context.Context) error {
 					start := time.Now()
-					syncTime, ok := n.instancesAPIResync(ctx)
-					if ok {
-						n.metricsAPI.ObserveBackgroundSync(success, time.Since(start))
-						n.Resync(ctx, syncTime)
-					} else {
+					syncTime, err := n.instancesAPIResync(ctx)
+					if err != nil {
 						n.metricsAPI.ObserveBackgroundSync(failed, time.Since(start))
+						return err
 					}
+					n.metricsAPI.ObserveBackgroundSync(success, time.Since(start))
+					n.Resync(ctx, syncTime)
 					return nil
 				},
 			})
@@ -309,8 +308,8 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 		ctx, cancel := context.WithCancel(context.Background())
 		// InstanceAPI is stale and the instances API is stable then do resync instancesAPI to sync instances
 		if !n.instancesAPI.HasInstance(resource.InstanceID()) && n.stableInstancesAPI {
-			if syncTime := n.instancesAPI.InstanceSync(ctx, resource.InstanceID()); syncTime.IsZero() {
-				node.logger.Load().Warn("Failed to resync the instance from the API after new node was found")
+			if _, err := n.instancesAPI.InstanceSync(ctx, resource.InstanceID()); err != nil {
+				node.logger.Load().Warn("Failed to resync the instance from the API after new node was found", logfields.Error, err)
 				n.stableInstancesAPI = false
 			} else {
 				n.stableInstancesAPI = true
@@ -374,9 +373,12 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 			MinInterval:     10 * time.Millisecond,
 			MetricsObserver: n.metricsAPI.ResyncTrigger(),
 			TriggerFunc: func(reasons []string) {
-				if syncTime, ok := node.instanceAPISync(ctx, resource.InstanceID()); ok {
-					node.manager.Resync(ctx, syncTime)
+				syncTime, err := node.manager.instancesAPI.InstanceSync(ctx, resource.InstanceID())
+				if err != nil {
+					node.logger.Load().Warn("Unable to sync instance", logfields.Error, err)
+					return
 				}
+				node.manager.Resync(ctx, syncTime)
 			},
 		})
 		if err != nil {

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -61,12 +61,12 @@ func (a *allocationImplementationMock) GetPoolQuota() ipamTypes.PoolQuotaMap {
 	}
 }
 
-func (a *allocationImplementationMock) Resync(ctx context.Context) time.Time {
-	return time.Now()
+func (a *allocationImplementationMock) Resync(ctx context.Context) (time.Time, error) {
+	return time.Now(), nil
 }
 
-func (a *allocationImplementationMock) InstanceSync(ctx context.Context, instanceID string) time.Time {
-	return time.Now()
+func (a *allocationImplementationMock) InstanceSync(ctx context.Context, instanceID string) (time.Time, error) {
+	return time.Now(), nil
 }
 
 func (a *allocationImplementationMock) HasInstance(instanceID string) bool {


### PR DESCRIPTION
The `AllocationImplementation` interface used `time.Time{}` as a sentinel value to signal failure from `Resync` and `InstanceSync`, forcing every caller to decode the convention via `.IsZero()` and discarding error context at the interface boundary.

This PR changes both methods signature to return `(time.Time, error)`, and propagate errors to callers, this avoids the previous situations where in case of sync failure, we'd get one warning log from the sync method with the actual low level error and then a fatal log from the higher level calling code but without the context of the lower error.

Now that the error is properly forwarded up the call chain, we get a single log with all the appropriate context.

See what the double logs look like currently without this patch:
<img width="1071" height="170" alt="image" src="https://github.com/user-attachments/assets/f189efe6-582e-4f75-a840-268ce34403d1" />

