### PR TITLE
egressgateway: use IPCache as endpoint data source instead of CEP/CES

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -76,6 +76,7 @@ import (
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/podendpointsource"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
@@ -279,6 +280,11 @@ var (
 
 		// IPAM provides IP address management.
 		ipamcell.Cell,
+
+		// Observes pod endpoints from the IPCache and exposes them as a
+		// typed event stream consumed by the Egress Gateway (and
+		// potentially other components in the future).
+		podendpointsource.Cell,
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -4,70 +4,22 @@
 package egressgateway
 
 import (
-	"fmt"
 	"net/netip"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
-	"github.com/cilium/cilium/pkg/labels"
 )
 
-// endpointMetadata stores relevant metadata associated with a endpoint that's updated during endpoint
-// add/update events
+// endpointMetadata stores relevant metadata associated with an endpoint.
+// Populated from IPCache notifications rather than directly from CiliumEndpoint
+// or CiliumEndpointSlice resources, making it source-agnostic.
 type endpointMetadata struct {
-	// Endpoint labels
+	// labels are the endpoint's identity labels (k8s string map form)
 	labels map[string]string
-	// Endpoint ID
+	// id uniquely identifies the endpoint (namespace/podName)
 	id endpointID
-	// ips are endpoint's unique IPs
+	// ips are the endpoint's unique IPs
 	ips []netip.Addr
-	// nodeIP is the IP of the node the endpoint is on
+	// nodeIP is the IP of the node the endpoint is running on
 	nodeIP string
 }
 
-// endpointID is based on endpoint's UID
-type endpointID = types.UID
-
-func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
-	var addrs []netip.Addr
-
-	if endpoint.UID == "" {
-		// this can happen when CiliumEndpointSlices are in use - which is not supported in the EGW yet
-		return nil, fmt.Errorf("endpoint has empty UID")
-	}
-
-	if endpoint.Networking == nil {
-		return nil, fmt.Errorf("endpoint has no networking metadata")
-	}
-
-	if len(endpoint.Networking.Addressing) == 0 {
-		return nil, fmt.Errorf("failed to get valid endpoint IPs")
-	}
-
-	for _, pair := range endpoint.Networking.Addressing {
-		if pair.IPV4 != "" {
-			addr, err := netip.ParseAddr(pair.IPV4)
-			if err != nil || !addr.Is4() {
-				continue
-			}
-			addrs = append(addrs, addr)
-		}
-		if pair.IPV6 != "" {
-			addr, err := netip.ParseAddr(pair.IPV6)
-			if err != nil || !addr.Is6() {
-				continue
-			}
-			addrs = append(addrs, addr)
-		}
-	}
-
-	data := &endpointMetadata{
-		ips:    addrs,
-		labels: identityLabels.K8sStringMap(),
-		id:     endpoint.UID,
-		nodeIP: endpoint.Networking.NodeIP,
-	}
-
-	return data, nil
-}
+// endpointID uniquely identifies an endpoint using namespace/podName.
+type endpointID = string

--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"slices"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/podendpointsource"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 )
@@ -217,30 +219,134 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 	return cegp, policy
 }
 
-func addEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
+// addEndpointAndReconcile delivers a pod endpoint Upsert directly to the
+// manager, mirroring what the podendpointsource would emit in production,
+// and waits for reconciliation to complete.
+func addEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, _ fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
 	currentRun := egressGatewayManager.reconciliationEventsCount.Load()
-	addEndpoint(tb, endpoints, ep)
+	addEndpoint(tb, egressGatewayManager, ep)
 	waitForReconciliationRun(tb, egressGatewayManager, currentRun)
 }
 
-func addEndpoint(tb testing.TB, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
-	endpoints.process(tb, resource.Event[*k8sTypes.CiliumEndpoint]{
-		Kind:   resource.Upsert,
-		Object: ep,
-	})
+// addEndpoint constructs a PodEndpoint from the given CiliumEndpoint and
+// hands it to the manager as an Upsert event. All IPs of the endpoint are
+// aggregated into a single event, as the podendpointsource does.
+func addEndpoint(tb testing.TB, manager *Manager, ep *k8sTypes.CiliumEndpoint) {
+	tb.Helper()
+
+	pe := podEndpointFromCiliumEndpoint(tb, ep)
+	if err := manager.handleEndpointEvent(context.Background(), podendpointsource.Event{
+		Kind:     podendpointsource.EventKindUpsert,
+		Endpoint: pe,
+	}); err != nil {
+		tb.Fatalf("handleEndpointEvent upsert: %v", err)
+	}
 }
 
-func deleteEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
+// deleteEndpointAndReconcile delivers a pod endpoint Delete to the manager
+// and waits for reconciliation.
+func deleteEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, _ fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
 	currentRun := egressGatewayManager.reconciliationEventsCount.Load()
-	deleteEndpoint(tb, endpoints, ep)
+	deleteEndpoint(tb, egressGatewayManager, ep)
 	waitForReconciliationRun(tb, egressGatewayManager, currentRun)
 }
 
