### PR TITLE
preflight: Remove obsolete `reserved:init` CNP validation warning

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -15,21 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
-	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-)
-
-var (
-	// We can remove the check for this warning once 1.15 is the oldest supported Cilium version.
-	logInitPolicyCNP = "It seems you have a CiliumNetworkPolicy with a " +
-		"match on the 'reserved:init' labels. This label is not " +
-		"supported in CiliumNetworkPolicy any more. If you wish to " +
-		"define a policy for endpoints before they receive a full " +
-		"security identity, change the resource type for the policy " +
-		"to CiliumClusterwideNetworkPolicy."
-	errInitPolicyCNP = fmt.Errorf("CiliumNetworkPolicy incorrectly matches reserved:init label")
-	logOnce          sync.Once
 )
 
 // NPValidator is a validator structure used to validate CNP and CCNP.
@@ -115,10 +99,6 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 		return err
 	}
 
-	if err := checkInitLabelsPolicy(n.logger, cnp); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -130,41 +110,6 @@ func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 
 	if err := detectUnknownFields(n.logger, ccnp); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func checkInitLabelsPolicy(logger *slog.Logger, cnp *unstructured.Unstructured) error {
-	cnpBytes, err := cnp.MarshalJSON()
-	if err != nil {
-		return err
-	}
-
-	resCNP := cilium_v2.CiliumNetworkPolicy{}
-	err = json.Unmarshal(cnpBytes, &resCNP)
-	if err != nil {
-		return err
-	}
-
-	for _, spec := range append(resCNP.Specs, resCNP.Spec) {
-		if spec == nil {
-			continue
-		}
-		podInitLbl := labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
-
-		if err := spec.EndpointSelector.Sanitize(); err != nil {
-			return err
-		}
-		if spec.EndpointSelector.HasKey(podInitLbl) {
-			logOnce.Do(func() {
-				logger.Error(
-					logInitPolicyCNP,
-					logfields.CiliumNetworkPolicyName, cnp.GetName(),
-				)
-			})
-			return errInitPolicyCNP
-		}
 	}
 
 	return nil

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -470,32 +470,3 @@ specs:
 		}
 	}
 }
-
-func Test_GH28007(t *testing.T) {
-	cnp := []byte(`apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: exampleapp
-  namespace: examplens
-spec:
-  egress:
-  - toEntities:
-    - world
-  endpointSelector:
-    matchExpressions:
-    - key: reserved:init
-      operator: DoesNotExist
-`)
-	jsnByte, err := yaml.YAMLToJSON(cnp)
-	require.NoError(t, err)
-
-	us := unstructured.Unstructured{}
-	err = json.Unmarshal(jsnByte, &us)
-	require.NoError(t, err)
-
-	validator, err := NewNPValidator(hivetest.Logger(t))
-	require.NoError(t, err)
-	err = validator.ValidateCNP(&us)
-	// Err can't be nil since validation should detect the policy is not correct.
-	require.Equal(t, errInitPolicyCNP, err)
-}


### PR DESCRIPTION
The `checkInitLabelsPolicy` check warned users that `CiliumNetworkPolicy` matching `reserved:init` labels should be migrated to `CiliumClusterwideNetworkPolicy`.

This has been marked for removal for the 1.18 release: 
https://github.com/cilium/cilium/blob/fffae2c8a1f165bf7be9791ab3056d05784d468b/pkg/k8s/apis/cilium.io/v2/validator/validator.go#L24

Followup to #28007