### PR TITLE
policy: Fix CCG matching for duplicate label keys

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -156,6 +156,10 @@ const (
 	// LabelSourceCIDRGroupKeyPrefix is the source as a k8s selector key prefix
 	LabelSourceCIDRGroupKeyPrefix = LabelSourceCIDRGroup + SourceDelimiter
 
+	// CIDRGroupEncodedSep is the separator for encoded key+value CIDRGroup labels.
+	// Safe because K8s label keys/values cannot contain "+".
+	CIDRGroupEncodedSep = "+"
+
 	// LabelSourceNode is the label source for remote-nodes.
 	LabelSourceNode = "node"
 
@@ -171,6 +175,12 @@ const (
 	// LabelSourceDirectory is the label source for policies read from files
 	LabelSourceDirectory = "directory"
 )
+
+// EncodedCIDRGroupLabel builds a label with the value baked into the key,
+// used for collision-free matching of CIDRGroup labels.
+func EncodedCIDRGroupLabel(key, val, source string) Label {
+	return Label{Key: key + CIDRGroupEncodedSep + val, Source: source}
+}
 
 type labelSourceDelimiter rune
 

--- a/pkg/policy/k8s/cilium_cidr_group.go
+++ b/pkg/policy/k8s/cilium_cidr_group.go
@@ -42,7 +42,14 @@ func (p *policyWatcher) cidrsAndLabelsForCIDRGroup(name string) (sets.Set[netip.
 
 	// If CIDRGroup isn't deleted; populate newCIDRs
 	if cidrGroup, ok := p.cidrGroupCache[name]; ok {
-		lbls = labels.Map2Labels(utils.RemoveCiliumLabels(cidrGroup.Labels), labels.LabelSourceCIDRGroup)
+		filtered := utils.RemoveCiliumLabels(cidrGroup.Labels)
+		lbls = make(labels.Labels, len(filtered)*2+1) // +1 for CIDRGroupRef label
+		for k, v := range filtered {
+			l := labels.NewLabel(k, v, labels.LabelSourceCIDRGroup)
+			lbls[l.Key] = l // may collide; only used for Exists
+			encoded := labels.EncodedCIDRGroupLabel(l.Key, l.Value, l.Source)
+			lbls[encoded.Key] = encoded
+		}
 		lbl := api.LabelForCIDRGroupRef(name)
 		lbls[lbl.Key] = lbl
 

--- a/pkg/policy/k8s/cilium_cidr_group_test.go
+++ b/pkg/policy/k8s/cilium_cidr_group_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"log/slog"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/policy/api"
+	policyTypes "github.com/cilium/cilium/pkg/policy/types"
+)
+
+// Two CCGs with the same label key but different values on a shared CIDR.
+func TestCIDRGroupDuplicateLabelKeys(t *testing.T) {
+	pw := &policyWatcher{
+		log: slog.Default(),
+		cidrGroupCache: map[string]*cilium_v2.CiliumCIDRGroup{
+			"app-bar": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "app-bar",
+					Labels: map[string]string{"app": "bar"},
+				},
+				Spec: cilium_v2.CiliumCIDRGroupSpec{
+					ExternalCIDRs: []api.CIDR{"10.48.0.0/24"},
+				},
+			},
+			"app-foo": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "app-foo",
+					Labels: map[string]string{"app": "foo"},
+				},
+				Spec: cilium_v2.CiliumCIDRGroupSpec{
+					ExternalCIDRs: []api.CIDR{"10.48.0.0/24"},
+				},
+			},
+		},
+	}
+
+	_, lblsBar := pw.cidrsAndLabelsForCIDRGroup("app-bar")
+	_, lblsFoo := pw.cidrsAndLabelsForCIDRGroup("app-foo")
+
+	// Simulate ipcache label merge: labels from different resources for the
+	// same prefix are unioned into one Labels map. maps.Copy uses last-write-wins,
+	// so if both CCGs produced the same map key, one label is silently dropped.
+	merged := maps.Clone(lblsBar)
+	maps.Copy(merged, lblsFoo)
+
+	arr := merged.LabelArray()
+
+	barSelector := policyTypes.ToSelector(api.CIDRRule{
+		CIDRGroupSelector: api.EndpointSelector{
+			LabelSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "bar"},
+			},
+		},
+	})
+	fooSelector := policyTypes.ToSelector(api.CIDRRule{
+		CIDRGroupSelector: api.EndpointSelector{
+			LabelSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "foo"},
+			},
+		},
+	})
+
+	assert.True(t, barSelector.Matches(arr),
+		"CIDRGroupSelector app=bar must match after merge; labels: %v", arr)
+	assert.True(t, fooSelector.Matches(arr),
+		"CIDRGroupSelector app=foo must match after merge; labels: %v", arr)
+}

--- a/pkg/policy/types/requirements.go
+++ b/pkg/policy/types/requirements.go
@@ -246,6 +246,42 @@ func MatchesRequirements[T labels.LabelMatcher](reqs Requirements, ls T) bool {
 	return true
 }
 
