### PR TITLE
bpf: Fix include ordering so HAVE_SET_RETVAL is defined before use

### DIFF
--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -6,8 +6,8 @@
 #include <linux/bpf.h>
 
 #include "compiler.h"
-#include "helpers.h"
 #include "features_skb.h"
+#include "helpers.h"
 
 /* Only used helpers in Cilium go below. */
 

--- a/bpf/include/bpf/helpers_xdp.h
+++ b/bpf/include/bpf/helpers_xdp.h
@@ -6,8 +6,8 @@
 #include <linux/bpf.h>
 
 #include "compiler.h"
-#include "helpers.h"
 #include "features_xdp.h"
+#include "helpers.h"
 
 /* Only used helpers in Cilium go below. */
 


### PR DESCRIPTION
Include features_{skb,xdp}.h before helpers.h in helpers_{skb,xdp}.h.

Previously, helpers.h was included first, causing `try_set_retval()` to compile as a no-op when helpers_skb.h was the entry point into include chain, since HAVE_SET_RETVAL was not yet defined.
This resulted in the kernel returning EPERM (the default for SYS_REJECT) instead of EHOSTUNREACH when a Service had no backends.

Fixes: #45184

```release-note
Fixed SocketLB returning EPERM instead of EHOSTUNREACH when a Service has no backends.
```
