### PR TITLE
cilium-cli: Fix panic parsing IPv6 URL in connectivity tests

### DIFF
--- a/cilium-cli/connectivity/tests/host.go
+++ b/cilium-cli/connectivity/tests/host.go
@@ -6,6 +6,8 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -148,7 +150,7 @@ func (s *podToHostPort) Run(ctx context.Context, t *check.Test) {
 				if err != nil {
 					return
 				}
-				baseURL := fmt.Sprintf("%s://%s:%d%s", echo.Scheme(), hostIP, ct.Params().EchoServerHostPort, echo.Path())
+				baseURL := fmt.Sprintf("%s://%s%s", echo.Scheme(), net.JoinHostPort(hostIP, strconv.Itoa(ct.Params().EchoServerHostPort)), echo.Path())
 				ep := check.HTTPEndpoint(echo.Name(), baseURL)
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, ep, ipFam).Run(func(a *check.Action) {
 					a.ExecInPod(ctx, a.CurlCommand(ep))

--- a/cilium-cli/connectivity/tests/pod.go
+++ b/cilium-cli/connectivity/tests/pod.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
 	"regexp"
 	"strconv"
@@ -145,7 +146,7 @@ func (s *podToPodWithEndpoints) Run(ctx context.Context, t *check.Test) {
 func (s *podToPodWithEndpoints) curlEndpoints(ctx context.Context, t *check.Test, name string,
 	client *check.Pod, echo check.TestPeer, ipFam features.IPFamily) {
 	ct := t.Context()
-	baseURL := fmt.Sprintf("%s://%s:%d", echo.Scheme(), echo.Address(ipFam), echo.Port())
+	baseURL := fmt.Sprintf("%s://%s", echo.Scheme(), net.JoinHostPort(echo.Address(ipFam), strconv.FormatUint(uint64(echo.Port()), 10)))
 	var curlOpts []string
 	if s.method != "" {
 		curlOpts = append(curlOpts, "-X", s.method)

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -6,7 +6,9 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net"
 	"slices"
+	"strconv"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -258,7 +260,7 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 
 			// Manually construct an HTTP endpoint to override the destination IP
 			// and port of the request.
-			ep := check.HTTPEndpoint(name, fmt.Sprintf("%s://%s:%d%s", svc.Scheme(), addr.Address, np, svc.Path()))
+			ep := check.HTTPEndpoint(name, fmt.Sprintf("%s://%s%s", svc.Scheme(), net.JoinHostPort(addr.Address, strconv.FormatUint(uint64(np), 10)), svc.Path()))
 
 			// Create the Action with the original svc as this will influence what the
 			// flow matcher looks for in the flow logs.

--- a/cilium-cli/connectivity/tests/ztunnel.go
+++ b/cilium-cli/connectivity/tests/ztunnel.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -655,12 +657,7 @@ func (s *ztunnelTestBase) executeTrafficTest(ctx context.Context, t *check.Test,
 func (s *ztunnelTestBase) executeTrafficForIPFamily(ctx context.Context, t *check.Test, ipFamily features.IPFamily,
 	encryptedSniffers, plainTextSniffers map[string]*sniff.Sniffer,
 ) {
-	var url string
-	if ipFamily == features.IPFamilyV4 {
-		url = fmt.Sprintf("http://%s:%d/", s.server.Address(ipFamily), echoServerPort)
-	} else {
-		url = fmt.Sprintf("http://[%s]:%d/", s.server.Address(ipFamily), echoServerPort)
-	}
+	url := fmt.Sprintf("http://%s/", net.JoinHostPort(s.server.Address(ipFamily), strconv.Itoa(echoServerPort)))
 
 	// Retry loop for curl command
 	var lastErr error


### PR DESCRIPTION
Go 1.26 (golang/go#31024) now rejects unbracketed IPv6 addresses in URLs. Use `net.JoinHostPort` to properly bracket IPv6 addresses, producing RFC 3986-compliant URLs like `http://[fc00:c111::2]:31661` instead of the malformed `http://fc00:c111::2:31661`.

See https://go.dev/doc/go1.26#neturlpkgneturl

See this panic (from #45336):
```
[=] [cilium-test-5] Test [client-ingress] [1/32]
panic: parse "http://fc00:c111::2:31661": invalid port ":c111::2:31661" after host

goroutine 4421 [running]:
github.com/cilium/cilium/cilium-cli/connectivity/check.HTTPEndpointWithLabels({0xe111b256000, 0x6}, {0xe111b4d4020, 0x19}, 0x0)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/peer.go:367 +0xca
github.com/cilium/cilium/cilium-cli/connectivity/check.HTTPEndpoint(...)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/peer.go:361
github.com/cilium/cilium/cilium-cli/connectivity/tests.curlNodePort.func1(0x2)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/tests/service.go:261 +0x357
github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).ForEachIPFamily(0xe111a950a88, 0xe111af9d908)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/context.go:1390 +0x215
github.com/cilium/cilium/cilium-cli/connectivity/check.(*Test).ForEachIPFamily(...)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/test.go:957
github.com/cilium/cilium/cilium-cli/connectivity/tests.curlNodePort({0x66059f0, 0xe111a930600}, {0x65f8ee0, 0xe111b813b00}, 0xe111a45c6e0, {0xe111b256000, 0x6}, 0xe111a53edc0, {0xe111ac38a08, {0x0, ...}}, ...)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/tests/service.go:245 +0x5d3
github.com/cilium/cilium/cilium-cli/connectivity/tests.(*podToRemoteNodePort).Run(0xe111b813b00, {0x66059f0, 0xe111a930600}, 0xe111a45c6e0)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/tests/service.go:175 +0x54a
github.com/cilium/cilium/cilium-cli/connectivity/check.(*Test).Run(0xe111a45c6e0, {0x66059f0, 0xe111a930600}, 0x1)
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/test.go:386 +0x6a4
github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).Run.func1()
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/context.go:460 +0x99
created by github.com/cilium/cilium/cilium-cli/connectivity/check.(*ConnectivityTest).Run in goroutine 4453
	/go/src/github.com/cilium/cilium/cilium-cli/connectivity/check/context.go:454 +0x91
```