### PR TITLE
gateway-api: clean up resources on GatewayClass handoff

### DIFF
--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -320,6 +320,54 @@ func Test_hasMatchingController(t *testing.T) {
 	})
 }
 
+func Test_gatewayReconcilePredicate(t *testing.T) {
+	logger := hivetest.Logger(t)
+	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(controllerTestFixture...).Build()
+	predicate := gatewayOwnedByController(hasMatchingController(t.Context(), c, controllerName, logger))
+
+	t.Run("update keeps handoff reconcile when old gateway matched", func(t *testing.T) {
+		require.True(t, predicate.Update(event.UpdateEvent{
+			ObjectOld: &gatewayv1.Gateway{
+				Spec: gatewayv1.GatewaySpec{GatewayClassName: "cilium"},
+			},
+			ObjectNew: &gatewayv1.Gateway{
+				Spec: gatewayv1.GatewaySpec{GatewayClassName: "non-existent"},
+			},
+		}))
+	})
+
+	t.Run("create ignores gateway that never matched", func(t *testing.T) {
+		require.False(t, predicate.Create(event.CreateEvent{
+			Object: &gatewayv1.Gateway{
+				Spec: gatewayv1.GatewaySpec{GatewayClassName: "non-existent"},
+			},
+		}))
+	})
+}
+
+func Test_gatewayClassReconcilePredicate(t *testing.T) {
+	predicate := gatewayClassOwnedByController(controllerName)
+
+	t.Run("update keeps handoff reconcile when old gatewayclass matched", func(t *testing.T) {
+		require.True(t, predicate.Update(event.UpdateEvent{
+			ObjectOld: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{ControllerName: controllerName},
+			},
+			ObjectNew: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+			},
+		}))
+	})
+
+	t.Run("create ignores unrelated gatewayclass", func(t *testing.T) {
+		require.False(t, predicate.Create(event.CreateEvent{
+			Object: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+			},
+		}))
+	})
+}
+
 func Test_getGatewaysForSecret(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(controllerTestFixture...).Build()
 	logger := hivetest.Logger(t)

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -20,6 +20,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -132,11 +133,11 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	gatewayBuilder := ctrl.NewControllerManagedBy(mgr).
 		// Watch its own resource
 		For(&gatewayv1.Gateway{},
-			builder.WithPredicates(predicate.NewPredicateFuncs(hasMatchingControllerFn))).
+			builder.WithPredicates(gatewayOwnedByController(hasMatchingControllerFn))).
 		// Watch GatewayClass resources, which are linked to Gateway
 		Watches(&gatewayv1.GatewayClass{},
 			r.enqueueRequestForOwningGatewayClass(),
-			builder.WithPredicates(predicate.NewPredicateFuncs(matchesControllerName(controllerName)))).
+			builder.WithPredicates(gatewayClassOwnedByController(controllerName))).
 		// Watch related backend Service for status
 		// LB Services are handled by the Owns call later.
 		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
@@ -171,6 +172,45 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return gatewayBuilder.Complete(r)
+}
+
+func gatewayOwnedByController(hasMatchingControllerFn func(object client.Object) bool) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return hasMatchingControllerFn(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return hasMatchingControllerFn(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Reconcile one last time when a Gateway moves away from this controller
+			// so previously managed resources can be cleaned up.
+			return hasMatchingControllerFn(e.ObjectOld) || hasMatchingControllerFn(e.ObjectNew)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return hasMatchingControllerFn(e.Object)
+		},
+	}
+}
+
+func gatewayClassOwnedByController(controllerName string) predicate.Predicate {
+	hasMatchingControllerName := matchesControllerName(controllerName)
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return hasMatchingControllerName(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return hasMatchingControllerName(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Reconcile one last time when a GatewayClass moves away from this controller
+			// so referenced Gateways can clean up previously managed resources.
+			return hasMatchingControllerName(e.ObjectOld) || hasMatchingControllerName(e.ObjectNew)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return hasMatchingControllerName(e.Object)
+		},
+	}
 }
 
 // enqueueRequestForOwningGatewayClass returns an event handler that, when given a GatewayClass,

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -82,6 +82,15 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Step 2: Gather all required information for the ingestion model
 	gwc := &gatewayv1.GatewayClass{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: string(gw.Spec.GatewayClassName)}, gwc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			scopedLog.InfoContext(ctx, "GatewayClass no longer exists, cleaning up previously managed resources",
+				gatewayClass, gw.Spec.GatewayClassName)
+			if err := r.cleanupOwnedResources(ctx, gw); err != nil {
+				scopedLog.ErrorContext(ctx, "Unable to cleanup managed Gateway resources", logfields.Error, err)
+				return controllerruntime.Fail(err)
+			}
+			return controllerruntime.Success()
+		}
 		scopedLog.ErrorContext(ctx, "Unable to get GatewayClass",
 			gatewayClass, gw.Spec.GatewayClassName,
 			logfields.Error, err)
@@ -90,7 +99,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if string(gwc.Spec.ControllerName) != controllerName {
-		scopedLog.DebugContext(ctx, "GatewayClass does not have matching controller name, doing nothing")
+		scopedLog.InfoContext(ctx, "GatewayClass does not have matching controller name, cleaning up previously managed resources",
+			gatewayClass, gw.Spec.GatewayClassName,
+			logfields.Controller, gwc.Spec.ControllerName)
+		if err := r.cleanupOwnedResources(ctx, gw); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to cleanup managed Gateway resources", logfields.Error, err)
+			return controllerruntime.Fail(err)
+		}
 		return controllerruntime.Success()
 	}
 
