### PR TITLE
v1.18: bpf: Clear `tc_classid` on all ingress code paths

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1187,13 +1187,16 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, __u32 __maybe_unused identity,
 __section_entry
 int cil_from_netdev(struct __ctx_buff *ctx)
 {
+	__u32 flags __maybe_unused;
 	__u32 src_id = UNKNOWN_ID;
 	__be16 proto = 0;
+	int ret;
+
+	bpf_clear_meta(ctx);
 
 #ifdef ENABLE_NODEPORT_ACCELERATION
-	__u32 flags = ctx_get_xfer(ctx, XFER_FLAGS);
+	flags = ctx_get_xfer(ctx, XFER_FLAGS);
 #endif
-	int ret;
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 * We will see the packet again in from-netdev@eth0.vlanXXX.
@@ -1266,6 +1269,12 @@ int cil_from_host(struct __ctx_buff *ctx)
 	int ret __maybe_unused;
 	__be16 proto = 0;
 	__u32 magic;
+
+	/* We can't clear all with bpf_clear_meta here because we may carry the
+	 * security identity in the skb->cb when IPsec is enabled. So instead
+	 * just clear the tc_classid and we'll clear the rest in do_netdev.
+	 */
+	WRITE_ONCE(ctx->tc_classid, 0);
 
 	/* Traffic from the host ns going through cilium_host device must
 	 * not be subject to EDT rate-limiting.


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/42105.