### PR TITLE
bandwidth: fix FQ qdisc setup on bond devices

### DIFF
--- a/pkg/datapath/linux/bandwidth/cell.go
+++ b/pkg/datapath/linux/bandwidth/cell.go
@@ -48,6 +48,7 @@ type registerParams struct {
 
 	Log              *slog.Logger
 	Table            statedb.RWTable[*tables.BandwidthQDisc]
+	Devices          statedb.Table[*tables.Device]
 	BWM              Manager
 	Config           types.Config
 	DeriveParams     statedb.DeriveParams[*tables.Device, *tables.BandwidthQDisc]
@@ -71,7 +72,7 @@ func registerReconciler(p registerParams) error {
 		(*tables.BandwidthQDisc).Clone,
 		(*tables.BandwidthQDisc).SetStatus,
 		(*tables.BandwidthQDisc).GetStatus,
-		newOps(p.Log, p.BWM),
+		newOps(p.Log, p.BWM, p.Devices),
 		nil,
 	)
 	return err

--- a/pkg/datapath/linux/bandwidth/ops.go
+++ b/pkg/datapath/linux/bandwidth/ops.go
@@ -21,10 +21,11 @@ import (
 type ops struct {
 	log       *slog.Logger
 	isEnabled func() bool
+	devices   statedb.Table[*tables.Device]
 }
 
-func newOps(log *slog.Logger, mgr Manager) reconciler.Operations[*tables.BandwidthQDisc] {
-	return &ops{log, mgr.Enabled}
+func newOps(log *slog.Logger, mgr Manager, devices statedb.Table[*tables.Device]) reconciler.Operations[*tables.BandwidthQDisc] {
+	return &ops{log, mgr.Enabled, devices}
 }
 
 // Delete implements reconciler.Operations.
@@ -53,20 +54,17 @@ func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, _ statedb.Revis
 	}
 
 	if link.Type() == "bond" {
-		return ops.updateBondDevice(link, q)
+		return ops.updateBondDevice(link, txn, q)
 	}
 
 	return ops.setupFQOnLink(link, q)
 }
 
-func (ops *ops) updateBondDevice(bond netlink.Link, q *tables.BandwidthQDisc) error {
-	slaves, err := ops.bondSlaves(bond)
-	if err != nil {
-		return err
-	}
+func (ops *ops) updateBondDevice(bond netlink.Link, txn statedb.ReadTxn, q *tables.BandwidthQDisc) error {
+	slaves := ops.bondSlaves(bond, txn)
 
 	if len(slaves) == 0 {
-		return ops.setupFQOnLink(bond, q)
+		return nil
 	}
 
 	if err := ops.ensureNoqueue(bond); err != nil {
@@ -74,25 +72,25 @@ func (ops *ops) updateBondDevice(bond netlink.Link, q *tables.BandwidthQDisc) er
 	}
 
 	for _, slave := range slaves {
-		if err := ops.setupFQOnLink(slave, q); err != nil {
-			return fmt.Errorf("bond slave %s: %w", slave.Attrs().Name, err)
+		slaveLink, err := netlink.LinkByIndex(slave.Index)
+		if err != nil {
+			return fmt.Errorf("bond slave %s: LinkByIndex: %w", slave.Name, err)
+		}
+		if err := ops.setupFQOnLink(slaveLink, q); err != nil {
+			return fmt.Errorf("bond slave %s: %w", slave.Name, err)
 		}
 	}
 	return nil
 }
 
-func (ops *ops) bondSlaves(bond netlink.Link) ([]netlink.Link, error) {
-	allLinks, err := safenetlink.LinkList()
-	if err != nil {
-		return nil, fmt.Errorf("LinkList: %w", err)
-	}
-	var slaves []netlink.Link
-	for _, link := range allLinks {
-		if link.Attrs().MasterIndex == bond.Attrs().Index {
-			slaves = append(slaves, link)
+func (ops *ops) bondSlaves(bond netlink.Link, txn statedb.ReadTxn) []*tables.Device {
+	var slaves []*tables.Device
+	for dev := range ops.devices.All(txn) {
+		if dev.MasterIndex == bond.Attrs().Index {
+			slaves = append(slaves, dev)
 		}
 	}
-	return slaves, nil
+	return slaves
 }
 
 func (ops *ops) ensureNoqueue(link netlink.Link) error {

--- a/pkg/datapath/linux/bandwidth/ops.go
+++ b/pkg/datapath/linux/bandwidth/ops.go
@@ -51,6 +51,76 @@ func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, _ statedb.Revis
 	if err != nil {
 		return fmt.Errorf("LinkByIndex: %w", err)
 	}
+
+	if link.Type() == "bond" {
+		return ops.updateBondDevice(link, q)
+	}
+
+	return ops.setupFQOnLink(link, q)
+}
+
+func (ops *ops) updateBondDevice(bond netlink.Link, q *tables.BandwidthQDisc) error {
+	slaves, err := ops.bondSlaves(bond)
+	if err != nil {
+		return err
+	}
+
+	if len(slaves) == 0 {
+		return ops.setupFQOnLink(bond, q)
+	}
+
+	if err := ops.ensureNoqueue(bond); err != nil {
+		return err
+	}
+
+	for _, slave := range slaves {
+		if err := ops.setupFQOnLink(slave, q); err != nil {
+			return fmt.Errorf("bond slave %s: %w", slave.Attrs().Name, err)
+		}
+	}
+	return nil
+}
+
+func (ops *ops) bondSlaves(bond netlink.Link) ([]netlink.Link, error) {
+	allLinks, err := safenetlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("LinkList: %w", err)
+	}
+	var slaves []netlink.Link
+	for _, link := range allLinks {
+		if link.Attrs().MasterIndex == bond.Attrs().Index {
+			slaves = append(slaves, link)
+		}
+	}
+	return slaves, nil
+}
+
+func (ops *ops) ensureNoqueue(link netlink.Link) error {
+	qdiscs, err := safenetlink.QdiscList(link)
+	if err != nil {
+		return fmt.Errorf("QdiscList for %s: %w", link.Attrs().Name, err)
+	}
+	for _, qdisc := range qdiscs {
+		if qdisc.Attrs().Parent == netlink.HANDLE_ROOT && qdisc.Type() == "noqueue" {
+			return nil
+		}
+	}
+	noqueue := &netlink.GenericQdisc{
+		QdiscAttrs: netlink.QdiscAttrs{
+			LinkIndex: link.Attrs().Index,
+			Parent:    netlink.HANDLE_ROOT,
+		},
+		QdiscType: "noqueue",
+	}
+	if err := netlink.QdiscReplace(noqueue); err != nil {
+		return fmt.Errorf("cannot set noqueue on bond master %s: %w", link.Attrs().Name, err)
+	}
+	ops.log.Info("Setting noqueue on bond master device",
+		logfields.Device, link.Attrs().Name)
+	return nil
+}
+
+func (ops *ops) setupFQOnLink(link netlink.Link, q *tables.BandwidthQDisc) error {
 	device := link.Attrs().Name
 
 	// Check if the qdiscs are already set up as expected.
@@ -83,7 +153,6 @@ func (ops *ops) Update(ctx context.Context, txn statedb.ReadTxn, _ statedb.Revis
 					updatedQdiscs++
 				}
 			}
-
 		}
 	}
 	if updatedQdiscs == numEgressQdiscs {

--- a/pkg/datapath/linux/bandwidth/ops_test.go
+++ b/pkg/datapath/linux/bandwidth/ops_test.go
@@ -5,6 +5,7 @@ package bandwidth
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -118,4 +119,165 @@ func TestPrivilegedOps(t *testing.T) {
 		})
 	})
 	require.Error(t, err, "expected no error from update of non-existing device")
+}
+
+func TestPrivilegedOpsBond(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	log := hivetest.Logger(t)
+
+	var bondIndex int
+	var err error
+
+	ns := netns.NewNetNS(t)
+	var slaveAssignErr error
+	require.NoError(t, ns.Do(func() error {
+		if err := netlink.LinkAdd(netlink.NewLinkBond(netlink.LinkAttrs{Name: "bond0"})); err != nil {
+			return fmt.Errorf("LinkAdd bond0: %w", err)
+		}
+		bond, err := netlink.LinkByName("bond0")
+		if err != nil {
+			return fmt.Errorf("LinkByName bond0: %w", err)
+		}
+		bondIndex = bond.Attrs().Index
+		if err := netlink.LinkSetUp(bond); err != nil {
+			return fmt.Errorf("LinkSetUp bond0: %w", err)
+		}
+		for _, name := range []string{"slave0", "slave1"} {
+			if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}); err != nil {
+				return fmt.Errorf("LinkAdd %s: %w", name, err)
+			}
+			slave, err := netlink.LinkByName(name)
+			if err != nil {
+				return fmt.Errorf("LinkByName %s: %w", name, err)
+			}
+			if err := netlink.LinkSetUp(slave); err != nil {
+				return fmt.Errorf("LinkSetUp %s: %w", name, err)
+			}
+			if e := netlink.LinkSetMasterByIndex(slave, bondIndex); e != nil {
+				slaveAssignErr = fmt.Errorf("LinkSetMasterByIndex %s: %w", name, e)
+				return nil
+			}
+		}
+		return nil
+	}), "bond/slave setup in netns")
+	if slaveAssignErr != nil {
+		t.Skipf("skipping: cannot assign bond slaves on this kernel (%v)", slaveAssignErr)
+	}
+
+	ops := &ops{
+		log:       log,
+		isEnabled: func() bool { return true },
+	}
+	ctx := context.TODO()
+
+	err = ns.Do(func() error {
+		return ops.Update(ctx, nil, 0, &tables.BandwidthQDisc{
+			LinkIndex: bondIndex,
+			LinkName:  "bond0",
+			FqHorizon: FqDefaultHorizon,
+			FqBuckets: FqDefaultBuckets,
+			Status:    reconciler.StatusPending(),
+		})
+	})
+	require.NoError(t, err, "Update bond master")
+
+	var bondQdiscs []netlink.Qdisc
+	err = ns.Do(func() error {
+		var e error
+		bondMaster, e2 := netlink.LinkByIndex(bondIndex)
+		if e2 != nil {
+			return e2
+		}
+		bondQdiscs, e = safenetlink.QdiscList(bondMaster)
+		return e
+	})
+	require.NoError(t, err, "QdiscList bond master")
+	t.Logf("bond master qdiscs: %+v", bondQdiscs)
+	require.Len(t, bondQdiscs, 1)
+	require.Equal(t, "noqueue", bondQdiscs[0].Type(), "bond master should have noqueue")
+
+	for _, slaveName := range []string{"slave0", "slave1"} {
+		var slaveQdiscs []netlink.Qdisc
+		err = ns.Do(func() error {
+			slave, e := netlink.LinkByName(slaveName)
+			if e != nil {
+				return e
+			}
+			var e2 error
+			slaveQdiscs, e2 = safenetlink.QdiscList(slave)
+			return e2
+		})
+		require.NoError(t, err, "QdiscList", slaveName)
+		t.Logf("slave %s qdiscs: %+v", slaveName, slaveQdiscs)
+
+		require.NotEmpty(t, slaveQdiscs, "slave %s should have qdiscs", slaveName)
+		rootType := slaveQdiscs[0].Type()
+		require.True(t, rootType == "mq" || rootType == "fq",
+			"slave %s root qdisc should be mq or fq, got %s", slaveName, rootType)
+	}
+
+	err = ns.Do(func() error {
+		return ops.Update(ctx, nil, 0, &tables.BandwidthQDisc{
+			LinkIndex: bondIndex,
+			LinkName:  "bond0",
+			FqHorizon: FqDefaultHorizon,
+			FqBuckets: FqDefaultBuckets,
+			Status:    reconciler.StatusPending(),
+		})
+	})
+	require.NoError(t, err, "second Update bond master should be idempotent")
+}
+
+func TestPrivilegedOpsBondNoSlaves(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	log := hivetest.Logger(t)
+
+	var nlh *netlink.Handle
+	var err error
+
+	ns := netns.NewNetNS(t)
+	require.NoError(t, ns.Do(func() error {
+		nlh, err = safenetlink.NewHandle(nil)
+		return err
+	}))
+
+	err = nlh.LinkAdd(netlink.NewLinkBond(netlink.LinkAttrs{Name: "bond0"}))
+	require.NoError(t, err, "LinkAdd bond0")
+
+	bondLink, err := safenetlink.WithRetryResult(func() (netlink.Link, error) {
+		return nlh.LinkByName("bond0")
+	})
+	require.NoError(t, err, "LinkByName bond0")
+	require.NoError(t, nlh.LinkSetUp(bondLink))
+
+	ops := &ops{
+		log:       log,
+		isEnabled: func() bool { return true },
+	}
+	ctx := context.TODO()
+
+	err = ns.Do(func() error {
+		return ops.Update(ctx, nil, 0, &tables.BandwidthQDisc{
+			LinkIndex: bondLink.Attrs().Index,
+			LinkName:  bondLink.Attrs().Name,
+			FqHorizon: FqDefaultHorizon,
+			FqBuckets: FqDefaultBuckets,
+			Status:    reconciler.StatusPending(),
+		})
+	})
+	require.NoError(t, err, "Update bond with no slaves")
+
+	var bondQdiscs []netlink.Qdisc
+	err = ns.Do(func() error {
+		var e error
+		bondQdiscs, e = safenetlink.QdiscList(bondLink)
+		return e
+	})
+	require.NoError(t, err, "QdiscList bond master")
+
+	t.Logf("bond master qdiscs (no slaves): %+v", bondQdiscs)
+	require.NotEmpty(t, bondQdiscs)
+	rootType := bondQdiscs[0].Type()
+	require.True(t, rootType == "mq" || rootType == "fq",
+		"bond master root qdisc should be mq or fq when no slaves, got %s", rootType)
 }

