### PR TITLE
Add 'dont-merge/needs-ci-validation' to PRs with workflow changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,30 +1,30 @@
 # Add 'cilium-cli' label to any file changes in 'cilium-cli/'
 cilium-cli:
-- changed-files:
-  - any-glob-to-any-file:
-    - cilium-cli/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - cilium-cli/**
 # Add 'cilium-cli-exclusive' label if the changed files are only in 'cilium-cli'
 cilium-cli-exclusive:
-- changed-files:
-  - all-globs-to-all-files:
-    - cilium-cli/**
+  - changed-files:
+      - all-globs-to-all-files:
+          - cilium-cli/**
 # Add 'hubble-cli' label to any file changes in 'hubble/'
 hubble-cli:
-- changed-files:
-  - any-glob-to-any-file:
-    - hubble/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - hubble/**
 # Add 'hubble-cli-exclusive' label if the changed files are only in 'hubble'
 hubble-cli-exclusive:
-- changed-files:
-  - all-globs-to-all-files:
-    - hubble/**
+  - changed-files:
+      - all-globs-to-all-files:
+          - hubble/**
 sig/policy:
-- changed-files:
-  - any-glob-to-any-file:
-    - daemon/cmd/policy*
-    - daemon/cmd/fqdn*
-    - pkg/fqdn/**
-    - pkg/policy/**
-    - pkg/identity/**
-    - pkg/proxy/dns.go
-    - test/**/net_policies.go
+  - changed-files:
+      - any-glob-to-any-file:
+          - daemon/cmd/policy*
+          - daemon/cmd/fqdn*
+          - pkg/fqdn/**
+          - pkg/policy/**
+          - pkg/identity/**
+          - pkg/proxy/dns.go
+          - test/**/net_policies.go

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,3 +28,26 @@ sig/policy:
           - pkg/identity/**
           - pkg/proxy/dns.go
           - test/**/net_policies.go
+# Workflows triggered on 'pull_request' are highly likely to be run as part of
+# the Pull Request submission process, so we do not impose additional checks
+# for changes to those files. However, changes to any other GitHub workflow may
+# not be validated by the CI. So, we set the 'dont-merge/needs-ci-validation'
+# label to assist contributors and reviewers to know when they should apply
+# additional scrutiny to changes to the workflows.
+dont-merge/needs-ci-validation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**/*'
+          - '**/Makefile*'
+          - 'images/**/*sh'
+      - all-globs-to-all-files:
+          - '!.github/workflows/auto-approve.yaml'
+          - '!.github/workflows/cilium-cli.yaml'
+          - '!.github/workflows/codeql.yaml'
+          - '!.github/workflows/conformance-kind-proxy-embedded.yaml'
+          - '!.github/workflows/conformance-kubespray.yaml'
+          - '!.github/workflows/k8s-kind-network-policies-e2e.yaml'
+          - '!.github/workflows/lint-codeowners.yaml'
+          - '!.github/workflows/lint-images-base.yaml'
+          - '!.github/workflows/renovate-config-validator.yaml'
+          - '!.github/workflows/tests-cifuzz.yaml'

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -192,7 +192,7 @@ jobs:
           done
 
   name-validation:
-    name: Validate Workflow Names
+    name: Validate Workflow and Labeler Format
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -278,6 +278,12 @@ jobs:
             fi
           done
           exit ${EXIT}
+
+      - name: Validate GitHub labeler configuration
+        shell: bash
+        run: |
+          cd src/github.com/cilium/cilium
+          contrib/scripts/update-ci-labeler.sh
 
   actionlint:
     name: actionlint

