### PR TITLE
hubble-relay: add h2 ALPN to TLS server config

### DIFF
--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -108,6 +108,7 @@ func New(options ...Option) (*Server, error) {
 	if opts.serverTLSConfig != nil {
 		tlsConfig := opts.serverTLSConfig.ServerConfig(&tls.Config{
 			MinVersion: MinTLSVersion,
+			NextProtos: []string{"h2"},
 		})
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}


### PR DESCRIPTION
## Summary

The hubble-relay gRPC server creates a `tls.Config` without setting `NextProtos`, which means it does not advertise the `h2` ALPN protocol during TLS handshakes. Starting with grpc-go v1.67, ALPN negotiation is enforced, causing all Hubble CLI versions compiled with recent Go/grpc-go to fail with:

```
rpc error: code = Unavailable desc = connection error: desc = "transport: authentication
handshake failed: credentials: cannot check peer: missing selected ALPN property"
```

### Fix

Add `NextProtos: []string{"h2"}` to the relay's server TLS config in `pkg/hubble/relay/server/server.go`.

### Verification

Confirmed on a live GKE cluster running Retina v1.1.0 with hubble-relay:

**Before fix:**
```bash
echo | openssl s_client -connect localhost:4245 -alpn h2 2>&1 | grep -i alpn
# Output: No ALPN negotiated

hubble observe --server localhost:4245 --tls --tls-allow-insecure -f
# rpc error: "missing selected ALPN property"
```

**After fix:**
```bash
hubble observe --server localhost:4245 --tls \
  --tls-ca-cert-files ca.crt --tls-client-cert-file client.crt \
  --tls-client-key-file client.key --tls-server-name "ui.hubble-relay.cilium.io" -f
# Successfully streams flows
```

### Impact

- **hubble CLI is completely unusable** against any hubble-relay with TLS enabled and certgen-generated certificates
- Affects any Hubble CLI compiled with Go >= 1.22 (grpc-go >= 1.67), including v1.18.6, v1.16.5, and v0.13.5
- Hubble UI is unaffected (connects from within the cluster)

### Reference

- grpc-go ALPN enforcement: https://github.com/grpc/grpc-go/issues/434