--- a/pkg/datapath/linux/bandwidth/ops_test.go
+++ b/pkg/datapath/linux/bandwidth/ops_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
@@ -66,6 +67,7 @@ func TestPrivilegedOps(t *testing.T) {
 	ops := &ops{
 		log:       log,
 		isEnabled: func() bool { return true },
+		devices:   nil, // not accessed for non-bond devices
 	}
 	ctx := context.TODO()
 
@@ -126,6 +128,7 @@ func TestPrivilegedOpsBond(t *testing.T) {
 	log := hivetest.Logger(t)
 
 	var bondIndex int
+	var slaveIndices = map[string]int{}
 	var err error
 
 	ns := netns.NewNetNS(t)
@@ -134,7 +137,7 @@ func TestPrivilegedOpsBond(t *testing.T) {
 		if err := netlink.LinkAdd(netlink.NewLinkBond(netlink.LinkAttrs{Name: "bond0"})); err != nil {
 			return fmt.Errorf("LinkAdd bond0: %w", err)
 		}
-		bond, err := netlink.LinkByName("bond0")
+		bond, err := safenetlink.LinkByName("bond0")
 		if err != nil {
 			return fmt.Errorf("LinkByName bond0: %w", err)
 		}
@@ -146,7 +149,7 @@ func TestPrivilegedOpsBond(t *testing.T) {
 			if err := netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}); err != nil {
 				return fmt.Errorf("LinkAdd %s: %w", name, err)
 			}
-			slave, err := netlink.LinkByName(name)
+			slave, err := safenetlink.LinkByName(name)
 			if err != nil {
 				return fmt.Errorf("LinkByName %s: %w", name, err)
 			}
@@ -157,6 +160,7 @@ func TestPrivilegedOpsBond(t *testing.T) {
 				slaveAssignErr = fmt.Errorf("LinkSetMasterByIndex %s: %w", name, e)
 				return nil
 			}
+			slaveIndices[name] = slave.Attrs().Index
 		}
 		return nil
 	}), "bond/slave setup in netns")
