### PR TITLE
.github/workflows: update renovate to 43.111.3

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -42,7 +42,7 @@ jobs:
           LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
         with:
           # renovate: datasource=github-releases depName=renovatebot/renovate
-          renovate-version: 43.86.0
+          renovate-version: 43.111.3
           docker-user: root
           docker-cmd-file: .github/actions/renovate/entrypoint.sh
           configurationFile: .github/renovate.json5


### PR DESCRIPTION
The 43.86.0 version has a bug that is preventing renovate from updating itself, thus we need to manually update it.