### PR TITLE
ipam: Migrate ipallocator from `net.IP` to `net/netip` types

### DIFF
--- a/pkg/alibabacloud/api/mock/mock.go
+++ b/pkg/alibabacloud/api/mock/mock.go
@@ -6,7 +6,7 @@ package mock
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/google/uuid"
 
@@ -32,15 +32,13 @@ type API struct {
 
 // NewAPI returns a new mocked ECS API
 func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, securityGroups []*types.SecurityGroup) *API {
-	_, cidr, _ := net.ParseCIDR("10.0.0.0/8")
-
 	api := &API{
 		unattached:     map[string]*eniTypes.ENI{},
 		enis:           map[string]ENIMap{},
 		subnets:        map[string]*ipamTypes.Subnet{},
 		vpcs:           map[string]*ipamTypes.VirtualNetwork{},
 		securityGroups: map[string]*types.SecurityGroup{},
-		allocator:      ipallocator.NewCIDRRange(cidr),
+		allocator:      ipallocator.NewCIDRRange(netip.MustParsePrefix("10.0.0.0/8")),
 	}
 
 	api.UpdateSubnets(subnets)
@@ -322,8 +320,7 @@ func (a *API) UnassignPrivateIPAddresses(ctx context.Context, eniID string, addr
 	releaseMap := make(map[string]int)
 	for _, addr := range addresses {
 		// Validate given addresses
-		ipaddr := net.ParseIP(addr)
-		if ipaddr == nil {
+		if _, err := netip.ParseAddr(addr); err != nil {
 			return fmt.Errorf("invalid IP address %s", addr)
 		}
 		releaseMap[addr] = 0
@@ -349,8 +346,8 @@ func (a *API) UnassignPrivateIPAddresses(ctx context.Context, eniID string, addr
 			if !ok {
 				addressesAfterRelease = append(addressesAfterRelease, address)
 			} else {
-				ip := net.ParseIP(address.PrivateIpAddress)
-				a.allocator.Release(ip)
+				addr, _ := netip.ParseAddr(address.PrivateIpAddress)
+				a.allocator.Release(addr)
 				subnet.AvailableAddresses++
 			}
 		}

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 	"github.com/google/uuid"
+	"go4.org/netipx"
 	"golang.org/x/time/rate"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
@@ -73,7 +75,8 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 	// Use 10.10.0.0/17 for IP allocations
 	cidrSet, _ := cidrset.NewCIDRSet(baseCidr, 17)
 	podCidr, _ := cidrSet.AllocateNext()
-	podCidrRange := ipallocator.NewCIDRRange(podCidr)
+	podCidrPrefix, _ := netipx.FromStdIPNet(podCidr)
+	podCidrRange := ipallocator.NewCIDRRange(podCidrPrefix)
 
 	// Use 10.10.128.0/17 for prefix allocations
 	pdCidr, _ := cidrSet.AllocateNext()
@@ -490,8 +493,7 @@ func (e *API) UnassignPrivateIpAddresses(ctx context.Context, eniID string, addr
 	releaseMap := make(map[string]int)
 	for _, addr := range addresses {
 		// Validate given addresses
-		ipaddr := net.ParseIP(addr)
-		if ipaddr == nil {
+		if _, err := netip.ParseAddr(addr); err != nil {
 			return fmt.Errorf("Invalid IP address %s", addr)
 		}
 		releaseMap[addr] = 0
@@ -514,8 +516,8 @@ func (e *API) UnassignPrivateIpAddresses(ctx context.Context, eniID string, addr
 			if !ok {
 				addressesAfterRelease = append(addressesAfterRelease, address)
 			} else {
-				ip := net.ParseIP(address)
-				e.allocator.Release(ip)
+				addr, _ := netip.ParseAddr(address)
+				e.allocator.Release(addr)
 				subnet.AvailableAddresses++
 			}
 		}

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -6,7 +6,7 @@ package mock
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
@@ -69,11 +69,11 @@ func (a *API) UpdateSubnets(subnets []*ipamTypes.Subnet) {
 	a.mutex.Lock()
 	a.subnets = map[string]*subnet{}
 	for _, s := range subnets {
-		_, cidr, _ := net.ParseCIDR(s.CIDR.String())
+		prefix, _ := netip.ParsePrefix(s.CIDR.String())
 
 		a.subnets[s.ID] = &subnet{
 			subnet:    s.DeepCopy(),
-			allocator: ipallocator.NewCIDRRange(cidr),
+			allocator: ipallocator.NewCIDRRange(prefix),
 		}
 	}
 	a.mutex.Unlock()

--- a/pkg/ipalloc/adapter.go
+++ b/pkg/ipalloc/adapter.go
@@ -4,8 +4,7 @@
 package ipalloc
 
 import (
-	"errors"
-	"net"
+	"math/bits"
 	"net/netip"
 
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
@@ -27,39 +26,24 @@ func NewServiceAllocatorAdapter(alloc Allocator[bool]) ipallocator.Interface {
 }
 
 // Allocate allocates the given IP address.
-func (saa *ServiceAllocatorAdapter) Allocate(ip net.IP) error {
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return errors.New("Invalid IP address")
-	}
-
+func (saa *ServiceAllocatorAdapter) Allocate(addr netip.Addr) error {
 	return saa.inner.Alloc(addr, true)
 }
 
 // AllocateNext allocates the next available IP address.
-func (saa *ServiceAllocatorAdapter) AllocateNext() (net.IP, error) {
-	addr, err := saa.inner.AllocAny(true)
-	if err != nil {
-		return nil, err
-	}
-
-	return addr.AsSlice(), nil
+func (saa *ServiceAllocatorAdapter) AllocateNext() (netip.Addr, error) {
+	return saa.inner.AllocAny(true)
 }
 
 // Release releases the given IP address.
-func (saa *ServiceAllocatorAdapter) Release(ip net.IP) error {
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return errors.New("Invalid IP address")
-	}
-
+func (saa *ServiceAllocatorAdapter) Release(addr netip.Addr) error {
 	return saa.inner.Free(addr)
 }
 
 // ForEach calls the given function for each allocated IP address.
-func (saa *ServiceAllocatorAdapter) ForEach(fn func(net.IP)) {
+func (saa *ServiceAllocatorAdapter) ForEach(fn func(netip.Addr)) {
 	saa.inner.ForEach(func(addr netip.Addr, val bool) error {
-		fn(addr.AsSlice())
+		fn(addr)
 		return nil
 	})
 }
@@ -67,52 +51,46 @@ func (saa *ServiceAllocatorAdapter) ForEach(fn func(net.IP)) {
 // CIDR returns the best approximation of a CIDR of the IP range managed by this allocator.
 // Some ranges can't be converted to an equal CIDR, so this CIDR should not be used for anything
 // other than user feedback.
-func (saa *ServiceAllocatorAdapter) CIDR() net.IPNet {
-	startAddr, stopAddr := saa.inner.Range()
-	start := startAddr.AsSlice()
-	stop := stopAddr.AsSlice()
-	return ipRangeToIPNet(start, stop)
+func (saa *ServiceAllocatorAdapter) CIDR() netip.Prefix {
+	start, stop := saa.inner.Range()
+	return ipRangeToPrefix(start, stop)
 }
 
-func ipRangeToIPNet(start, stop net.IP) net.IPNet {
-	var mask net.IPMask
-	if start.To4() == nil {
-		mask = make(net.IPMask, 16)
+// ipRangeToPrefix computes the smallest netip.Prefix that contains both start
+// and stop addresses.
+func ipRangeToPrefix(start, stop netip.Addr) netip.Prefix {
+	var prefixLen int
+	if start.Is4() {
+		s := start.As4()
+		e := stop.As4()
+		prefixLen = commonPrefixBits(s[:], e[:])
 	} else {
-		mask = make(net.IPMask, 4)
-		start = start.To4()
-		stop = stop.To4()
+		s := start.As16()
+		e := stop.As16()
+		prefixLen = commonPrefixBits(s[:], e[:])
 	}
+	prefix, _ := start.Prefix(prefixLen)
+	return prefix
+}
 
-	for i := range mask {
-		if start[i] == stop[i] {
-			mask[i] = 255
+// commonPrefixBits returns the number of leading bits that are identical
+// between a and b.
+func commonPrefixBits(a, b []byte) int {
+	n := 0
+	for i := range a {
+		xor := a[i] ^ b[i]
+		if xor == 0 {
+			n += 8
 			continue
 		}
-
-		// Find the first bit that differs
-		for ii := 7; ii >= 0; ii-- {
-			if (start[i] & (1 << (ii))) == (stop[i] & (1 << (ii))) {
-				mask[i] |= 1 << ii
-				continue
-			}
-			break
-		}
+		n += bits.LeadingZeros8(xor)
+		break
 	}
-
-	return net.IPNet{
-		IP:   start.To16(),
-		Mask: mask,
-	}
+	return n
 }
 
 // Has returns true if the given IP address is allocated.
-func (saa *ServiceAllocatorAdapter) Has(ip net.IP) bool {
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return false
-	}
-
+func (saa *ServiceAllocatorAdapter) Has(addr netip.Addr) bool {
 	_, found := saa.inner.Get(addr)
 	return found
 }

--- a/pkg/ipalloc/adapter_test.go
+++ b/pkg/ipalloc/adapter_test.go
@@ -4,44 +4,40 @@
 package ipalloc
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIPRangeToIPNet(t *testing.T) {
-	assert.Equal(t, net.IPNet{
-		IP:   net.ParseIP("192.168.1.0"),
-		Mask: net.IPv4Mask(255, 255, 255, 0),
-	}, ipRangeToIPNet(
-		net.ParseIP("192.168.1.0"),
-		net.ParseIP("192.168.1.255"),
-	))
+func TestIPRangeToPrefix(t *testing.T) {
+	assert.Equal(t,
+		netip.MustParsePrefix("192.168.1.0/24"),
+		ipRangeToPrefix(
+			netip.MustParseAddr("192.168.1.0"),
+			netip.MustParseAddr("192.168.1.255"),
+		))
 
-	assert.Equal(t, net.IPNet{
-		IP:   net.ParseIP("192.168.1.0"),
-		Mask: net.IPv4Mask(255, 255, 255, 128),
-	}, ipRangeToIPNet(
-		net.ParseIP("192.168.1.0"),
-		net.ParseIP("192.168.1.127"),
-	))
+	assert.Equal(t,
+		netip.MustParsePrefix("192.168.1.0/25"),
+		ipRangeToPrefix(
+			netip.MustParseAddr("192.168.1.0"),
+			netip.MustParseAddr("192.168.1.127"),
+		))
 
-	assert.Equal(t, net.IPNet{
-		IP:   net.ParseIP("192.168.1.128"),
-		Mask: net.IPv4Mask(255, 255, 255, 128),
-	}, ipRangeToIPNet(
-		net.ParseIP("192.168.1.128"),
-		net.ParseIP("192.168.1.255"),
-	))
+	assert.Equal(t,
+		netip.MustParsePrefix("192.168.1.128/25"),
+		ipRangeToPrefix(
+			netip.MustParseAddr("192.168.1.128"),
+			netip.MustParseAddr("192.168.1.255"),
+		))
 
 	// While technically incorrect, its the best guess since start and stop only
 	// share 192.168.1 as prefix so the closest CIDR is 192.168.1.0/24
-	assert.Equal(t, net.IPNet{
-		IP:   net.ParseIP("192.168.1.100"),
-		Mask: net.IPv4Mask(255, 255, 255, 0),
-	}, ipRangeToIPNet(
-		net.ParseIP("192.168.1.100"),
-		net.ParseIP("192.168.1.200"),
-	))
+	assert.Equal(t,
+		netip.MustParsePrefix("192.168.1.0/24"),
+		ipRangeToPrefix(
+			netip.MustParseAddr("192.168.1.100"),
+			netip.MustParseAddr("192.168.1.200"),
+		))
 }

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -5,92 +5,96 @@ package ipam
 
 import (
 	"fmt"
-	"math/big"
 	"net"
+	"net/netip"
+
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
 )
 
 type hostScopeAllocator struct {
-	allocCIDR *net.IPNet
+	allocCIDR netip.Prefix
 	allocator *ipallocator.Range
 }
 
 func newHostScopeAllocator(n *net.IPNet) Allocator {
+	prefix, ok := netipx.FromStdIPNet(n)
+	if !ok {
+		panic(fmt.Sprintf("invalid IPNet: %v", n))
+	}
 	return &hostScopeAllocator{
-		allocCIDR: n,
-		allocator: ipallocator.NewCIDRRange(n),
+		allocCIDR: prefix,
+		allocator: ipallocator.NewCIDRRange(prefix),
 	}
 }
 
-func (h *hostScopeAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	if err := h.allocator.Allocate(ip); err != nil {
+func (h *hostScopeAllocator) Allocate(ipAddr net.IP, owner string, pool Pool) (*AllocationResult, error) {
+	addr, ok := netip.AddrFromSlice(ipAddr)
+	if !ok {
+		return nil, fmt.Errorf("invalid IP address: %v", ipAddr)
+	}
+	if err := h.allocator.Allocate(addr.Unmap()); err != nil {
 		return nil, err
 	}
 
-	return &AllocationResult{IP: ip}, nil
+	return &AllocationResult{IP: ipAddr}, nil
 }
 
-func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	if err := h.allocator.Allocate(ip); err != nil {
+func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(ipAddr net.IP, owner string, pool Pool) (*AllocationResult, error) {
+	addr, ok := netip.AddrFromSlice(ipAddr)
+	if !ok {
+		return nil, fmt.Errorf("invalid IP address: %v", ipAddr)
+	}
+	if err := h.allocator.Allocate(addr.Unmap()); err != nil {
 		return nil, err
 	}
 
-	return &AllocationResult{IP: ip}, nil
+	return &AllocationResult{IP: ipAddr}, nil
 }
 
-func (h *hostScopeAllocator) Release(ip net.IP, pool Pool) error {
-	h.allocator.Release(ip)
+func (h *hostScopeAllocator) Release(ipAddr net.IP, pool Pool) error {
+	addr, ok := netip.AddrFromSlice(ipAddr)
+	if !ok {
+		return nil
+	}
+	h.allocator.Release(addr.Unmap())
 	return nil
 }
 
 func (h *hostScopeAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
-	ip, err := h.allocator.AllocateNext()
+	addr, err := h.allocator.AllocateNext()
 	if err != nil {
 		return nil, err
 	}
 
-	return &AllocationResult{IP: ip}, nil
+	return &AllocationResult{IP: net.IP(addr.AsSlice()).To16()}, nil
 }
 
 func (h *hostScopeAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
-	ip, err := h.allocator.AllocateNext()
+	addr, err := h.allocator.AllocateNext()
 	if err != nil {
 		return nil, err
 	}
 
-	return &AllocationResult{IP: ip}, nil
+	return &AllocationResult{IP: net.IP(addr.AsSlice()).To16()}, nil
 }
 
 func (h *hostScopeAllocator) Dump() (map[Pool]map[string]string, string) {
-	var origIP *big.Int
 	alloc := map[string]string{}
-	_, data, err := h.allocator.Snapshot()
-	if err != nil {
-		return nil, "Unable to get a snapshot of the allocator"
-	}
-	if h.allocCIDR.IP.To4() != nil {
-		origIP = big.NewInt(0).SetBytes(h.allocCIDR.IP.To4())
-	} else {
-		origIP = big.NewInt(0).SetBytes(h.allocCIDR.IP.To16())
-	}
-	bits := big.NewInt(0).SetBytes(data)
-	for i := range bits.BitLen() {
-		if bits.Bit(i) != 0 {
-			ip := net.IP(big.NewInt(0).Add(origIP, big.NewInt(int64(uint(i+1)))).Bytes()).String()
-			alloc[ip] = ""
-		}
-	}
+	h.allocator.ForEach(func(addr netip.Addr) {
+		alloc[addr.String()] = ""
+	})
 
-	maxIPs := ip.CountIPsInCIDR(h.allocCIDR)
+	maxIPs := ip.CountIPsInCIDR(netipx.PrefixIPNet(h.allocCIDR))
 	status := fmt.Sprintf("%d/%s allocated from %s", len(alloc), maxIPs.String(), h.allocCIDR.String())
 
 	return map[Pool]map[string]string{PoolDefault(): alloc}, status
 }
 
 func (h *hostScopeAllocator) Capacity() uint64 {
-	return ip.CountIPsInCIDR(h.allocCIDR).Uint64()
+	return ip.CountIPsInCIDR(netipx.PrefixIPNet(h.allocCIDR)).Uint64()
 }
 
 // RestoreFinished marks the status of restoration as done

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -59,10 +60,15 @@ func (p *cidrPool) allocate(ip net.IP) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return fmt.Errorf("invalid IP address: %v", ip)
+	}
+	addr = addr.Unmap()
+
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		if cidrNet.Contains(ip) {
-			return ipAllocator.Allocate(ip)
+		if ipAllocator.CIDR().Contains(addr) {
+			return ipAllocator.Allocate(addr)
 		}
 	}
 
@@ -76,15 +82,18 @@ func (p *cidrPool) allocateNext() (net.IP, error) {
 	// When allocating a random IP, we try the CIDRs in the order they are
 	// listed in the CRD. This avoids internal fragmentation.
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		cidrStr := cidrNet.String()
+		cidrStr := ipAllocator.CIDR().String()
 		if _, removed := p.removed[cidrStr]; removed {
 			continue
 		}
 		if ipAllocator.Free() == 0 {
 			continue
 		}
-		return ipAllocator.AllocateNext()
+		addr, err := ipAllocator.AllocateNext()
+		if err != nil {
+			return nil, err
+		}
+		return net.IP(addr.AsSlice()).To16(), nil
 	}
 
 	return nil, errors.New("all CIDR ranges are exhausted")
@@ -94,10 +103,15 @@ func (p *cidrPool) release(ip net.IP) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return
+	}
+	addr = addr.Unmap()
+
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		if cidrNet.Contains(ip) {
-			ipAllocator.Release(ip)
+		if ipAllocator.CIDR().Contains(addr) {
+			ipAllocator.Release(addr)
 			return
 		}
 	}
@@ -108,8 +122,7 @@ func (p *cidrPool) hasAvailableIPs() bool {
 	defer p.mutex.Unlock()
 
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		cidrStr := cidrNet.String()
+		cidrStr := ipAllocator.CIDR().String()
 		if _, removed := p.removed[cidrStr]; removed {
 			continue
 		}
@@ -140,8 +153,7 @@ func (p *cidrPool) inUseCIDRs() []types.IPAMCIDR {
 func (p *cidrPool) inUseCIDRsLocked() []types.IPAMCIDR {
 	CIDRs := make([]types.IPAMCIDR, 0, len(p.ipAllocators))
 	for _, ipAllocator := range p.ipAllocators {
-		ipnet := ipAllocator.CIDR()
-		CIDRs = append(CIDRs, types.IPAMCIDR(ipnet.String()))
+		CIDRs = append(CIDRs, types.IPAMCIDR(ipAllocator.CIDR().String()))
 	}
 	return CIDRs
 }
@@ -153,14 +165,13 @@ func (p *cidrPool) dump() (ipToOwner map[string]string, usedIPs, freeIPs, numCID
 
 	ipToOwner = map[string]string{}
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		cidrStr := cidrNet.String()
+		cidrStr := ipAllocator.CIDR().String()
 		usedIPs += ipAllocator.Used()
 		if _, removed := p.removed[cidrStr]; !removed {
 			freeIPs += ipAllocator.Free()
 		}
-		ipAllocator.ForEach(func(ip net.IP) {
-			ipToOwner[ip.String()] = ""
+		ipAllocator.ForEach(func(addr netip.Addr) {
+			ipToOwner[addr.String()] = ""
 		})
 	}
 	numCIDRs = len(p.ipAllocators)
@@ -174,8 +185,7 @@ func (p *cidrPool) capacity() (freeIPs int) {
 	defer p.mutex.Unlock()
 
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		cidrStr := cidrNet.String()
+		cidrStr := ipAllocator.CIDR().String()
 		if _, removed := p.removed[cidrStr]; !removed {
 			freeIPs += ipAllocator.Free()
 		}
@@ -199,8 +209,7 @@ func (p *cidrPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 	retainedAllocators := []*ipallocator.Range{}
 	for i := len(p.ipAllocators) - 1; i >= 0; i-- {
 		ipAllocator := p.ipAllocators[i]
-		cidrNet := ipAllocator.CIDR()
-		cidrStr := cidrNet.String()
+		cidrStr := ipAllocator.CIDR().String()
 
 		// If the CIDR is not used and releasing it would
 		// not take us below the release threshold, then release it immediately
@@ -230,10 +239,10 @@ func (p *cidrPool) updatePool(CIDRs []string) {
 	}
 
 	// Parse the CIDRs, ignoring invalid CIDRs, and de-duplicating them.
-	cidrNets := make([]*net.IPNet, 0, len(CIDRs))
+	prefixes := make([]netip.Prefix, 0, len(CIDRs))
 	cidrStrSet := make(map[string]struct{}, len(CIDRs))
 	for _, cidr := range CIDRs {
-		_, cidr, err := net.ParseCIDR(cidr)
+		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
 			p.logger.Error(
 				"ignoring invalid CIDR",
@@ -242,15 +251,16 @@ func (p *cidrPool) updatePool(CIDRs []string) {
 			)
 			continue
 		}
-		if _, ok := cidrStrSet[cidr.String()]; ok {
+		prefix = prefix.Masked()
+		if _, ok := cidrStrSet[prefix.String()]; ok {
 			p.logger.Error(
 				"ignoring duplicate CIDR",
 				logfields.CIDR, CIDRs,
 			)
 			continue
 		}
-		cidrNets = append(cidrNets, cidr)
-		cidrStrSet[cidr.String()] = struct{}{}
+		prefixes = append(prefixes, prefix)
+		cidrStrSet[prefix.String()] = struct{}{}
 	}
 
 	// Forget any released CIDRs no longer present in the CRD.
@@ -282,8 +292,7 @@ func (p *cidrPool) updatePool(CIDRs []string) {
 
 	// Add existing IP allocators to newIPAllocators in order.
 	for _, ipAllocator := range p.ipAllocators {
-		cidrNet := ipAllocator.CIDR()
-		cidrStr := cidrNet.String()
+		cidrStr := ipAllocator.CIDR().String()
 		if _, ok := cidrStrSet[cidrStr]; !ok {
 			if ipAllocator.Used() == 0 {
 				continue
@@ -303,18 +312,18 @@ func (p *cidrPool) updatePool(CIDRs []string) {
 	if p.allowFirstLastIPs {
 		rangeOpts = append(rangeOpts, ipallocator.WithAllowFirstLastIPs())
 	}
-	for _, cidrNet := range cidrNets {
-		cidrStr := cidrNet.String()
+	for _, prefix := range prefixes {
+		cidrStr := prefix.String()
 		if _, ok := existingAllocators[cidrStr]; ok {
 			continue
 		}
-		ipAllocator := ipallocator.NewCIDRRange(cidrNet, rangeOpts...)
+		ipAllocator := ipallocator.NewCIDRRange(prefix, rangeOpts...)
 		if ipAllocator.Free() == 0 {
 			p.logger.Error(
 				"skipping too-small CIDR",
-				logfields.CIDR, cidrNet,
+				logfields.CIDR, prefix,
 			)
-			p.released[cidrNet.String()] = struct{}{}
+			p.released[prefix.String()] = struct{}{}
 			continue
 		}
 		p.logger.Debug(

--- a/pkg/ipam/service/ipallocator/allocator.go
+++ b/pkg/ipam/service/ipallocator/allocator.go
@@ -5,10 +5,10 @@
 package ipallocator
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/big"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/ipam/service/allocator"
 )
@@ -16,12 +16,12 @@ import (
 // Interface manages the allocation of IP addresses out of a range. Interface
 // should be threadsafe.
 type Interface interface {
-	Allocate(net.IP) error
-	AllocateNext() (net.IP, error)
-	Release(net.IP) error
-	ForEach(func(net.IP))
-	CIDR() net.IPNet
-	Has(ip net.IP) bool
+	Allocate(netip.Addr) error
+	AllocateNext() (netip.Addr, error)
+	Release(netip.Addr) error
+	ForEach(func(netip.Addr))
+	CIDR() netip.Prefix
+	Has(addr netip.Addr) bool
 }
 
 var (
@@ -68,45 +68,46 @@ func WithAllowFirstLastIPs() CIDRRangeOption {
 //	|                                     |
 //	0 1 2 3 4 5 ...         ... 253 254 255
 //	  |                              |
-//	r.base                     r.base + r.max
+//	r.base               addOffset(r.base, r.max-1)
 //	  |                              |
-//	offset #0 of r.allocated   last offset of r.allocated
+//	offset #0 of r.alloc   last offset of r.alloc
 type Range struct {
-	net *net.IPNet
-	// base is a cached version of the start IP in the CIDR range as a *big.Int
-	base *big.Int
-	// max is the maximum size of the usable addresses in the range
+	prefix netip.Prefix
+	// base is the first allocatable address in the range.
+	base netip.Addr
+	// max is the maximum size of the usable addresses in the range.
 	max int
 
 	alloc allocator.Interface
 }
 
-// NewCIDRRange creates a Range over a net.IPNet, calling allocator.NewAllocationMap
+// NewCIDRRange creates a Range over a netip.Prefix, calling allocator.NewAllocationMap
 // to construct the backing store. By default, the first (network) and last
 // (broadcast) addresses are excluded for CIDRs with more than 2 addresses.
 // Pass functional options (e.g. WithAllowFirstLastIPs) to alter this behavior.
-func NewCIDRRange(cidr *net.IPNet, opts ...CIDRRangeOption) *Range {
+func NewCIDRRange(prefix netip.Prefix, opts ...CIDRRangeOption) *Range {
 	var o cidrRangeOptions
 	for _, opt := range opts {
 		opt(&o)
 	}
 
-	base := bigForIP(cidr.IP)
-	size := RangeSize(cidr)
+	prefix = prefix.Masked()
+	base := prefix.Addr()
+	size := RangeSize(prefix)
 
 	// for any CIDR other than /32 or /128:
 	if size > 2 && !o.allowFirstLastIPs {
 		// don't use the network broadcast
 		size = max(0, size-2)
 		// don't use the network base
-		base = base.Add(base, big.NewInt(1))
+		base = base.Next()
 	}
 
 	return &Range{
-		net:   cidr,
-		base:  base,
-		max:   int(size),
-		alloc: allocator.NewAllocationMap(int(size), cidr.String()),
+		prefix: prefix,
+		base:   base,
+		max:    int(size),
+		alloc:  allocator.NewAllocationMap(int(size), prefix.String()),
 	}
 }
 
@@ -121,18 +122,18 @@ func (r *Range) Used() int {
 }
 
 // CIDR returns the CIDR covered by the range.
-func (r *Range) CIDR() net.IPNet {
-	return *r.net
+func (r *Range) CIDR() netip.Prefix {
+	return r.prefix
 }
 
 // Allocate attempts to reserve the provided IP. ErrNotInRange or
 // ErrAllocated will be returned if the IP is not valid for this range
 // or has already been reserved.  ErrFull will be returned if there
 // are no addresses left.
-func (r *Range) Allocate(ip net.IP) error {
+func (r *Range) Allocate(ip netip.Addr) error {
 	ok, offset := r.contains(ip)
 	if !ok {
-		return &ErrNotInRange{r.net.String()}
+		return &ErrNotInRange{r.prefix.String()}
 	}
 
 	allocated := r.alloc.Allocate(offset)
@@ -144,18 +145,18 @@ func (r *Range) Allocate(ip net.IP) error {
 
 // AllocateNext reserves one of the IPs from the pool. ErrFull may
 // be returned if there are no addresses left.
-func (r *Range) AllocateNext() (net.IP, error) {
+func (r *Range) AllocateNext() (netip.Addr, error) {
 	offset, ok := r.alloc.AllocateNext()
 	if !ok {
-		return nil, ErrFull
+		return netip.Addr{}, ErrFull
 	}
-	return addIPOffset(r.base, offset), nil
+	return addOffset(r.base, offset), nil
 }
 
 // Release releases the IP back to the pool. Releasing an
 // unallocated IP or an IP out of the range is a no-op and
 // returns no error.
-func (r *Range) Release(ip net.IP) {
+func (r *Range) Release(ip netip.Addr) {
 	ok, offset := r.contains(ip)
 	if ok {
 		r.alloc.Release(offset)
@@ -163,15 +164,15 @@ func (r *Range) Release(ip net.IP) {
 }
 
 // ForEach calls the provided function for each allocated IP.
-func (r *Range) ForEach(fn func(net.IP)) {
+func (r *Range) ForEach(fn func(netip.Addr)) {
 	r.alloc.ForEach(func(offset int) {
-		fn(addIPOffset(r.base, offset))
+		fn(addOffset(r.base, offset))
 	})
 }
 
 // Has returns true if the provided IP is already allocated and a call
 // to Allocate(ip) would fail with ErrAllocated.
-func (r *Range) Has(ip net.IP) bool {
+func (r *Range) Has(ip netip.Addr) bool {
 	ok, offset := r.contains(ip)
 	if !ok {
 		return false
@@ -191,16 +192,16 @@ func (r *Range) Snapshot() (string, []byte, error) {
 }
 
 // Restore restores the pool to the previously captured state. ErrMismatchedNetwork
-// is returned if the provided IPNet range doesn't exactly match the previous range.
-func (r *Range) Restore(net *net.IPNet, data []byte) error {
-	if !net.IP.Equal(r.net.IP) || net.Mask.String() != r.net.Mask.String() {
+// is returned if the provided prefix doesn't exactly match the previous range.
+func (r *Range) Restore(prefix netip.Prefix, data []byte) error {
+	if prefix != r.prefix {
 		return ErrMismatchedNetwork
 	}
 	snapshottable, ok := r.alloc.(allocator.Snapshottable)
 	if !ok {
 		return fmt.Errorf("not a snapshottable allocator")
 	}
-	if err := snapshottable.Restore(net.String(), data); err != nil {
+	if err := snapshottable.Restore(prefix.String(), data); err != nil {
 		return fmt.Errorf("restoring snapshot encountered: %w", err)
 	}
 	return nil
@@ -208,42 +209,54 @@ func (r *Range) Restore(net *net.IPNet, data []byte) error {
 
 // contains returns true and the offset if the ip is in the range, and false
 // and 0 otherwise.
-func (r *Range) contains(ip net.IP) (bool, int) {
-	if !r.net.Contains(ip) {
+func (r *Range) contains(ip netip.Addr) (bool, int) {
+	if !r.prefix.Contains(ip) {
 		return false, 0
 	}
 
-	offset := calculateIPOffset(r.base, ip)
+	offset := addrOffset(r.base, ip)
 	if offset < 0 || offset >= r.max {
 		return false, 0
 	}
 	return true, offset
 }
 
-// bigForIP creates a big.Int based on the provided net.IP
-func bigForIP(ip net.IP) *big.Int {
-	// NOTE: Convert to 16-byte representation so we can
-	// handle v4 and v6 values the same way.
-	return big.NewInt(0).SetBytes(ip.To16())
+// addOffset adds an integer offset to a base address.
+func addOffset(base netip.Addr, offset int) netip.Addr {
+	if base.Is4() {
+		b := base.As4()
+		v := binary.BigEndian.Uint32(b[:]) + uint32(offset)
+		binary.BigEndian.PutUint32(b[:], v)
+		return netip.AddrFrom4(b)
+	}
+	b := base.As16()
+	hi := binary.BigEndian.Uint64(b[:8])
+	lo := binary.BigEndian.Uint64(b[8:])
+	newLo := lo + uint64(offset)
+	if newLo < lo {
+		hi++
+	}
+	binary.BigEndian.PutUint64(b[:8], hi)
+	binary.BigEndian.PutUint64(b[8:], newLo)
+	return netip.AddrFrom16(b)
 }
 
-// addIPOffset adds the provided integer offset to a base big.Int representing a net.IP
-// NOTE: If you started with a v4 address and overflow it, you get a v6 result.
-func addIPOffset(base *big.Int, offset int) net.IP {
-	r := big.NewInt(0).Add(base, big.NewInt(int64(offset))).Bytes()
-	r = append(make([]byte, 16), r...)
-	return net.IP(r[len(r)-16:])
-}
-
-// calculateIPOffset calculates the integer offset of ip from base such that
-// base + offset = ip. It requires ip >= base.
-func calculateIPOffset(base *big.Int, ip net.IP) int {
-	return int(big.NewInt(0).Sub(bigForIP(ip), base).Int64())
+// addrOffset returns the integer offset of addr from base (addr - base).
+func addrOffset(base, addr netip.Addr) int {
+	if base.Is4() {
+		b := base.As4()
+		a := addr.As4()
+		return int(binary.BigEndian.Uint32(a[:]) - binary.BigEndian.Uint32(b[:]))
+	}
+	b := base.As16()
+	a := addr.As16()
+	return int(binary.BigEndian.Uint64(a[8:]) - binary.BigEndian.Uint64(b[8:]))
 }
 
 // RangeSize returns the size of a range in valid addresses.
-func RangeSize(subnet *net.IPNet) int64 {
-	ones, bits := subnet.Mask.Size()
+func RangeSize(prefix netip.Prefix) int64 {
+	bits := prefix.Addr().BitLen()
+	ones := prefix.Bits()
 	if bits == 32 && (bits-ones) >= 31 || bits == 128 && (bits-ones) >= 127 {
 		return 0
 	}
@@ -253,7 +266,6 @@ func RangeSize(subnet *net.IPNet) int64 {
 	// the bitmap to 64k.
 	if bits == 128 && (bits-ones) >= 16 {
 		return int64(1) << uint(16)
-	} else {
-		return int64(1) << uint(bits-ones)
 	}
+	return int64(1) << uint(bits-ones)
 }

--- a/pkg/ipam/service/ipallocator/allocator_test.go
+++ b/pkg/ipam/service/ipallocator/allocator_test.go
@@ -1,81 +1,66 @@
 package ipallocator
 
 import (
-	"fmt"
-	"math/big"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func mustParseCidr(cidr string) *net.IPNet {
-	_, ipNet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		panic(fmt.Errorf("net.ParseCIDR: %w", err))
-	}
-	return ipNet
-}
-
-func ipForBig(i *big.Int) net.IP {
-	return addIPOffset(i, 0)
-}
-
 func TestNewCIDRRange(t *testing.T) {
 	testCases := []struct {
 		name     string
-		ipNet    *net.IPNet
-		wantBase net.IP
+		prefix   netip.Prefix
+		wantBase netip.Addr
 		wantMax  int
 	}{
 		{
 			name:     "IPv4 /27",
-			ipNet:    mustParseCidr("192.168.0.1/27"),
-			wantBase: net.ParseIP("192.168.0.1"),
+			prefix:   netip.MustParsePrefix("192.168.0.0/27"),
+			wantBase: netip.MustParseAddr("192.168.0.1"),
 			wantMax:  30, // (2^(32-27)) - 2
 		},
 		{
 			name:     "IPv4 /31",
-			ipNet:    mustParseCidr("192.168.0.1/31"),
-			wantBase: net.ParseIP("192.168.0.0"),
+			prefix:   netip.MustParsePrefix("192.168.0.0/31"),
+			wantBase: netip.MustParseAddr("192.168.0.0"),
 			wantMax:  2, // 2^1
 		},
 		{
 			name:     "IPv4 /32",
-			ipNet:    mustParseCidr("192.168.0.1/32"),
-			wantBase: net.ParseIP("192.168.0.1"),
+			prefix:   netip.MustParsePrefix("192.168.0.1/32"),
+			wantBase: netip.MustParseAddr("192.168.0.1"),
 			wantMax:  1, // 2^0
 		},
 		{
 			name:     "IPv6 /64",
-			ipNet:    mustParseCidr("2001:db8::1/64"),
-			wantBase: net.ParseIP("2001:db8::1"),
+			prefix:   netip.MustParsePrefix("2001:db8::/64"),
+			wantBase: netip.MustParseAddr("2001:db8::1"),
 			wantMax:  65534, // max(2^(128-64), 65536) - 2
 		},
 		{
 			name:     "IPv6 /120",
-			ipNet:    mustParseCidr("2001:db8::1/120"),
-			wantBase: net.ParseIP("2001:db8::1"),
+			prefix:   netip.MustParsePrefix("2001:db8::/120"),
+			wantBase: netip.MustParseAddr("2001:db8::1"),
 			wantMax:  254, // 2^(128-120) - 2
 		},
 		{
 			name:     "IPv6 /127",
-			ipNet:    mustParseCidr("2001:db8::1/127"),
-			wantBase: net.ParseIP("2001:db8::0"),
+			prefix:   netip.MustParsePrefix("2001:db8::/127"),
+			wantBase: netip.MustParseAddr("2001:db8::"),
 			wantMax:  2, // 2^1
 		},
 		{
 			name:     "IPv6 /128",
-			ipNet:    mustParseCidr("2001:db8::1/128"),
-			wantBase: net.ParseIP("2001:db8::1"),
+			prefix:   netip.MustParsePrefix("2001:db8::1/128"),
+			wantBase: netip.MustParseAddr("2001:db8::1"),
 			wantMax:  1, // 2^0
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := NewCIDRRange(tc.ipNet)
-			baseIP := ipForBig(actual.base)
-			require.Equal(t, tc.wantBase.String(), baseIP.String())
+			actual := NewCIDRRange(tc.prefix)
+			require.Equal(t, tc.wantBase, actual.base)
 			require.Equal(t, tc.wantMax, actual.max)
 		})
 	}
@@ -84,40 +69,39 @@ func TestNewCIDRRange(t *testing.T) {
 func TestNewCIDRRangeWithAllowFirstLastIPs(t *testing.T) {
 	testCases := []struct {
 		name     string
-		ipNet    *net.IPNet
-		wantBase net.IP
+		prefix   netip.Prefix
+		wantBase netip.Addr
 		wantMax  int
 	}{
 		{
 			name:     "IPv4 /28 prefix delegation",
-			ipNet:    mustParseCidr("10.0.0.0/28"),
-			wantBase: net.ParseIP("10.0.0.0"),
+			prefix:   netip.MustParsePrefix("10.0.0.0/28"),
+			wantBase: netip.MustParseAddr("10.0.0.0"),
 			wantMax:  16, // all 16 IPs usable
 		},
 		{
 			name:     "IPv4 /24",
-			ipNet:    mustParseCidr("10.0.0.0/24"),
-			wantBase: net.ParseIP("10.0.0.0"),
+			prefix:   netip.MustParsePrefix("10.0.0.0/24"),
+			wantBase: netip.MustParseAddr("10.0.0.0"),
 			wantMax:  256, // all 256 IPs usable
 		},
 		{
 			name:     "IPv6 /80 prefix delegation",
-			ipNet:    mustParseCidr("2001:db8::/80"),
-			wantBase: net.ParseIP("2001:db8::"),
+			prefix:   netip.MustParsePrefix("2001:db8::/80"),
+			wantBase: netip.MustParseAddr("2001:db8::"),
 			wantMax:  65536, // all 65536 IPs usable
 		},
 		{
 			name:     "IPv4 /32 unchanged",
-			ipNet:    mustParseCidr("10.0.0.1/32"),
-			wantBase: net.ParseIP("10.0.0.1"),
+			prefix:   netip.MustParsePrefix("10.0.0.1/32"),
+			wantBase: netip.MustParseAddr("10.0.0.1"),
 			wantMax:  1, // /32 is unaffected by the option
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewCIDRRange(tc.ipNet, WithAllowFirstLastIPs())
-			baseIP := ipForBig(r.base)
-			require.Equal(t, tc.wantBase.String(), baseIP.String())
+			r := NewCIDRRange(tc.prefix, WithAllowFirstLastIPs())
+			require.Equal(t, tc.wantBase, r.base)
 			require.Equal(t, tc.wantMax, r.max)
 		})
 	}
@@ -125,8 +109,8 @@ func TestNewCIDRRangeWithAllowFirstLastIPs(t *testing.T) {
 
 func TestAllowFirstLastIPsAllocateAll(t *testing.T) {
 	// Verify all 16 IPs in a /28 are allocatable with WithAllowFirstLastIPs.
-	cidr := mustParseCidr("10.0.0.0/28")
-	r := NewCIDRRange(cidr, WithAllowFirstLastIPs())
+	prefix := netip.MustParsePrefix("10.0.0.0/28")
+	r := NewCIDRRange(prefix, WithAllowFirstLastIPs())
 
 	require.Equal(t, 16, r.Free())
 
@@ -148,7 +132,7 @@ func TestAllowFirstLastIPsAllocateAll(t *testing.T) {
 
 	// Verify ForEach returns all allocated IPs.
 	forEachSet := map[string]struct{}{}
-	r.ForEach(func(ip net.IP) {
+	r.ForEach(func(ip netip.Addr) {
 		forEachSet[ip.String()] = struct{}{}
 	})
 	require.Len(t, forEachSet, 16)
@@ -157,71 +141,205 @@ func TestAllowFirstLastIPsAllocateAll(t *testing.T) {
 }
 
 func TestAllowFirstLastIPsAllocateSpecific(t *testing.T) {
-	cidr := mustParseCidr("10.0.0.0/28")
-	r := NewCIDRRange(cidr, WithAllowFirstLastIPs())
+	prefix := netip.MustParsePrefix("10.0.0.0/28")
+	r := NewCIDRRange(prefix, WithAllowFirstLastIPs())
 
 	// Allocate the first IP (network address).
-	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.0")))
-	require.True(t, r.Has(net.ParseIP("10.0.0.0")))
+	require.NoError(t, r.Allocate(netip.MustParseAddr("10.0.0.0")))
+	require.True(t, r.Has(netip.MustParseAddr("10.0.0.0")))
 
 	// Allocate the last IP (broadcast address).
-	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.15")))
-	require.True(t, r.Has(net.ParseIP("10.0.0.15")))
+	require.NoError(t, r.Allocate(netip.MustParseAddr("10.0.0.15")))
+	require.True(t, r.Has(netip.MustParseAddr("10.0.0.15")))
 
 	require.Equal(t, 14, r.Free())
 }
 
 func TestDefaultRangeExcludesFirstLastIPs(t *testing.T) {
-	cidr := mustParseCidr("10.0.0.0/28")
-	r := NewCIDRRange(cidr)
+	prefix := netip.MustParsePrefix("10.0.0.0/28")
+	r := NewCIDRRange(prefix)
 
 	require.Equal(t, 14, r.Free())
 
 	// .0 and .15 should be out of range.
-	require.ErrorContains(t, r.Allocate(net.ParseIP("10.0.0.0")), "not in the valid range")
-	require.ErrorContains(t, r.Allocate(net.ParseIP("10.0.0.15")), "not in the valid range")
+	require.ErrorContains(t, r.Allocate(netip.MustParseAddr("10.0.0.0")), "not in the valid range")
+	require.ErrorContains(t, r.Allocate(netip.MustParseAddr("10.0.0.15")), "not in the valid range")
 
 	// .1 and .14 should be allocatable (first and last usable IPs).
-	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.1")))
-	require.NoError(t, r.Allocate(net.ParseIP("10.0.0.14")))
+	require.NoError(t, r.Allocate(netip.MustParseAddr("10.0.0.1")))
+	require.NoError(t, r.Allocate(netip.MustParseAddr("10.0.0.14")))
 }
 
 func TestRangeSize(t *testing.T) {
 	testCases := []struct {
-		name  string
-		ipNet *net.IPNet
-		want  int64
+		name   string
+		prefix netip.Prefix
+		want   int64
 	}{
 		{
-			name:  "IPv4 /27",
-			ipNet: mustParseCidr("192.168.0.0/27"),
-			want:  32,
+			name:   "IPv4 /27",
+			prefix: netip.MustParsePrefix("192.168.0.0/27"),
+			want:   32,
 		},
 		{
-			name:  "IPv4 /32",
-			ipNet: mustParseCidr("192.168.0.0/32"),
-			want:  1,
+			name:   "IPv4 /32",
+			prefix: netip.MustParsePrefix("192.168.0.0/32"),
+			want:   1,
 		},
 		{
-			name:  "IPv6 /64",
-			ipNet: mustParseCidr("2001:db8::/64"),
-			want:  65536,
+			name:   "IPv6 /64",
+			prefix: netip.MustParsePrefix("2001:db8::/64"),
+			want:   65536,
 		},
 		{
-			name:  "IPv6 /120",
-			ipNet: mustParseCidr("2001:db8::/120"),
-			want:  256,
+			name:   "IPv6 /120",
+			prefix: netip.MustParsePrefix("2001:db8::/120"),
+			want:   256,
 		},
 		{
-			name:  "IPv6 /128",
-			ipNet: mustParseCidr("2001:db8::/128"),
-			want:  1,
+			name:   "IPv6 /128",
+			prefix: netip.MustParsePrefix("2001:db8::/128"),
+			want:   1,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := RangeSize(tc.ipNet)
+			actual := RangeSize(tc.prefix)
 			require.Equal(t, tc.want, actual)
 		})
+	}
+}
+
+func TestAddOffset(t *testing.T) {
+	testCases := []struct {
+		name   string
+		base   netip.Addr
+		offset int
+		want   netip.Addr
+	}{
+		{
+			name:   "IPv4 +0",
+			base:   netip.MustParseAddr("10.0.0.1"),
+			offset: 0,
+			want:   netip.MustParseAddr("10.0.0.1"),
+		},
+		{
+			name:   "IPv4 +1",
+			base:   netip.MustParseAddr("10.0.0.1"),
+			offset: 1,
+			want:   netip.MustParseAddr("10.0.0.2"),
+		},
+		{
+			name:   "IPv4 byte carry",
+			base:   netip.MustParseAddr("10.0.0.255"),
+			offset: 1,
+			want:   netip.MustParseAddr("10.0.1.0"),
+		},
+		{
+			name:   "IPv4 large offset",
+			base:   netip.MustParseAddr("10.0.0.0"),
+			offset: 256,
+			want:   netip.MustParseAddr("10.0.1.0"),
+		},
+		{
+			name:   "IPv6 +1",
+			base:   netip.MustParseAddr("2001:db8::1"),
+			offset: 1,
+			want:   netip.MustParseAddr("2001:db8::2"),
+		},
+		{
+			name:   "IPv6 low word carry",
+			base:   netip.MustParseAddr("2001:db8::ffff:ffff:ffff:ffff"),
+			offset: 1,
+			want:   netip.MustParseAddr("2001:db8::1:0:0:0:0"),
+		},
+		{
+			name:   "IPv6 large offset",
+			base:   netip.MustParseAddr("2001:db8::"),
+			offset: 65535,
+			want:   netip.MustParseAddr("2001:db8::ffff"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := addOffset(tc.base, tc.offset)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestAddrOffset(t *testing.T) {
+	testCases := []struct {
+		name string
+		base netip.Addr
+		addr netip.Addr
+		want int
+	}{
+		{
+			name: "IPv4 same address",
+			base: netip.MustParseAddr("10.0.0.1"),
+			addr: netip.MustParseAddr("10.0.0.1"),
+			want: 0,
+		},
+		{
+			name: "IPv4 +1",
+			base: netip.MustParseAddr("10.0.0.1"),
+			addr: netip.MustParseAddr("10.0.0.2"),
+			want: 1,
+		},
+		{
+			name: "IPv4 cross byte boundary",
+			base: netip.MustParseAddr("10.0.0.255"),
+			addr: netip.MustParseAddr("10.0.1.0"),
+			want: 1,
+		},
+		{
+			name: "IPv4 large offset",
+			base: netip.MustParseAddr("10.0.0.0"),
+			addr: netip.MustParseAddr("10.0.1.0"),
+			want: 256,
+		},
+		{
+			name: "IPv6 same address",
+			base: netip.MustParseAddr("2001:db8::1"),
+			addr: netip.MustParseAddr("2001:db8::1"),
+			want: 0,
+		},
+		{
+			name: "IPv6 +1",
+			base: netip.MustParseAddr("2001:db8::1"),
+			addr: netip.MustParseAddr("2001:db8::2"),
+			want: 1,
+		},
+		{
+			name: "IPv6 large offset",
+			base: netip.MustParseAddr("2001:db8::"),
+			addr: netip.MustParseAddr("2001:db8::ffff"),
+			want: 65535,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := addrOffset(tc.base, tc.addr)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestAddOffsetAddrOffsetRoundTrip(t *testing.T) {
+	bases := []netip.Addr{
+		netip.MustParseAddr("10.0.0.0"),
+		netip.MustParseAddr("192.168.1.100"),
+		netip.MustParseAddr("2001:db8::"),
+		netip.MustParseAddr("fe80::1"),
+	}
+	offsets := []int{0, 1, 127, 255, 256, 1000, 65535}
+
+	for _, base := range bases {
+		for _, offset := range offsets {
+			addr := addOffset(base, offset)
+			got := addrOffset(base, addr)
+			require.Equal(t, offset, got, "roundtrip failed for base=%s offset=%d", base, offset)
+		}
 	}
 }


### PR DESCRIPTION
Relates to: #24246

Migrate `pkg/ipam/service/ipallocator` from the `net.IP`/`net.IPNet` / `math/big` types to `net/netip` equivalents (`netip.Addr` and `netip.Prefix`).

In particular, I changed some field types for the `Range` struct:
* `net` (`*net.IPNet`) -> `prefix` (`netip.Prefix`)
* `base`: `*big.Int` -> `netip.Addr`

The old fields were pointer types backed by heap-allocated slices (`*net.IPNet` contains two `[]byte` slices for `IP` and `Mask` while `*big.Int` contains a `[]Word` slice). The new fields are value types with fixed-size inline storage (`netip.Prefix` is 32 bytes and `netip.Addr` is 24 bytes), eliminating three heap allocations per `Range` instance.

More importantly, the per-operation cost drops: the old `big.Int` offset arithmetic (`bigForIP`, `addIPOffset`, `calculateIPOffset`) allocated intermediate `big.Int`s on every `Allocate`/`Release`/`Has`/`ForEach` call. The replacements (`addOffset` and `addrOffset`) use stack-only `uint32`/`uint64` arithmetic via `encoding/binary`: zero heap allocations on the hot path.

Callers are updated to convert types at the boundary, except the ipalloc adapter as it already uses `netip` types internally so the type convertion is dropped there.