### PR TITLE
bpf: fix map_capacity metric not reported after Open()

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -642,14 +642,14 @@ func (m *Map) openOrCreate(pin bool) error {
 		return err
 	}
 
-	m.updateMetrics()
-	registerMap(m.Logger, m.path, m)
-
 	// Consume the MapSpec.
 	m.spec = nil
 
 	// Retain the Map.
 	m.m = em
+
+	m.updateMetrics()
+	registerMap(m.Logger, m.path, m)
 
 	return nil
 }
@@ -680,10 +680,10 @@ func (m *Map) open() error {
 		return fmt.Errorf("loading pinned map %s: %w", m.path, err)
 	}
 
+	m.m = em
+
 	m.updateMetrics()
 	registerMap(m.Logger, m.path, m)
-
-	m.m = em
 
 	return nil
 }


### PR DESCRIPTION
## Summary

In `(*Map).open()`, `updateMetrics()` was called before `m.m` was assigned. At that point both `m.m` and `m.spec` are `nil`, so `MaxEntries()` returns `0`, and `UpdateMapCapacity` silently skips the gauge due to the `capacity == 0` guard. As a result, `cilium_bpf_map_capacity` is never populated for maps that reach the metrics path via `open()` (e.g. opening an existing pin).

In `(*Map).openOrCreate()`, the call happened after `m.spec` was still set, so the value was correct, but the call order (metrics before `m.m = em`) was inconsistent with `open()`. This PR aligns both paths so `updateMetrics()` and `registerMap()` run after `m.m` is assigned.

## Changes

- `pkg/bpf/map_linux.go`: move `updateMetrics()` / `registerMap()` after `m.m = em` in both `open()` and `openOrCreate()`.

Fixes: #45334

## Test plan

- [x] `GOOS=linux go build ./pkg/bpf/`
- [x] `GOOS=linux go vet ./pkg/bpf/`
- [ ] Enable Egress Gateway, set `maxPolicyEntries` to a non-default value, restart agent, verify `cilium_bpf_map_capacity{map_group="cilium_egress_gw_policy_v4"}` is exposed at `:9962/metrics`.
- [ ] Restart agent with an already-pinned map (exercising the `open()` path) and verify the capacity metric is present.