### PR TITLE
fix(cilium-dbg): add missing flags for pre-flight configmap validation

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -30,6 +30,7 @@ cilium-agent [flags]
       --azure-interface-name string                               InterfaceName the cilium-operator will use to allocate all the IPs on at the node level
       --bgp-router-id-allocation-ip-pool string                   IP pool to allocate the BGP router-id from when the mode is 'ip-pool'
       --bgp-router-id-allocation-mode string                      BGP router-id allocation mode. Currently supported values: 'default' or 'ip-pool' (default "default")
+      --bgp-secrets-namespace string                              BGPSecretsNamespace is the namespace which BGP support will retrieve secrets from
       --bpf-auth-map-max int                                      Maximum number of entries in auth map (default 524288)
       --bpf-conntrack-accounting                                  Enable CT accounting for packets and bytes (default false)
       --bpf-ct-global-any-max int                                 Maximum number of entries in non-TCP CT table (default 262144)

--- a/cilium-dbg/Makefile
+++ b/cilium-dbg/Makefile
@@ -6,7 +6,7 @@
 ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs
-
+GO_TAGS_FLAGS+=ipam_provider_aws,ipam_provider_azure,ipam_provider_operator,ipam_provider_alibabacloud
 # Add the ability to override variables
 # ROOT_DIR changes to repo root after including Makefile.defs
 -include ${ROOT_DIR}/Makefile.override

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -824,6 +824,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableCiliumNodeCRDName)
 	option.BindEnv(vp, option.EnableCiliumNodeCRDName)
 
+	flags.String(option.BGPSecretsNamespace, "", "BGPSecretsNamespace is the namespace which BGP support will retrieve secrets from")
+	option.BindEnv(vp, option.BGPSecretsNamespace)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		logging.Fatal(logger, "BindPFlags failed", logfields.Error, err)
 	}


### PR DESCRIPTION
### Problem
Issue #45125 reports that the pre-flight configmap validator fails to recognize some keys in `cilium-config`.

### Root Cause
The validator matches config keys against flags registered in agent and operator. Some flags were either not registered or not included in the cilium-dbg build, resulting in "unrecognized keys" results.

### Fix
Add the `bgp-secrets-namespace` flag and include the IPAM provider package in the cilium-dbg build.

### Note
`enable-source-ip-verification` is addressed in PR #45245, while `custom-cni-conf` is not used by any component.
Some keys, such as `clean-cilium-bpf-state` and `cni-uninstall`, may still be falsely reported as unrecognized because they are consumed by initContainer scripts instead of the agent or operator.



```release-note
Fix false "unrecognized key" error in pre-flight configmap validation.
```
Fixes: #45125