### PR TITLE
.github: Remove USERS request in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,6 @@ Please ensure your pull request adheres to the following guidelines:
       please add the commit author[s] as reviewer[s] to this issue.
 - [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
 - [ ] Provide a title or release-note blurb suitable for the release notes.
-- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
 - [ ] Thanks for contributing!
 
 <!-- Description of change -->


### PR DESCRIPTION
The vast majority of PRs are submitted by regular contributors, so it
doesn't make sense to ask on every submission to update the USERS.md
file.

If we want to ask this, maybe it'd make sense to create a greeter bot that
only responds to first time contributors.
