### PR TITLE
Miscellaneous logging tidyups

### DIFF
--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -202,7 +202,6 @@ Hive also by default provides the following globally available objects:
 - :ref:`api_lifecycle`: Methods for registering Start and Stop functions that are executed when Hive is started and stopped. 
   The hooks are appended to it in dependency order (since the constructors are invoked in dependency order).
 - :ref:`api_shutdowner`: Allows gracefully shutting down the hive from anywhere in case of a fatal error post-start.
-- ``logrus.FieldLogger``: Interface to the logger. Module() decorates it with ``subsys=<module id>``.
 
 .. _api_provide:
 

--- a/clustermesh-apiserver/clustermesh/script_test.go
+++ b/clustermesh-apiserver/clustermesh/script_test.go
@@ -45,7 +45,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -96,7 +96,7 @@ func InitEtcdLocal(log *slog.Logger) (returnErr error) {
 	defer cancelFn()
 
 	if debug {
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log.Debug("Debug logging enabled")
 

--- a/clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go
+++ b/clustermesh-apiserver/mcsapi-coredns-cfg/script_test.go
@@ -34,7 +34,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 

--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -35,7 +36,7 @@ func TestAgentCell(t *testing.T) {
 	defer testutils.GoleakVerifyNone(t, goleakOptions...)
 	defer metrics.Reinitialize()
 
-	logging.SetLogLevelToDebug()
+	logging.SetLogLevel(slog.LevelDebug)
 
 	// Populate config with default values normally set by Viper flag defaults
 	option.Config.IPv4ServiceRange = AutoCIDR

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -276,7 +276,7 @@ func (h *ConfigModifyEventHandler) changedOption(key string, value option.Option
 	if key == option.Debug {
 		// Set the log level of the agent (this can be a no-op)
 		if option.Config.Opts.IsEnabled(option.Debug) {
-			logging.SetLogLevelToDebug()
+			logging.SetLogLevel(slog.LevelDebug)
 		} else {
 			logging.SetDefaultLogLevel()
 		}

--- a/operator/pkg/kvstore/nodesgc/script_test.go
+++ b/operator/pkg/kvstore/nodesgc/script_test.go
@@ -42,7 +42,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 

--- a/operator/watchers/script_test.go
+++ b/operator/watchers/script_test.go
@@ -43,7 +43,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -66,7 +66,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 

--- a/pkg/datapath/linux/device/scripttest/device_test.go
+++ b/pkg/datapath/linux/device/scripttest/device_test.go
@@ -91,7 +91,7 @@ func scriptEngine(t testing.TB, args []string) *script.Engine {
 	)
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 	t.Cleanup(func() {

--- a/pkg/datapath/neighbor/test/script_test.go
+++ b/pkg/datapath/neighbor/test/script_test.go
@@ -47,7 +47,7 @@ func TestPrivilegedScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 
 	scripttest.Test(t,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -398,13 +398,13 @@ type Endpoint struct {
 	// loggerAttrs are attributes.
 	policyLoggerAttrs lock.Map[string, any]
 
-	// logger is a logrus object with fields set to report an endpoints information.
+	// logger is a logging wrapper with endpoint information pre-cached.
 	// This must only be accessed with atomic.LoadPointer/StorePointer.
 	// 'mutex' must be Lock()ed to synchronize stores. No lock needs to be held
 	// when loading this pointer.
 	logger atomic.Pointer[slog.Logger]
 
-	// logger is a logrus object with fields set to report an endpoints information.
+	// loggerNoSubsys is a logging wrapper with endpoint information pre-cached.
 	// This must only be accessed with atomic.LoadPointer/StorePointer.
 	// 'mutex' must be Lock()ed to synchronize stores. No lock needs to be held
 	// when loading this pointer.
@@ -415,7 +415,7 @@ type Endpoint struct {
 	// Points to a shared policy debug log file.
 	policyDebugLog io.Writer
 
-	// policyLogger is a logrus object with fields set to report an endpoints information.
+	// policyLogger is a logging wrapper with endpoint information pre-cached.
 	// This must only be accessed with atomic LoadPointer/StorePointer.
 	// 'mutex' must be Lock()ed to synchronize stores. No lock needs to be held
 	// when loading this pointer.

--- a/pkg/envoy/envoyadminclient.go
+++ b/pkg/envoy/envoyadminclient.go
@@ -70,7 +70,7 @@ func (a *EnvoyAdminClient) Post(query string) (string, error) {
 	return string(body), nil
 }
 
-// ChangeLogLevel changes Envoy log level to correspond to the logrus log level 'level'.
+// ChangeLogLevel changes Envoy log level to correspond to the specified 'level'.
 func (a *EnvoyAdminClient) ChangeLogLevel(agentLogLevel slog.Level) error {
 	envoyLevel := mapLogLevel(agentLogLevel, a.defaultLogLevel)
 

--- a/pkg/envoy/standalone_envoy.go
+++ b/pkg/envoy/standalone_envoy.go
@@ -184,8 +184,8 @@ func (o *onDemandXdsStarter) startStandaloneEnvoyInternal(config standaloneEnvoy
 			// main and worker threads.
 			logFormat = "%t|%l|%n|%v"
 
-			// Create a piper that parses and writes into logrus the log
-			// messages from Envoy.
+			// Create a piper that parses Envoy log messages and
+			// writes them to the Cilium agent log.
 			logWriter = o.newEnvoyLogPiper()
 		}
 		defer logWriter.Close()
@@ -318,7 +318,7 @@ func (o *onDemandXdsStarter) newEnvoyLogPiper() io.WriteCloser {
 				continue
 			}
 
-			// Map the Envoy log level to a logrus level.
+			// Map the Envoy log level to a Cilium log level.
 			switch logLevel {
 			case envoyLogLevelOff, envoyLogLevelCritical, envoyLogLevelError:
 				scopedLog.Error(logMsg)

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -5,6 +5,7 @@ package envoy
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,7 +68,7 @@ func TestEnvoy(t *testing.T) {
 		t.Skip("skipping envoy unit test; CILIUM_ENABLE_ENVOY_UNIT_TEST not set")
 	}
 
-	logging.SetLogLevelToDebug()
+	logging.SetLogLevel(slog.LevelDebug)
 	flowdebug.Enable()
 
 	testRunDir, err := os.MkdirTemp("", "envoy_go_test")

--- a/pkg/hubble/container/ring_reader_test.go
+++ b/pkg/hubble/container/ring_reader_test.go
@@ -201,7 +201,6 @@ func TestRingReader_NextLost(t *testing.T) {
 func TestRingReader_NextFollow(t *testing.T) {
 	defer testutils.GoleakVerifyNone(
 		t,
-		// ignore goroutines started by the redirect we do from klog to logrus
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
@@ -279,7 +278,6 @@ func TestRingReader_NextFollow(t *testing.T) {
 func TestRingReader_NextFollow_WithEmptyRing(t *testing.T) {
 	defer testutils.GoleakVerifyNone(
 		t,
-		// ignore goroutines started by the redirect we do from klog to logrus
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -710,7 +710,6 @@ func TestRingFunctionalitySerialized(t *testing.T) {
 func TestRing_ReadFrom_Test_1(t *testing.T) {
 	defer testutils.GoleakVerifyNone(
 		t,
-		// ignore goroutines started by the redirect we do from klog to logrus
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
@@ -769,7 +768,6 @@ func TestRing_ReadFrom_Test_1(t *testing.T) {
 func TestRing_ReadFrom_Test_2(t *testing.T) {
 	defer testutils.GoleakVerifyNone(
 		t,
-		// ignore goroutines started by the redirect we do from klog to logrus
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))
@@ -866,7 +864,6 @@ func TestRing_ReadFrom_Test_2(t *testing.T) {
 func TestRing_ReadFrom_Test_3(t *testing.T) {
 	defer testutils.GoleakVerifyNone(
 		t,
-		// ignore goroutines started by the redirect we do from klog to logrus
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("k8s.io/klog/v2.(*loggingT).flushDaemon"),
 		testutils.GoleakIgnoreTopFunction("io.(*pipe).read"))

--- a/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
@@ -47,9 +47,6 @@ var (
 )
 
 func TestParseEnvoySpec(t *testing.T) {
-	// option.Config.Debug = true
-	// logging.DefaultLogger.SetLevel(logrus.DebugLevel)
-
 	jsonBytes, err := yaml.YAMLToJSON([]byte(envoySpec))
 	require.NoError(t, err)
 	cec := &CiliumEnvoyConfig{}

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -67,7 +67,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 	log := hivetest.Logger(t, opts...)
 

--- a/pkg/loadbalancer/redirectpolicy/script_test.go
+++ b/pkg/loadbalancer/redirectpolicy/script_test.go
@@ -60,7 +60,7 @@ func TestScript(t *testing.T) {
 	var opts []hivetest.LogOption
 	if *debug {
 		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 
 	scripttest.Test(t,

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -91,7 +91,7 @@ func testScript(t *testing.T) {
 			var opts []hivetest.LogOption
 			if *debug {
 				opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
-				logging.SetLogLevelToDebug()
+				logging.SetLogLevel(slog.LevelDebug)
 			}
 			log := hivetest.Logger(t, opts...)
 

--- a/pkg/logging/klog_bridge.go
+++ b/pkg/logging/klog_bridge.go
@@ -40,8 +40,7 @@ func initializeKLog(logger *slog.Logger) error {
 	// of klog so we want klog to log the errors to each writer of each level.
 	klogFlags.Set("logtostderr", "false")
 
-	// We don't need all headers because logrus will already print them if
-	// necessary.
+	// Cilium logger already prints the headers
 	klogFlags.Set("skip_headers", "true")
 
 	infoWriter, err := severityOverrideWriter(slog.LevelInfo, log, nil)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -108,7 +108,7 @@ func SetLogLevelToDebug() {
 	slogLeveler.Set(slog.LevelDebug)
 }
 
-// AddHandlers adds additional logrus hook to default logger
+// AddHandlers adds additional hooks to the default logger
 func AddHandlers(hooks ...slog.Handler) {
 	defaultMultiSlogHandler.AddHandlers(hooks...)
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -103,11 +103,6 @@ func SetDefaultLogLevel() {
 	SetLogLevel(DefaultLogLevel)
 }
 
-// SetLogLevelToDebug updates the DefaultLogger with the logrus.DebugLevel
-func SetLogLevelToDebug() {
-	slogLeveler.Set(slog.LevelDebug)
-}
-
 // AddHandlers adds additional hooks to the default logger
 func AddHandlers(hooks ...slog.Handler) {
 	defaultMultiSlogHandler.AddHandlers(hooks...)

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -37,8 +37,8 @@ var defaultMultiSlogHandler = NewMultiSlogHandler(slog.NewTextHandler(
 // Default slog logger. Will be overwritten once initializeSlog is called.
 var DefaultSlogLogger = slog.New(defaultMultiSlogHandler)
 
-// Approximates the logrus output via slog for job groups during the transition
-// phase.
+// initializeSlog configures the slog library with options that retain parity
+// with the format that Cilium has traditionally used for outputting logs.
 func initializeSlog(logOpts LogOptions, loggers []string) {
 	opts := *slogHandlerOpts
 	opts.Level = logOpts.GetLogLevel()

--- a/pkg/metrics/logging_hook.go
+++ b/pkg/metrics/logging_hook.go
@@ -39,8 +39,7 @@ func FlushLoggingMetrics() {
 	})
 }
 
-// LoggingHook is a hook for logrus which counts error and warning messages as a
-// Prometheus metric.
+// LoggingHook counts error and warning messages as a Prometheus metric.
 type LoggingHook struct {
 	errs, warn *atomic.Uint64
 	attrs      map[string]slog.Value

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3573,7 +3573,7 @@ func InitConfig(logger *slog.Logger, cmd *cobra.Command, programName, configName
 		// loading the configuration file since on configuration file read failure
 		// we will emit a debug log entry.
 		if vp.GetBool(DebugArg) {
-			logging.SetLogLevelToDebug()
+			logging.SetLogLevel(slog.LevelDebug)
 		}
 
 		// If a config file is found, read it in.
@@ -3592,7 +3592,7 @@ func InitConfig(logger *slog.Logger, cmd *cobra.Command, programName, configName
 		// Check for the debug flag again now that the configuration file may has
 		// been loaded, as it might have changed.
 		if vp.GetBool(DebugArg) {
-			logging.SetLogLevelToDebug()
+			logging.SetLogLevel(slog.LevelDebug)
 		}
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -338,7 +338,7 @@ func (p *Proxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	p.envoyIntegration.RemoveNetworkPolicy(ep)
 }
 
-// ChangeLogLevel changes proxy log level to correspond to the logrus log level 'level'.
+// ChangeLogLevel changes proxy log level to correspond to the Cilium log 'level'.
 func (p *Proxy) ChangeLogLevel(level slog.Level) {
 	if err := p.envoyIntegration.changeLogLevel(level); err != nil {
 		p.logger.Debug("failed to change log level in Envoy proxy", logfields.Error, err)

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -159,7 +160,7 @@ func (d SignalData) String() string {
 }
 
 func TestLifeCycle(t *testing.T) {
-	logging.SetLogLevelToDebug()
+	logging.SetLogLevel(slog.LevelDebug)
 	logger := hivetest.Logger(t)
 
 	buf1 := new(bytes.Buffer)

--- a/test/controlplane/suite/flags.go
+++ b/test/controlplane/suite/flags.go
@@ -5,6 +5,7 @@ package suite
 
 import (
 	"flag"
+	"log/slog"
 
 	"github.com/cilium/cilium/pkg/logging"
 )
@@ -18,6 +19,6 @@ var (
 func ParseFlags() {
 	flag.Parse()
 	if *FlagDebug {
-		logging.SetLogLevelToDebug()
+		logging.SetLogLevel(slog.LevelDebug)
 	}
 }


### PR DESCRIPTION
The tree had a bunch of remaining references to logrus which are no longer
relevant, so I took a stab at removing most of them. There's still a few where
the code was inspired (and hence it makes sense to retain the reference) or
also under `/test/` where the code still relies on logrus. Clean up most of the
rest of the references.
