### PR TITLE
maps/netdev: switch cilium_devices from array to hash map

### DIFF
--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -34,9 +34,7 @@ add_l2_hdr(struct __ctx_buff *ctx)
 }
 
 static __always_inline int
-maybe_add_l2_hdr(struct __ctx_buff *ctx __maybe_unused,
-		 __u32 ifindex __maybe_unused,
-		 bool *l2_hdr_required __maybe_unused)
+maybe_add_l2_hdr(struct __ctx_buff *ctx, __u32 ifindex, bool *l2_hdr_required)
 {
 	if (device_is_l3(ifindex)) {
 		/* The packet is going to be redirected to L3 dev, so
@@ -167,8 +165,8 @@ fib_lookup_skip_neigh() {
 
 static __always_inline int
 fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
-	     struct bpf_fib_lookup_padded *fib_params __maybe_unused,
-	     bool use_neigh_map, __s8 *ext_err __maybe_unused, int *oif)
+	     struct bpf_fib_lookup_padded *fib_params, bool use_neigh_map,
+	     __s8 *ext_err, int *oif)
 {
 	int ret;
 
@@ -247,8 +245,7 @@ fib_lookup_src_v6(struct __ctx_buff *ctx, struct in6_addr *src,
 static __always_inline int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		struct ipv6hdr *ip6, const bool needs_l2_check,
-		bool allow_neigh_map, __s8 *ext_err __maybe_unused, int *oif,
-		__u32 tbid)
+		bool allow_neigh_map, __s8 *ext_err, int *oif, __u32 tbid)
 {
 	int ret;
 	struct bpf_fib_lookup_padded fib_params = {0};
@@ -330,8 +327,7 @@ fib_lookup_src_v4(struct __ctx_buff *ctx, __be32 *src, const __be32 dst)
 static __always_inline int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		struct iphdr *ip4, const bool needs_l2_check,
-		bool allow_neigh_map, __s8 *ext_err __maybe_unused, int *oif,
-		__u32 tbid)
+		bool allow_neigh_map, __s8 *ext_err, int *oif, __u32 tbid)
 {
 	int ret;
 	struct bpf_fib_lookup_padded fib_params = {0};

--- a/bpf/lib/network_device.h
+++ b/bpf/lib/network_device.h
@@ -24,11 +24,11 @@ struct device_state {
  * verifier.
  */
 struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u32);
 	__type(value, struct device_state);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, 4096);
+	__uint(max_entries, 512);
 } cilium_devices __section_maps_btf;
 
 static __always_inline const struct device_state *

