### PR TITLE
renovate: allow golangci-lint to be automatically updated

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -538,17 +538,6 @@
       ]
     },
     {
-      // Do not allow any updates into stable branches.
-      "enabled": false,
-      "matchDepNames": [
-        "golangci/golangci-lint",
-        "golangci/golangci-lint-action"
-      ],
-      "matchBaseBranches": [
-        "!main",
-      ]
-    },
-    {
       "matchDepNames": [
         "quay.io/lvh-images/complexity-test",
         "quay.io/lvh-images/kind"


### PR DESCRIPTION
There's no special reason for this linter to not be automatically updated by renovate. Thus, we are going to enable its automatic updates.