### PR TITLE
bpf/tests: regularize __be16 usage

### DIFF
--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -2,7 +2,7 @@
 /* Copyright Authors of Cilium */
 
 static __always_inline __u8
-policy_calc_wildcard_bits(__u8 protocol, __u16 dport, __u8 port_range)
+policy_calc_wildcard_bits(__u8 protocol, __be16 dport, __u8 port_range)
 {
 	__u8 wildcard_bits = 0;
 
@@ -22,7 +22,7 @@ policy_calc_wildcard_bits(__u8 protocol, __u16 dport, __u8 port_range)
 }
 
 static __always_inline void
-policy_delete_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
+policy_delete_entry(bool egress, __u32 sec_label, __u8 protocol, __be16 dport,
 		    __u8 port_range)
 {
 	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport, port_range);
@@ -41,7 +41,7 @@ policy_delete_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
 }
 
 static __always_inline void
-policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
+policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __be16 dport,
 		 __u8 port_range, bool deny, __be16 proxy_port)
 {
 	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport, port_range);
@@ -66,14 +66,14 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport,
 }
 
 static __always_inline void
-policy_add_ingress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport,
+policy_add_ingress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __be16 dport,
 				     __u8 port_range)
 {
 	policy_add_entry(false, sec_label, protocol, dport, port_range, false, 0);
 }
 
 static __always_inline void
-policy_add_ingress_deny_l4_entry(__u8 protocol, __u16 dport, __u8 port_range)
+policy_add_ingress_deny_l4_entry(__u8 protocol, __be16 dport, __u8 port_range)
 {
 	policy_add_entry(false, 0, protocol, dport, port_range, true, 0);
 }
@@ -85,7 +85,7 @@ policy_add_ingress_deny_all_entry(void)
 }
 
 static __always_inline void
-policy_add_egress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport,
+policy_add_egress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __be16 dport,
 				    __u8 port_range)
 {
 	policy_add_entry(true, sec_label, protocol, dport, port_range, false, 0);
@@ -98,7 +98,7 @@ policy_add_egress_allow_l3_entry(__u32 sec_label)
 }
 
 static __always_inline void
-policy_add_egress_allow_l4_entry(__u8 protocol, __u16 dport, __u8 port_range)
+policy_add_egress_allow_l4_entry(__u8 protocol, __be16 dport, __u8 port_range)
 {
 	policy_add_egress_allow_l3_l4_entry(0, protocol, dport, port_range);
 }
@@ -114,7 +114,7 @@ static __always_inline void policy_add_egress_deny_all_entry(void)
 }
 
 static __always_inline void
-policy_delete_egress_l3_l4_entry(__u32 sec_label, __u8 protocol, __u16 dport,
+policy_delete_egress_l3_l4_entry(__u32 sec_label, __u8 protocol, __be16 dport,
 				 __u8 port_range)
 {
 	policy_delete_entry(true, sec_label, protocol, dport, port_range);
@@ -127,7 +127,7 @@ policy_delete_egress_l3_entry(__u32 sec_label)
 }
 
 static __always_inline void
-policy_delete_egress_l4_entry(__u8 protocol, __u16 dport, __u8 port_range)
+policy_delete_egress_l4_entry(__u8 protocol, __be16 dport, __u8 port_range)
 {
 	policy_delete_egress_l3_l4_entry(0, protocol, dport, port_range);
 }

--- a/bpf/tests/session_affinity_maglev_test.c
+++ b/bpf/tests/session_affinity_maglev_test.c
@@ -131,7 +131,7 @@ ASSIGN_CONFIG(__u32, hash_init4_seed, 0xcafe)
 ASSIGN_CONFIG(__u32, hash_init6_seed, 0xeb9f)
 
 static __always_inline int
-generate_packet(struct __ctx_buff *ctx, int client_id, __u16 src_port)
+generate_packet(struct __ctx_buff *ctx, int client_id, __be16 src_port)
 {
 	__u8 *src_mac;
 	__u32 src_ip;

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -762,7 +762,7 @@ static __always_inline int build_reply(struct __ctx_buff *ctx)
 	struct pktgen builder;
 	struct tcphdr *l4;
 	void *data;
-	__u16 nat_source_port = 0;
+	__be16 nat_source_port = 0;
 	__u32 key = 0;
 
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
@@ -904,7 +904,7 @@ SETUP("tc", "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_setup(struct __ctx_buff *ctx)
 {
 	/* Delete the Rev NAT */
-	__u16 nat_source_port = 0;
+	__be16 nat_source_port = 0;
 	__u32 key = 0;
 
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
@@ -1143,7 +1143,7 @@ int nodeport_nat_fwd_original_renated_check(const struct __ctx_buff *ctx)
 	struct tcphdr *l4;
 	struct iphdr *l3;
 	__u32 key = 0;
-	__u16 nat_source_port = 0;
+	__be16 nat_source_port = 0;
 
 	test_init();
 
@@ -1282,7 +1282,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_check(struct __ctx_buff *ctx
 	struct tcphdr *l4;
 	struct iphdr *l3;
 	__u32 key = 0;
-	__u16 nat_source_port = 0;
+	__be16 nat_source_port = 0;
 
 	test_init();
 

--- a/bpf/tests/tc_nodeport_lb4_wildcard_drop.c
+++ b/bpf/tests/tc_nodeport_lb4_wildcard_drop.c
@@ -31,7 +31,7 @@ ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 #include "lib/lb.h"
 
 static __always_inline int build_packet(struct __ctx_buff *ctx,
-					const __u16 fe_dport, const __u8 proto)
+					const __be16 fe_dport, const __u8 proto)
 {
 	struct pktgen builder;
 	void *data;
@@ -97,7 +97,7 @@ static __always_inline void setup_services(struct __ctx_buff *ctx __maybe_unused
 static __always_inline int validate_packet(const struct __ctx_buff *ctx,
 					   const __u8 *smac, const __u8 *dmac,
 					   const __u32 saddr, const __u32 daddr,
-					   const __u16 dport, const __u8 proto,
+					   const __be16 dport, const __u8 proto,
 					   const __u32 exp_status)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb6_wildcard_drop.c
+++ b/bpf/tests/tc_nodeport_lb6_wildcard_drop.c
@@ -32,7 +32,7 @@ static const union v6addr frontend_ip = { .addr = v6_svc_one_addr };
 static const union v6addr backend_ip = { .addr = v6_pod_one_addr };
 
 static __always_inline int build_packet(struct __ctx_buff *ctx,
-					const __u16 fe_dport, const __u8 proto)
+					const __be16 fe_dport, const __u8 proto)
 {
 	struct pktgen builder;
 	void *data;
@@ -98,7 +98,7 @@ static __always_inline void setup_services(struct __ctx_buff *ctx __maybe_unused
 static __always_inline int validate_packet(const struct __ctx_buff *ctx,
 					   const __u8 *smac, const __u8 *dmac,
 					   const __u8 *saddr, const __u8 *daddr,
-					   const __u16 dport, const __u8 proto,
+					   const __be16 dport, const __u8 proto,
 					   const __u32 exp_status)
 {
 	void *data, *data_end;

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -419,7 +419,7 @@ static __always_inline int build_reply(struct __ctx_buff *ctx)
 	struct pktgen builder;
 	struct tcphdr *l4;
 	void *data;
-	__u16 nat_source_port = 0;
+	__be16 nat_source_port = 0;
 	__u32 key = 0;
 
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);


### PR DESCRIPTION
This PR replaces `__u16` with `__be16` where appropriate in BPF tests, as [per discussion](https://github.com/cilium/cilium/pull/45030#discussion_r3050295731).