### PR TITLE
bpf: sock: streamline wildcard lookup logic

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -239,14 +239,43 @@ sock4_wildcard_lookup_full(struct lb4_key *key __maybe_unused,
 			   const bool in_hostns __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
-	/* Save the original address, as the sock4_wildcard_lookup zeroes it */
 	bool loopback = is_v4_loopback(key->address);
-	__u32 orig_addr = key->address;
+	const struct remote_endpoint_info *info;
 	const struct lb4_service *svc;
+	bool in_nodeport_range;
+	__u16 service_port;
 
-	svc = sock4_wildcard_lookup(key, true, false, in_hostns);
-	if (svc && lb4_svc_is_nodeport(svc))
-		return svc;
+	service_port = bpf_ntohs(key->dport);
+	in_nodeport_range = service_port >= CONFIG(nodeport_port_min) &&
+			    service_port <= CONFIG(nodeport_port_max);
+
+	if (in_hostns && loopback)
+		goto lookup;
+
+	info = lookup_ip4_remote_endpoint(key->address, 0);
+	if (!info)
+		return NULL;
+
+	if (in_nodeport_range) {
+		/* NodePort: accept HOST_ID and remote nodes */
+		if (info->sec_identity != HOST_ID &&
+		    !(identity_is_remote_node(info->sec_identity) &&
+		      !info->flag_remote_cluster))
+			return NULL;
+	} else {
+		/* HostPort: accept HOST_ID only */
+		if (info->sec_identity != HOST_ID)
+			return NULL;
+	}
+
+lookup:
+	key->address = 0;
+	svc = lb4_lookup_service(key, true);
+	if (!svc)
+		return NULL;
+
+	if (in_nodeport_range)
+		return lb4_svc_is_nodeport(svc) ? svc : NULL;
 
 	/*
 	 * We perform a wildcard hostport lookup. If the SVC_FLAG_LOOPBACK
@@ -254,10 +283,8 @@ sock4_wildcard_lookup_full(struct lb4_key *key __maybe_unused,
 	 * using a loopback IP address, in which case we only want to allow
 	 * connections to loopback addresses
 	 */
-	key->address = orig_addr;
-	svc = sock4_wildcard_lookup(key, false, true, in_hostns);
-	if (svc && lb4_svc_is_hostport(svc) && (!lb4_svc_is_loopback(svc) || loopback))
-		return svc;
+	return (lb4_svc_is_hostport(svc) &&
+		(!lb4_svc_is_loopback(svc) || loopback)) ? svc : NULL;
 #endif /* ENABLE_NODEPORT */
 
 	return NULL;
@@ -782,22 +809,46 @@ sock6_wildcard_lookup_full(struct lb6_key *key __maybe_unused,
 			   const bool in_hostns __maybe_unused)
 {
 #ifdef ENABLE_NODEPORT
-	/* Save the original address, as the sock6_wildcard_lookup zeroes it */
 	bool loopback = is_v6_loopback(&key->address);
-	union v6addr orig_address;
+	const struct remote_endpoint_info *info;
 	const struct lb6_service *svc;
+	bool in_nodeport_range;
+	__u16 service_port;
 
-	memcpy(&orig_address, &key->address, sizeof(orig_address));
-	svc = sock6_wildcard_lookup(key, true, false, in_hostns);
-	if (svc && lb6_svc_is_nodeport(svc))
-		return svc;
+	service_port = bpf_ntohs(key->dport);
+	in_nodeport_range = service_port >= CONFIG(nodeport_port_min) &&
+			    service_port <= CONFIG(nodeport_port_max);
 
-	/* See a corresponding commment in sock4_wildcard_lookup_full */
-	memcpy(&key->address, &orig_address, sizeof(orig_address));
-	svc = sock6_wildcard_lookup(key, false, true, in_hostns);
-	if (svc && lb6_svc_is_hostport(svc) && (!lb6_svc_is_loopback(svc) || loopback))
-		return svc;
+	if (in_hostns && loopback)
+		goto lookup;
 
+	info = lookup_ip6_remote_endpoint(&key->address, 0);
+	if (!info)
+		return NULL;
+
+	if (in_nodeport_range) {
+		/* NodePort: accept HOST_ID and remote nodes */
+		if (info->sec_identity != HOST_ID &&
+		    !(identity_is_remote_node(info->sec_identity) &&
+		      !info->flag_remote_cluster))
+			return NULL;
+	} else {
+		/* HostPort: accept HOST_ID only */
+		if (info->sec_identity != HOST_ID)
+			return NULL;
+	}
+
+lookup:
+	memset(&key->address, 0, sizeof(key->address));
+	svc = lb6_lookup_service(key, true);
+	if (!svc)
+		return NULL;
+
+	if (in_nodeport_range)
+		return lb6_svc_is_nodeport(svc) ? svc : NULL;
+
+	return (lb6_svc_is_hostport(svc) &&
+		(!lb6_svc_is_loopback(svc) || loopback)) ? svc : NULL;
 #endif /* ENABLE_NODEPORT */
 	return NULL;
 }

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -203,28 +203,25 @@ sock4_skip_xlate(const struct lb4_service *svc, __be32 address)
 
 #ifdef ENABLE_NODEPORT
 static __always_inline const struct lb4_service *
-sock4_wildcard_lookup(struct lb4_key *key, const bool include_remote_hosts,
-		      const bool inv_match, const bool in_hostns)
+sock4_wildcard_lookup(struct lb4_key *key)
 {
 	const struct remote_endpoint_info *info;
 	__u16 service_port;
 
 	service_port = bpf_ntohs(key->dport);
-	if ((service_port < CONFIG(nodeport_port_min) ||
-	     service_port > CONFIG(nodeport_port_max)) ^ inv_match)
+	if (service_port < CONFIG(nodeport_port_min) ||
+	    service_port > CONFIG(nodeport_port_max))
 		return NULL;
 
 	/* When connecting to node port services in our cluster that
 	 * have either {REMOTE_NODE,HOST}_ID or loopback address, we
 	 * do a wild-card lookup with IP of 0.
 	 */
-	if (in_hostns && is_v4_loopback(key->address))
+	if (is_v4_loopback(key->address))
 		goto wildcard_lookup;
 
 	info = lookup_ip4_remote_endpoint(key->address, 0);
-	if (info && (info->sec_identity == HOST_ID ||
-		     (include_remote_hosts && identity_is_remote_node(info->sec_identity) &&
-		      !info->flag_remote_cluster)))
+	if (info && info->sec_identity == HOST_ID)
 		goto wildcard_lookup;
 
 	return NULL;
@@ -499,7 +496,7 @@ static __always_inline int __sock4_post_bind(struct bpf_sock *ctx,
 		 * tries to bind to loopback or an address with host identity
 		 * (without remote hosts).
 		 */
-		svc = sock4_wildcard_lookup(&key, false, false, true);
+		svc = sock4_wildcard_lookup(&key);
 	}
 
 	/* If the sockaddr of this socket overlaps with a NodePort,
@@ -773,28 +770,25 @@ sock6_skip_xlate(const struct lb6_service *svc, const union v6addr *address)
 
 #ifdef ENABLE_NODEPORT
 static __always_inline __maybe_unused const struct lb6_service *
-sock6_wildcard_lookup(struct lb6_key *key, const bool include_remote_hosts,
-		      const bool inv_match, const bool in_hostns)
+sock6_wildcard_lookup(struct lb6_key *key)
 {
 	const struct remote_endpoint_info *info;
 	__u16 service_port;
 
 	service_port = bpf_ntohs(key->dport);
-	if ((service_port < CONFIG(nodeport_port_min) ||
-	     service_port > CONFIG(nodeport_port_max)) ^ inv_match)
+	if (service_port < CONFIG(nodeport_port_min) ||
+	    service_port > CONFIG(nodeport_port_max))
 		return NULL;
 
 	/* When connecting to node port services in our cluster that
 	 * have either {REMOTE_NODE,HOST}_ID or loopback address, we
 	 * do a wild-card lookup with IP of 0.
 	 */
-	if (in_hostns && is_v6_loopback(&key->address))
+	if (is_v6_loopback(&key->address))
 		goto wildcard_lookup;
 
 	info = lookup_ip6_remote_endpoint(&key->address, 0);
-	if (info && (info->sec_identity == HOST_ID ||
-		     (include_remote_hosts && identity_is_remote_node(info->sec_identity) &&
-		      !info->flag_remote_cluster)))
+	if (info && info->sec_identity == HOST_ID)
 		goto wildcard_lookup;
 
 	return NULL;
@@ -924,7 +918,7 @@ static __always_inline int __sock6_post_bind(struct bpf_sock *ctx)
 
 	svc = lb6_lookup_service(&key, true);
 	if (!svc) {
-		svc = sock6_wildcard_lookup(&key, false, false, true);
+		svc = sock6_wildcard_lookup(&key);
 		if (!svc)
 			return sock6_post_bind_v4_in_v6(ctx);
 	}

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -124,12 +124,7 @@ int test_v4_check(__maybe_unused struct xdp_md *ctx)
 	TEST("bad-port-range", {
 		/* fail: dport is out of nodeport range, but we want a nodeport */
 		key.dport = bpf_htons(123);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, DONT_CARE(0));
-		assert(!ret);
-
-		/* fail: dport is inside the nodeport range, but we want a hostport */
-		key.dport = bpf_htons((CONFIG(nodeport_port_min) + CONFIG(nodeport_port_max)) / 2);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, DONT_CARE(0));
+		ret = sock4_wildcard_lookup(&key);
 		assert(!ret);
 	});
 