--- a/pkg/datapath/maps/maps_generated.go
+++ b/pkg/datapath/maps/maps_generated.go
@@ -279,12 +279,12 @@ func newCiliumCTAny6GlobalSpec(btf *btf.Spec) *ebpf.MapSpec {
 func newCiliumDevicesSpec(btf *btf.Spec) *ebpf.MapSpec {
 	return &ebpf.MapSpec{
 		Name:       CiliumDevices,
-		Type:       ebpf.Array,
+		Type:       ebpf.Hash,
 		KeySize:    4,
 		Key:        anyTypeByName(btf, "__u32"),
 		ValueSize:  16,
 		Value:      anyTypeByName(btf, "device_state"),
-		MaxEntries: 4096,
+		MaxEntries: 512,
 		Flags:      0,
 		Pinning:    ebpf.PinByName,
 	}

--- a/pkg/maps/netdev/netdev.go
+++ b/pkg/maps/netdev/netdev.go
@@ -111,9 +111,8 @@ func NewDeviceState(mac net.HardwareAddr) DeviceState {
 	state := DeviceState{}
 	if len(mac) == len(state.MAC) {
 		copy(state.MAC[:], mac)
-	}
-	if len(mac) != 6 {
-		state.SetL3(true)
+	} else {
+		state.L3 |= deviceStateL3Mask
 	}
 	return state
 }
@@ -129,16 +128,4 @@ func (s *DeviceState) New() bpf.MapValue {
 
 func (s *DeviceState) String() string {
 	return fmt.Sprintf("%s %b", s.MAC.String(), s.L3)
-}
-
-func (s *DeviceState) IsL3() bool {
-	return s.L3&deviceStateL3Mask != 0
-}
-
-func (s *DeviceState) SetL3(enabled bool) {
-	if enabled {
-		s.L3 |= deviceStateL3Mask
-		return
-	}
-	s.L3 &^= deviceStateL3Mask
 }

--- a/pkg/maps/netdev/netdev.go
+++ b/pkg/maps/netdev/netdev.go
@@ -20,7 +20,7 @@ type Map interface {
 
 	IterateWithCallback(cb IterateCallback) error
 
-	Clear(ifindex uint32) error
+	Delete(ifindex uint32) error
 }
 
 type netDevMap struct {
@@ -32,10 +32,10 @@ func newNetDevMap() *netDevMap {
 	return &netDevMap{
 		Map: bpf.NewMap(
 			"cilium_devices",
-			ebpf.Array,
+			ebpf.Hash,
 			&index,
 			&DeviceState{},
-			4096,
+			512,
 			0,
 		),
 	}
@@ -64,12 +64,10 @@ func (m *netDevMap) IterateWithCallback(cb IterateCallback) error {
 	})
 }
 
-var zeroDeviceState = DeviceState{}
-
-// Clear resets an entry to the zero value.
-func (m *netDevMap) Clear(ifindex uint32) error {
+// Delete removes an entry from the map.
+func (m *netDevMap) Delete(ifindex uint32) error {
 	key := Index(ifindex)
-	return m.Map.Update(&key, &zeroDeviceState)
+	return m.Map.Delete(&key)
 }
 
 func (m *netDevMap) init() error {

--- a/pkg/maps/netdev/netdev_sync.go
+++ b/pkg/maps/netdev/netdev_sync.go
@@ -94,8 +94,8 @@ func pruneStaleDevices(p netDevMapSyncParams, desired map[uint32]DeviceState) {
 		p.Logger.Warn("Failed to iterate network devices map", logfields.Error, err)
 	}
 	for _, ifindex := range stale {
-		if err := p.DeviceMap.Clear(ifindex); err != nil {
-			p.Logger.Warn("Failed to clear stale network devices map entry",
+		if err := p.DeviceMap.Delete(ifindex); err != nil {
+			p.Logger.Warn("Failed to delete stale network devices map entry",
 				logfields.Error, err,
 				logfields.Interface, ifindex,
 			)

--- a/pkg/maps/netdev/netdev_test.go
+++ b/pkg/maps/netdev/netdev_test.go
@@ -30,7 +30,7 @@ func TestNewDeviceState(t *testing.T) {
 		mac := net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
 		state := NewDeviceState(mac)
 
-		require.False(t, state.IsL3())
+		require.Equal(t, DeviceStateL3(0x00), state.L3&deviceStateL3Mask)
 		require.Equal(t, types.MACAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, state.MAC)
 	})
 
@@ -38,7 +38,7 @@ func TestNewDeviceState(t *testing.T) {
 		mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee}
 		state := NewDeviceState(mac)
 
-		require.True(t, state.IsL3())
+		require.Equal(t, deviceStateL3Mask, state.L3&deviceStateL3Mask)
 		require.Equal(t, types.MACAddr{}, state.MAC)
 	})
 }

--- a/pkg/maps/netdev/netdev_test.go
+++ b/pkg/maps/netdev/netdev_test.go
@@ -77,8 +77,7 @@ func TestPrivilegedNetDevMap(t *testing.T) {
 	require.Equal(t, state1, seen[1])
 	require.Equal(t, state2, seen[2])
 
-	require.NoError(t, dm.Clear(2))
-	got2, err = dm.Lookup(2)
-	require.NoError(t, err)
-	require.Equal(t, DeviceState{}, *got2)
+	require.NoError(t, dm.Delete(2))
+	_, err = dm.Lookup(2)
+	require.Error(t, err)
 }


### PR DESCRIPTION
`BPF_MAP_TYPE_ARRAY` uses the key directly as an index into the backing
array. For `cilium_devices`, the index is the network interface index
(ifindex) which is allocated monotonically per network namespace and
only wraps around at `INT_MAX` (`xa_limit_31b`)[^1]. On nodes that have
hosted many pods over their lifetime, the host netns ifindex could thus
potentially exceed 4096. This would cause silently dropped map updates
in the control plane and either incorrect L3 device detection or packet
drops in the datapath.

Also, currently, if a network device goes away, the device_mac lookup
for its ifindex in the datapath will still return a non-NULL entry with
zero MAC and thus the `if (!smac)` check in `fib_do_redirect`[^2] would
never evalulate as true and the packet would be rewritten and redirected
with a zero source MAC.

To address these two problems, switch cilium_devices to map type
`BPF_MAP_TYPE_HASH`. For this map type `max_entries` limits the number of
active entries rather than the key range. Any ifindex is a valid key as
long as the map is not full, which eliminates the out-of-range failure
mode mentioned in the first section.

Since the map only holds currently selected Cilium devices, reduce
`max_entries` to 512. Even on large nodes with many pods, the number of
simultaneously active selected devices should be well within this limit.

The only downside of switching to `BPF_MAP_TYPE_HASH` is the slightly
higher overhead per lookup. This is likely acceptable given how
infrequently this map is accessed relative to other hot-path maps.

[^1]: https://elixir.bootlin.com/linux/v6.19.10/source/net/core/dev.c#L10795-L10796
[^2]: https://github.com/cilium/cilium/blob/86ed05736395ad91d66e3f9bae7f3e645214f187/bpf/lib/fib.h#L131-L135

Fixes: 585e63f7e965 ("datapath: move device metadata to cilium_devices map")

/cc @viktor-kurchenko