### PR TITLE
.gitattributes: Ignore generated docs dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@ Documentation/cmdref/*.md linguist-generated
 Documentation/crdlist.rst linguist-generated
 Documentation/helm-values.rst linguist-generated
 Documentation/codeowners.rst linguist-generated
+Documentation/requirements.txt linguist-generated
 Documentation/_static/* -diff
 *svg -diff
 pkg/k8s/client/clientset/** linguist-generated


### PR DESCRIPTION
The actual source for this is under Documentation/requirements-min.
