### PR TITLE
ipam: Switch ENI IPAM from CRD to multi-pool allocator

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -154,7 +154,8 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		}
 
 		if params.DaemonConfig.IPAM == ipamOption.IPAMClusterPool ||
-			params.DaemonConfig.IPAM == ipamOption.IPAMMultiPool {
+			params.DaemonConfig.IPAM == ipamOption.IPAMMultiPool ||
+			params.DaemonConfig.IPAM == ipamOption.IPAMENI {
 			// Create the CiliumNode custom resource. This call will block until
 			// the custom resource has been created
 			params.NodeDiscovery.UpdateCiliumNodeResource()

--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -579,74 +579,6 @@ func (n *Node) Pool() (pool ipamTypes.AllocationMap) {
 	return
 }
 
-// buildPoolAllocated constructs Spec.IPAM.Pools.Allocated from the ENI state
-// on the CiliumNode.
-//
-// Secondary IPs are represented as /32 CIDRs and delegated prefixes as /28 CIDRs
-// Addresses that are covered by a prefix are omitted to avoid overlap, only addresses
-// outside any prefix (e.g. the ENI primary IP with UsePrimaryAddress) are
-// written as /32 CIDRs.
-//
-// Returns nil if the node has no ENI status (non-ENI IPAM modes).
-func (n *Node) buildPoolAllocated(node *v2.CiliumNode) []ipamTypes.IPAMPoolAllocation {
-	if len(node.Status.ENI.ENIs) == 0 {
-		return nil
-	}
-
-	var cidrs []ipamTypes.IPAMCIDR
-	for _, eni := range node.Status.ENI.ENIs {
-		if eni.IsExcludedBySpec(node.Spec.ENI) {
-			continue
-		}
-
-		var prefixes []netip.Prefix
-		for _, p := range eni.Prefixes {
-			cidrs = append(cidrs, ipamTypes.IPAMCIDR(p))
-			if parsed, err := netip.ParsePrefix(p); err == nil {
-				prefixes = append(prefixes, parsed)
-			}
-		}
-
-		// In parseENI (pkg/aws/ec2), we currently use PrefixToIps to flatten each prefixes
-		// into 16 individual IPs and append those IPs to the ENI Addresses field.
-		// Here we need to apply a reverse logic to only advertise as /32 CIDRs in the pool
-		// regular secondary addresses (or the ENI primary IP when using UsePrimaryAddress)
-		// and not addresses that are already being advertised through a /28 CIDR.
-		for _, addrStr := range eni.Addresses {
-			parsed, err := netip.ParseAddr(addrStr)
-			if err != nil {
-				continue
-			}
-			if addressCoveredByPrefix(parsed, prefixes) {
-				continue
-			}
-			cidrs = append(cidrs, ipamTypes.IPAMCIDR(addrStr+"/32"))
-		}
-	}
-
-	if len(cidrs) == 0 {
-		return nil
-	}
-
-	return []ipamTypes.IPAMPoolAllocation{
-		{
-			Pool:  defaults.IPAMDefaultIPPool,
-			CIDRs: cidrs,
-		},
-	}
-}
-
-// addressCoveredByPrefix returns true if the given IP address falls
-// within any of the provided prefixes.
-func addressCoveredByPrefix(addr netip.Addr, prefixes []netip.Prefix) bool {
-	for _, p := range prefixes {
-		if p.Contains(addr) {
-			return true
-		}
-	}
-	return false
-}
-
 // ResourceCopy returns a deep copy of the CiliumNode custom resource
 // associated with the node
 func (n *Node) ResourceCopy() *v2.CiliumNode {
@@ -1280,15 +1212,6 @@ func (n *Node) syncToAPIServer() error {
 	for retry := range maxRetries {
 		node.Spec.IPAM.Pool = pool
 		n.logger.Load().Debug("Updating node in apiserver", logfields.PoolSize, len(node.Spec.IPAM.Pool))
-
-		// Dual-write: populate Spec.IPAM.Pools.Allocated alongside
-		// Spec.IPAM.Pool for the ENI multi-pool migration
-		// (https://github.com/cilium/design-cfps/pull/87).
-		// 1.20 agents read CIDRs from Pools.Allocated; 1.19 agents continue
-		// to use Pool. This dual-write will be removed in 1.21
-		if allocated := n.buildPoolAllocated(node); allocated != nil {
-			node.Spec.IPAM.Pools.Allocated = allocated
-		}
 
 		// The PreAllocate value is added here rather than where the CiliumNode
 		// resource is created ((*NodeDiscovery).mutateNodeResource() inside

--- a/operator/pkg/ipam/nodemanager/node_test.go
+++ b/operator/pkg/ipam/nodemanager/node_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
-	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -113,88 +112,6 @@ func TestSyncToAPIServerForNonExistingNode(t *testing.T) {
 	node.updateLogger()
 
 	require.NoError(t, node.syncToAPIServer())
-}
-
-type prefixDelegationMock struct {
-	nodeOperationsMock
-	prefixDelegated bool
-}
-
-func (p *prefixDelegationMock) IsPrefixDelegated() bool {
-	return p.prefixDelegated
-}
-
-func TestBuildPoolAllocated(t *testing.T) {
-	t.Run("no ENIs returns nil", func(t *testing.T) {
-		n := &Node{ops: &nodeOperationsMock{}}
-		node := &v2.CiliumNode{}
-		require.Nil(t, n.buildPoolAllocated(node))
-	})
-
-	t.Run("secondary IPs as /32 CIDRs", func(t *testing.T) {
-		n := &Node{ops: &prefixDelegationMock{prefixDelegated: false}}
-		node := &v2.CiliumNode{}
-		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
-			"eni-1": {
-				Addresses: []string{"10.0.0.1", "10.0.0.2"},
-			},
-		}
-
-		result := n.buildPoolAllocated(node)
-		require.Len(t, result, 1)
-		require.Equal(t, defaults.IPAMDefaultIPPool, result[0].Pool)
-		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.1/32"))
-		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
-	})
-
-	t.Run("prefix delegation writes prefixes and excludes covered addresses", func(t *testing.T) {
-		n := &Node{ops: &prefixDelegationMock{prefixDelegated: true}}
-		node := &v2.CiliumNode{}
-		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
-			"eni-1": {
-				// Mimics the pkg/aws/ec2.parseENI behavior: Addresses contains the ENI secondary
-				// IPs, the ENI primary if UsePrimaryAddress annd the 16 IPs expanded from the /28 prefix.
-				// Prefixes contains the raw /28.
-				Addresses: []string{
-					"10.0.0.1", // ENI primary IP (UsePrimaryAddress)
-					"10.0.0.16", "10.0.0.17", "10.0.0.18", "10.0.0.19",
-					"10.0.0.20", "10.0.0.21", "10.0.0.22", "10.0.0.23",
-					"10.0.0.24", "10.0.0.25", "10.0.0.26", "10.0.0.27",
-					"10.0.0.28", "10.0.0.29", "10.0.0.30", "10.0.0.31",
-				},
-				Prefixes: []string{"10.0.0.16/28"},
-			},
-		}
-
-		result := n.buildPoolAllocated(node)
-		require.Len(t, result, 1)
-		require.Equal(t, defaults.IPAMDefaultIPPool, result[0].Pool)
-		// Should contain the /28 prefix and the primary IP as /32,
-		// but not the 16 expanded prefix IPs.
-		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.16/28"))
-		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.1/32"))
-		require.Len(t, result[0].CIDRs, 2) // 1 prefix + 1 primary IP
-	})
-
-	t.Run("excluded ENIs are skipped", func(t *testing.T) {
-		n := &Node{ops: &prefixDelegationMock{prefixDelegated: false}}
-		node := &v2.CiliumNode{}
-		node.Spec.ENI.ExcludeInterfaceTags = map[string]string{"skip": "true"}
-		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
-			"eni-1": {
-				Addresses: []string{"10.0.0.1"},
-				Tags:      map[string]string{"skip": "true"},
-			},
-			"eni-2": {
-				Addresses: []string{"10.0.0.2"},
-			},
-		}
-
-		result := n.buildPoolAllocated(node)
-		require.Len(t, result, 1)
-		require.Len(t, result[0].CIDRs, 1)
-		require.Contains(t, result[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
-	})
 }
 
 func TestPoolRequestedIPv4(t *testing.T) {

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -712,7 +712,7 @@ func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.
 	switch a.conf.IPAMMode() {
 
 	case ipamOption.IPAMENI:
-		return buildENIAllocationResult(a.logger, addr, a.store.ownNode, a.conf, a.ipMasqAgent)
+		return buildENIAllocationResult(a.logger, addr, "", a.store.ownNode.Status.ENI.ENIs, a.conf, a.ipMasqAgent)
 
 	// In Azure mode, the Resource points to the azure interface so we can
 	// derive the master interface

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -349,7 +349,7 @@ func (n *nodeStore) hasMinimumIPsInPool(localNodeStore *node.LocalNodeStore) (mi
 			minimumReached = true
 		}
 
-		if n.conf.IPAMMode() == ipamOption.IPAMENI || n.conf.IPAMMode() == ipamOption.IPAMAzure || n.conf.IPAMMode() == ipamOption.IPAMAlibabaCloud {
+		if n.conf.IPAMMode() == ipamOption.IPAMAzure || n.conf.IPAMMode() == ipamOption.IPAMAlibabaCloud {
 			if !n.autoDetectIPv4NativeRoutingCIDR(localNodeStore) {
 				minimumReached = false
 			}
@@ -482,14 +482,6 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 func (n *nodeStore) setOwnNodeWithoutPoolUpdate(node *ciliumv2.CiliumNode) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-
-	// Do not update to an inconsistent state (see updateLocalNodeResource)
-	if n.conf.IPAMMode() == ipamOption.IPAMENI {
-		if err := validateENIConfig(node); err != nil {
-			n.logger.Info("ENI state is not consistent yet", logfields.Error, err)
-			return
-		}
-	}
 
 	n.ownNode = node
 }
@@ -710,9 +702,6 @@ func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.
 	}
 
 	switch a.conf.IPAMMode() {
-
-	case ipamOption.IPAMENI:
-		return buildENIAllocationResult(a.logger, addr, "", a.store.ownNode.Status.ENI.ENIs, a.conf, a.ipMasqAgent)
 
 	// In Azure mode, the Resource points to the azure interface so we can
 	// derive the master interface

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -4,23 +4,18 @@
 package ipam
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/netip"
 	"testing"
 	"time"
 
-	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/cilium/hive/job"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
-	"github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
@@ -154,14 +149,15 @@ func (m ipMasqMapDummy) Dump() ([]netip.Prefix, error) { return []netip.Prefix{}
 
 func TestIPMasq(t *testing.T) {
 	cn := newCiliumNode("node1", 4, 4, 0)
-	dummyResource := ipamTypes.AllocationIP{Resource: "eni-1"}
-	cn.Spec.IPAM.Pool["10.1.1.226"] = dummyResource
 	cn.Status.ENI.ENIs = map[string]eniTypes.ENI{
 		"eni-1": {
 			ID: "eni-1",
 			Addresses: []string{
 				"10.1.1.226",
 				"10.1.1.229",
+			},
+			Subnet: eniTypes.AwsSubnet{
+				CIDR: "10.1.1.0/24",
 			},
 			VPC: eniTypes.AwsVPC{
 				ID:          "vpc-1",
@@ -173,43 +169,13 @@ func TestIPMasq(t *testing.T) {
 		},
 	}
 
-	fakeAddressing := fakenode.NewAddressing()
 	conf := testConfigurationCRD
-	conf.IPAM = ipamOption.IPAMENI
 	conf.EnableIPMasqAgent = true
 	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})
 	err := ipMasqAgent.Start()
 	require.NoError(t, err)
 
-	initNodeStore.Do(func() {}) // Ensure the real initNodeStore is not called
-	sharedNodeStore = newFakeNodeStore(conf, t)
-	sharedNodeStore.ownNode = cn
-
-	var jg job.Group
-	h := hive.New(
-		cell.Invoke(func(jg_ job.Group) { jg = jg_ }),
-	)
-	tlog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
-	require.NoError(t, h.Start(tlog, t.Context()))
-	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
-
-	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
-	ipam := NewIPAM(NewIPAMParams{
-		Logger:         hivetest.Logger(t),
-		NodeAddressing: fakeAddressing,
-		AgentConfig:    conf,
-		NodeDiscovery:  &ownerMock{},
-		LocalNodeStore: localNodeStore,
-		K8sEventReg:    &ownerMock{},
-		NodeResource:   &resourceMock{},
-		MTUConfig:      &mtuMock,
-		IPMasqAgent:    ipMasqAgent,
-		JobGroup:       jg,
-	})
-	ipam.ConfigureAllocator()
-
-	epipv4 := netip.MustParseAddr("10.1.1.226")
-	result, err := ipam.ipv4Allocator.Allocate(epipv4, "test1", PoolDefault())
+	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("10.1.1.226"), "", cn.Status.ENI.ENIs, conf, ipMasqAgent)
 	require.NoError(t, err)
 	// The resulting CIDRs should contain the VPC CIDRs and the default ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
 	require.ElementsMatch(

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -146,63 +145,6 @@ func (m ipMasqMapDummy) Update(netip.Prefix) error { return nil }
 func (m ipMasqMapDummy) Delete(netip.Prefix) error { return nil }
 
 func (m ipMasqMapDummy) Dump() ([]netip.Prefix, error) { return []netip.Prefix{}, nil }
-
-func TestIPMasq(t *testing.T) {
-	cn := newCiliumNode("node1", 4, 4, 0)
-	cn.Status.ENI.ENIs = map[string]eniTypes.ENI{
-		"eni-1": {
-			ID: "eni-1",
-			Addresses: []string{
-				"10.1.1.226",
-				"10.1.1.229",
-			},
-			Subnet: eniTypes.AwsSubnet{
-				CIDR: "10.1.1.0/24",
-			},
-			VPC: eniTypes.AwsVPC{
-				ID:          "vpc-1",
-				PrimaryCIDR: "10.1.0.0/16",
-				CIDRs: []string{
-					"10.2.0.0/16",
-				},
-			},
-		},
-	}
-
-	conf := testConfigurationCRD
-	conf.EnableIPMasqAgent = true
-	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})
-	err := ipMasqAgent.Start()
-	require.NoError(t, err)
-
-	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("10.1.1.226"), "", cn.Status.ENI.ENIs, conf, ipMasqAgent)
-	require.NoError(t, err)
-	// The resulting CIDRs should contain the VPC CIDRs and the default ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
-	require.ElementsMatch(
-		t,
-		[]netip.Prefix{
-			// VPC CIDRs
-			netip.MustParsePrefix("10.1.0.0/16"),
-			netip.MustParsePrefix("10.2.0.0/16"),
-			// Default ip-masq-agent CIDRs
-			netip.MustParsePrefix("10.0.0.0/8"),
-			netip.MustParsePrefix("172.16.0.0/12"),
-			netip.MustParsePrefix("192.168.0.0/16"),
-			netip.MustParsePrefix("100.64.0.0/10"),
-			netip.MustParsePrefix("192.0.0.0/24"),
-			netip.MustParsePrefix("192.0.2.0/24"),
-			netip.MustParsePrefix("192.88.99.0/24"),
-			netip.MustParsePrefix("198.18.0.0/15"),
-			netip.MustParsePrefix("198.51.100.0/24"),
-			netip.MustParsePrefix("203.0.113.0/24"),
-			netip.MustParsePrefix("240.0.0.0/4"),
-			netip.MustParsePrefix("169.254.0.0/16"),
-		},
-		result.CIDRs,
-	)
-
-	ipMasqAgent.Stop()
-}
 
 func TestAzureIPMasq(t *testing.T) {
 	cn := newCiliumNode("node1", 4, 4, 0)

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"slices"
 	"strconv"
+	"sync"
 
 	"github.com/cilium/hive/job"
 	"github.com/vishvananda/netlink"
@@ -21,14 +22,19 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -66,6 +72,168 @@ func startENIDeviceConfigurator(
 			nodeResource,
 		),
 	)
+}
+
+// startENINativeRoutingCIDRSync starts a CiliumNode observer that auto-detects
+// the IPv4 native routing CIDR from the VPC CIDR reported in the ENI status.
+//
+// When BPF masquerading is enabled, Cilium needs the native routing CIDR to
+// know which destination CIDRs should NOT be masqueraded. Without it,
+// cross-node pod-to-pod traffic gets SNAT'd to the node IP, breaking
+// connectivity.
+//
+// If the native routing CIDR is already configured (via Helm or CLI), this
+// validates that the configured value contains the VPC CIDR.
+//
+// The returned channel is closed once the native routing CIDR has been set
+// in the local node store. Callers must wait on it before programming the
+// datapath, otherwise masquerade exclusion may be configured against an
+// empty CIDR.
+func startENINativeRoutingCIDRSync(
+	logger *slog.Logger,
+	jg job.Group,
+	nodeResource agentK8s.LocalCiliumNodeResource,
+	localNodeStore *node.LocalNodeStore,
+	conf *option.DaemonConfig,
+) <-chan struct{} {
+	ready := make(chan struct{})
+	var once sync.Once
+	jg.Add(
+		job.Observer(
+			"eni-native-routing-cidr-sync",
+			func(ctx context.Context, ev resource.Event[*ciliumv2.CiliumNode]) error {
+				defer ev.Done(nil)
+
+				if ev.Kind != resource.Upsert {
+					return nil
+				}
+
+				// Once configured, ignore further events: a regression in
+				// the CN status (e.g. malformed CIDR written later) would
+				// otherwise degrade cell health for an issue that no longer
+				// affects the agent.
+				select {
+				case <-ready:
+					return nil
+				default:
+				}
+
+				// Each Upsert retries until the operator populates
+				// Status.ENI.ENIs[].VPC.PrimaryCIDR with a parseable value.
+				// A non-nil error degrades cell health to surface persistent
+				// malformed data, while an empty PrimaryCIDR (operator hasn't
+				// written yet) is treated as a transient absence.
+				primaryCIDR, err := deriveENIVpcCIDR(logger, ev.Object)
+				if err != nil {
+					return err
+				}
+				if primaryCIDR == nil {
+					return nil
+				}
+
+				once.Do(func() {
+					autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+					close(ready)
+				})
+				return nil
+			},
+			nodeResource,
+		),
+	)
+	return ready
+}
+
+// waitForENINativeRoutingCIDR blocks until the eni-native-routing-cidr-sync
+// observer has populated Local.IPv4NativeRoutingCIDR in the local node store.
+// Aborts the agent with a fatal log if the operator has not reported the VPC
+// CIDR within waitForENINativeRoutingCIDRTimeout.
+func waitForENINativeRoutingCIDR(logger *slog.Logger, ready <-chan struct{}) {
+	deadline := time.After(waitForENINativeRoutingCIDRTimeout)
+	for {
+		select {
+		case <-ready:
+			return
+		case <-deadline:
+			logging.Fatal(logger,
+				"Timed out waiting for ENI VPC CIDR to be reported in CiliumNode status",
+				logfields.Duration, waitForENINativeRoutingCIDRTimeout,
+			)
+		case <-time.After(5 * time.Second):
+			logger.Info("Waiting for ENI VPC CIDR to be reported in CiliumNode status")
+		}
+	}
+}
+
+const waitForENINativeRoutingCIDRTimeout = 5 * time.Minute
+
+// autoDetectENINativeRoutingCIDR either validates an existing native routing
+// CIDR configuration against the given VPC primary CIDR, or uses the VPC CIDR
+// as the autodetected native routing CIDR.
+func autoDetectENINativeRoutingCIDR(
+	logger *slog.Logger,
+	primaryCIDR *cidr.CIDR,
+	localNodeStore *node.LocalNodeStore,
+	conf *option.DaemonConfig,
+) {
+	if nativeCIDR := conf.IPv4NativeRoutingCIDR; nativeCIDR != nil {
+		// Validate that the configured native routing CIDR contains the VPC CIDR.
+		ranges4, _ := ip.CoalesceCIDRs([]*net.IPNet{nativeCIDR.IPNet, primaryCIDR.IPNet})
+		if len(ranges4) == 1 {
+			logger.Info(
+				"Native routing CIDR contains VPC CIDR, ignoring autodetected VPC CIDR.",
+				logfields.VPCCIDR, primaryCIDR,
+				option.IPv4NativeRoutingCIDR, nativeCIDR,
+			)
+		} else {
+			logging.Fatal(logger, "Configured native routing CIDR does not contain VPC CIDR",
+				logfields.VPCCIDR, primaryCIDR,
+				option.IPv4NativeRoutingCIDR, nativeCIDR,
+			)
+		}
+		return
+	}
+
+	logger.Info(
+		"Using autodetected VPC primary CIDR as native routing CIDR.",
+		logfields.VPCCIDR, primaryCIDR,
+	)
+	localNodeStore.Update(func(n *node.LocalNode) {
+		n.Local.IPv4NativeRoutingCIDR = primaryCIDR
+	})
+}
+
+// deriveENIVpcCIDR extracts the VPC primary CIDR from the first ENI in the
+// CiliumNode status. All ENIs on a node belong to the same VPC, so any ENI
+// can be used.
+//
+// Returns (nil, nil) when no ENI has populated PrimaryCIDR yet (transient
+// startup state) and (nil, err) when at least one ENI had a non-empty value
+// that failed to parse (persistent, surfaces via cell health).
+func deriveENIVpcCIDR(logger *slog.Logger, node *ciliumv2.CiliumNode) (*cidr.CIDR, error) {
+	var parseErrs []error
+	for _, eni := range node.Status.ENI.ENIs {
+		if eni.VPC.PrimaryCIDR == "" {
+			continue
+		}
+		c, err := cidr.ParseCIDR(eni.VPC.PrimaryCIDR)
+		if err != nil {
+			// Per-ENI warn keeps granularity even when another ENI
+			// later in the iteration succeeds.
+			logger.Warn(
+				"Failed to parse VPC primary CIDR from ENI status",
+				logfields.ENI, eni.ID,
+				logfields.VPCCIDR, eni.VPC.PrimaryCIDR,
+				logfields.Error, err,
+			)
+			parseErrs = append(parseErrs, fmt.Errorf("ENI %s: %w", eni.ID, err))
+			continue
+		}
+		return c, nil
+	}
+	if len(parseErrs) > 0 {
+		return nil, fmt.Errorf("no valid VPC primary CIDR found: %w", errors.Join(parseErrs...))
+	}
+	return nil, nil
 }
 
 // validateENIConfig validates the ENI configuration in the CiliumNode resource
@@ -340,17 +508,19 @@ func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sy
 func buildENIAllocationResult(
 	logger *slog.Logger,
 	allocatedAddr netip.Addr,
-	node *ciliumv2.CiliumNode,
+	pool Pool,
+	enis map[string]eniTypes.ENI,
 	conf *option.DaemonConfig,
 	ipMasqAgent *ipmasq.IPMasqAgent,
 ) (*AllocationResult, error) {
-	for _, eni := range node.Status.ENI.ENIs {
+	for _, eni := range enis {
 		if !eniContainsIP(eni, allocatedAddr) {
 			continue
 		}
 
 		result := &AllocationResult{
 			IP:         allocatedAddr,
+			IPPoolName: pool,
 			PrimaryMAC: eni.MAC,
 		}
 		if primaryCIDR, err := netip.ParsePrefix(eni.VPC.PrimaryCIDR); err == nil {
@@ -489,4 +659,116 @@ func addressCoveredByPrefix(addr netip.Addr, prefixes []netip.Prefix) bool {
 		}
 	}
 	return false
+}
+
+// eniMultiPoolAllocator wraps multiPoolAllocator to enrich AllocationResult
+// with ENI-specific metadata.
+type eniMultiPoolAllocator struct {
+	multiPoolAllocator
+	logger      *slog.Logger
+	conf        *option.DaemonConfig
+	ipMasqAgent *ipmasq.IPMasqAgent
+}
+
+func (a *eniMultiPoolAllocator) enrichResult(result *AllocationResult, err error) (*AllocationResult, error) {
+	if err != nil || result == nil {
+		return result, err
+	}
+
+	// Take a DeepCopy of the ENIs map under the lock so buildENIAllocationResult
+	// can safely iterate it without holding the mutex. Scoped to Status.ENI
+	// since that's all buildENIAllocationResult reads.
+	a.manager.nodeMutex.Lock()
+	var enis map[string]eniTypes.ENI
+	if a.manager.node != nil {
+		enis = a.manager.node.Status.ENI.DeepCopy().ENIs
+	}
+	a.manager.nodeMutex.Unlock()
+
+	enriched, enrichErr := buildENIAllocationResult(a.logger, result.IP, result.IPPoolName, enis, a.conf, a.ipMasqAgent)
+	if enrichErr != nil {
+		// The underlying Allocate* call already reserved the IP in the
+		// allocator. Release it to avoid leaking the reservation when the
+		// caller treats the wrapped error as an allocation failure.
+		if relErr := a.multiPoolAllocator.Release(result.IP, result.IPPoolName); relErr != nil {
+			return nil, errors.Join(enrichErr, fmt.Errorf("release after enrichment failure: %w", relErr))
+		}
+		return nil, enrichErr
+	}
+	return enriched, nil
+}
+
+func (a *eniMultiPoolAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	return a.enrichResult(a.multiPoolAllocator.Allocate(addr, owner, pool))
+}
+
+func (a *eniMultiPoolAllocator) AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	return a.enrichResult(a.multiPoolAllocator.AllocateWithoutSyncUpstream(addr, owner, pool))
+}
+
+func (a *eniMultiPoolAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
+	return a.enrichResult(a.multiPoolAllocator.AllocateNext(owner, pool))
+}
+
+func (a *eniMultiPoolAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
+	return a.enrichResult(a.multiPoolAllocator.AllocateNextWithoutSyncUpstream(owner, pool))
+}
+
+// ENIMultiPoolAllocatorParams contains the parameters for creating ENI
+// multi-pool allocators.
+type ENIMultiPoolAllocatorParams struct {
+	Logger *slog.Logger
+
+	IPv4Enabled          bool
+	IPv6Enabled          bool
+	CiliumNodeUpdateRate time.Duration
+
+	Node           agentK8s.LocalCiliumNodeResource
+	LocalNodeStore *node.LocalNodeStore
+	CNClient       cilium_v2.CiliumNodeInterface
+	JobGroup       job.Group
+
+	Conf        *option.DaemonConfig
+	IPMasqAgent *ipmasq.IPMasqAgent
+}
+
+func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Allocator) {
+	preallocMap := preAllocatePerPool{
+		Pool(defaults.IPAMDefaultIPPool): defaults.IPAMPreAllocation,
+	}
+
+	mgr := newMultiPoolManager(MultiPoolManagerParams{
+		Logger:               p.Logger,
+		IPv4Enabled:          p.IPv4Enabled,
+		IPv6Enabled:          p.IPv6Enabled,
+		CiliumNodeUpdateRate: p.CiliumNodeUpdateRate,
+		PreallocMap:          preallocMap,
+		Node:                 p.Node,
+		CNClient:             p.CNClient,
+		JobGroup:             p.JobGroup,
+		PoolsFromResource:    eniPoolsFromResource,
+		AllowFirstLastIPs:    true,
+		LinearPreAlloc:       true,
+	})
+
+	allocCIDRsReady := startLocalNodeAllocCIDRsSync(p.IPv4Enabled, p.IPv6Enabled, p.JobGroup, p.Node, p.LocalNodeStore)
+	nativeRoutingCIDRReady := startENINativeRoutingCIDRSync(p.Logger, p.JobGroup, p.Node, p.LocalNodeStore, p.Conf)
+
+	// Wait for local node to be updated to avoid propagating spurious updates.
+	waitForLocalNodeUpdate(p.Logger, mgr)
+	// Independently wait for the alloc-CIDR and native-routing-CIDR observers:
+	// they run in separate jobs from the multi-pool manager and are not
+	// synchronized with mgr.localNodeUpdated().
+	waitForLocalNodeAllocCIDRs(p.Logger, allocCIDRsReady)
+	waitForENINativeRoutingCIDR(p.Logger, nativeRoutingCIDRReady)
+
+	newAllocator := func(family Family) *eniMultiPoolAllocator {
+		return &eniMultiPoolAllocator{
+			multiPoolAllocator: multiPoolAllocator{manager: mgr, family: family},
+			logger:             p.Logger,
+			conf:               p.Conf,
+			ipMasqAgent:        p.IPMasqAgent,
+		}
+	}
+	return newAllocator(IPv4), newAllocator(IPv6)
 }

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -415,5 +416,77 @@ func eniContainsIP(eni eniTypes.ENI, addr netip.Addr) bool {
 		}
 	}
 
+	return false
+}
+
+// eniPoolsFromResource returns the pool specification for ENI IPAM mode.
+// Unlike the standard multi-pool mode which reads Allocated CIDRs from
+// Spec.IPAM.Pools.Allocated, ENI mode derives them from Status.ENI.ENIs
+// which is maintained by the operator. This allows the agent to be the
+// sole writer of Spec.IPAM.Pools.Allocated while reading CIDRs from a
+// different source.
+//
+// Secondary IPs are represented as /32 CIDRs and delegated prefixes as /28 CIDRs.
+func eniPoolsFromResource(node *ciliumv2.CiliumNode) *ipamTypes.IPAMPoolSpec {
+	pools := &ipamTypes.IPAMPoolSpec{
+		Requested: node.Spec.IPAM.Pools.Requested,
+		Allocated: node.Spec.IPAM.Pools.Allocated,
+	}
+
+	if len(node.Status.ENI.ENIs) == 0 {
+		return pools
+	}
+
+	var cidrs []ipamTypes.IPAMCIDR
+	for _, eni := range node.Status.ENI.ENIs {
+		if eni.IsExcludedBySpec(node.Spec.ENI) {
+			continue
+		}
+
+		var prefixes []netip.Prefix
+		for _, p := range eni.Prefixes {
+			cidrs = append(cidrs, ipamTypes.IPAMCIDR(p))
+			if parsed, err := netip.ParsePrefix(p); err == nil {
+				prefixes = append(prefixes, parsed)
+			}
+		}
+
+		// In parseENI (pkg/aws/ec2), we currently use PrefixToIps to flatten each prefixes
+		// into 16 individual IPs and append those IPs to the ENI Addresses field.
+		// Here we need to apply a reverse logic to only advertise as /32 CIDRs in the pool
+		// regular secondary addresses (or the ENI primary IP when using UsePrimaryAddress)
+		// and not addresses that are already being advertised through a /28 CIDR.
+		for _, addrStr := range eni.Addresses {
+			parsed, err := netip.ParseAddr(addrStr)
+			if err != nil {
+				continue
+			}
+			if addressCoveredByPrefix(parsed, prefixes) {
+				continue
+			}
+			cidrs = append(cidrs, ipamTypes.IPAMCIDR(addrStr+"/32"))
+		}
+	}
+
+	if len(cidrs) > 0 {
+		pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{
+				Pool:  defaults.IPAMDefaultIPPool,
+				CIDRs: cidrs,
+			},
+		}
+	}
+
+	return pools
+}
+
+// addressCoveredByPrefix returns true if the given IP address falls
+// within any of the provided prefixes.
+func addressCoveredByPrefix(addr netip.Addr, prefixes []netip.Prefix) bool {
+	for _, p := range prefixes {
+		if p.Contains(addr) {
+			return true
+		}
+	}
 	return false
 }

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -4,6 +4,7 @@
 package ipam
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -267,7 +269,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	t.Run("secondary IP on eni-1", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
@@ -277,7 +279,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	})
 
 	t.Run("secondary IP on eni-2", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.3.1.20"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.3.1.20"), "", node.Status.ENI.ENIs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:02", result.PrimaryMAC)
 		require.Equal(t, "2", result.InterfaceNumber)
@@ -285,7 +287,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	})
 
 	t.Run("unknown IP returns error", func(t *testing.T) {
-		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.99.99.99"), node, conf, nil)
+		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.99.99.99"), "", node.Status.ENI.ENIs, conf, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to find ENI for IP")
 	})
