### PR TITLE
Fix bgp manager check active backend state, fixes #45276

### DIFF
--- a/pkg/bgp/manager/reconciler/service.go
+++ b/pkg/bgp/manager/reconciler/service.go
@@ -367,13 +367,16 @@ func (r *ServiceReconciler) modifiedServiceAdvertisements(metadata *ServiceRecon
 }
 
 // hasBackends loops through Frontend backends and returns:
-// 1) true, false - backends > 0, no local backend
-// 2) true, true - backends > 0, at least 1 local backend
-// 3) false, false - no backends, no local backend
+// 1) true, false - active backends > 0, no local backend
+// 2) true, true - active backends > 0, at least 1 local backend
+// 3) false, false - no active backends, no local backend
 func hasBackends(p ReconcileParams, fe *loadbalancer.Frontend) (hasBackends, hasLocalBackends bool) {
 	for backend := range fe.Backends {
+		if backend.State != loadbalancer.BackendStateActive {
+			continue
+		}
 		hasBackends = true
-		if backend.NodeName == p.CiliumNode.Name && backend.State == loadbalancer.BackendStateActive {
+		if backend.NodeName == p.CiliumNode.Name {
 			hasLocalBackends = true
 			return
 		}

--- a/pkg/bgp/test/testdata/svc-no-endpoints.txtar
+++ b/pkg/bgp/test/testdata/svc-no-endpoints.txtar
@@ -32,8 +32,8 @@ k8s/add endpoints.yaml
 gobgp/routes -o routes.actual
 * cmp gobgp-routes.expected routes.actual
 
-# Delete the service
-k8s/delete service.yaml
+# Update endpoints with terminating=true, ready=false
+k8s/update endpoints-terminating.yaml
 sleep 0.1s # give some time for the change to propagate to avoid false positive
 
 # Validate that LB IP is withdrawn
@@ -155,6 +155,28 @@ endpoints:
     ready: true
     serving: true
     terminating: false
+  nodeName: test-node
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpoints-terminating.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo1
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.20
+  conditions:
+    ready: false
+    serving: false
+    terminating: true
   nodeName: test-node
 ports:
 - name: http


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Checks for backend state == active when checking IP path for BGP announcements.

Fixes: #45276 

```release-note
Respect backends for BGP only when they are in state: active
```
