### PR TITLE
gateway-api: only create TLS passthrough listeners for TLS protocol

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -281,6 +281,9 @@ func Test_Conformance(t *testing.T) {
 			{FullName: types.NamespacedName{Name: "gateway-tlsroute-https-only", Namespace: "gateway-conformance-infra"}, wantErr: false},
 			{FullName: types.NamespacedName{Name: "gateway-tlsroute-tls-passthrough-only", Namespace: "gateway-conformance-infra"}, wantErr: false},
 		}},
+		{name: "tlsroute-mixed-protocol-listeners", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "gateway-tlsroute-mixed", Namespace: "gateway-conformance-infra"}},
+		}},
 	}
 
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -130,11 +130,18 @@ func listenerisAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gatew
 }
 
 func isKindAllowed(listener gatewayv1.Listener, route metav1.Object) bool {
-	if listener.AllowedRoutes.Kinds == nil {
-		return true
-	}
-
 	routeKind := getGatewayKindForObject(route)
+
+	if listener.AllowedRoutes.Kinds == nil {
+		// Per Gateway API spec, when AllowedRoutes.Kinds is unspecified the listener
+		// accepts only the route kinds compatible with its protocol.
+		for _, supported := range getSupportedRouteKinds(listener.Protocol) {
+			if supported.Kind == routeKind {
+				return true
+			}
+		}
+		return false
+	}
 
 	for _, kind := range listener.AllowedRoutes.Kinds {
 		if (kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName) &&

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
@@ -13,6 +13,16 @@ spec:
       allowedRoutes:
         namespaces:
           from: Same
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
     - name: tls
       port: 443
       protocol: TLS

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-mixed
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: tls
+      port: 443
+      protocol: TLS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Passthrough
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-mixed
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tlsroute-mixed
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -1,0 +1,99 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-tlsroute-mixed
+  name: cilium-gateway-gateway-tlsroute-mixed
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: gateway-tlsroute-mixed
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: tls-backend
+      namespace: gateway-conformance-infra
+      number:
+        - "443"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - tls.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: gateway-conformance-infra:tls-backend:443
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/tls-backend:443
+      name: gateway-conformance-infra:tls-backend:443
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+  services:
+    - name: cilium-gateway-gateway-tlsroute-mixed
+      namespace: gateway-conformance-infra
+      ports:
+        - 80
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -51,6 +51,41 @@ spec:
                   - upgradeType: websocket
                 useRemoteAddress: true
         - filterChainMatch:
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-secure
+                statPrefix: listener-secure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: /gateway-conformance-infra-tls-checks-certificate
+        - filterChainMatch:
             serverNames:
               - tls.example.com
             transportProtocol: tls
@@ -84,6 +119,8 @@ spec:
           name: "6"
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
       name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-secure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend:443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/gateway-tlsroute-mixed.yaml
@@ -15,6 +15,16 @@ spec:
   - allowedRoutes:
       namespaces:
         from: Same
+    name: https
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - name: tls-checks-certificate
+      mode: Terminate
+  - allowedRoutes:
+      namespaces:
+        from: Same
     name: tls
     port: 443
     protocol: TLS
@@ -51,6 +61,29 @@ status:
       status: "False"
       type: Programmed
     name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: https
     supportedKinds:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/gateway-tlsroute-mixed.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tlsroute-mixed
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: tls
+    port: 443
+    protocol: TLS
+    tls:
+      mode: Passthrough
+status:
+  conditions:
+  - lastTransitionTime: "2025-07-01T14:29:32Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2025-07-01T05:06:15Z"
+    message: Gateway waiting for address
+    reason: AddressNotAssigned
+    status: "False"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: tls
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: TLSRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/tlsroute-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/tlsroute-tlsroute-mixed.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-mixed
+  namespace: gateway-conformance-infra
+spec:
+  hostnames:
+    - tls.example.com
+  parentRefs:
+    - name: gateway-tlsroute-mixed
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tlsroute-mixed

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -116,24 +116,26 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 			Service:        toServiceModel(input.GatewayClassConfig),
 		})
 
