### PR TITLE
feat(sdp): Add metrics for standalone dns proxy

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"log/slog"
+	"net"
 	"regexp"
 
 	"github.com/cilium/hive/cell"
@@ -79,5 +80,5 @@ func initializeMetrics(p params) {
 	p.Registry.MustRegister(metrics.ErrorsWarnings)
 	metrics.FlushLoggingMetrics()
 
-	p.Registry.AddServerRuntimeHooks("operator-prometheus-server", p.TLSConfigPromise)
+	p.Registry.AddServerRuntimeHooks("operator-prometheus-server", p.TLSConfigPromise, net.ListenConfig{})
 }

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -83,7 +84,7 @@ func (reg *Registry) Gather() ([]*dto.MetricFamily, error) {
 	return reg.inner.Gather()
 }
 
-func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLSConfigPromise) {
+func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLSConfigPromise, listenConfig net.ListenConfig) {
 	if reg.params.Config.PrometheusServeAddr != "" {
 		// The Handler function provides a default handler to expose metrics
 		// via an HTTP server. "/metrics" is the usual endpoint for that.
@@ -102,20 +103,27 @@ func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLS
 				logfields.TLS, tlsEnabled,
 			)
 
-			listenAndServeFn := srv.ListenAndServe
+			ln, err := listenConfig.Listen(ctx, "tcp", reg.params.Config.PrometheusServeAddr)
+			if err != nil {
+				reg.params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+				return nil
+			}
+
+			var serveFn func() error
 			if tlsEnabled {
 				reg.params.Logger.Info("Waiting for TLS certificates to become available")
 				tlsConfig, err := tlsConfigPromise.Await(ctx)
 				if err != nil {
+					ln.Close()
 					return err
 				}
 				srv.TLSConfig = tlsConfig
-				listenAndServeFn = func() error {
-					return srv.ListenAndServeTLS("", "")
-				}
+				serveFn = func() error { return srv.ServeTLS(ln, "", "") }
+			} else {
+				serveFn = func() error { return srv.Serve(ln) }
 			}
 
-			if err := listenAndServeFn(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if err := serveFn(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				reg.params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 			}
 			return nil
@@ -148,7 +156,7 @@ func NewAgentRegistry(params RegistryParams) *Registry {
 	// Resolve the global registry variable for as long as we still have global functions
 	registryResolver.Resolve(reg)
 
-	reg.AddServerRuntimeHooks("agent-prometheus-server", nil)
+	reg.AddServerRuntimeHooks("agent-prometheus-server", nil, net.ListenConfig{})
 
 	return reg
 }

--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/defaults"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/lookup"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/messagehandler"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 	sdpshell "github.com/cilium/cilium/standalone-dns-proxy/pkg/shell"
 )
 
@@ -49,6 +50,9 @@ var (
 
 		// includes the message handler for receiving messages from the proxy and sending messages to the gRPC client which in turn sends them to the cilium agent
 		messagehandler.Cell,
+
+		// Prometheus metrics registry and HTTP server for standalone DNS proxy
+		metrics.Cell,
 
 		// Shell for inspecting the standalone DNS proxy. Listens on the Unix domain socket.
 		shell.ServerCell(defaults.ShellSockPath),
@@ -131,6 +135,7 @@ type standaloneDNSProxyParams struct {
 	DNSProxier        proxy.DNSProxier
 	DNSRulesTable     statedb.RWTable[client.DNSRules]
 	DB                *statedb.DB
+	Metrics           *metrics.Metrics
 }
 
 type hooksParams struct {

--- a/standalone-dns-proxy/cmd/standalonednsproxy.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
+	sdpmetrics "github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 )
 
 // ReadinessStatusProvider is an interface for checking the readiness status
@@ -43,6 +44,9 @@ type StandaloneDNSProxy struct {
 	dnsRulesTable statedb.RWTable[client.DNSRules]
 	db            *statedb.DB
 	jobGroup      job.Group
+
+	// metrics tracks errors for the standalone DNS proxy
+	metrics *sdpmetrics.Metrics
 
 	// readinessStatus tracks the readiness status of this standalone DNS proxy instance
 	readinessStatus atomic.Bool
@@ -71,6 +75,7 @@ func NewStandaloneDNSProxy(params standaloneDNSProxyParams) *StandaloneDNSProxy 
 		db:                           params.DB,
 		dnsRulesTable:                params.DNSRulesTable,
 		jobGroup:                     params.JobGroup,
+		metrics:                      params.Metrics,
 	}
 }
 
@@ -115,6 +120,7 @@ func (sdp *StandaloneDNSProxy) WatchConnection(ctx context.Context, _ cell.Healt
 				// Start the DNS proxy once the connection is established
 				if err := sdp.dnsProxier.Listen(sdp.proxyPort); err != nil {
 					sdp.logger.Error("Failed to start DNS proxy", logfields.Error, err)
+					sdp.metrics.ProxyBootstrapError.Inc()
 					return err
 				}
 				return nil

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/client"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/lookup"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/messagehandler"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 )
 
 var (
@@ -82,6 +83,7 @@ func setupTestEnv(t *testing.T) *StandaloneDNSProxy {
 						ToFQDNsProxyPort: 1001,
 					}
 				},
+				metrics.NewMetrics,
 				NewStandaloneDNSProxy,
 				NewReadinessStatusProvider,
 			)),

--- a/standalone-dns-proxy/pkg/client/cell.go
+++ b/standalone-dns-proxy/pkg/client/cell.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 )
 
 const (
@@ -46,6 +47,7 @@ type clientParams struct {
 	DNSRulesTable         statedb.RWTable[DNSRules]
 	IPtoEndpointTable     statedb.RWTable[IPtoEndpointInfo]
 	PrefixToIdentityTable statedb.RWTable[PrefixToIdentity]
+	Metrics               *metrics.Metrics
 }
 
 // newGRPCClient creates a new gRPC connection handler client for standalone DNS proxy

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
+	sdpmetrics "github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 
 	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
@@ -235,6 +236,9 @@ type GRPCClient struct {
 
 	// grpc client connection to the Cilium agent
 	client *grpc.ClientConn
+
+	// metrics tracks errors for the standalone DNS proxy gRPC client
+	metrics *sdpmetrics.Metrics
 }
 
 // createGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
@@ -248,6 +252,7 @@ func createGRPCClient(params clientParams) *GRPCClient {
 		dnsRulesTable:         params.DNSRulesTable,
 		ipToEndpointTable:     params.IPtoEndpointTable,
 		prefixToIdentityTable: params.PrefixToIdentityTable,
+		metrics:               params.Metrics,
 	}
 }
 
