### PR TITLE
iptables: sort the routes by network mask size

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -203,10 +203,10 @@ For the advanced case where the routing layer would select different source
 addresses depending on the destination CIDR, the option
 ``enable-masquerade-to-route-source: "true"`` can be used in order to
 masquerade to the source addresses rather than to the primary interface
-address. The latter is then only considered as a catch-all fallback, and for
-the default routes. For these advanced cases the user needs to ensure that
-there are no overlapping destination CIDRs as routes on the relevant
-masquerading interfaces.
+address. In cases where there are overlapping destination CIDRs
+as routes, the generated iptables rules are sorted by the destination
+network mask in descending order to simulate the routing table's longest
+prefix match lookup.
 
 With the ``enable-masquerade-to-route-source: "true"`` option, Cilium will, by
 default, use interfaces listed in the ``devices`` field as the egress

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1515,8 +1515,6 @@ func (m *manager) installMasqueradeRules(
 	// If this option is enabled, then it takes precedence over the catch-all
 	// MASQUERADE further below.
 	if m.sharedCfg.EnableMasqueradeRouteSource {
-		var defaultRoutes []netlink.Route
-
 		if len(m.sharedCfg.MasqueradeInterfaces) > 0 {
 			devices = m.sharedCfg.MasqueradeInterfaces
 		}
@@ -1524,86 +1522,9 @@ func (m *manager) installMasqueradeRules(
 		if prog == m.ip6tables {
 			family = netlink.FAMILY_V6
 		}
-		initialPass := true
 		if routes, err := safenetlink.RouteList(nil, family); err == nil {
-		nextPass:
-			for _, r := range routes {
-				var link netlink.Link
-				match := false
-				if r.LinkIndex > 0 {
-					link, err = netlink.LinkByIndex(r.LinkIndex)
-					if err != nil {
-						continue
-					}
-					// Routes are dedicated to the specific interface, so we
-					// need to install the SNAT rules also for that interface
-					// via -o. If we cannot correlate to anything because no
-					// devices were specified, we need to bail out.
-					if len(devices) == 0 {
-						return fmt.Errorf("cannot correlate source route device for generating masquerading rules")
-					}
-					for _, device := range devices {
-						filter := tables.DeviceFilter{device}
-						m, reverse := filter.Match(link.Attrs().Name)
-						if m {
-							match = !reverse
-							break
-						}
-					}
-				} else {
-					// There might be next hop groups where ifindex is zero
-					// and the underlying next hop devices might not be known
-					// to Cilium. In this case, assume match and don't encode
-					// -o device.
-					match = true
-				}
-				_, exclusionCIDR, err := net.ParseCIDR(snatDstExclusionCIDR)
-				if !match || r.Src == nil || (err == nil && cidr.Equal(r.Dst, exclusionCIDR)) {
-					continue
-				}
-				if initialPass && cidr.Equal(r.Dst, cidr.ZeroNet(r.Family)) {
-					defaultRoutes = append(defaultRoutes, r)
-					continue
-				}
-				progArgs := []string{
-					"-t", "nat",
-					"-A", ciliumPostNatChain,
-					"-s", allocRange,
-				}
-				if cidr.Equal(r.Dst, cidr.ZeroNet(r.Family)) {
-					progArgs = append(
-						progArgs,
-						"!", "-d", snatDstExclusionCIDR)
-				} else {
-					progArgs = append(
-						progArgs,
-						"-d", r.Dst.String())
-				}
-				if link != nil {
-					progArgs = append(
-						progArgs,
-						"-o", link.Attrs().Name)
-				} else {
-					progArgs = append(
-						progArgs,
-						"!", "-o", "cilium_+")
-				}
-				progArgs = append(
-					progArgs,
-					"-m", "comment", "--comment", "cilium snat non-cluster via source route",
-					"-j", "SNAT",
-					"--to-source", r.Src.String())
-				if m.cfg.IPTablesRandomFully {
-					progArgs = append(progArgs, "--random-fully")
-				}
-				if err := prog.runProg(progArgs); err != nil {
-					return err
-				}
-			}
-			if initialPass {
-				initialPass = false
-				routes = defaultRoutes
-				goto nextPass
+			if err := m.installMasqueradeRouteSourceRules(prog, routes, netlink.LinkByIndex, devices, snatDstExclusionCIDR, allocRange); err != nil {
+				return err
 			}
 		}
 	} else {
@@ -1717,6 +1638,93 @@ func (m *manager) installMasqueradeRules(
 		}
 	}
 
+	return nil
+}
+
+func (m *manager) installMasqueradeRouteSourceRules(
+	prog runnable, routes []netlink.Route, linkByIndex func(int) (netlink.Link, error),
+	devices []string, snatDstExclusionCIDR, allocRange string,
+) error {
+	slices.SortFunc(routes, func(a, b netlink.Route) int {
+		aPfx, bPfx := 0, 0
+		if a.Dst != nil {
+			aPfx, _ = a.Dst.Mask.Size()
+		}
+		if b.Dst != nil {
+			bPfx, _ = b.Dst.Mask.Size()
+		}
+		return bPfx - aPfx
+	})
+	for _, r := range routes {
+		var link netlink.Link
+		match := false
+		if r.LinkIndex > 0 {
+			var err error
+			link, err = linkByIndex(r.LinkIndex)
+			if err != nil {
+				continue
+			}
+			// Routes are dedicated to the specific interface, so we
+			// need to install the SNAT rules also for that interface
+			// via -o. If we cannot correlate to anything because no
+			// devices were specified, we need to bail out.
+			if len(devices) == 0 {
+				return fmt.Errorf("cannot correlate source route device for generating masquerading rules")
+			}
+			for _, device := range devices {
+				filter := tables.DeviceFilter{device}
+				m, reverse := filter.Match(link.Attrs().Name)
+				if m {
+					match = !reverse
+					break
+				}
+			}
+		} else {
+			// There might be next hop groups where ifindex is zero
+			// and the underlying next hop devices might not be known
+			// to Cilium. In this case, assume match and don't encode
+			// -o device.
+			match = true
+		}
+		_, exclusionCIDR, err := net.ParseCIDR(snatDstExclusionCIDR)
+		if !match || r.Src == nil || (err == nil && cidr.Equal(r.Dst, exclusionCIDR)) {
+			continue
+		}
+		progArgs := []string{
+			"-t", "nat",
+			"-A", ciliumPostNatChain,
+			"-s", allocRange,
+		}
+		if cidr.Equal(r.Dst, cidr.ZeroNet(r.Family)) {
+			progArgs = append(
+				progArgs,
+				"!", "-d", snatDstExclusionCIDR)
+		} else {
+			progArgs = append(
+				progArgs,
+				"-d", r.Dst.String())
+		}
+		if link != nil {
+			progArgs = append(
+				progArgs,
+				"-o", link.Attrs().Name)
+		} else {
+			progArgs = append(
+				progArgs,
+				"!", "-o", "cilium_+")
+		}
+		progArgs = append(
+			progArgs,
+			"-m", "comment", "--comment", "cilium snat non-cluster via source route",
+			"-j", "SNAT",
+			"--to-source", r.Src.String())
+		if m.cfg.IPTablesRandomFully {
+			progArgs = append(progArgs, "--random-fully")
+		}
+		if err := prog.runProg(progArgs); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -5,11 +5,13 @@ package iptables
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
 )
 
 type expectation struct {
@@ -1230,4 +1232,37 @@ func TestAllEgressMasqueradeCmdsRandomFully(t *testing.T) {
 		assert.Contains(t, cmd, "--random-fully",
 			"Expected --random-fully when enabled with multiple interfaces")
 	}
+}
+
+func TestInstallMasqueradeRouteSourceRules(t *testing.T) {
+	routes := []netlink.Route{
+		{Dst: mustParseCIDR("0.0.0.0/0"), Src: net.ParseIP("198.18.4.4"), LinkIndex: 0, Family: 2},
+		{Dst: mustParseCIDR("10.0.0.0/16"), Src: net.ParseIP("10.0.0.1"), LinkIndex: 5, Family: 2},
+		{Dst: mustParseCIDR("10.0.1.0/24"), Src: net.ParseIP("10.0.1.1"), LinkIndex: 5, Family: 2},
+	}
+
+	mockProg := &mockIptables{t: t, prog: "iptables", expectations: []expectation{
+		{args: "-t nat -A CILIUM_POST_nat -s 11.0.0.0/24 -d 10.0.1.0/24 -o eth0 -m comment --comment cilium snat non-cluster via source route -j SNAT --to-source 10.0.1.1"},
+		{args: "-t nat -A CILIUM_POST_nat -s 11.0.0.0/24 -d 10.0.0.0/16 -o eth0 -m comment --comment cilium snat non-cluster via source route -j SNAT --to-source 10.0.0.1"},
+		{args: "-t nat -A CILIUM_POST_nat -s 11.0.0.0/24 ! -d 11.0.0.0/24 ! -o cilium_+ -m comment --comment cilium snat non-cluster via source route -j SNAT --to-source 198.18.4.4"},
+	}}
+
+	linkByIndex := func(index int) (netlink.Link, error) {
+		return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0", Index: 5}}, nil
+	}
+
+	mgr := &manager{}
+	err := mgr.installMasqueradeRouteSourceRules(
+		mockProg, routes, linkByIndex,
+		[]string{"eth0"}, "11.0.0.0/24", "11.0.0.0/24",
+	)
+	require.NoError(t, err)
+	require.NoError(t, mockProg.checkExpectations())
+}
+func mustParseCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
 }


### PR DESCRIPTION
Please read the commit message

With my test environment, if I have the following rules, a lot of packets will hit the 1st rule.

```
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 0.0.0.0/1 -o ens4 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 198.18.4.4
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 10.0.0.0/8 ! -o cilium_+ -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 10.200.52.67
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 12.0.0.0/24 -o ens6 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 10.200.52.67
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 128.0.0.0/1 -o ens5 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 10.200.52.67
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.24/31 -o ens4.1 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.25
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.26/31 -o ens4 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.27
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.176/31 -o ens5.5 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.177
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.178/31 -o ens5 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.179
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.1.0/24 -o ens6 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.1.1
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.10.0/24 -o ens6.10 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.10.6
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 192.168.122.0/24 -o ens3 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 192.168.122.11
-A CILIUM_POST_nat -s 11.0.0.0/24 ! -d 11.0.0.0/24 ! -o cilium_+ -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 198.18.4.4
-A CILIUM_POST_nat -m mark --mark 0xa00/0xe00 -m comment --comment "exclude proxy return traffic from masquerade" -j ACCEPT
-A CILIUM_POST_nat ! -s 11.0.0.0/24 ! -d 11.0.0.0/24 -o cilium_host -m comment --comment "cilium host->cluster masquerade" -j SNAT --to-source 11.0.0.20
-A CILIUM_POST_nat -s 127.0.0.1/32 -o cilium_host -m comment --comment "cilium host->cluster from 127.0.0.1 masquerade" -j SNAT --to-source 11.0.0.20
-A CILIUM_POST_nat -o cilium_host -m mark --mark 0xf00/0xf00 -m conntrack --ctstate DNAT -m comment --comment "hairpin traffic that originated from a local pod" -j SNAT --to-source 11.0.0.20
```

with the PR, we sort the rules by subnet mask most of the packets will not hit /1 rule

```
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.24/31 -o ens4.1 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.25
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.178/31 -o ens5 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.179
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.176/31 -o ens5.5 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.177
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.0.26/31 -o ens4 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.0.27
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 12.0.0.0/24 -o ens6 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 10.200.52.67
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.1.0/24 -o ens6 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.1.1
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 172.24.10.0/24 -o ens6.10 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 172.24.10.6
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 192.168.122.0/24 -o ens3 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 192.168.122.11
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 10.0.0.0/8 ! -o cilium_+ -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 10.200.52.67
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 128.0.0.0/1 -o ens5 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 10.200.52.67
-A CILIUM_POST_nat -s 11.0.0.0/24 -d 0.0.0.0/1 -o ens4 -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 198.18.4.4
-A CILIUM_POST_nat -s 11.0.0.0/24 ! -d 11.0.0.0/24 ! -o cilium_+ -m comment --comment "cilium snat non-cluster via source route" -j SNAT --to-source 198.18.4.4
-A CILIUM_POST_nat -m mark --mark 0xa00/0xe00 -m comment --comment "exclude proxy return traffic from masquerade" -j ACCEPT
-A CILIUM_POST_nat ! -s 11.0.0.0/24 ! -d 11.0.0.0/24 -o cilium_host -m comment --comment "cilium host->cluster masquerade" -j SNAT --to-source 11.0.0.20
-A CILIUM_POST_nat -s 127.0.0.1/32 -o cilium_host -m comment --comment "cilium host->cluster from 127.0.0.1 masquerade" -j SNAT --to-source 11.0.0.20
-A CILIUM_POST_nat -o cilium_host -m mark --mark 0xf00/0xf00 -m conntrack --ctstate DNAT -m comment --comment "hairpin traffic that originated from a local pod" -j SNAT --to-source 11.0.0.20
```


```release-note
iptables-based masquerading: Ensure iptables rules respect longest prefix match by sorting routes by mask length when enable-masquerade-to-route-source is enabled
```
