### PR TITLE
gateway-api: Filter GAMMA Routes correctly

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -133,10 +133,13 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return controllerruntime.Fail(err)
 	}
 
+	httpRoutes := r.filterHTTPRoutesByService(ctx, originalSvc, httpRouteList.Items)
+	grpcRoutes := r.filterGRPCRoutesByService(ctx, originalSvc, grpcRouteList.Items)
+
 	// TODO(youngnick): GammaHTTPRoutes needs to be updated now that we have a source Service.
 	httpListeners := ingestion.GammaHTTPRoutes(r.logger, ingestion.GammaInput{
-		HTTPRoutes: httpRouteList.Items,
-		GRPCRoutes: grpcRouteList.Items,
+		HTTPRoutes: httpRoutes,
+		GRPCRoutes: grpcRoutes,
 		Services:   servicesList.Items,
 
 		ReferenceGrants: grants.Items,
@@ -166,7 +169,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
 	gammaLogger.DebugContext(ctx, "Updating HTTPRoute statuses for GAMMA Service", numRoutes, len(httpRoutes.Items))
-	for _, original := range httpRoutes.Items {
+	for httpRouteIndex, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
 
@@ -234,6 +237,8 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 				}
 			}
 
+			// Update the cached copy with the same status changes to prevent re-fetching from client cache.
+			httpRoutes.Items[httpRouteIndex].Status = hr.Status
 		}
 
 		if err := r.updateHTTPRouteStatus(ctx, &original, hr); err != nil {
@@ -244,9 +249,29 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 	return nil
 }
 
+func (r *gammaReconciler) filterHTTPRoutesByService(ctx context.Context, gammaService *corev1.Service, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+	var filtered []gatewayv1.HTTPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gammaReconciler) filterGRPCRoutesByService(ctx context.Context, gammaService *corev1.Service, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
+	var filtered []gatewayv1.GRPCRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
 func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, grpcRoutes *gatewayv1.GRPCRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
 	gammaLogger.DebugContext(ctx, "Updating GRPCRoute statuses for GAMMA Service", numRoutes, len(grpcRoutes.Items))
-	for _, original := range grpcRoutes.Items {
+	for grpcRouteIndex, original := range grpcRoutes.Items {
 
 		grpc := original.DeepCopy()
 
@@ -313,6 +338,9 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 					break
 				}
 			}
+
+			// Update the cached copy with the same status changes to prevent re-fetching from client cache.
+			grpcRoutes.Items[grpcRouteIndex].Status = grpc.Status
 
 		}
 

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -119,7 +119,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 
 					t.Logf("Test %s, HTTPRoutes: %d, GRPCRoutes: %d", tt.name, len(filterHTTPRouteList), len(filterGRPCRouteList))
 					result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: serviceKey})
-					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
+					require.Equal(t, tt.wantErr, err != nil, "Error mismatch, error was %s", err)
 					require.Equal(t, ctrl.Result{}, result)
 
 					// Checking the output for Service

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -324,7 +324,7 @@ func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *g
 	var filtered []gatewayv1.HTTPRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
@@ -336,7 +336,7 @@ func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *g
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
@@ -346,7 +346,7 @@ func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *g
 func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -359,7 +359,7 @@ func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *
 func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -412,7 +412,7 @@ func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route
 func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TLSRoute) []gatewayv1alpha2.TLSRoute {
 	var filtered []gatewayv1alpha2.TLSRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) &&
 			len(computeHosts(gw, route.Spec.Hostnames, nil)) > 0 {
 			filtered = append(filtered, route)
 		}
@@ -423,7 +423,7 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TLSRoute) []gatewayv1alpha2.TLSRoute {
 	var filtered []gatewayv1alpha2.TLSRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -431,26 +431,6 @@ func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *g
 		}
 	}
 	return filtered
