### PR TITLE
loadbalancer: Apply compatibility filters in TrafficDistribution lookahead loops

### DIFF
--- a/pkg/loadbalancer/tests/testdata/prefer-same-node.txtar
+++ b/pkg/loadbalancer/tests/testdata/prefer-same-node.txtar
@@ -25,10 +25,21 @@ db/cmp frontends frontends-remote.table
 k8s/add endpointslice.yaml
 db/cmp frontends frontends-local.table
 
+# Test case: Local backend exists but has wrong port name.
+# It should fall back to remote backend.
+k8s/update endpointslice-wrong-port.yaml
+db/cmp frontends frontends-remote.table
+
+# Revert to original state
+k8s/update endpointslice.yaml
+db/cmp frontends frontends-local.table
+
 # Disable PreferSameNode by removing trafficDistribution. All backends selected.
 sed 'PreferSameNode' 'Disabled' service.yaml
 k8s/update service.yaml
 db/cmp frontends frontends-all.table
+
+
 
 #####
 
@@ -116,3 +127,26 @@ ports:
 - name: http
   port: 80
   protocol: TCP
+
+-- endpointslice-wrong-port.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: wrong-port
+  port: 80
+  protocol: TCP
+

--- a/pkg/loadbalancer/tests/testdata/prefer-same-zone-fallback.txtar
+++ b/pkg/loadbalancer/tests/testdata/prefer-same-zone-fallback.txtar
@@ -1,0 +1,105 @@
+#! --enable-service-topology --lb-test-fault-probability=0.0
+#
+# Test PreferSameZone fallback: when zone backends are incompatible,
+# we should fall back to out-of-zone backends.
+
+# Set the node zone label before starting
+test/set-node-labels topology.kubernetes.io/zone=foo
+
+# Start and wait for watchers
+hive start
+
+# Add the service with trafficDistribution=PreferSameZone
+k8s/add service.yaml
+
+# Add endpoints:
+# 10.244.1.1 in zone foo, but with wrong port name.
+# 10.244.2.1 in zone bar (remote), with correct port name.
+k8s/add endpointslice-wrong-port.yaml endpointslice-remote.yaml
+
+# We expect to fall back to the remote backend because the local one has the wrong port.
+# If the bug is present, it will commit to zone routing and find no backends,
+# resulting in an empty frontends table or failure to match.
+db/cmp frontends frontends-remote.table
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy  Flags
+test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferSameZone
+
+-- frontends-remote.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.2.1:80/TCP
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+  trafficDistribution: PreferSameZone
+
+-- endpointslice-wrong-port.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: node-local
+  zone: foo
+  hints:
+    forZones:
+    - name: foo
+ports:
+- name: wrong-port
+  port: 80
+  protocol: TCP
+
+-- endpointslice-remote.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: node-remote
+  zone: bar
+  hints:
+    forZones:
+    - name: bar
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -385,17 +385,29 @@ func (w *Writer) RefreshFrontends(txn WriteTxn, name loadbalancer.ServiceName) e
 	return nil
 }
 