-func deleteEndpoint(tb testing.TB, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
-	endpoints.process(tb, resource.Event[*k8sTypes.CiliumEndpoint]{
-		Kind:   resource.Delete,
-		Object: ep,
+// deleteEndpoint hands the manager a whole-endpoint Delete event.
+func deleteEndpoint(tb testing.TB, manager *Manager, ep *k8sTypes.CiliumEndpoint) {
+	tb.Helper()
+
+	if err := manager.handleEndpointEvent(context.Background(), podendpointsource.Event{
+		Kind: podendpointsource.EventKindDelete,
+		Endpoint: podendpointsource.PodEndpoint{
+			ID: ep.Namespace + "/" + ep.Name,
+		},
+	}); err != nil {
+		tb.Fatalf("handleEndpointEvent delete: %v", err)
+	}
+}
+
+// podEndpointFromCiliumEndpoint turns a test CiliumEndpoint into the shape
+// the podendpointsource would emit. IPs are sorted IPv4-first then IPv6, as
+// the production Source does.
+func podEndpointFromCiliumEndpoint(tb testing.TB, ep *k8sTypes.CiliumEndpoint) podendpointsource.PodEndpoint {
+	tb.Helper()
+
+	var nodeIP string
+	if ep.Networking != nil {
+		nodeIP = ep.Networking.NodeIP
+	}
+
+	pe := podendpointsource.PodEndpoint{
+		ID:     ep.Namespace + "/" + ep.Name,
+		NodeIP: nodeIP,
+	}
+
+	if ep.Networking != nil {
+		for _, pair := range ep.Networking.Addressing {
+			if pair.IPV4 != "" {
+				addr, err := netip.ParseAddr(pair.IPV4)
+				if err != nil {
+					tb.Fatalf("invalid IPv4 %q: %v", pair.IPV4, err)
+				}
+				pe.IPs = append(pe.IPs, addr)
+			}
+			if pair.IPV6 != "" {
+				addr, err := netip.ParseAddr(pair.IPV6)
+				if err != nil {
+					tb.Fatalf("invalid IPv6 %q: %v", pair.IPV6, err)
+				}
+				pe.IPs = append(pe.IPs, addr)
+			}
+		}
+	}
+	slices.SortFunc(pe.IPs, func(a, b netip.Addr) int {
+		switch {
+		case a.Is4() && !b.Is4():
+			return -1
+		case !a.Is4() && b.Is4():
+			return 1
+		default:
+			return a.Compare(b)
+		}
 	})
+
+	if ep.Identity != nil {
+		lbls := make(map[string]string, len(ep.Identity.Labels))
+		for _, lbl := range ep.Identity.Labels {
+			// Identity labels in CEP fixtures are in "k8s:<key>=<value>"
+			// form. The source always emits K8s labels in the string-
+			// map form (key -> value) after stripping the source prefix;
+			// reproduce that here.
+			key, value, _ := parseIdentityLabel(lbl)
+			if key != "" {
+				lbls[key] = value
+			}
+		}
+		pe.Labels = lbls
+	}
+	return pe
+}
+
+// parseIdentityLabel splits a label of the form "src:key=value" into its key
+// and value. Labels without an explicit source are accepted as-is.
+func parseIdentityLabel(lbl string) (key, value string, ok bool) {
+	// Strip optional "<source>:" prefix.
+	if i := indexByte(lbl, ':'); i >= 0 {
+		lbl = lbl[i+1:]
+	}
+	if i := indexByte(lbl, '='); i >= 0 {
+		return lbl[:i], lbl[i+1:], true
+	}
+	return lbl, "", true
+}
+
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
 }
 
 func addNodeAndReconcile(tb testing.TB, k *EgressGatewayTestSuite, egressGatewayManager *Manager, node *nodeTypes.Node) {
@@ -266,3 +372,8 @@ func waitForReconciliationRun(tb testing.TB, egressGatewayManager *Manager, curr
 	tb.Fatal("Reconciliation is taking too long to run")
 	return 0
 }
+
+// Remote-cluster filtering is now the responsibility of the
+// podendpointsource, so the egress gateway manager never sees events for
+// non-local endpoints. The corresponding test lives alongside the source
+// implementation in pkg/podendpointsource.

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -15,25 +15,22 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/identity"
-	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/podendpointsource"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -100,6 +97,12 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 // The egressgateway manager stores the internal data tracking the node, policy,
 // endpoint, and lease mappings. It also hooks up all the callbacks to update
 // egress bpf policy map accordingly.
+//
+// Endpoint data is obtained from a [podendpointsource.Source], which abstracts
+// away the underlying endpoint data source (CiliumEndpoint, CiliumEndpointSlice
+// or kvstore via IPCache). The manager is a pure consumer of the typed event
+// stream and has no knowledge of IPCache internals, identity allocation, or
+// clustermesh filtering.
 type Manager struct {
 	logger *slog.Logger
 
@@ -121,17 +124,12 @@ type Manager struct {
 	// nodesResource allows reading node CRD from k8s.
 	ciliumNodes resource.Resource[*cilium_api_v2.CiliumNode]
 
-	// endpoints allows reading endpoint CRD from k8s.
-	endpoints resource.Resource[*k8sTypes.CiliumEndpoint]
-
 	// policyConfigs stores policy configs indexed by policyID
 	policyConfigs map[policyID]*PolicyConfig
 
-	// epDataStore stores endpointId to endpoint metadata mapping
+	// epDataStore stores endpointId to endpoint metadata mapping.
+	// Populated from pod endpoint source events.
 	epDataStore map[endpointID]*endpointMetadata
-
-	// identityAllocator is used to fetch identity labels for endpoint updates
-	identityAllocator identityCache.IdentityAllocator
 
 	// policyMap4 communicates the active IPv4 policies to the datapath.
 	policyMap4 *egressmap.PolicyMap4
@@ -165,18 +163,18 @@ type Params struct {
 
 	Logger *slog.Logger
 
-	Config            Config
-	DaemonConfig      *option.DaemonConfig
-	TunnelConfig      tunnel.Config
-	IdentityAllocator identityCache.IdentityAllocator
-	PolicyMap4        *egressmap.PolicyMap4
-	PolicyMap6        *egressmap.PolicyMap6
-	Policies          resource.Resource[*Policy]
-	Nodes             resource.Resource[*cilium_api_v2.CiliumNode]
-	Endpoints         resource.Resource[*k8sTypes.CiliumEndpoint]
-	Sysctl            sysctl.Sysctl
+	Config       Config
+	DaemonConfig *option.DaemonConfig
+	TunnelConfig tunnel.Config
+	PodEndpoints podendpointsource.Source
+	PolicyMap4   *egressmap.PolicyMap4
+	PolicyMap6   *egressmap.PolicyMap6
+	Policies     resource.Resource[*Policy]
+	Nodes        resource.Resource[*cilium_api_v2.CiliumNode]
+	Sysctl       sysctl.Sysctl
 
 	Lifecycle cell.Lifecycle
+	JobGroup  job.Group
 }
 
 func NewEgressGatewayManager(p Params) (out struct {
@@ -189,14 +187,6 @@ func NewEgressGatewayManager(p Params) (out struct {
 
 	if !dcfg.EnableEgressGateway {
 		return out, nil
-	}
-
-	if dcfg.IdentityAllocationMode != option.IdentityAllocationModeCRD {
-		return out, fmt.Errorf("egress gateway is not supported in %s identity allocation mode", dcfg.IdentityAllocationMode)
-	}
-
-	if dcfg.EnableCiliumEndpointSlice {
-		return out, errors.New("egress gateway is not supported in combination with the CiliumEndpointSlice feature")
 	}
 
 	// TODO: refactor config checks for both ipv4 and ipv6, and derive whether the environment supports egress gateway policies for either protocol
@@ -230,13 +220,11 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 		logger:                        p.Logger,
 		policyConfigs:                 make(map[policyID]*PolicyConfig),
 		epDataStore:                   make(map[endpointID]*endpointMetadata),
-		identityAllocator:             p.IdentityAllocator,
 		reconciliationTriggerInterval: p.Config.EgressGatewayReconciliationTriggerInterval,
 		policyMap4:                    p.PolicyMap4,
 		policyMap6:                    p.PolicyMap6,
 		policies:                      p.Policies,
 		ciliumNodes:                   p.Nodes,
-		endpoints:                     p.Endpoints,
 		sysctl:                        p.Sysctl,
 		nodesAddresses2Labels:         make(map[string]map[string]string),
 	}
@@ -259,6 +247,17 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 
 	manager.reconciliationTrigger = t
 
+	// Subscribe to pod endpoint events. The Source replays its current
+	// state as Upsert events on subscription, so the manager does not
+	// need a separate "endpoints synced" signal.
+	if p.PodEndpoints != nil {
+		p.JobGroup.Add(job.Observer(
+			"egressgateway-endpoint-events",
+			manager.handleEndpointEvent,
+			p.PodEndpoints,
+		))
+	}
+
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -267,12 +266,10 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 			wg.Go(func() {
 				manager.processEvents(ctx)
 			})
-
 			return nil
 		},
 		OnStop: func(hc cell.HookContext) error {
 			cancel()
-
 			wg.Wait()
 			return nil
 		},
@@ -297,26 +294,50 @@ func (manager *Manager) eventBitmapIsSet(events ...eventType) bool {
 	return false
 }
 
-// getIdentityLabels waits for the global identities to be populated to the cache,
-// then looks up identity by ID from the cached identity allocator and return its labels.
-func (manager *Manager) getIdentityLabels(securityIdentity uint32) (labels.Labels, error) {
-	if err := manager.identityAllocator.WaitForInitialGlobalIdentities(context.Background()); err != nil {
-		return nil, fmt.Errorf("failed to wait for initial global identities: %w", err)
+// handleEndpointEvent is the [job.Observer] handler invoked for each event
+// emitted by the pod endpoint source. It writes the event into epDataStore
+// and triggers an async reconciliation.
+//
+// Events arrive already filtered for local-cluster pod endpoints, already
+// deduplicated per pod, and with their identity labels resolved. The manager
+// therefore only needs to mirror the event into its internal data store
+// under its own lock.
+func (manager *Manager) handleEndpointEvent(_ context.Context, ev podendpointsource.Event) error {
+	manager.Lock()
+	defer manager.Unlock()
+
+	switch ev.Kind {
+	case podendpointsource.EventKindUpsert:
+		ep := ev.Endpoint
+		manager.epDataStore[endpointID(ep.ID)] = &endpointMetadata{
+			id:     endpointID(ep.ID),
+			labels: ep.Labels,
+			ips:    ep.IPs,
+			nodeIP: ep.NodeIP,
+		}
+		manager.setEventBitmap(eventUpdateEndpoint)
+	case podendpointsource.EventKindDelete:
+		if _, ok := manager.epDataStore[endpointID(ev.Endpoint.ID)]; !ok {
+			return nil
+		}
+		delete(manager.epDataStore, endpointID(ev.Endpoint.ID))
+		manager.setEventBitmap(eventDeleteEndpoint)
 	}
 
-	identity := manager.identityAllocator.LookupIdentityByID(context.Background(), identity.NumericIdentity(securityIdentity))
-	if identity == nil {
-		return nil, fmt.Errorf("identity %d not found", securityIdentity)
-	}
-	return identity.Labels, nil
+	manager.reconciliationTrigger.TriggerWithReason("endpoint changed")
+	return nil
 }
 
 // processEvents spawns a goroutine that waits for the agent to
 // sync with k8s and then runs the first reconciliation.
+//
+// Endpoint data arrives independently via handleEndpointEvent; the Source's
+// replay-on-subscribe contract means we never need to wait for an explicit
+// "endpoints synced" signal here.
 func (manager *Manager) processEvents(ctx context.Context) {
-	var policySync, nodeSync, endpointSync bool
+	var policySync, nodeSync bool
 	maybeTriggerReconcile := func() {
-		if !policySync || !nodeSync || !endpointSync {
+		if !policySync || !nodeSync {
 			return
 		}
 
@@ -332,18 +353,8 @@ func (manager *Manager) processEvents(ctx context.Context) {
 		manager.reconciliationTrigger.TriggerWithReason("k8s sync done")
 	}
 
-	// here we try to mimic the same exponential backoff retry logic used by
-	// the identity allocator, where the minimum retry timeout is set to 20
-	// milliseconds and the max number of attempts is 16 (so 20ms * 2^16 ==
-	// ~20 minutes)
-	endpointsRateLimit := workqueue.NewTypedItemExponentialFailureRateLimiter[resource.WorkItem](
-		time.Millisecond*20,
-		time.Minute*20,
-	)
-
 	policyEvents := manager.policies.Events(ctx)
 	nodeEvents := manager.ciliumNodes.Events(ctx)
-	endpointEvents := manager.endpoints.Events(ctx, resource.WithRateLimiter(endpointsRateLimit))
 
 	for {
 		select {
@@ -366,15 +377,6 @@ func (manager *Manager) processEvents(ctx context.Context) {
 				event.Done(nil)
 			} else {
 				manager.handleNodeEvent(event)
-			}
-
-		case event := <-endpointEvents:
-			if event.Kind == resource.Sync {
-				endpointSync = true
-				maybeTriggerReconcile()
-				event.Done(nil)
-			} else {
-				manager.handleEndpointEvent(event)
 			}
 		}
 	}
@@ -455,90 +457,6 @@ func (manager *Manager) onDeleteEgressPolicy(policy *Policy) {
 
 	manager.setEventBitmap(eventDeletePolicy)
 	manager.reconciliationTrigger.TriggerWithReason("policy deleted")
-}
-
-func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
-	var epData *endpointMetadata
-	var err error
-	var identityLabels labels.Labels
-
-	manager.Lock()
-	defer manager.Unlock()
-
-	logger := manager.logger.With(
-		logfields.K8sEndpointName, endpoint.Name,
-		logfields.K8sNamespace, endpoint.Namespace,
-		logfields.K8sUID, endpoint.UID,
-	)
-
-	if endpoint.Identity == nil {
-		logger.Warn(
-			"Endpoint is missing identity metadata, skipping update to egress policy.",
-		)
-		return nil
-	}
-
-	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
-		logger.Warn(
-			"Failed to get identity labels for endpoint",
-			logfields.Error, err,
-		)
-		return err
-	}
-
-	if epData, err = getEndpointMetadata(endpoint, identityLabels); err != nil {
-		logger.Error(
-			"Failed to get valid endpoint metadata, skipping update to egress policy.",
-			logfields.Error, err,
-		)
-		return nil
-	}
-
-	if _, ok := manager.epDataStore[epData.id]; ok {
-		logger.Debug(
-			"Updated CiliumEndpoint",
-			logfields.Error, err,
-		)
-	} else {
-		logger.Debug(
-			"Added CiliumEndpoint",
-			logfields.Error, err,
-		)
-	}
-
-	manager.epDataStore[epData.id] = epData
-
-	manager.setEventBitmap(eventUpdateEndpoint)
-	manager.reconciliationTrigger.TriggerWithReason("endpoint updated")
-
-	return nil
-}
-
-func (manager *Manager) deleteEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
-	manager.Lock()
-	defer manager.Unlock()
-
-	manager.logger.Debug(
-		"Deleted CiliumEndpoint",
-		logfields.K8sEndpointName, endpoint.Name,
-		logfields.K8sNamespace, endpoint.Namespace,
-		logfields.K8sUID, endpoint.UID,
-	)
-	delete(manager.epDataStore, endpoint.UID)
-
-	manager.setEventBitmap(eventDeleteEndpoint)
-	manager.reconciliationTrigger.TriggerWithReason("endpoint deleted")
-}
-
-func (manager *Manager) handleEndpointEvent(event resource.Event[*k8sTypes.CiliumEndpoint]) {
-	endpoint := event.Object
-
-	if event.Kind == resource.Upsert {
-		event.Done(manager.addEndpoint(endpoint))
-	} else {
-		manager.deleteEndpoint(endpoint)
-		event.Done(nil)
-	}
 }
 
 // handleNodeEvent takes care of node upserts and removals.

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -135,11 +135,10 @@ type rpFilterSetting struct {
 }
 
 type EgressGatewayTestSuite struct {
-	manager   *Manager
-	policies  fakeResource[*Policy]
-	nodes     fakeResource[*cilium_api_v2.CiliumNode]
-	endpoints fakeResource[*k8sTypes.CiliumEndpoint]
-	sysctl    sysctl.Sysctl
+	manager  *Manager
+	policies fakeResource[*Policy]
+	nodes    fakeResource[*cilium_api_v2.CiliumNode]
+	sysctl   sysctl.Sysctl
 }
 
 func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
@@ -156,7 +155,6 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	k := &EgressGatewayTestSuite{}
 	k.policies = make(fakeResource[*Policy])
 	k.nodes = make(fakeResource[*cilium_api_v2.CiliumNode])
-	k.endpoints = make(fakeResource[*k8sTypes.CiliumEndpoint])
 	k.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
 
 	lc := hivetest.Lifecycle(t)
@@ -164,17 +162,17 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	policyMap6 := egressmap.CreatePrivatePolicyMap6(lc, nil, egressmap.DefaultPolicyConfig)
 
 	k.manager, err = newEgressGatewayManager(Params{
-		Logger:            logger,
-		Lifecycle:         lc,
-		Config:            Config{1 * time.Millisecond},
-		DaemonConfig:      &option.DaemonConfig{},
-		IdentityAllocator: identityAllocator,
-		PolicyMap4:        policyMap4,
-		PolicyMap6:        policyMap6,
-		Policies:          k.policies,
-		Nodes:             k.nodes,
-		Endpoints:         k.endpoints,
-		Sysctl:            k.sysctl,
+		Logger:       logger,
+		Lifecycle:    lc,
+		JobGroup:     nil, // pod endpoint events are delivered synchronously via handleEndpointEvent
+		Config:       Config{1 * time.Millisecond},
+		DaemonConfig: &option.DaemonConfig{},
+		PodEndpoints: nil, // tests drive events directly; no live subscription needed
+		PolicyMap4:   policyMap4,
+		PolicyMap6:   policyMap6,
+		Policies:     k.policies,
+		Nodes:        k.nodes,
+		Sysctl:       k.sysctl,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, k.manager)
@@ -320,7 +318,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	addNodeAndReconcile(t, k, egressGatewayManager, &node1)
@@ -351,7 +349,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Add a new endpoint & ID which matches policy-1
 	ep1, id1 := newEndpointAndIdentity("ep-1", ep1IP, ep1IPv6, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, 0},
@@ -362,14 +360,14 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Update the endpoint labels in order for it to not be a match
 	id1 = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{})
 	assertEgressRules6(t, policyMap6, []egressRule{})
 
 	// Restore the old endpoint lables in order for it to be a match
 	id1 = updateEndpointAndIdentity(&ep1, id1, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, 0},
@@ -417,7 +415,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Add a new endpoint and ID which matches policy-2
 	ep2, _ := newEndpointAndIdentity("ep-2", ep2IP, ep2IPv6, ep2Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, 0},
@@ -575,7 +573,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Update the endpoint labels in order for it to not be a match
 	_ = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep2IP, destCIDR, zeroIP4, node2IP, 0},
@@ -602,7 +600,7 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	addNodeAndReconcile(t, k, egressGatewayManager, &node1)
@@ -631,7 +629,7 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 
 	// Add a new endpoint & ID which matches policy-1
 	ep1, _ := newEndpointAndIdentityWithNodeIP("ep-1", ep1IP, ep1IPv6, node1IP, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{}) // This ep1 should not match the policy-1
 	assertEgressRules6(t, policyMap6, []egressRule{})
@@ -641,8 +639,8 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 	ep2, _ := newEndpointAndIdentityWithNodeIP(ep1.Name, ep2IP, ep2IPv6, node2IP, ep1Labels)
 
 	// Test event order: add new -> delete old
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{ // This ep2 should match the policy-1
 		{ep2IP, destCIDR, egressIP1, node1IP, 0},
@@ -655,8 +653,8 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 	ep3, _ := newEndpointAndIdentityWithNodeIP(ep1.Name, ep3IP, ep3IPv6, node1IP, ep1Labels)
 
 	// Test event order: delete old -> update new
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep3)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep3)
 
 	assertEgressRules4(t, policyMap4, []egressRule{}) // This ep3 should not match the policy-1
 	assertEgressRules6(t, policyMap6, []egressRule{})
@@ -679,7 +677,7 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	addNodeAndReconcile(t, k, egressGatewayManager, &node1)
@@ -704,7 +702,7 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 
 	// Add a new endpoint & ID which matches policy-1
 	ep1, _ := newEndpointAndIdentity("ep-1", ep1IP, ep1IPv6, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, 0},
@@ -720,8 +718,8 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 	ep2, _ := newEndpointAndIdentity(ep1.Name, ep2IP, ep2IPv6, ep1Labels)
 
 	// Test event order: add new -> delete old
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep2IP, destCIDR, egressIP1, node1IP, 0},
@@ -734,8 +732,8 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 	ep3, _ := newEndpointAndIdentity(ep1.Name, ep3IP, ep3IPv6, ep1Labels)
 
 	// Test event order: delete old -> update new
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep3)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep3)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep3IP, destCIDR, egressIP1, node1IP, 0},
@@ -763,7 +761,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	_ = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -805,7 +803,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	}
 	for i, ep := range eps {
 		newEP, newID := newEndpointAndIdentity(ep.name, ep.ipv4, ep.ipv6, ep1Labels)
-		addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &newEP)
+		addEndpointAndReconcile(t, egressGatewayManager, nil, &newEP)
 		eps[i].ep = &newEP
 		eps[i].id = newID
 	}
@@ -816,7 +814,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 		var rules []egressRule
 
 		for _, endpoint := range endpoints {
-			h := computeEndpointHash(endpoint.ep.UID)
+			h := computeEndpointHash(endpointID(endpoint.ep.Namespace + "/" + endpoint.ep.Name))
 			gw := gateways[h%uint32(len(gateways))]
 			ifindex := egressIfindex
 
@@ -885,12 +883,12 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
 
 	// Remove one endpoint and check that the remaining endpoints have not changed gateways.
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, eps[0].ep)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, eps[0].ep)
 	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap[1:])
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap[1:])
 
 	// Add one endpoint and check the configuration went back to the previous state.
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, eps[0].ep)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, eps[0].ep)
 	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap)
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
 