-}
-
-func isAttachable(_ context.Context, gw *gatewayv1.Gateway, route metav1.Object, parents []gatewayv1.RouteParentStatus) bool {
-	for _, rps := range parents {
-		if helpers.NamespaceDerefOr(rps.ParentRef.Namespace, route.GetNamespace()) != gw.GetNamespace() ||
-			string(rps.ParentRef.Name) != gw.GetName() {
-			continue
-		}
-
-		for _, cond := range rps.Conditions {
-			if cond.Type == string(gatewayv1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
-				return true
-			}
-
-			if cond.Type == string(gatewayv1.RouteConditionResolvedRefs) && cond.Status == metav1.ConditionFalse {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {

--- a/operator/pkg/gateway-api/helpers/routes.go
+++ b/operator/pkg/gateway-api/helpers/routes.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func IsParentAttachable(_ context.Context, reconcileParent metav1.Object, route metav1.Object, parents []gatewayv1.RouteParentStatus) bool {
+	for _, rps := range parents {
+		if NamespaceDerefOr(rps.ParentRef.Namespace, route.GetNamespace()) != reconcileParent.GetNamespace() ||
+			string(rps.ParentRef.Name) != reconcileParent.GetName() {
+			continue
+		}
+
+		acceptedValid := false
+		for _, cond := range rps.Conditions {
+			if cond.Type == string(gatewayv1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
+				acceptedValid = true
+			}
+		}
+		if acceptedValid {
+			return true
+		}
+	}
+	return false
+}

--- a/operator/pkg/gateway-api/helpers/routes_test.go
+++ b/operator/pkg/gateway-api/helpers/routes_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIsParentAttachable(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		reconcileParent metav1.Object
+		route           metav1.Object
+		parents         []gatewayv1.RouteParentStatus
+		want            bool
+	}{
+		{
+			name: "Gateway parent, all okay",
+			reconcileParent: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gateway",
+				nil),
+			parents: parentStatus("gateway",
+				nil,
+				true),
+			want: true,
+		},
+		{
+			name: "Gateway parent, Not Accepted",
+			reconcileParent: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gateway",
+				nil),
+			parents: parentStatus("gateway",
+				nil,
+				false),
+			want: false,
+		},
+		{
+			name: "Gateway parent, Accepted but namespace mismatch",
+			reconcileParent: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gateway",
+				ptr.To("otherns")),
+			parents: parentStatus("gateway",
+				ptr.To("otherns"),
+				true),
+			want: false,
+		},
+
+		{
+			name: "GAMMA Service parent, same namespace",
+			reconcileParent: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gammaParent",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gammaParent",
+				nil),
+			parents: parentStatus("gammaParent",
+				nil,
+				true),
+
+			want: true,
+		},
+		{
+			name: "GAMMA Service parent, diff namespace",
+			reconcileParent: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gammaParent",
+					Namespace: "otherns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"",
+				ptr.To("otherns")),
+			parents: parentStatus("gateway",
+				ptr.To("otherns"),
+				false),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsParentAttachable(context.Background(), tt.reconcileParent, tt.route, tt.parents)
+			// TODO: update the condition below to compare got with tt.want.
+			if tt.want != got {
+				t.Errorf("IsParentAttachable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func httpRouteWithParentAndStatus(name, ns, parentName string, parentNS *string) *gatewayv1.HTTPRoute {
+	gwParentName := gatewayv1.ObjectName(parentName)
+	var gwParentNS *gatewayv1.Namespace
+	if parentNS != nil {
+		tempNS := gatewayv1.Namespace(*parentNS)
+		gwParentNS = &tempNS
+	} else {
+		gwParentNS = nil
+	}
+
+	parentRef := gatewayv1.ParentReference{
+		Name:      gwParentName,
+		Namespace: gwParentNS,
+	}
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					parentRef,
+				},
+			},
+		},
+	}
+}
+
+func parentStatus(parentName string, parentNS *string, status bool) []gatewayv1.RouteParentStatus {
+	gwParentName := gatewayv1.ObjectName(parentName)
+	var gwParentNS *gatewayv1.Namespace
+	if parentNS != nil {
+		tempNS := gatewayv1.Namespace(*parentNS)
+		gwParentNS = &tempNS
+	} else {
+		gwParentNS = nil
+	}
+
+	parentRef := gatewayv1.ParentReference{
+		Name:      gwParentName,
+		Namespace: gwParentNS,
+	}
+	var condStatus metav1.ConditionStatus
+
+	if status {
+		condStatus = metav1.ConditionTrue
+	} else {
+		condStatus = metav1.ConditionFalse
+	}
+
+	return []gatewayv1.RouteParentStatus{
+		{
+			ParentRef: parentRef,
+			Conditions: []metav1.Condition{
+				{
+					Type:   "Accepted",
+					Status: condStatus,
+				},
+				{
+					Type:   "ResolvedRefs",
+					Status: condStatus,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
GAMMA HTTPRoutes are checked correctly for conflicts, but the updated routes were not being filtered correctly before being passed to the model.

This meant that HTTPRoutes that targeted a Service in another namespace (which is not valid for Cilium) would still generate CiliumEnvoyConfig objects and other config for that Service, and intercept traffic regardless.

This commit properly filters GAMMA HTTPRoutes and GRPCRoutes before passing them to the model ingestion phase.

Thanks to Oleh Konko (@1seal) for the report.

Reported-by: Oleh Konko <security@1seal.org>

```release-note
gateway-api: GAMMA Routes are now filtered correctly before being passed to model ingestion.
```
