### PR TITLE
gha/clustermesh: use OCI registry for cert-manager

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -634,10 +634,9 @@ jobs:
       - name: Install cert-manager
         if: matrix.tls-auto-method == 'certmanager'
         run: |
-          helm repo add jetstack https://charts.jetstack.io
           for ctx in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
             helm --kube-context $ctx install \
-              cert-manager jetstack/cert-manager \
+              cert-manager oci://quay.io/jetstack/charts/cert-manager \
               --namespace cert-manager \
               --create-namespace \
               --version ${{ env.CERT_MANAGER_VERSION }}


### PR DESCRIPTION
The cert-manager documentation recommends \[1] using the OCI helm chart, over the legacy helm repository. Hence, let's change it.

\[1]: https://cert-manager.io/docs/installation/helm/#installing-cert-manager-with-helm

Reported-by: Julian Wiedmann <jwi@isovalent.com>
