### PR TITLE
Fix typo in end-to-end tests documentation

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -15,7 +15,7 @@ Introduction
 Cilium uses `cilium-cli connectivity tests
 <https://github.com/cilium/cilium-cli/#connectivity-check>`_
 for implementing and running end-to-end tests which test Cilium all the way
-from the API level (for example, importing policies, CLI) to the datapath (in order words, whether
+from the API level (for example, importing policies, CLI) to the datapath (in other words, whether
 policy that is imported is enforced accordingly in the datapath).
 
 Running End-To-End Connectivity Tests


### PR DESCRIPTION
Corrected a typo in the e2e.rst documentation.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

