### PR TITLE
connectivity: apply namespace labels/annotations to CCNP test namespaces

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -954,7 +954,9 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 			name: "cilium-test-ccnp1",
 			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cilium-test-ccnp1",
+					Name:        "cilium-test-ccnp1",
+					Annotations: ct.params.NamespaceAnnotations,
+					Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
 				},
 			},
 		},
@@ -962,7 +964,9 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 			name: "cilium-test-ccnp2",
 			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cilium-test-ccnp2",
+					Name:        "cilium-test-ccnp2",
+					Annotations: ct.params.NamespaceAnnotations,
+					Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

The `--namespace-labels` and `--namespace-annotations` connectivity test options are not applied to the `cilium-test-ccnp1` and `cilium-test-ccnp2` namespaces created by `deployCCNPTestEnv`. This is because these namespaces are created with a bare `ObjectMeta` containing only the `Name` field.

The main test namespace created in `deployNamespace` correctly uses `ct.params.NamespaceLabels` and `ct.params.NamespaceAnnotations`:

```go
namespace = &corev1.Namespace{
    ObjectMeta: metav1.ObjectMeta{
        Name:        ct.params.TestNamespace,
        Annotations: ct.params.NamespaceAnnotations,
        Labels:      labels.Merge(ct.params.NamespaceLabels, appLabels),
    },
}
```

But the CCNP test namespaces only had:

```go
obj: &corev1.Namespace{
    ObjectMeta: metav1.ObjectMeta{
        Name: "cilium-test-ccnp1",
    },
}
```

## Fix

This PR adds `Annotations: ct.params.NamespaceAnnotations` and `Labels: labels.Merge(ct.params.NamespaceLabels, appLabels)` to both CCNP test namespace definitions, making them consistent with the main test namespace.

## How to reproduce

```
cilium connectivity test --namespace-labels "pod-security.kubernetes.io/enforce=privileged"
```

Before this fix, `cilium-test-ccnp1` and `cilium-test-ccnp2` namespaces would not have the label set, while `cilium-test-1` would.

Fixes: cilium/cilium-cli#3173