@@ -308,6 +323,50 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *cili
 		return nil
 	})
 	return err
+}
+
+func (r *gatewayReconciler) cleanupOwnedResources(ctx context.Context, gw *gatewayv1.Gateway) error {
+	if err := r.ensureOwnedServiceDeleted(ctx, gw); err != nil {
+		return err
+	}
+	if err := r.ensureOwnedEnvoyConfigDeleted(ctx, gw); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *gatewayReconciler) ensureOwnedServiceDeleted(ctx context.Context, gw *gatewayv1.Gateway) error {
+	svc := &corev1.Service{}
+	key := types.NamespacedName{
+		Namespace: gw.Namespace,
+		Name:      shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + gw.Name),
+	}
+
+	if err := r.Client.Get(ctx, key, svc); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(svc, gw) {
+		return nil
+	}
+
+	return client.IgnoreNotFound(r.Client.Delete(ctx, svc))
+}
+
+func (r *gatewayReconciler) ensureOwnedEnvoyConfigDeleted(ctx context.Context, gw *gatewayv1.Gateway) error {
+	cec := &ciliumv2.CiliumEnvoyConfig{}
+	key := types.NamespacedName{
+		Namespace: gw.Namespace,
+		Name:      gwModel.CiliumGatewayPrefix + gw.Name,
+	}
+
+	if err := r.Client.Get(ctx, key, cec); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if !metav1.IsControlledBy(cec, gw) {
+		return nil
+	}
+
+	return client.IgnoreNotFound(r.Client.Delete(ctx, cec))
 }
 
 func (r *gatewayReconciler) updateStatus(ctx context.Context, original *gatewayv1.Gateway, new *gatewayv1.Gateway) error {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 var (
@@ -409,6 +410,110 @@ func Test_Conformance(t *testing.T) {
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/backendtlspolicy-%s.yaml", tt.name, btlsp.Name), expectedBTLSP)
 				require.Empty(t, cmp.Diff(expectedBTLSP, actualBTLSP, cmpIgnoreFields...))
 			}
+		})
+	}
+}
+
+func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		gatewayClass string
+		objects      []client.Object
+	}{
+		{
+			name:         "gatewayclass missing",
+			gatewayClass: "missing",
+		},
+		{
+			name:         "gatewayclass controller no longer matches",
+			gatewayClass: "other",
+			objects: []client.Object{
+				&gatewayv1.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "other"},
+					Spec: gatewayv1.GatewayClassSpec{
+						ControllerName: "example.com/other-controller",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "handoff-gateway",
+					Namespace: "default",
+					UID:       types.UID("gateway-uid"),
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: gatewayv1.ObjectName(tc.gatewayClass),
+				},
+			}
+
+			serviceName := shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name)
+			shortGatewayName := shortener.ShortenK8sResourceName(gw.Name)
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceName,
+					Namespace: gw.Namespace,
+					Labels: map[string]string{
+						owningGatewayLabel:                       shortGatewayName,
+						"gateway.networking.k8s.io/gateway-name": shortGatewayName,
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: gatewayv1.GroupVersion.String(),
+							Kind:       "Gateway",
+							Name:       gw.Name,
+							UID:        gw.UID,
+							Controller: ptr.To(true),
+						},
+					},
+				},
+			}
+			cec := &ciliumv2.CiliumEnvoyConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayApiTranslation.CiliumGatewayPrefix + gw.Name,
+					Namespace: gw.Namespace,
+					Labels: map[string]string{
+						"gateway.networking.k8s.io/gateway-name": shortGatewayName,
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: gatewayv1.GroupVersion.String(),
+							Kind:       "Gateway",
+							Name:       gw.Name,
+							UID:        gw.UID,
+							Controller: ptr.To(true),
+						},
+					},
+				},
+			}
+
+			objects := append([]client.Object{gw, svc, cec}, tc.objects...)
+			c := fake.NewClientBuilder().
+				WithScheme(testScheme()).
+				WithObjects(objects...).
+				Build()
+
+			r := &gatewayReconciler{
+				Client: c,
+				logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+			}
+
+			result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gw)})
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{}, result)
+
+			err = c.Get(t.Context(), client.ObjectKeyFromObject(svc), &corev1.Service{})
+			require.ErrorContains(t, err, "not found")
+
+			err = c.Get(t.Context(), client.ObjectKeyFromObject(cec), &ciliumv2.CiliumEnvoyConfig{})
+			require.ErrorContains(t, err, "not found")
+
+			actualGateway := &gatewayv1.Gateway{}
+			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(gw), actualGateway))
 		})
 	}
 }


### PR DESCRIPTION
Currently, when a `Gateway` stops being owned by the Cilium Gateway controller because its referenced `GatewayClass` is removed or no longer uses `io.cilium/gateway-controller`, the reconciler used to return early and leave the generated K8s `Service` and `CiliumEnvoyConfig` behind.

Therefore, this commit adds explicit cleanup for those Cilium managed resources in the handoff path, while preserving owner-ref based cleanup for real Gateway deletion. Also update Gateway and GatewayClass watch predicates so old->new transitions that move away from the OSS controller still trigger the final reconcile needed for cleanup.