@@ -164,14 +168,30 @@ func TestPrivilegedOpsBond(t *testing.T) {
 		t.Skipf("skipping: cannot assign bond slaves on this kernel (%v)", slaveAssignErr)
 	}
 
+	// Populate the device table with the bond slave devices.
+	db := statedb.New()
+	deviceTable, err := tables.NewDeviceTable(db)
+	require.NoError(t, err, "NewDeviceTable")
+	wtxn := db.WriteTxn(deviceTable)
+	for name, idx := range slaveIndices {
+		deviceTable.Insert(wtxn, &tables.Device{
+			Index:       idx,
+			Name:        name,
+			MasterIndex: bondIndex,
+		})
+	}
+	wtxn.Commit()
+
 	ops := &ops{
 		log:       log,
 		isEnabled: func() bool { return true },
+		devices:   deviceTable,
 	}
 	ctx := context.TODO()
+	rtxn := db.ReadTxn()
 
 	err = ns.Do(func() error {
-		return ops.Update(ctx, nil, 0, &tables.BandwidthQDisc{
+		return ops.Update(ctx, rtxn, 0, &tables.BandwidthQDisc{
 			LinkIndex: bondIndex,
 			LinkName:  "bond0",
 			FqHorizon: FqDefaultHorizon,
@@ -199,7 +219,7 @@ func TestPrivilegedOpsBond(t *testing.T) {
 	for _, slaveName := range []string{"slave0", "slave1"} {
 		var slaveQdiscs []netlink.Qdisc
 		err = ns.Do(func() error {
-			slave, e := netlink.LinkByName(slaveName)
+			slave, e := safenetlink.LinkByName(slaveName)
 			if e != nil {
 				return e
 			}
@@ -217,7 +237,7 @@ func TestPrivilegedOpsBond(t *testing.T) {
 	}
 
 	err = ns.Do(func() error {
-		return ops.Update(ctx, nil, 0, &tables.BandwidthQDisc{
+		return ops.Update(ctx, rtxn, 0, &tables.BandwidthQDisc{
 			LinkIndex: bondIndex,
 			LinkName:  "bond0",
 			FqHorizon: FqDefaultHorizon,
@@ -245,19 +265,27 @@ func TestPrivilegedOpsBondNoSlaves(t *testing.T) {
 	require.NoError(t, err, "LinkAdd bond0")
 
 	bondLink, err := safenetlink.WithRetryResult(func() (netlink.Link, error) {
+		//nolint:forbidigo
 		return nlh.LinkByName("bond0")
 	})
 	require.NoError(t, err, "LinkByName bond0")
 	require.NoError(t, nlh.LinkSetUp(bondLink))
 
+	// Empty device table — no slaves registered.
+	db := statedb.New()
+	deviceTable, err := tables.NewDeviceTable(db)
+	require.NoError(t, err, "NewDeviceTable")
+
 	ops := &ops{
 		log:       log,
 		isEnabled: func() bool { return true },
+		devices:   deviceTable,
 	}
 	ctx := context.TODO()
+	rtxn := db.ReadTxn()
 
 	err = ns.Do(func() error {
-		return ops.Update(ctx, nil, 0, &tables.BandwidthQDisc{
+		return ops.Update(ctx, rtxn, 0, &tables.BandwidthQDisc{
 			LinkIndex: bondLink.Attrs().Index,
 			LinkName:  bondLink.Attrs().Name,
 			FqHorizon: FqDefaultHorizon,
@@ -265,19 +293,5 @@ func TestPrivilegedOpsBondNoSlaves(t *testing.T) {
 			Status:    reconciler.StatusPending(),
 		})
 	})
-	require.NoError(t, err, "Update bond with no slaves")
-
-	var bondQdiscs []netlink.Qdisc
-	err = ns.Do(func() error {
-		var e error
-		bondQdiscs, e = safenetlink.QdiscList(bondLink)
-		return e
-	})
-	require.NoError(t, err, "QdiscList bond master")
-
-	t.Logf("bond master qdiscs (no slaves): %+v", bondQdiscs)
-	require.NotEmpty(t, bondQdiscs)
-	rootType := bondQdiscs[0].Type()
-	require.True(t, rootType == "mq" || rootType == "fq",
-		"bond master root qdisc should be mq or fq when no slaves, got %s", rootType)
+	require.NoError(t, err, "Update bond with no slaves should succeed")
 }


### PR DESCRIPTION
When the bandwidth manager runs on a bond device, all outgoing traffic ends up in a single FQ qdisc because bond_select_queue always returns TX queue 0. This happens because the EDT code resets queue_mapping to 0 after reading the endpoint ID, which makes the multi-queue setup on the bond master pointless.

The fix installs FQ qdiscs on the bond slave devices instead, where physical NIC drivers do proper hash-based queue selection across multiple queues. The skb->tstamp departure time set by the TC BPF program survives through the bond's internal transmission path to the slave, so EDT pacing continues to work correctly.

Fixes: #45283.