### PR TITLE
mtu: account for DSR Geneve overhead in route MTU calculation

### DIFF
--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -18,6 +18,7 @@ import (
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -59,6 +60,8 @@ type mtuParams struct {
 	DaemonConfig    *option.DaemonConfig
 	LocalCiliumNode k8s.LocalCiliumNodeResource
 	WgConfig        wgTypes.Config
+
+	LBConfig     loadbalancer.Config
 
 	Config Config
 }
@@ -133,12 +136,17 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 		OnStart: func(ctx cell.HookContext) error {
 			tunnelOverIPv6 := option.Config.RoutingMode == option.RoutingModeTunnel &&
 				p.TunnelConfig.UnderlayProtocol() == tunnel.IPv6
+			dsrOverhead := 0
+			if p.LBConfig.LoadBalancerUsesDSR() && p.LBConfig.DSRDispatch == loadbalancer.DSRDispatchGeneve {
+				dsrOverhead = DsrTunnelOverhead
+			}
 			*c = NewConfiguration(
 				p.IPsec.AuthKeySize(),
 				p.IPsec.Enabled(),
 				p.TunnelConfig.ShouldAdaptMTU(),
 				p.WgConfig.Enabled(),
 				tunnelOverIPv6,
+				dsrOverhead,
 			)
 
 			configuredMTU := cc.MTU

--- a/pkg/mtu/manager.go
+++ b/pkg/mtu/manager.go
@@ -70,7 +70,10 @@ func (m *MTUManager) Updater(ctx context.Context, health cell.Health) error {
 
 		// Update the IPv4 default route MTU if it has changed
 		existing, _, found := m.MTUTable.Get(txn, MTURouteIndex.Query(DefaultPrefixV4))
-		if !found || existing.DeviceMTU != routeMTU.DeviceMTU {
+		if !found ||
+			existing.DeviceMTU != routeMTU.DeviceMTU ||
+			existing.RouteMTU != routeMTU.RouteMTU ||
+			existing.RoutePostEncryptMTU != routeMTU.RoutePostEncryptMTU {
 			routeMTU.Prefix = DefaultPrefixV4
 			_, _, err := m.MTUTable.Insert(txn, routeMTU)
 			if err != nil {
@@ -82,7 +85,10 @@ func (m *MTUManager) Updater(ctx context.Context, health cell.Health) error {
 
 		// Update the IPv6 default route MTU if it has changed
 		existing, _, found = m.MTUTable.Get(txn, MTURouteIndex.Query(DefaultPrefixV6))
-		if !found || existing.DeviceMTU != routeMTU.DeviceMTU {
+		if !found ||
+			existing.DeviceMTU != routeMTU.DeviceMTU ||
+			existing.RouteMTU != routeMTU.RouteMTU ||
+			existing.RoutePostEncryptMTU != routeMTU.RoutePostEncryptMTU {
 			routeMTU.Prefix = DefaultPrefixV6
 			_, _, err := m.MTUTable.Insert(txn, routeMTU)
 			if err != nil {

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -84,11 +84,12 @@ type Configuration struct {
 	encryptEnabled   bool
 	wireguardEnabled bool
 	tunnelOverhead   int
+	dsrOverhead      int
 }
 
 // NewConfiguration returns a new MTU configuration which is used to calculate
 // MTU values from a base MTU based on the config.
-func NewConfiguration(authKeySize int, encryptEnabled, encapEnabled, wireguardEnabled, tunnelOverIPv6 bool) Configuration {
+func NewConfiguration(authKeySize int, encryptEnabled, encapEnabled, wireguardEnabled, tunnelOverIPv6 bool, dsrOverhead int) Configuration {
 	tunnelOverhead := TunnelOverheadIPv4
 	if tunnelOverIPv6 {
 		tunnelOverhead = TunnelOverheadIPv6
@@ -99,6 +100,7 @@ func NewConfiguration(authKeySize int, encryptEnabled, encapEnabled, wireguardEn
 		encryptEnabled:   encryptEnabled,
 		wireguardEnabled: wireguardEnabled,
 		tunnelOverhead:   tunnelOverhead,
+		dsrOverhead:      dsrOverhead,
 	}
 }
 
@@ -119,13 +121,13 @@ func (c Configuration) Calculate(baseMTU int) RouteMTU {
 func (c *Configuration) getRouteMTU(baseMTU int) int {
 	if c.wireguardEnabled {
 		if c.encapEnabled {
-			return c.getDeviceMTU(baseMTU) - (WireguardOverhead + c.tunnelOverhead)
+			return c.getDeviceMTU(baseMTU) - (WireguardOverhead + c.tunnelOverhead) - c.dsrOverhead
 		}
-		return c.getDeviceMTU(baseMTU) - WireguardOverhead
+		return c.getDeviceMTU(baseMTU) - WireguardOverhead - c.dsrOverhead
 	}
 
 	if !c.encapEnabled && !c.encryptEnabled {
-		return c.getDeviceMTU(baseMTU)
+		return c.getDeviceMTU(baseMTU) - c.dsrOverhead
 	}
 
 	encryptOverhead := 0
@@ -139,20 +141,20 @@ func (c *Configuration) getRouteMTU(baseMTU int) int {
 	if c.encryptEnabled && !c.encapEnabled {
 		preEncryptMTU := baseMTU - encryptOverhead
 		if preEncryptMTU == 0 {
-			return EthernetMTU - EncryptionIPsecOverhead
+			return EthernetMTU - EncryptionIPsecOverhead - c.dsrOverhead
 		}
-		return preEncryptMTU
+		return preEncryptMTU - c.dsrOverhead
 	}
 
 	tunnelMTU := baseMTU - (c.tunnelOverhead + encryptOverhead)
 	if tunnelMTU <= 0 {
 		if c.encryptEnabled {
-			return EthernetMTU - (c.tunnelOverhead + EncryptionIPsecOverhead)
+			return EthernetMTU - (c.tunnelOverhead + EncryptionIPsecOverhead) - c.dsrOverhead
 		}
-		return EthernetMTU - c.tunnelOverhead
+		return EthernetMTU - c.tunnelOverhead - c.dsrOverhead
 	}
 
-	return tunnelMTU
+	return tunnelMTU - c.dsrOverhead
 }
 
 // getDeviceMTU returns the MTU to be used on workload facing devices.

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -11,62 +11,111 @@ import (
 
 func TestNewConfiguration(t *testing.T) {
 	// Add routes with no encryption or tunnel
-	conf := NewConfiguration(0, false, false, false, false)
+	conf := NewConfiguration(0, false, false, false, false, 0)
 	require.NotEqual(t, 0, conf.getDeviceMTU(0))
 	require.Equal(t, conf.getDeviceMTU(0), conf.getRouteMTU(0))
 
 	// Add routes with no encryption or tunnel and set MTU
-	conf = NewConfiguration(0, false, false, false, false)
+	conf = NewConfiguration(0, false, false, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400), conf.getRouteMTU(1400))
 
 	// Add routes with tunnel
-	conf = NewConfiguration(0, false, true, false, false)
+	conf = NewConfiguration(0, false, true, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv4, conf.getRouteMTU(1400))
 
 	// Add routes with tunnel over IPv6
-	conf = NewConfiguration(0, false, true, false, true)
+	conf = NewConfiguration(0, false, true, false, true, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv6, conf.getRouteMTU(1400))
 
 	// Add routes with tunnel and set MTU
-	conf = NewConfiguration(0, false, true, false, false)
+	conf = NewConfiguration(0, false, true, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-TunnelOverheadIPv4, conf.getRouteMTU(1400))
 
 	// Add routes with encryption and set MTU using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, false, false, false)
+	conf = NewConfiguration(16, true, false, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-EncryptionIPsecOverhead, conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, false, false, false)
+	conf = NewConfiguration(32, true, false, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(12, true, false, false, false)
+	conf = NewConfiguration(12, true, false, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead-4), conf.getRouteMTU(1400))
 
 	// Add routes with encryption and tunnels using standard 128bit, larger 256bit and smaller 96bit ICVlen keys
-	conf = NewConfiguration(16, true, true, false, false)
+	conf = NewConfiguration(16, true, true, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, true, false, false)
+	conf = NewConfiguration(32, true, true, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, true, true, false, false)
+	conf = NewConfiguration(32, true, true, false, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+EncryptionIPsecOverhead+16), conf.getRouteMTU(1400))
 
 	// Add routes with WireGuard enabled
-	conf = NewConfiguration(32, false, false, true, false)
+	conf = NewConfiguration(32, false, false, true, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-WireguardOverhead, conf.getRouteMTU(1400))
 
-	conf = NewConfiguration(32, false, true, true, false)
+	conf = NewConfiguration(32, false, true, true, false, 0)
 	require.Equal(t, 1400, conf.getDeviceMTU(1400))
 	require.Equal(t, conf.getDeviceMTU(1400)-(WireguardOverhead+TunnelOverheadIPv4), conf.getRouteMTU(1400))
+
+	// Add routes with DSR Geneve overhead
+	conf = NewConfiguration(0, false, false, false, false, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-DsrTunnelOverhead, conf.getRouteMTU(1400))
+
+	// Add routes with tunnel + DSR Geneve overhead
+	conf = NewConfiguration(0, false, true, false, false, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-(TunnelOverheadIPv4+DsrTunnelOverhead), conf.getRouteMTU(1400))
+
+	// Add routes with encryption + DSR Geneve overhead
+	conf = NewConfiguration(16, true, false, false, false, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, conf.getDeviceMTU(1400)-(EncryptionIPsecOverhead+DsrTunnelOverhead), conf.getRouteMTU(1400))
+
+	// No DSR overhead (default)
+	conf = NewConfiguration(0, false, false, false, false, 0)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, conf.getRouteMTU(1400), 1400)
+}
+
+func TestDSROverheadCombinations(t *testing.T) {
+	// WireGuard + DSR Geneve
+	conf := NewConfiguration(0, false, false, true, false, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, 1400-(WireguardOverhead+DsrTunnelOverhead), conf.getRouteMTU(1400))
+
+	// WireGuard + tunnel + DSR Geneve
+	conf = NewConfiguration(0, false, true, true, false, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, 1400-(WireguardOverhead+TunnelOverheadIPv4+DsrTunnelOverhead), conf.getRouteMTU(1400))
+
+	// Tunnel + encryption + DSR Geneve
+	conf = NewConfiguration(16, true, true, false, false, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, 1400-(TunnelOverheadIPv4+EncryptionIPsecOverhead+DsrTunnelOverhead), conf.getRouteMTU(1400))
+
+	// Tunnel IPv6 + DSR Geneve
+	conf = NewConfiguration(0, false, true, false, true, DsrTunnelOverhead)
+	require.Equal(t, 1400, conf.getDeviceMTU(1400))
+	require.Equal(t, 1400-(TunnelOverheadIPv6+DsrTunnelOverhead), conf.getRouteMTU(1400))
+
+	// DSR overhead with low baseMTU (boundary: overhead exceeds base)
+	conf = NewConfiguration(0, false, true, false, false, DsrTunnelOverhead)
+	routeMTU := conf.getRouteMTU(50)
+	// TunnelOverheadIPv4(50) + DsrTunnelOverhead(12) = 62 > 50, so tunnelMTU <= 0 fallback fires
+	// Result: EthernetMTU(1500) - TunnelOverheadIPv4(50) - DsrTunnelOverhead(12) = 1438
+	require.Equal(t, EthernetMTU-TunnelOverheadIPv4-DsrTunnelOverhead, routeMTU)
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Commit 0addb32 ("Remove deprecated high-scale ipcache code") removed the
DsrTunnelOverhead subtraction from the MTU calculation along with the
hsIpcacheDSRenabled flag. The DSR Geneve option still adds 12 bytes per
packet, but the route MTU no longer accounts for it.

This adds dsrOverhead to Configuration and subtracts it from every
getRouteMTU return path. DSR dispatch mode is plumbed from
loadbalancer.Config into the MTU cell — the overhead is applied when DSR
or hybrid mode is active with Geneve dispatch.

The original code only applied DSR overhead to the tunnel path. This fix
applies it to all paths (direct, encrypt, wireguard) since the Geneve
option is inserted regardless of encapsulation mode.

Also broadens the MTU table update trigger in manager.go to compare
RouteMTU and RoutePostEncryptMTU, not just DeviceMTU — without this,
DSR-induced MTU changes would not propagate to routes.

Notes for reviewers:
* NewConfiguration() gains a dsrOverhead parameter. No external consumers
  found in the Go module index; effectively an internal API.
* LoadBalancerUsesDSR() returns true for hybrid mode, so hybrid gets the
  overhead. This is conservative (penalizes UDP SNAT path by 12B) but
  correct for TCP DSR safety. Happy to scope to pure DSR only if preferred.

Fixes: #45076

```release-note
Fixed DSR Geneve MTU calculation regression introduced in v1.18 where
DsrTunnelOverhead (12B) was no longer subtracted from route MTU, causing
packets to exceed underlay MTU when DSR with Geneve dispatch is enabled.
```