### PR TITLE
network driver: fix allocation lifecycle and add rollback on prepare failure

### DIFF
--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -242,6 +242,28 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 		devicesStatus []resourceapi.AllocatedDeviceStatus
 	)
 
+	// rollback releases IPs and calls Device.Free() for every device that was
+	// fully set up before an error interrupted the loop.  It is called on every
+	// early-return path inside the device loop below.
+	defer func() {
+		if err != nil {
+			for _, a := range alloc {
+				if err := a.Device.Free(a.Config); err != nil {
+					driver.logger.Warn("failed to free device during rollback",
+						logfields.Device, a.Device.IfName(),
+						logfields.Error, err,
+					)
+				}
+				if err := driver.releaseAddrs(a.Config); err != nil {
+					driver.logger.Warn("failed to release addresses during rollback",
+						logfields.Device, a.Device.IfName(),
+						logfields.Error, err,
+					)
+				}
+			}
+		}
+	}()
+
 	for _, result := range claim.Status.Allocation.Devices.Results {
 		var thisAlloc allocation
 
@@ -264,14 +286,14 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 		}
 
 		if !found {
+			err = fmt.Errorf("%w with ifname %s for %s", errDeviceNotFound, result.Device, path.Join(claim.Namespace, claim.Name))
 			return kubeletplugin.PrepareResult{
-				Err: fmt.Errorf("%w with ifname %s for %s", errDeviceNotFound, result.Device, path.Join(claim.Namespace, claim.Name)),
+				Err: err,
 			}
 		}
 
 		var (
 			v4Addr, v6Addr, zeroAddr netip.Addr
-			err                      error
 		)
 
 		// if static IP addresses are not specified, request addresses from the referenced pool
@@ -286,11 +308,14 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 					logfields.PoolName, cfg.IPPool,
 					logfields.Error, err,
 				)
+
+				err = fmt.Errorf("failed to get IP addresses for device %s in claim %s: %w", result.Device, path.Join(claim.Namespace, claim.Name), err)
 				return kubeletplugin.PrepareResult{
-					Err: fmt.Errorf("failed to get IP addresses for device %s in claim %s: %w", result.Device, path.Join(claim.Namespace, claim.Name), err),
+					Err: err,
 				}
 			}
 		}
+
 		if v4Needed {
 			thisAlloc.Config.IPv4Addr = netip.PrefixFrom(v4Addr, v4Addr.BitLen())
 		}
@@ -298,15 +323,25 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 			thisAlloc.Config.IPv6Addr = netip.PrefixFrom(v6Addr, v6Addr.BitLen())
 		}
 
-		if err := thisAlloc.Device.Setup(thisAlloc.Config); err != nil {
+		if setupErr := thisAlloc.Device.Setup(thisAlloc.Config); setupErr != nil {
 			driver.logger.ErrorContext(ctx, "failed to set up device",
 				logfields.Device, thisAlloc.Device.IfName(),
 				logfields.Config, thisAlloc.Config,
-				logfields.Error, err,
+				logfields.Error, setupErr,
 			)
 
+			// thisAlloc is not yet appended to alloc, so release its IPs
+			// explicitly before rolling back the already-set-up devices.
+			if releaseErr := driver.releaseAddrs(thisAlloc.Config); releaseErr != nil {
+				driver.logger.Warn("failed to release addresses for failed device during rollback",
+					logfields.Device, thisAlloc.Device.IfName(),
+					logfields.Error, releaseErr,
+				)
+			}
+
+			err = fmt.Errorf("%w for ifname %s on %s", setupErr, thisAlloc.Device.IfName(), path.Join(claim.Namespace, claim.Name))
 			return kubeletplugin.PrepareResult{
-				Err: fmt.Errorf("%w for ifname %s on %s", err, thisAlloc.Device.IfName(), path.Join(claim.Namespace, claim.Name)),
+				Err: err,
 			}
 		}
 
@@ -320,8 +355,9 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 				logfields.Error, err,
 			)
 
+			err = fmt.Errorf("failed to serialize device %s for claim %s: %w", thisAlloc.Device.IfName(), path.Join(claim.Namespace, claim.Name), err)
 			return kubeletplugin.PrepareResult{
-				Err: fmt.Errorf("failed to serialize device %s for claim %s: %w", thisAlloc.Device.IfName(), path.Join(claim.Namespace, claim.Name), err),
+				Err: err,
 			}
 		}
 
@@ -345,14 +381,21 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 			},
 		})
 	}
+
 	driver.allocations[pod.UID] = make(map[kube_types.UID][]allocation)
 	driver.allocations[pod.UID][claim.UID] = alloc
 
+	// Persist the allocation to Kubernetes before committing it to memory.
+	// If UpdateStatus fails we roll back the devices so the next
+	// PrepareResourceClaims call can start fresh rather than hitting the
+	// "allocation already exists" guard.
 	newClaim := claim.DeepCopy()
 	newClaim.Status.Devices = append(newClaim.Status.Devices, devicesStatus...)
-	if _, err := driver.kubeClient.ResourceV1().ResourceClaims(claim.Namespace).UpdateStatus(ctx, newClaim, metav1.UpdateOptions{}); err != nil {
+
+	if _, updateErr := driver.kubeClient.ResourceV1().ResourceClaims(claim.Namespace).UpdateStatus(ctx, newClaim, metav1.UpdateOptions{}); updateErr != nil {
+		err = fmt.Errorf("failed to update claim %s status: %w", path.Join(claim.Namespace, claim.Name), updateErr)
 		return kubeletplugin.PrepareResult{
-			Err: fmt.Errorf("failed to update claim %s status: %w", path.Join(claim.Namespace, claim.Name), err),
+			Err: err,
 		}
 	}
 

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -200,7 +200,6 @@ func (driver *Driver) addrsForDevice(ctx context.Context, device string, cfg typ
 			if err := driver.multiPoolMgr.ReleaseIP(v6Addr.AsSlice(), ipam.Pool(cfg.IPPool), ipam.IPv6, true); err != nil {
 				errs = append(errs, fmt.Errorf("failed to release IPv6 address %s: %w", v6Addr, err))
 			}
-			errs = append(errs, driver.multiPoolMgr.ReleaseIP(v6Addr.AsSlice(), ipam.Pool(cfg.IPPool), ipam.IPv6, true))
 		}
 		return netip.Addr{}, netip.Addr{}, fmt.Errorf("failed to get IP addresses for device %s from pool %s: %w", device, cfg.IPPool, errors.Join(errs...))
 	}

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -361,6 +361,16 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 			}
 		}
 
