### PR TITLE
Update daemon init sequence

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -193,15 +193,15 @@ func configureDaemon(ctx context.Context, params daemonParams) error {
 		return fmt.Errorf("failed to determine host firewall's external facing device (use --%s to specify)", option.Devices)
 	}
 
+	// Configure and start IPAM without using the configuration yet.
+	params.IPAMInitializer.ConfigureAndStartIPAM(ctx)
+
 	// Launch the K8s watchers in parallel as we continue to process other
 	// daemon options.
 	// Some of the k8s watchers rely on option flags set above (specifically
 	// EnableBPFMasquerade), so we should only start them once the flag values
 	// are set.
 	params.K8sWatcher.InitK8sSubsystem(ctx)
-
-	// Configure and start IPAM without using the configuration yet.
-	params.IPAMInitializer.ConfigureAndStartIPAM(ctx)
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Currently when the agent initializes it kicks off the k8s watchers first and then provisions node ips. Under heavy load aka when a cluster is provisioned with several new nodes (read 100's) it is possible for the ip allocator to lag. When this occurs and since the watchers are initialized first and are constrained by a timeout, we could run into situations where ip allocations take more than the default 3min and cause the watchers timer to trip hence triggering agents startup failures.

This PR proposes modifying daemon initialization order and move k8s watchers initialization after the ip allocator run which should help when ips provisioning lag while under load.

> NOTE while working on this issue, we also noted a canned 5sec sleep
during ip allocation cycle. Not sure how this lag was assessed but could further compound to the problem while the cluster is under heavy load?

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>