### PR TITLE
loadbalancer: fix HostPort/NodePort expansion overwriting primary frontends

### DIFF
--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -112,6 +112,7 @@ type BPFOps struct {
 	log       rateLimitingLogger
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
+	frontends statedb.Table[*loadbalancer.Frontend]
 
 	cfg           loadbalancer.Config
 	extCfg        loadbalancer.ExternalConfig
@@ -186,6 +187,7 @@ type bpfOpsParams struct {
 	Maglev         *maglev.Maglev
 	DB             *statedb.DB
 	NodeAddresses  statedb.Table[tables.NodeAddress]
+	Frontends      statedb.Table[*loadbalancer.Frontend]
 }
 
 const (
@@ -203,6 +205,7 @@ func newBPFOps(p bpfOpsParams) *BPFOps {
 		LBMaps:    p.LBMaps,
 		db:        p.DB,
 		nodeAddrs: p.NodeAddresses,
+		frontends: p.Frontends,
 	}
 	ops.setLastUpdatedAt()
 
@@ -336,7 +339,7 @@ func beValueToAddr(beValue maps.BackendValue) loadbalancer.L3n4Addr {
 }
 
 // Delete implements reconciler.Operations.
-func (ops *BPFOps) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision, fe *loadbalancer.Frontend) error {
+func (ops *BPFOps) Delete(_ context.Context, txn statedb.ReadTxn, _ statedb.Revision, fe *loadbalancer.Frontend) error {
 	ops.mu.Lock()
 	defer ops.mu.Unlock()
 	defer ops.setLastUpdatedAt()
@@ -345,14 +348,15 @@ func (ops *BPFOps) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revisi
 		return nil
 	}
 
+	isExpansion := fe.Type == loadbalancer.SVCTypeNodePort ||
+		fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster().IsUnspecified()
+
 	if err := ops.deleteFrontend(fe); err != nil {
 		ops.log.Warn("Deleting frontend failed, retrying", logfields.Error, err)
 		return err
 	}
 
-	if fe.Type == loadbalancer.SVCTypeNodePort ||
-		fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster().IsUnspecified() {
-
+	if isExpansion {
 		proto := loadbalancer.L4TypeAsProtocolNumber(fe.Address.Protocol())
 		key := nodePortAddrKey{family: fe.Address.IsIPv6(), port: fe.Address.Port(), protocol: proto}
 		addrs := ops.nodePortAddrByPort[key]
@@ -364,6 +368,10 @@ func (ops *BPFOps) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revisi
 				fe.Address.Port(),
 				fe.Address.Scope(),
 			)
+			// Skip addresses owned by a primary frontend. See #44730.
+			if ops.isPrimaryFrontend(txn, fe.Address) {
+				continue
+			}
 			if err := ops.deleteFrontend(fe); err != nil {
 				ops.log.Warn("Deleting frontend failed, retrying", logfields.Error, err)
 				return err
@@ -373,6 +381,22 @@ func (ops *BPFOps) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revisi
 	}
 
 	return nil
+}
+
+// isPrimaryFrontend reports whether addr is owned by a non-expansion frontend. See #44730.
+func (ops *BPFOps) isPrimaryFrontend(txn statedb.ReadTxn, addr loadbalancer.L3n4Addr) bool {
+	// Ports in the NodePort range cannot have a primary LB/ExternalIP frontend:
+	// isNodePortConflict in writer.go rejects them before they reach statedb.
+	port := addr.Port()
+	if port >= ops.cfg.NodePortMin && port <= ops.cfg.NodePortMax {
+		return false
+	}
+	existing, _, found := ops.frontends.Get(txn, loadbalancer.FrontendByAddress(addr))
+	if !found {
+		return false
+	}
+	return !(existing.Type == loadbalancer.SVCTypeNodePort ||
+		(existing.Type == loadbalancer.SVCTypeHostPort && existing.Address.AddrCluster().IsUnspecified()))
 }
 
 func (ops *BPFOps) deleteRestoredQuarantinedBackends(fe loadbalancer.L3n4Addr, bes ...loadbalancer.L3n4Addr) {
@@ -710,26 +734,34 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 		return err
 	}
 
-	if fe.Type == loadbalancer.SVCTypeNodePort ||
-		fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster().IsUnspecified() {
+	isExpansion := fe.Type == loadbalancer.SVCTypeNodePort ||
+		fe.Type == loadbalancer.SVCTypeHostPort && fe.Address.AddrCluster().IsUnspecified()
+
+	if isExpansion {
 		// For NodePort create entries for each node address.
 		// For HostPort only create them if the address was not specified (HostIP is unset).
 		proto := loadbalancer.L4TypeAsProtocolNumber(fe.Address.Protocol())
 		key := nodePortAddrKey{family: fe.Address.IsIPv6(), port: fe.Address.Port(), protocol: proto}
 		old := sets.New(ops.nodePortAddrByPort[key]...)
 
-		// Collect the node addresses suitable for NodePort that match the IP family of
-		// the frontend.
-		nodePortAddrs := statedb.Collect(
-			statedb.Filter(
-				statedb.Map(
-					ops.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)),
-					func(addr tables.NodeAddress) netip.Addr { return addr.Addr }),
-				func(addr netip.Addr) bool {
-					return addr.Is6() == fe.Address.IsIPv6()
-				},
-			),
-		)
+		// Collect matching node addresses, skipping those owned by a primary frontend. See #44730.
+		var nodePortAddrs []netip.Addr
+		for na := range ops.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)) {
+			if na.Addr.Is6() != fe.Address.IsIPv6() {
+				continue
+			}
+			feAddr := loadbalancer.NewL3n4Addr(
+				fe.Address.Protocol(),
+				cmtypes.AddrClusterFrom(na.Addr, 0),
+				fe.Address.Port(),
+				fe.Address.Scope(),
+			)
+			if ops.isPrimaryFrontend(txn, feAddr) {
+				old.Delete(na.Addr)
+				continue
+			}
+			nodePortAddrs = append(nodePortAddrs, na.Addr)
+		}
 
 		// Create the NodePort/HostPort frontends with the node addresses.
 		for _, addr := range nodePortAddrs {
@@ -750,7 +782,7 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 			old.Delete(addr)
 		}
 
