### PR TITLE
Update go to 1.26 and fix related linting issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -108,6 +108,7 @@ linters:
     modernize:
       disable: # TODO: remove each disabled rule and fix it
         - omitzero
+        - newexpr
     govet:
       enable:
         - nilness

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/pkg/alignchecker/alignchecker.go
+++ b/pkg/alignchecker/alignchecker.go
@@ -163,19 +163,19 @@ func check(name string, toCheck []any, structs map[string]*structInfo, checkOffs
 			continue
 		}
 
-		for i := range g.NumField() {
-			fieldName := g.Field(i).Tag.Get("align")
+		for field := range g.Fields() {
+			fieldName := field.Tag.Get("align")
 			// Ignore fields without `align` struct tag
 			if fieldName == "" {
 				continue
 			}
-			goOffset := uint32(g.Field(i).Offset)
+			goOffset := uint32(field.Offset)
 			if cOffset, ok := c.fieldOffsets[fieldName]; !ok {
 				return fmt.Errorf("%s.%s does not match any field (should match %s.%s) [debug=%v]",
-					g, g.Field(i).Name, name, fieldName, c.fieldOffsets)
+					g, field.Name, name, fieldName, c.fieldOffsets)
 			} else if goOffset != cOffset {
 				return fmt.Errorf("%s.%s offset(%d) does not match %s.%s(%d) [debug=%v]",
-					g, g.Field(i).Name, goOffset, name, fieldName, cOffset, c.fieldOffsets)
+					g, field.Name, goOffset, name, fieldName, cOffset, c.fieldOffsets)
 			}
 		}
 	}

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -152,7 +152,7 @@ func (n *linuxNodeHandler) allocateIDForNode(oldNode *nodeTypes.Node, node *node
 				logfields.SPI, node.EncryptionKey,
 			)
 			errs = errors.Join(errs,
-				fmt.Errorf("failed to map IP %q with node ID %q: %w", nodeID, nodeID, err))
+				fmt.Errorf("failed to map IP %s with node ID %d: %w", ip, nodeID, err))
 		}
 	}
 	return nodeID, errs

--- a/pkg/maps/l2respondermap/l2_responder_map4.go
+++ b/pkg/maps/l2respondermap/l2_responder_map4.go
@@ -138,5 +138,5 @@ type L2ResponderStats struct {
 }
 
 func (s *L2ResponderStats) String() string {
-	return fmt.Sprintf("responses_sent=%q", s.ResponsesSent)
+	return fmt.Sprintf("responses_sent=%d", s.ResponsesSent)
 }

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -97,8 +97,7 @@ func Metric[S any](ctor func() S) cell.Cell {
 		))
 	}
 
-	for i := range outTyp.NumField() {
-		field := outTyp.Field(i)
+	for field := range outTyp.Fields() {
 		if !field.IsExported() {
 			panic(fmt.Errorf(
 				"The struct returned by the constructor passed to metrics.Metric has a private field '%s', which "+

--- a/pkg/metrics/features/metrics.go
+++ b/pkg/metrics/features/metrics.go
@@ -1129,11 +1129,11 @@ func (m Metrics) update(params enabledFeatures, config *option.DaemonConfig, lbC
 func (m Metrics) toGatherer() (prometheus.Gatherer, error) {
 	rv := reflect.ValueOf(m)
 	reg := prometheus.NewPedanticRegistry()
-	for i := 0; i < rv.NumField(); i++ {
-		if !rv.Field(i).CanInterface() {
+	for _, f := range rv.Fields() {
+		if !f.CanInterface() {
 			continue
 		}
-		c, ok := rv.Field(i).Interface().(prometheus.Collector)
+		c, ok := f.Interface().(prometheus.Collector)
 		if !ok {
 			continue
 		}

--- a/pkg/metrics/features/operator/metrics.go
+++ b/pkg/metrics/features/operator/metrics.go
@@ -114,11 +114,11 @@ func (m Metrics) update(params enabledFeatures, config *option.OperatorConfig) {
 func (m Metrics) toGatherer() (prometheus.Gatherer, error) {
 	rv := reflect.ValueOf(m)
 	reg := prometheus.NewPedanticRegistry()
-	for i := 0; i < rv.NumField(); i++ {
-		if !rv.Field(i).CanInterface() {
+	for _, f := range rv.Fields() {
+		if !f.CanInterface() {
 			continue
 		}
-		c, ok := rv.Field(i).Interface().(prometheus.Collector)
+		c, ok := f.Interface().(prometheus.Collector)
 		if !ok {
 			continue
 		}

--- a/test/controlplane/node/nodehandler.go
+++ b/test/controlplane/node/nodehandler.go
@@ -54,7 +54,7 @@ func validateNodes(fnh *fakenode.Handler) error {
 	}
 
 	if !podCIDR.Equal(minimal.IPv4AllocCIDR) {
-		return fmt.Errorf("cidr mismatch: %q vs %q", podCIDR, minimal)
+		return fmt.Errorf("cidr mismatch: %q vs %q", podCIDR, minimal.IPv4AllocCIDR)
 	}
 
 	return nil


### PR DESCRIPTION
This PR updates go to 1.26 and fixes the new golangci-lint failures that trigger on 1.26:
* `govet`: Fix printf format verb mismatches
* `modernize/stditerators`: Use reflect iterator methods, see https://go.dev/doc/go1.26#reflectpkgreflect

There is another new analyzer that triggers under 1.26 that I opted to disable for now as fixing it causes a huge diff throughout the whole repository: [`modernize/newexpr`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_newexpr), which replaces pointer-helper calls with  go 1.26's `new(x)`, see https://go.dev/doc/go1.26#language.

Note: this is a necessary prerequisite to update the k8s libs to 1.36