### PR TITLE
bpf: encrypt: extract shared helper for source encryption policy

### DIFF
--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -62,3 +62,33 @@ strict_allow(struct __ctx_buff *ctx, __be16 proto) {
 	}
 }
 #endif /* ENCRYPTION_STRICT_MODE_EGRESS */
+
+/* checks whether the source endpoint matches the encryption policy */
+static __always_inline bool
+encrypt_src_matches_policy(__u32 src_sec_identity) {
+#ifndef ENABLE_NODE_ENCRYPTION
+	/* Unless node encryption is enabled, we don't want to encrypt
+	 * traffic from the hostns.
+	 *
+	 * NB: if iptables has SNAT-ed the packet, its sec id is HOST_ID.
+	 * This means that the packet won't be encrypted. This is fine,
+	 * as with --encrypt-node=false we encrypt only pod-to-pod packets.
+	 */
+	if (src_sec_identity == HOST_ID)
+		return false;
+#endif /* !ENABLE_NODE_ENCRYPTION */
+
+	/* We don't want to encrypt any traffic that originates from outside
+	 * the cluster. This check excludes DSR traffic from the LB node to a remote backend.
+	 */
+	if (!identity_is_cluster(src_sec_identity))
+		return false;
+
+	/* If source is remote node we should treat it like outside traffic.
+	 * This is possible when connection is done from pod to load balancer with DSR enabled.
+	 */
+	if (identity_is_remote_node(src_sec_identity))
+		return false;
+
+	return true;
+}

--- a/bpf/lib/ipsec.h
+++ b/bpf/lib/ipsec.h
@@ -174,19 +174,6 @@ do_decrypt(struct __ctx_buff *ctx, __be16 proto)
 	return ctx_redirect(ctx, CONFIG(cilium_host_ifindex), 0);
 }
 
-/* checks whether a IPsec redirect should be performed for the source
- */
-static __always_inline int
-ipsec_redirect_sec_id_ok(__u32 src_sec_id) {
-	if (src_sec_id == HOST_ID)
-		return 0;
-	if (!identity_is_cluster(src_sec_id))
-		return 0;
-	if (identity_is_remote_node(src_sec_id))
-		return 0;
-	return 1;
-}
-
 static __always_inline int
 ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 				__u32 src_sec_identity)
@@ -281,7 +268,7 @@ ipsec_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	if (!dst || !dst->flag_has_tunnel_ep || !dst->key)
 		return CTX_ACT_OK;
 
-	if (!ipsec_redirect_sec_id_ok(src_sec_identity))
+	if (!encrypt_src_matches_policy(src_sec_identity))
 		return CTX_ACT_OK;
 
 #  if defined(TUNNEL_MODE)

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -7,6 +7,7 @@
 #include <bpf/api.h>
 
 #include "common.h"
+#include "encrypt.h"
 #include "overloadable.h"
 #include "identity.h"
 
@@ -147,28 +148,9 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto,
 	if (magic == MARK_MAGIC_PROXY_INGRESS ||
 	    magic == MARK_MAGIC_SKIP_TPROXY)
 		goto maybe_encrypt;
-
-	/* Unless node encryption is enabled, we don't want to encrypt
-	 * traffic from the hostns (an exception - L7 proxy traffic).
-	 *
-	 * NB: if iptables has SNAT-ed the packet, its sec id is HOST_ID.
-	 * This means that the packet won't be encrypted. This is fine,
-	 * as with --encrypt-node=false we encrypt only pod-to-pod packets.
-	 */
-	if (src_sec_identity == HOST_ID)
-		goto out;
 #endif /* !ENABLE_NODE_ENCRYPTION */
 
-	/* We don't want to encrypt any traffic that originates from outside
-	 * the cluster. This check excludes DSR traffic from the LB node to a remote backend.
-	 */
-	if (!identity_is_cluster(src_sec_identity))
-		goto out;
-
-	/* If source is remote node we should treat it like outside traffic.
-	 * This is possible when connection is done from pod to load balancer with DSR enabled.
-	 */
-	if (identity_is_remote_node(src_sec_identity))
+	if (!encrypt_src_matches_policy(src_sec_identity))
 		goto out;
 
 maybe_encrypt: __maybe_unused


### PR DESCRIPTION
Both IPsec and Wireguard apply the same checks for the source endpoint's endpoint, to determine whether the packet should be encrypted.

Turn this into a shared helper.