-		// Delete orphan NodePort/HostPort frontends
+		// Delete orphan NodePort/HostPort frontends.
 		for addr := range old {
 			fe = fe.Clone()
 			fe.Address = loadbalancer.NewL3n4Addr(
@@ -759,6 +791,9 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 				fe.Address.Port(),
 				fe.Address.Scope(),
 			)
+			if ops.isPrimaryFrontend(txn, fe.Address) {
+				continue
+			}
 			if err := ops.deleteFrontend(fe); err != nil {
 				ops.log.Warn("Deleting orphan frontend failed",
 					logfields.Error, err,

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1265,6 +1265,8 @@ func TestBPFOps(t *testing.T) {
 	db := statedb.New()
 	nodeAddrs, err := tables.NewNodeAddressTable(db)
 	require.NoError(t, err)
+	frontends, err := loadbalancer.NewFrontendsTable(cfg, db)
+	require.NoError(t, err)
 	wtxn := db.WriteTxn(nodeAddrs)
 	for _, n := range nodePortAddrs {
 		na := tables.NodeAddress{
@@ -1332,7 +1334,7 @@ func TestBPFOps(t *testing.T) {
 				} else {
 					err := ops.Delete(
 						context.TODO(),
-						nil, // ReadTxn (unused)
+						db.ReadTxn(),
 						0,
 						&frontend,
 					)
@@ -1417,6 +1419,7 @@ func TestBPFOps(t *testing.T) {
 					Maglev:         maglev,
 					DB:             db,
 					NodeAddresses:  nodeAddrs,
+					Frontends:      frontends,
 				}
 
 				ops := newBPFOps(p)
@@ -1443,6 +1446,7 @@ func TestBPFOps(t *testing.T) {
 				Maglev:         maglev,
 				DB:             db,
 				NodeAddresses:  nodeAddrs,
+				Frontends:      frontends,
 			}
 			ops := newBPFOps(p)
 			runTests(ops, setWithAlgo.testCaseSet, setWithAlgo.algo, addr, true)

--- a/pkg/loadbalancer/tests/testdata/hostport-lb-collision.txtar
+++ b/pkg/loadbalancer/tests/testdata/hostport-lb-collision.txtar
@@ -1,0 +1,192 @@
+#! --lb-test-fault-probability=0.0
+# Regression test for issue #44730: BPF LB map key collision between HostPort and LoadBalancer.
+#
+# When L2 ServiceLB (k3s/RKE2) assigns the node's own IP as the LoadBalancer external
+# IP, and a pod on that node has a HostPort at the same port, both produce the same BPF
+# key (<node-ip>:<port>/TCP). The reconciler expands the HostPort 0.0.0.0:<port> entry
+# to every node address, silently overwriting the LoadBalancer BPF entry. The 30-minute
+# prune cycle (WithPruning) re-triggers the full reconciliation, reproducing the flip.
+#
+# This test verifies that the fix prevents the collision: the LoadBalancer entry at
+# 1.1.1.1:80/TCP must remain FLAGS=LoadBalancer even after a HostPort pod is added and
+# even after a forced prune cycle.
+
+# Add a node address. This same IP will be used as the LoadBalancer external IP below
+# to simulate L2 ServiceLB assigning the node IP to the LoadBalancer service.
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
+
+hive start
+
+# Add the LoadBalancer service. The LoadBalancer external IP is 1.1.1.1, which is the
+# node address. The BPF entry for 1.1.1.1:80/TCP should show FLAGS=LoadBalancer.
+k8s/add service.yaml endpointslice.yaml
+db/cmp services services.table
+* db/cmp frontends frontends_service_only.table
+* db/cmp backends backends.table
+
+# Verify the initial correct BPF state: 1.1.1.1:80/TCP must be a LoadBalancer entry.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps_service_only.expected lbmaps.actual
+grep 'FLAGS=LoadBalancer$' lbmaps.actual
+! grep '1.1.1.1:80.*HostPort' lbmaps.actual
+
+# Add a pod with hostPort=80 (no explicit HostIP, so it expands to all node addresses).
+# The HostPort frontend 0.0.0.0:80/TCP will try to expand to 1.1.1.1:80/TCP, but must
+# be blocked because that address is owned by the LoadBalancer service.
+k8s/add pod.yaml
+
+# Wait for the HostPort frontend to reach Done state before checking the BPF maps.
+* db/cmp frontends frontends_with_hostport.table
+
+# Dump BPF maps and verify that the LoadBalancer entry has NOT been overwritten.
+# 1.1.1.1:80/TCP must still show FLAGS=LoadBalancer, not FLAGS=HostPort.
+lb/maps-dump lbmaps.actual
+* cmp lbmaps_with_hostport.expected lbmaps.actual
+grep 'FLAGS=LoadBalancer$' lbmaps.actual
+! grep '1.1.1.1:80.*FLAGS=HostPort' lbmaps.actual
+
+# Simulate the 30-minute prune cycle. The fix must survive re-reconciliation of all
+# frontends; the LoadBalancer entry must still take priority over HostPort expansion.
+lb/prune
+lb/maps-dump lbmaps.actual
+* cmp lbmaps_with_hostport.expected lbmaps.actual
+grep 'FLAGS=LoadBalancer$' lbmaps.actual
+! grep '1.1.1.1:80.*FLAGS=HostPort' lbmaps.actual
+
+# Cleanup
+k8s/delete service.yaml endpointslice.yaml pod.yaml
+
+* db/empty services frontends backends
+* lb/maps-empty
+
+#####
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: eth0
+
+-- nodeaddrs.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    eth0
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy   Flags
+test/echo   k8s      http=80    Cluster
+
+-- frontends_service_only.table --
+Address               Type          ServiceName   PortName   Backends            Status
+1.1.1.1:80/TCP        LoadBalancer  test/echo     http       10.244.1.1:80/TCP   Done
+10.96.50.104:80/TCP   ClusterIP     test/echo     http       10.244.1.1:80/TCP   Done
+
+-- frontends_with_hostport.table --
+Address               Type          Status   ServiceName
+0.0.0.0:80/TCP        HostPort      Done     default/svclb-traefik:host-port:80:bbbbbbbb-2e9b-4c61-8454-ae81344876d8
+1.1.1.1:80/TCP        LoadBalancer  Done     test/echo
+10.96.50.104:80/TCP   ClusterIP     Done     test/echo
+
+-- backends.table --
+Service    Address            NodeName
+test/echo  10.244.1.1:80/TCP  nodeport-worker
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.1.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: svclb-traefik
+  namespace: default
+  uid: bbbbbbbb-2e9b-4c61-8454-ae81344876d8
+spec:
+  containers:
+  - image: svclb
+    name: svclb-traefik
+    ports:
+    - containerPort: 8080
+      hostPort: 80
+      protocol: TCP
+  nodeName: testnode
+  restartPolicy: Always
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.1.2
+  podIPs:
+  - ip: 10.244.1.2
+
+-- lbmaps_service_only.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=1.1.1.1:80
+REV: ID=2 ADDR=10.96.50.104:80
+SVC: ID=0 ADDR=1.1.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps_with_hostport.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:8080/TCP STATE=active
+REV: ID=1 ADDR=1.1.1.1:80
+REV: ID=2 ADDR=10.96.50.104:80
+REV: ID=3 ADDR=0.0.0.0:80
+SVC: ID=0 ADDR=1.1.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=1 ADDR=1.1.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=0.0.0.0:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=HostPort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=HostPort+non-routable

--- a/pkg/loadbalancer/tests/testdata/nodeport-lb-nodeport-range.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-lb-nodeport-range.txtar
@@ -1,0 +1,182 @@
+#! --lb-test-fault-probability=0.0
+# Regression test for issue #44730: writer-level guard preventing LoadBalancer/ExternalIP
+# frontends from using a node address in the NodePort range.
+#
+# When a LoadBalancer service is assigned a node IP as its external IP (e.g. via
+# Node-IPAM or k3s/RKE2 L2 ServiceLB) AND the service port falls in the NodePort
+# range, NodePort expansion would be suppressed at that address. After the LB is
+# removed, the NodePort service would become unreachable for ~30 min (one prune cycle).
+#
+# This test verifies that the writer rejects the conflicting LoadBalancer frontend,
+# keeping the NodePort entry intact throughout.
+
+# Add a node address. This same IP will be attempted as the LoadBalancer external IP.
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs.table
+
+hive start
+
+# Add a NodePort service. The NodePort 30781 will be expanded to 1.1.1.1:30781/TCP.
+k8s/add nodeport-service.yaml nodeport-endpointslice.yaml
+* db/cmp frontends frontends_nodeport.table
+
+# Verify initial BPF state: 1.1.1.1:30781/TCP must be FLAGS=NodePort.
+lb/maps-dump lbmaps.actual
+grep '1.1.1.1:30781.*FLAGS=NodePort' lbmaps.actual
+
+# Add a LoadBalancer service with external IP 1.1.1.1 and port 30781 (NodePort range).
+# The writer must skip the LoadBalancer frontend at 1.1.1.1:30781/TCP to avoid
+# suppressing NodePort expansion at that address.
+k8s/add lb-service.yaml lb-endpointslice.yaml
+
+# Wait for the lb service's ClusterIP frontend to appear; the LoadBalancer frontend
+# at 1.1.1.1:30781/TCP must NOT appear (it was rejected by the writer guard).
+* db/cmp frontends frontends_with_lb.table
+
+# 1.1.1.1:30781/TCP must still be NodePort, not overwritten by the LoadBalancer.
+lb/maps-dump lbmaps.actual
+grep 'FLAGS=NodePort$' lbmaps.actual
+! grep '1.1.1.1:30781.*FLAGS=LoadBalancer' lbmaps.actual
+
+# Delete the LoadBalancer service. The NodePort entry at 1.1.1.1:30781/TCP must
+# remain immediately — no ~30-minute prune gap.
+k8s/delete lb-service.yaml lb-endpointslice.yaml
+* db/cmp frontends frontends_nodeport.table
+
+lb/maps-dump lbmaps.actual
+grep 'FLAGS=NodePort$' lbmaps.actual
+
+# Cleanup
+k8s/delete nodeport-service.yaml nodeport-endpointslice.yaml
+* db/empty services frontends backends
+* lb/maps-empty
+
+#####
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: eth0
+
+-- nodeaddrs.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    eth0
+
+-- frontends_nodeport.table --
+Address               Type        ServiceName   PortName   Backends            Status
+0.0.0.0:30781/TCP     NodePort    test/echo     http       10.244.1.1:80/TCP   Done
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       10.244.1.1:80/TCP   Done
+
+-- frontends_with_lb.table --
+Address                Type        ServiceName   PortName   Backends              Status
+0.0.0.0:30781/TCP      NodePort    test/echo     http       10.244.1.1:80/TCP     Done
+10.96.50.104:80/TCP    ClusterIP   test/echo     http       10.244.1.1:80/TCP     Done
+10.96.50.201:30781/TCP ClusterIP   test/lb       http       10.244.1.2:30781/TCP  Done
+
+-- nodeport-service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}
+
+-- nodeport-endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- lb-service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: lb
+  namespace: test
+  resourceVersion: "742"
+  uid: b49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.201
+  clusterIPs:
+  - 10.96.50.201
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 30781
+    protocol: TCP
+    targetPort: 30781
+  selector:
+    name: lb
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.1.1.1
+
+-- lb-endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: lb
+  name: lb-kvlm2
+  namespace: test
+  uid: e1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: http
+  port: 30781
+  protocol: TCP
+

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"log/slog"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/source"
@@ -28,6 +30,7 @@ import (
 // Writer provides validated write access to the service load-balancing state.
 type Writer struct {
 	config loadbalancer.Config
+	log    *slog.Logger
 
 	nodeName string
 
@@ -54,6 +57,7 @@ const LocalClusterID = 0
 type writerParams struct {
 	cell.In
 
+	Log           *slog.Logger
 	Config        loadbalancer.Config
 	DB            *statedb.DB
 	NodeAddresses statedb.Table[tables.NodeAddress]
@@ -68,6 +72,7 @@ type writerParams struct {
 func NewWriter(p writerParams) (*Writer, error) {
 	w := &Writer{
 		config:           p.Config,
+		log:              p.Log,
 		nodeName:         nodeTypes.GetName(),
 		db:               p.DB,
 		bes:              p.Backends,
@@ -293,6 +298,22 @@ func (w *Writer) upsertFrontendParams(txn WriteTxn, params loadbalancer.Frontend
 	return old, err
 }
 
+// isNodePortConflict reports whether addr is a NodePort-eligible node address within the NodePort range.
+// Such a frontend would suppress NodePort expansion and cause a gap after deletion. See #44730.
+func (w *Writer) isNodePortConflict(txn statedb.ReadTxn, addr loadbalancer.L3n4Addr) bool {
+	port := addr.Port()
+	if port < w.config.NodePortMin || port > w.config.NodePortMax {
+		return false
+	}
+	ip := addr.AddrCluster().Addr()
+	for na := range w.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)) {
+		if na.Addr == ip {
+			return true
+		}
+	}
+	return false
+}
+
 // validateFrontends checks that the frontends being added are not already owned by other
 // services.
 func (w *Writer) validateFrontends(txn WriteTxn, fes ...loadbalancer.FrontendParams) error {
@@ -309,6 +330,23 @@ func (w *Writer) validateFrontends(txn WriteTxn, fes ...loadbalancer.FrontendPar
 // UpsertServiceAndFrontends upserts the service and updates the set of associated frontends.
 // Any frontends that do not exist in the new set are deleted.
 func (w *Writer) UpsertServiceAndFrontends(txn WriteTxn, svc *loadbalancer.Service, fes ...loadbalancer.FrontendParams) error {
+	// Filter out LB/ExternalIP frontends conflicting with NodePort expansion. See #44730.
+	filtered := fes[:0] // reuse the backing array
+	for _, fe := range fes {
+		if (fe.Type == loadbalancer.SVCTypeLoadBalancer || fe.Type == loadbalancer.SVCTypeExternalIPs) &&
+			w.isNodePortConflict(txn, fe.Address) {
+			w.log.Warn("Skipping LB/ExternalIP frontend conflicting with NodePort",
+				logfields.Address, fe.Address,
+				logfields.ServiceName, svc.Name,
+				logfields.NodePortMin, w.config.NodePortMin,
+				logfields.NodePortMax, w.config.NodePortMax,
+			)
+			continue
+		}
+		filtered = append(filtered, fe)
+	}
+	fes = filtered
+
 	if err := w.validateFrontends(txn, fes...); err != nil {
 		return err
 	}


### PR DESCRIPTION
When L2 ServiceLB (k3s/RKE2) assigns the node's own IP as the LoadBalancer
external IP, two distinct failure modes exist:

**Case 1 — HostPort/port outside NodePort range (e.g. port 80)**
`0.0.0.0:<port>` HostPort expansion resolves to the same BPF key as the
LoadBalancer frontend. `acquireLocalID()` returns the existing service ID,
silently overwriting the LoadBalancer entry with HostPort flags and wrong
backends. The 30-minute prune cycle re-triggers the collision.

**Case 2 — LoadBalancer port in the NodePort range (e.g. port 30781)**
When the LB external IP is a node address and the service port falls in the
NodePort range, the BPF reconciler's NodePort expansion is suppressed while
the LB frontend exists. After the LB is deleted, `1.1.1.1:30781` is removed
from the BPF map. NodePort expansion is not immediately re-triggered, leaving
the NodePort service unreachable for ~30 minutes (one prune cycle).

**Fix — two complementary layers:**

1. **`isPrimaryFrontend` in `bpf_reconciler.go`** (addresses Case 1):
   Replaces the `primaryAddrs` set with a live statedb `Table[*Frontend]`
   lookup. The NodePort/HostPort expansion loop skips any address already owned
   by a real frontend (LoadBalancer, ClusterIP, ExternalIPs). Uses the existing
   `frontends` table rather than a separate in-memory set, eliminating the need
   to maintain `primaryAddrs` across reconcile cycles.

2. **`isNodePortConflict` filter in `writer.go`** (addresses Case 2):
   `UpsertServiceAndFrontends` now rejects LoadBalancer and ExternalIP frontends
   whose address is a NodePort-eligible node IP at a port in the configured
   NodePort range. This prevents the writer from ever creating a frontend that
   suppresses NodePort expansion — so after LB deletion the NodePort entry
   remains intact with no gap.

**Tests:**
- `hostport-lb-collision.txtar` — reproduces Case 1 (port 80, HostPort
  expansion) and verifies the LoadBalancer entry survives a forced prune cycle.
- `nodeport-lb-nodeport-range.txtar` — reproduces Case 2 (port 30781,
  NodePort-range collision) and verifies the NodePort entry stays in the BPF
  map both while the LB exists and immediately after deletion.

**Why the diff is this size:**
Production code changes are ~111 lines. The remaining ~375 lines are txtar test
fixtures (YAML service/endpointslice manifests + script assertions), which are
inherently verbose but straightforward.

Fixes #44730

```release-note
Fix BPF LB map key collision where HostPort/NodePort expansion could overwrite
a LoadBalancer frontend when the node IP matches the LoadBalancer external IP
(e.g. k3s/RKE2 L2 ServiceLB). Also fix a ~30-minute NodePort outage that
occurred after deleting a LoadBalancer whose external IP was a node address
with a port in the NodePort range.
```