### PR TITLE
monitor, proxy: convert net.IP to netip.Addr

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"syscall"
 
@@ -96,8 +95,7 @@ func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled
 			if !hostDeviceFound {
 				return fmt.Errorf("failed to get host device %s", defaults.HostDevice)
 			}
-			netIP, _ := netipx.FromStdIP(ipv6)
-			if err := installFromProxyRoutesIPv6(p.routeOwner, p.routeManager, netIP, hostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
+			if err := installFromProxyRoutesIPv6(p.routeOwner, p.routeManager, ipv6, hostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
 			}
 		} else {
@@ -147,18 +145,20 @@ func requireFromProxyRoutes(ipsecEnabled, wireguardEnabled bool, mtuIn int) (fro
 }
 
 // getCiliumNetIPv6 retrieves the first IPv6 address from the cilium_net device.
-func getCiliumNetIPv6() (net.IP, error) {
+func getCiliumNetIPv6() (netip.Addr, error) {
 	link, err := safenetlink.LinkByName(defaults.SecondHostDevice)
 	if err != nil {
-		return nil, fmt.Errorf("cannot find link '%s': %w", defaults.SecondHostDevice, err)
+		return netip.Addr{}, fmt.Errorf("cannot find link '%s': %w", defaults.SecondHostDevice, err)
 	}
 
 	addrList, err := safenetlink.AddrList(link, netlink.FAMILY_V6)
 	if err == nil && len(addrList) > 0 {
-		return addrList[0].IP, nil
+		if addr, ok := netip.AddrFromSlice(addrList[0].IP); ok {
+			return addr.Unmap(), nil
+		}
 	}
 
-	return nil, fmt.Errorf("failed to find valid IPv6 address for cilium_net")
+	return netip.Addr{}, fmt.Errorf("failed to find valid IPv6 address for cilium_net")
 }
 
 // installToProxyRoutesIPv4 configures routes and rules needed to redirect ingress


### PR DESCRIPTION
Migrate remaining net.IP usages to netip.Addr in two packages:

- pkg/monitor/datapath_debug.go: Convert ip4Str() helper from make(net.IP, 4) + binary.NativeEndian.PutUint32 to netip.AddrFrom4 with a [4]byte buffer. This eliminates the heap allocation from make() and removes the last net.IP usage in the file, allowing the "net" import to be dropped entirely.

- pkg/proxy/routes.go: Convert getCiliumNetIPv6() return type from net.IP to netip.Addr, using netip.AddrFromSlice to convert the netlink Addr.IP at the source. This eliminates the netipx.FromStdIP conversion at the call site in ReinstallRoutingRules and removes the "net" import from the file.

Related: #24246

