### PR TITLE
gateway-api: Fix BackendTLSPolicy SDS name ignoring configured secrets namespace

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -58,6 +58,7 @@ var (
 func Test_Conformance(t *testing.T) {
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 	cecTranslator := translation.NewCECTranslator(translation.Config{
+		SecretsNamespace: "cilium-secrets",
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: true,
 		},

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-malformed-secret.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-malformed-secret.yaml
@@ -79,7 +79,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: /gateway-conformance-infra-malformed-certificate
+            - name: cilium-secrets/gateway-conformance-infra-malformed-certificate
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-nonexistent-secret.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-nonexistent-secret.yaml
@@ -79,7 +79,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: /gateway-conformance-infra-nonexistent-certificate
+            - name: cilium-secrets/gateway-conformance-infra-nonexistent-certificate
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-group.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-group.yaml
@@ -79,7 +79,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: /gateway-conformance-infra-tls-validity-checks-certificate
+            - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-tls-configuration/output/cec-gateway-certificate-unsupported-kind.yaml
@@ -79,7 +79,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: /gateway-conformance-infra-tls-validity-checks-certificate
+            - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-add-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-add-listener.yaml
@@ -86,7 +86,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: /gateway-conformance-infra-tls-validity-checks-certificate
+            - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
@@ -86,7 +86,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: /gateway-conformance-infra-tls-validity-checks-certificate
+            - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-all-in-namespace/output/cec-gateway-secret-reference-grant-all-in-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-all-in-namespace/output/cec-gateway-secret-reference-grant-all-in-namespace.yaml
@@ -79,7 +79,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-web-backend-all-certificate
+                  - name: cilium-secrets/gateway-conformance-web-backend-all-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-specific/output/cec-gateway-secret-reference-grant-specific.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-specific/output/cec-gateway-secret-reference-grant-specific.yaml
@@ -79,7 +79,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-web-backend-specific-certificate
+                  - name: cilium-secrets/gateway-conformance-web-backend-specific-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-unresolved-gateway-with-one-attached-unresolved-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-unresolved-gateway-with-one-attached-unresolved-route.yaml
@@ -79,7 +79,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-does-not-exist
+                  - name: cilium-secrets/gateway-conformance-infra-does-not-exist
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
@@ -88,7 +88,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-checks-certificate
+                  - name: cilium-secrets/gateway-conformance-infra-tls-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/cec-same-namespace-with-https-listener.yaml
@@ -84,7 +84,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-validity-checks-certificate
+                  - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-reencrypt/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-reencrypt/output/cec-same-namespace-with-https-listener.yaml
@@ -84,7 +84,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-validity-checks-certificate
+                  - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-https-listener/output/cec-same-namespace-with-https-listener.yaml
@@ -88,7 +88,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-validity-checks-certificate
+                  - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-https-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-https-only.yaml
@@ -79,7 +79,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-validity-checks-certificate
+                  - name: cilium-secrets/gateway-conformance-infra-tls-validity-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -84,7 +84,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-checks-certificate
+                  - name: cilium-secrets/gateway-conformance-infra-tls-checks-certificate
         - filterChainMatch:
             serverNames:
               - tls.example.com

--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -36,7 +36,7 @@ func (i *cecTranslator) clusterMutators(grpcService bool, appProtocol string, tl
 		withIdleTimeout(i.Config.ClusterConfig.IdleTimeoutSeconds),
 		withClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
 		withOutlierDetection(true),
-		withTLSOrigination(tls),
+		withTLSOrigination(i.Config.SecretsNamespace, tls),
 	}
 	if grpcService {
 		res = append(res, withProtocol(HTTPVersion2))

--- a/operator/pkg/model/translation/envoy_cluster_mutator.go
+++ b/operator/pkg/model/translation/envoy_cluster_mutator.go
@@ -108,7 +108,7 @@ func withProtocol(protocolVersion HTTPVersionType) ClusterMutator {
 	}
 }
 
-func withTLSOrigination(tls *model.BackendTLSOrigination) ClusterMutator {
+func withTLSOrigination(secretsNamespace string, tls *model.BackendTLSOrigination) ClusterMutator {
 	return func(cluster *envoy_config_cluster_v3.Cluster) *envoy_config_cluster_v3.Cluster {
 		// This mutator should not get added to the list if this is the case, but just to be safe.
 		if tls == nil {
@@ -142,11 +142,11 @@ func withTLSOrigination(tls *model.BackendTLSOrigination) ClusterMutator {
 							//
 							// * BackendTLSPolicy references ConfigMap
 							// * SecretSync sees ConfigMap reference
-							// * SecretSync copies ConfigMap into Secret in cilium-secrets namespace, using the below
+							// * SecretSync copies ConfigMap into Secret in the configured secrets namespace, using the below
 							//   naming format
 							// * This translation references that Secret
 							// * The Cilium Agent reads the Secret directly and suppies it to Envoy via SDS.
-							Name: "cilium-secrets" + "/" + tls.CACertRef.Namespace + "-cfgmap-" + tls.CACertRef.Name,
+							Name: secretsNamespace + "/" + tls.CACertRef.Namespace + "-cfgmap-" + tls.CACertRef.Name,
 						},
 					},
 				},

--- a/operator/pkg/model/translation/envoy_cluster_test.go
+++ b/operator/pkg/model/translation/envoy_cluster_test.go
@@ -110,6 +110,46 @@ func Test_httpClusterWithTLSOriginationAllowsTLS13(t *testing.T) {
 	require.Equal(t, envoy_config_tls.TlsParameters_TLSv1_3, tlsContext.CommonTlsContext.TlsParams.TlsMaximumProtocolVersion)
 }
 
+func Test_withTLSOrigination(t *testing.T) {
+	tls := &model.BackendTLSOrigination{
+		SNI: "my-backend.svc.cluster.local",
+		CACertRef: &model.FullyQualifiedResource{
+			Name:      "my-ca-configmap",
+			Namespace: "my-namespace",
+		},
+	}
+
+	t.Run("uses configured secrets namespace in SDS name", func(t *testing.T) {
+		fn := withTLSOrigination("my-secrets-ns", tls)
+		cluster := fn(&envoy_config_cluster_v3.Cluster{})
+		require.NotNil(t, cluster.TransportSocket)
+
+		upstreamTLS := &envoy_config_tls.UpstreamTlsContext{}
+		err := proto.Unmarshal(cluster.TransportSocket.GetTypedConfig().GetValue(), upstreamTLS)
+		require.NoError(t, err)
+
+		combined := upstreamTLS.CommonTlsContext.GetCombinedValidationContext()
+		require.NotNil(t, combined)
+		sdsName := combined.ValidationContextSdsSecretConfig.GetName()
+		require.Equal(t, "my-secrets-ns/my-namespace-cfgmap-my-ca-configmap", sdsName)
+	})
+
+	t.Run("default secrets namespace produces correct SDS name", func(t *testing.T) {
+		fn := withTLSOrigination("cilium-secrets", tls)
+		cluster := fn(&envoy_config_cluster_v3.Cluster{})
+		require.NotNil(t, cluster.TransportSocket)
+
+		upstreamTLS := &envoy_config_tls.UpstreamTlsContext{}
+		err := proto.Unmarshal(cluster.TransportSocket.GetTypedConfig().GetValue(), upstreamTLS)
+		require.NoError(t, err)
+
+		combined := upstreamTLS.CommonTlsContext.GetCombinedValidationContext()
+		require.NotNil(t, combined)
+		sdsName := combined.ValidationContextSdsSecretConfig.GetName()
+		require.Equal(t, "cilium-secrets/my-namespace-cfgmap-my-ca-configmap", sdsName)
+	})
+}
+
 func Test_tcpCluster(t *testing.T) {
 	c := &cecTranslator{}
 	res, err := c.httpCluster("dummy-name", "dummy-name", false, "", nil)


### PR DESCRIPTION
## Summary

When `gatewayAPI.secretsNamespace.name` is set to a non-default value, `withTLSOrigination` was hardcoding `"cilium-secrets"` as the SDS secret namespace prefix for upstream TLS cluster config generated from `BackendTLSPolicy` CA certificate references. This caused Envoy to get stuck in `dynamic_warming_secrets` because the physical secret was correctly synced to the configured namespace, but Envoy requested it under the hardcoded `cilium-secrets/` prefix.

The downstream TLS path (listener side) already used `i.Config.SecretsNamespace` correctly — this bug only affected the upstream/BackendTLSPolicy path. The fix passes `SecretsNamespace` into `withTLSOrigination` and adds a unit test covering both the default and custom namespace cases.

Fixes: #45202

```release-note
Fix BackendTLSPolicy upstream TLS SDS secret name when using a non-default `gatewayAPI.secretsNamespace`
```