### PR TITLE
pkg/multicast: convert net.IP to netip.Addr

### DIFF
--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -149,7 +149,7 @@ func (a Address) Key() int32 {
 // SolicitedNodeMaddr returns solicited node multicast address
 func (a Address) SolicitedNodeMaddr() netip.Addr {
 	ipv6 := netip.Addr(a)
-	if !ipv6.IsValid() {
+	if !ipv6.Is6() {
 		return netip.Addr{}
 	}
 

--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -29,27 +29,27 @@ var (
 var (
 	// AllNodesIfcLocalMaddr is the multicast address that identifies the group of
 	// all IPv6 nodes, within scope 1 (interface-local)
-	AllNodesIfcLocalMaddr net.IP = net.ParseIP("ff01::1")
+	AllNodesIfcLocalMaddr = netip.MustParseAddr("ff01::1")
 
 	// AllNodesLinkLocalMaddr is the multicast address that identifies the group of
 	// all IPv6 nodes, within scope 2 (link-local)
-	AllNodesLinkLocalMaddr net.IP = net.ParseIP("ff02::1")
+	AllNodesLinkLocalMaddr = netip.MustParseAddr("ff02::1")
 
 	// AllRoutersIfcLocalMaddr is the multicast address that identifies the group of
 	// all IPv6 routers, within scope 1 (interface-local)
-	AllRoutersIfcLocalMaddr net.IP = net.ParseIP("ff01::2")
+	AllRoutersIfcLocalMaddr = netip.MustParseAddr("ff01::2")
 
 	// AllRoutersLinkLocalMaddr is the multicast address that identifies the group of
 	// all IPv6 routers, within scope 2 (link-local)
-	AllRoutersLinkLocalMaddr net.IP = net.ParseIP("ff02::2")
+	AllRoutersLinkLocalMaddr = netip.MustParseAddr("ff02::2")
 
 	// AllRoutersSiteLocalMaddr is the multicast address that identifies the group of
 	// all IPv6 routers, within scope 5 (site-local)
-	AllRoutersSiteLocalMaddr net.IP = net.ParseIP("ff05::2")
+	AllRoutersSiteLocalMaddr = netip.MustParseAddr("ff05::2")
 
 	// SolicitedNodeMaddrPrefix is the prefix of the multicast address that is used
 	// as part of NDP
-	SolicitedNodeMaddrPrefix net.IP = net.ParseIP("ff02::1:ff00:0")
+	SolicitedNodeMaddrPrefix = netip.MustParseAddr("ff02::1:ff00:0")
 )
 
 func initSocket(logger *slog.Logger) error {
@@ -154,7 +154,8 @@ func (a Address) SolicitedNodeMaddr() netip.Addr {
 	}
 
 	maddr := make([]byte, 16)
-	copy(maddr[:13], SolicitedNodeMaddrPrefix[:13])
+	prefix := SolicitedNodeMaddrPrefix.As16()
+	copy(maddr[:13], prefix[:13])
 	copy(maddr[13:], ipv6.AsSlice()[13:])
 
 	return netip.AddrFrom16([16]byte(maddr))


### PR DESCRIPTION
## Description

Convert package-level multicast address variables in `pkg/multicast` from `net.IP` to `netip.Addr`.

All six predefined multicast address variables (`AllNodesIfcLocalMaddr`, `AllNodesLinkLocalMaddr`, `AllRoutersIfcLocalMaddr`, `AllRoutersLinkLocalMaddr`, `AllRoutersSiteLocalMaddr`, `SolicitedNodeMaddrPrefix`) are converted from `net.IP = net.ParseIP(...)` to `netip.MustParseAddr(...)`.

The `SolicitedNodeMaddr()` method is updated to extract the underlying `[16]byte` via `As16()` before slicing, since `netip.Addr` does not support direct slice indexing.

These variables are only used within `pkg/multicast/` — no downstream callers are affected. The `net` import is retained for `PacketConn`, `UDPAddr`, `Interface`, and related socket types still in use.

Related: #24246

### Checklist

- [x] For first-time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Related: #24246` line.
- [x] All commits are signed off. See [Developer Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin)
- [x] Provide a title or release-note blurb suitable for the release notes.