@@ -294,7 +296,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 		confWithNative := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.0.0.0/8"),
 		}
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), node, confWithNative, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, confWithNative, nil)
 		require.NoError(t, err)
 		require.Contains(t, result.CIDRs, netip.MustParsePrefix("10.0.0.0/8"))
 	})
@@ -324,20 +326,20 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	t.Run("IP in first prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.5"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.5"), "", node.Status.ENI.ENIs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
 	})
 
 	t.Run("IP in second prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.20"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.20"), "", node.Status.ENI.ENIs, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 	})
 
 	t.Run("IP outside all prefixes", func(t *testing.T) {
-		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), node, conf, nil)
+		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), "", node.Status.ENI.ENIs, conf, nil)
 		require.Error(t, err)
 	})
 }
@@ -461,5 +463,103 @@ func TestEniPoolsFromResource(t *testing.T) {
 		require.Len(t, result.Allocated, 1)
 		require.Len(t, result.Allocated[0].CIDRs, 1)
 		require.Contains(t, result.Allocated[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
+	})
+}
+
+func TestDeriveENIVpcCIDR(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	t.Run("returns primary VPC CIDR from first ENI", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				VPC: eniTypes.AwsVPC{
+					PrimaryCIDR: "10.0.0.0/16",
+				},
+			},
+		}
+		result, err := deriveENIVpcCIDR(logger, node)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "10.0.0.0/16", result.String())
+	})
+
+	t.Run("returns nil when no ENIs", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		result, err := deriveENIVpcCIDR(logger, node)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("returns nil when VPC CIDR is empty", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				VPC: eniTypes.AwsVPC{},
+			},
+		}
+		result, err := deriveENIVpcCIDR(logger, node)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("returns error when all CIDRs are malformed", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				VPC: eniTypes.AwsVPC{PrimaryCIDR: "not-a-cidr"},
+			},
+		}
+		result, err := deriveENIVpcCIDR(logger, node)
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("returns first valid CIDR even when another is malformed", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				VPC: eniTypes.AwsVPC{PrimaryCIDR: "not-a-cidr"},
+			},
+			"eni-2": {
+				VPC: eniTypes.AwsVPC{PrimaryCIDR: "10.0.0.0/16"},
+			},
+		}
+		result, err := deriveENIVpcCIDR(logger, node)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "10.0.0.0/16", result.String())
+	})
+}
+
+func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
+	t.Run("auto-detects VPC CIDR when not configured", func(t *testing.T) {
+		logger := hivetest.Logger(t)
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+
+		primaryCIDR := cidr.MustParseCIDR("10.0.0.0/16")
+		conf := &option.DaemonConfig{}
+		autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+
+		localNode, err := localNodeStore.Get(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, localNode.Local.IPv4NativeRoutingCIDR)
+		require.Equal(t, "10.0.0.0/16", localNode.Local.IPv4NativeRoutingCIDR.String())
+	})
+
+	t.Run("does not overwrite when already configured", func(t *testing.T) {
+		logger := hivetest.Logger(t)
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+
+		primaryCIDR := cidr.MustParseCIDR("10.0.0.0/16")
+		conf := &option.DaemonConfig{
+			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.0.0.0/8"),
+		}
+		autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+
+		localNode, err := localNodeStore.Get(context.Background())
+		require.NoError(t, err)
+		// Should NOT have been written since the config already has a value.
+		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
 	})
 }

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -12,6 +12,7 @@ import (
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/option"
@@ -363,4 +364,102 @@ func TestEniContainsIP(t *testing.T) {
 
 	// Empty ENI
 	require.False(t, eniContainsIP(eniTypes.ENI{}, netip.MustParseAddr("10.0.0.1")))
+}
+
+func TestAddressCoveredByPrefix(t *testing.T) {
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/24"),
+		netip.MustParsePrefix("192.168.1.0/28"),
+	}
+
+	tests := []struct {
+		name     string
+		addr     netip.Addr
+		prefixes []netip.Prefix
+		want     bool
+	}{
+		{"address in first prefix", netip.MustParseAddr("10.0.0.50"), prefixes, true},
+		{"address in second prefix", netip.MustParseAddr("192.168.1.10"), prefixes, true},
+		{"address outside all prefixes", netip.MustParseAddr("172.16.0.1"), prefixes, false},
+		{"empty prefixes", netip.MustParseAddr("10.0.0.1"), nil, false},
+		{"boundary - first address", netip.MustParseAddr("10.0.0.0"), prefixes, true},
+		{"boundary - last address", netip.MustParseAddr("10.0.0.255"), prefixes, true},
+		{"boundary - just outside", netip.MustParseAddr("10.0.1.0"), prefixes, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, addressCoveredByPrefix(tt.addr, tt.prefixes))
+		})
+	}
+}
+
+func TestEniPoolsFromResource(t *testing.T) {
+	t.Run("no ENIs returns spec pools", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		result := eniPoolsFromResource(node)
+		require.Empty(t, result.Allocated)
+	})
+
+	t.Run("secondary IPs as /32 CIDRs", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1", "10.0.0.2"},
+			},
+		}
+
+		result := eniPoolsFromResource(node)
+		require.Len(t, result.Allocated, 1)
+		require.Equal(t, defaults.IPAMDefaultIPPool, result.Allocated[0].Pool)
+		require.Contains(t, result.Allocated[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.1/32"))
+		require.Contains(t, result.Allocated[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
+	})
+
+	t.Run("prefix delegation writes prefixes and excludes covered addresses", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				// Mimics the pkg/aws/ec2.parseENI behavior: Addresses contains the ENI secondary
+				// IPs, the ENI primary if UsePrimaryAddress and the 16 IPs expanded from the /28 prefix.
+				// Prefixes contains the raw /28.
+				Addresses: []string{
+					"10.0.0.1", // ENI primary IP (UsePrimaryAddress)
+					"10.0.0.16", "10.0.0.17", "10.0.0.18", "10.0.0.19",
+					"10.0.0.20", "10.0.0.21", "10.0.0.22", "10.0.0.23",
+					"10.0.0.24", "10.0.0.25", "10.0.0.26", "10.0.0.27",
+					"10.0.0.28", "10.0.0.29", "10.0.0.30", "10.0.0.31",
+				},
+				Prefixes: []string{"10.0.0.16/28"},
+			},
+		}
+
+		result := eniPoolsFromResource(node)
+		require.Len(t, result.Allocated, 1)
+		require.Equal(t, defaults.IPAMDefaultIPPool, result.Allocated[0].Pool)
+		// Should contain the /28 prefix and the primary IP as /32,
+		// but not the 16 expanded prefix IPs.
+		require.Contains(t, result.Allocated[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.16/28"))
+		require.Contains(t, result.Allocated[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.1/32"))
+		require.Len(t, result.Allocated[0].CIDRs, 2) // 1 prefix + 1 primary IP
+	})
+
+	t.Run("excluded ENIs are skipped", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Spec.ENI.ExcludeInterfaceTags = map[string]string{"skip": "true"}
+		node.Status.ENI.ENIs = map[string]eniTypes.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Tags:      map[string]string{"skip": "true"},
+			},
+			"eni-2": {
+				Addresses: []string{"10.0.0.2"},
+			},
+		}
+
+		result := eniPoolsFromResource(node)
+		require.Len(t, result.Allocated, 1)
+		require.Len(t, result.Allocated[0].CIDRs, 1)
+		require.Contains(t, result.Allocated[0].CIDRs, ipamTypes.IPAMCIDR("10.0.0.2/32"))
+	})
 }

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/ipmasq"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -342,6 +343,60 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), "", node.Status.ENI.ENIs, conf, nil)
 		require.Error(t, err)
 	})
