### PR TITLE
cilium-cli: introduce dedicated connectivity test skip condition helpers

### DIFF
--- a/cilium-cli/connectivity/builder/all_ingress_deny_from_outside.go
+++ b/cilium-cli/connectivity/builder/all_ingress_deny_from_outside.go
@@ -13,7 +13,7 @@ type allIngressDenyFromOutside struct{}
 
 func (t allIngressDenyFromOutside) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("all-ingress-deny-from-outside", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithCiliumPolicy(denyAllIngressPolicyYAML).
 		WithFeatureRequirements(features.RequireEnabled(features.NodeWithoutCilium)).
 		WithIPRoutesFromOutsideToPodCIDRs().

--- a/cilium-cli/connectivity/builder/bgp_control_plane.go
+++ b/cilium-cli/connectivity/builder/bgp_control_plane.go
@@ -15,9 +15,7 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 	newTest("bgp-control-plane-v1", ct).
 		// NOTE: BGPv1 was removed in v1.19, this test can be removed once v1.18 is out of support
 		WithCiliumVersion(">=1.16.0 <1.19.0").
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
-		}).
+		WithUnsafeTests().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),
 			features.RequireEnabled(features.NodeWithoutCilium),
@@ -26,9 +24,7 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 
 	newTest("bgp-control-plane-v2", ct).
 		WithCiliumVersion(">=1.16.0").
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
-		}).
+		WithUnsafeTests().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),
 			features.RequireEnabled(features.NodeWithoutCilium),

