### PR TITLE
logging: Update leader election log level override

### DIFF
--- a/pkg/logging/klog_bridge.go
+++ b/pkg/logging/klog_bridge.go
@@ -19,9 +19,9 @@ import (
 
 var klogErrorOverrides = []logLevelOverride{
 	{
-		// TODO: We can drop the misspelled case here once client-go version is bumped to include:
-		//	https://github.com/kubernetes/client-go/commit/ae43527480ee9d8750fbcde3d403363873fd3d89
-		matcher:     regexp.MustCompile("Failed to update lock (optimitically|optimistically).*falling back to slow path"),
+		// TODO: We can drop this once bumped to new client-go version which has this at info level:
+		// https://github.com/kubernetes/client-go/commit/ea7a7e7cf9697850f17631f79ef4ef45b95c449e.
+		matcher:     regexp.MustCompile("Failed to update.*falling back to slow path"),
 		targetLevel: slog.LevelInfo,
 	},
 }


### PR DESCRIPTION
client-go had slightly changed the error message leading to our log level override to no longer match. Update the matcher so we'll match it again:

```
$ git grep "Failed to update.*falling back to slow path" vendor/k8s.io
vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:         logger.Error(err, "Failed to update lease optimistically, falling back to slow path", "lock", le.config.Lock.Describe())
```

Upstream the log level has been now changed to INFO, so we can drop this hack once we bump to a version that includes the change (https://github.com/kubernetes/client-go/commit/ea7a7e7cf9697850f17631f79ef4ef45b95c449e)

Fixes: #45258