### PR TITLE
contrib: Add saved replies directory

### DIFF
--- a/contrib/replies/README.md
+++ b/contrib/replies/README.md
@@ -1,0 +1,16 @@
+# Saved replies
+
+This directory contains some sample replies that are useful to share with
+community members who are engaging with the project:
+
+- [Let's build this together](./build-together.txt)
+- [Mark as draft to address feedback](./address-feedback.txt)
+
+To use these, browse to [your saved replies] and add a new saved reply using
+the form at the bottom. When responding to an issue or PR, there is an icon in
+the top right that you can use to recall the saved replies.
+
+For more information, see the GitHub [saved replies documentation].
+
+[saved replies documentation]: https://docs.github.com/en/get-started/writing-on-github/working-with-saved-replies
+[your saved replies]: https://github.com/settings/replies

--- a/contrib/replies/address-feedback.txt
+++ b/contrib/replies/address-feedback.txt
@@ -1,0 +1,3 @@
+I've marked this PR as draft. When you have addressed the comments and workflow
+test results, bring the PR back to the attention of reviewers by scrolling to
+the bottom of the page and clicking the "Ready for Review" button. Thanks!

--- a/contrib/replies/build-together.txt
+++ b/contrib/replies/build-together.txt
@@ -1,0 +1,5 @@
+Thank you for your attention on this. As an open source project, Cilium relies
+on the contributions from participants in the community to develop
+functionality that is useful for everyone. If this is critical to you, I'd
+encourage you to work on this, or find someone you can work with on this in
+order to extend the functionality to support this use case.


### PR DESCRIPTION
This directory contains some useful snippets that reviewers and
committers can use to share when interacting with community members.

See the included README.md and saved replies under `contrib/replies`
for more details.
