### PR TITLE
GHA: Node without Cilium for EKS workflows

### DIFF
--- a/.github/actions/generic-external-targets/action.sh
+++ b/.github/actions/generic-external-targets/action.sh
@@ -27,8 +27,8 @@ openssl req -newkey rsa:2048 -nodes \
     -out external-service.cilium.req.pem
 
 # Figure out the addresses of the external nodes.
-mapfile -d ' ' -t IPTARGET < <(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-mapfile -d ' ' -t IPOTHERTARGET < <(kubectl get nodes -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')
+mapfile -d ' ' -t IPTARGET < <(kubectl get nodes -l cilium.io/no-schedule=true -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+mapfile -d ' ' -t IPOTHERTARGET < <(kubectl get nodes -l cilium.io/no-schedule=true -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')
 
 # Create a config file to tell openssl how to turn the signing request into a certificate
 # Make sure the key usage is such that we can use the cert for HTTPS traffic.

--- a/.github/actions/generic-external-targets/nginx-external.yaml
+++ b/.github/actions/generic-external-targets/nginx-external.yaml
@@ -87,7 +87,7 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoSchedule"
-      # On AKS the no-schedule nodes are made Ready with a dummy CNI conf and
+      # On AKS and EKS the no-schedule nodes are made Ready with a dummy CNI conf and
       # then explicitly tainted cilium.io/no-schedule:NoSchedule to keep regular
       # test pods off. Tolerate it so the external targets still schedule here.
       # No-op on GKE, where these nodes are only labeled, never tainted.

--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -26,6 +26,16 @@ inputs:
     description: 'eksctl create nodegroup timeout (e.g. 15m). If empty, no --timeout flag is passed.'
     required: false
     default: ''
+  nodes_without_cilium:
+    description: 'How many nodes will not run Cilium'
+    required: false
+    default: 0
+  az_cluster:
+    description: 'Availability zone of nodes belonging to the cluster'
+    required: false
+  az_external:
+    description: 'Availability zone of nodes without Cilium'
+    required: false
 runs:
   using: composite
   steps:
@@ -33,11 +43,33 @@ runs:
       if: ${{ inputs.node_groups_override == '' }}
       shell: bash
       run: |
+        if [ -n "${{ inputs.az_external }}" ]; then
+          SUBNET_IDS=$(aws eks describe-cluster \
+            --name ${{ inputs.cluster_name }} \
+            --region ${{ inputs.region }} \
+            --query 'cluster.resourcesVpcConfig.subnetIds' \
+            --output text)
+          SUBNET=$(aws ec2 describe-subnets \
+            --region ${{ inputs.region }} \
+            --subnet-ids $SUBNET_IDS \
+            --filters "Name=availability-zone,Values=${{ inputs.az_external }}" \
+            --query 'Subnets[0].SubnetId' \
+            --output text)
+        fi
+
         cat <<EOF > nodegroup-details.yaml
         managedNodeGroups:
         - name: ng-amd64
           instanceTypes:
            - t3a.medium
+        EOF
+        if [ -n "${{ inputs.az_cluster }}" ]; then
+          cat <<EOF >> nodegroup-details.yaml
+          availabilityZones:
+          - ${{ inputs.az_cluster }}
+        EOF
+        fi
+        cat <<EOF >> nodegroup-details.yaml
           desiredCapacity: 2
           spot: ${{ inputs.spot }}
           privateNetworking: true
@@ -47,9 +79,45 @@ runs:
            - key: "node.cilium.io/agent-not-ready"
              value: "true"
              effect: "NoExecute"
+        - name: ng-amd64-external
+          instanceTypes:
+           - t3a.medium
+          desiredCapacity: ${{ inputs.nodes_without_cilium }}
+          spot: ${{ inputs.spot }}
+          privateNetworking: true
+          volumeType: "gp3"
+          volumeSize: 25
+        EOF
+        if [ -n "${{ inputs.az_external }}" ]; then
+          cat <<EOF >> nodegroup-details.yaml
+          subnets:
+           - $SUBNET
+        EOF
+        fi
+        cat <<EOF >> nodegroup-details.yaml
+          taints:
+           - key: "cilium.io/no-schedule"
+             value: "true"
+             effect: "NoSchedule"
+          labels:
+            cilium.io/no-schedule: "true"
+          # Manually inject a dummy CNI configuration to let the Kubelet turn
+          # ready. This is necessary as otherwise the node creation would
+          # never complete, given that Cilium is intentionally not scheduled
+          # on these nodes.
+          preBootstrapCommands:
+           - "echo '{ \"cniVersion\": \"0.3.1\", \"name\": \"dummy\", \"type\": \"dummy-cni\", \"log-file\": \"/var/run/dummy.log\" }' > /etc/cni/net.d/05-dummy.conf"
         - name: ng-arm64
           instanceTypes:
            - t4g.medium
+        EOF
+        if [ -n "${{ inputs.az_cluster }}" ]; then
+          cat <<EOF >> nodegroup-details.yaml
+          availabilityZones:
+          - ${{ inputs.az_cluster }}
+        EOF
+        fi
+        cat <<EOF >> nodegroup-details.yaml
           desiredCapacity: 1
           spot: ${{ inputs.spot }}
           privateNetworking: true

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -301,6 +301,8 @@ jobs:
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           # shellcheck disable=SC2046
           echo owner=${OWNER} >> $GITHUB_OUTPUT
+          echo eks_zone_1=${{ matrix.region }}b >> $GITHUB_OUTPUT
+          echo eks_zone_2=${{ matrix.region }}c >> $GITHUB_OUTPUT
 
       - name: Install kubectl
         run: |
@@ -328,6 +330,7 @@ jobs:
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           region: ${{ matrix.region }}
+          zones: "${{ steps.vars.outputs.eks_zone_1 }} ${{ steps.vars.outputs.eks_zone_2 }}"
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
           addons: "coredns kube-proxy vpc-cni"
@@ -341,6 +344,9 @@ jobs:
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
           spot: false
+          nodes_without_cilium: 2
+          az_cluster: ${{ steps.vars.outputs.eks_zone_1 }}
+          az_external: ${{ steps.vars.outputs.eks_zone_2 }}
 
       - name: Generate cilium-cli kubeconfig
         id: gen-kubeconfig
@@ -378,10 +384,28 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
 
+      - name: Determine the native routing CIDR
+        id: native_cidr
+        run: |
+          # Retrieve the CIDR associated with the availability zone where the cluster
+          # is deployed, and configure it as native routing CIDR. Otherwise, Cilium
+          # would default to the VPC CIDR, but we want to masquerade traffic towards
+          # the external destination (which is located in the same VPC, but different
+          # availability zone), to reflect the most common type of real deployments.
+          NATIVE_CIDR=$(aws ec2 describe-subnets --region ${{ matrix.region }} \
+            --filters Name=availability-zone,Values=${{ steps.vars.outputs.eks_zone_1 }} \
+                Name=tag:alpha.eksctl.io/cluster-name,Values=${{ steps.vars.outputs.cluster_name }} \
+                Name=map-public-ip-on-launch,Values=false \
+            --query 'Subnets[*].CidrBlock' --output text)
+          echo "ipv4_native_cidr=$NATIVE_CIDR" >> $GITHUB_OUTPUT
+          echo "Native routing CIDR: $NATIVE_CIDR"
+
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --nodes-without-cilium \
+          --set=ipv4NativeRoutingCIDR="${{ steps.native_cidr.outputs.ipv4_native_cidr }}"
 
       - name: Wait for Cilium to be ready
         run: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -222,14 +222,6 @@ jobs:
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
 
-      - name: Get connectivity test flags
-        id: e2e_config
-        uses: ./.github/actions/cli-test-config
-        with:
-          external-target: 'amazon.com.'
-          hubble: false
-          test-concurrency: 3
-
       - name: Get PR base branch
         id: get-base-branch
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -290,14 +282,10 @@ jobs:
                                       --helm-set=cni.enableRouteMTUForCNIChaining=true"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
-
           # shellcheck disable=SC2046
           echo cluster_name=${CLUSTER_NAME} >> $GITHUB_OUTPUT
           # shellcheck disable=SC2046
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
-          # shellcheck disable=SC2046
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           # shellcheck disable=SC2046
           echo owner=${OWNER} >> $GITHUB_OUTPUT
@@ -412,6 +400,48 @@ jobs:
           cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
+      - name: Add external targets to the cluster
+        uses: ./.github/actions/generic-external-targets
+        id: external_targets
+
+      - name: Determine the CIDR of fake external targets
+        id: external_cidr
+        run: |
+          SUBNETS=$(aws eks describe-nodegroup \
+            --cluster-name ${{ steps.setup-cluster.outputs.cluster_name }} \
+            --nodegroup-name ng-amd64-external \
+            --query 'nodegroup.subnets' \
+            --output text)
+          CIDRS=$(aws ec2 describe-subnets \
+            --subnet-ids $SUBNETS \
+            --query 'Subnets[].CidrBlock' \
+            --output text)
+          # Supposed to be one subnet and one CIDR with the default setup-eks-nodegroup config.
+          CIDRV4=$(echo "$CIDRS" | awk '{print $1}')
+          echo "ipv4_external_cidr=$CIDRV4" >> $GITHUB_OUTPUT
+
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-cidr: ${{ steps.external_cidr.outputs.ipv4_external_cidr }}
+          external-ip: ${{ steps.external_targets.outputs.ipv4_external_target }}
+          external-other-ip: ${{ steps.external_targets.outputs.ipv4_other_external_target }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
+          external-target-fake-dns: true
+          hubble: false
+          test-concurrency: 3
+
+      - name: Set up job variables for connectivity tests
+        id: vars-conn
+        run: |
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+
       - name: Check that AWS iptables chains have not been removed
         run: |
           for pod in $(kubectl get po -n kube-system -l app.kubernetes.io/name=cilium-agent -o name); do
@@ -429,7 +459,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         id: run-tests
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -409,6 +409,8 @@ jobs:
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
+          echo eks_zone_1=${{ matrix.region }}b >> $GITHUB_OUTPUT
+          echo eks_zone_2=${{ matrix.region }}c >> $GITHUB_OUTPUT
 
       - name: Install kubectl
         run: |
@@ -437,6 +439,7 @@ jobs:
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}
           region: ${{ matrix.region }}
+          zones: "${{ steps.vars.outputs.eks_zone_1 }} ${{ steps.vars.outputs.eks_zone_2 }}"
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
           addons: "coredns kube-proxy"
@@ -483,10 +486,28 @@ jobs:
           sparse-checkout: |
             install/kubernetes/cilium
 
+      - name: Determine the native routing CIDR
+        id: native_cidr
+        run: |
+          # Retrieve the CIDR associated with the availability zone where the cluster
+          # is deployed, and configure it as native routing CIDR. Otherwise, Cilium
+          # would default to the VPC CIDR, but we want to masquerade traffic towards
+          # the external destination (which is located in the same VPC, but different
+          # availability zone), to reflect the most common type of real deployments.
+          NATIVE_CIDR=$(aws ec2 describe-subnets --region ${{ matrix.region }} \
+            --filters Name=availability-zone,Values=${{ steps.vars.outputs.eks_zone_1 }} \
+                Name=tag:alpha.eksctl.io/cluster-name,Values=${{ steps.vars.outputs.cluster_name }} \
+                Name=map-public-ip-on-launch,Values=false \
+            --query 'Subnets[*].CidrBlock' --output text)
+          echo "ipv4_native_cidr=$NATIVE_CIDR" >> $GITHUB_OUTPUT
+          echo "Native routing CIDR: $NATIVE_CIDR"
+
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --nodes-without-cilium \
+          --set=ipv4NativeRoutingCIDR="${{ steps.native_cidr.outputs.ipv4_native_cidr }}"
 
       # Wait for Cilium to be ready after install (before creating nodegroups)
       # since the nodegroups creation depends on Cilium being ready.
@@ -498,6 +519,9 @@ jobs:
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
           spot: false
+          nodes_without_cilium: 2
+          az_cluster: ${{ steps.vars.outputs.eks_zone_1 }}
+          az_external: ${{ steps.vars.outputs.eks_zone_2 }}
 
       - name: Wait for Cilium to be ready
         run: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -317,13 +317,6 @@ jobs:
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
 
-      - name: Get connectivity test flags
-        id: e2e_config
-        uses: ./.github/actions/cli-test-config
-        with:
-          external-target: 'amazon.com.'
-          hubble: false
-
       - name: Get PR base branch
         id: get-base-branch
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
@@ -402,11 +395,8 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.datapathMode=${BPF_DATAPATH}"
           fi
 
-          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
-
           echo cluster_name=${CLUSTER_NAME} >> $GITHUB_OUTPUT
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
-          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
           echo eks_zone_1=${{ matrix.region }}b >> $GITHUB_OUTPUT
@@ -528,6 +518,47 @@ jobs:
           cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
+      - name: Add external targets to the cluster
+        uses: ./.github/actions/generic-external-targets
+        id: external_targets
+
+      - name: Determine the CIDR of fake external targets
+        id: external_cidr
+        run: |
+          SUBNETS=$(aws eks describe-nodegroup \
+            --cluster-name ${{ steps.setup-cluster.outputs.cluster_name }} \
+            --nodegroup-name ng-amd64-external \
+            --query 'nodegroup.subnets' \
+            --output text)
+          CIDRS=$(aws ec2 describe-subnets \
+            --subnet-ids $SUBNETS \
+            --query 'Subnets[].CidrBlock' \
+            --output text)
+          # Supposed to be one subnet and one CIDR with the default setup-eks-nodegroup config.
+          CIDRV4=$(echo "$CIDRS" | awk '{print $1}')
+          echo "ipv4_external_cidr=$CIDRV4" >> $GITHUB_OUTPUT
+
+      - name: Get connectivity test flags
+        id: e2e_config
+        uses: ./.github/actions/cli-test-config
+        with:
+          external-target: ${{ steps.external_targets.outputs.external_target_name }}
+          external-other-target: ${{ steps.external_targets.outputs.other_external_target_name }}
+          external-cidr: ${{ steps.external_cidr.outputs.ipv4_external_cidr }}
+          external-ip: ${{ steps.external_targets.outputs.ipv4_external_target }}
+          external-other-ip: ${{ steps.external_targets.outputs.ipv4_other_external_target }}
+          external-target-ca-namespace: external-target-secrets
+          external-target-ca-name: custom-ca
+          external-target-fake-dns: true
+          hubble: false
+
+      - name: Set up job variables for connectivity tests
+        id: vars-conn
+        run: |
+          CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
+
+          echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+
       - name: Check that AWS leftover iptables chains have been removed
         run: |
           for pod in $(kubectl get po -n kube-system -l app.kubernetes.io/name=cilium-agent -o name); do
@@ -546,7 +577,7 @@ jobs:
       - name: Run connectivity test (${{ join(matrix.*, ', ') }})
         id: run-tests
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --test-concurrency=${{ env.test_concurrency }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
@@ -574,7 +605,7 @@ jobs:
           job-name: ${{ env.job_name }}-${{ matrix.version }}-post-rotate
           full-test: 'true'
           test-concurrency: ${{ env.test_concurrency }}
-          extra-connectivity-test-flags: ${{ steps.vars.outputs.connectivity_test_defaults }}
+          extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}


### PR DESCRIPTION
```release-note
Use fake external targets on nodes without Cilium in EKS CI workflows for better stability.
```
