### PR TITLE
cilium-cli: respect --ip-families in validateDeployment

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -3000,6 +3000,9 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 					(addrFamily == features.IPFamilyV6 && !ct.Features[features.IPv6].Enabled) {
 					continue
 				}
+				if !slices.Contains(features.GetIPFamilies(ct.Params().IPFamilies), addrFamily) {
+					continue
+				}
 
 				// On GKE, ExternalIP is not reachable from inside a cluster.
 				// Skip validation for external IPs in GKE to match the actual test behavior.
@@ -3047,7 +3050,8 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			ct.hostNetNSPodsByNode[pod.Spec.NodeName] = p
 
 			if iface := ct.params.SecondaryNetworkIface; iface != "" {
-				if ct.Features[features.IPv4].Enabled {
+				ipFams := features.GetIPFamilies(ct.Params().IPFamilies)
+				if slices.Contains(ipFams, features.IPFamilyV4) && ct.Features[features.IPv4].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
 					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 					if err != nil {
@@ -3055,7 +3059,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 					}
 					ct.secondaryNetworkNodeIPv4[pod.Spec.NodeName] = strings.TrimSuffix(addr.String(), "\n")
 				}
-				if ct.Features[features.IPv6].Enabled {
+				if slices.Contains(ipFams, features.IPFamilyV6) && ct.Features[features.IPv6].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet6 -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
 					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 					if err != nil {


### PR DESCRIPTION
NodePort readiness checks and secondary network IP collection were gated only on cluster-enabled IP families, ignoring --ip-families. This caused setup to validate IPv6 NodePort addresses even when only IPv4 was requested, resulting in timeouts on unreachable IPv6 addresses.

AI was used to implement this change.