### PR TITLE
.github: Add AIL disclosure to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,11 @@ Please ensure your pull request adheres to the following guidelines:
       please add the commit author[s] as reviewer[s] to this issue.
 - [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
 - [ ] Provide a title or release-note blurb suitable for the release notes.
+- [ ] Write a short paragraph that states whether you used machine learning models
+      (including LLMs and other generative AI), and indicate the rating using
+      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
+      Example: "This PR was prepared with AIL:3. I personally reviewed each line
+      of the submission prior to opening this PR."
 - [ ] Thanks for contributing!
 
 <!-- Description of change -->


### PR DESCRIPTION
Add a prompt to the PR template to request that contributors disclose
the use of AI in their contributions.
