### PR TITLE
bgp: add instance_name metric label

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -796,15 +796,15 @@ Name                                           Labels                           
 BGP Control Plane
 ~~~~~~~~~~~~~~~~~
 
-================================== =============================================================== ======== ===================================================================
-Name                               Labels                                                          Default  Description
-================================== =============================================================== ======== ===================================================================
-``session_state``                  ``vrouter``, ``neighbor``, ``neighbor_asn``                     Enabled  Current state of the BGP session with the peer, Up = 1 or Down = 0
-``advertised_routes``              ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes advertised to the peer
-``received_routes``                ``vrouter``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes received from the peer
-``reconcile_errors_total``         ``vrouter``                                                     Enabled  Number of reconciliation runs that returned an error
-``reconcile_run_duration_seconds`` ``vrouter``                                                     Enabled  Histogram of reconciliation run duration
-================================== =============================================================== ======== ===================================================================
+=================================== ==================================================================================== ======== ===================================================================
+Name                                Labels                                                                               Default  Description
+=================================== ==================================================================================== ======== ===================================================================
+``session_state``                   ``instance_name``, ``local_asn``, ``neighbor``, ``neighbor_asn``                     Enabled  Current state of the BGP session with the peer, Up = 1 or Down = 0
+``advertised_routes``               ``instance_name``, ``local_asn``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes advertised to the peer
+``received_routes``                 ``instance_name``, ``local_asn``, ``neighbor``, ``neighbor_asn``, ``afi``, ``safi``  Enabled  Number of routes received from the peer
+``reconcile_errors_total``          ``instance_name``                                                                    Enabled  Number of reconciliation runs that returned an error
+``reconcile_run_duration_seconds``  ``instance_name``                                                                    Enabled  Histogram of reconciliation run duration
+=================================== ==================================================================================== ======== ===================================================================
 
 All metrics are enabled only when the BGP Control Plane is enabled.
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -393,6 +393,9 @@ Changed Metrics
 * The metric ``policy_change_total`` now reports additional ``source`` (directory, k8s, custom, generated)
   and ``operation`` (update, delete) dimensions.
 * The metric ``endpoint_regeneration_total`` now reports additional ``reason`` and ``error`` dimensions.
+* The ``session_state``, ``advertised_routes``, ``received_routes``, ``reconcile_errors_total``, ``reconcile_run_duration_seconds`` metrics
+  now include ``instance_name`` label. Label ``vrouter`` is removed please use ``instance_name`` instead.
+* The ``session_state``, ``advertised_routes``, ``received_routes`` metrics now include ``local_asn`` label.
 
 Deprecated Metrics
 ##################

--- a/pkg/bgp/gobgp/state.go
+++ b/pkg/bgp/gobgp/state.go
@@ -55,6 +55,10 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context, req *types.GetPeerStateR
 
 		state := types.PeerState{}
 
+		if peer.Transport != nil {
+			state.Port = int64(peer.Transport.RemotePort)
+		}
+
 		if peer.Conf != nil {
 			if peer.Conf.Description != "" {
 				pd := peerDescription{}
@@ -69,6 +73,8 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context, req *types.GetPeerStateR
 			// the invalid case.
 			addr, _ := netip.ParseAddr(peer.Conf.NeighborAddress)
 			state.Address = addr
+			state.LocalAsn = int64(peer.Conf.LocalAsn)
+			state.PeerAsn = int64(peer.Conf.PeerAsn)
 		}
 
 		if peer.State != nil {

--- a/pkg/bgp/manager/metrics.go
+++ b/pkg/bgp/manager/metrics.go
@@ -26,12 +26,12 @@ func NewBGPManagerMetrics() *BGPManagerMetrics {
 			Subsystem: types.MetricsSubsystem,
 			Name:      types.MetricReconcileErrorsTotal,
 			Help:      "The number of errors during reconciliation of the BGP manager",
-		}, []string{types.LabelVRouter}),
+		}, []string{types.LabelName}),
 		ReconcileRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: types.MetricsSubsystem,
 			Name:      types.MetricReconcileRunDurationSeconds,
 			Help:      "The duration of the BGP manager reconciliation run",
-		}, []string{types.LabelVRouter}),
+		}, []string{types.LabelName}),
 	}
 }

--- a/pkg/bgp/metrics/metrics.go
+++ b/pkg/bgp/metrics/metrics.go
@@ -54,17 +54,17 @@ func RegisterCollector(in collectorIn) {
 		SessionState: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.Namespace, types.MetricsSubsystem, "session_state"),
 			"Current state of the BGP session with the peer, Up = 1 or Down = 0",
-			[]string{types.LabelVRouter, types.LabelNeighbor, types.LabelNeighborAsn}, nil,
+			[]string{types.LabelName, types.LabelLocalAsn, types.LabelNeighbor, types.LabelNeighborAsn}, nil,
 		),
 		TotalAdvertisedRoutes: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.Namespace, types.MetricsSubsystem, "advertised_routes"),
 			"Number of routes advertised to the peer",
-			[]string{types.LabelVRouter, types.LabelNeighbor, types.LabelNeighborAsn, types.LabelAfi, types.LabelSafi}, nil,
+			[]string{types.LabelName, types.LabelLocalAsn, types.LabelNeighbor, types.LabelNeighborAsn, types.LabelAfi, types.LabelSafi}, nil,
 		),
 		TotalReceivedRoutes: prometheus.NewDesc(
 			prometheus.BuildFQName(metrics.Namespace, types.MetricsSubsystem, "received_routes"),
 			"Number of routes received from the peer",
-			[]string{types.LabelVRouter, types.LabelNeighbor, types.LabelNeighborAsn, types.LabelAfi, types.LabelSafi}, nil,
+			[]string{types.LabelName, types.LabelLocalAsn, types.LabelNeighbor, types.LabelNeighborAsn, types.LabelAfi, types.LabelSafi}, nil,
 		),
 		in: in,
 	})
