### PR TITLE
cilium-cli/sysdump: collect Cilium L2 Announcement Policies

### DIFF
--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -1019,6 +1019,10 @@ func (c *Client) ListCiliumPodIPPools(ctx context.Context, opts metav1.ListOptio
 	return c.CiliumClientset.CiliumV2alpha1().CiliumPodIPPools().List(ctx, opts)
 }
 
+func (c *Client) ListCiliumL2AnnouncementPolicies(ctx context.Context, opts metav1.ListOptions) (*ciliumv2alpha1.CiliumL2AnnouncementPolicyList, error) {
+	return c.CiliumClientset.CiliumV2alpha1().CiliumL2AnnouncementPolicies().List(ctx, opts)
+}
+
 func (c *Client) GetLogs(ctx context.Context, namespace, name, container string, opts corev1.PodLogOptions, out io.Writer) error {
 	opts.Container = container
 	r := c.Clientset.CoreV1().Pods(namespace).GetLogs(name, &opts)

--- a/cilium-cli/sysdump/client.go
+++ b/cilium-cli/sysdump/client.go
@@ -62,6 +62,7 @@ type KubernetesClient interface {
 	ListCiliumEndpoints(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEndpointList, error)
 	ListCiliumEndpointSlices(ctx context.Context, options metav1.ListOptions) (*ciliumv2alpha1.CiliumEndpointSliceList, error)
 	ListCiliumEnvoyConfigs(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumEnvoyConfigList, error)
+	ListCiliumL2AnnouncementPolicies(ctx context.Context, options metav1.ListOptions) (*ciliumv2alpha1.CiliumL2AnnouncementPolicyList, error)
 	ListCiliumLocalRedirectPolicies(ctx context.Context, namespace string, options metav1.ListOptions) (*ciliumv2.CiliumLocalRedirectPolicyList, error)
 	ListCiliumNetworkPolicies(ctx context.Context, namespace string, opts metav1.ListOptions) (*ciliumv2.CiliumNetworkPolicyList, error)
 	ListCiliumNodes(ctx context.Context) (*ciliumv2.CiliumNodeList, error)

--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -66,6 +66,7 @@ const (
 	ciliumEtcdSecretFileName                 = "cilium-etcd-secrets-secret-<ts>.yaml"
 	ciliumIdentitiesFileName                 = "ciliumidentities-<ts>.yaml"
 	ciliumCIDRGroupsFileName                 = "ciliumcidrgroups-<ts>.yaml"
+	ciliumL2AnnouncementPoliciesFileName     = "ciliuml2announcementpolicies-<ts>.yaml"
 	ciliumLocalRedirectPoliciesFileName      = "ciliumlocalredirectpolicies-<ts>.yaml"
 	ciliumLogsFileName                       = "logs-%s-%s-<ts>.log"
 	ciliumPreviousLogsFileName               = "logs-%s-%s-<ts>-prev.log"

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -892,6 +892,20 @@ func (c *Collector) Run() error {
 			},
 		},
 		{
+			Description: "Collecting Cilium L2 Announcement Policies",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				v, err := c.Client.ListCiliumL2AnnouncementPolicies(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect Cilium L2 announcement policies: %w", err)
+				}
+				if err := c.WriteYAML(ciliumL2AnnouncementPoliciesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect Cilium L2 announcement policies: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: fmt.Sprintf("Checking if %s exists in %s namespace", ciliumEtcdSecretsSecretName, c.Options.CiliumNamespace),
 			Quick:       true,
 			Task: func(ctx context.Context) error {

--- a/cilium-cli/sysdump/sysdump_test.go
+++ b/cilium-cli/sysdump/sysdump_test.go
@@ -414,6 +414,10 @@ func (c *fakeClient) ListCiliumPodIPPools(_ context.Context, _ metav1.ListOption
 	panic("implement me")
 }
 
+func (c *fakeClient) ListCiliumL2AnnouncementPolicies(_ context.Context, _ metav1.ListOptions) (*ciliumv2alpha1.CiliumL2AnnouncementPolicyList, error) {
+	panic("implement me")
+}
+
 func (c *fakeClient) ListCiliumClusterwideEnvoyConfigs(_ context.Context, _ metav1.ListOptions) (*ciliumv2.CiliumClusterwideEnvoyConfigList, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
Let the cilium sysdump command collect any CiliumL2AnnouncementPolicy resources from the cluster.

This will help to triage issues like #41646.