--- a/cilium-cli/connectivity/builder/echo_ingress_from_outside.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_from_outside.go
@@ -13,7 +13,7 @@ type echoIngressFromOutside struct{}
 
 func (t echoIngressFromOutside) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("echo-ingress-from-outside", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithCiliumPolicy(echoIngressFromOtherClientPolicyYAML).
 		WithFeatureRequirements(features.RequireEnabled(features.NodeWithoutCilium)).
 		WithIPRoutesFromOutsideToPodCIDRs().

--- a/cilium-cli/connectivity/builder/echo_ingress_l7.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_l7.go
@@ -43,7 +43,7 @@ func (t echoIngressL7) build(ct *check.ConnectivityTest, templates map[string]st
 		WithExpectations(expectation)
 
 	newTest("echo-ingress-l7-via-hostport", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithCondition(func() bool {
 			if ok, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.L7Proxy)); !ok {
 				return false

--- a/cilium-cli/connectivity/builder/egress_gateway.go
+++ b/cilium-cli/connectivity/builder/egress_gateway.go
@@ -15,7 +15,7 @@ type egressGateway struct{}
 
 func (t egressGateway) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("egress-gateway", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
 			Name:            fmt.Sprintf("cegp-sample-client-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "client",

--- a/cilium-cli/connectivity/builder/egress_gateway_multigateway.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_multigateway.go
@@ -16,7 +16,7 @@ type egressGatewayMultigateway struct{}
 func (t egressGatewayMultigateway) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("egress-gateway-multigateway", ct).
 		WithCiliumVersion(">=1.18.0").
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithCiliumEgressGatewayPolicy(check.CiliumEgressGatewayPolicyParams{
 			Name:            fmt.Sprintf("cegp-sample-client-%d", ct.Params().TestNamespaceIndex),
 			PodSelectorKind: "client",

--- a/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -23,9 +23,7 @@ type egressGatewayWithL7Policy struct{}
 func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("egress-gateway-with-l7-policy", ct).
 		WithCiliumVersion(">=1.16.0").
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
-		}).
+		WithUnsafeTests().
 		WithCiliumPolicy(clientEgressICMPYAML).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).  // DNS resolution only
 		WithCiliumPolicy(templates["clientEgressL7HTTPExternalYAML"]). // L7 allow policy with HTTP introspection

--- a/cilium-cli/connectivity/builder/from_cidr_host_netns.go
+++ b/cilium-cli/connectivity/builder/from_cidr_host_netns.go
@@ -13,7 +13,7 @@ type fromCidrHostNetns struct{}
 
 func (t fromCidrHostNetns) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("from-cidr-host-netns", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithFeatureRequirements(features.RequireEnabled(features.NodeWithoutCilium)).
 		WithCiliumPolicy(templates["echoIngressFromCIDRYAML"]).
 		WithIPRoutesFromOutsideToPodCIDRs().

--- a/cilium-cli/connectivity/builder/host_firewall_egress.go
+++ b/cilium-cli/connectivity/builder/host_firewall_egress.go
@@ -18,7 +18,7 @@ type hostFirewallEgress struct{}
 
 func (t hostFirewallEgress) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("host-firewall-egress", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithFeatureRequirements(features.RequireEnabled(features.HostFirewall)).
 		WithCiliumClusterwidePolicy(hostFirewallEgressPolicyYAML).
 		WithScenarios(tests.HostToPod()).

--- a/cilium-cli/connectivity/builder/host_firewall_ingress.go
+++ b/cilium-cli/connectivity/builder/host_firewall_ingress.go
@@ -18,7 +18,7 @@ type hostFirewallIngress struct{}
 
 func (t hostFirewallIngress) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("host-firewall-ingress", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithFeatureRequirements(features.RequireEnabled(features.HostFirewall)).
 		WithCiliumClusterwidePolicy(hostFirewallIngressPolicyYAML).
 		WithScenarios(tests.PodToHost()).

--- a/cilium-cli/connectivity/builder/ipsec_key_derivation.go
+++ b/cilium-cli/connectivity/builder/ipsec_key_derivation.go
@@ -14,9 +14,7 @@ type ipsecKeyDerivation struct{}
 func (t ipsecKeyDerivation) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("ipsec-key-derivation-validation", ct).
 		WithCiliumVersion(">=1.19.0-pre.0").
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
-		}).
+		WithUnsafeTests().
 		WithFeatureRequirements(features.RequireMode(features.EncryptionPod, "ipsec")).
 		WithScenarios(tests.IPsecKeyDerivationValidation())
 }

--- a/cilium-cli/connectivity/builder/local_redirect_policy_with_nodedns.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy_with_nodedns.go
@@ -18,7 +18,7 @@ type localRedirectPolicyWithNodeDNS struct{}
 
 func (t localRedirectPolicyWithNodeDNS) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("local-redirect-policy-with-node-dns", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithCiliumPolicy(templates["clientEgressNodeLocalDNSYAML"]).
 		WithFeatureRequirements(
 			features.RequireEnabled(features.NodeLocalDNS),

--- a/cilium-cli/connectivity/builder/multicast.go
+++ b/cilium-cli/connectivity/builder/multicast.go
@@ -14,9 +14,7 @@ type multicast struct{}
 func (t multicast) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("multicast", ct).
 		WithCiliumVersion(">=1.16.0").
-		WithCondition(func() bool {
-			return ct.Params().IncludeUnsafeTests
-		}).
+		WithUnsafeTests().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.Multicast),
 		).

--- a/cilium-cli/connectivity/builder/network_bandwidth_limit.go
+++ b/cilium-cli/connectivity/builder/network_bandwidth_limit.go
@@ -12,6 +12,6 @@ type networkBandwidthLimit struct{}
 
 func (t networkBandwidthLimit) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("network-bandwidth-limit", ct).
-		WithCondition(func() bool { return ct.Params().Perf }).
+		WithPerf().
 		WithScenarios(netperf.NetBandwidth(""))
 }

--- a/cilium-cli/connectivity/builder/network_perf.go
+++ b/cilium-cli/connectivity/builder/network_perf.go
@@ -12,6 +12,6 @@ type networkPerf struct{}
 
 func (t networkPerf) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("network-perf", ct).
-		WithCondition(func() bool { return ct.Params().Perf }).
+		WithPerf().
 		WithScenarios(netperf.Netperf(""))
 }

--- a/cilium-cli/connectivity/builder/network_qos.go
+++ b/cilium-cli/connectivity/builder/network_qos.go
@@ -12,6 +12,6 @@ type networkQos struct{}
 
 func (t networkQos) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("network-qos", ct).
-		WithCondition(func() bool { return ct.Params().Perf }).
+		WithPerf().
 		WithScenarios(netperf.NetQos(""))
 }

--- a/cilium-cli/connectivity/builder/no_fragmentation.go
+++ b/cilium-cli/connectivity/builder/no_fragmentation.go
@@ -12,7 +12,7 @@ type noFragmentation struct{}
 
 func (t noFragmentation) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("pod-to-pod-no-frag", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithScenarios(
 			tests.PodToPodNoFrag(),
 		)

--- a/cilium-cli/connectivity/builder/no_policies_from_outside.go
+++ b/cilium-cli/connectivity/builder/no_policies_from_outside.go
@@ -13,7 +13,7 @@ type noPoliciesFromOutside struct{}
 
 func (t noPoliciesFromOutside) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("no-policies-from-outside", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithFeatureRequirements(features.RequireEnabled(features.NodeWithoutCilium)).
 		WithIPRoutesFromOutsideToPodCIDRs().
 		WithScenarios(tests.FromCIDRToPod())

--- a/cilium-cli/connectivity/builder/node_to_node_encryption.go
+++ b/cilium-cli/connectivity/builder/node_to_node_encryption.go
@@ -15,7 +15,7 @@ func (t nodeToNodeEncryption) build(ct *check.ConnectivityTest, _ map[string]str
 	// Encryption checks are always executed as a sanity check, asserting whether
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("node-to-node-encryption", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithScenarios(
 			tests.NodeToNodeEncryption(
 				features.RequireEnabled(features.EncryptionPod),

--- a/cilium-cli/connectivity/builder/pod_to_controlplane_host.go
+++ b/cilium-cli/connectivity/builder/pod_to_controlplane_host.go
@@ -17,7 +17,7 @@ type podToControlplaneHost struct{}
 
 func (t podToControlplaneHost) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("pod-to-controlplane-host", ct).
-		WithCondition(func() bool { return ct.Params().K8sLocalHostTest }).
+		WithK8sLocalHostTest().
 		WithCiliumPolicy(clientEgressToEntitiesHostPolicyYAML).
 		WithScenarios(tests.PodToControlPlaneHost())
 }

--- a/cilium-cli/connectivity/builder/pod_to_controlplane_host_cidr.go
+++ b/cilium-cli/connectivity/builder/pod_to_controlplane_host_cidr.go
@@ -15,7 +15,7 @@ func (t podToControlplaneHostCidr) build(ct *check.ConnectivityTest, templates m
 	// Check that pods can access  when referencing them by CIDR selectors
 	// (when this feature is enabled).
 	newTest("pod-to-controlplane-host-cidr", ct).
-		WithCondition(func() bool { return ct.Params().K8sLocalHostTest }).
+		WithK8sLocalHostTest().
 		WithFeatureRequirements(features.RequireEnabled(features.CIDRMatchNodes)).
 		WithK8SPolicy(templates["clientEgressToCIDRCPHostPolicyYAML"]).
 		WithScenarios(tests.PodToControlPlaneHost())

--- a/cilium-cli/connectivity/builder/pod_to_k8s_on_controlplane.go
+++ b/cilium-cli/connectivity/builder/pod_to_k8s_on_controlplane.go
@@ -17,7 +17,7 @@ type podToK8sOnControlplane struct{}
 
 func (t podToK8sOnControlplane) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("pod-to-k8s-on-controlplane", ct).
-		WithCondition(func() bool { return ct.Params().K8sLocalHostTest }).
+		WithK8sLocalHostTest().
 		WithCiliumPolicy(clientEgressToEntitiesK8sPolicyYAML).
 		WithScenarios(tests.PodToK8sLocal())
 }

--- a/cilium-cli/connectivity/builder/pod_to_k8s_on_controlplane_cidr.go
+++ b/cilium-cli/connectivity/builder/pod_to_k8s_on_controlplane_cidr.go
@@ -13,7 +13,7 @@ type podToK8sOnControlplaneCidr struct{}
 
 func (t podToK8sOnControlplaneCidr) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("pod-to-k8s-on-controlplane-cidr", ct).
-		WithCondition(func() bool { return ct.Params().K8sLocalHostTest }).
+		WithK8sLocalHostTest().
 		WithFeatureRequirements(features.RequireEnabled(features.CIDRMatchNodes)).
 		WithCiliumPolicy(templates["clientEgressToCIDRK8sPolicyKNPYAML"]).
 		WithScenarios(tests.PodToK8sLocal())

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -21,7 +21,7 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 	// Encryption checks are always executed as a sanity check, asserting whether
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("pod-to-pod-encryption", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithCiliumVersion("<1.18.0").
 		WithFeatureRequirements(features.RequireDisabled(features.Ztunnel)).
 		WithScenarios(
@@ -29,7 +29,7 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		)
 
 	newTest("pod-to-pod-with-l7-policy-encryption", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithCiliumVersion("<1.18.0").
 		WithCondition(func() bool {
 			if ok, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec")); ok {

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption_v2.go
@@ -17,7 +17,7 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 	// Encryption checks are always executed as a sanity check, asserting whether
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("pod-to-pod-encryption-v2", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(features.RequireDisabled(features.Ztunnel)).
 		WithScenarios(
@@ -25,7 +25,7 @@ func (t podToPodEncryptionV2) build(ct *check.ConnectivityTest, _ map[string]str
 		)
 
 	newTest("pod-to-pod-with-l7-policy-encryption-v2", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(
 			features.RequireEnabled(features.L7Proxy),

--- a/cilium-cli/connectivity/builder/strict_mode_encryption.go
+++ b/cilium-cli/connectivity/builder/strict_mode_encryption.go
@@ -14,7 +14,7 @@ type strictModeEncryption struct{}
 
 func (t strictModeEncryption) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("strict-mode-encryption", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		// Until https://github.com/cilium/cilium/pull/35454 is backported to <1.17.0
 		WithCiliumVersion(">=1.17.0 <1.18.0").
 		WithFeatureRequirements(
@@ -30,7 +30,7 @@ func (t strictModeEncryption) build(ct *check.ConnectivityTest, _ map[string]str
 		})
 
 	newTest("strict-mode-encryption-v2", ct).
-		WithCondition(func() bool { return ct.Params().IncludeUnsafeTests }).
+		WithUnsafeTests().
 		WithCiliumVersion(">=1.18.0").
 		WithFeatureRequirements(
 			features.RequireEnabled(features.EncryptionStrictModeEgress),

--- a/cilium-cli/connectivity/builder/ztunnel_pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/ztunnel_pod_to_pod_encryption.go
@@ -18,7 +18,7 @@ func (t ztunnelPodToPodEncryption) build(ct *check.ConnectivityTest, _ map[strin
 	// Encryption checks are always executed as a sanity check, asserting whether
 	// unencrypted packets shall, or shall not, be observed based on the feature set.
 	newTest("ztunnel-pod-to-pod-encryption", ct).
-		WithCondition(func() bool { return !ct.Params().SingleNode }).
+		WithMultiNodeOnly().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.Ztunnel),
 			features.RequireMode(features.EncryptionPod, "ztunnel"),

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -5,6 +5,7 @@ package check
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	_ "embed"
 	"errors"
@@ -63,13 +64,13 @@ func NewTest(name string, verbose bool, debug bool) *Test {
 		panic("empty test name")
 	}
 	test := &Test{
-		name:        name,
-		scenarios:   make(map[Scenario][]*Action),
-		resources:   []k8s.Object{},
-		clrps:       make(map[string]*ciliumv2.CiliumLocalRedirectPolicy),
-		logBuf:      &bytes.Buffer{}, // maintain internal buffer by default
-		conditionFn: nil,
-		verbose:     verbose,
+		name:       name,
+		scenarios:  make(map[Scenario][]*Action),
+		resources:  []k8s.Object{},
+		clrps:      make(map[string]*ciliumv2.CiliumLocalRedirectPolicy),
+		logBuf:     &bytes.Buffer{}, // maintain internal buffer by default
+		conditions: nil,
+		verbose:    verbose,
 	}
 	// Setting the internal buffer to nil causes the logger to
 	// write directly to stdout in verbose or debug mode.
@@ -146,10 +147,9 @@ type Test struct {
 	logBuf  io.ReadWriter
 	verbose bool
 
-	// conditionFn is a function that returns true if the test needs to run,
-	// and false otherwise. By default, it's set to a function that returns
-	// true.
-	conditionFn []func() bool
+	// conditions is a list of test conditions to evaluate whether the test
+	// should be run or skipped.
+	conditions []testCondition
 
 	// List of functions to be called when Run() returns.
 	finalizers []func(ctx context.Context) error
@@ -250,13 +250,15 @@ func (t *Test) versionInRange(version semver.Version) (bool, string) {
 	return true, "running version within range"
 }
 
-func (t *Test) checkConditions() bool {
-	for _, fn := range t.conditionFn {
-		if !fn() {
-			return false
+// checkConditions returns whether the test should be run based on the test
+// conditions and an optional skip reason string in case the test should be skipped.
+func (t *Test) checkConditions() (bool, string) {
+	for _, cond := range t.conditions {
+		if !cond.fn() {
+			return false, cmp.Or(cond.reason, "skipped by condition")
 		}
 	}
-	return true
+	return true, ""
 }
 
 // willRun returns false if all of the Test's Scenarios are skipped by the user,
@@ -269,8 +271,8 @@ func (t *Test) checkConditions() bool {
 // excluding tests, they're most likely interested in other reasons why their
 // test is not being executed.
 func (t *Test) willRun() (bool, string) {
-	if !t.checkConditions() {
-		return false, "skipped by condition"
+	if run, reason := t.checkConditions(); !run {
+		return false, reason
 	}
 
 	// Check if the running Cilium version is within range of the value specified
@@ -394,12 +396,27 @@ func (t *Test) Run(ctx context.Context, index int) error {
 	return nil
 }
 
+// testCondition is a test condition to evaluate whether a test should be run.
+type testCondition struct {
+	// fn is a function that returns true if the test needs to run, and
+	// false if the test should be skipped.
+	fn func() bool
+	// reason is an optional message that is printed if the test is skipped
+	// based on the test condition.
+	reason string
+}
+
 // WithCondition takes a function containing condition check logic that
 // returns true if the test needs to be run, and false otherwise. If
 // WithCondition gets called multiple times, all the conditions need to be
-// satisfied for the test to run.
-func (t *Test) WithCondition(fn func() bool) *Test {
-	t.conditionFn = append(t.conditionFn, fn)
+// satisfied for the test to run. It takes an optional reason message that is
+// printed if the test is skipped based on the condition.
+func (t *Test) WithCondition(fn func() bool, reason ...string) *Test {
+	r := ""
+	if len(reason) > 0 {
+		r = reason[0]
+	}
+	t.conditions = append(t.conditions, testCondition{fn, r})
 	return t
 }
 

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -430,6 +430,15 @@ func (t *Test) WithUnsafeTests() *Test {
 	)
 }
 
+// WithMultiNodeOnly causes the test to only be executed in multi-node
+// environments.
+func (t *Test) WithMultiNodeOnly() *Test {
+	return t.WithCondition(
+		func() bool { return !t.ctx.Params().SingleNode },
+		"test requires a multi-node cluster",
+	)
+}
+
 // WithCiliumVersion limits test execution to Cilium versions that fall within
 // the given range. The input string is passed to [semver.ParseRange], see
 // package semver. Simple examples: ">1.0.0 <2.0.0" or ">=1.14.0".

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -420,6 +420,16 @@ func (t *Test) WithCondition(fn func() bool, reason ...string) *Test {
 	return t
 }
 
+// WithUnsafeTests causes the test to only be executed in case unsafe tests
+// modifying the state of cluster nodes are included via the
+// include-unsafe-tests command line option.
+func (t *Test) WithUnsafeTests() *Test {
+	return t.WithCondition(
+		func() bool { return t.ctx.Params().IncludeUnsafeTests },
+		"unsafe test which can modify state of cluster nodes",
+	)
+}
+
 // WithCiliumVersion limits test execution to Cilium versions that fall within
 // the given range. The input string is passed to [semver.ParseRange], see
 // package semver. Simple examples: ">1.0.0 <2.0.0" or ">=1.14.0".

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -403,6 +403,19 @@ func (t *Test) WithCondition(fn func() bool) *Test {
 	return t
 }
 
+// WithCiliumVersion limits test execution to Cilium versions that fall within
+// the given range. The input string is passed to [semver.ParseRange], see
+// package semver. Simple examples: ">1.0.0 <2.0.0" or ">=1.14.0".
+func (t *Test) WithCiliumVersion(vr string) *Test {
+	// Compile the input but don't store the result. A semver.Range is a func()
+	// that doesn't implement String(), so the original version constraint cannot
+	// be recovered to display to the user. The original constraint is echoed in
+	// Test/Scenario skip messages together with the running Cilium version.
+	_ = versioncheck.MustCompile(vr)
+	t.versionRange = vr
+	return t
+}
+
 // WithResources registers the list of one or more YAML-defined
 // Kubernetes resources (e.g. NetworkPolicy, etc.)
 //
@@ -649,19 +662,6 @@ func (t *Test) WithFeatureRequirements(reqs ...features.Requirement) *Test {
 // Cilium before running the test (and removed after the test completion).
 func (t *Test) WithIPRoutesFromOutsideToPodCIDRs() *Test {
 	t.installIPRoutesFromOutsideToPodCIDRs = true
-	return t
-}
-
-// WithCiliumVersion limits test execution to Cilium versions that fall within
-// the given range. The input string is passed to [semver.ParseRange], see
-// package semver. Simple examples: ">1.0.0 <2.0.0" or ">=1.14.0".
-func (t *Test) WithCiliumVersion(vr string) *Test {
-	// Compile the input but don't store the result. A semver.Range is a func()
-	// that doesn't implement String(), so the original version constraint cannot
-	// be recovered to display to the user. The original constraint is echoed in
-	// Test/Scenario skip messages together with the running Cilium version.
-	_ = versioncheck.MustCompile(vr)
-	t.versionRange = vr
 	return t
 }
 

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -448,6 +448,15 @@ func (t *Test) WithPerf() *Test {
 	)
 }
 
+// WithK8sLocalHostTest causes the test to only be executed when k8s localhost
+// tests are enabled via the k8s-localhost-test command line option.
+func (t *Test) WithK8sLocalHostTest() *Test {
+	return t.WithCondition(
+		func() bool { return t.ctx.Params().K8sLocalHostTest },
+		"k8s localhost tests excluded",
+	)
+}
+
 // WithCiliumVersion limits test execution to Cilium versions that fall within
 // the given range. The input string is passed to [semver.ParseRange], see
 // package semver. Simple examples: ">1.0.0 <2.0.0" or ">=1.14.0".

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -439,6 +439,15 @@ func (t *Test) WithMultiNodeOnly() *Test {
 	)
 }
 
+// WithPerf causes the test to only be executed when perf connectivity tests
+// are enabled.
+func (t *Test) WithPerf() *Test {
+	return t.WithCondition(
+		func() bool { return t.ctx.Params().Perf },
+		"network performance tests excluded",
+	)
+}
+
 // WithCiliumVersion limits test execution to Cilium versions that fall within
 // the given range. The input string is passed to [semver.ParseRange], see
 // package semver. Simple examples: ">1.0.0 <2.0.0" or ">=1.14.0".

--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -57,23 +57,48 @@ func TestWithFeatureRequirements(t *testing.T) {
 
 func TestWithCondition(t *testing.T) {
 	mytest := NewTest("my-test", false, false)
-	assert.True(t, mytest.checkConditions())
+	run, reason := mytest.checkConditions()
+	assert.True(t, run)
+	assert.Empty(t, reason)
 
 	mytest = NewTest("my-test", false, false).
 		WithCondition(func() bool { return true })
-	assert.True(t, mytest.checkConditions())
+	run, reason = mytest.checkConditions()
+	assert.True(t, run)
+	assert.Empty(t, reason)
 
 	mytest = NewTest("my-test", false, false).
 		WithCondition(func() bool { return false })
-	assert.False(t, mytest.checkConditions())
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "skipped by condition", reason)
 
 	mytest = NewTest("my-test", false, false).
 		WithCondition(func() bool { return true }).
 		WithCondition(func() bool { return false })
-	assert.False(t, mytest.checkConditions())
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "skipped by condition", reason)
 
 	mytest = NewTest("my-test", false, false).
 		WithCondition(func() bool { return false }).
 		WithCondition(func() bool { return true })
-	assert.False(t, mytest.checkConditions())
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "skipped by condition", reason)
+
+	mytest = NewTest("my-test", false, false).
+		WithCondition(func() bool { return false }).
+		WithCondition(func() bool { return true }, "reason")
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "skipped by condition", reason)
+
+	mytest = NewTest("my-test", false, false).
+		WithCondition(func() bool { return false }, "reason 1").
+		WithCondition(func() bool { return true }, "reason 2")
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "reason 1", reason)
+
 }

--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -102,3 +102,17 @@ func TestWithCondition(t *testing.T) {
 	assert.Equal(t, "reason 1", reason)
 
 }
+
+func TestWithUnsafeTests(t *testing.T) {
+	mytest := NewTest("my-test", false, false).WithUnsafeTests()
+	mytest.ctx = &ConnectivityTest{params: Parameters{IncludeUnsafeTests: true}}
+	run, reason := mytest.checkConditions()
+	assert.True(t, run)
+	assert.Empty(t, reason)
+
+	mytest = NewTest("my-test", false, false).WithUnsafeTests()
+	mytest.ctx = &ConnectivityTest{params: Parameters{IncludeUnsafeTests: false}}
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "unsafe test which can modify state of cluster nodes", reason)
+}

--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -144,3 +144,17 @@ func TestWithPerf(t *testing.T) {
 	assert.False(t, run)
 	assert.Equal(t, "network performance tests excluded", reason)
 }
+
+func TestWithK8sLocalHostTest(t *testing.T) {
+	mytest := NewTest("my-test", false, false).WithK8sLocalHostTest()
+	mytest.ctx = &ConnectivityTest{params: Parameters{K8sLocalHostTest: true}}
+	run, reason := mytest.checkConditions()
+	assert.True(t, run)
+	assert.Empty(t, reason)
+
+	mytest = NewTest("my-test", false, false).WithK8sLocalHostTest()
+	mytest.ctx = &ConnectivityTest{params: Parameters{K8sLocalHostTest: false}}
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "k8s localhost tests excluded", reason)
+}

--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -116,3 +116,17 @@ func TestWithUnsafeTests(t *testing.T) {
 	assert.False(t, run)
 	assert.Equal(t, "unsafe test which can modify state of cluster nodes", reason)
 }
+
+func TestWithMultiNodeOnly(t *testing.T) {
+	mytest := NewTest("my-test", false, false).WithMultiNodeOnly()
+	mytest.ctx = &ConnectivityTest{params: Parameters{SingleNode: false}}
+	run, reason := mytest.checkConditions()
+	assert.True(t, run)
+	assert.Empty(t, reason)
+
+	mytest = NewTest("my-test", false, false).WithMultiNodeOnly()
+	mytest.ctx = &ConnectivityTest{params: Parameters{SingleNode: true}}
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "test requires a multi-node cluster", reason)
+}

--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -130,3 +130,17 @@ func TestWithMultiNodeOnly(t *testing.T) {
 	assert.False(t, run)
 	assert.Equal(t, "test requires a multi-node cluster", reason)
 }
+
+func TestWithPerf(t *testing.T) {
+	mytest := NewTest("my-test", false, false).WithPerf()
+	mytest.ctx = &ConnectivityTest{params: Parameters{Perf: true}}
+	run, reason := mytest.checkConditions()
+	assert.True(t, run)
+	assert.Empty(t, reason)
+
+	mytest = NewTest("my-test", false, false).WithPerf()
+	mytest.ctx = &ConnectivityTest{params: Parameters{Perf: false}}
+	run, reason = mytest.checkConditions()
+	assert.False(t, run)
+	assert.Equal(t, "network performance tests excluded", reason)
+}


### PR DESCRIPTION
Currently, common test skip conditions (e.g. unsafe tests only, multi-node only, perf tests only) are expressed via raw `WithCondition` calls that inline parameter checks. This is verbose, repetitive, and produces a generic "skipped by condition" message at runtime when a test is skipped.

Refactor the skip conditions to provide dedicated skip condition helpers for common cases and use them in the existing tests:

- `WithUnsafeTests()` skips the test unless `--include-unsafe-tests` is set; prints "unsafe test which can modify state of cluster nodes" when skipping the test
- `WithMultiNodeOnly()` skips the test on single-node clusters; prints "test requires a multi-node cluster" when skipping the test
- `WithPerf()` skips the test unless `--perf` is set; prints "network performance tests excluded" when skipping the test
- `WithK8sLocalHostTest()` skips the test if k8s localhost tests are disabled, `--k8s-localhost-test` is not set; prints "k8s localhost tests excluded" when skipping the test

See individual commits for details.