### PR TITLE
gateway-api: restore EndpointSlice creation for external LB controllers

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -28,10 +27,8 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
-	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/shortener"
 )
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -53,13 +50,6 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			return controllerruntime.Success()
 		}
 		scopedLog.ErrorContext(ctx, "Unable to get Service for GAMMA checks", logfields.Error, err)
-		return controllerruntime.Fail(err)
-	}
-
-	// Ensure that any existing EndpointSlice from a previous version gets deleted (dummy ingress endpoints are no longer required)
-	// This can be removed in v1.21
-	if err := r.ensureEndpointSliceDeleted(ctx, types.NamespacedName{Namespace: originalSvc.Namespace, Name: shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + originalSvc.Name)}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure EndpointSlice deleted", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
 
@@ -144,7 +134,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	setGammaServiceAccepted(svc, true, "Gamma Service has routes attached", CiliumGammaReasonAccepted)
 
-	cec, _, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
+	cec, _, _, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
@@ -320,27 +310,6 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 			return fmt.Errorf("failed to update GRPCRoute status: %w", err)
 		}
 	}
-
-	return nil
-}
-
-func (r *gatewayReconciler) ensureEndpointSliceDeleted(ctx context.Context, name types.NamespacedName) error {
-	eps := discoveryv1.EndpointSlice{}
-
-	if err := r.Client.Get(ctx, name, &eps); err != nil {
-		if k8serrors.IsNotFound(err) {
-			// no longer exists
-			return nil
-		}
-
-		return fmt.Errorf("failed to get existing EndpointSlice (%s): %w", name, err)
-	}
-
-	if err := r.Client.Delete(ctx, &eps); err != nil {
-		return fmt.Errorf("failed to delete existing EndpointSlice (%s): %w", name, err)
-	}
-
-	r.logger.DebugContext(ctx, "Successfully deleted EndpointSlice", logfields.Name, name)
 
 	return nil
 }

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -158,7 +159,8 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.ConfigMap{}, r.enqueueRequestForBackendTLSPolicyConfigMap()).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
-		Owns(&corev1.Service{})
+		Owns(&corev1.Service{}).
+		Owns(&discoveryv1.EndpointSlice{})
 
 	if tlsRouteEnabled {
 		// Watch TLSRoute linked to Gateway

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
-	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -61,13 +60,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return controllerruntime.Success()
 		}
 		scopedLog.ErrorContext(ctx, "Unable to get Gateway", logfields.Error, err)
-		return controllerruntime.Fail(err)
-	}
-
-	// Ensure that any existing EndpointSlice from a previous version gets deleted (dummy ingress endpoints are no longer required)
-	// This can be removed in v1.21
-	if err := r.ensureEndpointSliceDeleted(ctx, types.NamespacedName{Namespace: original.Namespace, Name: shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + original.Name)}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure EndpointSlice deleted", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
 
@@ -213,7 +205,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 
 	// Step 3: Translate the listeners into Cilium model
-	cec, svc, err := r.translator.Translate(&model.Model{HTTP: httpListeners, TLSPassthrough: tlsPassthroughListeners})
+	cec, svc, ep, err := r.translator.Translate(&model.Model{HTTP: httpListeners, TLSPassthrough: tlsPassthroughListeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to translate resources", gatewayv1.GatewayReasonNoResources)
@@ -230,6 +222,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "Unable to create Service", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to create Service resource", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create Service resource", gatewayv1.GatewayReasonNoResources)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	}
+
+	if err = r.ensureEndpointSlice(ctx, ep); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to create EndpointSlice", logfields.Error, err)
+		setGatewayAccepted(gw, false, "Unable to create EndpointSlice resource", gatewayv1.GatewayReasonNoResources)
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create EndpointSlice resource", gatewayv1.GatewayReasonNoResources)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
@@ -299,6 +298,18 @@ func (r *gammaReconciler) ensureEndpointSliceDeleted(ctx context.Context, name t
 	r.logger.DebugContext(ctx, "Successfully deleted EndpointSlice", logfields.Name, name)
 
 	return nil
+}
+
+func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
+	eps := desired.DeepCopy()
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, eps, func() error {
+		eps.Endpoints = desired.Endpoints
+		eps.Ports = desired.Ports
+		eps.OwnerReferences = desired.OwnerReferences
+		setMergedLabelsAndAnnotations(eps, desired)
+		return nil
+	})
+	return err
 }
 
 func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -264,7 +264,7 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 		m.HTTP = append(m.HTTP, ingestion.Ingress(nil, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
-	cec, svc, err := r.dedicatedTranslator.Translate(m)
+	cec, svc, _, err := r.dedicatedTranslator.Translate(m)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to translate model into resources: %w", err)
 	}

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1144,11 +1144,12 @@ type fakeDedicatedIngressTranslator struct {
 	model *model.Model
 }
 
-func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	r.model = model
 
 	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		nil,
 		nil
 }
 

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -42,10 +43,10 @@ func NewTranslator(cecTranslator translation.CECTranslator, cfg translation.Conf
 	}
 }
 
-func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	listeners := m.GetListeners()
 	if len(listeners) == 0 || len(listeners[0].GetSources()) == 0 {
-		return nil, nil, fmt.Errorf("model source can't be empty, %d listeners", len(listeners))
+		return nil, nil, nil, fmt.Errorf("model source can't be empty, %d listeners", len(listeners))
 	}
 
 	// source is the main object that is the source of the model.Model