+func matchesFrontend(be *loadbalancer.Backend, fe *loadbalancer.Frontend) bool {
+	if fe == nil {
+		return true
+	}
+	if fe.Address.Protocol() != be.Address.Protocol() {
+		return false
+	}
+	if be.Address.IsIPv6() != fe.Address.IsIPv6() {
+		return false
+	}
+	if fe.PortName != "" && len(be.PortNames) > 0 {
+		if !slices.Contains(be.PortNames, string(fe.PortName)) {
+			return false
+		}
+	}
+	return true
+}
+
 func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadbalancer.Backend, statedb.Revision], svc *loadbalancer.Service, fe *loadbalancer.Frontend) iter.Seq2[*loadbalancer.Backend, statedb.Revision] {
 	onlyLocal := false
-	ipv4, ipv6 := true, true
 	isLocalProxyDelegation := func(loadbalancer.L3n4Addr) bool { return true }
 	if fe != nil {
 		onlyLocal = shouldUseLocalBackends(fe)
-		if fe.Address.IsIPv6() {
-			ipv4, ipv6 = false, true
-		} else {
-			ipv4, ipv6 = true, false
-		}
 	} else {
 		onlyLocal = svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal
 
@@ -414,10 +426,14 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 	if w.config.EnableServiceTopology && fe != nil && fe.Service.TrafficDistribution == loadbalancer.TrafficDistributionPreferSameNode {
 		candidatesFound := false
 		for be := range bes {
-			if be.NodeName == w.nodeName {
-				candidatesFound = true
-				break
+			if be.NodeName != w.nodeName {
+				continue
 			}
+			if !matchesFrontend(be, fe) {
+				continue
+			}
+			candidatesFound = true
+			break
 		}
 
 		if candidatesFound {
@@ -426,24 +442,8 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 					if be.NodeName != w.nodeName {
 						continue
 					}
-					if fe != nil && fe.Address.Protocol() != be.Address.Protocol() {
+					if !matchesFrontend(be, fe) {
 						continue
-					}
-					if be.Address.IsIPv6() {
-						if !ipv6 {
-							continue
-						}
-					} else if !ipv4 {
-						continue
-					}
-					if fe != nil {
-						if fe.PortName != "" && len(be.PortNames) > 0 {
-							// A backend with specific port name requested. Look up what this backend
-							// is called for this service when the backend has multiple (named) ports.
-							if !slices.Contains(be.PortNames, string(fe.PortName)) {
-								continue
-							}
-						}
 					}
 					if !yield(be, rev) {
 						return
@@ -472,6 +472,18 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 		// https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#safeguards
 		candidatesFound, missingHints := false, false
 		for be := range bes {
+			if !matchesFrontend(be, fe) {
+				continue
+			}
+			if onlyLocal {
+				if len(be.NodeName) != 0 && be.NodeName != w.nodeName {
+					continue
+				}
+				if !isLocalProxyDelegation(be.Address) {
+					continue
+				}
+			}
+
 			if be.Zone != nil && len(be.Zone.ForZones) > 0 {
 				if !candidatesFound && slices.Contains(be.Zone.ForZones, *thisZone) {
 					candidatesFound = true
@@ -488,14 +500,7 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 		// NOTE: [txn] is no longer valid here. Use it outside this closure.
 
 		for be, rev := range bes {
-			if fe != nil && fe.Address.Protocol() != be.Address.Protocol() {
-				continue
-			}
-			if be.Address.IsIPv6() {
-				if !ipv6 {
-					continue
-				}
-			} else if !ipv4 {
+			if !matchesFrontend(be, fe) {
 				continue
 			}
 			if onlyLocal {
@@ -508,15 +513,6 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 			}
 			if checkZoneHints && !slices.Contains(be.Zone.ForZones, *thisZone) {
 				continue
-			}
-			if fe != nil {
-				if fe.PortName != "" && len(be.PortNames) > 0 {
-					// A backend with specific port name requested. Look up what this backend
-					// is called for this service when the backend has multiple (named) ports.
-					if !slices.Contains(be.PortNames, string(fe.PortName)) {
-						continue
-					}
-				}
 			}
 			if !yield(be, rev) {
 				return


### PR DESCRIPTION
## Description
This PR fixes a bug in the Cilium Load Balancer's traffic distribution logic where `PreferSameNode` and `PreferSameZone` policies could lead to zero backends being selected instead of falling back to all available backends.

The issue occurred because the initial lookahead loops (which determine if there are candidates matching the topology) only checked for topology matching (node name or zone) without verifying if the backends were compatible with the frontend (e.g., matching protocol, IP family, and port name). If an incompatible backend matched the topology, the algorithm committed to that topology but later filtered out the backend in the yielding loop, resulting in an empty set of backends.

## Changes Made
- Added protocol, IP family, and port name checks to the `PreferSameNode` lookahead loop.
- Added protocol, IP family, and port name checks to the `PreferSameZone` lookahead loop.
- Extracted a helper function `matchesFrontend` in `writer.go` to reduce code duplication for these compatibility checks.

## Verification
- Added a new test case to `prefer-same-node.txtar` verifying fallback when a local backend has a mismatching port name.
- Added a new test file `prefer-same-zone-fallback.txtar` verifying fallback when a zone-matching backend has a mismatching port name.
- Verified that both tests failed before the fix and passed after.
- Ran all regression tests in `pkg/loadbalancer/tests/` and they passed.

Fixes: #45214

```release-note
Fix a bug in load balancer traffic distribution (PreferSameNode/PreferSameZone) where incompatible local or zone backends could cause traffic to be dropped instead of falling back to other backends.
```