@@ -1003,6 +1001,11 @@ func newCiliumNode(name, nodeIP string, nodeLabels map[string]string) nodeTypes.
 }
 
 // Mock the creation of endpoint and its corresponding identity, returns endpoint and ID.
+//
+// The CiliumEndpoint's Identity.Labels field is populated with the K8s-form
+// labels so that the test's podendpointsource emulation (see
+// podEndpointFromCiliumEndpoint in helpers_test.go) can resolve them without
+// querying the identity allocator.
 func newEndpointAndIdentity(name, ipv4, ipv6 string, epLabels map[string]string) (k8sTypes.CiliumEndpoint, *identity.Identity) {
 	id, _, _ := identityAllocator.AllocateIdentity(context.Background(), labels.Map2Labels(epLabels, labels.LabelSourceK8s), true, identity.InvalidIdentity)
 
@@ -1012,7 +1015,8 @@ func newEndpointAndIdentity(name, ipv4, ipv6 string, epLabels map[string]string)
 			UID:  types.UID(uuid.New().String()),
 		},
 		Identity: &cilium_api_v2.EndpointIdentity{
-			ID: int64(id.ID),
+			ID:     int64(id.ID),
+			Labels: identityLabelsFor(epLabels),
 		},
 		Networking: &cilium_api_v2.EndpointNetworking{
 			Addressing: cilium_api_v2.AddressPairList{
@@ -1035,7 +1039,8 @@ func newEndpointAndIdentityWithNodeIP(name, ipv4, ipv6, nodeIP string, epLabels 
 			UID:  types.UID(uuid.New().String()),
 		},
 		Identity: &cilium_api_v2.EndpointIdentity{
-			ID: int64(id.ID),
+			ID:     int64(id.ID),
+			Labels: identityLabelsFor(epLabels),
 		},
 		Networking: &cilium_api_v2.EndpointNetworking{
 			Addressing: cilium_api_v2.AddressPairList{
@@ -1056,7 +1061,18 @@ func updateEndpointAndIdentity(endpoint *k8sTypes.CiliumEndpoint, oldID *identit
 	identityAllocator.Release(ctx, oldID, true)
 	newID, _, _ := identityAllocator.AllocateIdentity(ctx, labels.Map2Labels(newEpLabels, labels.LabelSourceK8s), true, identity.InvalidIdentity)
 	endpoint.Identity.ID = int64(newID.ID)
+	endpoint.Identity.Labels = identityLabelsFor(newEpLabels)
 	return newID
+}
+
+// identityLabelsFor renders a k8s label map as the "<source>:<key>=<value>"
+// slice that CiliumEndpoint.Identity.Labels contains in the real world.
+func identityLabelsFor(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, "k8s:"+k+"="+v)
+	}
+	return out
 }
 
 func parseEgressRule(sourceIP, destCIDR, egressIP, gatewayIP string, egressIfindex uint32) parsedEgressRule {
@@ -1170,6 +1186,11 @@ func tryAssertEgressRules6(policyMap *egressmap.PolicyMap6, rules []egressRule) 
 
 	return nil
 }
+
+// Note: remote-cluster filtering is now tested at the podendpointsource
+// layer (see pkg/podendpointsource/source_test.go:TestRemoteClusterIgnored).
+// The egress gateway manager never observes non-local endpoints because the
+// source filters them out before emitting.
 
 func assertRPFilter(t *testing.T, sysctl sysctl.Sysctl, rpFilterSettings []rpFilterSetting) {
 	t.Helper()

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -252,9 +252,9 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc 
 	return nil
 }
 
-func computeEndpointHash(endpointUID types.UID) uint32 {
+func computeEndpointHash(id endpointID) uint32 {
 	h := fnv.New32a()
-	h.Write([]byte(endpointUID))
+	h.Write([]byte(id))
 	return h.Sum32()
 }
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -686,9 +686,13 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	oldK8sMeta := ipc.getK8sMetadata(ip)
 	oldEndpointFlags := ipc.getEndpointFlagsRLocked(ip)
 	var newHostIP net.IP
+	var newEncryptKey uint8
 	var oldIdentity *Identity
 	newIdentity := cachedIdentity
 	callbackListeners := true
+	callbackK8sMeta := oldK8sMeta
+	callbackEndpointFlags := oldEndpointFlags
+	callbackEncryptKey := encryptKey
 
 	var err error
 	if cidrCluster, err = cmtypes.ParsePrefixCluster(ip); err == nil {
@@ -709,7 +713,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 		// restore its mapping with the listeners if that was the case.
 		cidrClusterStr := cidrCluster.String()
 		if cidrIdentity, cidrFound := ipc.ipToIdentityCache[cidrClusterStr]; cidrFound {
-			newHostIP, _ = ipc.getHostIPCacheRLocked(cidrClusterStr)
+			newHostIP, newEncryptKey = ipc.getHostIPCacheRLocked(cidrClusterStr)
 			if cidrIdentity.ID != cachedIdentity.ID || !oldHostIP.Equal(newHostIP) {
 				ipc.logger.Debug(
 					"Removal of endpoint IP revives shadowed CIDR to identity mapping",
@@ -719,6 +723,12 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 				ipc.ipToIdentityCache[cidrClusterStr] = cidrIdentity
 				oldIdentity = &cachedIdentity
 				newIdentity = cidrIdentity
+				// The revived mapping is the CIDR entry, not the deleted
+				// endpoint IP. Report the CIDR's current metadata/flags/key
+				// to listeners so they don't observe stale pod-scoped data.
+				callbackK8sMeta = ipc.getK8sMetadata(cidrClusterStr)
+				callbackEndpointFlags = ipc.getEndpointFlagsRLocked(cidrClusterStr)
+				callbackEncryptKey = newEncryptKey
 			} else {
 				// The endpoint IP and the CIDR were associated with the same
 				// identity and host IP. Nothing changes for the listeners.
@@ -760,7 +770,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	if callbackListeners {
 		for _, listener := range ipc.listeners {
 			listener.OnIPIdentityCacheChange(cacheModification, cidrCluster, oldHostIP, newHostIP,
-				oldIdentity, newIdentity, encryptKey, oldK8sMeta, oldEndpointFlags)
+				oldIdentity, newIdentity, callbackEncryptKey, callbackK8sMeta, callbackEndpointFlags)
 		}
 	}
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -578,6 +578,22 @@ type dummyListener struct {
 	ipc     *IPCache
 }
 
+type recordedChange struct {
+	modType       CacheModification
+	cidrCluster   cmtypes.PrefixCluster
+	oldHostIP     net.IP
+	newHostIP     net.IP
+	oldID         *Identity
+	newID         Identity
+	encryptKey    uint8
+	k8sMeta       *K8sMetadata
+	endpointFlags uint8
+}
+
+type recordingListener struct {
+	events []recordedChange
+}
+
 func newDummyListener(ipc *IPCache) *dummyListener {
 	return &dummyListener{
 		ipc: ipc,
@@ -594,6 +610,45 @@ func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
 	default:
 		// Ignore, for simplicity we just clear the cache every time
 	}
+}
+
+func (rl *recordingListener) OnIPIdentityCacheChange(modType CacheModification,
+	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *Identity,
+	newID Identity, encryptKey uint8, k8sMeta *K8sMetadata, endpointFlags uint8) {
+
+	var oldIDCopy *Identity
+	if oldID != nil {
+		copied := *oldID
+		oldIDCopy = &copied
+	}
+
+	var metaCopy *K8sMetadata
+	if k8sMeta != nil {
+		copied := *k8sMeta
+		metaCopy = &copied
+	}
+
+	rl.events = append(rl.events, recordedChange{
+		modType:       modType,
+		cidrCluster:   cidrCluster,
+		oldHostIP:     slices.Clone(oldHostIP),
+		newHostIP:     slices.Clone(newHostIP),
+		oldID:         oldIDCopy,
+		newID:         newID,
+		encryptKey:    encryptKey,
+		k8sMeta:       metaCopy,
+		endpointFlags: endpointFlags,
+	})
+}
+
+func upsertTestEntry(t *testing.T, ipc *IPCache, ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity, endpointFlags uint8) {
+	t.Helper()
+
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+
+	_, err := ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, endpointFlags, false, false)
+	require.NoError(t, err)
 }
 
 func (dl *dummyListener) ExpectMapping(t *testing.T, targetIP string, targetIdentity identityPkg.NumericIdentity) {
@@ -655,4 +710,55 @@ func TestIPCacheShadowing(t *testing.T) {
 	ipc.Delete(endpointIP, source.KVStore)
 	_, exists := ipc.LookupByPrefix(cidrOverlap)
 	require.False(t, exists)
+}
+
+func TestIPCacheShadowedCIDRRevivalUsesCurrentAttributes(t *testing.T) {
+	t.Parallel()
+	s := setupIPCacheTestSuite(t)
+
+	const (
+		endpointKey   = uint8(7)
+		cidrKey       = uint8(9)
+		endpointFlags = uint8(0x1)
+		cidrFlags     = uint8(0x2)
+	)
+
+	endpointIP := "10.0.0.15"
+	cidrOverlap := "10.0.0.15/32"
+	endpointHostIP := net.ParseIP("192.0.2.10")
+	cidrHostIP := net.ParseIP("192.0.2.20")
+	endpointMeta := &K8sMetadata{
+		Namespace: "default",
+		PodName:   "pod-a",
+	}
+	endpointIdentity := Identity{
+		ID:     identityPkg.NumericIdentity(68),
+		Source: source.KVStore,
+	}
+	cidrIdentity := Identity{
+		ID:     identityPkg.NumericIdentity(202),
+		Source: source.Generated,
+	}
+
+	upsertTestEntry(t, s.IPIdentityCache, endpointIP, endpointHostIP, endpointKey, endpointMeta, endpointIdentity, endpointFlags)
+	upsertTestEntry(t, s.IPIdentityCache, cidrOverlap, cidrHostIP, cidrKey, nil, cidrIdentity, cidrFlags)
+
+	listener := &recordingListener{}
+	s.IPIdentityCache.AddListener(listener)
+	listener.events = nil
+
+	s.IPIdentityCache.Delete(endpointIP, source.KVStore)
+
+	require.Len(t, listener.events, 1)
+	event := listener.events[0]
+	require.Equal(t, Upsert, event.modType)
+	require.Equal(t, cidrOverlap, event.cidrCluster.String())
+	require.NotNil(t, event.oldID)
+	require.Equal(t, endpointIdentity.ID, event.oldID.ID)
+	require.Equal(t, cidrIdentity.ID, event.newID.ID)
+	require.True(t, endpointHostIP.Equal(event.oldHostIP))
+	require.True(t, cidrHostIP.Equal(event.newHostIP))
+	require.Equal(t, cidrKey, event.encryptKey)
+	require.Nil(t, event.k8sMeta)
+	require.Equal(t, cidrFlags, event.endpointFlags)
 }

--- a/pkg/podendpointsource/cell.go
+++ b/pkg/podendpointsource/cell.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package podendpointsource observes pod endpoints via the IPCache and
+// exposes them as a [stream.Observable] of per-pod [Event]s.
+//
+// The package centralises the filtering, identity resolution and backpressure
+// concerns that were previously replicated in every consumer of pod endpoint
+// data (CiliumEndpoint or CiliumEndpointSlice watchers). Consumers inject a
+// [Source] and subscribe to [Source.Observe]; they receive a deduplicated
+// per-pod view of local-cluster pod endpoints with their identity labels
+// already resolved.
+package podendpointsource
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell provides a [Source] of pod endpoint events backed by the IPCache.
+//
+// The cell registers an IPCache listener during the agent's OnStart hook,
+// after the global identity cache has been synced, and runs a background
+// consumer goroutine that turns IPCache notifications into deduplicated
+// per-pod events.
+var Cell = cell.Module(
+	"pod-endpoint-source",
+	"Observes pod endpoints from the IPCache and exposes them as a stream",
+
+	cell.Provide(newSource),
+)

--- a/pkg/podendpointsource/cell_test.go
+++ b/pkg/podendpointsource/cell_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// TestCell verifies that the cell can be populated with a minimal set of
+// external dependencies. The lifecycle hook (AddListener,
+// WaitForInitialGlobalIdentities) is not exercised here — it runs only when
+// the hive is Start()-ed. Populate is enough to catch wiring regressions.
+func TestCell(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	err := hive.New(
+		Cell,
+		cell.Provide(
+			func() identityCache.IdentityAllocator {
+				return testidentity.NewMockIdentityAllocator(nil)
+			},
+			func() *ipcache.IPCache {
+				return ipcache.NewIPCache(&ipcache.Configuration{
+					Context:           t.Context(),
+					Logger:            logger,
+					IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+					IdentityUpdater:   &noopIdentityUpdater{},
+				})
+			},
+		),
+	).Populate(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// noopIdentityUpdater satisfies the ipcachetypes.IdentityUpdater contract
+// required by the IPCache constructor without performing any work.
+type noopIdentityUpdater struct{}
+
+func (*noopIdentityUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/pkg/podendpointsource/source.go
+++ b/pkg/podendpointsource/source.go
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/netip"
+	"slices"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/stream"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// Source exposes pod endpoints, aggregated across all IPs of each pod, as a
+// stream of [Event]s.
+//
+// Source subscribes to the IPCache on behalf of its consumers, filters out
+// entries that are not pod endpoints (non-local cluster, non-/32 or non-/128
+// prefixes, and entries without Kubernetes metadata), resolves identity
+// labels via the IdentityAllocator, and emits deduplicated per-pod events
+// that match the semantics previously provided by CiliumEndpoint watchers.
+//
+// Source is safe for concurrent use. Subscribers should consume events via
+// [job.Observer] so that event delivery is automatically bounded by the
+// job's context. On subscription the current state is replayed as a sequence
+// of Upsert events, after which live updates are delivered.
+type Source interface {
+	stream.Observable[Event]
+}
+
+// queueSize bounds the internal channel between the IPCache listener
+// callback and the consumer goroutine. The consumer is cheap (one identity
+// lookup and a map update per event), so the buffer only needs to absorb
+// short bursts during the IPCache dump and transient storms. A larger value
+// trades a small amount of memory for resilience against head-of-line
+// blocking of the IPCache.
+const queueSize = 4096
+
+// blockedWarnInterval throttles the "enqueue is blocking" warning so that a
+// sustained overload condition does not flood the logs.
+const blockedWarnInterval = 30 * time.Second
+
+// callbackEvent is the internal representation of an IPCache change,
+// decoupled from the [ipcache.IPIdentityMappingListener] signature so that
+// the callback can return immediately.
+//
+// For Upsert events, namespace/podName come from the "new" K8sMetadata and
+// identify the pod that owns the IP after the change. For Delete events,
+// they come from the "old" K8sMetadata (as passed by IPCache) and identify
+// the pod that owned the IP before the change. In both cases hasMeta
+// discriminates between an event for a pod endpoint and an event for a
+// non-pod source (CIDR, world identity, etc.).
+type callbackEvent struct {
+	modType ipcache.CacheModification
+	addr    netip.Addr
+	newID   identity.NumericIdentity
+	hostIP  string
+
+	namespace string
+	podName   string
+	hasMeta   bool
+}
+
+// source is the default [Source] implementation backed by an IPCache
+// listener.
+type source struct {
+	logger *slog.Logger
+
+	identityAllocator identityCache.IdentityAllocator
+
+	// queue carries pre-filtered IPCache events from the listener
+	// callback to the consumer goroutine. A bounded channel bounds
+	// memory and provides backpressure; the callback blocks when the
+	// queue is full so no events are ever lost.
+	queue chan callbackEvent
+
+	// mu protects endpoints and ipToID during Observe replay. All state
+	// mutations happen from a single consumer goroutine, so mu is only
+	// contended when a new subscriber is attaching.
+	mu        lock.RWMutex
+	endpoints map[string]*PodEndpoint
+	ipToID    map[netip.Addr]string
+
+	// observable is the live event stream. emit and complete are its
+	// producer-side handles; see [stream.Multicast].
+	observable stream.Observable[Event]
+	emit       func(Event)
+	complete   func(error)
+
+	// lastBlockedWarn throttles the log line emitted when the callback
+	// has to block on a full queue.
+	lastBlockedWarn struct {
+		lock.Mutex
+		t time.Time
+	}
+}
+
+type params struct {
+	cell.In
+
+	Logger            *slog.Logger
+	Lifecycle         cell.Lifecycle
+	JobGroup          job.Group
+	IPCache           *ipcache.IPCache
+	IdentityAllocator identityCache.IdentityAllocator
+}
+
+func newSource(p params) Source {
+	s := &source{
+		logger:            p.Logger,
+		identityAllocator: p.IdentityAllocator,
+		queue:             make(chan callbackEvent, queueSize),
+		endpoints:         map[string]*PodEndpoint{},
+		ipToID:            map[netip.Addr]string{},
+	}
+	s.observable, s.emit, s.complete = stream.Multicast[Event]()
+
+	// Run the consumer goroutine for the lifetime of the cell.
+	p.JobGroup.Add(job.OneShot("pod-endpoint-source", s.run))
+
+	// Register the IPCache listener after the global identity cache is
+	// warmed up, so identity lookups in the consumer goroutine succeed
+	// for the IPs delivered by the initial dump. This is done in a job
+	// rather than an OnStart hook because WaitForInitialGlobalIdentities
+	// depends on work (such as [identity/cache.CachingIdentityAllocator.InitIdentityAllocator])
+	// performed by other OnStart hooks — notably the legacy daemon cell —
+	// and blocking here would prevent those later hooks from running
+	// inside the lifecycle's sequential start pass.
+	p.JobGroup.Add(job.OneShot(
+		"pod-endpoint-listener-registration",
+		func(ctx context.Context, _ cell.Health) error {
+			if err := p.IdentityAllocator.WaitForInitialGlobalIdentities(ctx); err != nil {
+				return err
+			}
+			p.IPCache.AddListener(s)
+			return nil
+		},
+	))
+
+	p.Lifecycle.Append(cell.Hook{
+		OnStop: func(cell.HookContext) error {
+			// The job group's context cancellation will stop the
+			// consumer; signal subscribers that the observable is
+			// complete so that any pending Observe calls unblock.
+			s.complete(nil)
+			return nil
+		},
+	})
+
+	return s
+}
+
+// Observe replays the current set of pod endpoints as a sequence of Upsert
+// events and then delegates to the live multicast observable. It is safe to
+// subscribe at any time after the cell has been constructed.
+//
+// The replay holds a read lock on the source's state, which is briefly
+// contended with the consumer goroutine. This matches the
+// "snapshot then subscribe" pattern used by
+// pkg/identity/cache/local.localIdentityCache.
+func (s *source) Observe(ctx context.Context, next func(Event), complete func(error)) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, ep := range s.endpoints {
+		select {
+		case <-ctx.Done():
+			complete(ctx.Err())
+			return
+		default:
+		}
+		next(Event{Kind: EventKindUpsert, Endpoint: cloneEndpoint(ep)})
+	}
+
+	s.observable.Observe(ctx, next, complete)
+}
+
+// OnIPIdentityCacheChange implements [ipcache.IPIdentityMappingListener].
+//
+// The listener runs with the IPCache lock held, so this function performs
+// only cheap filtering before enqueueing the event to the consumer
+// goroutine. All heavier work — identity lookup, endpoint mirror mutation,
+// event emission — happens downstream of the queue, outside the IPCache
+// lock.
+func (s *source) OnIPIdentityCacheChange(
+	modType ipcache.CacheModification,
+	cidrCluster cmtypes.PrefixCluster,
+	_ net.IP, newHostIP net.IP,
+	_ *ipcache.Identity, newID ipcache.Identity,
+	_ uint8,
+	k8sMeta *ipcache.K8sMetadata,
+	_ uint8,
+) {
+	// Only process local cluster entries. Remote clustermesh entries
+	// (non-zero ClusterID) previously were not observed by the CiliumEndpoint
+	// watcher; mirroring that behaviour prevents namespace/name collisions
+	// with local pods and keeps remote traffic out of the local gateway
+	// decision path.
+	if cidrCluster.ClusterID() != 0 {
+		return
+	}
+
+	// Only pod endpoints are of interest. A pod IP is represented by a
+	// host-length prefix (/32 for IPv4, /128 for IPv6). Reject CIDR
+	// entries up-front so that we never enqueue an event for them.
+	prefix := cidrCluster.AsPrefix()
+	addr := prefix.Addr()
+	if !addr.IsValid() {
+		return
+	}
+	switch {
+	case addr.Is4() && prefix.Bits() == 32:
+	case !addr.Is4() && prefix.Bits() == 128:
+	default:
+		return
+	}
+
+	ev := callbackEvent{
+		modType: modType,
+		addr:    addr,
+		newID:   newID.ID,
+	}
+	if newHostIP != nil {
+		ev.hostIP = newHostIP.String()
+	}
+	if k8sMeta != nil && k8sMeta.Namespace != "" && k8sMeta.PodName != "" {
+		// Copy out the fields we need. K8sMetadata is owned by the
+		// IPCache and must not be retained by listeners.
+		ev.namespace = k8sMeta.Namespace
+		ev.podName = k8sMeta.PodName
+		ev.hasMeta = true
+	}
+
+	// Fast path: non-blocking send. On overflow fall back to a blocking
+	// send with a throttled warning so we never lose events.
+	select {
+	case s.queue <- ev:
+	default:
+		s.warnBlocked()
+		s.queue <- ev
+	}
+}
+
+func (s *source) warnBlocked() {
+	now := time.Now()
+	s.lastBlockedWarn.Lock()
+	defer s.lastBlockedWarn.Unlock()
+	if now.Sub(s.lastBlockedWarn.t) < blockedWarnInterval {
+		return
+	}
+	s.lastBlockedWarn.t = now
+	s.logger.Warn(
+		"pod-endpoint-source event queue is full; IPCache listener is blocking. "+
+			"This may indicate slow subscribers or a sustained IPCache update storm.",
+		logfields.Capacity, cap(s.queue),
+	)
+}
+
+// run consumes events from the queue until ctx is cancelled.
+//
+// The health argument is unused: this job does not have a notion of
+// "degraded" vs "healthy" — it either runs or it doesn't.
+func (s *source) run(ctx context.Context, _ cell.Health) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev := <-s.queue:
+			s.handleEvent(ev)
+		}
+	}
+}
+
+func (s *source) handleEvent(ev callbackEvent) {
+	switch ev.modType {
+	case ipcache.Upsert:
+		if ev.hasMeta {
+			s.upsertPodIP(ev)
+		} else {
+			// The same IP is now associated with something other
+			// than a pod (e.g. a CIDR identity). Evict any prior
+			// pod owner so the mirror doesn't leak.
+			s.evictIP(ev.addr)
+		}
+	case ipcache.Delete:
+		if ev.hasMeta {
+			// Scope the eviction to the pod that IPCache says
+			// owned the IP before this delete. If the IP has
+			// since been reassigned to a different pod (e.g. the
+			// source has already applied a synthetic eviction in
+			// upsertPodIP for a pod-a→pod-b reassignment, and this
+			// delete is the stale one for pod-a), this check
+			// prevents the stale delete from erasing the new pod.
+			s.evictIPForPod(ev.addr, ev.namespace+"/"+ev.podName)
+		} else {
+			// Delete of a non-pod entry. If a pod currently owns
+			// this IP we still want to evict it, for the same
+			// leak-prevention reason as the Upsert-without-meta
+			// path above.
+			s.evictIP(ev.addr)
+		}
+	}
+}
+
+// upsertPodIP applies an Upsert for an IPCache entry that carries pod
+// metadata. It handles three cases uniformly:
+//   - the pod+IP pair is new
+//   - the pod already exists and the IP is added to it
+//   - the IP previously belonged to a different pod (reassignment)
+func (s *source) upsertPodIP(ev callbackEvent) {
+	epID := ev.namespace + "/" + ev.podName
+
+	// Identity lookup may internally go to the kvstore. Do it outside
+	// any of our locks so that a slow lookup never blocks a concurrent
+	// Observe replay on a new subscriber.
+	labels, identityOK := s.lookupIdentityLabels(ev.newID)
+
+	// The state mutation and the corresponding emit are performed under
+	// a single critical section so that a new subscriber's
+	// snapshot-then-subscribe in [source.Observe] cannot race with a
+	// half-applied update and observe the same Upsert twice.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If this IP is currently owned by a different endpoint, remove it
+	// from that endpoint first. This covers pod-to-pod IP reassignment
+	// without waiting for the stale Delete to arrive.
+	if prevID, owned := s.ipToID[ev.addr]; owned && prevID != epID {
+		if evicted := s.removeIPLocked(prevID, ev.addr); evicted != nil {
+			s.emit(*evicted)
+		}
+	}
+
+	ep, exists := s.endpoints[epID]
+	if !identityOK {
+		if !exists {
+			// Without labels we cannot match any policy, so
+			// creating a new endpoint here would only produce a
+			// degenerate entry. Skip it; a subsequent IPCache
+			// upsert will redeliver once the identity is
+			// resolvable.
+			s.logger.Debug(
+				"Skipping pod endpoint upsert: identity not resolvable",
+				logfields.Identity, ev.newID,
+				logfields.K8sNamespace, ev.namespace,
+				logfields.K8sPodName, ev.podName,
+			)
+			return
+		}
+		// Preserve the previously-known labels rather than wiping
+		// them to empty. The endpoint still has its current IPs and
+		// node IP updated.
+		labels = ep.Labels
+		s.logger.Debug(
+			"Preserving last-known labels for pod endpoint: identity not resolvable",
+			logfields.Identity, ev.newID,
+			logfields.K8sNamespace, ev.namespace,
+			logfields.K8sPodName, ev.podName,
+		)
+	}
+
+	if !exists {
+		ep = &PodEndpoint{
+			ID:     epID,
+			IPs:    []netip.Addr{ev.addr},
+			Labels: labels,
+			NodeIP: ev.hostIP,
+		}
+		s.endpoints[epID] = ep
+	} else {
+		ep.Labels = labels
+		ep.NodeIP = ev.hostIP
+		if !slices.Contains(ep.IPs, ev.addr) {
+			ep.IPs = append(ep.IPs, ev.addr)
+			sortIPs(ep.IPs)
+		}
+	}
+	s.ipToID[ev.addr] = epID
+
+	s.emit(Event{Kind: EventKindUpsert, Endpoint: cloneEndpoint(ep)})
+}
+
+// evictIP drops an IP from whichever endpoint currently owns it, if any,
+// and emits the appropriate Upsert or Delete event.
+func (s *source) evictIP(addr netip.Addr) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prevID, owned := s.ipToID[addr]
+	if !owned {
+		return
+	}
+	if ev := s.removeIPLocked(prevID, addr); ev != nil {
+		s.emit(*ev)
+	}
+}
+
+// evictIPForPod drops an IP, but only if it is currently attributed to the
+// given pod. It is the ownership-scoped variant of evictIP used for
+// pod-targeted Delete events.
+//
+// This is the primary defence against stale Delete events clobbering a pod
+// that has just taken over the IP. A reassignment pod-a → pod-b is handled
+// eagerly in upsertPodIP by removing the IP from pod-a; if a stale delete
+// for pod-a then arrives, ipToID[addr] already points at pod-b and this
+// function leaves pod-b untouched.
+func (s *source) evictIPForPod(addr netip.Addr, epID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prevID, owned := s.ipToID[addr]
+	if !owned || prevID != epID {
+		return
+	}
+	if ev := s.removeIPLocked(prevID, addr); ev != nil {
+		s.emit(*ev)
+	}
+}
+
+// removeIPLocked removes addr from the endpoint identified by epID. It
+// returns the Event that should be emitted to subscribers to describe the
+// change, or nil if no change is observable (which can only happen if epID
+// or addr cannot be found — a defensive code path).
+//
+// Must be called with s.mu held.
+func (s *source) removeIPLocked(epID string, addr netip.Addr) *Event {
+	delete(s.ipToID, addr)
+
+	ep, ok := s.endpoints[epID]
+	if !ok {
+		return nil
+	}
+	ep.IPs = slices.DeleteFunc(ep.IPs, func(a netip.Addr) bool { return a == addr })
+	if len(ep.IPs) == 0 {
+		delete(s.endpoints, epID)
+		return &Event{
+			Kind:     EventKindDelete,
+			Endpoint: PodEndpoint{ID: epID},
+		}
+	}
+	return &Event{Kind: EventKindUpsert, Endpoint: cloneEndpoint(ep)}
+}
+
+// lookupIdentityLabels resolves an identity ID to its labels in the
+// Kubernetes string-map form. The bool return signals whether the identity
+// was resolvable; the caller decides how to treat an unresolved identity.
+func (s *source) lookupIdentityLabels(id identity.NumericIdentity) (map[string]string, bool) {
+	ident := s.identityAllocator.LookupIdentityByID(context.Background(), id)
+	if ident == nil {
+		return nil, false
+	}
+	return ident.Labels.K8sStringMap(), true
+}
+
+// cloneEndpoint returns a detached copy of ep that is safe to hand out to
+// subscribers without risking mutation of the source's internal state.
+func cloneEndpoint(ep *PodEndpoint) PodEndpoint {
+	out := PodEndpoint{
+		ID:     ep.ID,
+		NodeIP: ep.NodeIP,
+		IPs:    slices.Clone(ep.IPs),
+	}
+	if ep.Labels != nil {
+		out.Labels = make(map[string]string, len(ep.Labels))
+		for k, v := range ep.Labels {
+			out.Labels[k] = v
+		}
+	}
+	return out
+}
+
+// sortIPs orders IPs so that IPv4 addresses come first, then IPv6, numeric
+// within each family. This matches the ordering that the previous
+// CiliumEndpoint-based source produced.
+func sortIPs(ips []netip.Addr) {
+	slices.SortFunc(ips, func(a, b netip.Addr) int {
+		switch {
+		case a.Is4() && !b.Is4():
+			return -1
+		case !a.Is4() && b.Is4():
+			return 1
+		default:
+			return a.Compare(b)
+		}
+	})
+}
+
+// Ensure interface satisfaction at compile time.
+var (
+	_ ipcache.IPIdentityMappingListener = (*source)(nil)
+	_ Source                            = (*source)(nil)
+)

--- a/pkg/podendpointsource/source_test.go
+++ b/pkg/podendpointsource/source_test.go
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/stream"
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// newTestSource constructs a source without hive/IPCache/job wiring so that
+// unit tests can drive OnIPIdentityCacheChange directly and observe emitted
+// events. The caller is responsible for stopping the source via the returned
+// cancel func.
+func newTestSource(t *testing.T) (s *source, stop func()) {
+	t.Helper()
+
+	allocator := testidentity.NewMockIdentityAllocator(nil)
+	s = &source{
+		logger:            hivetest.Logger(t),
+		identityAllocator: allocator,
+		queue:             make(chan callbackEvent, queueSize),
+		endpoints:         map[string]*PodEndpoint{},
+		ipToID:            map[netip.Addr]string{},
+	}
+	s.observable, s.emit, s.complete = stream.Multicast[Event]()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = s.run(ctx, nil)
+		close(done)
+	}()
+
+	stop = func() {
+		cancel()
+		<-done
+		s.complete(nil)
+	}
+	return s, stop
+}
+
+// allocateIdentity creates an identity in the mock allocator so that the
+// source's lookupIdentityLabels can resolve it. Returns the numeric ID.
+func allocateIdentity(t *testing.T, s *source, lbls map[string]string) identity.NumericIdentity {
+	t.Helper()
+	alloc := s.identityAllocator.(*testidentity.MockIdentityAllocator)
+	id, _, err := alloc.AllocateIdentity(context.Background(), labels.Map2Labels(lbls, labels.LabelSourceK8s), false, 0)
+	require.NoError(t, err)
+	return id.ID
+}
+
+// subscribe returns a channel that receives events emitted by s after the
+// call returns. The subscription is cancelled when the test ends.
+func subscribe(t *testing.T, s *source) <-chan Event {
+	t.Helper()
+	ch := make(chan Event, 64)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan struct{})
+	go func() {
+		s.Observe(ctx, func(ev Event) { ch <- ev }, func(error) { close(done) })
+	}()
+	return ch
+}
+
+// waitForEvent reads one event with a timeout.
+func waitForEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for event")
+		return Event{}
+	}
+}
+
+// drainFor drains events from ch until no event arrives for idleFor. This is
+// used when a single IPCache change is expected to produce a fixed small
+// number of events and we want the entire sequence.
+func drainFor(ch <-chan Event, idleFor time.Duration) []Event {
+	var out []Event
+	for {
+		select {
+		case ev := <-ch:
+			out = append(out, ev)
+		case <-time.After(idleFor):
+			return out
+		}
+	}
+}
+
+func mustAddr(s string) netip.Addr {
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func prefixCluster(addr netip.Addr, bits int, clusterID uint32) cmtypes.PrefixCluster {
+	return cmtypes.PrefixClusterFrom(
+		netip.PrefixFrom(addr, bits),
+		cmtypes.WithClusterID(clusterID),
+	)
+}
+
+func pushUpsert(s *source, addr netip.Addr, bits int, clusterID uint32,
+	id identity.NumericIdentity, namespace, podName string, hostIP string,
+) {
+	var k8sMeta *ipcache.K8sMetadata
+	if namespace != "" || podName != "" {
+		k8sMeta = &ipcache.K8sMetadata{Namespace: namespace, PodName: podName}
+	}
+	var hostIPnet net.IP
+	if hostIP != "" {
+		hostIPnet = net.ParseIP(hostIP)
+	}
+	s.OnIPIdentityCacheChange(
+		ipcache.Upsert,
+		prefixCluster(addr, bits, clusterID),
+		nil, hostIPnet,
+		nil, ipcache.Identity{ID: id},
+		0, k8sMeta, 0,
+	)
+}
+
+func pushDelete(s *source, addr netip.Addr, bits int, clusterID uint32,
+	namespace, podName string,
+) {
+	var k8sMeta *ipcache.K8sMetadata
+	if namespace != "" || podName != "" {
+		k8sMeta = &ipcache.K8sMetadata{Namespace: namespace, PodName: podName}
+	}
+	s.OnIPIdentityCacheChange(
+		ipcache.Delete,
+		prefixCluster(addr, bits, clusterID),
+		nil, nil,
+		nil, ipcache.Identity{},
+		0, k8sMeta, 0,
+	)
+}
+
+// TestPrefixFilter verifies that only /32 and /128 entries are accepted.
+func TestPrefixFilter(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "test"})
+	ch := subscribe(t, s)
+
+	// /24 — rejected
+	pushUpsert(s, mustAddr("10.0.0.0"), 24, 0, id, "default", "pod", "192.168.1.1")
+	// /64 — rejected
+	pushUpsert(s, mustAddr("fd00::"), 64, 0, id, "default", "pod", "192.168.1.1")
+	// /32 — accepted
+	pushUpsert(s, mustAddr("10.0.0.1"), 32, 0, id, "default", "pod", "192.168.1.1")
+
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, "default/pod", ev.Endpoint.ID)
+	require.Equal(t, []netip.Addr{mustAddr("10.0.0.1")}, ev.Endpoint.IPs)
+
+	// No further events should have fired from the rejected prefixes.
+	require.Empty(t, drainFor(ch, 100*time.Millisecond))
+}
+
+// TestIPv128Accepted verifies that /128 prefixes are accepted.
+func TestIPv128Accepted(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "v6"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("fd00::1"), 128, 0, id, "default", "v6pod", "192.168.1.1")
+
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, []netip.Addr{mustAddr("fd00::1")}, ev.Endpoint.IPs)
+}
+
+// TestRemoteClusterIgnored verifies that entries from remote clustermesh
+// clusters are not processed.
+func TestRemoteClusterIgnored(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "remote"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("10.0.0.99"), 32, 2, id, "default", "remote", "192.168.1.1")
+	require.Empty(t, drainFor(ch, 100*time.Millisecond))
+
+	// The same IP from the local cluster should still be processed.
+	pushUpsert(s, mustAddr("10.0.0.99"), 32, 0, id, "default", "local", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, "default/local", ev.Endpoint.ID)
+}
+
+// TestUpsertAndDelete covers the basic lifecycle of a pod endpoint.
+func TestUpsertAndDelete(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "web"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("10.0.0.1"), 32, 0, id, "default", "web", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, "default/web", ev.Endpoint.ID)
+	require.Equal(t, map[string]string{"app": "web"}, ev.Endpoint.Labels)
+	require.Equal(t, "192.168.1.1", ev.Endpoint.NodeIP)
+
+	pushDelete(s, mustAddr("10.0.0.1"), 32, 0, "default", "web")
+	ev = waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+	require.Equal(t, "default/web", ev.Endpoint.ID)
+}
+
+// TestIPOrdering verifies IPs are sorted IPv4-first then numeric within each
+// family, regardless of insertion order.
+func TestIPOrdering(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "dual"})
+	ch := subscribe(t, s)
+
+	// Push an IPv6 first, then two IPv4s out of numeric order.
+	pushUpsert(s, mustAddr("fd00::10"), 128, 0, id, "default", "dual", "192.168.1.1")
+	<-ch
+	pushUpsert(s, mustAddr("10.0.0.2"), 32, 0, id, "default", "dual", "192.168.1.1")
+	<-ch
+	pushUpsert(s, mustAddr("10.0.0.1"), 32, 0, id, "default", "dual", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+
+	require.Equal(t, []netip.Addr{
+		mustAddr("10.0.0.1"),
+		mustAddr("10.0.0.2"),
+		mustAddr("fd00::10"),
+	}, ev.Endpoint.IPs)
+}
+
+// TestIPReassignmentBetweenPods covers the O2 leak scenario where an IP is
+// reclaimed by a different pod before the original pod's Delete arrives,
+// and additionally verifies that a subsequently-arriving stale Delete for
+// the original pod does not clobber the new pod.
+func TestIPReassignmentBetweenPods(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	idA := allocateIdentity(t, s, map[string]string{"app": "a"})
+	idB := allocateIdentity(t, s, map[string]string{"app": "b"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.5")
+
+	pushUpsert(s, addr, 32, 0, idA, "default", "pod-a", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, "default/pod-a", ev.Endpoint.ID)
+
+	// Reassign the same IP to a different pod without a preceding
+	// Delete. The source should synthesise the eviction of pod-a and
+	// the upsert of pod-b.
+	pushUpsert(s, addr, 32, 0, idB, "default", "pod-b", "192.168.1.1")
+	events := drainFor(ch, 200*time.Millisecond)
+	require.Len(t, events, 2, "expected eviction + upsert, got %v", events)
+
+	// The eviction is emitted first as a Delete (pod-a had no other
+	// IPs), followed by the Upsert for pod-b.
+	require.Equal(t, EventKindDelete, events[0].Kind)
+	require.Equal(t, "default/pod-a", events[0].Endpoint.ID)
+
+	require.Equal(t, EventKindUpsert, events[1].Kind)
+	require.Equal(t, "default/pod-b", events[1].Endpoint.ID)
+	require.Equal(t, []netip.Addr{addr}, events[1].Endpoint.IPs)
+
+	// Now send a stale Delete for pod-a that lost the race with the
+	// reassignment Upsert. Because IPCache attaches the old
+	// K8sMetadata to Delete events, the source can tell that this
+	// delete targets pod-a, not the current owner (pod-b), and must
+	// leave pod-b untouched.
+	pushDelete(s, addr, 32, 0, "default", "pod-a")
+	require.Empty(t, drainFor(ch, 200*time.Millisecond),
+		"stale delete for pod-a must not evict pod-b or emit any event")
+
+	// pod-b must still be present with its IP intact.
+	s.mu.RLock()
+	remaining, ok := s.endpoints["default/pod-b"]
+	owner, owned := s.ipToID[addr]
+	s.mu.RUnlock()
+	require.True(t, ok, "pod-b must still exist after stale delete for pod-a")
+	require.Equal(t, []netip.Addr{addr}, remaining.IPs)
+	require.True(t, owned)
+	require.Equal(t, "default/pod-b", owner)
+}
+
+// TestDeleteOwnershipCheckForUnrelatedPod is the direct regression test for
+// the stale-Delete ownership bug: IPCache emits a Delete whose oldK8sMeta
+// identifies a pod that no longer owns the IP, and the source must ignore
+// it.
+func TestDeleteOwnershipCheckForUnrelatedPod(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "owner"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.42")
+	pushUpsert(s, addr, 32, 0, id, "ns", "owner", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, "ns/owner", ev.Endpoint.ID)
+
+	// A Delete whose K8sMetadata points at a pod that never owned this
+	// IP — or that has since been replaced — must not affect the
+	// current owner.
+	pushDelete(s, addr, 32, 0, "other-ns", "ghost")
+	require.Empty(t, drainFor(ch, 150*time.Millisecond),
+		"delete targeted at an unrelated pod must be a no-op")
+
+	s.mu.RLock()
+	_, stillThere := s.endpoints["ns/owner"]
+	owner := s.ipToID[addr]
+	s.mu.RUnlock()
+	require.True(t, stillThere)
+	require.Equal(t, "ns/owner", owner)
+
+	// A correctly-targeted Delete still evicts the pod.
+	pushDelete(s, addr, 32, 0, "ns", "owner")
+	ev = waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+	require.Equal(t, "ns/owner", ev.Endpoint.ID)
+}
+
+// TestUpsertWithoutMetaEvictsExistingIP covers odinuge's leak concern: an
+// Upsert for an IP that is already owned by a pod, but delivered with no K8s
+// metadata, must evict the IP from the pod.
+func TestUpsertWithoutMetaEvictsExistingIP(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "x"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.7")
+	pushUpsert(s, addr, 32, 0, id, "default", "pod-x", "192.168.1.1")
+	<-ch
+
+	// IP now re-upserted without K8s metadata (e.g. the IP moved to
+	// a CIDR identity). Must evict pod-x's IP.
+	pushUpsert(s, addr, 32, 0, identity.ReservedIdentityWorld, "", "", "")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+	require.Equal(t, "default/pod-x", ev.Endpoint.ID)
+
+	// The source's internal mirror must agree.
+	s.mu.RLock()
+	_, exists := s.endpoints["default/pod-x"]
+	_, owned := s.ipToID[addr]
+	s.mu.RUnlock()
+	require.False(t, exists)
+	require.False(t, owned)
+}
+
+// TestMultipleIPsPartialDelete checks that deleting one of two IPs from an
+// endpoint emits an Upsert (not a Delete) with the remaining IP.
+func TestMultipleIPsPartialDelete(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "multi"})
+	ch := subscribe(t, s)
+
+	v4 := mustAddr("10.0.0.8")
+	v6 := mustAddr("fd00::8")
+
+	pushUpsert(s, v4, 32, 0, id, "default", "multi", "192.168.1.1")
+	<-ch
+	pushUpsert(s, v6, 128, 0, id, "default", "multi", "192.168.1.1")
+	<-ch
+
+	pushDelete(s, v4, 32, 0, "default", "multi")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, []netip.Addr{v6}, ev.Endpoint.IPs)
+
+	pushDelete(s, v6, 128, 0, "default", "multi")
+	ev = waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+}
+
+// TestNilIdentityOnExistingEndpointPreservesLabels covers T2: when a later
+// Upsert arrives with an identity that cannot be resolved, the endpoint's
+// existing labels are preserved rather than being wiped.
+func TestNilIdentityOnExistingEndpointPreservesLabels(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "stable"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.9")
+	pushUpsert(s, addr, 32, 0, id, "default", "stable", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, map[string]string{"app": "stable"}, ev.Endpoint.Labels)
+
+	// Push an Upsert for a numeric identity that was never allocated;
+	// the mock allocator returns nil for unknown IDs.
+	unresolved := identity.NumericIdentity(9_999_999)
+	pushUpsert(s, addr, 32, 0, unresolved, "default", "stable", "192.168.2.2")
+	ev = waitForEvent(t, ch)
+	// Labels preserved from the prior Upsert.
+	require.Equal(t, map[string]string{"app": "stable"}, ev.Endpoint.Labels)
+	// But NodeIP was updated.
+	require.Equal(t, "192.168.2.2", ev.Endpoint.NodeIP)
+}
+
+// TestNilIdentityOnNewEndpointIsSkipped verifies that an Upsert for a pod
+// we have not seen before, with an unresolvable identity, is dropped rather
+// than creating a degenerate entry.
+func TestNilIdentityOnNewEndpointIsSkipped(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	ch := subscribe(t, s)
+
+	unresolved := identity.NumericIdentity(9_999_999)
+	pushUpsert(s, mustAddr("10.0.0.10"), 32, 0, unresolved, "default", "ghost", "192.168.1.1")
+	require.Empty(t, drainFor(ch, 100*time.Millisecond))
+
+	s.mu.RLock()
+	_, exists := s.endpoints["default/ghost"]
+	s.mu.RUnlock()
+	require.False(t, exists)
+}
+
+// TestObserveReplaysCurrentState verifies that a subscriber joining after
+// some upserts have been processed receives them as Upsert events on
+// subscription.
+func TestObserveReplaysCurrentState(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "r"})
+
+	pushUpsert(s, mustAddr("10.0.0.20"), 32, 0, id, "default", "r1", "192.168.1.1")
+	pushUpsert(s, mustAddr("10.0.0.21"), 32, 0, id, "default", "r2", "192.168.1.1")
+
+	// Give the consumer time to process both events before subscribing.
+	require.Eventually(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return len(s.endpoints) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	ch := subscribe(t, s)
+	events := drainFor(ch, 200*time.Millisecond)
+	require.Len(t, events, 2)
+
+	ids := map[string]bool{}
+	for _, ev := range events {
+		require.Equal(t, EventKindUpsert, ev.Kind)
+		ids[ev.Endpoint.ID] = true
+	}
+	require.True(t, ids["default/r1"])
+	require.True(t, ids["default/r2"])
+}
+
+// TestConcurrentIPCacheEvents stresses the queue path with many concurrent
+// OnIPIdentityCacheChange callers and verifies that the consumer drains
+// them all without data races. Run with `go test -race`.
+func TestConcurrentIPCacheEvents(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "stress"})
+
+	const pods = 50
+	var wg sync.WaitGroup
+	for i := range pods {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			addr := netip.AddrFrom4([4]byte{10, 0, byte(i >> 8), byte(i)})
+			pushUpsert(s, addr, 32, 0, id, "default", "pod", "192.168.1.1")
+			pushDelete(s, addr, 32, 0, "default", "pod")
+		}(i)
+	}
+	wg.Wait()
+
+	// Every pod shares the same name so the final state is either
+	// "pod" with no IPs (so the entry is gone) or with some subset of
+	// IPs — but never panics.
+	require.Eventually(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return len(s.queue) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestCloneEndpointIsolatesSubscribers ensures that mutating the labels or
+// IPs of a received event does not corrupt the source's internal state.
+func TestCloneEndpointIsolatesSubscribers(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "iso"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("10.0.0.50"), 32, 0, id, "default", "iso", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+
+	// Mutate the received event's maps and slices.
+	ev.Endpoint.Labels["evil"] = "mutation"
+	ev.Endpoint.IPs[0] = mustAddr("127.0.0.1")
+
+	// Internal state must be unaffected.
+	s.mu.RLock()
+	internal := s.endpoints["default/iso"]
+	s.mu.RUnlock()
+	require.NotContains(t, internal.Labels, "evil")
+	require.Equal(t, mustAddr("10.0.0.50"), internal.IPs[0])
+}

--- a/pkg/podendpointsource/types.go
+++ b/pkg/podendpointsource/types.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"net/netip"
+)
+
+// EventKind describes the kind of change an Event carries.
+type EventKind int
+
+const (
+	// EventKindUpsert signals that a pod endpoint was added or updated.
+	//
+	// The event's PodEndpoint reflects the endpoint's current state after
+	// applying the change. Consumers may safely replace any cached copy
+	// keyed by Endpoint.ID with the endpoint carried by the event.
+	EventKindUpsert EventKind = iota
+
+	// EventKindDelete signals that a pod endpoint was removed.
+	//
+	// The PodEndpoint field identifies the deleted endpoint by ID; its
+	// IPs, Labels and NodeIP fields are best-effort and MUST NOT be relied
+	// upon. Consumers should drop any cached copy keyed by Endpoint.ID.
+	EventKindDelete
+)
+
+// PodEndpoint is a snapshot of a pod endpoint assembled from IPCache state.
+//
+// A PodEndpoint is uniquely identified by ID (namespace/podName) and groups
+// all pod IPs (IPv4 and IPv6) belonging to that pod along with its identity
+// labels and the IP of the node it runs on. IPs are sorted with IPv4
+// addresses first, followed by IPv6 addresses, each family ordered by its
+// numeric address. This matches the ordering that downstream consumers of
+// CiliumEndpoint-based sources have historically observed.
+type PodEndpoint struct {
+	// ID is "namespace/podName".
+	ID string
+
+	// IPs are the endpoint's pod IPs. Sorted IPv4-first then IPv6, numeric
+	// within each family.
+	IPs []netip.Addr
+
+	// Labels are the endpoint's identity labels in the k8s string-map form.
+	// Nil iff the labels could not be resolved.
+	Labels map[string]string
+
+	// NodeIP is the IP of the node the endpoint runs on. May be empty if
+	// the IPCache entry did not carry a host IP.
+	NodeIP string
+}
+
+// Event is emitted by a Source whenever a pod endpoint changes.
+type Event struct {
+	Kind     EventKind
+	Endpoint PodEndpoint
+}


