### PR TITLE
gateway-api: shorten generated CEC names

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -356,7 +356,7 @@ func (r *gatewayReconciler) ensureOwnedEnvoyConfigDeleted(ctx context.Context, g
 	cec := &ciliumv2.CiliumEnvoyConfig{}
 	key := types.NamespacedName{
 		Namespace: gw.Namespace,
-		Name:      gwModel.CiliumGatewayPrefix + gw.Name,
+		Name:      shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + gw.Name),
 	}
 
 	if err := r.Client.Get(ctx, key, cec); err != nil {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -359,7 +359,10 @@ func Test_Conformance(t *testing.T) {
 				if !gwDetail.wantErr {
 					// Checking the output for CiliumEnvoyConfig
 					actualCEC := &ciliumv2.CiliumEnvoyConfig{}
-					err = c.Get(t.Context(), client.ObjectKey{Namespace: gwDetail.FullName.Namespace, Name: "cilium-gateway-" + gwDetail.FullName.Name}, actualCEC)
+					err = c.Get(t.Context(), client.ObjectKey{
+						Namespace: gwDetail.FullName.Namespace,
+						Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gwDetail.FullName.Name),
+					}, actualCEC)
 					require.NoError(t, err, "Could not get CiliumEnvoyConfig and wasn't expecting a reconciliation error")
 					expectedCEC := &ciliumv2.CiliumEnvoyConfig{}
 					readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/cec-%s.yaml", tt.name, gwDetail.FullName.Name), expectedCEC)
@@ -474,7 +477,7 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 			}
 			cec := &ciliumv2.CiliumEnvoyConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      gatewayApiTranslation.CiliumGatewayPrefix + gw.Name,
+					Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
 					Namespace: gw.Namespace,
 					Labels: map[string]string{
 						"gateway.networking.k8s.io/gateway-name": shortGatewayName,

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation-with-hostname-intersection.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-http-listener-isolation/output/cec-http-listener-isolation-with-hostname-intersection.yaml
@@ -4,7 +4,7 @@ metadata:
     cec.cilium.io/use-original-source-address: "false"
   labels:
     gateway.networking.k8s.io/gateway-name: http-listener-isolation-with-hostname-intersection
-  name: cilium-gateway-http-listener-isolation-with-hostname-intersection
+  name: cilium-gateway-http-listener-isolation-with-hostname-h56mb54hf8
   namespace: gateway-conformance-infra
   ownerReferences:
   - apiVersion: gateway.networking.k8s.io/v1

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-unresolved-gateway-with-one-attached-unresolved-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/cec-unresolved-gateway-with-one-attached-unresolved-route.yaml
@@ -4,7 +4,7 @@ metadata:
     cec.cilium.io/use-original-source-address: "false"
   labels:
     gateway.networking.k8s.io/gateway-name: unresolved-gateway-with-one-attached-unresolved-route
-  name: cilium-gateway-unresolved-gateway-with-one-attached-unresolved-route
+  name: cilium-gateway-unresolved-gateway-with-one-attached--44kc7f446g
   namespace: gateway-conformance-infra
   ownerReferences:
     - apiVersion: gateway.networking.k8s.io/v1

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -83,7 +83,7 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	if source.Kind == "Service" {
 		generatedName = source.Name
 	}
-	cec, err := t.cecTranslator.Translate(source.Namespace, generatedName, m)
+	cec, err := t.cecTranslator.Translate(source.Namespace, shortener.ShortenK8sResourceName(generatedName), m)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 func Test_translator_Translate(t *testing.T) {
@@ -378,6 +379,40 @@ func Test_getService(t *testing.T) {
 			assert.LessOrEqual(t, len(got.Name), 63, "Service name is too long")
 		})
 	}
+}
+
+func Test_translator_Translate_ShortensCECName(t *testing.T) {
+	trans := &gatewayAPITranslator{
+		cecTranslator: translation.NewCECTranslator(translation.Config{}),
+	}
+
+	longName := "test-long-long-long-long-long-long-long-long-long-long-long-long-name"
+	input := &model.Model{
+		HTTP: []model.HTTPListener{
+			{
+				Name: "listener",
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      longName,
+						Namespace: "default",
+						Group:     gatewayv1.GroupVersion.Group,
+						Version:   gatewayv1.GroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       "57889650-380b-4c05-9a2e-3baee7fd5271",
+					},
+				},
+				Port: 80,
+			},
+		},
+	}
+
+	cec, svc, err := trans.Translate(input)
+	require.NoError(t, err)
+	require.NotNil(t, cec)
+	require.NotNil(t, svc)
+	require.Equal(t, shortener.ShortenK8sResourceName(CiliumGatewayPrefix+longName), cec.Name)
+	require.Equal(t, svc.Name, cec.Name)
+	require.LessOrEqual(t, len(cec.Name), 63, "CiliumEnvoyConfig name is too long")
 }
 
 func readInput(t *testing.T, file string, obj any) {


### PR DESCRIPTION
Use the Kubernetes resource name shortener for generated Gateway API CiliumEnvoyConfig
objects so they follow the same naming constraints as the generated K8s Service resources.
This avoids errors when creating CECs, inconsistent reconciliation and cleanup behavior
for long Gateway names.