### PR TITLE
docs: Update sphinx theme to v3.1.0

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -65,7 +65,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:edfc28f47c6abfb017912a752f4e06274b126a28@sha256:98069787f6f4c375c31ab536558952daf24c1ca521fb05b283d870178bddfd61
+        uses: docker://quay.io/cilium/docs-builder:299b1b0619ca41010e1a3d930848cfbba6166df5@sha256:30b84cea76127ba89cf3aec9dc6cc2a7d81825e49957a59b648f8b26c414800b
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/community/community.rst
+++ b/Documentation/community/community.rst
@@ -40,9 +40,11 @@ This is a monthly community meeting held at APAC friendly time.
 Slack
 =====
 
-Our `Cilium & eBPF Slack <Cilium Slack_>`_ is the main discussion space for the
+Our `Cilium & eBPF Slack <Cilium Slack>`_ is the main discussion space for the
 Cilium community. Please be sure to follow and abide by the `Slack Guidelines
 <https://github.com/cilium/community/blob/main/slack-guidelines.md>`__
+
+.. _Cilium Slack: https://slack.cilium.io
 
 Slack channels
 --------------

--- a/Documentation/contributing/development/reviewers_committers/review_vendor.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_vendor.rst
@@ -56,7 +56,7 @@ Existing Dependencies
 ---------------------
 
 Updates to existing dependencies most commonly occur through PRs opened by
-`Renovate <renovate_>`_, which is a 3rd party service used throughout the
+`Renovate`_, which is a 3rd party service used throughout the
 Cilium organization. Renovate continually checks repositories for out-of-date
 dependencies and opens new PRs to update any it finds.
 
@@ -67,7 +67,7 @@ GitHub Action CI workflows, which are triggered by commenting ``/test`` within
 a PR. See :ref:`CI  / GitHub Actions <ci_gha>` for more information on their
 use.
 
-.. _renovate: https://docs.renovatebot.com
+.. _Renovate: https://docs.renovatebot.com
 
 New Dependencies
 ----------------
@@ -84,7 +84,7 @@ be assigned to ensure the new dependency meets the following criteria:
    releases within the past year.
 4. The new dependency must appear to be of generally good quality, having a
    strong user base, automated testing with high code coverage, and documentation.
-5. The new dependency must have a license which is allowed by the `CNCF <cncf_>`_,
+5. The new dependency must have a license which is allowed by the `CNCF`_,
    as either one of the `generally approved licenses <allowed_licenses_>`_ or one
    that is allowed via `exception <license_exceptions_>`_. An automated CI check
    is in place to help check this requirement, but may need updating as the list
@@ -94,7 +94,7 @@ be assigned to ensure the new dependency meets the following criteria:
 These criteria ensure the long-term success of the project by justifying the
 inclusion of the new dependency into the project's codebase.
 
-.. _cncf: https://www.cncf.io
+.. _CNCF: https://www.cncf.io
 .. _allowed_licenses: https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md
 .. _license_exceptions: https://github.com/cncf/foundation/tree/main/license-exceptions
 .. _licensecheck: https://github.com/cilium/cilium/blob/main/tools/licensecheck/allowed.go

--- a/Documentation/contributing/docs/docsframework.rst
+++ b/Documentation/contributing/docs/docsframework.rst
@@ -21,9 +21,10 @@ discrepancies, please update this page.
 Sphinx
 ======
 
-Cilium relies on `Sphinx`_ to generate its documentation.
+Cilium relies on the `Sphinx Documentation Framework`_ to generate its
+documentation.
 
-.. _Sphinx: https://www.sphinx-doc.org
+.. _Sphinx Documentation Framework: https://www.sphinx-doc.org
 
 Sphinx usage
 ------------

--- a/Documentation/requirements-min/requirements.txt
+++ b/Documentation/requirements-min/requirements.txt
@@ -1,14 +1,14 @@
-sphinx==7.1.2
+sphinx==9.0.4
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-git+https://github.com/cilium/sphinx_rtd_theme.git@cilium/rebase-2023-09#egg=sphinx-rtd-theme-cilium
+git+https://github.com/cilium/sphinx_rtd_theme.git@cilium/main#egg=sphinx-rtd-theme-cilium
 
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 
 # Sphinx extensions
-myst-parser==2.0.0
+myst-parser==5.0.0
 sphinx-tabs==3.5.0
 sphinx-version-warning==1.1.2
 sphinxcontrib-googleanalytics==0.5

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,13 +1,13 @@
 ## Auto-generated from requirements-min/requirements.txt with "make update-requirements"
