### PR TITLE
v1.18: Update sphinx theme to v3.1.0

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -64,7 +64,7 @@ jobs:
           # Needed to detect missing redirects
           fetch-depth: 0
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:3ab6d69f19839c63c59621c3ac3630c9f9b2b24c@sha256:66afd1ed23861dfcf5dafcf34f2a9ecf2969766fff81c8072efb38d336de4802
+        uses: docker://quay.io/cilium/docs-builder:8db39c302f656ed3a9b8781e2d7986a9fc2220f6@sha256:129debfeea8329f7a85393cbf6bcd1689b5d0e9c87d89bf424c2c02a93a30e5d
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/requirements-min/requirements.txt
+++ b/Documentation/requirements-min/requirements.txt
@@ -1,14 +1,14 @@
-sphinx==7.1.2
+sphinx==7.4.7
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-git+https://github.com/cilium/sphinx_rtd_theme.git@cilium/rebase-2023-09#egg=sphinx-rtd-theme-cilium
+git+https://github.com/cilium/sphinx_rtd_theme.git@cilium/main#egg=sphinx-rtd-theme-cilium
 
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 
 # Sphinx extensions
-myst-parser==2.0.0
+myst-parser==4.0.1
 sphinx-tabs==3.5.0
 sphinx-version-warning==1.1.2
 sphinxcontrib-googleanalytics==0.5

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,13 +1,13 @@
 ## Auto-generated from requirements-min/requirements.txt with "make update-requirements"
-Sphinx==7.1.2
+Sphinx==7.4.7
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@77d60dbce4cc93358fa6156cbafd7c49214b3c89
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@98b0d4664556de6b5ab94e5abcff5d35246a7c46
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 # Sphinx extensions
-myst-parser==2.0.0
+myst-parser==4.0.1
 sphinx-tabs==3.5.0
 sphinx-version-warning==1.1.2
 sphinxcontrib-googleanalytics==0.5
@@ -22,14 +22,14 @@ yamllint==1.38.0
 alabaster==0.7.16
 annotated-doc==0.0.4
 annotated-types==0.7.0
-attrs==25.4.0
+attrs==26.1.0
 babel==2.18.0
 certifi==2026.2.25
-charset-normalizer==3.4.5
-click==8.3.1
+charset-normalizer==3.4.7
+click==8.3.2
 colorama==0.4.6
 deepmerge==2.0
-docutils==0.20.1
+docutils==0.21.2
 idna==3.11
 imagesize==2.0.0
 Jinja2==3.1.6
@@ -44,14 +44,14 @@ mistune==3.2.0
 packaging==26.0
 pathspec==1.0.4
 picobox==4.0.0
-pydantic==2.12.5
-pydantic_core==2.41.5
+pydantic==2.13.0
+pydantic_core==2.46.0
 pyenchant==3.3.0
-Pygments==2.19.2
+Pygments==2.20.0
 PyYAML==6.0.3
 referencing==0.37.0
-requests==2.32.5
-rich==14.3.3
+requests==2.33.1
+rich==15.0.0
 rpds-py==0.30.0
 rstcheck-core==1.2.2
 shellingham==1.5.4
@@ -65,7 +65,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
-tornado==6.5.4
+tornado==6.5.5
 typer==0.24.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0


### PR DESCRIPTION
Backports:
- #45289
  - Note: Only updated Sphinx to latest 7.x release. Dropped content changes.

```upstream-prs
45289
```