### PR TITLE
Init: Add check for any CiliumNode IPAM errors on Daemon startup

### DIFF
--- a/pkg/node/sync/local_node_sync_wait.go
+++ b/pkg/node/sync/local_node_sync_wait.go
@@ -42,6 +42,14 @@ func (ini *localNodeSynchronizer) retrieveNodeInformation(ctx context.Context) *
 			if event.Kind == resource.Upsert {
 				no := nodeTypes.ParseCiliumNode(event.Object)
 				n = &no
+				if event.Object.Status.IPAM.OperatorStatus.Error != "" {
+					ini.Logger.Log(ctx, 18, "Cilium Operator set an IPAM error in this node's CiliumNode object. Please review and correct the CiliumNode object. Unable to continue.",
+						logfields.NodeName, n.Name,
+						logfields.Error, event.Object.Status.IPAM.OperatorStatus.Error,
+					)
+					event.Done(nil)
+					return nil
+				}
 				ini.Logger.Info("Retrieved node information from cilium node", logfields.NodeName, n.Name)
 				if err := waitForCIDR(); err != nil {
 					ini.Logger.Warn("Waiting for k8s node information", logfields.Error, err)


### PR DESCRIPTION
This commit adds a check during daemon startup to crash when Cilium is running in either "cluster-pool" or "multi-pool" IPAM modes and the CiliumNode object associated with the daemon contains an error set by the Cilium Operator.

This prevents a scenario in which Cilium could be misconfigured with a CIDR range that provides IP addresses to pods that collide with other IP addresses in the network.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->


```release-note
Init: Add check for any CiliumNode IPAM errors on Daemon startup
```