@@ -137,52 +132,14 @@ int test_v4_check(__maybe_unused struct xdp_md *ctx)
 		/* pass: get a service by loopback address [we're in the root namespace] */
 		key.address = bpf_htonl(INADDR_LOOPBACK);
 		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, HOST_NS);
+		ret = sock4_wildcard_lookup(&key);
 		assert(ret);
-
-		/* fail: get a service by loopback address [we're not in the root namespace] */
-		key.address = bpf_htonl(INADDR_LOOPBACK);
-		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, OTHER_NS);
-		assert(!ret);
 
 		/* pass: get a service by host address [we're in the root namespace] */
 		key.address = bpf_htonl(HOST_IP);
 		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, HOST_NS);
+		ret = sock4_wildcard_lookup(&key);
 		assert(ret);
-
-		/* fail: get a service by host address [we're not in the root namespace] */
-		key.address = bpf_htonl(HOST_IP);
-		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, OTHER_NS);
-		assert(ret);
-	});
-
-	TEST("hostport", {
-		/* pass: get a service by loopback address [we're in the root namespace] */
-		key.address = bpf_htonl(INADDR_LOOPBACK);
-		key.dport = bpf_htons(HOSTPORT_EXISTS);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, HOST_NS);
-		assert(ret);
-
-		/* fail: get a service by loopback address [we're not in the root namespace] */
-		key.address = bpf_htonl(INADDR_LOOPBACK);
-		key.dport = bpf_htons(HOSTPORT_EXISTS);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, OTHER_NS);
-		assert(!ret);
-
-		/* pass: get a service by loopback address [we're in the root namespace] */
-		key.address = bpf_htonl(INADDR_LOOPBACK);
-		key.dport = bpf_htons(HOSTPORT_EXISTS_LOCALHOST);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, HOST_NS);
-		assert(ret);
-
-		/* fail: get a service by loopback address [we're not in the root namespace] */
-		key.address = bpf_htonl(INADDR_LOOPBACK);
-		key.dport = bpf_htons(HOSTPORT_EXISTS_LOCALHOST);
-		ret = sock4_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, OTHER_NS);
-		assert(!ret);
 	});
 
 	/* full wildcard lookups */
