### PR TITLE
fix(agent/sip): correctly default EnableSourceIPVerification to true

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -824,6 +824,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableCiliumNodeCRDName)
 	option.BindEnv(vp, option.EnableCiliumNodeCRDName)
 
+	flags.Bool(option.EnableSourceIPVerification, defaults.EnableSourceIPVerification, "Enable the check of the source IP on pod egress")
+	option.BindEnv(vp, option.EnableSourceIPVerification)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		logging.Fatal(logger, "BindPFlags failed", logfields.Error, err)
 	}


### PR DESCRIPTION
fix(agent/sip): correctly default EnableSourceIPVerification to true

Fixes: #45244

```release-note
Fix: correctly default source IP validation to true when not specified in the config map
```
