### PR TITLE
docs: fix typo in bgp-control-plane-configuration.rst

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-configuration.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-configuration.rst
@@ -916,7 +916,7 @@ Labels were then configured using:
 .. code-block:: shell-session
 
     kubectl label service hello-world vpc1=true
-    kubectl label service hello-world vpc1=true
+    kubectl label service hello-world vpc2=true
 
 The resulting BGP advertisement set both communities ``1111:1111:1111`` and ``2222:2222:2222``.
 All possible combinations of communities (``Standard``, ``Large``, ``WellKnown``) are 


### PR DESCRIPTION
Fix typo found after review bgp control plane docs.