### PR TITLE
[v1.19] wireguard: respect underlay-protocol for peer endpoint selection

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/ipcache"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/lock"
@@ -551,7 +552,9 @@ func (a *Agent) updatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	}
 
 	ep := ""
-	if a.config.EnableIPv4 && nodeIPv4 != nil {
+	if a.config.TunnelingEnabled && a.config.UnderlayProtocol == tunnel.IPv6 && a.config.EnableIPv6 && nodeIPv6 != nil {
+		ep = net.JoinHostPort(nodeIPv6.String(), strconv.Itoa(types.ListenPort))
+	} else if a.config.EnableIPv4 && nodeIPv4 != nil {
 		ep = net.JoinHostPort(nodeIPv4.String(), strconv.Itoa(types.ListenPort))
 	} else if a.config.EnableIPv6 && nodeIPv6 != nil {
 		ep = net.JoinHostPort(nodeIPv6.String(), strconv.Itoa(types.ListenPort))

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/option"
@@ -559,6 +560,172 @@ func TestAgent_AllowedIPsRestoration(t *testing.T) {
 			// Ensure that a node IP change gets reflected
 			err = wgAgent.updatePeer(k8s2NodeName, wgDummyPeerKey.String(), k8s2NodeIPv4_2, k8s2NodeIPv6_2)
 			require.Error(t, err, "node %q is not allowed to use the dummy peer key", k8s2NodeName)
+		})
+	}
+}
+
+func TestAgent_PeerEndpointSelection(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       Config
+		nodeIPv4     net.IP
+		nodeIPv6     net.IP
+		expectError  bool
+		expectedIP   net.IP
+		expectedPort int
+	}{
+		{
+			name: "IPv6 underlay with dual-stack selects IPv6 endpoint",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       true,
+				EnableIPv6:       true,
+				TunnelingEnabled: true,
+				UnderlayProtocol: tunnel.IPv6,
+			},
+			nodeIPv4:     k8s1NodeIPv4,
+			nodeIPv6:     k8s1NodeIPv6,
+			expectedIP:   k8s1NodeIPv6,
+			expectedPort: types.ListenPort,
+		},
+		{
+			name: "IPv4 underlay with dual-stack selects IPv4 endpoint",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       true,
+				EnableIPv6:       true,
+				TunnelingEnabled: true,
+				UnderlayProtocol: tunnel.IPv4,
+			},
+			nodeIPv4:     k8s1NodeIPv4,
+			nodeIPv6:     k8s1NodeIPv6,
+			expectedIP:   k8s1NodeIPv4,
+			expectedPort: types.ListenPort,
+		},
+		{
+			name: "Native routing with dual-stack selects IPv4 endpoint",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       true,
+				EnableIPv6:       true,
+				TunnelingEnabled: false,
+				UnderlayProtocol: tunnel.IPv6,
+			},
+			nodeIPv4:     k8s1NodeIPv4,
+			nodeIPv6:     k8s1NodeIPv6,
+			expectedIP:   k8s1NodeIPv4,
+			expectedPort: types.ListenPort,
+		},
+		{
+			name: "IPv6 underlay with IPv6-only cluster selects IPv6 endpoint",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       false,
+				EnableIPv6:       true,
+				TunnelingEnabled: true,
+				UnderlayProtocol: tunnel.IPv6,
+			},
+			nodeIPv4:     nil,
+			nodeIPv6:     k8s1NodeIPv6,
+			expectedIP:   k8s1NodeIPv6,
+			expectedPort: types.ListenPort,
+		},
+		{
+			name: "IPv6 underlay without nodeIPv6 falls back to IPv4",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       true,
+				EnableIPv6:       true,
+				TunnelingEnabled: true,
+				UnderlayProtocol: tunnel.IPv6,
+			},
+			nodeIPv4:     k8s1NodeIPv4,
+			nodeIPv6:     nil,
+			expectedIP:   k8s1NodeIPv4,
+			expectedPort: types.ListenPort,
+		},
+		{
+			name: "IPv4-only cluster selects IPv4 endpoint",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       true,
+				EnableIPv6:       false,
+				TunnelingEnabled: true,
+				UnderlayProtocol: tunnel.IPv4,
+			},
+			nodeIPv4:     k8s1NodeIPv4,
+			nodeIPv6:     nil,
+			expectedIP:   k8s1NodeIPv4,
+			expectedPort: types.ListenPort,
+		},
+		{
+			name: "No node IPs returns error",
+			config: Config{
+				UserConfig: UserConfig{
+					EnableWireguard:              true,
+					WireguardTrackAllIPsFallback: false,
+					WireguardPersistentKeepalive: 0,
+					NodeEncryptionOptOutLabels:   "",
+				},
+				EnableIPv4:       true,
+				EnableIPv6:       true,
+				TunnelingEnabled: true,
+				UnderlayProtocol: tunnel.IPv4,
+			},
+			nodeIPv4:    nil,
+			nodeIPv6:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wgAgent, _ := newTestAgent(t.Context(), hivetest.Logger(t), newFakeWgClient(), tt.config)
+
+			err := wgAgent.updatePeer(k8s1NodeName, k8s1PubKey, tt.nodeIPv4, tt.nodeIPv6)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			peer := wgAgent.peerByNodeName[k8s1NodeName]
+			require.NotNil(t, peer)
+			require.NotNil(t, peer.endpoint)
+			require.Equal(t, tt.expectedIP.String(), peer.endpoint.IP.String())
+			require.Equal(t, tt.expectedPort, peer.endpoint.Port)
 		})
 	}
 }

--- a/pkg/wireguard/agent/cell.go
+++ b/pkg/wireguard/agent/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/wireguard/types"
@@ -47,7 +48,7 @@ func newWireguardConfig(c Config) types.WireguardConfig {
 }
 
 // buildConfigFrom creates the [Config] from [UserConfig] and [option.DaemonConfig].
-func buildConfigFrom(uc UserConfig, dc *option.DaemonConfig) Config {
+func buildConfigFrom(uc UserConfig, dc *option.DaemonConfig, tunnelConfig tunnel.Config) Config {
 	return Config{
 		UserConfig: uc,
 
@@ -56,6 +57,7 @@ func buildConfigFrom(uc UserConfig, dc *option.DaemonConfig) Config {
 		EnableIPv6:       dc.EnableIPv6,
 		TunnelingEnabled: dc.TunnelingEnabled(),
 		EncryptNode:      dc.EncryptNode,
+		UnderlayProtocol: tunnelConfig.UnderlayProtocol(),
 	}
 }
 
@@ -91,6 +93,7 @@ type Config struct {
 	EnableIPv6       bool
 	TunnelingEnabled bool
 	EncryptNode      bool
+	UnderlayProtocol tunnel.UnderlayProtocol
 }
 
 // Returns true when enabled. Implements [types.WireguardConfig].


### PR DESCRIPTION
## Summary

Backport of #44629 to v1.19.

WireGuard peer endpoints now respect the `underlay-protocol=ipv6` setting in dual-stack clusters. When tunneling is enabled with IPv6 underlay, WireGuard will use IPv6 node addresses for peer endpoints instead of unconditionally preferring IPv4.

Fixes #44560

### Changes from main PR

Adapted for v1.19 codebase differences:
- `UserConfig` uses `EnableWireguard bool` directly (no `EnableConfig` struct in v1.19)
- `tunnel.Config` injected via `buildConfigFrom` parameter (same pattern as main)
- Test cases adapted: no `Auto` or `Empty` underlay (only `IPv4`/`IPv6` exist in v1.19)

/cc @rgo3 @julianwiedmann

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 44629
```