+}
+
+func TestBuildENIAllocationResultIPMasq(t *testing.T) {
+	enis := map[string]eniTypes.ENI{
+		"eni-1": {
+			ID: "eni-1",
+			Addresses: []string{
+				"10.1.1.226",
+				"10.1.1.229",
+			},
+			Subnet: eniTypes.AwsSubnet{
+				CIDR: "10.1.1.0/24",
+			},
+			VPC: eniTypes.AwsVPC{
+				ID:          "vpc-1",
+				PrimaryCIDR: "10.1.0.0/16",
+				CIDRs: []string{
+					"10.2.0.0/16",
+				},
+			},
+		},
+	}
+
+	conf := &option.DaemonConfig{EnableIPMasqAgent: true}
+	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})
+	require.NoError(t, ipMasqAgent.Start())
+	defer ipMasqAgent.Stop()
+
+	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("10.1.1.226"), "", enis, conf, ipMasqAgent)
+	require.NoError(t, err)
+	// The resulting CIDRs should contain the VPC CIDRs and the default
+	// ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
+	require.ElementsMatch(
+		t,
+		[]netip.Prefix{
+			// VPC CIDRs
+			netip.MustParsePrefix("10.1.0.0/16"),
+			netip.MustParsePrefix("10.2.0.0/16"),
+			// Default ip-masq-agent CIDRs
+			netip.MustParsePrefix("10.0.0.0/8"),
+			netip.MustParsePrefix("172.16.0.0/12"),
+			netip.MustParsePrefix("192.168.0.0/16"),
+			netip.MustParsePrefix("100.64.0.0/10"),
+			netip.MustParsePrefix("192.0.0.0/24"),
+			netip.MustParsePrefix("192.0.2.0/24"),
+			netip.MustParsePrefix("192.88.99.0/24"),
+			netip.MustParsePrefix("198.18.0.0/15"),
+			netip.MustParsePrefix("198.51.100.0/24"),
+			netip.MustParsePrefix("203.0.113.0/24"),
+			netip.MustParsePrefix("240.0.0.0/4"),
+			netip.MustParsePrefix("169.254.0.0/16"),
+		},
+		result.CIDRs,
+	)
 }
 
 func TestEniContainsIP(t *testing.T) {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -169,11 +169,29 @@ func (ipam *IPAM) ConfigureAllocator() {
 		if ipam.config.IPv4Enabled() {
 			ipam.ipv4Allocator = v4Allocator
 		}
-	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
-		ipam.logger.Info("Initializing CRD-based IPAM")
-		if ipam.config.IPAMMode() == ipamOption.IPAMENI {
-			startENIDeviceConfigurator(ipam.logger, ipam.jg, ipam.nodeResource, ipam.mtuConfig, ipam.sysctl)
+	case ipamOption.IPAMENI:
+		ipam.logger.Info("Initializing ENI multi-pool IPAM")
+		startENIDeviceConfigurator(ipam.logger, ipam.jg, ipam.nodeResource, ipam.mtuConfig, ipam.sysctl)
+		v4Allocator, v6Allocator := newENIMultiPoolAllocators(ENIMultiPoolAllocatorParams{
+			Logger:               ipam.logger,
+			IPv4Enabled:          ipam.config.IPv4Enabled(),
+			IPv6Enabled:          ipam.config.IPv6Enabled(),
+			CiliumNodeUpdateRate: ipam.config.IPAMCiliumNodeUpdateRate,
+			Node:                 ipam.nodeResource,
+			LocalNodeStore:       ipam.localNodeStore,
+			CNClient:             ipam.clientset.CiliumV2().CiliumNodes(),
+			JobGroup:             ipam.jg,
+			Conf:                 ipam.config,
+			IPMasqAgent:          ipam.ipMasqAgent,
+		})
+		if ipam.config.IPv6Enabled() {
+			ipam.ipv6Allocator = v6Allocator
 		}
+		if ipam.config.IPv4Enabled() {
+			ipam.ipv4Allocator = v4Allocator
+		}
+	case ipamOption.IPAMCRD, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
+		ipam.logger.Info("Initializing CRD-based IPAM")
 		if ipam.config.IPv6Enabled() {
 			ipam.ipv6Allocator = newCRDAllocator(ipam.logger, IPv6, ipam.config, ipam.nodeDiscovery, ipam.localNodeStore, ipam.clientset, ipam.k8sEventReg, ipam.mtuConfig, ipam.sysctl, ipam.ipMasqAgent)
 		}

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"sync"
 
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
@@ -77,10 +78,13 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 
 	waitForAllPools(p.Logger, p.DB, p.PodIPPools, preallocMap)
 
-	startLocalNodeAllocCIDRsSync(p.IPv4Enabled, p.IPv6Enabled, p.JobGroup, p.Node, p.LocalNodeStore)
+	allocCIDRsReady := startLocalNodeAllocCIDRsSync(p.IPv4Enabled, p.IPv6Enabled, p.JobGroup, p.Node, p.LocalNodeStore)
 
 	// wait for local node to be updated to avoid propagating spurious updates.
 	waitForLocalNodeUpdate(p.Logger, mgr)
+	// Independently wait for the alloc-CIDR observer: it runs in its own job
+	// and is not synchronized with mgr.localNodeUpdated().
+	waitForLocalNodeAllocCIDRs(p.Logger, allocCIDRsReady)
 
 	return &multiPoolAllocator{
 			manager: mgr,
@@ -186,12 +190,50 @@ func waitForLocalNodeUpdate(logger *slog.Logger, mgr *multiPoolManager) {
 	}
 }
 
+// waitForLocalNodeAllocCIDRs blocks until the multi-pool-local-node-syncer
+// observer has processed its first CiliumNode upsert event. This synchronizes
+// the observer with the multi-pool manager's own CN-events handler so callers
+// that subsequently read the local node store see state derived from at least
+// the same first event the manager saw.
+//
+// Aborts the agent with a fatal log if no CiliumNode event is received within
+// waitForLocalNodeAllocCIDRsTimeout.
+func waitForLocalNodeAllocCIDRs(logger *slog.Logger, ready <-chan struct{}) {
+	deadline := time.After(waitForLocalNodeAllocCIDRsTimeout)
+	for {
+		select {
+		case <-ready:
+			return
+		case <-deadline:
+			logging.Fatal(logger,
+				"Timed out waiting for the multi-pool local node syncer to process the first CiliumNode event",
+				logfields.Duration, waitForLocalNodeAllocCIDRsTimeout,
+			)
+		case <-time.After(5 * time.Second):
+			logger.Info("Waiting for the multi-pool local node syncer to process the first CiliumNode event")
+		}
+	}
+}
+
+const waitForLocalNodeAllocCIDRsTimeout = 5 * time.Minute
+
+// startLocalNodeAllocCIDRsSync starts a CiliumNode observer that mirrors the
+// alloc CIDRs (Spec.IPAM.PodCIDRs / Spec.IPAM.Pools.Allocated) into the local
+// node store.
+//
+// The returned channel is closed once the observer has processed its first
+// Upsert event. Callers must wait on it before reading the local node store,
+// otherwise they may race with this observer (which runs in a separate job
+// from the multi-pool manager and is not synchronized with
+// mgr.localNodeUpdated()).
 func startLocalNodeAllocCIDRsSync(
 	enableIPv4, enableIPv6 bool,
 	jobGroup job.Group,
 	localNode agentK8s.LocalCiliumNodeResource,
 	localNodeStore *node.LocalNodeStore,
-) {
+) <-chan struct{} {
+	ready := make(chan struct{})
+	var once sync.Once
 	jobGroup.Add(
 		job.Observer(
 			"multi-pool-local-node-syncer",
@@ -214,9 +256,11 @@ func startLocalNodeAllocCIDRsSync(
 					}
 				})
 
+				once.Do(func() { close(ready) })
 				return nil
 			},
 			localNode,
 		),
 	)
+	return ready
 }

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
@@ -235,6 +236,16 @@ type MultiPoolManagerParams struct {
 	PoolsFromResource ciliumv2.PoolsFromResourceFunc
 
 	SkipMasqueradeForPool SkipMasqueradeForPoolFn
+
+	// AllowFirstLastIPs makes CIDR pools include the first and last IPs.
+	// Used for ENI prefix delegation where the entire /28 is allocatable.
+	AllowFirstLastIPs bool
+
+	// LinearPreAlloc uses a simple inUse + preAlloc formula for demand
+	// computation instead of the multi-pool's neededIPCeil rounding. This
+	// matches the CRD allocator's calculateNeededIPs behavior and allows
+	// the operator to recover exact usage from the demand signal.
+	LinearPreAlloc bool
 }
 
 type multiPoolManager struct {
@@ -263,6 +274,9 @@ type multiPoolManager struct {
 
 	poolsFromResource     ciliumv2.PoolsFromResourceFunc
 	skipMasqueradeForPool SkipMasqueradeForPoolFn
+
+	allowFirstLastIPs bool
+	linearPreAlloc    bool
 }
 
 func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
@@ -284,6 +298,8 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 			close(localNodeUpdated)
 		}),
 		poolsFromResource: p.PoolsFromResource,
