### PR TITLE
policy: Allow CIDR selectors to match in-cluster IPs

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -380,7 +380,7 @@ cilium-agent [flags]
       --packetization-layer-pmtud-mode string                     Enables kernel packetization layer path mtu discovery on Pod netns (if empty will use host setting) (default "blackhole")
       --policy-accounting                                         Maintain packet and byte counters for every policy entry (default true)
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
-      --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes'
+      --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes', 'pods'
       --policy-default-local-cluster                              Control whether policy rules assume by default the local cluster if not explicitly selected (default true)
       --policy-deny-response string                               How to handle pod egress traffic dropped by network policy: either drop the packet ("none") or reject with an ICMP Destination Unreachable ("icmp") (default "none")
       --policy-queue-size uint                                    Size of queue for policy-related events (default 100)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -780,7 +780,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableCiliumClusterwideNetworkPolicy)
 	option.BindEnv(vp, option.EnableCiliumClusterwideNetworkPolicy)
 
-	flags.StringSlice(option.PolicyCIDRMatchMode, defaults.PolicyCIDRMatchMode, "The entities that can be selected by CIDR policy. Supported values: 'nodes'")
+	flags.StringSlice(option.PolicyCIDRMatchMode, defaults.PolicyCIDRMatchMode, "The entities that can be selected by CIDR policy. Supported values: 'nodes', 'pods'")
 	option.BindEnv(vp, option.PolicyCIDRMatchMode)
 
 	flags.Duration(option.MaxInternalTimerDelay, defaults.MaxInternalTimerDelay, "Maximum internal timer value across the entire agent. Use in test environments to detect race conditions in agent logic.")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -305,6 +305,9 @@ func (c *controller) GetLastErrorTimestamp() time.Time {
 	return c.lastErrorStamp
 }
 
+// timeAfter allows overriding time.After in unit tests.
+var timeAfter = time.After
+
 func (c *controller) runController() {
 	params := c.Params()
 	errorRetries := 1
@@ -320,7 +323,7 @@ func (c *controller) runController() {
 		if params.Jitter > 0 {
 			jitter = time.Duration(rand.Int64N(int64(params.Jitter)))
 			select {
-			case <-time.After(jitter):
+			case <-timeAfter(jitter):
 				// jitter sleep finished
 			case <-params.Context.Done():
 				// context cancelled, exit early but ensure shutdown logic runs
@@ -328,6 +331,9 @@ func (c *controller) runController() {
 			case <-c.stop:
 				// controller stopped during jitter sleep
 				goto shutdown
+			case <-c.update:
+				// woken up early by update, loop again to reload params and re-evaluate jitter
+				continue
 			}
 		}
 		err = params.DoFunc(params.Context)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -321,3 +321,76 @@ func TestConcurrentControllerUpdate(t *testing.T) {
 	require.NoError(t, mngr.RemoveControllerAndWait("test"))
 	require.Equal(t, result.Load(), events[len(events)-1].result)
 }
+
+func TestControllerUpdateDuringJitter(t *testing.T) {
+	var afterCalls atomic.Int32
+	timeAfterCh := make(chan time.Time)
+
+	// Mock timeAfter to never fire, and track how many times the controller
+	// enters the jitter sleep block.
+	oldTimeAfter := timeAfter
+	defer func() { timeAfter = oldTimeAfter }()
+	timeAfter = func(d time.Duration) <-chan time.Time {
+		afterCalls.Add(1)
+		return timeAfterCh
+	}
+
+	mngr := NewManager()
+
+	var runs atomic.Int32
+	doFunc := func(ctx context.Context) error {
+		runs.Add(1)
+		return nil
+	}
+
+	// 1. Start controller with a jitter > 0.
+	mngr.UpdateController("test-jitter", ControllerParams{
+		DoFunc: doFunc,
+		Jitter: 1 * time.Hour,
+	})
+
+	// Wait until the controller has entered the jitter sleep (afterCalls == 1)
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		return afterCalls.Load() == 1
+	}, 5*time.Second))
+	require.Equal(t, int32(0), runs.Load())
+
+	// 2. Update it with Jitter = 0. It should run immediately.
+	mngr.UpdateController("test-jitter", ControllerParams{
+		DoFunc: doFunc,
+		Jitter: 0,
+	})
+
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		return runs.Load() == 1
+	}, 5*time.Second))
+
+	runs.Store(0)
+
+	// 3. Update it with Jitter > 0 again. It should go back to sleep.
+	mngr.UpdateController("test-jitter", ControllerParams{
+		DoFunc: doFunc,
+		Jitter: 1 * time.Hour,
+	})
+
+	// Wait until it enters the second jitter sleep.
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		return afterCalls.Load() == 2
+	}, 5*time.Second))
+	require.Equal(t, int32(0), runs.Load())
+
+	// 4. Update it with Jitter > 0 again. This should restart the jitter sleep.
+	mngr.UpdateController("test-jitter", ControllerParams{
+		DoFunc: doFunc,
+		Jitter: 1 * time.Hour,
+	})
+
+	// Wait until it enters the third jitter sleep.
+	require.NoError(t, testutils.WaitUntil(func() bool {
+		return afterCalls.Load() == 3
+	}, 5*time.Second))
+	require.Equal(t, int32(0), runs.Load())
+
+	// Cleanup
+	require.NoError(t, mngr.RemoveControllerAndWait("test-jitter"))
+}

