### PR TITLE
loadbalancer: Fix script test transaction handling and path usage

### DIFF
--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -10,7 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -146,7 +146,7 @@ func testScript(t *testing.T) {
 			// Expand $WORK in args. Used by testdata/file.txtar.
 			// This works by creating a new temporary directory for this test (e.g. /tmp/<tempdir/002)
 			// and replacing the directory with /001 which is the temp directory that scripttest created.
-			tempDir := path.Join(path.Dir(t.TempDir()), "001")
+			tempDir := filepath.Join(filepath.Dir(t.TempDir()), "001")
 			for i := range args {
 				args[i] = strings.ReplaceAll(args[i], "$WORK", tempDir)
 			}

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -219,10 +219,13 @@ func (tc testCommands) updateHealth() script.Cmd {
 			}
 
 			txn := tc.w.WriteTxn()
-			defer txn.Commit()
-
 			_, err = tc.w.UpdateBackendHealth(txn, svc, beAddr, healthy)
-			return nil, err
+			if err != nil {
+				txn.Abort()
+				return nil, err
+			}
+			txn.Commit()
+			return nil, nil
 		})
 }
 


### PR DESCRIPTION
<!-- Description of change -->

This PR fixes two issues in `pkg/loadbalancer/tests/script_test.go`:
1. **Transaction Handling**: In the `updateHealth` command, transactions were being committed unconditionally via `defer txn.Commit()`, even when `UpdateBackendHealth` returned an error. This could leave the state partially modified on failure. This PR changes it to explicitly abort the transaction on error and commit only on success.
2. **Path Usage**: Replaced `path` with `path/filepath` for file system paths (specifically when constructing `tempDir`) to ensure compatibility with Windows.

Fixes: #45229

```release-note
Fix transaction handling and path usage in loadbalancer script tests.