@@ -342,12 +299,7 @@ int test_v6_check(__maybe_unused struct xdp_md *ctx)
 	TEST("bad-port-range", {
 		/* fail: dport is out of nodeport range, but we want a nodeport */
 		key.dport = bpf_htons(123);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, DONT_CARE(0));
-		assert(!ret);
-
-		/* fail: dport is inside the nodeport range, but we want a hostport */
-		key.dport = bpf_htons((CONFIG(nodeport_port_min) + CONFIG(nodeport_port_max)) / 2);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, DONT_CARE(0));
+		ret = sock6_wildcard_lookup(&key);
 		assert(!ret);
 	});
 
@@ -355,52 +307,14 @@ int test_v6_check(__maybe_unused struct xdp_md *ctx)
 		/* pass: get a service by loopback address [we're in the root namespace] */
 		memcpy(&key.address, &LOOPBACK, sizeof(LOOPBACK));
 		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, HOST_NS);
+		ret = sock6_wildcard_lookup(&key);
 		assert(ret);
-
-		/* fail: get a service by loopback address [we're not in the root namespace] */
-		memcpy(&key.address, &LOOPBACK, sizeof(LOOPBACK));
-		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, OTHER_NS);
-		assert(!ret);
 
 		/* pass: get a service by host address [we're in the root namespace] */
 		memcpy(&key.address, &HOST_IP6, sizeof(HOST_IP6));
 		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, HOST_NS);
+		ret = sock6_wildcard_lookup(&key);
 		assert(ret);
-
-		/* fail: get a service by host address [we're not in the root namespace] */
-		memcpy(&key.address, &HOST_IP6, sizeof(HOST_IP6));
-		key.dport = bpf_htons(NODEPORT_EXISTS);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), NODEPORT_LOOKUP, OTHER_NS);
-		assert(ret);
-	});
-
-	TEST("hostport", {
-		/* pass: get a service by loopback address [we're in the root namespace] */
-		memcpy(&key.address, &LOOPBACK, sizeof(LOOPBACK));
-		key.dport = bpf_htons(HOSTPORT_EXISTS);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, HOST_NS);
-		assert(ret);
-
-		/* fail: get a service by loopback address [we're not in the root namespace] */
-		memcpy(&key.address, &LOOPBACK, sizeof(LOOPBACK));
-		key.dport = bpf_htons(HOSTPORT_EXISTS);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, OTHER_NS);
-		assert(!ret);
-
-		/* pass: get a service by loopback address [we're in the root namespace] */
-		memcpy(&key.address, &LOOPBACK, sizeof(LOOPBACK));
-		key.dport = bpf_htons(HOSTPORT_EXISTS_LOCALHOST);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, HOST_NS);
-		assert(ret);
-
-		/* fail: get a service by loopback address [we're not in the root namespace] */
-		memcpy(&key.address, &LOOPBACK, sizeof(LOOPBACK));
-		key.dport = bpf_htons(HOSTPORT_EXISTS_LOCALHOST);
-		ret = sock6_wildcard_lookup(&key, DONT_CARE(0), HOSTPORT_LOOKUP, OTHER_NS);
-		assert(!ret);
 	});
 
 	/* full wildcard lookups */


### PR DESCRIPTION
Align the wildcard lookups in `bpf_sock` with the recent change from https://github.com/cilium/cilium/pull/45115.