+		var ips []string
+
+		if thisAlloc.Config.IPv4Addr.IsValid() {
+			ips = append(ips, thisAlloc.Config.IPv4Addr.String())
+		}
+
+		if thisAlloc.Config.IPv6Addr.IsValid() {
+			ips = append(ips, thisAlloc.Config.IPv6Addr.String())
+		}
+
 		devicesStatus = append(devicesStatus, resourceapi.AllocatedDeviceStatus{
 			Driver:     driver.config.DriverName,
 			Pool:       result.Pool,
@@ -374,10 +384,7 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 					}
 					return thisAlloc.Device.IfName()
 				}(),
-				IPs: []string{
-					thisAlloc.Config.IPv4Addr.String(),
-					thisAlloc.Config.IPv6Addr.String(),
-				},
+				IPs: ips,
 			},
 		})
 	}

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -382,9 +382,6 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 		})
 	}
 
-	driver.allocations[pod.UID] = make(map[kube_types.UID][]allocation)
-	driver.allocations[pod.UID][claim.UID] = alloc
-
 	// Persist the allocation to Kubernetes before committing it to memory.
 	// If UpdateStatus fails we roll back the devices so the next
 	// PrepareResourceClaims call can start fresh rather than hitting the
@@ -398,6 +395,9 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 			Err: err,
 		}
 	}
+
+	driver.allocations[pod.UID] = make(map[kube_types.UID][]allocation)
+	driver.allocations[pod.UID][claim.UID] = alloc
 
 	// we dont need to return anything here.
 	return kubeletplugin.PrepareResult{}