@@ -260,6 +265,7 @@ func (c *GRPCClient) InitClient() error {
 	)
 	if err != nil {
 		c.logger.Error("Client creation failed", logfields.Error, err)
+		c.metrics.CiliumAgentConnection.WithLabelValues(sdpmetrics.LabelErrorClientCreation).Inc()
 		return err
 	}
 
@@ -280,6 +286,7 @@ func (c *GRPCClient) createPolicyStream(ctx context.Context) error {
 		stream, err := fqdnClient.StreamPolicyState(context.Background())
 		if err != nil {
 			c.logger.Error("Failed to open policy stream", logfields.Error, err)
+			c.metrics.CiliumAgentConnection.WithLabelValues(sdpmetrics.LabelErrorOpenPolicyStream).Inc()
 			return err
 		}
 		defer stream.CloseSend()
@@ -290,6 +297,7 @@ func (c *GRPCClient) createPolicyStream(ctx context.Context) error {
 			state, err := stream.Recv()
 			if err != nil {
 				c.logger.Error("Policy stream recv failed", logfields.Error, err)
+				c.metrics.RetrieveDNSRules.WithLabelValues(sdpmetrics.LabelErrorPolicyStreamRecv).Inc()
 				return err
 			}
 			response := &pb.PolicyStateResponse{
@@ -303,6 +311,7 @@ func (c *GRPCClient) createPolicyStream(ctx context.Context) error {
 			}
 			if sendErr := stream.Send(response); sendErr != nil {
 				c.logger.Error("Policy stream ACK send failed", logfields.Error, sendErr)
+				c.metrics.RetrieveDNSRules.WithLabelValues(sdpmetrics.LabelErrorPolicyStreamSend).Inc()
 				return sendErr
 			}
 			c.connected.Store(true)
@@ -336,10 +345,14 @@ func (c *GRPCClient) NotifyOnMsg(msg *pb.FQDNMapping) error {
 	client := pb.NewFQDNDataClient(c.client)
 
 	_, err := client.UpdateMappingRequest(context.Background(), msg)
-	if err != nil && isConnectionError(err) {
-		c.logger.Error("Connection error during UpdateMappingRequest", logfields.Error, err)
-		// Return nil as standalone dns proxy can still continue to handle the DNS requests
-		return nil
+	if err != nil {
+		if isConnectionError(err) {
+			c.logger.Error("Connection error during UpdateMappingRequest", logfields.Error, err)
+			c.metrics.FQDNMappingSync.WithLabelValues(sdpmetrics.LabelErrorMappingSyncConnection).Inc()
+			// Return nil as standalone dns proxy can still continue to handle the DNS requests
+			return nil
+		}
+		c.metrics.FQDNMappingSync.WithLabelValues(sdpmetrics.LabelErrorMappingSyncRequest).Inc()
 	}
 	return err
 }

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 
 	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
@@ -125,6 +126,7 @@ func setupClientAndServer(t *testing.T) (ConnectionHandler, *mockFqdnDataServer,
 			return newMockDialConfig(lis)
 		},
 			newGRPCClient),
+		cell.Provide(metrics.NewMetrics),
 		cell.Invoke(func(_c ConnectionHandler) {
 			connHandler = _c
 		}),

--- a/standalone-dns-proxy/pkg/metrics/cell.go
+++ b/standalone-dns-proxy/pkg/metrics/cell.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+const (
+	// SDPPrometheusServeAddr is the flag name for the standalone DNS proxy
+	// prometheus metrics serve address.
+	SDPPrometheusServeAddr = "sdp-prometheus-serve-addr"
+)
+
+// Cell provides the modular metrics registry and metric HTTP server
+// for the standalone DNS proxy.
+var Cell = cell.Module(
+	"sdp-metrics",
+	"Standalone DNS Proxy Metrics",
+
+	cell.Config(defaultConfig),
+	cell.Provide(func(conf Config) metrics.RegistryConfig {
+		return metrics.RegistryConfig{
+			PrometheusServeAddr: conf.SDPPrometheusServeAddr,
+		}
+	}),
+	metrics.NewCell("sdp"),
+	metrics.Metric(NewMetrics),
+	cell.Invoke(initializeMetrics),
+)
+
+type Config struct {
+	SDPPrometheusServeAddr string
+}
+
+var defaultConfig = Config{
+	SDPPrometheusServeAddr: ":9961",
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String(SDPPrometheusServeAddr, def.SDPPrometheusServeAddr, "Address to serve Prometheus metrics for the standalone DNS proxy")
+}

--- a/standalone-dns-proxy/pkg/metrics/metrics.go
+++ b/standalone-dns-proxy/pkg/metrics/metrics.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"regexp"
+	"syscall"
+
+	"github.com/cilium/hive/cell"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	sdpNamespace = "standalone_dns_proxy"
+
+	// Error labels for CiliumAgentConnection metric.
+	LabelErrorClientCreation   = "client_creation"    // gRPC client creation failed
+	LabelErrorOpenPolicyStream = "open_policy_stream" // opening the policy stream failed
+
+	// Error labels for RetrieveDNSRules metric.
+	LabelErrorPolicyStreamSend = "policy_stream_send" // sending ACK on the policy stream failed
+	LabelErrorPolicyStreamRecv = "policy_stream_recv" // receiving from the policy stream failed
+
+	// Error labels for FQDNMappingSync metric.
+	LabelErrorMappingSyncConnection = "mapping_sync_connection" // FQDN mapping sync failed due to connection error
+	LabelErrorMappingSyncRequest    = "mapping_sync_request"    // FQDN mapping sync request failed
+)
+
+// goCustomCollectorsRX tracks enabled go runtime metrics.
+var goCustomCollectorsRX = regexp.MustCompile(`^/sched/latencies:seconds`)
+
+// Metrics contains all metrics for the standalone DNS proxy.
+type Metrics struct {
+	// CiliumAgentConnection tracks total errors while connecting to cilium-agent.
+	CiliumAgentConnection metric.Vec[metric.Counter]
+
+	// FQDNMappingSync tracks errors while syncing FQDN mappings.
+	FQDNMappingSync metric.Vec[metric.Counter]
+
+	// RetrieveDNSRules tracks errors while retrieving DNS rules.
+	RetrieveDNSRules metric.Vec[metric.Counter]
+
+	// ProxyBootstrapError tracks errors that occurred during proxy bootstrap.
+	ProxyBootstrapError metric.Counter
+}
+
+// NewMetrics creates the SDP metrics.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		CiliumAgentConnection: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: sdpNamespace,
+			Name:      "cilium_agent_connection_errors",
+			Help:      "Total errors while connecting to cilium-agent",
+		}, []string{metrics.LabelError}),
+		FQDNMappingSync: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: sdpNamespace,
+			Name:      "fqdn_mapping_sync_errors",
+			Help:      "Total errors while syncing FQDN mappings",
+		}, []string{metrics.LabelError}),
+		RetrieveDNSRules: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: sdpNamespace,
+			Name:      "retrieve_dns_rules_errors",
+			Help:      "Total errors while retrieving DNS rules",
+		}, []string{metrics.LabelError}),
+		ProxyBootstrapError: metric.NewCounter(metric.CounterOpts{
+			Namespace: sdpNamespace,
+			Name:      "proxy_bootstrap_errors",
+			Help:      "Number of errors occurred during proxy bootstrap",
+		}),
+	}
+}
+
+type initParams struct {
+	cell.In
+
+	Logger   *slog.Logger
+	Registry *metrics.Registry
+
+	Metrics []metric.WithMetadata `group:"hive-metrics"`
+}
+
+func initializeMetrics(p initParams) {
+	p.Registry.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(
+			collectors.GoRuntimeMetricsRule{Matcher: goCustomCollectorsRX},
+		),
+	))
+
+	p.Registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
+		Namespace: sdpNamespace,
+	}))
+
+	for _, m := range p.Metrics {
+		p.Registry.MustRegister(m.(prometheus.Collector))
+	}
+
+	p.Registry.AddServerRuntimeHooks("sdp-prometheus-server", nil, net.ListenConfig{
+		Control: setsockoptReusePort,
+	})
+}
+
+// setsockoptReusePort sets SO_REUSEPORT on the socket to allow the new SDP pod
+// to bind the metrics port while the old pod is still terminating during a
+// surge-based rolling update.
+func setsockoptReusePort(network, address string, c syscall.RawConn) error {
+	var soerr error
+	if err := c.Control(func(su uintptr) {
+		s := int(su)
+		if err := unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+			soerr = fmt.Errorf("failed to setsockopt(SO_REUSEPORT): %w", err)
+		}
+	}); err != nil {
+		return err
+	}
+	return soerr
+}


### PR DESCRIPTION
Add a dedicated Prometheus metrics subsystem for the standalone DNS proxy (SDP), exposing error counters for observability:

- `cilium_agent_connection_errors`: gRPC client creation and policy stream failures
- `fqdn_mapping_sync_errors`: FQDN mapping sync connection and request errors
- `retrieve_dns_rules_errors`: policy stream send/recv failures
- `proxy_bootstrap_errors`: DNS proxy listener startup failures

The metrics are served on :9961

Metrics:
```
standalone_dns_proxy_cilium_agent_connection_errors{error="open_policy_stream"} 9
standalone_dns_proxy_fqdn_mapping_sync_errors{error="mapping_sync_connection"} 12
standalone_dns_proxy_proxy_bootstrap_errors 0
standalone_dns_proxy_retrieve_dns_rules_errors{error="policy_stream_recv"} 5
```

```release-note
feat(sdp): Add metrics for standalone dns proxy
```
