### PR TITLE
fix(endpoint): ensure regeneration when endpoint policy is empty despite selector match

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -736,24 +736,63 @@ func (e *Endpoint) UpdatePolicy(idsToRegen *set.Set[identityPkg.NumericIdentity]
 	// If this endpoint's security ID has a policy update, we must regenerate. Otherwise,
 	// bump the policy revision directly (as long as we didn't miss an update somehow).
 	if !idsToRegen.Has(secID) {
+
+		// FIRST: preserve original behavior — if we missed a revision, regenerate.
 		if e.policyRevision < fromRev {
 			// FIXME: https://github.com/cilium/cilium/issues/36493
-			// Currently policy repository version can be bumped through multiple triggers
-			// async to each other. This can lead to out of order processing of regeneration
-			// events. Continue with endpoint regeneration to be safe but log as Info.
+			// Policy repository revisions may be processed out-of-order due to async updates.
+			// Continue with endpoint regeneration to be safe.
 			e.getLogger().Info(
 				"Endpoint missed a policy revision; triggering regeneration",
 				logfields.PolicyRevision, fromRev,
 			)
 		} else {
-			e.getLogger().Debug(
-				"Policy update is a no-op, bumping policyRevision",
-				logfields.PolicyRevision, toRev,
-			)
-			e.setPolicyRevision(toRev)
 
-			unlock()
-			return
+			// SAFETY: During bootstrap, endpoint identity may be missed in idsToRegen
+			// due to race between policy import and endpoint creation. This can leave
+			// the endpoint with an empty datapath policy despite matching selectors.
+			//
+			// This fallback enforces the invariant:
+			//   selector match ⇒ endpoint must have non-empty policy
+			//
+			// TODO: This does not address the root cause. The underlying issue likely
+			// lies in idsToRegen computation during bootstrap.
+
+			shouldForceRegen := false
+
+			if e.desiredPolicy == nil || e.realizedPolicy == nil {
+				shouldForceRegen = true
+				if e.logLimiter.Allow() {
+					e.getLogger().Warn(
+						"Forcing regeneration: endpoint policy state is nil",
+						logfields.Identity, secID,
+					)
+				}
+			} else {
+				ms := e.desiredPolicy.GetMapState()
+
+				if ms == nil || ms.Len() == 0 {
+					shouldForceRegen = true
+					if e.logLimiter.Allow() {
+						e.getLogger().Warn(
+							"Forcing regeneration: endpoint has empty policy despite selector match",
+							logfields.Identity, secID,
+						)
+					}
+				}
+			}
+
+			// If no fallback condition triggered, retain original skip behavior
+			if !shouldForceRegen {
+				e.getLogger().Debug(
+					"Policy update is a no-op, bumping policyRevision",
+					logfields.PolicyRevision, toRev,
+				)
+				e.setPolicyRevision(toRev)
+
+				unlock()
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

On fresh node bootstrap, endpoints may skip policy regeneration even when
Kubernetes NetworkPolicy selectors match their identity.

As reported in #45233, this results in endpoints:

- Reporting `policy-enabled: both`, `state: ready`, and correct `policy-revision`
- Showing selector matches via `cilium-dbg policy selectors`
- But missing corresponding rules in the BPF policy map

This leads to silent traffic drops (default-deny), even though policy appears
correctly applied from a control-plane perspective.

## Root Cause

`Endpoint.UpdatePolicy()` relies solely on `idsToRegen` to determine whether
an endpoint should regenerate.

During bootstrap, a race between policy import and endpoint creation can cause
endpoint identities to be absent from `idsToRegen`. In such cases:

- Regeneration is skipped
- Only `policyRevision` is bumped
- The endpoint remains with empty or incomplete datapath policy

There is no validation of the actual policy state before skipping regeneration.

## Solution

Introduce a safety fallback in `Endpoint.UpdatePolicy()`:

- Preserve existing behavior for revision mismatch (`policyRevision < fromRev`)
- When `idsToRegen` does not include the endpoint:
  - Detect if policy state is nil (`desiredPolicy` or `realizedPolicy`)
  - Detect if computed policy map (`MapState`) is empty
- If policy is nil or empty, force regeneration

This enforces the invariant:

    selector match ⇒ endpoint must have non-empty datapath policy

## Impact

- Fixes silent policy drops during node bootstrap
- Ensures datapath (BPF) policy is consistent with selector matches
- Does not alter normal regeneration behavior
- Adds negligible overhead (constant-time checks)
- Logging is rate-limited to avoid excessive logs

## Limitations

This change is a defensive safeguard and does not address the root cause in
`idsToRegen` computation during bootstrap. Further investigation may be required
in the policy importer or selector cache logic.

Fixes: #45233

```release-note
Fix endpoints missing NetworkPolicy rules in BPF during node bootstrap due to skipped regeneration