@@ -71,7 +72,7 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	}
 
 	if source == nil || source.Name == "" {
-		return nil, nil, fmt.Errorf("model source name can't be empty")
+		return nil, nil, nil, fmt.Errorf("model source name can't be empty")
 	}
 
 	// generatedName is the name of the generated objects.
@@ -85,7 +86,7 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	}
 	cec, err := t.cecTranslator.Translate(source.Namespace, generatedName, m)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var allLabels, allAnnotations map[string]string
@@ -97,12 +98,13 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	}
 
 	if err = decorateCEC(cec, owner, allLabels, allAnnotations); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	lbSvc := t.desiredService(listeners[0].GetService(), source, ports, allLabels, allAnnotations)
+	ep := t.desiredEndpointSlice(source, allLabels, allAnnotations)
 
-	return cec, lbSvc, err
+	return cec, lbSvc, ep, err
 }
 
 func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *model.FullyQualifiedResource,
@@ -342,4 +344,35 @@ func mergeMap(left, right map[string]string) map[string]string {
 	}
 	maps.Copy(left, right)
 	return left
+}
+
+func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedResource, labels, annotations map[string]string) *discoveryv1.EndpointSlice {
+	if owner == nil {
+		return nil
+	}
+	shortenedName := shortener.ShortenK8sResourceName(owner.Name)
+
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
+			Namespace: owner.Namespace,
+			Labels: mergeMap(map[string]string{
+				owningGatewayLabel: shortenedName,
+				gatewayNameLabel:   shortenedName,
+			}, labels),
+			Annotations: annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: gatewayv1beta1.GroupVersion.String(),
+					Kind:       owner.Kind,
+					Name:       owner.Name,
+					UID:        types.UID(owner.UID),
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   nil,
+		Ports:       nil,
+	}
 }

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -83,7 +83,7 @@ func Test_translator_Translate(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, err := trans.Translate(input)
+			cec, svc, _, err := trans.Translate(input)
 
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
@@ -197,7 +197,7 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					expectedService := &corev1.Service{}
 					readOutput(t, fmt.Sprintf("testdata/%s/%s/service-output.yaml", tt.name, translatorCase.name), expectedService)
 
-					cec, svc, err := trans.Translate(input)
+					cec, svc, _, err := trans.Translate(input)
 					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 					require.Equal(t, expectedService, svc, "Service mismatch")
 
@@ -250,7 +250,7 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, err := trans.Translate(input)
+			cec, svc, _, err := trans.Translate(input)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
 			diffOutput := cmp.Diff(output, cec, protocmp.Transform())

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -40,9 +41,9 @@ func NewDedicatedIngressTranslator(log *slog.Logger, cecTranslator translation.C
 	}
 }
 
-func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	if m == nil || (len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0) {
-		return nil, nil, fmt.Errorf("model source can't be empty")
+		return nil, nil, nil, fmt.Errorf("model source can't be empty")
 	}
 
 	var name string
@@ -71,7 +72,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	// (i.e. the HTTP listeners are just belonged to one Ingress resource).
 	cec, err := d.cecTranslator.Translate(namespace, name, m)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Set the name to avoid any breaking change during upgrade.
@@ -79,7 +80,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 
 	dedicatedService := d.getService(sourceResource, modelService, tlsOnly)
 
-	return cec, dedicatedService, err
+	return cec, dedicatedService, nil, err
 }
 
 func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedResource, service *model.Service, tlsOnly bool) *corev1.Service {

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -296,7 +296,7 @@ func Test_translator_Translate(t *testing.T) {
 			input := &model.Model{}
 			readInput(t, fmt.Sprintf("testdata/%s/input.yaml", tt.name), input)
 
-			cec, svc, err := trans.Translate(input)
+			cec, svc, _, err := trans.Translate(input)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 
 			output := &ciliumv2.CiliumEnvoyConfig{}

--- a/operator/pkg/model/translation/types.go
+++ b/operator/pkg/model/translation/types.go
@@ -5,17 +5,18 @@ package translation
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
-// Translator is the interface to take the model and generate required CiliumEnvoyConfig
-// and LoadBalancer Service.
+// Translator is the interface to take the model and generate required CiliumEnvoyConfig,
+// LoadBalancer Service, and EndpointSlice.
 //
 // Different use cases (e.g. Ingress, Gateway API) can provide its own generation logic.
 type Translator interface {
-	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error)
+	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error)
 }
 
 // CECTranslator is the interface to take the model and generate required CiliumEnvoyConfig.


### PR DESCRIPTION
Commit d9fd29a3a1 ("ingress/gateway-api: remove EndpointSlice creation")
removed the dummy EndpointSlice that was created alongside the Gateway
LoadBalancer Service. This broke external LB controllers (MetalLB, etc.)
that require an EndpointSlice to exist before announcing Service IPs.

The EndpointSlices are empty (nil Endpoints, nil Ports) — Cilium routes
traffic via eBPF + CiliumEnvoyConfig, so they serve no datapath purpose.
They only need to exist as a signal to external controllers.

Changes:
- Restored `desiredEndpointSlice()` in the gateway-api translator
- Added `*discoveryv1.EndpointSlice` to the `Translator` interface return
- Added `ensureEndpointSlice()` to the gateway reconciler
- Removed `ensureEndpointSliceDeleted()` calls that were cleaning up
  EndpointSlices on every reconcile
- Re-added `Owns(&discoveryv1.EndpointSlice{})` controller watch
- Updated ingress translator and all callers/tests to match

Fixes: #45209

```release-note
Restore EndpointSlice creation for Gateway API Services to ensure compatibility with external LoadBalancer controllers (e.g., MetalLB) that require EndpointSlices to announce Service IPs.