### PR TITLE
bpf: Pull skb data before accessing IP headers in TAIL_CT_LOOKUP{4,6}

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -531,7 +531,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	ct_state = (struct ct_state *)&ct_buffer.ct_state;			\
 	tuple = (struct ipv4_ct_tuple *)&ct_buffer.tuple;			\
 										\
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))			\
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))		\
 		return drop_for_direction(ctx, DIR, DROP_INVALID, ext_err);	\
 										\
 	tuple->nexthdr = ip4->protocol;						\
@@ -601,7 +601,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	ct_state = (struct ct_state *)&ct_buffer.ct_state;			\
 	tuple = (struct ipv6_ct_tuple *)&ct_buffer.tuple;			\
 										\
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))			\
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))		\
 		return drop_for_direction(ctx, DIR, DROP_INVALID, ext_err);	\
 										\
 	tuple->nexthdr = ip6->nexthdr;						\


### PR DESCRIPTION
On NICs that use header-data split for large packets (> ~640B), the linear skb head may not contain the full l3 header.  For instance this was observed in UDP-encapsulated packets where upstream BPF filters stripped the encapsulation and just left 15 bytes in linear, with the rest in page fragments.

For those packets, the TAIL_CT_LOOKUP6 macro uses revalidate_data() which does not call bpf_skb_pull_data(), causing the data bounds check to fail (needs 54 bytes, only 15 available) and dropping the packet with DROP_INVALID (TC_ACT_SHOT).

Switch to revalidate_data_pull() which calls bpf_skb_pull_data() to linearize at least ETH_HLEN + sizeof(struct ipv6hdr) before accessing the headers. This is a no-op when data is already linear and matches what the egress path already does.

As Cilium does not control the NIC or other upstream BPF filters, it seems a good practice to pull defensively

```release-note
Fixes dropped packets on ingress when full header not in linear skb area
```