### PR TITLE
clustermesh: fix missing remote backends when multiple service ports share the same target port

### DIFF
--- a/pkg/clustermesh/service_merger.go
+++ b/pkg/clustermesh/service_merger.go
@@ -5,6 +5,7 @@ package clustermesh
 
 import (
 	"context"
+	"slices"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -98,27 +99,44 @@ func ClusterServiceToBackendParams(service *serviceStore.ClusterService) (beps [
 			backendZone = ptr.To(zone.ToLBBackendZone())
 		}
 
+		currentIdx := len(beps)
 		for name, l4 := range portConfig {
-			portNames := []string(nil)
+			currentBeps := beps[currentIdx:]
+			// Cilium loadbalancer needs to encode a Service with multiple port names
+			// for the same target port with a single loadbalancer.Backend with multiple
+			// port names. The clustermesh service data on the other end contains all the
+			// ports as distinct entries so we need to de-duplicate those.
+			idx := slices.IndexFunc(currentBeps, func(b loadbalancer.Backend) bool {
+				return b.Address.Protocol() == l4.Protocol && b.Address.Port() == l4.Port
+			})
+			// No existing backend for this L4 address, create a new one.
+			if idx == -1 {
+				beps = append(beps, loadbalancer.Backend{
+					Address: loadbalancer.NewL3n4Addr(
+						l4.Protocol,
+						addrCluster,
+						l4.Port,
+						loadbalancer.ScopeExternal,
+					),
+					Weight:    loadbalancer.DefaultBackendWeight,
+					NodeName:  "",
+					ClusterID: service.ClusterID,
+					State:     loadbalancer.BackendStateActive,
+					Zone:      backendZone,
+				})
+				idx = len(currentBeps)
+			}
 			if name != "" {
-				portNames = []string{name}
+				beps[currentIdx+idx].PortNames = append(beps[currentIdx+idx].PortNames, name)
 			}
-			bep := loadbalancer.Backend{
-				Address: loadbalancer.NewL3n4Addr(
-					l4.Protocol,
-					addrCluster,
-					l4.Port,
-					loadbalancer.ScopeExternal,
-				),
-				PortNames: portNames,
-				Weight:    loadbalancer.DefaultBackendWeight,
-				NodeName:  "",
-				ClusterID: service.ClusterID,
-				State:     loadbalancer.BackendStateActive,
-				Zone:      backendZone,
-			}
-			beps = append(beps, bep)
 		}
 	}
+
+	// Sort port names to ensure a stable order since map iteration is
+	// non-deterministic, which is required for DeepEqual comparisons.
+	for _, bep := range beps {
+		slices.Sort(bep.PortNames)
+	}
+
 	return
 }

--- a/pkg/clustermesh/testdata/clusterservice-multiport.txtar
+++ b/pkg/clustermesh/testdata/clusterservice-multiport.txtar
@@ -1,0 +1,124 @@
+#! --cluster-id=1 --cluster-name=cluster1
+
+hive/start
+
+# Create a service to which to add the external backends with multiple ports.
+k8s/add service.yaml
+
+# Add a remote cluster service with multiple backend IPs and ports.
+# Some ports are the same and should be added to a single backend entry
+# containing all the associated port names.
+kvstore/update cilium/state/services/v1/cluster2/test/echo clusterservice2.json
+db/cmp backends backends.table
+db/cmp frontends frontends-with-clusterservice.table
+
+# Remove the cluster service
+kvstore/delete cilium/state/services/v1/cluster2/test/echo
+
+# Frontends should no longer have backends, and backends should be empty
+db/cmp frontends frontends-without-clusterservice.table
+db/empty backends
+
+###
+
+-- backends.table --
+Address              PortNames                           NodeName
+20.0.0.2:80/TCP      http-alt,http-direct,http-remapped
+20.0.0.2:443/TCP     https
+20.0.0.3:80/TCP      http-alt,http-direct,http-remapped
+20.0.0.3:443/TCP     https
+
+-- frontends-with-clusterservice.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:80/TCP    ClusterIP  test/echo     Done    20.0.0.2:80/TCP, 20.0.0.3:80/TCP
+10.0.0.1:443/TCP   ClusterIP  test/echo     Done    20.0.0.2:443/TCP, 20.0.0.3:443/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:80/TCP, 20.0.0.3:80/TCP
+10.0.0.1:9090/TCP  ClusterIP  test/echo     Done    20.0.0.2:80/TCP, 20.0.0.3:80/TCP
+
+-- frontends-without-clusterservice.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:80/TCP    ClusterIP  test/echo     Done
+10.0.0.1:443/TCP   ClusterIP  test/echo     Done
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done
+10.0.0.1:9090/TCP  ClusterIP  test/echo     Done
+
+-- clusterservice2.json --
+{
+  "name": "echo",
+  "namespace": "test",
+  "includeExternal": true,
+  "shared": true,
+  "cluster": "cluster2",
+  "clusterID": 2,
+  "backends": {
+    "20.0.0.2": {
+      "http-alt": {
+        "Protocol": "TCP",
+        "Port": 80
+      },
+      "http-direct": {
+        "Protocol": "TCP",
+        "Port": 80
+      },
+      "http-remapped": {
+        "Protocol": "TCP",
+        "Port": 80
+      },
+      "https": {
+        "Protocol": "TCP",
+        "Port": 443
+      }
+    },
+    "20.0.0.3": {
+      "http-alt": {
+        "Protocol": "TCP",
+        "Port": 80
+      },
+      "http-direct": {
+        "Protocol": "TCP",
+        "Port": 80
+      },
+      "http-remapped": {
+        "Protocol": "TCP",
+        "Port": 80
+      },
+      "https": {
+        "Protocol": "TCP",
+        "Port": 443
+      }
+    }
+  }
+}
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.cilium.io/global: "true"
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.0.0.1
+  clusterIPs:
+  - 10.0.0.1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: http-direct
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: http-remapped
+    port: 8080
+    protocol: TCP
+    targetPort: 80
+  - name: http-alt
+    port: 9090
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  type: ClusterIP


### PR DESCRIPTION
Using Cluster Mesh, when a Kubernetes Service exposes multiple ports that resolve to the same container target port (e.g., service ports 80, 8080, and 9090 all mapping to target port 80), the `ClusterServiceToBackendParams` function previously created separate `loadbalancer.Backend` instances for each port name. However, since these backends share the same `L3n4Addr`, and `updateBackends` uses `BackendKey{ServiceName, Address, SourcePriority}` as a unique key, subsequent insertions overwrote earlier ones. As a result, only the last port name was retained, and the remaining service ports lost their remote backends in the eBPF maps.
This patch modifies `ClusterServiceToBackendParams` to group port configurations by protocol and port number during iteration, ensuring that a single `Backend` is emitted per unique L4 address with all associated port names correctly aggregated. Unit tests covering the affected scenarios have been added.

Fixes: #45109

```release-note
Fix missing global service backends in Cluster Mesh when multiple service ports point to the same target port.
```