@@ -83,69 +83,63 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	// revisit this timeout when the metrics collection starts to involve a
 	// network communication.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	peers, err := c.in.RouterManager.GetPeersLegacy(ctx)
+	getPeersResponse, err := c.in.RouterManager.GetPeers(ctx, &agent.GetPeersRequest{})
 	cancel()
 	if err != nil {
 		c.in.Logger.Error("Failed to retrieve BGP peer information. Metrics is not collected.", logfields.Error, err)
 		return
 	}
 
-	for _, peer := range peers {
-		if peer == nil {
-			continue
-		}
+	for _, instance := range getPeersResponse.Instances {
+		for _, peer := range instance.Peers {
+			localAsnLabel := strconv.FormatInt(peer.LocalAsn, 10)
+			neighborLabel := netip.AddrPortFrom(peer.Address, uint16(peer.Port)).String()
+			neighborAsnLabel := strconv.FormatInt(peer.PeerAsn, 10)
 
-		vrouterLabel := strconv.FormatInt(peer.LocalAsn, 10)
-
-		addr, err := netip.ParseAddr(peer.PeerAddress)
-		if err != nil {
-			continue
-		}
-
-		neighborLabel := netip.AddrPortFrom(addr, uint16(peer.PeerPort)).String()
-		neighborAsnLabel := strconv.FormatInt(peer.PeerAsn, 10)
-
-		// Collect session state metrics
-		var up float64
-		if peer.SessionState == types.SessionEstablished.String() {
-			up = 1
-		} else {
-			up = 0
-		}
-		ch <- prometheus.MustNewConstMetric(
-			c.SessionState,
-			prometheus.GaugeValue,
-			up,
-			vrouterLabel,
-			neighborLabel,
-			neighborAsnLabel,
-		)
-
-		// Collect route metrics per address family
-		for _, family := range peer.Families {
-			if family == nil {
-				continue
+			// Collect session state metrics
+			var up float64
+			if peer.SessionState == types.SessionEstablished {
+				up = 1
+			} else {
+				up = 0
 			}
 			ch <- prometheus.MustNewConstMetric(
-				c.TotalAdvertisedRoutes,
+				c.SessionState,
 				prometheus.GaugeValue,
-				float64(family.Advertised),
-				vrouterLabel,
+				up,
+				instance.Name,
+				localAsnLabel,
 				neighborLabel,
 				neighborAsnLabel,
-				family.Afi,
-				family.Safi,
 			)
-			ch <- prometheus.MustNewConstMetric(
-				c.TotalReceivedRoutes,
-				prometheus.GaugeValue,
-				float64(family.Received),
-				vrouterLabel,
-				neighborLabel,
-				neighborAsnLabel,
-				family.Afi,
-				family.Safi,
-			)
+
+			// Collect route metrics per address family
+			if up == 1 {
+				for _, family := range peer.Families {
+					ch <- prometheus.MustNewConstMetric(
+						c.TotalAdvertisedRoutes,
+						prometheus.GaugeValue,
+						float64(family.AdvertisedRoutes),
+						instance.Name,
+						localAsnLabel,
+						neighborLabel,
+						neighborAsnLabel,
+						family.Family.Afi.String(),
+						family.Family.Safi.String(),
+					)
+					ch <- prometheus.MustNewConstMetric(
+						c.TotalReceivedRoutes,
+						prometheus.GaugeValue,
+						float64(family.ReceivedRoutes),
+						instance.Name,
+						localAsnLabel,
+						neighborLabel,
+						neighborAsnLabel,
+						family.Family.Afi.String(),
+						family.Family.Safi.String(),
+					)
+				}
+			}
 		}
 	}
 }

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -18,7 +18,8 @@ import (
 // BGP metric labels
 const (
 	LabelClusterConfig = "bgp_cluster_config"
-	LabelVRouter       = "vrouter"
+	LabelName          = "instance_name"
+	LabelLocalAsn      = "local_asn"
 	LabelNeighbor      = "neighbor"
 	LabelNeighborAsn   = "neighbor_asn"
 	LabelAfi           = "afi"
@@ -146,6 +147,17 @@ type PeerState struct {
 
 	// Address of the peer
 	Address netip.Addr
+
+	// Local AS Number
+	LocalAsn int64
+
+	// Peer AS Number
+	PeerAsn int64
+
+	// TCP port number of peer
+	// Maximum: 65535
+	// Minimum: 1
+	Port int64
 
 	// BGP peer state
 	SessionState SessionState


### PR DESCRIPTION
In BGPv2, the instance name is used as the primary identifier instead of the BGPv1 ASN. This change aligns our metrics with that.

- Added instance_name label to ReconcileErrorsTotal, ReconcileRunDuration, SessionState, TotalAdvertisedRoutes and TotalReceivedRoutes.
- Marked the vrouter label as deprecated in favor of instance_name.
- Added LocalAsn, PeerAsn and Port to types.PeerState.
- Updated gobgp.GoBGPServer.GetPeerState to populate the new fields and refactored metrics.collector to utilize the updated GetPeers method.

```release-note
metrics: add instance_name and local_asn label to BGP Control Plane metrics and delete the vrouter label
```