-		resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
-			Name: string(l.Name),
-			Sources: []model.FullyQualifiedResource{
-				{
-					Name:      input.Gateway.GetName(),
-					Namespace: input.Gateway.GetNamespace(),
-					Group:     gatewayv1.SchemeGroupVersion.Group,
-					Version:   gatewayv1.SchemeGroupVersion.Version,
-					Kind:      "Gateway",
-					UID:       string(input.Gateway.GetUID()),
+		if l.Protocol == gatewayv1.TLSProtocolType {
+			resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+				Name: string(l.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
 				},
-			},
-			Port:           uint32(l.Port),
-			Hostname:       toHostname(l.Hostname),
-			Routes:         toTLSRoutes(l, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
-			Infrastructure: infra,
-			Service:        toServiceModel(input.GatewayClassConfig),
-		})
+				Port:           uint32(l.Port),
+				Hostname:       toHostname(l.Hostname),
+				Routes:         toTLSRoutes(l, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
+		}
 	}
 
 	return resHTTP, resTLSPassthrough

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -73,6 +73,7 @@ func TestTLSGatewayAPI(t *testing.T) {
 		"basic tls http": {},
 		"Conformance/TLSRouteSimpleSameNamespace":  {},
 		"Conformance/TLSRouteHostnameIntersection": {},
+		"mixed protocol listeners TLSRoute":        {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-gateway.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: argocd-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - name: http-internal
+    port: 80
+    protocol: HTTP
+  - name: https-internal
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: argocd-cert
+  - name: tls-internal
+    port: 443
+    protocol: TLS
+    tls:
+      mode: Passthrough
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-service.yaml
@@ -1,0 +1,7 @@
+- metadata:
+    creationTimestamp: null
+    name: argocd-server
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/input-tlsroute.yaml
@@ -1,0 +1,15 @@
+- metadata:
+    creationTimestamp: null
+    name: argocd-tlsroute
+    namespace: default
+  spec:
+    hostnames:
+    - argocd.example.com
+    parentRefs:
+    - name: argocd-gateway
+    rules:
+    - backendRefs:
+      - name: argocd-server
+        port: 443
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/mixed_protocol_listeners_TLSRoute/output-listeners.yaml
@@ -1,0 +1,17 @@
+- hostname: '*'
+  name: tls-internal
+  port: 443
+  routes:
+  - backends:
+    - name: argocd-server
+      namespace: default
+      port:
+        port: 443
+    hostnames:
+    - argocd.example.com
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: argocd-gateway
+    namespace: default
+    version: v1


### PR DESCRIPTION
**Problem:** TLSRoutes silently stop working after upgrading to v1.19.2 when the gateway has mixed HTTP, HTTPS, and TLS listeners, while route status continues to show `Accepted: True`.

**Root cause:** `GatewayAPI()` in `operator/pkg/model/ingestion/gateway.go` unconditionally appended a `TLSPassthroughListener` for every listener protocol (HTTP, HTTPS, and TLS). When a `TLSRoute` has no `sectionName`, `toTLSRoutes()` matches it against all listeners, producing three identical `TLSPassthroughListeners`. Before commit `9ee2db2b32`, `TLSBackendsToHostnames()` keyed entries by backend (map), so duplicates collapsed into one Envoy filter chain. After that commit, `TLSBackends()` returns a slice with no deduplication, yielding three `FilterChain` objects with identical `ServerNames`. Envoy silently drops duplicate `FilterChainMatch`es, so TLS passthrough stops routing traffic.

**Fix (commit 1):** Guard the `resTLSPassthrough` append with `l.Protocol == gatewayv1.TLSProtocolType`. Per the Gateway API spec, TLSRoutes may only attach to TLS listeners; the route-status path already enforces this via `CheckGatewayMatchingProtocol`. The ingestion path now respects the same constraint.

**Fix (commit 2):** `isKindAllowed` in `helpers.go` returned `true` for all route kinds when `AllowedRoutes.Kinds` is unspecified. Per Gateway API spec §4.2.1.1, the default set of allowed kinds is determined by the listener's protocol. The faulty early return was latent on single-protocol gateways (no compatible listener → TLSRoute `Accepted: False` → `isAttachable` fails before `isKindAllowed` is reached). On a mixed gateway the TLS listener causes `Accepted: True`, and `isKindAllowed` then erroneously counted the TLSRoute as `attachedRoutes: 1` on the HTTP listener. Fixed to fall through to `getSupportedRouteKinds(listener.Protocol)`, which already encodes the correct mapping.

**Reconciler test:** Added `Test_Conformance/tlsroute-mixed-protocol-listeners` with golden files covering the full `Reconcile()` path. The CEC golden file asserts exactly two Envoy filter chains (`raw_buffer` for HTTP, `tls` passthrough for TLS), and the gateway golden file asserts `attachedRoutes: 0` on the HTTP listener and `attachedRoutes: 1` on the TLS listener.

**Verification:**
```
go test ./operator/pkg/model/ingestion/... -count=1 -run TestTLSGatewayAPI -v
go test ./operator/pkg/gateway-api/... -count=1 -run Test_Conformance/tlsroute-mixed-protocol-listeners -v
```

Fixes: #45050

```release-note
Fix TLS passthrough routes failing silently when a gateway has mixed HTTP, HTTPS, and TLS listeners and a TLSRoute with no sectionName.
```