-Sphinx==7.1.2
+Sphinx==9.0.4
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@77d60dbce4cc93358fa6156cbafd7c49214b3c89
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@98b0d4664556de6b5ab94e5abcff5d35246a7c46
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 # Sphinx extensions
-myst-parser==2.0.0
+myst-parser==5.0.0
 sphinx-tabs==3.5.0
 sphinx-version-warning==1.1.2
 sphinxcontrib-googleanalytics==0.5
@@ -19,24 +19,24 @@ sphinxext-rediraffe==0.3.0
 rstcheck==6.2.5
 yamllint==1.38.0
 ## The following requirements were added by pip freeze:
-alabaster==0.7.16
+alabaster==1.0.0
 annotated-doc==0.0.4
 annotated-types==0.7.0
-attrs==25.4.0
+attrs==26.1.0
 babel==2.18.0
 certifi==2026.2.25
-charset-normalizer==3.4.5
-click==8.3.1
+charset-normalizer==3.4.7
+click==8.3.2
 colorama==0.4.6
 deepmerge==2.0
-docutils==0.20.1
+docutils==0.22.4
 idna==3.11
 imagesize==2.0.0
 Jinja2==3.1.6
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 livereload==2.7.1
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
 MarkupSafe==3.0.3
 mdit-py-plugins==0.5.0
 mdurl==0.1.2
@@ -47,11 +47,12 @@ picobox==4.0.0
 pydantic==2.12.5
 pydantic_core==2.41.5
 pyenchant==3.3.0
-Pygments==2.19.2
+Pygments==2.20.0
 PyYAML==6.0.3
 referencing==0.37.0
-requests==2.32.5
+requests==2.33.1
 rich==14.3.3
+roman-numerals==4.1.0
 rpds-py==0.30.0
 rstcheck-core==1.2.2
 shellingham==1.5.4

--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ Getting Started
 ===============
 
 * `Why Cilium?`_
-* `Getting Started`_
+* `Getting Started <gs>`_
 * `Architecture and Concepts`_
 * `Installing Cilium`_
 * `Frequently Asked Questions`_
@@ -296,18 +296,18 @@ The BPF code templates are dual-licensed under the
 and the `2-Clause BSD License <bsd-license_>`__
 (you can use the terms of either license, at your option).
 
-.. _`Cilium Upgrade Guide`: https://docs.cilium.io/en/stable/operations/upgrade/
-.. _`Why Cilium?`: https://docs.cilium.io/en/stable/overview/intro
-.. _`Getting Started`: https://docs.cilium.io/en/stable/#getting-started
-.. _`Architecture and Concepts`: https://docs.cilium.io/en/stable/overview/component-overview/
-.. _`Installing Cilium`: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/
-.. _`Frequently Asked Questions`: https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Akind%2Fquestion+
+.. _Cilium Upgrade Guide: https://docs.cilium.io/en/stable/operations/upgrade/
+.. _Why Cilium?: https://docs.cilium.io/en/stable/overview/intro
+.. _gs: https://docs.cilium.io/en/stable/#getting-started
+.. _Architecture and Concepts: https://docs.cilium.io/en/stable/overview/component-overview/
+.. _Installing Cilium: https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/
+.. _Frequently Asked Questions: https://github.com/cilium/cilium/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Akind%2Fquestion+
 .. _Contributing: https://docs.cilium.io/en/stable/contributing/development/
 .. _Prerequisites: https://docs.cilium.io/en/stable/operations/system_requirements/
-.. _`eBPF`: https://ebpf.io
-.. _`eBPF.io`: https://ebpf.io
-.. _`Meeting Notes and Zoom Info`: https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#
-.. _`APAC Meeting Notes and Zoom Info`: https://docs.google.com/document/d/1egv4qLydr0geP-GjQexYKm4tz3_tHy-LCBjVQcXcT5M/edit#
+.. _eBPF: https://ebpf.io
+.. _eBPF.io: https://ebpf.io
+.. _Meeting Notes and Zoom Info: https://docs.google.com/document/d/1Y_4chDk4rznD6UgXPlPvn3Dc7l-ZutGajUv1eF0VDwQ/edit#
+.. _APAC Meeting Notes and Zoom Info: https://docs.google.com/document/d/1egv4qLydr0geP-GjQexYKm4tz3_tHy-LCBjVQcXcT5M/edit#
 
 .. |go-report| image:: https://goreportcard.com/badge/github.com/cilium/cilium
     :alt: Go Report Card


### PR DESCRIPTION
This theme is based on the upstream sphinx_rtd_theme 3.1.0, and it no
longer includes Algolia DocSearch plugin. This includes a few minor
visual improvements and also updates several of the dependencies to more
recent versions.

See https://github.com/cilium/sphinx_rtd_theme/pull/30 for full details of the update.

Fixes: https://github.com/cilium/cilium/issues/43578