### PR DESCRIPTION
## Summary

Replace the CiliumEndpoint and CiliumEndpointSlice watchers in the egress
gateway manager with an IPCache listener (`IPIdentityMappingListener`).
This makes the egress gateway agnostic to the underlying endpoint data
source and automatically supports CiliumEndpoint, CiliumEndpointSlice,
and kvstore identity allocation modes.

This is a follow-up to #44488, rearchitected based on review feedback from
@odinuge, @joestringer, and @tommyp1ckles requesting a more generic
solution that avoids teaching egress-gateway about agent configuration
and endpoint source implementation details.

## Key changes

- **Implement `OnIPIdentityCacheChange` on Manager** — receives endpoint
  IP-to-identity change notifications from the IPCache, which already
  aggregates data from all sources (CEP, CES, kvstore)
- **Remove `endpoints`/`endpointSlices` resource dependencies** — no more
  direct watching of CiliumEndpoint or CiliumEndpointSlice resources
- **Remove `EnableCiliumEndpointSlice` and `IdentityAllocationModeCRD`
  checks** — egress gateway no longer needs to know about these
- **Wait for initial global identities before registering listener** —
  prevents storing endpoints with nil labels during startup
- **Filter out remote clustermesh endpoints** (`ClusterID != 0`) — the
  previous CEP watcher only observed local endpoints; this preserves
  that behavior and prevents namespace/name collisions