--- a/pkg/egressgateway/script_test.go
+++ b/pkg/egressgateway/script_test.go
@@ -5,6 +5,7 @@ package egressgateway
 
 import (
 	"context"
+	"log/slog"
 	"maps"
 	"net"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
 	k8sFake "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	k8sTables "github.com/cilium/cilium/pkg/k8s/tables"
 	"github.com/cilium/cilium/pkg/kpr"
@@ -69,6 +71,11 @@ func TestPrivilegedScripts(t *testing.T) {
 				// using the mock node sync type.
 				node.LocalNodeStoreCell,
 				endpointmanager.Cell,
+				cell.Provide(func(log *slog.Logger) *ipcache.IPCache {
+					return ipcache.NewIPCache(&ipcache.Configuration{
+						Logger: log,
+					})
+				}),
 				cell.Provide(func() promise.Promise[endpointstate.Restorer] {
 					resolver, promise := promise.New[endpointstate.Restorer]()
 					resolver.Resolve(&fakeRestorer{})

--- a/pkg/endpoint/cell/cell.go
+++ b/pkg/endpoint/cell/cell.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/watchdog"
 	"github.com/cilium/cilium/pkg/endpointcleanup"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/ipcache"
 )
 
 // Endpoint control-plane meta cell.
@@ -38,4 +39,8 @@ var Cell = cell.Group(
 
 	// Cell triggers a job to ensure device tc programs remain loaded.
 	watchdog.Cell,
+
+	cell.Provide(
+		func(ipc *ipcache.IPCache) endpoint.IPCache { return ipc },
+	),
 )

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -142,6 +142,8 @@ type Endpoint struct {
 	policyRepo    policy.PolicyRepository
 	policyFetcher compute.PolicyRecomputer
 
+	ipcache IPCache
+
 	// kvstoreSyncher updates the kvstore (e.g., etcd) with up-to-date
 	// information about endpoints. Initialized by manager.expose.
 	kvstoreSyncher *ipcache.IPIdentitySynchronizer
@@ -481,6 +483,11 @@ func (e *Endpoint) Close() {
 	}
 }
 
+// IPCache defines the subset of ipcache.IPCache methods used by the endpoint.
+type IPCache interface {
+	GetMetadataLabels(ip netip.Addr) labels.Labels
+}
+
 type DNSRulesAPI interface {
 	// GetDNSRules creates a fresh copy of DNS rules that can be used when
 	// endpoint is restored on a restart.
@@ -599,6 +606,7 @@ func createEndpoint(
 		policyMapFactory:   p.PolicyMapFactory,
 		policyRepo:         p.PolicyRepo,
 		policyFetcher:      p.PolicyFetcher,
+		ipcache:            p.IPCache,
 		ID:                 ID,
 		createdAt:          time.Now(),
 		proxy:              proxy,
@@ -2227,6 +2235,18 @@ func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
 	return myChangeRev != e.identityRevision
 }
 
+// ForceUpdateCIDRLabels triggers a re-evaluation of the endpoint's CIDR labels
+// and runs the identity resolver to update its security identity if needed.
+func (e *Endpoint) ForceUpdateCIDRLabels(ctx context.Context) {
+	if err := e.lockAlive(); err != nil {
+		return
+	}
+	e.identityRevision++
+	e.unlock()
+
+	e.runIdentityResolver(ctx, false, 0)
+}
+
 // runIdentityResolver resolves the numeric identity for the set of labels that
 // are currently configured on the endpoint.
 //
@@ -2286,12 +2306,57 @@ func (e *Endpoint) runIdentityResolver(ctx context.Context, blocking bool, updat
 	return regenTriggered
 }
 
+// computeCIDRLabelsRLocked should be called with a lock held on the Endpoint.
+func (e *Endpoint) computeCIDRLabelsRLocked() labels.Labels {
+	newCIDRLabels := labels.Labels{}
+	if !option.Config.PolicyCIDRMatchesPods() || e.ipcache == nil {
+		return newCIDRLabels
+	}
+
+	for _, ip := range []netip.Addr{e.IPv4, e.IPv6} {
+		if !ip.IsValid() {
+			continue
+		}
+		hasCIDR := false
+		// Filter labels retrieved from the IPCache. We only match and propagate
+		// CIDR and CIDRGroup labels (source=cidr or source=cidrgroup). Other metadata
+		// labels (such as reserved:world or FQDN labels) are ignored.
+		for _, lbl := range e.ipcache.GetMetadataLabels(ip) {
+			if lbl.Source == labels.LabelSourceCIDR || lbl.Source == labels.LabelSourceCIDRGroup {
+				newCIDRLabels[lbl.GetExtendedKey()] = lbl
+				if lbl.Source == labels.LabelSourceCIDR {
+					hasCIDR = true
+				}
+			}
+		}
+		if !hasCIDR {
+			var wildcard string
+			if ip.Is4() {
+				wildcard = "cidr:0.0.0.0/0"
+			} else {
+				wildcard = "cidr:::/0"
+			}
+			lbl := labels.ParseLabel(wildcard)
+			newCIDRLabels[lbl.GetExtendedKey()] = lbl
+		}
+	}
+
+	return newCIDRLabels
+}
+
 func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bool, err error) {
 	// e.setState() called below, can't take a read lock.
 	if err := e.lockAlive(); err != nil {
 		return false, err
 	}
 	newLabels := e.labels.IdentityLabels()
+
+	if !newLabels.IsReserved() {
+		newLabels.RemoveFromSource(labels.LabelSourceCIDR)
+		newLabels.RemoveFromSource(labels.LabelSourceCIDRGroup)
+		maps.Copy(newLabels, e.computeCIDRLabelsRLocked())
+	}
+
 	myChangeRev := e.identityRevision
 	scopedLog := e.getLogger().With(
 		logfields.IdentityLabels, newLabels,

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -1493,3 +1494,112 @@ func (g fakeNodeGetter) Get(ctx context.Context) (node.LocalNode, error) {
 }
 
 type fakeNodeGetter struct{}
+
+type mockIPCache struct {
+	labels map[string]labels.Labels
+}
+
+func (m *mockIPCache) GetMetadataLabels(ip netip.Addr) labels.Labels {
+	if m.labels == nil {
+		return nil
+	}
+	return m.labels[ip.String()]
+}
+
+func TestComputeCIDRLabels(t *testing.T) {
+	// Backup and restore configuration
+	originalMode := option.Config.PolicyCIDRMatchMode
+	defer func() {
+		option.Config.PolicyCIDRMatchMode = originalMode
+	}()
+
+	ipv4 := netip.MustParseAddr("10.0.0.1")
+	ipv6 := netip.MustParseAddr("fd00::1")
+
+	lblGroup := labels.NewLabel("groupA", "", labels.LabelSourceCIDRGroup)
+	lblCIDR := labels.NewLabel("10.0.0.0/24", "", labels.LabelSourceCIDR)
+
+	tests := []struct {
+		name         string
+		matchMode    []string
+		ipv4         netip.Addr
+		ipv6         netip.Addr
+		ipcache      map[string]labels.Labels
+		expectLabels labels.Labels
+	}{
+		{
+			name:         "PolicyCIDRMatchesPods disabled",
+			matchMode:    nil,
+			ipv4:         ipv4,
+			expectLabels: labels.Labels{},
+		},
+		{
+			name:      "No labels in ipcache (IPv4 only)",
+			matchMode: []string{"pods"},
+			ipv4:      ipv4,
+			expectLabels: labels.Labels{
+				"cidr:0.0.0.0/0": labels.ParseLabel("cidr:0.0.0.0/0"),
+			},
+		},
+		{
+			name:      "No labels in ipcache (dual stack)",
+			matchMode: []string{"pods"},
+			ipv4:      ipv4,
+			ipv6:      ipv6,
+			expectLabels: labels.Labels{
+				"cidr:0.0.0.0/0": labels.ParseLabel("cidr:0.0.0.0/0"),
+				"cidr:::/0":      labels.ParseLabel("cidr:::/0"),
+			},
+		},
+		{
+			name:      "Solely cidrgroup labels in ipcache",
+			matchMode: []string{"pods"},
+			ipv4:      ipv4,
+			ipcache: map[string]labels.Labels{
+				ipv4.String(): {lblGroup.GetExtendedKey(): lblGroup},
+			},
+			expectLabels: labels.Labels{
+				lblGroup.GetExtendedKey(): lblGroup,
+				"cidr:0.0.0.0/0":          labels.ParseLabel("cidr:0.0.0.0/0"),
+			},
+		},
+		{
+			name:      "Specific cidr labels in ipcache",
+			matchMode: []string{"pods"},
+			ipv4:      ipv4,
+			ipcache: map[string]labels.Labels{
+				ipv4.String(): {lblCIDR.GetExtendedKey(): lblCIDR},
+			},
+			expectLabels: labels.Labels{
+				lblCIDR.GetExtendedKey(): lblCIDR,
+			},
+		},
+		{
+			name:      "Both cidr and cidrgroup labels in ipcache",
+			matchMode: []string{"pods"},
+			ipv4:      ipv4,
+			ipcache: map[string]labels.Labels{
+				ipv4.String(): {
+					lblCIDR.GetExtendedKey():  lblCIDR,
+					lblGroup.GetExtendedKey(): lblGroup,
+				},
+			},
+			expectLabels: labels.Labels{
+				lblCIDR.GetExtendedKey():  lblCIDR,
+				lblGroup.GetExtendedKey(): lblGroup,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option.Config.PolicyCIDRMatchMode = tt.matchMode
+			ep := &Endpoint{
+				IPv4:    tt.ipv4,
+				IPv6:    tt.ipv6,
+				ipcache: &mockIPCache{labels: tt.ipcache},
+			}
+			assert.Equal(t, tt.expectLabels, ep.computeCIDRLabelsRLocked())
+		})
+	}
+}

--- a/pkg/endpoint/params.go
+++ b/pkg/endpoint/params.go
@@ -50,4 +50,5 @@ type EndpointParams struct {
 	IPSecConfig         ipsec.Config
 	LxcMap              lxcmap.Map
 	LocalNodeStore      node.NodeGetter
+	IPCache             IPCache
 }

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -42,6 +43,11 @@ var Cell = cell.Module(
 	defaultGroup,
 	cell.Invoke(
 		registerNamespaceUpdater,
+		func(ipc *ipcache.IPCache, epMgr EndpointManager, daemonConfig *option.DaemonConfig) {
+			if daemonConfig.PolicyCIDRMatchesPods() {
+				ipc.AddCIDRSelectorAllocator(epMgr)
+			}
+		},
 	),
 )
 

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -182,6 +182,15 @@ type EndpointManager interface {
 	// Endpoints with security IDs in provided set will be regenerated. Otherwise, the endpoint's
 	// policy revision will be bumped to toRev.
 	UpdatePolicy(idsToRegen *set.Set[identity.NumericIdentity], fromRev, toRev uint64)
+
+	// UpdateCIDRLabels triggers identity resolution for all pod endpoints
+	// whose IPs are contained within the given prefix.
+	//
+	// If the prefix represents a single IP address (e.g. /32 or /128), it performs
+	// an optimized O(1) lookup and returns true if a matching local endpoint was found
+	// and had its identity resolution triggered.
+	// Otherwise, it performs a linear O(N) scan over all endpoints and returns false.
+	UpdateCIDRLabels(ctx context.Context, prefix netip.Prefix) bool
 }
 
 // EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -912,3 +912,32 @@ func (mgr *endpointManager) stopEndpoints() {
 
 	mgr.logger.Info("All endpoints' goroutines stopped.")
 }
+
+// UpdateCIDRLabels triggers identity resolution for all pod endpoints
+// whose IPs are contained within the given prefix. Implements ipcache.CIDRSelectorAllocator.
+//
+// If the prefix represents a single IP address, it performs an optimized map lookup
+// and returns true if a matching endpoint is found. Otherwise, it performs a linear
+// scan over all endpoints and returns false.
+func (mgr *endpointManager) UpdateCIDRLabels(ctx context.Context, prefix netip.Prefix) bool {
+	if prefix.IsSingleIP() {
+		ep := mgr.LookupIP(prefix.Addr())
+		if ep == nil {
+			return false // No endpoint matching this IP is managed on this node.
+		}
+
+		// Trigger asynchronous identity resolution for the endpoint.
+		// Since this is called from the label injector thread, running it asynchronously
+		// prevents blocking the metadata injection pipeline on KVStore/APIServer latency.
+		ep.ForceUpdateCIDRLabels(ctx)
+		return true
+	}
+
+	for _, ep := range mgr.GetEndpoints() {
+		if (ep.IPv4.IsValid() && prefix.Contains(ep.IPv4)) || (ep.IPv6.IsValid() && prefix.Contains(ep.IPv6)) {
+			// Trigger asynchronous identity resolution for the endpoint.
+			ep.ForceUpdateCIDRLabels(ctx)
+		}
+	}
+	return false
+}

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -1125,3 +1125,69 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 		tt.postTestRun()
 	}
 }
+
+func TestUpdateCIDRLabelsPrefixScan(t *testing.T) {
+	logger := hivetest.Logger(t)
+	s := setupEndpointManagerSuite(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+
+	// Create and expose two endpoints, one inside the subnet, one outside
+	model1 := newTestEndpointModel(1, endpoint.StateReady)
+	ep1, err := func() (*endpoint.Endpoint, error) {
+		p := makeTestEndpointParams(logger, s.repo)
+		p.KVStoreSynchronizer = kvstoreSync
+		return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model1, nil)
+	}()
+	require.NoError(t, err)
+	ep1.IPv4 = netip.MustParseAddr("10.20.30.50")
+	ep1.Start(uint16(model1.ID))
+	t.Cleanup(ep1.Stop)
+	require.NoError(t, mgr.expose(ep1))
+	defer mgr.WaitEndpointRemoved(ep1)
+
+	model2 := newTestEndpointModel(2, endpoint.StateReady)
+	ep2, err := func() (*endpoint.Endpoint, error) {
+		p := makeTestEndpointParams(logger, s.repo)
+		p.KVStoreSynchronizer = kvstoreSync
+		return endpoint.NewEndpointFromChangeModel(p, nil, &endpoint.FakeEndpointProxy{}, model2, nil)
+	}()
+	require.NoError(t, err)
+	ep2.IPv4 = netip.MustParseAddr("10.30.30.50")
+	ep2.Start(uint16(model2.ID))
+	t.Cleanup(ep2.Stop)
+	require.NoError(t, mgr.expose(ep2))
+	defer mgr.WaitEndpointRemoved(ep2)
+
+	// Call UpdateCIDRLabels for the prefix 10.20.30.0/24
+	subnet := netip.MustParsePrefix("10.20.30.0/24")
+	_ = mgr.UpdateCIDRLabels(context.Background(), subnet)
+
+	// Verify that the controller for ep1 was triggered or is present, while ep2 was not
+	m1 := ep1.GetModel()
+	require.NotNil(t, m1)
+	require.NotNil(t, m1.Status)
+
+	// Find controller for resolve-identity-1
+	foundEP1Ctrl := false
+	for _, c := range m1.Status.Controllers {
+		if c.Name == "resolve-identity-1" {
+			foundEP1Ctrl = true
+			break
+		}
+	}
+	assert.True(t, foundEP1Ctrl, "ep1 should have triggered identity resolver")
+
+	m2 := ep2.GetModel()
+	require.NotNil(t, m2)
+	require.NotNil(t, m2.Status)
+	foundEP2Ctrl := false
+	for _, c := range m2.Status.Controllers {
+		if c.Name == "resolve-identity-2" {
+			foundEP2Ctrl = true
+			break
+		}
+	}
+	assert.False(t, foundEP2Ctrl, "ep2 should not have triggered identity resolver")
+}

--- a/pkg/ipam/migration/script_test.go
+++ b/pkg/ipam/migration/script_test.go
@@ -321,5 +321,6 @@ func (noopEndpointManager) OverrideEndpointOpts(option.OptionMap)               
 func (noopEndpointManager) InitHostEndpointLabels(context.Context)                    {}
 func (noopEndpointManager) UpdatePolicy(*set.Set[identity.NumericIdentity], uint64, uint64) {
 }
+func (noopEndpointManager) UpdateCIDRLabels(context.Context, netip.Prefix) bool { return false }
 
 var _ endpointmanager.EndpointManager = noopEndpointManager{}

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -13,7 +13,6 @@ import (
 
 	policyapi "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
-	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/endpointstate"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -81,7 +80,6 @@ type ipCacheParams struct {
 	IdentityRestorer       *restoration.LocalIdentityRestorer
 	CacheIdentityAllocator cache.IdentityAllocator
 	IdentityUpdater        policycell.IdentityUpdater
-	EndpointManager        endpointmanager.EndpointManager
 	EndpointRestorePromise promise.Promise[endpointstate.Restorer]
 	CacheStatus            synced.CacheStatus
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -148,6 +148,8 @@ type IPCache struct {
 	// metadata is the ipcache identity metadata map, which maps IPs to labels.
 	metadata *metadata
 
+	cidrSelectorAllocators []CIDRSelectorAllocator
+
 	// prefixLengths tracks the unique set of prefix lengths for IPv4 and
 	// IPv6 addresses in order to optimize longest prefix match lookups.
 	prefixLengths *counter.PrefixLengthCounter
@@ -155,6 +157,21 @@ type IPCache struct {
 	// injectionStarted is a sync.Once so we can lazily start the prefix injection controller,
 	// but only once
 	injectionStarted sync.Once
+}
+
+// CIDRSelectorAllocator defines the interface to trigger identity resolution for
+// a CIDR selector (e.g. pod or node).
+type CIDRSelectorAllocator interface {
+	// UpdateCIDRLabels triggers identity resolution for all resources (e.g. pod endpoints)
+	// whose IPs are contained within the given prefix.
+	//
+	// Returns true if a matching local resource was found and had its identity resolution triggered.
+	UpdateCIDRLabels(ctx context.Context, prefix netip.Prefix) bool
+}
+
+// AddCIDRSelectorAllocator adds a CIDR selector allocator to this IPCache.
+func (ipc *IPCache) AddCIDRSelectorAllocator(allocator CIDRSelectorAllocator) {
+	ipc.cidrSelectorAllocators = append(ipc.cidrSelectorAllocators, allocator)
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
@@ -236,6 +253,22 @@ func (ipc *IPCache) GetK8sMetadata(ip netip.Addr) *K8sMetadata {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
 	return ipc.getK8sMetadata(ip.String())
+}
+
+// GetMetadataLabels returns the merged labels for the given IP address from the metadata map.
+//
+// Callers must not call this while holding the IPCache mutex (such as via IPCache.RLock())
+//
+// Note: This returns all matching parent labels (including non-CIDR ones). The caller is
+// responsible for filtering labels if only specific label sources are needed (e.g. cidr).
+func (ipc *IPCache) GetMetadataLabels(ip netip.Addr) labels.Labels {
+	if !ip.IsValid() {
+		return nil
+	}
+	prefix := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(ip, ip.BitLen()))
+	lbls := labels.Labels{}
+	ipc.metadata.mergeLabels(lbls, prefix)
+	return lbls
 }
 
 // getK8sMetadata returns Kubernetes metadata for the given IP address.

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -297,15 +297,15 @@ func (m *metadata) getLockedSource(prefix cmtypes.PrefixCluster) source.Source {
 	return source.Unspec
 }
 
-// mergeParentLabels pulls down all labels from parent prefixes, with "longer" prefixes having
-// preference.
+// mergeLabels pulls down all labels from parent prefixes, with "longer" prefixes having
+// preference, including the prefix itself.
 //
 // Thus, if the ipcache contains:
 // - 10.0.0.0/8 -> "a=b, foo=bar"
 // - 10.1.0.0/16 -> "a=c"
 // - 10.1.1.0/24 -> "d=e"
 // the complete set of labels for 10.1.1.0/24 is [a=c, d=e, foo=bar]
-func (m *metadata) mergeParentLabels(lbls labels.Labels, prefixCluster cmtypes.PrefixCluster) {
+func (m *metadata) mergeLabels(lbls labels.Labels, prefixCluster cmtypes.PrefixCluster) {
 	m.Lock()
 	defer m.Unlock()
 	hasCIDR := lbls.HasSource(labels.LabelSourceCIDR) // we should only merge one CIDR label
@@ -313,7 +313,7 @@ func (m *metadata) mergeParentLabels(lbls labels.Labels, prefixCluster cmtypes.P
 	// Iterate over all shorter prefixes, from `prefix` to 0.0.0.0/0 // ::/0.
 	// Merge all labels, preferring those from longer prefixes, but only merge a single "cidr:XXX" label at most.
 	prefix := prefixCluster.AsPrefix()
-	for bits := prefix.Bits() - 1; bits >= 0; bits-- {
+	for bits := prefix.Bits(); bits >= 0; bits-- {
 		parent, _ := prefix.Addr().Unmap().Prefix(bits) // canonical
 		if info := m.getLocked(cmtypes.NewPrefixCluster(parent, prefixCluster.ClusterID())); info != nil {
 			for k, v := range info.ToLabels() {
@@ -405,6 +405,17 @@ func (ipc *IPCache) doInjectLabels(ctx context.Context, modifiedPrefixes []cmtyp
 		prefixInfo := ipc.metadata.get(prefix)
 		var newID *identity.Identity
 		var isNew bool
+
+		// If this prefix exactly matches a known in-cluster resource (e.g. pod or node),
+		// we don't need to allocate a standalone CIDR identity. The resource's own
+		// identity will dynamically update its CIDR labels.
+		for _, allocator := range ipc.cidrSelectorAllocators {
+			if allocator.UpdateCIDRLabels(ctx, prefix.AsPrefix()) {
+				prefixInfo = nil
+				break
+			}
+		}
+
 		if prefixInfo == nil {
 			if !entryExists {
 				// Already deleted, no new metadata to associate
@@ -706,8 +717,8 @@ func (ipc *IPCache) resolveIdentity(prefix cmtypes.PrefixCluster, info *resource
 
 	lbls := info.ToLabels()
 
-	// unconditionally merge any parent labels down in to this prefix
-	ipc.metadata.mergeParentLabels(lbls, prefix)
+	// unconditionally merge any parent labels down in to this prefix, including the prefix itself
+	ipc.metadata.mergeLabels(lbls, prefix)
 
 	// Enforce certain label invariants, e.g. adding or removing `reserved:world`.
 	resolveLabels(lbls, prefix)

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1234,10 +1234,11 @@ func Test_canonicalPrefix(t *testing.T) {
 func Test_metadata_mergeParentLabels(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name       string
-		existing   map[string]labels.Labels
-		prefix     string
-		wantLabels labels.Labels
+		name        string
+		existing    map[string]labels.Labels
+		prefix      string
+		includeSelf bool
+		wantLabels  labels.Labels
 	}{
 		{
 			name: "no self-match",
@@ -1246,6 +1247,26 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 			},
 			prefix:     "1.1.1.1/32",
 			wantLabels: labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.1/32")),
+		},
+
+		{
+			name: "includes self-match",
+			existing: map[string]labels.Labels{
+				"1.1.1.1/32": labels.ParseLabelArray("cidr:1.1.1.1/32", "cidrgroup:foo").Labels(),
+			},
+			prefix:      "1.1.1.1/32",
+			wantLabels:  labels.ParseLabelArray("cidr:1.1.1.1/32", "cidrgroup:foo").Labels(),
+			includeSelf: true,
+		},
+
+		{
+			name: "merge self and parents",
+			existing: map[string]labels.Labels{
+				"1.1.1.1/32": labels.ParseLabelArray("cidr:1.1.0.0/16", "cidrgroup:foo").Labels(),
+			},
+			prefix:      "1.1.1.1/32",
+			wantLabels:  labels.ParseLabelArray("cidr:1.1.0.0/16", "cidrgroup:foo").Labels(),
+			includeSelf: true,
 		},
 
 		{
@@ -1322,7 +1343,7 @@ func Test_metadata_mergeParentLabels(t *testing.T) {
 			pfx := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix(tt.prefix))
 
 			lbls := m.getLocked(pfx).ToLabels()
-			m.mergeParentLabels(lbls, pfx)
+			m.mergeLabels(lbls, pfx)
 
 			assert.Equal(t, tt.wantLabels, lbls)
 		})
@@ -1713,4 +1734,209 @@ func TestResolveFQDNLabels(t *testing.T) {
 		require.Equal(t, tc.expected, lbls, "row %d", i)
 	}
 
+}
+
+type mockCIDRSelectorAllocator struct {
+	allocatedIPs      map[netip.Addr]struct{}
+	allocatedPrefixes []netip.Prefix
+}
+
+func (m *mockCIDRSelectorAllocator) UpdateCIDRLabels(ctx context.Context, prefix netip.Prefix) bool {
+	m.allocatedPrefixes = append(m.allocatedPrefixes, prefix)
+	if prefix.IsSingleIP() {
+		_, ok := m.allocatedIPs[prefix.Addr()]
+		return ok
+	}
+	return false
+}
+
+func TestIPCachePodCIDRShadowing(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	ctx := t.Context()
+
+	oldPolicyConfig := option.Config.PolicyCIDRMatchMode
+	t.Cleanup(func() { option.Config.PolicyCIDRMatchMode = oldPolicyConfig })
+	option.Config.PolicyCIDRMatchMode = []string{"pods"}
+
+	mockAlloc := &mockCIDRSelectorAllocator{
+		allocatedIPs: make(map[netip.Addr]struct{}),
+	}
+	s.IPIdentityCache.AddCIDRSelectorAllocator(mockAlloc)
+
+	// -------------------------------------------------------------------------
+	// Scenario 1: Pod IP CIDR is shadowed by pod endpoint first.
+	// When the pod endpoint is deleted, a standalone CIDR identity should
+	// be allocated for the remaining CIDR policy.
+	// -------------------------------------------------------------------------
+	podIP1 := "10.20.30.45"
+	podAddr1 := netip.MustParseAddr(podIP1)
+	podCIDR1 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.20.30.45/32"))
+	podIdentity1 := identity.NumericIdentity(1234)
+
+	// 1. Upsert Pod IP to IPCache
+	s.IPIdentityCache.Upsert(podIP1, nil, 0, nil, Identity{
+		ID:     podIdentity1,
+		Source: source.Kubernetes,
+	})
+	mockAlloc.allocatedIPs[podAddr1] = struct{}{}
+
+	// 2. Add CIDR Metadata matching Pod IP
+	s.IPIdentityCache.metadata.upsertLocked(podCIDR1, source.CustomResource, "r3",
+		labels.NewLabelsFromSortedList("cidr:10.20.30.45/32"),
+	)
+
+	// 3. Inject labels
+	_, err := s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{podCIDR1})
+	require.NoError(t, err)
+
+	// 4. Verify that it maps to Pod Identity (shadowed)
+	nid, ok := s.IPIdentityCache.LookupByPrefix(podCIDR1.String())
+	assert.True(t, ok)
+	assert.Equal(t, podIdentity1, nid.ID)
+
+	// 5. Delete Pod IP from IPCache (emulating pod deletion)
+	s.IPIdentityCache.Delete(podIP1, source.Kubernetes)
+	delete(mockAlloc.allocatedIPs, podAddr1)
+
+	// 6. Inject labels again. This should fall back to allocating a standalone CIDR identity
+	_, err = s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{podCIDR1})
+	require.NoError(t, err)
+
+	// 7. Verify that it now maps to a newly allocated standalone CIDR identity
+	nid, ok = s.IPIdentityCache.LookupByPrefix(podCIDR1.String())
+	assert.True(t, ok)
+	assert.NotEqual(t, podIdentity1, nid.ID)
+	assert.NotEqual(t, identity.ReservedIdentityWorldIPv4, nid.ID)
+	standaloneID1 := nid.ID
+	idObj1 := s.Allocator.LookupIdentityByID(ctx, standaloneID1)
+	require.NotNil(t, idObj1)
+
+	// -------------------------------------------------------------------------
+	// Scenario 2: Network policy exists first (allocating standalone identity),
+	// then pod endpoint is created with matching IP.
+	// The standalone identity should be released and the pod identity used.
+	// -------------------------------------------------------------------------
+	podIP2 := "10.20.30.50"
+	podAddr2 := netip.MustParseAddr(podIP2)
+	podCIDR2 := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.20.30.50/32"))
+	podIdentity2 := identity.NumericIdentity(5678)
+
+	// 1. Add CIDR Metadata first
+	s.IPIdentityCache.metadata.upsertLocked(podCIDR2, source.CustomResource, "r4",
+		labels.NewLabelsFromSortedList("cidr:10.20.30.50/32"),
+	)
+
+	// 2. Inject labels. This allocates a standalone identity.
+	_, err = s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{podCIDR2})
+	require.NoError(t, err)
+
+	nid, ok = s.IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.NotEqual(t, identity.ReservedIdentityWorldIPv4, nid.ID)
+	standaloneID2 := nid.ID
+
+	// Verify the standalone identity is registered in the allocator
+	idObj := s.Allocator.LookupIdentityByID(ctx, standaloneID2)
+	require.NotNil(t, idObj)
+
+	// 3. Upsert Pod IP to IPCache
+	s.IPIdentityCache.Upsert(podIP2, nil, 0, nil, Identity{
+		ID:     podIdentity2,
+		Source: source.Kubernetes,
+	})
+	mockAlloc.allocatedIPs[podAddr2] = struct{}{}
+
+	// 4. Inject labels. The pod should now shadow the CIDR mapping.
+	_, err = s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{podCIDR2})
+	require.NoError(t, err)
+
+	// 5. Verify that it maps to Pod Identity (shadowed)
+	nid, ok = s.IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.Equal(t, podIdentity2, nid.ID)
+
+	// 6. Verify that the standalone identity was released and cleaned up
+	idObj = s.Allocator.LookupIdentityByID(ctx, standaloneID2)
+	assert.Nil(t, idObj, "Standalone CIDR identity should have been released from the allocator")
+
+	// -------------------------------------------------------------------------
+	// Scenario 3: Repeat lifecycle multiple times (re-creation check) to
+	// verify we don't leak references to security identities.
+	// -------------------------------------------------------------------------
+
+	// 1. Delete Pod IP again (pod goes away)
+	s.IPIdentityCache.Delete(podIP2, source.Kubernetes)
+	delete(mockAlloc.allocatedIPs, podAddr2)
+
+	// 2. Inject labels. Standalone CIDR identity should be re-allocated.
+	_, err = s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{podCIDR2})
+	require.NoError(t, err)
+
+	nid, ok = s.IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.NotEqual(t, podIdentity2, nid.ID)
+	standaloneID2AfterDelete := nid.ID
+
+	// Standalone identity must exist in allocator
+	idObj = s.Allocator.LookupIdentityByID(ctx, standaloneID2AfterDelete)
+	require.NotNil(t, idObj)
+
+	// 3. Re-create Pod IP (pod comes back)
+	s.IPIdentityCache.Upsert(podIP2, nil, 0, nil, Identity{
+		ID:     podIdentity2,
+		Source: source.Kubernetes,
+	})
+	mockAlloc.allocatedIPs[podAddr2] = struct{}{}
+
+	// 4. Inject labels. Standalone identity should be released again.
+	_, err = s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{podCIDR2})
+	require.NoError(t, err)
+
+	nid, ok = s.IPIdentityCache.LookupByPrefix(podCIDR2.String())
+	assert.True(t, ok)
+	assert.Equal(t, podIdentity2, nid.ID)
+
+	// Verify it was released
+	idObj = s.Allocator.LookupIdentityByID(ctx, standaloneID2AfterDelete)
+	assert.Nil(t, idObj, "Re-allocated standalone CIDR identity should have been released again")
+
+	// Clean up Metadata
+	s.IPIdentityCache.metadata.Lock()
+	s.IPIdentityCache.metadata.remove(podCIDR1, "r3")
+	s.IPIdentityCache.metadata.remove(podCIDR2, "r4")
+	s.IPIdentityCache.metadata.Unlock()
+}
+
+func TestIPCacheSubnetCIDRInject(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	ctx := t.Context()
+
+	oldPolicyConfig := option.Config.PolicyCIDRMatchMode
+	t.Cleanup(func() { option.Config.PolicyCIDRMatchMode = oldPolicyConfig })
+	option.Config.PolicyCIDRMatchMode = []string{"pods"}
+
+	mockAlloc := &mockCIDRSelectorAllocator{
+		allocatedIPs: make(map[netip.Addr]struct{}),
+	}
+	s.IPIdentityCache.AddCIDRSelectorAllocator(mockAlloc)
+
+	subnetPrefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.20.30.0/24"))
+
+	// 1. Add subnet CIDR Metadata
+	s.IPIdentityCache.metadata.upsertLocked(subnetPrefix, source.CustomResource, "r3",
+		labels.NewLabelsFromSortedList("cidr:10.20.30.0/24"),
+	)
+
+	// 2. Inject labels. This should trigger UpdateCIDRLabels for the subnet prefix.
+	_, err := s.IPIdentityCache.doInjectLabels(ctx, []cmtypes.PrefixCluster{subnetPrefix})
+	require.NoError(t, err)
+
+	// 3. Verify that UpdateCIDRLabels was called with the subnet prefix
+	require.Len(t, mockAlloc.allocatedPrefixes, 1)
+	assert.Equal(t, subnetPrefix.AsPrefix(), mockAlloc.allocatedPrefixes[0])
+
+	// Clean up Metadata
+	s.IPIdentityCache.metadata.Lock()
+	s.IPIdentityCache.metadata.remove(subnetPrefix, "r3")
+	s.IPIdentityCache.metadata.Unlock()
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2143,6 +2143,10 @@ func (c *DaemonConfig) PolicyCIDRMatchesNodes() bool {
 	return slices.Contains(c.PolicyCIDRMatchMode, "nodes")
 }
 
+func (c *DaemonConfig) PolicyCIDRMatchesPods() bool {
+	return slices.Contains(c.PolicyCIDRMatchMode, "pods")
+}
+
 // PerNodeLabelsEnabled returns true if per-node labels feature
 // is enabled
 func (c *DaemonConfig) PerNodeLabelsEnabled() bool {
@@ -2150,10 +2154,10 @@ func (c *DaemonConfig) PerNodeLabelsEnabled() bool {
 }
 
 func (c *DaemonConfig) validatePolicyCIDRMatchMode() error {
-	// Currently, the only acceptable values is "nodes".
+	// Currently, the acceptable values are "nodes" and "pods".
 	for _, mode := range c.PolicyCIDRMatchMode {
 		switch mode {
-		case "nodes":
+		case "nodes", "pods":
 			continue
 		default:
 			return fmt.Errorf("unknown CIDR match mode: %s", mode)

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -13,6 +13,7 @@ import (
 
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 )
@@ -51,6 +52,9 @@ func TestCIDRGroupDuplicateLabelKeys(t *testing.T) {
 	// so if both CCGs produced the same map key, one label is silently dropped.
 	merged := maps.Clone(lblsBar)
 	maps.Copy(merged, lblsFoo)
+
+	// CIDR selectors require a world label by default
+	merged[labels.IDNameWorldIPv4] = labels.NewLabel(labels.IDNameWorldIPv4, "", labels.LabelSourceReserved)
 
 	arr := merged.LabelArray()
 

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1125,14 +1125,14 @@ func TestL3RuleLabels(t *testing.T) {
 			Verdict:     types.Allow,
 			Subject:     labelSelectorA,
 			Labels:      ruleLabels["rule1"],
-			L3:          types.ToSelectors(api.CIDRSlice{"10.0.1.0/32"}...),
+			L3:          types.ToSelectors(api.CIDR("10.0.1.0/32")),
 		}, {
 			Ingress:     false,
 			DefaultDeny: true,
 			Verdict:     types.Allow,
 			Subject:     labelSelectorA,
 			Labels:      ruleLabels["rule1"],
-			L3:          types.ToSelectors(api.CIDRSlice{"10.1.0.0/32"}...),
+			L3:          types.ToSelectors(api.CIDR("10.1.0.0/32")),
 		}},
 		"rule2": {{
 			Ingress:     true,
@@ -1140,14 +1140,14 @@ func TestL3RuleLabels(t *testing.T) {
 			Verdict:     types.Allow,
 			Subject:     labelSelectorA,
 			Labels:      ruleLabels["rule2"],
-			L3:          types.ToSelectors(api.CIDRSlice{"10.0.2.0/32"}...),
+			L3:          types.ToSelectors(api.CIDR("10.0.2.0/32")),
 		}, {
 			Ingress:     false,
 			DefaultDeny: true,
 			Verdict:     types.Allow,
 			Subject:     labelSelectorA,
 			Labels:      ruleLabels["rule2"],
-			L3:          types.ToSelectors(api.CIDRSlice{"10.2.0.0/32"}...),
+			L3:          types.ToSelectors(api.CIDR("10.2.0.0/32")),
 		}},
 	}
 
@@ -1213,7 +1213,7 @@ func TestL3RuleLabels(t *testing.T) {
 
 						matches = false
 						for sel := range filter.PerSelectorPolicies {
-							cidrLabels := labels.ParseLabelArray("cidr:" + cidr)
+							cidrLabels := labels.ParseLabelArray("cidr:"+cidr, "reserved:world")
 							t.Logf("Testing %+v", cidrLabels)
 							cidr, ok := sel.(*identitySelector).source.(*types.CIDRSelector)
 							if ok {

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -20,6 +20,7 @@ import (
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
@@ -510,11 +511,65 @@ func (p *CIDRSelector) SelectedNamespaces() []string {
 	return nil
 }
 
+// hasCIDRLabel returns true if the labels contain an IPv4 (ip4==true) or IPv6 CIDR label.
+func hasCIDRLabel(lbls labels.Labels, is4 bool) bool {
+	for _, l := range lbls {
+		if pfx := l.GetCIDRPrefix(); pfx != nil {
+			if pfx.IsValid() && pfx.Addr().Is4() == is4 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (p *CIDRSelector) Matches(ls labels.LabelArray) bool {
+	lbls := ls.Labels()
+	isWorld := lbls.HasWorldLabel()
+	isNode := lbls.HasHostLabel() || lbls.HasRemoteNodeLabel()
+	allowed := isWorld ||
+		(isNode && option.Config.PolicyCIDRMatchesNodes()) ||
+		(!isWorld && !isNode && option.Config.PolicyCIDRMatchesPods())
+
+	if !allowed {
+		return false
+	}
+
 	if p.encoded {
 		return matchesEncodedRequirements(p.requirements, ls)
 	}
-	return MatchesRequirements(p.requirements, ls)
+
+	for i := range p.requirements {
+		req := &p.requirements[i]
+		if matchesCIDRWildcard(req, lbls) {
+			continue // Wildcard requirement satisfied.
+		}
+		if !MatchesRequirement(req, ls) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchesCIDRWildcard returns true if the requirement is a wildcard and matches
+// the target under the PolicyCIDRMatchesPods configuration.
+func matchesCIDRWildcard(req *Requirement, lbls labels.Labels) bool {
+	if !option.Config.PolicyCIDRMatchesPods() || req.key.Source != labels.LabelSourceReserved {
+		return false
+	}
+
+	isIPv4Req := (req.key.Key == labels.IDNameWorldIPv4 || req.key.Key == labels.IDNameWorld)
+	isIPv6Req := (req.key.Key == labels.IDNameWorldIPv6 || req.key.Key == labels.IDNameWorld)
+
+	if option.Config.IPv4Enabled() && isIPv4Req && hasCIDRLabel(lbls, true /* ip4 */) {
+		return true
+	}
+	if option.Config.IPv6Enabled() && isIPv6Req && hasCIDRLabel(lbls, false /* ip4 */) {
+		return true
+	}
+
+	return false
 }
 
 func (p *CIDRSelector) GetFQDNSelector() (*api.FQDNSelector, bool) {

--- a/pkg/policy/types/selector_test.go
+++ b/pkg/policy/types/selector_test.go
@@ -19,9 +19,11 @@ import (
 func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 	oldv4 := option.Config.EnableIPv4
 	oldv6 := option.Config.EnableIPv6
+	oldPolicyCIDRMatchMode := option.Config.PolicyCIDRMatchMode
 	t.Cleanup(func() {
 		option.Config.EnableIPv4 = oldv4
 		option.Config.EnableIPv6 = oldv6
+		option.Config.PolicyCIDRMatchMode = oldPolicyCIDRMatchMode
 	})
 
 	selectors := func(needKeys ...string) Selectors {
@@ -70,12 +72,12 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 	}
 
 	tt := []struct {
-		name                   string
-		rule                   api.CIDRRule
-		expected               Selectors
-		enableIPv4, enableIPv6 bool
-		matchesLabels          []string
-		notMatchesLabels       []string
+		name                                                                  string
+		rule                                                                  api.CIDRRule
+		expected                                                              Selectors
+		enableIPv4, enableIPv6, policyCIDRMatchesPods, policyCIDRMatchesNodes bool
+		matchesLabels                                                         []string
+		notMatchesLabels                                                      []string
 	}{
 		{
 			name:       "basic cidr",
@@ -83,7 +85,21 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 			expected:   selectors("cidr:1.2.3.4/32"),
 			enableIPv4: true, enableIPv6: true,
 			matchesLabels:    []string{"cidr:1.2.3.4/32;reserved:world-ipv4"},
-			notMatchesLabels: []string{"cidr:1.2.3.5/32;reserved:world-ipv4"},
+			notMatchesLabels: []string{"cidr:1.2.3.4/32", "cidr:1.2.3.5/32", "cidr:1.2.3.5/32;reserved:world-ipv4"},
+		},
+		{
+			name: "basic cidr with match scope all",
+			rule: api.CIDRRule{Cidr: "1.2.3.4/32"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:1.2.3.4/32",
+				requirements: Requirements{
+					NewExistRequirement(labels.NewLabel("1.2.3.4/32", "", labels.LabelSourceCIDR)),
+				},
+			}},
+			enableIPv4: true, enableIPv6: true,
+			policyCIDRMatchesPods: true,
+			matchesLabels:         []string{"cidr:1.2.3.4/32", "cidr:1.2.3.4/32;reserved:world-ipv4"},
+			notMatchesLabels:      []string{"cidr:1.2.3.5/32", "cidr:1.2.3.5/32;reserved:world-ipv4"},
 		},
 		{
 			name: "except",
@@ -104,8 +120,8 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 			rule:       api.CIDRRule{CIDRGroupRef: "foo"},
 			expected:   selectors("cidrgroup:io.cilium.policy.cidrgroupname/foo"),
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"cidrgroup:io.cilium.policy.cidrgroupname/foo"},
-			notMatchesLabels: []string{"cidrgroup:io.cilium.policy.cidrgroupname/bar"},
+			matchesLabels:    []string{"cidrgroup:io.cilium.policy.cidrgroupname/foo;reserved:world-ipv4"},
+			notMatchesLabels: []string{"cidrgroup:io.cilium.policy.cidrgroupname/bar;reserved:world-ipv4"},
 		},
 		{
 			name: "cidr group with exception",
@@ -118,8 +134,8 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 				},
 			}},
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"cidrgroup:io.cilium.policy.cidrgroupname/foo"},
-			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidrgroup:io.cilium.policy.cidrgroupname/bar"},
+			matchesLabels:    []string{"cidrgroup:io.cilium.policy.cidrgroupname/foo;reserved:world-ipv4"},
+			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidrgroup:io.cilium.policy.cidrgroupname/bar;reserved:world-ipv4"},
 		},
 		{
 			name: "cidr group ls",
@@ -134,8 +150,8 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 				encoded: true,
 			}},
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"cidrgroup:foo=bar;cidrgroup:foo+bar"},
-			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz;cidrgroup:foo+baz"},
+			matchesLabels:    []string{"cidrgroup:foo=bar;cidrgroup:foo+bar;reserved:world-ipv4"},
+			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz;cidrgroup:foo+baz;reserved:world-ipv4"},
 		},
 		{
 			name: "cidr group ls with exceptions",
@@ -152,8 +168,8 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 				encoded: true,
 			}},
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"cidrgroup:foo=bar;cidrgroup:foo+bar"},
-			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.1681.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz;cidrgroup:foo+baz"},
+			matchesLabels:    []string{"cidrgroup:foo=bar;cidrgroup:foo+bar;reserved:world-ipv4"},
+			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.168.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz;cidrgroup:foo+baz;reserved:world-ipv4"},
 		},
 		{
 			name: "world v4 ss",
@@ -204,7 +220,7 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 				},
 			}},
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"reserved:world-ipv6", "cidr:::/0;reserved:world-ipv6", "cidr:::1/128;;reserved:world-ipv6"},
+			matchesLabels:    []string{"reserved:world-ipv6", "cidr:::/0;reserved:world-ipv6", "cidr:::1/128;reserved:world-ipv6"},
 			notMatchesLabels: []string{"cidr:::/0", "reserved:world", "reserved:world-ipv4", "cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.168.1.1/32;reserved:world-ipv4"},
 		},
 		{
@@ -222,6 +238,21 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 			notMatchesLabels: []string{"cidr:::/0;reserved:world-ipv6", "cidr:::1/128;reserved:world-ipv6", "cidr:1.2.3.4/32;reserved:world-ipv4"},
 		},
 		{
+			name: "world v4 ds except scope all",
+			rule: api.CIDRRule{Cidr: "0.0.0.0/0", ExceptCIDRs: []api.CIDR{"1.2.3.4/32"}},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:0.0.0.0/0-[1.2.3.4/32]",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabelV4),
+					NewExceptRequirement(labels.NewLabel("1.2.3.4/32", "", labels.LabelSourceCIDR)),
+				},
+			}},
+			enableIPv4: true, enableIPv6: true,
+			policyCIDRMatchesPods: true,
+			matchesLabels:         []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.168.1.1/32;reserved:world-ipv4", "cidr:192.168.2.1/32"},
+			notMatchesLabels:      []string{"cidr:::/0;reserved:world-ipv6", "cidr:::1/128;reserved:world-ipv6", "cidr:1.2.3.4/32;reserved:world-ipv4", "cidr:1.2.3.4/32"},
+		},
+		{
 			name: "world v4 ds multiple exceptions",
 			rule: api.CIDRRule{Cidr: "0.0.0.0/0", ExceptCIDRs: []api.CIDR{"1.2.3.4/32", "10.1.1.0/24"}},
 			expected: Selectors{&CIDRSelector{
@@ -236,12 +267,103 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 			matchesLabels:    []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.168.1.1/32;reserved:world-ipv4"},
 			notMatchesLabels: []string{"cidr:::/0;reserved:world-ipv6", "cidr:::1/128;reserved:world-ipv6", "cidr:1.2.3.4/32;reserved:world-ipv4", "cidr:10.1.1.5/32;reserved:world-ipv4"},
 		},
+		{
+			name: "world v4 single stack scope all",
+			rule: api.CIDRRule{Cidr: "0.0.0.0/0"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:0.0.0.0/0",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabel),
+				},
+			}},
+			enableIPv4: true, enableIPv6: false,
+			policyCIDRMatchesPods: true,
+			matchesLabels:         []string{"cidr:1.1.1.1/32;reserved:world", "cidr:1.1.1.1/32", "reserved:world", "cidr:1.1.1.1/32;reserved:world-ipv4"},
+			notMatchesLabels:      []string{"reserved:world-ipv4", "cidr:2001:db8::/64;reserved:world-ipv6", "cidr:2001:db8::/64"},
+		},
+		{
+			name: "world v4 dual stack scope all",
+			rule: api.CIDRRule{Cidr: "0.0.0.0/0"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:0.0.0.0/0",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabelV4),
+				},
+			}},
+			enableIPv4: true, enableIPv6: true,
+			policyCIDRMatchesPods: true,
+			matchesLabels:         []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:1.1.1.1/32", "reserved:world-ipv4", "cidr:1.1.1.1/32;reserved:world"},
+			notMatchesLabels:      []string{"reserved:world", "cidr:2001:db8::/64;reserved:world-ipv6", "cidr:2001:db8::/64"},
+		},
+		{
+			name: "world v6 single stack scope all",
+			rule: api.CIDRRule{Cidr: "::/0"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:::/0",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabel),
+				},
+			}},
+			enableIPv4: false, enableIPv6: true,
+			policyCIDRMatchesPods: true,
+			matchesLabels:         []string{"cidr:2001:db8::/64;reserved:world-ipv6", "cidr:2001:db8::/64", "reserved:world"},
+			notMatchesLabels:      []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:1.1.1.1/32", "reserved:world-ipv6"},
+		},
+		{
+			name: "world v6 dual stack scope all",
+			rule: api.CIDRRule{Cidr: "::/0"},
+			expected: Selectors{&CIDRSelector{
+				key: "cidr:::/0",
+				requirements: Requirements{
+					NewExistRequirement(labels.WorldLabelV6),
+				},
+			}},
+			enableIPv4: true, enableIPv6: true,
+			policyCIDRMatchesPods: true,
+			matchesLabels:         []string{"cidr:2001:db8::/64;reserved:world-ipv6", "cidr:2001:db8::/64", "reserved:world-ipv6"},
+			notMatchesLabels:      []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:1.1.1.1/32"},
+		},
+		{
+			name:                   "CIDR matching nodes enabled, matches node",
+			rule:                   api.CIDRRule{Cidr: "192.168.1.0/24"},
+			expected:               selectors("cidr:192.168.1.0/24"),
+			enableIPv4:             true,
+			enableIPv6:             true,
+			policyCIDRMatchesNodes: true,
+			matchesLabels: []string{
+				"cidr:192.168.1.10/32;reserved:remote-node",
+				"cidr:192.168.1.10/32;reserved:host",
+			},
+			notMatchesLabels: []string{
+				"cidr:192.168.1.10/32", // pod: MatchPods is false
+				"cidr:192.168.2.10/32;reserved:remote-node",
+			},
+		},
+		{
+			name:                   "CIDR matching nodes disabled, does not match node",
+			rule:                   api.CIDRRule{Cidr: "192.168.1.0/24"},
+			expected:               selectors("cidr:192.168.1.0/24"),
+			enableIPv4:             true,
+			enableIPv6:             true,
+			policyCIDRMatchesNodes: false,
+			notMatchesLabels: []string{
+				"cidr:192.168.1.10/32;reserved:remote-node",
+				"cidr:192.168.1.10/32;reserved:host",
+			},
+		},
 	}
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			option.Config.EnableIPv6 = test.enableIPv6
 			option.Config.EnableIPv4 = test.enableIPv4
+			option.Config.PolicyCIDRMatchMode = []string{}
+			if test.policyCIDRMatchesPods {
+				option.Config.PolicyCIDRMatchMode = append(option.Config.PolicyCIDRMatchMode, "pods")
+			}
+			if test.policyCIDRMatchesNodes {
+				option.Config.PolicyCIDRMatchMode = append(option.Config.PolicyCIDRMatchMode, "nodes")
+			}
 
 			if test.rule.CIDRGroupSelector.LabelSelector != nil {
 				test.rule.CIDRGroupSelector = api.NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, test.rule.CIDRGroupSelector.LabelSelector)

--- a/pkg/testutils/endpointmanager/endpointmanager.go
+++ b/pkg/testutils/endpointmanager/endpointmanager.go
@@ -188,3 +188,7 @@ func (*MockEndpointManager) InitHostEndpointLabels(ctx context.Context) {
 func (*MockEndpointManager) UpdatePolicy(idsToRegen *set.Set[identity.NumericIdentity], fromRev, toRev uint64) {
 	panic("MockEndpointManager.UpdatePolicy not implemented")
 }
+
+func (*MockEndpointManager) UpdateCIDRLabels(ctx context.Context, prefix netip.Prefix) bool {
+	panic("MockEndpointManager.UpdateCIDRLabels not implemented")
+}


### PR DESCRIPTION
This commit introduces the ability to use CIDR selectors to match pods, in addition to external entities, by implementing a synchronized metadata-driven allocation pipeline.
    
To achieve this, the following changes were made:

* Refactors CIDRSelector matching logic to evaluate wildcard requirements at the individual requirement level. This ensures that wildcard selectors with exceptions (e.g., 0.0.0.0/0 except a specific subnet) correctly match pod IPs under the global PolicyCIDRMatchesPods configuration. Extends selector_test with test cases for wildcard selectors with exceptions.
* Wires the ipcache during initialization to register endpointManager as a CIDRSelectorAllocator. This links ipcache prefix events directly to endpoint CIDR label updates.
* Implements UpdateCIDRLabels on the Endpoint struct to dynamically pull the latest CIDR and CIDRGroup metadata from the ipcache and update the endpoint's identity labels.
* Introduces the CIDRSelectorAllocator interface in the ipcache package.
Updates doInjectLabels to notify this allocator whenever new CIDR prefixes/metadata are injected or removed, propagating updates to the endpoint manager.
* Modifies the controller execution loop to listen on the c.update channel during its jitter sleep phase.
This allows the controller to immediately wake up and re-evaluate parameters (such as running immediately if jitter is updated to 0) instead of blocking until the original sleep window expires.
Adds TestControllerUpdateDuringJitter to verify this behavior.

```release-note
Allow CIDR selectors in network policies to match in-cluster IPs
```