+// matchesEncodedRequirements is like MatchesRequirements but checks for
+// encoded key+value labels. Used by CIDRGroupSelector.
+func matchesEncodedRequirements(reqs Requirements, ls labels.LabelArray) bool {
+	for i := range reqs {
+		if !matchesEncodedRequirement(&reqs[i], ls) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchesEncodedRequirement converts value-match operators into existence
+// checks on encoded key+value labels. Exists/DoesNotExist pass through.
+func matchesEncodedRequirement(r *Requirement, ls labels.LabelArray) bool {
+	encodedValueExists := func() bool {
+		for val := range r.values.Members() {
+			encoded := labels.EncodedCIDRGroupLabel(r.key.Key, val, r.key.Source)
+			if _, exists := ls.LookupLabel(&encoded); exists {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch r.operator {
+	case selection.In, selection.Equals, selection.DoubleEquals:
+		return encodedValueExists()
+	case selection.NotIn, selection.NotEquals:
+		return !encodedValueExists()
+	case selection.Exists, selection.DoesNotExist:
+		return MatchesRequirement(r, ls)
+	default:
+		return false
+	}
+}
+
 // GetFirstK8sMatch checks for a match on the specified k8s key, and returns the values that the key
 // must match, and true. If a match cannot be found, or is with operator other than "In", "Equals",
 // or "DoubleEquals", returns nil, false.  Note: The values of first requirement with the given k8s

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -427,6 +427,7 @@ type CIDRSelector struct {
 	key          string
 	requirements Requirements
 	generated    bool // only needed for current unit tests via Selectors.CIDRRules()
+	encoded      bool // true for CIDRGroupSelector: use key+value encoded matching
 }
 
 func (p *CIDRSelector) MarshalJSON() ([]byte, error) {
@@ -481,6 +482,7 @@ func newCIDRRuleSelector(rule api.CIDRRule) (ps *CIDRSelector) {
 		es := rule.CIDRGroupSelector
 		requirements := LabelSelectorToRequirements(es.LabelSelector)
 		ps = newCIDRSelectorFromRequirements(key, requirements, rule.ExceptCIDRs)
+		ps.encoded = true
 	default: // rule.Cidr != ""
 		ps = NewCIDRSelector(key, rule.Cidr, rule.ExceptCIDRs)
 	}
@@ -507,6 +509,9 @@ func (p *CIDRSelector) SelectedNamespaces() []string {
 }
 
 func (p *CIDRSelector) Matches(ls labels.LabelArray) bool {
+	if p.encoded {
+		return matchesEncodedRequirements(p.requirements, ls)
+	}
 	return MatchesRequirements(p.requirements, ls)
 }
 

--- a/pkg/policy/types/selector_test.go
+++ b/pkg/policy/types/selector_test.go
@@ -126,10 +126,16 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 			rule: api.CIDRRule{CIDRGroupSelector: api.EndpointSelector{LabelSelector: &v1.LabelSelector{
 				MatchLabels: map[string]v1.MatchLabelsValue{"foo": "bar"},
 			}}},
-			expected:   selectors("cidrgroup:foo=bar"),
+			expected: Selectors{&CIDRSelector{
+				key: "&LabelSelector{MatchLabels:map[string]string{cidrgroup:foo: bar,},MatchExpressions:[]LabelSelectorRequirement{},}",
+				requirements: Requirements{
+					NewEqualsRequirement(labels.NewLabel("foo", "bar", labels.LabelSourceCIDRGroup)),
+				},
+				encoded: true,
+			}},
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"cidrgroup:foo=bar"},
-			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz"},
+			matchesLabels:    []string{"cidrgroup:foo=bar;cidrgroup:foo+bar"},
+			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz;cidrgroup:foo+baz"},
 		},
 		{
 			name: "cidr group ls with exceptions",
@@ -143,10 +149,11 @@ func TestCIDRRuleToCIDRSelectors(t *testing.T) {
 					NewExceptRequirement(labels.NewLabel("1.1.1.1/32", "", labels.LabelSourceCIDR)),
 					NewExceptRequirement(labels.NewLabel("192.168.0.0/16", "", labels.LabelSourceCIDR)),
 				},
+				encoded: true,
 			}},
 			enableIPv4: true, enableIPv6: true,
-			matchesLabels:    []string{"cidrgroup:foo=bar"},
-			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.1681.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz"},
+			matchesLabels:    []string{"cidrgroup:foo=bar;cidrgroup:foo+bar"},
+			notMatchesLabels: []string{"cidr:1.1.1.1/32;reserved:world-ipv4", "cidr:192.1681.1.1/32;reserved:world-ipv4", "cidrgroup:foo=baz;cidrgroup:foo+baz"},
 		},
 		{
 			name: "world v4 ss",

--- a/pkg/policy/types/zz_generated.deepequal.go
+++ b/pkg/policy/types/zz_generated.deepequal.go
@@ -38,6 +38,9 @@ func (in *CIDRSelector) DeepEqual(other *CIDRSelector) bool {
 	if in.generated != other.generated {
 		return false
 	}
+	if in.encoded != other.encoded {
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
When two CCGs share a label key with different values on the same CIDR
prefix, ipcache merges their labels into one map. LookupLabel returns
the first match by key, so Equals matching for the other value silently
fails.

Fix this by emitting an extra encoded label (key+value as the label key)
for each CCG label, and teaching CIDRGroupSelector to check for encoded
key existence instead of value comparison.