--- a/contrib/scripts/update-ci-labeler.sh
+++ b/contrib/scripts/update-ci-labeler.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../.."
+WORKFLOW_PATH=".github/workflows"
+LABELER_PATH=".github/labeler.yml"
+
+# renovate: datasource=docker
+YQ_IMAGE="docker.io/mikefarah/yq@sha256:495c1e1db2d653cce61a06da52cfca0c7d68d6249cc6e61b2a134d92c609c016" # 4.27.3
+YQ="docker run --rm -v ${SCRIPT_ROOT}:/workdir --user $(id -u):$(id -g) $YQ_IMAGE"
+
+function generate_ci_labeler() {
+    cat <<EOF
+dont-merge/needs-ci-validation:
+- changed-files:
+  - any-glob-to-any-file:
+      - '.github/**/*'
+      - '**/Makefile*'
+      - 'images/**/*sh'
+  - all-globs-to-all-files:
+EOF
+
+    grep -rl 'pull_request:$' "$WORKFLOW_PATH" \
+    | while read -r path; do
+        echo "    - '!$path'";
+    done | sort
+}
+
+function check_diff() {
+    local diff diff_staged
+    diff="$(git diff)"
+    diff_staged="$(git diff --staged)"
+
+    if [ -n "$diff" ] || [ -n "$diff_staged" ]; then
+        echo "Updated labeler configuration:"
+        echo "$diff"
+        echo "$diff_staged"
+        echo "Please run 'contrib/scripts/update-ci-labeler.sh' and submit your changes"
+        exit 1
+    fi
+}
+
+function main() {
+    local ci_labeler_yaml
+
+    cd "$SCRIPT_ROOT"
+    ci_labeler_yaml=$(mktemp "cilium-gh-labeler-XXXXXX.yaml")
+    trap "rm $ci_labeler_yaml" EXIT
+
+    generate_ci_labeler > "$ci_labeler_yaml"
+    $YQ eval-all '. as $item ireduce ({}; . * $item )' \
+        "$LABELER_PATH" \
+        "$ci_labeler_yaml" \
+    > "$LABELER_PATH.new"
+    mv "$LABELER_PATH.new" "$LABELER_PATH"
+
+    check_diff
+}
+
+main "$@"


### PR DESCRIPTION
The goal of this PR is to add the label `dont-merge/needs-ci-validation` to
any PR which modifies CI workflows whenever the CI doesn't run the changes
as part of the PR submission workflow. By highlighting such changes, it will
be easier for contributors and reviewers to apply additional scrutiny to those
changes during development. 

Broadly speaking this is done by applying the label automatically whenever a
PR is opened with content changes to `.github/`. Workflows triggered on 
`pull_request` are highly likely to be run as part of the Pull Request submission 
process, so we do not impose additional checks for changes to those files.
However, changes to any *other* GitHub workflow may not be validated by the CI,
so those files are targeted here.

This PR adds a script and hooks that script into the workflow linter to ensure
that the labeler is updated if any new `pull_request` workflows are added to
the tree. This is done as part of the linting of the workflows rather than as a
runtime check against the PR in order to avoid checking out untrusted code
in a `pull_request_target` workflow which is used to label the PRs.

The full submission process for affected PRs is expected to be:
1. Someone creates a PR with changes to a workflow that is not triggered
   on `pull_request`.
2. The `.github/workflows/auto-labeler.yaml` workflow runs on open of
   the PR, and uses the `.github/labeler.yml` configuration to apply
   labels, including the new label `dont-merge/needs-ci-validation`.
3. The contributor and/or reviewer observes this label and coordinates
   to ensure that the workflow is manually validated. One common method
   is for a reviewer to first review that the changes are safe and will
   not compromise the repository, then clone the PR into the cilium/cilium
   repository, modify the workflow triggers to add `pull_request`, and
   open the test PR. If the contributor is also a reviewer, then the
   contributor is responsible for this step.
4. If the test PR does not pass, the contributor iterates on the
   workflow to ensure that it does not break. Coordinate with the
   reviewer(s) as needed to validate the changes.
5. When the test PR workflow completes successfully, the contributor
   and/or reviewer should create a comment on the original PR, linking
   to the successful PR and workflow result.
6. Repeat steps 3-5 as needed after any modification of the PR.
7. Once the PR review is complete and tests are validated, the test PR
   can be closed and the reviewer(s) should remove the label
   `dont-merge/needs-ci-validation` from the PR. The PR can be merged by a
   committer.

Fixes: #43939