### PR TITLE
datapath/tables: add interface altnames to devices table

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -419,6 +419,7 @@ func populateFromLink(d *tables.Device, link netlink.Link) {
 	d.Index = a.Index
 	d.MTU = a.MTU
 	d.Name = a.Name
+	d.AltNames = slices.Clone(a.AltNames)
 	d.HardwareAddr = tables.HardwareAddr(a.HardwareAddr)
 	d.Flags = a.Flags
 	d.RawFlags = a.RawFlags
@@ -624,6 +625,15 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 	// If the device does not match and user requested auto detection, then continue to further checks.
 	if dc.filter.NonEmpty() {
 		matched, reverse := dc.filter.Match(d.Name)
+		if !matched {
+			// Also try to match against alternative names.
+			for _, altName := range d.AltNames {
+				matched, reverse = dc.filter.Match(altName)
+				if matched {
+					break
+				}
+			}
+		}
 		if matched {
 			return !reverse, ""
 		}

--- a/pkg/datapath/linux/testdata/device-controller-tables.txtar
+++ b/pkg/datapath/linux/testdata/device-controller-tables.txtar
@@ -68,7 +68,91 @@ db/cmp devices --grep dummy devices_empty.table
 db/cmp routes routes_empty.table
 db/cmp neighbors neighbors_empty.table
 
+# Add dummy2.
+exec ip link add dummy2 type dummy
+exec ip link set dummy2 addrgenmode none
+exec ip link set dummy2 up
+exec ip addr add 192.168.2.12/24 dev dummy2
+exec ip route add 192.168.2.254/32 dev dummy2
+exec ip route add default via 192.168.2.254 dev dummy2
+
+# Verify dummy2 appears without altnames.
+db/cmp --grep='^dummy2' devices devices_dummy2_no_altname.table
+
+# Verify lookup by primary name works.
+db/get devices --index=name --columns=Name,Selected dummy2
+stdout 'dummy2\s+true'
+
+# Add an alternative name to dummy2.
+exec ip link property add dev dummy2 altname mynet
+
+# Verify the altname appears in the devices table Name column.
+db/cmp --grep='^dummy2' devices devices_dummy2_with_altname.table
+
+# Verify lookup by the alternative name returns the device.
+db/get devices --index=name --columns=Name,Selected mynet
+stdout 'dummy2 \(mynet\).*true'
+
+# Add a second alternative name.
+exec ip link property add dev dummy2 altname longinterfacename
+
+# Verify both altnames appear in the devices table.
+db/cmp --grep='^dummy2' devices devices_dummy2_with_two_altnames.table
+
+# Verify lookup by the second alternative name also returns the device.
+db/get devices --index=name --columns=Name,Selected longinterfacename
+stdout 'dummy2 \(mynet, longinterfacename\).*true'
+
+# Remove the first alternative name.
+exec ip link property del dev dummy2 altname mynet
+
+# Verify only the second altname remains.
+db/cmp --grep='^dummy2' devices devices_dummy2_with_one_altname.table
+
+# Verify the primary name lookup still returns the device.
+db/get devices --index=name --columns=Name,Selected dummy2
+stdout 'dummy2 \(longinterfacename\).*true'
+
+# Remove the second alternative name.
+exec ip link property del dev dummy2 altname longinterfacename
+
+# Verify no altname remains.
+db/cmp --grep='^dummy2' devices devices_dummy2_no_altname.table
+
+# Verify the primary name lookup still returns the device.
+db/get devices --index=name --columns=Name,Selected dummy2
+stdout 'dummy2\s+true'
+
+# Delete dummy2
+exec ip link del dummy2
+
+# Add dummy3 with altnames without creating an actual interface.
+db/insert devices device-dummy3.yaml
+
+# Verify lookup by primary name works.
+db/get devices --index=name --columns=Name dummy3
+stdout 'dummy3 \(altdummy, anotherlonginterfacename\)'
+
+# Verify lookup by the alternative name returns the device.
+db/get devices --index=name --columns=Name altdummy
+stdout 'dummy3 \(altdummy, anotherlonginterfacename\)'
+
+# Verify both altnames appear in the devices table.
+db/cmp --grep='^dummy3' devices devices_dummy3_altnames.table
+
+db/delete devices device-dummy3.yaml
+
 # ---------------------------------------------
+-- device-dummy3.yaml --
+index: 33
+name: dummy3
+altnames:
+  - altdummy
+  - anotherlonginterfacename
+addrs:
+  - addr: 192.168.3.13
+type: dummy
+operstatus: up
 
 -- devices_empty.table --
 Name   Selected   Type     Addresses     OperStatus
@@ -89,6 +173,25 @@ dummy1   true       dummy   192.168.1.1, 192.168.1.2   unknown
 -- devices_dummy1.table --
 Name     Selected   Type    Addresses                  OperStatus
 dummy1   true       dummy   192.168.1.1, 192.168.1.2   unknown
+-- devices_dummy2_no_altname.table --
+Name     Selected   Type    Addresses                  OperStatus
+dummy2   true       dummy   192.168.2.12               unknown
+
+-- devices_dummy2_with_altname.table --
+Name              Selected   Type   Addresses          OperStatus
+dummy2 (mynet)    true       dummy  192.168.2.12       unknown
+
+-- devices_dummy2_with_two_altnames.table --
+Name                                  Selected   Type   Addresses     OperStatus
+dummy2 (mynet, longinterfacename)     true       dummy  192.168.2.12  unknown
+
+-- devices_dummy2_with_one_altname.table --
+Name                                  Selected   Type   Addresses     OperStatus
+dummy2 (longinterfacename)            true       dummy  192.168.2.12  unknown
+
+-- devices_dummy3_altnames.table --
+Name                                         Selected   Type   Addresses     OperStatus
+dummy3 (altdummy, anotherlonginterfacename)  false      dummy  192.168.3.13  up
 -- devices_placeholder --
 
 

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -29,7 +29,12 @@ var (
 	DeviceNameIndex = statedb.Index[*Device, string]{
 		Name: "name",
 		FromObject: func(d *Device) index.KeySet {
-			return index.NewKeySet(index.String(d.Name))
+			keys := make([]index.Key, 0, 1+len(d.AltNames))
+			keys = append(keys, index.String(d.Name))
+			for _, altName := range d.AltNames {
+				keys = append(keys, index.String(altName))
+			}
+			return index.NewKeySet(keys...)
 		},
 		FromKey:    index.String,
 		FromString: index.FromString,
@@ -92,6 +97,7 @@ type Device struct {
 	Index        int             // positive integer that starts at one, zero is never used
 	MTU          int             // maximum transmission unit
 	Name         string          // e.g., "en0", "lo0", "eth0.100"
+	AltNames     []string        // alternative names
 	HardwareAddr HardwareAddr    // IEEE MAC-48, EUI-48 and EUI-64 form
 	Flags        net.Flags       // e.g. net.FlagUp, net.eFlagLoopback, net.FlagMulticast
 	Addrs        []DeviceAddress // Addresses assigned to the device
@@ -106,6 +112,7 @@ type Device struct {
 
 func (d *Device) DeepCopy() *Device {
 	copy := *d
+	copy.AltNames = slices.Clone(d.AltNames)
 	copy.Addrs = slices.Clone(d.Addrs)
 	return &copy
 }
@@ -138,8 +145,12 @@ func (d *Device) TableRow() []string {
 	for _, addr := range d.Addrs {
 		addrs = append(addrs, addr.Addr.String())
 	}
+	name := d.Name
+	if len(d.AltNames) > 0 {
+		name += " (" + strings.Join(d.AltNames, ", ") + ")"
+	}
 	return []string{
-		d.Name,
+		name,
 		fmt.Sprintf("%d", d.Index),
 		fmt.Sprintf("%v", d.Selected),
 		d.Type,

--- a/pkg/datapath/tables/zz_generated.deepequal.go
+++ b/pkg/datapath/tables/zz_generated.deepequal.go
@@ -24,6 +24,23 @@ func (in *Device) DeepEqual(other *Device) bool {
 	if in.Name != other.Name {
 		return false
 	}
+	if ((in.AltNames != nil) && (other.AltNames != nil)) || ((in.AltNames == nil) != (other.AltNames == nil)) {
+		in, other := &in.AltNames, &other.AltNames
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if inElement != (*other)[i] {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.HardwareAddr != nil) && (other.HardwareAddr != nil)) || ((in.HardwareAddr == nil) != (other.HardwareAddr == nil)) {
 		in, other := &in.HardwareAddr, &other.HardwareAddr
 		if other == nil {


### PR DESCRIPTION
Network interfaces can have alternatives names[^1]. This allows to e.g. use multiple names for the same network interface or interface names longer than IFNAMSIZ (16 bytes). The netlink library's LinkByName function also supports looking up links by alternative names[^2].

However, these alternative interface names are currently not considered for lookup in the datapath devices table. Fix this by also indexing the devices table by alternative name in DeviceNameIndex. This allows using the alternative name e.g. in user-provided input (CRD fields, CLI flags) which are then successively looked up in the devices table.

Also allow the alternative names to be used when matching network interfaces using the `--devices` cilium-agent command line option.

[^1]: https://lwn.net/Articles/794289
[^2]: https://github.com/vishvananda/netlink/blob/c822ed716ea170073a6fa4239082c2512be1fe99/link_linux.go#L1984-L1989
