### PR TITLE
l2responder: fix BPF map entry deletion caused by pointer reuse

### DIFF
--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -286,23 +286,25 @@ func (p *l2ResponderReconciler) fullReconciliation(txn statedb.ReadTxn) (err err
 	}
 
 	// Loop over all map values, use the desired entries index to see which we want to delete.
-	var toDelete []*l2respondermap.L2ResponderKey
+	// Note: IterateWithCallback reuses the same key pointer across iterations,
+	// so we must copy the key values rather than storing pointers.
+	var toDelete []l2respondermap.L2ResponderKey
 	arMap.IterateWithCallback(func(key *l2respondermap.L2ResponderKey, _ *l2respondermap.L2ResponderStats) {
 		e, found := desiredMap[*key]
 		if !found {
-			toDelete = append(toDelete, key)
+			toDelete = append(toDelete, *key)
 			return
 		}
 		e.satisfied = true
 		desiredMap[*key] = e
 	})
-	var toDelete6 []*l2v6respondermap.L2V6ResponderKey
+	var toDelete6 []l2v6respondermap.L2V6ResponderKey
 	ndMap.IterateWithCallback(func(key *l2v6respondermap.L2V6ResponderKey, _ *l2respondermap.L2ResponderStats) {
 		currMcMACMap.Add(int(key.IfIndex), netip.AddrFrom16(key.IP))
 
 		e, found := desiredMap6[*key]
 		if !found {
-			toDelete6 = append(toDelete6, key)
+			toDelete6 = append(toDelete6, *key)
 			return
 		}
 		e.satisfied = true

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -85,6 +85,7 @@ var (
 	ip3     = netip.MustParseAddr("3.4.5.6")
 	ipv6_1  = netip.MustParseAddr("fd01::c0a8:0")
 	ipv6_2  = netip.MustParseAddr("fd02::c0a8:0")
+	ipv6_3  = netip.MustParseAddr("fd03::c0a8:0")
 	ns_mac  = mac.MustParseMAC("33:33:ff:a8:00:00")
 	origin1 = resource.Key{Name: "abc"}
 )
@@ -524,6 +525,123 @@ func TestIpv6McasMAC(t *testing.T) {
 
 	_, ok = macRem[key]
 	assert.True(t, ok, "expected key %v to exist in map", key)
+}
+
+// Regression test for https://github.com/cilium/cilium/issues/45068
+func TestFullReconciliationPointerReuse(t *testing.T) {
+	type mapOps struct {
+		create func(ip netip.Addr, ifIndex uint32) error
+		lookup func(ip netip.Addr, ifIndex uint32) (any, error)
+	}
+
+	for _, tt := range []struct {
+		name     string
+		ips      [3]netip.Addr
+		ipLabels [3]string
+		mapOpsFn func(fix *fixture) mapOps
+	}{
+		{
+			name:     "v4",
+			ips:      [3]netip.Addr{ip1, ip2, ip3},
+			ipLabels: [3]string{"ip1", "ip2", "ip3"},
+			mapOpsFn: func(fix *fixture) mapOps {
+				return mapOps{
+					create: fix.respondermap.Create,
+					lookup: func(ip netip.Addr, ifIndex uint32) (any, error) {
+						return fix.respondermap.Lookup(ip, ifIndex)
+					},
+				}
+			},
+		},
+		{
+			name:     "v6",
+			ips:      [3]netip.Addr{ipv6_1, ipv6_2, ipv6_3},
+			ipLabels: [3]string{"ipv6_1", "ipv6_2", "ipv6_3"},
+			mapOpsFn: func(fix *fixture) mapOps {
+				return mapOps{
+					create: fix.respondermap6.Create,
+					lookup: func(ip netip.Addr, ifIndex uint32) (any, error) {
+						return fix.respondermap6.Lookup(ip, ifIndex)
+					},
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fix := newFixture(t)
+			ops := tt.mapOpsFn(fix)
+
+			fix.mockNetlink.LinkByNameFn = func(name string) (netlink.Link, error) {
+				return &mockLink{
+					attr: netlink.LinkAttrs{Index: ifidx1},
+				}, nil
+			}
+
+			// Add IP1 only as desired entry in state DB. Therefore, IP2 and IP3
+			// are rogue entries that should be removed from the BPF map.
+			txn := fix.stateDB.WriteTxn(fix.proxyNeighborTable)
+			_, _, err := fix.proxyNeighborTable.Insert(txn, &tables.L2AnnounceEntry{
+				L2AnnounceKey: tables.L2AnnounceKey{
+					IP:               tt.ips[0],
+					NetworkInterface: if1,
+				},
+				Origins: []resource.Key{origin1},
+			})
+			assert.NoError(t, err)
+			txn.Commit()
+
+			for _, ip := range tt.ips {
+				assert.NoError(t, ops.create(ip, ifidx1))
+			}
+
+			err = fix.reconciler.fullReconciliation(fix.stateDB.ReadTxn())
+			assert.NoError(t, err)
+
+			stats, err := ops.lookup(tt.ips[0], ifidx1)
+			assert.NoError(t, err)
+			assert.NotNil(t, stats, "desired entry %s was wrongly deleted from BPF map", tt.ipLabels[0])
+
+			stats, err = ops.lookup(tt.ips[1], ifidx1)
+			assert.NoError(t, err)
+			assert.Nil(t, stats, "rogue entry %s was not deleted from BPF map", tt.ipLabels[1])
+
+			stats, err = ops.lookup(tt.ips[2], ifidx1)
+			assert.NoError(t, err)
+			assert.Nil(t, stats, "rogue entry %s was not deleted from BPF map", tt.ipLabels[2])
+
+			// Now add also IP2 as desired entry in state DB. Therefore, IP3 is
+			// the only rogue entry that should be removed from the BPF map.
+			txn = fix.stateDB.WriteTxn(fix.proxyNeighborTable)
+			_, _, err = fix.proxyNeighborTable.Insert(txn, &tables.L2AnnounceEntry{
+				L2AnnounceKey: tables.L2AnnounceKey{
+					IP:               tt.ips[1],
+					NetworkInterface: if1,
+				},
+				Origins: []resource.Key{origin1},
+			})
+			assert.NoError(t, err)
+			txn.Commit()
+
+			for _, ip := range tt.ips {
+				assert.NoError(t, ops.create(ip, ifidx1))
+			}
+
+			err = fix.reconciler.fullReconciliation(fix.stateDB.ReadTxn())
+			assert.NoError(t, err)
+
+			stats, err = ops.lookup(tt.ips[0], ifidx1)
+			assert.NoError(t, err)
+			assert.NotNil(t, stats, "desired entry %s was wrongly deleted from BPF map", tt.ipLabels[0])
+
+			stats, err = ops.lookup(tt.ips[1], ifidx1)
+			assert.NoError(t, err)
+			assert.NotNil(t, stats, "desired entry %s was wrongly deleted from BPF map", tt.ipLabels[1])
+
+			stats, err = ops.lookup(tt.ips[2], ifidx1)
+			assert.NoError(t, err)
+			assert.Nil(t, stats, "rogue entry %s was not deleted from BPF map", tt.ipLabels[2])
+		})
+	}
 }
 
 type mockNeighborNetlink struct {

--- a/pkg/maps/l2respondermap/l2_responder_map4_fake.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4_fake.go
@@ -35,8 +35,12 @@ func (fm *fakeMap) Delete(ip netip.Addr, ifIndex uint32) error {
 }
 
 func (fm *fakeMap) IterateWithCallback(cb IterateCallback) error {
+	var key L2ResponderKey
+	var val L2ResponderStats
 	for k, v := range fm.entries {
-		cb(&k, &v)
+		key = k
+		val = v
+		cb(&key, &val)
 	}
 
 	return nil

--- a/pkg/maps/l2v6respondermap/l2_responder_map6_fake.go
+++ b/pkg/maps/l2v6respondermap/l2_responder_map6_fake.go
@@ -37,8 +37,12 @@ func (fm *fakeMap) Delete(ip netip.Addr, ifIndex uint32) error {
 }
 
 func (fm *fakeMap) IterateWithCallback(cb IterateCallback) error {
+	var key L2V6ResponderKey
+	var val l2respondermap.L2ResponderStats
 	for k, v := range fm.entries {
-		cb(&k, &v)
+		key = k
+		val = v
+		cb(&key, &val)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fix the L2 responder reconciler incorrectly deleting desired BPF map
entries during full reconciliation, which causes intermittent ARP
failures for LoadBalancer services using L2 announcements.

**Root cause:** `ebpf.Map.IterateWithCallback` reuses the same key
pointer across iterations. The `fullReconciliation` method stored
these pointers directly in the `toDelete` slice, so all entries ended
up pointing to the last iterated key. This caused the reconciler to
delete desired entries instead of rogue ones.

**Changes:**

- Copy key values (`*key`) instead of storing pointers (`key`) when
  building the `toDelete` / `toDelete6` slices during BPF map iteration
- Tolerate `ErrKeyNotExist` errors during deletion in both partial and
  full reconciliation, since entries may be removed between iteration
  and the delete loop
- Add regression tests with a `pointerReusingFakeMap` that mimics real
  BPF map iteration behavior

```release-note
Fixed intermittent ARP failures for LoadBalancer services caused by pointer reuse during BPF map iteration in the L2 responder reconciler.
```

Fixes: #45068
Signed-off-by: Kc Balusu <krishnabkc15@gmail.com>

## Test plan

- [x] Added `TestFullReconciliationPointerReuse` — verifies desired
  entry survives and rogue entry is deleted with pointer-reusing
  iteration
- [x] Added `TestFullReconciliationMultipleRoguePointerReuse` — same
  with multiple rogue entries
- [x] Cross-compiled for Linux (`GOOS=linux go build` / `go test -c`)
- [x] `gofmt`, `go vet`, `golangci-lint` all pass with 0 issues
- [x] Existing tests continue to pass