--- a/pkg/networkdriver/driver.go
+++ b/pkg/networkdriver/driver.go
@@ -274,6 +274,21 @@ func (driver *Driver) deviceFromClaim(devStatus resourceapi.AllocatedDeviceStatu
 func (driver *Driver) restoreDevicesFromClaim(claim *resourceapi.ResourceClaim) error {
 	var errs []error
 
+	// Detect the crash-before-UpdateStatus case: the claim is allocated and
+	// reserved (the scheduler+kubelet did their part) but Status.Devices is
+	// empty because the driver crashed between Device.Setup() and UpdateStatus.
+	// We have no serialized device state to restore from, so the kernel device
+	// is left configured but completely invisible to the driver. Log a warning
+	// so the operator can identify and manually clean up the orphaned device.
+	if claim.Status.Allocation != nil && len(claim.Status.ReservedFor) > 0 && len(claim.Status.Devices) == 0 {
+		driver.logger.Warn("claim is allocated and reserved but has no device status — "+
+			"driver may have crashed before UpdateStatus; the kernel device may be orphaned",
+			logfields.Name, claim.Name,
+			logfields.K8sNamespace, claim.Namespace,
+			logfields.UID, string(claim.UID),
+		)
+	}
+
 	for _, devStatus := range claim.Status.Devices {
 		if devStatus.Driver != driver.config.DriverName {
 			continue
@@ -291,20 +306,22 @@ func (driver *Driver) restoreDevicesFromClaim(claim *resourceapi.ResourceClaim) 
 		}
 		podUID := claim.Status.ReservedFor[0].UID
 
-		if alloc.Config.IPPool == "" {
-			// no need to allocate from pool in case of static addresses
-			continue
-		}
-
 		var claimAllocs map[kube_types.UID][]allocation
+
 		claimAllocs, found := driver.allocations[podUID]
 		if !found {
 			claimAllocs = make(map[kube_types.UID][]allocation)
 			driver.allocations[podUID] = claimAllocs
 		}
+
 		claimAllocs[claim.UID] = append(claimAllocs[claim.UID], alloc)
 
-		if driver.ipv4Enabled {
+		if alloc.Config.IPPool == "" {
+			// Static addresses: no pool bookkeeping needed, allocation already restored above.
+			continue
+		}
+
+		if alloc.Config.IPv4Addr.IsValid() {
 			if _, err := driver.multiPoolMgr.AllocateIP(
 				alloc.Config.IPv4Addr.Addr().AsSlice(),
 				alloc.Device.IfName(),
@@ -319,7 +336,7 @@ func (driver *Driver) restoreDevicesFromClaim(claim *resourceapi.ResourceClaim) 
 			}
 		}
 
-		if driver.ipv6Enabled {
+		if alloc.Config.IPv6Addr.IsValid() {
 			if _, err := driver.multiPoolMgr.AllocateIP(
 				alloc.Config.IPv6Addr.Addr().AsSlice(),
 				alloc.Device.IfName(),

--- a/pkg/networkdriver/macvlan/macvlan.go
+++ b/pkg/networkdriver/macvlan/macvlan.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"slices"
 	"strconv"
 	"strings"
@@ -30,17 +29,12 @@ var (
 // netlinkLinkByIndex is a variable that can be mocked in tests
 var netlinkLinkByIndex = netlink.LinkByIndex
 
-// netlinkLinkAdd, netlinkLinkSetUp and netlinkLinkDel are variables that can be mocked in tests.
-var (
-	netlinkLinkAdd   func(link netlink.Link) error = netlink.LinkAdd
-	netlinkLinkSetUp func(link netlink.Link) error = netlink.LinkSetUp
-	netlinkLinkDel   func(link netlink.Link) error = netlink.LinkDel
-)
-
 type MacvlanManager struct {
 	logger            *slog.Logger
 	config            *v2alpha1.MacvlanDeviceManagerConfig
 	netlinkLinkLister func() ([]netlink.Link, error)
+	netlinkLinkAdd    func(link netlink.Link) error
+	netlinkLinkDel    func(link netlink.Link) error
 }
 
 func (m *MacvlanManager) init() error {
@@ -56,6 +50,8 @@ func NewManager(logger *slog.Logger, cfg *v2alpha1.MacvlanDeviceManagerConfig, o
 		logger:            logger,
 		config:            cfg,
 		netlinkLinkLister: safenetlink.LinkList,
+		netlinkLinkAdd:    netlink.LinkAdd,
+		netlinkLinkDel:    netlink.LinkDel,
 	}
 
 	for _, opt := range opts {
@@ -80,11 +76,6 @@ func (mgr *MacvlanManager) ListDevices() ([]types.Device, error) {
 
 	for _, link := range links {
 		if link.Type() != "macvlan" {
-			continue
-		}
-
-		// Skip down interfaces
-		if link.Attrs().Flags&net.FlagUp == 0 {
 			continue
 		}
 
@@ -221,7 +212,7 @@ func (mgr *MacvlanManager) setupMacvlans(ifaces []v2alpha1.MacvlanDeviceConfig) 
 
 	cleanup := func() {
 		for _, mv := range created {
-			if err := netlinkLinkDel(mv); err != nil {
+			if err := mgr.netlinkLinkDel(mv); err != nil {
 				mgr.logger.Warn(
 					"failed to delete macvlan sub-interface during cleanup",
 					logfields.Interface, mv.Attrs().Name,
@@ -287,7 +278,7 @@ func (mgr *MacvlanManager) setupMacvlans(ifaces []v2alpha1.MacvlanDeviceConfig) 
 				Mode: mode,
 			}
 
-			if err := netlinkLinkAdd(macvlan); err != nil {
+			if err := mgr.netlinkLinkAdd(macvlan); err != nil {
 				errs = errors.Join(errs, fmt.Errorf(
 					"failed to create macvlan sub-interface %s: %w",
 					subIfName, err,
@@ -298,15 +289,6 @@ func (mgr *MacvlanManager) setupMacvlans(ifaces []v2alpha1.MacvlanDeviceConfig) 
 
 			// Track the newly created interface for potential cleanup.
 			created = append(created, macvlan)
-
-			if err := netlinkLinkSetUp(macvlan); err != nil {
-				errs = errors.Join(errs, fmt.Errorf(
-					"failed to bring up macvlan sub-interface %s: %w",
-					subIfName, err,
-				))
-
-				continue
-			}
 
 			mgr.logger.Info(
 				"created macvlan sub-interface",

--- a/pkg/networkdriver/macvlan/macvlan_test.go
+++ b/pkg/networkdriver/macvlan/macvlan_test.go
@@ -146,7 +146,7 @@ func TestMacvlanManager_ListDevices(t *testing.T) {
 				Name:        "eth0.0",
 				Index:       10,
 				ParentIndex: 2,
-				Flags:       1, // UP
+				Flags:       1,
 				MTU:         1500,
 			},
 			Mode: netlink.MACVLAN_MODE_BRIDGE,
@@ -156,18 +156,17 @@ func TestMacvlanManager_ListDevices(t *testing.T) {
 				Name:        "eth0.1",
 				Index:       11,
 				ParentIndex: 2,
-				Flags:       1, // UP
+				Flags:       1,
 				MTU:         1500,
 			},
 			Mode: netlink.MACVLAN_MODE_BRIDGE,
 		},
-		// This one should be filtered out (down)
 		&netlink.Macvlan{
 			LinkAttrs: netlink.LinkAttrs{
 				Name:        "eth0.2",
 				Index:       12,
 				ParentIndex: 2,
-				Flags:       0, // DOWN
+				Flags:       0,
 				MTU:         1500,
 			},
 			Mode: netlink.MACVLAN_MODE_BRIDGE,
@@ -198,7 +197,7 @@ func TestMacvlanManager_ListDevices(t *testing.T) {
 
 	devices, err := mgr.ListDevices()
 	require.NoError(t, err)
-	require.Len(t, devices, 2) // Only 2 up macvlan devices
+	require.Len(t, devices, 3)
 
 	// Verify device names (dots replaced with dashes)
 	names := make([]string, len(devices))
@@ -209,31 +208,29 @@ func TestMacvlanManager_ListDevices(t *testing.T) {
 	}
 	require.Contains(t, names, "eth0-0")
 	require.Contains(t, names, "eth0-1")
-	require.NotContains(t, names, "eth0-2") // Down interface should be filtered
+	require.Contains(t, names, "eth0-2")
 
 	// Kernel names should preserve the dot notation
 	require.Contains(t, kernelNames, "eth0.0")
 	require.Contains(t, kernelNames, "eth0.1")
+	require.Contains(t, kernelNames, "eth0.2")
 }
 
-// mockNetlinkOps records calls to LinkAdd, LinkSetUp and LinkDel so tests can
+// mockNetlinkOps records calls to LinkAdd and LinkDel so tests can
 // assert the exact sequence of operations performed by setupMacvlans.
 type mockNetlinkOps struct {
 	added   []string
-	setUp   []string
 	deleted []string
 
 	// Injected errors – keyed by interface name.  A nil value means success.
-	addErrors   map[string]error
-	setUpErrors map[string]error
-	delErrors   map[string]error
+	addErrors map[string]error
+	delErrors map[string]error
 }
 
 func newMockNetlinkOps() *mockNetlinkOps {
 	return &mockNetlinkOps{
-		addErrors:   make(map[string]error),
-		setUpErrors: make(map[string]error),
-		delErrors:   make(map[string]error),
+		addErrors: make(map[string]error),
+		delErrors: make(map[string]error),
 	}
 }
 
@@ -243,34 +240,16 @@ func (m *mockNetlinkOps) LinkAdd(link netlink.Link) error {
 	return m.addErrors[name]
 }
 
-func (m *mockNetlinkOps) LinkSetUp(link netlink.Link) error {
-	name := link.Attrs().Name
-	m.setUp = append(m.setUp, name)
-	return m.setUpErrors[name]
-}
-
 func (m *mockNetlinkOps) LinkDel(link netlink.Link) error {
 	name := link.Attrs().Name
 	m.deleted = append(m.deleted, name)
 	return m.delErrors[name]
 }
 
-// installMockNetlinkOps replaces the package-level netlink function vars with
-// the mock and returns a restore function to be deferred by the caller.
-func installMockNetlinkOps(m *mockNetlinkOps) func() {
-	origAdd := netlinkLinkAdd
-	origSetUp := netlinkLinkSetUp
-	origDel := netlinkLinkDel
-
-	netlinkLinkAdd = m.LinkAdd
-	netlinkLinkSetUp = m.LinkSetUp
-	netlinkLinkDel = m.LinkDel
-
-	return func() {
-		netlinkLinkAdd = origAdd
-		netlinkLinkSetUp = origSetUp
-		netlinkLinkDel = origDel
-	}
+// installMockNetlinkOps wires the mock's LinkAdd/LinkDel into the manager.
+func installMockNetlinkOps(mgr *MacvlanManager, m *mockNetlinkOps) {
+	mgr.netlinkLinkAdd = m.LinkAdd
+	mgr.netlinkLinkDel = m.LinkDel
 }
 
 // parentLink returns a minimal Device link that acts as a parent interface.
@@ -292,26 +271,26 @@ func newTestManager(links []netlink.Link, ifaces []v2alpha1.MacvlanDeviceConfig)
 		netlinkLinkLister: func() ([]netlink.Link, error) {
 			return links, nil
 		},
+		netlinkLinkAdd: func(link netlink.Link) error { return nil },
+		netlinkLinkDel: func(link netlink.Link) error { return nil },
 	}
 }
 
 // TestSetupMacvlans_Success verifies that when everything succeeds, the right
-// interfaces are created and brought up and nothing is deleted.
+// interfaces are created and nothing is deleted.
 func TestSetupMacvlans_Success(t *testing.T) {
-	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
-
 	ifaces := []v2alpha1.MacvlanDeviceConfig{
 		{ParentIfName: "eth0", Mode: "bridge", Count: 3},
 	}
 
+	mock := newMockNetlinkOps()
 	mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(ifaces)
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"eth0.0", "eth0.1", "eth0.2"}, mock.added)
-	require.Equal(t, []string{"eth0.0", "eth0.1", "eth0.2"}, mock.setUp)
 	require.Empty(t, mock.deleted, "no cleanup expected on success")
 }
 
@@ -319,15 +298,13 @@ func TestSetupMacvlans_Success(t *testing.T) {
 // no-op and no kernel calls are made.
 func TestSetupMacvlans_NoInterfaces(t *testing.T) {
 	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
-
 	mgr := newTestManager(nil, nil)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(nil)
 	require.NoError(t, err)
 
 	require.Empty(t, mock.added)
-	require.Empty(t, mock.setUp)
 	require.Empty(t, mock.deleted)
 }
 
@@ -335,11 +312,9 @@ func TestSetupMacvlans_NoInterfaces(t *testing.T) {
 // created before a LinkAdd failure are deleted during cleanup, and that
 // interfaces created after the failure (the loop continues) are also cleaned up.
 func TestSetupMacvlans_CleanupOnLinkAddError(t *testing.T) {
-	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
-
 	// eth0.1 will fail to be created; eth0.0 was already added successfully,
 	// and eth0.2 will succeed after the continue.
+	mock := newMockNetlinkOps()
 	mock.addErrors["eth0.1"] = errors.New("kernel error")
 
 	ifaces := []v2alpha1.MacvlanDeviceConfig{
@@ -347,6 +322,7 @@ func TestSetupMacvlans_CleanupOnLinkAddError(t *testing.T) {
 	}
 
 	mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(ifaces)
 	require.Error(t, err)
@@ -360,40 +336,11 @@ func TestSetupMacvlans_CleanupOnLinkAddError(t *testing.T) {
 	require.Equal(t, []string{"eth0.0", "eth0.2"}, mock.deleted)
 }
 
-// TestSetupMacvlans_CleanupOnLinkSetUpError verifies that an interface whose
-// LinkAdd succeeded but LinkSetUp failed is still included in the cleanup.
-func TestSetupMacvlans_CleanupOnLinkSetUpError(t *testing.T) {
-	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
-
-	// eth0.1 is created successfully but fails to come up.
-	mock.setUpErrors["eth0.1"] = errors.New("link set up failed")
-
-	ifaces := []v2alpha1.MacvlanDeviceConfig{
-		{ParentIfName: "eth0", Mode: "bridge", Count: 3},
-	}
-
-	mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
-
-	err := mgr.setupMacvlans(ifaces)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "eth0.1")
-
-	// All three LinkAdd calls are expected.
-	require.Equal(t, []string{"eth0.0", "eth0.1", "eth0.2"}, mock.added)
-
-	// All three were tracked in `created` (LinkAdd succeeded for all), so
-	// cleanup must delete all three.
-	require.Equal(t, []string{"eth0.0", "eth0.1", "eth0.2"}, mock.deleted)
-}
-
 // TestSetupMacvlans_CleanupAcrossMultipleParents verifies that interfaces
 // created under a first parent are cleaned up when a later parent fails.
 func TestSetupMacvlans_CleanupAcrossMultipleParents(t *testing.T) {
-	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
-
 	// eth1.0 will fail to be added.
+	mock := newMockNetlinkOps()
 	mock.addErrors["eth1.0"] = errors.New("kernel error")
 
 	ifaces := []v2alpha1.MacvlanDeviceConfig{
@@ -407,6 +354,7 @@ func TestSetupMacvlans_CleanupAcrossMultipleParents(t *testing.T) {
 	}
 
 	mgr := newTestManager(links, ifaces)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(ifaces)
 	require.Error(t, err)
@@ -422,7 +370,6 @@ func TestSetupMacvlans_CleanupAcrossMultipleParents(t *testing.T) {
 // interface is an error and that previously created interfaces are cleaned up.
 func TestSetupMacvlans_CleanupOnMissingParent(t *testing.T) {
 	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
 
 	ifaces := []v2alpha1.MacvlanDeviceConfig{
 		{ParentIfName: "eth0", Mode: "bridge", Count: 2},
@@ -434,6 +381,7 @@ func TestSetupMacvlans_CleanupOnMissingParent(t *testing.T) {
 	links := []netlink.Link{parentLink("eth0", 1)}
 
 	mgr := newTestManager(links, ifaces)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(ifaces)
 	require.Error(t, err)
@@ -448,7 +396,6 @@ func TestSetupMacvlans_CleanupOnMissingParent(t *testing.T) {
 // already present in the link map are skipped and not re-created.
 func TestSetupMacvlans_SkipsExistingInterfaces(t *testing.T) {
 	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
 
 	// eth0.0 already exists in the kernel.
 	existingMacvlan := &netlink.Macvlan{
@@ -463,13 +410,13 @@ func TestSetupMacvlans_SkipsExistingInterfaces(t *testing.T) {
 	links := []netlink.Link{parentLink("eth0", 1), existingMacvlan}
 
 	mgr := newTestManager(links, ifaces)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(ifaces)
 	require.NoError(t, err)
 
 	// Only eth0.1 should have been created (eth0.0 was skipped).
 	require.Equal(t, []string{"eth0.1"}, mock.added)
-	require.Equal(t, []string{"eth0.1"}, mock.setUp)
 	require.Empty(t, mock.deleted)
 }
 
@@ -477,7 +424,6 @@ func TestSetupMacvlans_SkipsExistingInterfaces(t *testing.T) {
 // the cleanup (LinkDel) does not mask the original error returned to the caller.
 func TestSetupMacvlans_CleanupDelErrorsAreLogged(t *testing.T) {
 	mock := newMockNetlinkOps()
-	defer installMockNetlinkOps(mock)()
 
 	linkAddErr := errors.New("kernel add error")
 	linkDelErr := errors.New("kernel del error")
@@ -490,6 +436,7 @@ func TestSetupMacvlans_CleanupDelErrorsAreLogged(t *testing.T) {
 	}
 
 	mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
+	installMockNetlinkOps(mgr, mock)
 
 	err := mgr.setupMacvlans(ifaces)
 

--- a/pkg/networkdriver/prepare_test.go
+++ b/pkg/networkdriver/prepare_test.go
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package networkdriver
+
+// Tests for prepareResourceClaim covering:
+//
+//   - driver.allocations is written only after UpdateStatus
+//     succeeds; if UpdateStatus fails the map stays empty.
+//     this avoids keeping a local map entry that does not have a
+//     persistent reference in kubernetes
+//
+//   - when any step inside the device loop fails, rollback
+//     calls Device.Free() and releaseAddrs() for every previously set-up device.
+//     this avoids leftover state that can end up untracked
+//
+// Tests build a *Driver directly (no hive) using a fake Kubernetes client and
+// instrumented device stubs so they run without a real cluster or kernel
+// privileges.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/dynamic-resource-allocation/kubeletplugin"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/networkdriver/types"
+)
+
+// ---------------------------------------------------------------------------
+// Instrumented device stub
+// ---------------------------------------------------------------------------
+
+// trackedDevice is a minimal types.Device implementation that records calls
+// to Setup and Free and can be configured to return errors on either.
+type trackedDevice struct {
+	name       string
+	setupErr   error
+	freeErr    error
+	setupCalls atomic.Int32
+	freeCalls  atomic.Int32
+}
+
+func (d *trackedDevice) IfName() string       { return d.name }
+func (d *trackedDevice) KernelIfName() string { return d.name }
+
+func (d *trackedDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
+	return nil
+}
+
+func (d *trackedDevice) Setup(_ types.DeviceConfig) error {
+	d.setupCalls.Add(1)
+	return d.setupErr
+}
+
+func (d *trackedDevice) Free(_ types.DeviceConfig) error {
+	d.freeCalls.Add(1)
+	return d.freeErr
+}
+
+func (d *trackedDevice) Match(_ v2alpha1.CiliumNetworkDriverDeviceFilter) bool { return true }
+
+func (d *trackedDevice) MarshalBinary() ([]byte, error) {
+	return json.Marshal(map[string]string{"name": d.name})
+}
+
+func (d *trackedDevice) UnmarshalBinary(data []byte) error {
+	m := map[string]string{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+	d.name = m["name"]
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Constants shared by all tests
+// ---------------------------------------------------------------------------
+
+const (
+	prepTestDriverName = "test.cilium.k8s.io"
+	prepTestPool       = "test-pool"
+	prepTestRequest    = "req-0"
+	prepTestClaimNS    = "default"
+	prepTestClaimName  = "test-claim"
+	prepTestClaimUID   = kubetypes.UID("aaaaaaaa-0000-0000-0000-000000000001")
+	prepTestPodUID     = kubetypes.UID("bbbbbbbb-0000-0000-0000-000000000002")
+	prepTestDev0       = "dev-0"
+	prepTestDev1       = "dev-1"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+// buildPrepClaim returns a ResourceClaim whose Results request the given
+// device names. Static IPv4/IPv6 addresses are embedded in the opaque config
+// so no IPAM pool manager is needed.
+func buildPrepClaim(devices ...string) *resourceapi.ResourceClaim {
+	rawParam, _ := json.Marshal(map[string]string{
+		"ipv4Addr": "10.1.0.1/32",
+		"ipv6Addr": "fd00::1/128",
+	})
+
+	results := make([]resourceapi.DeviceRequestAllocationResult, 0, len(devices))
+	for _, d := range devices {
+		results = append(results, resourceapi.DeviceRequestAllocationResult{
+			Device:  d,
+			Driver:  prepTestDriverName,
+			Pool:    prepTestPool,
+			Request: prepTestRequest,
+		})
+	}
+
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            prepTestClaimName,
+			Namespace:       prepTestClaimNS,
+			UID:             prepTestClaimUID,
+			ResourceVersion: "1",
+		},
+		Status: resourceapi.ResourceClaimStatus{
+			Allocation: &resourceapi.AllocationResult{
+				Devices: resourceapi.DeviceAllocationResult{
+					Config: []resourceapi.DeviceAllocationConfiguration{
+						{
+							Source:   resourceapi.AllocationConfigSourceClaim,
+							Requests: []string{prepTestRequest},
+							DeviceConfiguration: resourceapi.DeviceConfiguration{
+								Opaque: &resourceapi.OpaqueDeviceConfiguration{
+									Driver:     prepTestDriverName,
+									Parameters: runtime.RawExtension{Raw: rawParam},
+								},
+							},
+						},
+					},
+					Results: results,
+				},
+			},
+			ReservedFor: []resourceapi.ResourceClaimConsumerReference{
+				{Resource: "pods", Name: "test-pod", UID: prepTestPodUID},
+			},
+		},
+	}
+}
+
+// buildPrepDriver builds a *Driver with a fake kube client and the given
+// devices pre-populated in driver.devices. No IPAM pool manager is wired
+// because all test claims use static IP addresses (releaseAddrs is a no-op
+// when IPPool == "").
+func buildPrepDriver(t *testing.T, cs *k8sClient.FakeClientset, devs ...*trackedDevice) *Driver {
+	t.Helper()
+
+	deviceList := make([]types.Device, 0, len(devs))
+	for _, d := range devs {
+		deviceList = append(deviceList, d)
+	}
+
+	return &Driver{
+		logger:     hivetest.Logger(t),
+		kubeClient: cs,
+		config: &v2alpha1.CiliumNetworkDriverNodeConfigSpec{
+			DriverName: prepTestDriverName,
+		},
+		devices: map[types.DeviceManagerType][]types.Device{
+			types.DeviceManagerTypeDummy: deviceList,
+		},
+		allocations: make(map[kubetypes.UID]map[kubetypes.UID][]allocation),
+		// ipv4Enabled/ipv6Enabled left false so releaseAddrs is always a no-op.
+	}
+}
+
+// createPrepClaim pre-creates the claim in the fake API server and updates
+// the ResourceVersion on the local object so subsequent UpdateStatus works.
+func createPrepClaim(t *testing.T, cs *k8sClient.FakeClientset, claim *resourceapi.ResourceClaim) {
+	t.Helper()
+	updated, err := cs.KubernetesFakeClientset.ResourceV1().
+		ResourceClaims(claim.Namespace).Create(context.Background(), claim, metav1.CreateOptions{})
+	require.NoError(t, err)
+	claim.ResourceVersion = updated.ResourceVersion
+}
+
+// namedObject is a small helper to build a kubeletplugin.NamespacedObject.
+func namedObject(ns, name string, uid kubetypes.UID) kubeletplugin.NamespacedObject {
+	return kubeletplugin.NamespacedObject{
+		NamespacedName: kubetypes.NamespacedName{Namespace: ns, Name: name},
+		UID:            uid,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests — happy path
+// ---------------------------------------------------------------------------
+
+// TestPrepare_Success verifies the happy path: device is set up, Kubernetes
+// status is updated, and the allocation is committed to memory.
+func TestPrepare_Success(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+	claim := buildPrepClaim(prepTestDev0)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.NoError(t, result.Err)
+
+	assert.EqualValues(t, 1, dev.setupCalls.Load(), "Setup must be called once")
+	assert.EqualValues(t, 0, dev.freeCalls.Load(), "Free must not be called on success")
+
+	require.Contains(t, driver.allocations, prepTestPodUID)
+	require.Contains(t, driver.allocations[prepTestPodUID], prepTestClaimUID)
+	assert.Len(t, driver.allocations[prepTestPodUID][prepTestClaimUID], 1)
+
+	updated, err := cs.KubernetesFakeClientset.ResourceV1().
+		ResourceClaims(prepTestClaimNS).Get(t.Context(), prepTestClaimName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Len(t, updated.Status.Devices, 1)
+	assert.Equal(t, prepTestDev0, updated.Status.Devices[0].Device)
+}
+
+// TestPrepare_TwoDevices_BothSucceed verifies that two devices in one claim
+// both get set up and both appear in the allocation map.
+func TestPrepare_TwoDevices_BothSucceed(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	dev0 := &trackedDevice{name: prepTestDev0}
+	dev1 := &trackedDevice{name: prepTestDev1}
+
+	claim := buildPrepClaim(prepTestDev0, prepTestDev1)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev0, dev1)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.NoError(t, result.Err)
+
+	assert.EqualValues(t, 1, dev0.setupCalls.Load())
+	assert.EqualValues(t, 1, dev1.setupCalls.Load())
+	assert.EqualValues(t, 0, dev0.freeCalls.Load())
+	assert.EqualValues(t, 0, dev1.freeCalls.Load())
+
+	require.Contains(t, driver.allocations, prepTestPodUID)
+	assert.Len(t, driver.allocations[prepTestPodUID][prepTestClaimUID], 2)
+
+	updated, err := cs.KubernetesFakeClientset.ResourceV1().
+		ResourceClaims(prepTestClaimNS).Get(t.Context(), prepTestClaimName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Len(t, updated.Status.Devices, 2)
+}
+
+// TestPrepare_UpdateStatusFails_RollbackCalled verifies that roll back
+// is also triggered by an UpdateStatus failure: Setup was called, so Free
+// must be called to roll back the device.
+func TestPrepare_UpdateStatusFails_RollbackCalled(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+
+	// Claim not in API → UpdateStatus fails.
+	claim := buildPrepClaim(prepTestDev0)
+
+	driver := buildPrepDriver(t, cs, dev)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+
+	assert.EqualValues(t, 1, dev.setupCalls.Load(), "Setup should have been attempted")
+	assert.EqualValues(t, 1, dev.freeCalls.Load(),
+		"Free must be called to roll back when UpdateStatus fails")
+}
+
+// TestPrepare_SecondSetupFails_FirstRolledBack verifies that
+// when the second device's Setup fails, the first (already set up) device
+// must be freed.
+func TestPrepare_SecondSetupFails_FirstRolledBack(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	dev0 := &trackedDevice{name: prepTestDev0}
+	dev1 := &trackedDevice{name: prepTestDev1, setupErr: errors.New("setup exploded")}
+
+	claim := buildPrepClaim(prepTestDev0, prepTestDev1)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev0, dev1)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+	assert.Contains(t, result.Err.Error(), "setup exploded")
+
+	// dev0 succeeded → must be freed by rollback.
+	assert.EqualValues(t, 1, dev0.setupCalls.Load())
+	assert.EqualValues(t, 1, dev0.freeCalls.Load(),
+		"dev0 must be freed after dev1 Setup fails")
+
+	// dev1 failed → Setup returned error, so Free must NOT be called for it.
+	assert.EqualValues(t, 1, dev1.setupCalls.Load())
+	assert.EqualValues(t, 0, dev1.freeCalls.Load(),
+		"dev1 Free must not be called because its Setup failed")
+
+	assert.Empty(t, driver.allocations)
+}
+
+// TestPrepare_DeviceNotFound_PreviousRolledBack verifies that
+// when a requested device is not found in driver.devices, all previously
+// set-up devices must be freed.
+func TestPrepare_DeviceNotFound_PreviousRolledBack(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	dev0 := &trackedDevice{name: prepTestDev0}
+	// prepTestDev1 is referenced in the claim but NOT registered in the driver.
+
+	claim := buildPrepClaim(prepTestDev0, prepTestDev1)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev0) // only dev0 registered
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+	assert.ErrorIs(t, result.Err, errDeviceNotFound)
+
+	// dev0 was set up before the not-found error → must be freed.
+	assert.EqualValues(t, 1, dev0.setupCalls.Load())
+	assert.EqualValues(t, 1, dev0.freeCalls.Load(),
+		"dev0 must be freed when a later device is not found")
+
+	assert.Empty(t, driver.allocations)
+}
+
+// TestPrepare_FirstSetupFails_NoRollbackNeeded verifies that when the very
+// first device's Setup fails, rollback doesn't panic and no Free is called
+// (nothing was successfully set up).
+func TestPrepare_FirstSetupFails_NoRollbackNeeded(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	dev0 := &trackedDevice{name: prepTestDev0, setupErr: errors.New("first device broken")}
+
+	claim := buildPrepClaim(prepTestDev0)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev0)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+
+	assert.EqualValues(t, 1, dev0.setupCalls.Load())
+	assert.EqualValues(t, 0, dev0.freeCalls.Load(),
+		"Free must not be called for the device whose own Setup failed")
+	assert.Empty(t, driver.allocations)
+}
+
+// TestPrepare_RollbackFreeError_OriginalErrReturned verifies that a Free
+// error during rollback does not shadow the original error that triggered it.
+func TestPrepare_RollbackFreeError_OriginalErrReturned(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	setupKaboom := errors.New("setup kaboom")
+	dev0 := &trackedDevice{name: prepTestDev0, freeErr: errors.New("free also failed")}
+	dev1 := &trackedDevice{name: prepTestDev1, setupErr: setupKaboom}
+
+	claim := buildPrepClaim(prepTestDev0, prepTestDev1)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev0, dev1)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+
+	// The original setup error is what the caller must see.
+	assert.Contains(t, result.Err.Error(), "setup kaboom",
+		"original error must propagate even when Free also fails")
+
+	// Free was still attempted on dev0 despite returning an error itself.
+	assert.EqualValues(t, 1, dev0.freeCalls.Load(),
+		"Free must be attempted even when it will fail")
+
+	assert.Empty(t, driver.allocations)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — early rejection paths
+// ---------------------------------------------------------------------------
+
+// TestPrepare_DuplicatePodUID_Rejected verifies that a second
+// PrepareResourceClaims call for the same pod UID is rejected without calling
+// Setup again.
+func TestPrepare_DuplicatePodUID_Rejected(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+	claim := buildPrepClaim(prepTestDev0)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev)
+
+	// First call succeeds.
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.NoError(t, result.Err)
+
+	// Second call with the same pod UID must be rejected.
+	result2 := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result2.Err)
+	assert.ErrorIs(t, result2.Err, errAllocationAlreadyExistsForPod)
+
+	// Setup must only have been called once (by the first call).
+	assert.EqualValues(t, 1, dev.setupCalls.Load())
+}
+
+// TestPrepare_InvalidPodIfName_NoSetup verifies that podIfName validation
+// happens before any Setup call.
+func TestPrepare_InvalidPodIfName_NoSetup(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+
+	rawParam, _ := json.Marshal(map[string]string{
+		"ipv4Addr":  "10.1.0.1/32",
+		"ipv6Addr":  "fd00::1/128",
+		"podIfName": "this-name-is-way-too-long-for-linux",
+	})
+	claim := buildPrepClaim(prepTestDev0)
+	claim.Status.Allocation.Devices.Config[0].Opaque.Parameters = runtime.RawExtension{Raw: rawParam}
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+
+	assert.EqualValues(t, 0, dev.setupCalls.Load(),
+		"Setup must not be called when podIfName validation fails")
+	assert.Empty(t, driver.allocations)
+}
+
+// TestPrepare_WrongReservedForLength_Rejected verifies early rejection when
+// ReservedFor has more than one entry.
+func TestPrepare_WrongReservedForLength_Rejected(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+
+	claim := buildPrepClaim(prepTestDev0)
+	claim.Status.ReservedFor = append(claim.Status.ReservedFor,
+		resourceapi.ResourceClaimConsumerReference{Resource: "pods", Name: "other", UID: "cccc"})
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+	assert.ErrorIs(t, result.Err, errUnexpectedInput)
+	assert.EqualValues(t, 0, dev.setupCalls.Load())
+	assert.Empty(t, driver.allocations)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — UnprepareResourceClaims
+// ---------------------------------------------------------------------------
+
+// TestUnprepare_RemovesAllocationAndCallsFree verifies that
+// UnprepareResourceClaims removes the pod entry from the allocations map and
+// calls Free on the device.
+func TestUnprepare_RemovesAllocationAndCallsFree(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+	claim := buildPrepClaim(prepTestDev0)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev)
+
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.NoError(t, result.Err)
+	require.Contains(t, driver.allocations, prepTestPodUID)
+
+	releaseResults, err := driver.UnprepareResourceClaims(t.Context(),
+		[]kubeletplugin.NamespacedObject{namedObject(prepTestClaimNS, prepTestClaimName, prepTestClaimUID)})
+	require.NoError(t, err)
+	require.Contains(t, releaseResults, prepTestClaimUID)
+	assert.NoError(t, releaseResults[prepTestClaimUID])
+
+	assert.Empty(t, driver.allocations,
+		"allocations map must be empty after unprepare")
+	assert.EqualValues(t, 1, dev.freeCalls.Load(), "Free must be called once on unprepare")
+}
+
+// TestUnprepare_MultipleDevices_AllFreed verifies that every device in a
+// multi-device claim is freed on unprepare.
+func TestUnprepare_MultipleDevices_AllFreed(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev0 := &trackedDevice{name: prepTestDev0}
+	dev1 := &trackedDevice{name: prepTestDev1}
+
+	claim := buildPrepClaim(prepTestDev0, prepTestDev1)
+	createPrepClaim(t, cs, claim)
+
+	driver := buildPrepDriver(t, cs, dev0, dev1)
+
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.NoError(t, result.Err)
+
+	_, err := driver.UnprepareResourceClaims(t.Context(),
+		[]kubeletplugin.NamespacedObject{namedObject(prepTestClaimNS, prepTestClaimName, prepTestClaimUID)})
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, dev0.freeCalls.Load(), "dev0 must be freed")
+	assert.EqualValues(t, 1, dev1.freeCalls.Load(), "dev1 must be freed")
+	assert.Empty(t, driver.allocations)
+}
+
+// TestUnprepare_UnknownClaim_NoError verifies that unpreparing an unknown
+// claim returns no error (it may simply not belong to this driver instance).
+func TestUnprepare_UnknownClaim_NoError(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	driver := buildPrepDriver(t, cs)
+
+	releaseResults, err := driver.UnprepareResourceClaims(t.Context(),
+		[]kubeletplugin.NamespacedObject{namedObject(prepTestClaimNS, "nonexistent", "zzzz")})
+	require.NoError(t, err)
+	assert.NoError(t, releaseResults["zzzz"])
+}

--- a/pkg/networkdriver/prepare_test.go
+++ b/pkg/networkdriver/prepare_test.go
@@ -261,6 +261,26 @@ func TestPrepare_TwoDevices_BothSucceed(t *testing.T) {
 	assert.Len(t, updated.Status.Devices, 2)
 }
 
+// TestPrepare_UpdateStatusFails_MapEmpty verifies that
+// when UpdateStatus returns an error the allocations map must stay empty.
+func TestPrepare_UpdateStatusFails_MapEmpty(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+
+	// Claim is NOT created in the API server → UpdateStatus will fail with
+	// "not found".
+	claim := buildPrepClaim(prepTestDev0)
+
+	driver := buildPrepDriver(t, cs, dev)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err, "UpdateStatus should fail because claim was not pre-created")
+
+	// no partial entry must be left in the map.
+	assert.Empty(t, driver.allocations,
+		"allocations map must be empty when UpdateStatus fails")
+}
+
 // TestPrepare_UpdateStatusFails_RollbackCalled verifies that roll back
 // is also triggered by an UpdateStatus failure: Setup was called, so Free
 // must be called to roll back the device.
@@ -279,6 +299,30 @@ func TestPrepare_UpdateStatusFails_RollbackCalled(t *testing.T) {
 	assert.EqualValues(t, 1, dev.setupCalls.Load(), "Setup should have been attempted")
 	assert.EqualValues(t, 1, dev.freeCalls.Load(),
 		"Free must be called to roll back when UpdateStatus fails")
+}
+
+// TestPrepare_UpdateStatusFails_TwoDevices_BothRolledBack verifies that
+// the logic works correctly when two devices were set up before
+// UpdateStatus fails.
+func TestPrepare_UpdateStatusFails_TwoDevices_BothRolledBack(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+
+	dev0 := &trackedDevice{name: prepTestDev0}
+	dev1 := &trackedDevice{name: prepTestDev1}
+
+	// Claim not in API → UpdateStatus fails after both devices are set up.
+	claim := buildPrepClaim(prepTestDev0, prepTestDev1)
+
+	driver := buildPrepDriver(t, cs, dev0, dev1)
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+
+	assert.EqualValues(t, 1, dev0.setupCalls.Load())
+	assert.EqualValues(t, 1, dev1.setupCalls.Load())
+	assert.EqualValues(t, 1, dev0.freeCalls.Load(), "dev0 must be rolled back")
+	assert.EqualValues(t, 1, dev1.freeCalls.Load(), "dev1 must be rolled back")
+	assert.Empty(t, driver.allocations)
 }
 
 // TestPrepare_SecondSetupFails_FirstRolledBack verifies that
@@ -530,4 +574,36 @@ func TestUnprepare_UnknownClaim_NoError(t *testing.T) {
 		[]kubeletplugin.NamespacedObject{namedObject(prepTestClaimNS, "nonexistent", "zzzz")})
 	require.NoError(t, err)
 	assert.NoError(t, releaseResults["zzzz"])
+}
+
+// TestUnprepare_PrepareRollbackThenPrepareAgain verifies that
+// after a failed prepare (UpdateStatus error), a second prepare
+// attempt for the same pod can succeed once the claim exists in the API.
+func TestUnprepare_PrepareRollbackThenPrepareAgain(t *testing.T) {
+	tlog := hivetest.Logger(t)
+	cs, _ := k8sClient.NewFakeClientset(tlog)
+	dev := &trackedDevice{name: prepTestDev0}
+	claim := buildPrepClaim(prepTestDev0)
+
+	driver := buildPrepDriver(t, cs, dev)
+
+	// First attempt: claim not in API → UpdateStatus fails → rollback.
+	result := driver.prepareResourceClaim(t.Context(), claim)
+	require.Error(t, result.Err)
+	assert.Empty(t, driver.allocations, "map must be clean after failed prepare")
+
+	// Now create the claim in the API.
+	createPrepClaim(t, cs, claim)
+
+	// Second attempt: should succeed because the map is clean
+	// (no "allocation already exists" guard fires).
+	result2 := driver.prepareResourceClaim(t.Context(), claim)
+	require.NoError(t, result2.Err, "second prepare must succeed after rollback cleaned up")
+
+	require.Contains(t, driver.allocations, prepTestPodUID)
+	assert.Len(t, driver.allocations[prepTestPodUID][prepTestClaimUID], 1)
+
+	// Setup called twice (once per attempt), Free called once (rollback of first attempt).
+	assert.EqualValues(t, 2, dev.setupCalls.Load())
+	assert.EqualValues(t, 1, dev.freeCalls.Load())
 }


### PR DESCRIPTION
fixing two main issues:

1- the in memory allocation entry was written before UpdateStatus in the kube resource claim is written. if UpdateStatus fails for whatever reason, there would be a drift in state between kube api and agent.

fix: write the map after UpdateStatus succeeds

2- if any step in the device loop failed, devices
that were set up previously in the same loop would leak: their kernel state would be left configured but ips not released from ipam.

fix: introduce a rollback-on-error logic that frees devices and releases ips for any previously
configured devices in the loop.

four minor issues:

1- double release call for ipv6 error path.
2- ignore macvlan state on device discovery
3- fix writing empty addresses into the status field
4- restore allocation from claim status even if the ip pool isnt set

added unit tests

```release-note
network driver: fix allocation lifecycle and add rollback on prepare failure
```