- **Simplify `endpointID` to plain `string`** (`namespace/podName`)
- **Remove `getEndpointMetadata`** in favor of IPCache-provided data
- **Update tests** to simulate endpoint events via IPCache callbacks,
  including coverage for the clustermesh filtering case

## How it works

The egress gateway manager registers as an `IPIdentityMappingListener`
on the IPCache during `OnStart` (after global identities are synced).
The IPCache dumps all existing entries and subsequently notifies the
manager of any changes. For each pod endpoint (identified by non-nil
K8sMetadata with namespace/podName), the manager:

1. Looks up identity labels via `IdentityAllocator.LookupIdentityByID()`
2. Stores/updates the endpoint in `epDataStore` keyed by `namespace/podName`
3. Triggers reconciliation

This follows the same pattern used by WireGuard, Envoy, BPF datapath,
and FQDN subsystems in Cilium.

## Testing

- Unit tests updated to use IPCache callbacks instead of CEP events
- Added `TestRemoteClusterEndpointsIgnored` for clustermesh filtering
- Validated on a live 8-node cluster with CES enabled:
  - 500 pods, all BPF egress map entries populated correctly
  - Egress traffic verified through gateway nodes

Fixes: https://github.com/cilium/cilium/issues/24833
Ref: https://github.com/cilium/cilium/issues/37562
Supersedes: https://github.com/cilium/cilium/pull/44488