+		allowFirstLastIPs: p.AllowFirstLastIPs,
+		linearPreAlloc:    p.LinearPreAlloc,
 		skipMasqueradeForPool: func(Pool) (bool, error) {
 			return false, nil
 		},
@@ -389,9 +405,15 @@ func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
 	m.poolsMutex.Lock()
 	defer m.poolsMutex.Unlock()
 
-	pools := m.poolsFromResource(newNode)
-	for _, pool := range pools.Allocated {
+	for _, pool := range m.poolsFromResource(newNode).Allocated {
 		m.upsertPoolLocked(Pool(pool.Pool), pool.CIDRs)
+	}
+
+	// Sync pre-allocate value from the CiliumNode spec. For cloud IPAM modes,
+	// the agent writes it during node discovery and the operator may adjust
+	// it. For standard multi-pool mode this field is unset (0).
+	if newNode.Spec.IPAM.PreAllocate > 0 {
+		m.preallocatedIPsPerPool[Pool(defaults.IPAMDefaultIPPool)] = newNode.Spec.IPAM.PreAllocate
 	}
 
 	// node will only be nil the first time this callback is invoked
@@ -474,12 +496,27 @@ func (m *multiPoolManager) computeNeededIPsPerPoolLocked() map[Pool]types.IPAMPo
 	// + preAllocIPs
 	for poolName, preAlloc := range m.preallocatedIPsPerPool {
 		ipv4Addrs := demand[poolName].IPv4Addrs
-		if m.ipv4Enabled {
-			ipv4Addrs = neededIPCeil(ipv4Addrs, preAlloc)
-		}
 		ipv6Addrs := demand[poolName].IPv6Addrs
-		if m.ipv6Enabled {
-			ipv6Addrs = neededIPCeil(ipv6Addrs, preAlloc)
+
+		if m.linearPreAlloc {
+			// Linear pre-allocation: inUse + preAlloc. This matches the
+			// CRD allocator's calculateNeededIPs formula and allows the
+			// operator to recover exact usage as requested - preAllocate.
+			if m.ipv4Enabled {
+				ipv4Addrs += preAlloc
+			}
+			if m.ipv6Enabled {
+				ipv6Addrs += preAlloc
+			}
+		} else {
+			// Standard multi-pool rounding: rounds up to ensure at least
+			// one full preAlloc buffer above usage.
+			if m.ipv4Enabled {
+				ipv4Addrs = neededIPCeil(ipv4Addrs, preAlloc)
+			}
+			if m.ipv6Enabled {
+				ipv6Addrs = neededIPCeil(ipv6Addrs, preAlloc)
+			}
 		}
 
 		demand[poolName] = types.IPAMPoolDemand{
@@ -568,25 +605,45 @@ func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
 		})
 	}
 
-	newPools := m.poolsFromResource(newNode)
-
 	sort.Slice(requested, func(i, j int) bool {
 		return requested[i].Pool < requested[j].Pool
 	})
 	sort.Slice(allocated, func(i, j int) bool {
 		return allocated[i].Pool < allocated[j].Pool
 	})
-	newPools.Requested = requested
-	newPools.Allocated = allocated
+	newNode.Spec.IPAM.Pools.Requested = requested
+	// Only write Allocated once local pools have been populated. Before
+	// that, the agent has no CIDRs of its own and writing an empty
+	// Allocated would clear CIDRs that may still be in use from a
+	// previous agent run. Once the agent has observed at least one CIDR
+	// (from Status.ENI.ENIs in ENI mode, or from Pools.Allocated in
+	// standard multi-pool mode), it writes Allocated to communicate
+	// in-use CIDRs back to the operator.
+	if len(m.pools) > 0 {
+		newNode.Spec.IPAM.Pools.Allocated = allocated
+	}
 
 	m.poolsMutex.Unlock()
 
-	pools := m.poolsFromResource(curNode)
-
-	if !newPools.DeepEqual(pools) {
-		_, err := m.cnClient.Update(ctx, newNode, metav1.UpdateOptions{})
+	if !newNode.Spec.IPAM.Pools.DeepEqual(&curNode.Spec.IPAM.Pools) {
+		updatedNode, err := m.cnClient.Update(ctx, newNode, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to update node spec: %w", err)
+		}
+		newNode = updatedNode
+	}
+
+	// Clear stale Status.IPAM.Used left by the previous CRD allocator.
+	// This is needed so the operator detects the agent as multi-pool
+	// (the detection heuristic checks len(Status.IPAM.Used) == 0).
+	//
+	// This only happens when an agent starts on a node that was previously
+	// running a 1.19 agent.
+	// TODO: Remove with 1.21.
+	if len(newNode.Status.IPAM.Used) > 0 {
+		newNode.Status.IPAM.Used = nil
+		if _, err := m.cnClient.UpdateStatus(ctx, newNode, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to clear stale Status.IPAM.Used: %w", err)
 		}
 	}
 
@@ -600,10 +657,10 @@ func (m *multiPoolManager) upsertPoolLocked(poolName Pool, cidrs []types.IPAMCID
 	if !ok {
 		pool = &poolPair{}
 		if m.ipv4Enabled {
-			pool.v4 = newCIDRPool(m.logger, false)
+			pool.v4 = newCIDRPool(m.logger, m.allowFirstLastIPs)
 		}
 		if m.ipv6Enabled {
-			pool.v6 = newCIDRPool(m.logger, false)
+			pool.v6 = newCIDRPool(m.logger, m.allowFirstLastIPs)
 		}
 	}
 

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -283,6 +283,9 @@ func (p *cidrPool) updatePool(prefixes []netip.Prefix) {
 		if _, ok := existingAllocators[prefix]; ok {
 			continue
 		}
+		if _, ok := p.released[prefix]; ok {
+			continue
+		}
 		ipAllocator := ipallocator.NewCIDRRange(prefix, rangeOpts...)
 		if ipAllocator.Free() == 0 {
 			p.logger.Error(


### PR DESCRIPTION
Replace the CRD allocator with the multi-pool allocator for ENI IPAM mode on the agent side. Previous PR #45124 ensures the operator already supports this new agent setup.

The new `eniMultiPoolAllocator` is a light wrapper on the standard `multiPoolAllocator` that enriches `AllocationResult` with ENI-specific required metadata via `buildENIAllocationResult` (see #45089).

Key differences from the standard multi-pool allocator:
* `AllowFirstLastIPs` is enabled so /28 prefix delegation ranges are fully allocatable (see #45025 and #45082).
* `LinearPreAlloc` uses a simple `inUse + preAlloc` formula for demand computation instead of `neededIPCeil` rounding. This matches the CRD allocator's `calculateNeededIPs` semantics and is necessary to ensure the operator can recover the exact IP usage from the demand signal (`requested - preAllocate`) (see #45124).
* No dependency on `CiliumPodIPPool` CRDs, pools are instead populated by the agent from `Status.ENI.ENIs` which is maintained by the operator.

The agents now read CIDRs from `Status.ENI.ENIs`, allocate IPs locally, and write aggregate demand to `Spec.IPAM.Pools.Requested`. They no longer writes per-IP usage to `Status.IPAM.Used`, achieving a reduction of kubernetes API pressure.

Relates to cilium/design-cfps#87

```release-note
ipam: Switch ENI IPAM from CRD to multi-pool allocator
```

## Testing

There's a matrix of scenarios depending on the relative versions of the agents and the operator:
|       | Operator 1.19 | Operator 1.20 |
|-------|-------|-------|
| Agent 1.19 | Case A | Case C |
| Agent 1.20 | Case B | Case D |

### Case A

This case is both agent and operator on 1.19, we didn't touch anything there, nothing to say.

### Case B

This case has agents updated to 1.20 before the operator. This case is not expected to be supported. The operator should be updated to 1.20 before the agents. Updating both together with a single helm upgrade is fine as the new operator deployment should be ready before most 1.20 agents become ready themselves.
In this situation, a 1.20 agent will be able to start with the new ENI multi-pool allocator as all it needs from the operator is `Status.ENI.ENIs` which the 1.19 operator already maintains. The only issue is that the agents won't be able to request more IPs as the 1.19 operator doesn't know where to look for the new demand signal.

### Case C

This case has 1.19 agents with a 1.20 operator, since the operator still maintains and updates `spec.ipam.pool` (see #45110) which is the only field 1.19 agents read, they continue to work with the CRD allocator without any issue, expressing their demand via `status.ipam.used`, which the operator still watches (see #45124).

### Case D

This is the case where both agents and operator are running with the new 1.20 logic: the operator maintains `Status.ENI.ENIs`, agents watch that and construct `spec.ipam.pools.allocated` from it, using the new ENI multipool allocator, they express their needs through `spec.ipam.pools.requested` and zero out `status.ipam.used` to clearly indicate to the operator that they're using multipool.

Here's what a ciliumnode looks like in this case:

<details> 

<summary>kubectl get ciliumnode $node -ojson | jq '.spec.ipam'</summary>

```json
{
  "min-allocate": 3,
  "pool": {
    "100.120.116.112": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.113": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.114": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.115": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.116": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.117": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.118": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.119": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.120": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.121": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.122": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.123": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.124": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.125": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.126": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.116.127": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.176": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.177": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.178": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.179": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.180": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.181": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.182": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.183": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.184": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.185": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.186": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.187": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.188": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.189": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.190": {
      "resource": "eni-024ee4a1e521cda8c"
    },
    "100.120.26.191": {
      "resource": "eni-024ee4a1e521cda8c"
    }
  },
  "pools": {
    "allocated": [
      {
        "cidrs": [
          "100.120.116.112/28",
          "100.120.26.176/28"
        ],
        "pool": "default"
      }
    ],
    "requested": [
      {
        "needed": {
          "ipv4-addrs": 20
        },
        "pool": "default"
      }
    ]
  },
  "pre-allocate": 1
}
```

</details>

<details> 

<summary>kubectl get ciliumnode $node -ojson | jq '.status.eni.enis["eni-024ee4a1e521cda8c"]'</summary>

```json
{
  "addresses": [
    "100.120.26.176",
    "100.120.26.177",
    "100.120.26.178",
    "100.120.26.179",
    "100.120.26.180",
    "100.120.26.181",
    "100.120.26.182",
    "100.120.26.183",
    "100.120.26.184",
    "100.120.26.185",
    "100.120.26.186",
    "100.120.26.187",
    "100.120.26.188",
    "100.120.26.189",
    "100.120.26.190",
    "100.120.26.191",
    "100.120.116.112",
    "100.120.116.113",
    "100.120.116.114",
    "100.120.116.115",
    "100.120.116.116",
    "100.120.116.117",
    "100.120.116.118",
    "100.120.116.119",
    "100.120.116.120",
    "100.120.116.121",
    "100.120.116.122",
    "100.120.116.123",
    "100.120.116.124",
    "100.120.116.125",
    "100.120.116.126",
    "100.120.116.127"
  ],
  "description": "Cilium-CNI (i-XXXX)",
  "id": "eni-024ee4a1e521cda8c",
  "ip": "100.120.117.66",
  "mac": "0e:d5:7d:00:64:d5",
  "number": 1,
  "prefixes": [
    "100.120.26.176/28",
    "100.120.116.112/28"
  ],
  "security-groups": [
    "sg-XXXX",
    "sg-YYYY"
  ],
  "subnet": {
    "cidr": "100.120.0.0/17",
    "id": "subnet-XXXX"
  },
  "tags": {
    "io.cilium/cilium-managed": "true",
    "io.cilium/cluster-name": "redacted"
  },
  "vpc": {
    "cidrs": [
      "100.120.0.0/16"
    ],
    "id": "vpc-XXXX",
    "primary-cidr": "10.0.0.0/19"
  }
}
```

</details>

<details> 

<summary>kubectl get ciliumnode $node -ojson | jq '.status.ipam'</summary>

```json
{
  "operator-status": {}
}
```

 </details>