### PR TITLE
ipam: Remove unused `InterfaceRevision` wrapper struct

### DIFF
--- a/pkg/alibabacloud/api/api.go
+++ b/pkg/alibabacloud/api/api.go
@@ -73,7 +73,7 @@ func NewClient(vpcClient *vpc.Client, client *ecs.Client, metrics MetricsAPI, ra
 // GetInstance returns the instance including its ENIs by the given instanceID
 func (c *Client) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
 	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
+	instance.Interfaces = map[string]ipamTypes.Interface{}
 
 	networkInterfaceSets, err := c.describeNetworkInterfacesByInstance(ctx, instanceID)
 	if err != nil {
@@ -84,9 +84,7 @@ func (c *Client) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkM
 		ifId := iface.NetworkInterfaceId
 		_, eni := parseENI(&iface, vpcs, subnets)
 
-		instance.Interfaces[ifId] = ipamTypes.InterfaceRevision{
-			Resource: eni,
-		}
+		instance.Interfaces[ifId] = eni
 	}
 	return &instance, nil
 }
@@ -110,9 +108,7 @@ func (c *Client) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetwork
 	for _, iface := range networkInterfaceSets {
 		id, eni := parseENI(&iface, vpcs, subnets)
 
-		instances.Update(id, ipamTypes.InterfaceRevision{
-			Resource: eni,
-		})
+		instances.Update(id, eni)
 	}
 	return instances, nil
 }

--- a/pkg/alibabacloud/api/mock/mock.go
+++ b/pkg/alibabacloud/api/mock/mock.go
@@ -86,7 +86,7 @@ func (a *API) UpdateENIs(enis map[string]ENIMap) {
 
 func (a *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
 	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
+	instance.Interfaces = map[string]ipamTypes.Interface{}
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
@@ -110,8 +110,7 @@ func (a *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap,
 				}
 			}
 
-			eniRevision := ipamTypes.InterfaceRevision{Resource: eni.DeepCopy()}
-			instance.Interfaces[ifaceID] = eniRevision
+			instance.Interfaces[ifaceID] = eni.DeepCopy()
 		}
 	}
 
@@ -140,8 +139,7 @@ func (a *API) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap
 				}
 			}
 
-			eniRevision := ipamTypes.InterfaceRevision{Resource: eni.DeepCopy()}
-			instances.Update(instanceID, eniRevision)
+			instances.Update(instanceID, eni.DeepCopy())
 		}
 	}
 

--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -204,8 +204,7 @@ func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.Inter
 func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	eniRevision := ipamTypes.InterfaceRevision{Resource: eni}
-	m.instances.Update(instanceID, eniRevision)
+	m.instances.Update(instanceID, eni)
 }
 
 // FindOneVSwitch returns the vSwitch with the most available addresses, matching vpc and az.

--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -81,8 +81,8 @@ func (n *Node) PopulateStatusFields(resource *v2.CiliumNode) {
 	resource.Status.AlibabaCloud.ENIs = map[string]eniTypes.ENI{}
 
 	n.manager.ForeachInstance(n.node.InstanceID(),
-		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-			e, ok := rev.Resource.(*eniTypes.ENI)
+		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*eniTypes.ENI)
 			if ok {
 				resource.Status.AlibabaCloud.ENIs[interfaceID] = *e.DeepCopy()
 			}
@@ -215,8 +215,8 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	n.enis = map[string]eniTypes.ENI{}
 
 	n.manager.ForeachInstance(instanceID,
-		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-			e, ok := rev.Resource.(*eniTypes.ENI)
+		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*eniTypes.ENI)
 			if !ok {
 				return nil
 			}
@@ -466,8 +466,8 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.Spec) (
 	var securityGroups []string
 
 	n.manager.ForeachInstance(n.node.InstanceID(),
-		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-			e, ok := rev.Resource.(*eniTypes.ENI)
+		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*eniTypes.ENI)
 			if ok && e.Type == eniTypes.ENITypePrimary {
 				securityGroups = append(securityGroups, e.SecurityGroupIDs...)
 			}

--- a/pkg/alibabacloud/eni/node_stat_test.go
+++ b/pkg/alibabacloud/eni/node_stat_test.go
@@ -32,9 +32,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 			},
 		},
 	}
-	m.Update("vm1", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	m.Update("vm1", resource.DeepCopy())
 
 	n := &Node{
 		logger: hivetest.Logger(t),

--- a/pkg/alibabacloud/eni/node_test.go
+++ b/pkg/alibabacloud/eni/node_test.go
@@ -83,8 +83,8 @@ func TestCreateInterface(t *testing.T) {
 	}, 10*time.Second)
 	require.NoError(t, err)
 
-	instances.ForeachInstance("i-1", func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-		e, ok := rev.Resource.(*eniTypes.ENI)
+	instances.ForeachInstance("i-1", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+		e, ok := iface.(*eniTypes.ENI)
 		if !ok {
 			return fmt.Errorf("resource is not ENI type")
 		}

--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -550,7 +550,7 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 // GetInstance returns the instance including its ENIs by the given instanceID
 func (c *Client) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
 	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
+	instance.Interfaces = map[string]ipamTypes.Interface{}
 
 	var networkInterfaces []ec2_types.NetworkInterface
 	var err error
@@ -567,9 +567,7 @@ func (c *Client) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkM
 			return nil, err
 		}
 
-		instance.Interfaces[ifId] = ipamTypes.InterfaceRevision{
-			Resource: eni,
-		}
+		instance.Interfaces[ifId] = eni
 	}
 	return &instance, nil
 }
@@ -598,7 +596,7 @@ func (c *Client) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetwork
 		}
 
 		if id != "" {
-			instances.Update(id, ipamTypes.InterfaceRevision{Resource: eni})
+			instances.Update(id, eni)
 		}
 	}
 

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -639,7 +639,7 @@ func (e *API) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []
 
 func (e *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
 	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
+	instance.Interfaces = map[string]ipamTypes.Interface{}
 
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
@@ -662,7 +662,7 @@ func (e *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap,
 				}
 			}
 
-			eniRevision := ipamTypes.InterfaceRevision{Resource: eni.DeepCopy()}
+			eniRevision := eni.DeepCopy()
 			instance.Interfaces[ifaceID] = eniRevision
 		}
 	}
@@ -716,7 +716,7 @@ func (e *API) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap
 				}
 			}
 
-			eniRevision := ipamTypes.InterfaceRevision{Resource: eni.DeepCopy()}
+			eniRevision := eni.DeepCopy()
 			instances.Update(instanceID, eniRevision)
 		}
 	}

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -289,7 +289,7 @@ func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) 
 // added to the instance.
 func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.mutex.Lock()
-	eniRevision := ipamTypes.InterfaceRevision{Resource: eni}
+	eniRevision := eni
 	m.instances.Update(instanceID, eniRevision)
 	m.mutex.Unlock()
 }
@@ -305,7 +305,7 @@ func (m *InstancesManager) RemoveIPsFromENI(instanceID string, eniID string, ips
 func (m *InstancesManager) modifyIPsToENI(instanceID string, eniID string, ips []string, isAdd bool) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	ifaces, ok := m.instances.GetInterface(instanceID, eniID)
+	iface, ok := m.instances.GetInterface(instanceID, eniID)
 	if !ok {
 		m.logger.Warn(
 			"ENI not found",
@@ -315,8 +315,7 @@ func (m *InstancesManager) modifyIPsToENI(instanceID string, eniID string, ips [
 		return
 	}
 
-	eniIntf := ifaces.Resource.DeepCopyInterface()
-	eni, ok := eniIntf.(*eniTypes.ENI)
+	eni, ok := iface.DeepCopyInterface().(*eniTypes.ENI)
 	if !ok {
 		m.logger.Warn(
 			"Unexpected resource type, expected *eniTypes.ENI",
@@ -338,7 +337,7 @@ func (m *InstancesManager) modifyIPsToENI(instanceID string, eniID string, ips [
 			})
 		}
 	}
-	m.instances.Update(instanceID, ipamTypes.InterfaceRevision{Resource: eni})
+	m.instances.Update(instanceID, eni)
 }
 
 // ForeachInstance will iterate over each interface for a particular instance inside `instances`

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -111,8 +111,8 @@ func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 	k8sObj.Status.ENI.ENIs = map[string]eniTypes.ENI{}
 
 	n.manager.ForeachInstance(n.node.InstanceID(),
-		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-			e, ok := rev.Resource.(*eniTypes.ENI)
+		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*eniTypes.ENI)
 			if ok {
 				k8sObj.Status.ENI.ENIs[interfaceID] = *e.DeepCopy()
 			}
@@ -475,8 +475,8 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 	var securityGroups []string
 
 	n.manager.ForeachInstance(n.node.InstanceID(),
-		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-			e, ok := rev.Resource.(*eniTypes.ENI)
+		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*eniTypes.ENI)
 			if ok && e.Number == 0 {
 				securityGroups = make([]string, len(e.SecurityGroups))
 				copy(securityGroups, e.SecurityGroups)
@@ -745,8 +745,8 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	stats.NodeCapacity *= limits.Adapters
 
 	n.manager.ForeachInstance(instanceID,
-		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
-			e, ok := rev.Resource.(*eniTypes.ENI)
+		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*eniTypes.ENI)
 			if !ok {
 				return nil
 			}

--- a/pkg/aws/eni/node_stat_test.go
+++ b/pkg/aws/eni/node_stat_test.go
@@ -28,9 +28,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 		},
 	)
 	im := ipamTypes.NewInstanceMap()
-	im.Update(instanceID, ipamTypes.InterfaceRevision{
-		Resource: &eniTypes.ENI{},
-	})
+	im.Update(instanceID, &eniTypes.ENI{})
 
 	ipamNode := &mockIPAMNode{
 		instanceID: "i-000",
@@ -93,11 +91,9 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 		ID:       "eni-a",
 		Prefixes: []string{"10.0.0.1/28"},
 	}
-	n.manager.instances.Update("i-000", ipamTypes.InterfaceRevision{
-		Resource: &eniTypes.ENI{
-			ID:       "eni-a",
-			Prefixes: []string{"10.0.0.1/28"},
-		},
+	n.manager.instances.Update("i-000", &eniTypes.ENI{
+		ID:       "eni-a",
+		Prefixes: []string{"10.0.0.1/28"},
 	})
 
 	// Finally, we have the case where an eni has a leftover prefix available.

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -401,7 +401,7 @@ func (c *Client) ParseInterfacesIntoInstanceMap(networkInterfaces []*armnetwork.
 
 	for _, iface := range networkInterfaces {
 		if instanceID, azureInterface := parseInterface(iface, subnets, c.usePrimary); instanceID != "" {
-			instances.Update(instanceID, ipamTypes.InterfaceRevision{Resource: azureInterface})
+			instances.Update(instanceID, azureInterface)
 		}
 	}
 
@@ -445,11 +445,11 @@ func (c *Client) ListVMNetworkInterfaces(ctx context.Context, instanceID string)
 // without making additional Azure API calls
 func (c *Client) ParseInterfacesIntoInstance(networkInterfaces []*armnetwork.Interface, subnets ipamTypes.SubnetMap) *ipamTypes.Instance {
 	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
+	instance.Interfaces = map[string]ipamTypes.Interface{}
 
 	for _, networkInterface := range networkInterfaces {
 		_, azureInterface := parseInterface(networkInterface, subnets, c.usePrimary)
-		instance.Interfaces[azureInterface.ID] = ipamTypes.InterfaceRevision{Resource: azureInterface}
+		instance.Interfaces[azureInterface.ID] = azureInterface
 	}
 
 	return &instance

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -140,8 +140,8 @@ func (a *API) GetInstance(ctx context.Context, subnets ipamTypes.SubnetMap, inst
 	}
 
 	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
-	if err := a.instances.ForeachInterface(instanceID, func(instanceID, interfaceID string, iface ipamTypes.InterfaceRevision) error {
+	instance.Interfaces = map[string]ipamTypes.Interface{}
+	if err := a.instances.ForeachInterface(instanceID, func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
 		instance.Interfaces[interfaceID] = iface
 		return nil
 	}); err != nil {
@@ -238,8 +238,8 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 
 	foundInterface := false
 	instances := a.instances.DeepCopy()
-	err := instances.ForeachInterface("", func(id, _ string, iface ipamTypes.InterfaceRevision) error {
-		intf, ok := iface.Resource.(*types.AzureInterface)
+	err := instances.ForeachInterface("", func(id, _ string, iface ipamTypes.Interface) error {
+		intf, ok := iface.(*types.AzureInterface)
 		if !ok {
 			return fmt.Errorf("invalid interface object")
 		}
@@ -352,5 +352,5 @@ func (a *API) ParseInterfacesIntoInstance(networkInterfaces []*armnetwork.Interf
 	defer a.mutex.RUnlock()
 	// The instance will be populated by the caller based on the mock's data
 	// Return a basic structure that will be filled in
-	return &ipamTypes.Instance{Interfaces: map[string]ipamTypes.InterfaceRevision{}}
+	return &ipamTypes.Instance{Interfaces: map[string]ipamTypes.Interface{}}
 }

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -35,14 +35,12 @@ func TestMock(t *testing.T) {
 	instances = ipamTypes.NewInstanceMap()
 	resource := &types.AzureInterface{Name: "eth0"}
 	resource.SetID(ifaceID)
-	instances.Update("vm1", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	instances.Update("vm1", resource.DeepCopy())
 	api.UpdateInstances(instances)
 	instances, err = api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.NoError(t, err)
 	require.Equal(t, 1, instances.NumInstances())
-	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.InterfaceRevision) error {
+	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
 		require.Equal(t, "vm1", instanceID)
 		require.Equal(t, ifaceID, interfaceID)
 		return nil
@@ -53,13 +51,13 @@ func TestMock(t *testing.T) {
 	instances, err = api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
 	require.NoError(t, err)
 	require.Equal(t, 1, instances.NumInstances())
-	instances.ForeachInterface("", func(instanceID, interfaceID string, revision ipamTypes.InterfaceRevision) error {
+	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
 		require.Equal(t, "vm1", instanceID)
 		require.Equal(t, ifaceID, interfaceID)
 
-		iface, ok := revision.Resource.(*types.AzureInterface)
+		azIface, ok := iface.(*types.AzureInterface)
 		require.True(t, ok)
-		require.Len(t, iface.Addresses, 2)
+		require.Len(t, azIface.Addresses, 2)
 		return nil
 	})
 
@@ -67,12 +65,10 @@ func TestMock(t *testing.T) {
 	vmInstances := ipamTypes.NewInstanceMap()
 	resource = &types.AzureInterface{Name: "eth0"}
 	resource.SetID(vmIfaceID)
-	vmInstances.Update("vm2", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	vmInstances.Update("vm2", resource.DeepCopy())
 	require.NoError(t, err)
 	require.Equal(t, 1, vmInstances.NumInstances())
-	vmInstances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.InterfaceRevision) error {
+	vmInstances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
 		require.Equal(t, "vm2", instanceID)
 		require.Equal(t, vmIfaceID, interfaceID)
 		return nil

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -84,9 +84,7 @@ func iteration1(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		State: types.StateSucceeded,
 	}
 	resource.SetID("intf-1")
-	instances.Update("i-1", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	instances.Update("i-1", resource.DeepCopy())
 
 	resource = &types.AzureInterface{
 		SecurityGroup: "sg3",
@@ -100,9 +98,7 @@ func iteration1(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		State: types.StateSucceeded,
 	}
 	resource.SetID("intf-3")
-	instances.Update("i-2", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	instances.Update("i-2", resource.DeepCopy())
 
 	api.UpdateInstances(instances)
 	_, err := mngr.Resync(t.Context())
@@ -126,9 +122,7 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		State: types.StateSucceeded,
 	}
 	resource.SetID("intf-1")
-	instances.Update("i-1", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	instances.Update("i-1", resource.DeepCopy())
 
 	resource = &types.AzureInterface{
 		SecurityGroup: "sg2",
@@ -142,9 +136,7 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		State: types.StateSucceeded,
 	}
 	resource.SetID("intf-2")
-	instances.Update("i-1", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	instances.Update("i-1", resource.DeepCopy())
 
 	resource = &types.AzureInterface{
 		SecurityGroup: "sg3",
@@ -158,9 +150,7 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		State: types.StateSucceeded,
 	}
 	resource.SetID("intf-3")
-	instances.Update("i-2", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	instances.Update("i-2", resource.DeepCopy())
 
 	api.UpdateInstances(instances)
 	_, err := mngr.Resync(t.Context())
@@ -229,9 +219,7 @@ func TestExtractSubnetIDs(t *testing.T) {
 		}
 		resource.SetID(interfaceID)
 
-		instances.Update(instanceID, ipamTypes.InterfaceRevision{
-			Resource: resource.DeepCopy(),
-		})
+		instances.Update(instanceID, resource.DeepCopy())
 	}
 
 	// Extract subnet IDs and verify deduplication

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -166,9 +166,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 	}
 	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
 	vm1ID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1"
-	m.Update(vm1ID, ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	m.Update(vm1ID, resource.DeepCopy())
 	api.UpdateInstances(m)
 
 	_, err := instances.Resync(t.Context())
@@ -230,9 +228,7 @@ func TestIpamMinAllocate10(t *testing.T) {
 	}
 	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
 	vm1ID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1"
-	m.Update(vm1ID, ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	m.Update(vm1ID, resource.DeepCopy())
 	api.UpdateInstances(m)
 
 	_, err := instances.Resync(t.Context())
@@ -323,9 +319,7 @@ func TestIpamManyNodes(t *testing.T) {
 					State: types.StateSucceeded,
 				}
 				resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
-				allInstances.Update(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i), ipamTypes.InterfaceRevision{
-					Resource: resource.DeepCopy(),
-				})
+				allInstances.Update(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i), resource.DeepCopy())
 			}
 
 			api.UpdateInstances(allInstances)
@@ -401,9 +395,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 			State:         types.StateSucceeded,
 		}
 		resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
-		allInstances.Update(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i), ipamTypes.InterfaceRevision{
-			Resource: resource.DeepCopy(),
-		})
+		allInstances.Update(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i), resource.DeepCopy())
 	}
 
 	api.UpdateInstances(allInstances)

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -48,8 +48,8 @@ func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 
 	n.manager.mutex.RLock()
 	defer n.manager.mutex.RUnlock()
-	n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.InterfaceRevision) error {
-		iface, ok := interfaceObj.Resource.(*types.AzureInterface)
+	n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.Interface) error {
+		iface, ok := interfaceObj.(*types.AzureInterface)
 		if ok {
 			k8sObj.Status.Azure.Interfaces = append(k8sObj.Status.Azure.Interfaces, *(iface.DeepCopy()))
 		}
@@ -80,8 +80,8 @@ func (n *Node) PrepareIPAllocation(scopedLog *slog.Logger) (a *ipam.AllocationAc
 	requiredIfaceName := n.k8sObj.Spec.Azure.InterfaceName
 	n.manager.mutex.RLock()
 	defer n.manager.mutex.RUnlock()
-	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.InterfaceRevision) error {
-		iface, ok := interfaceObj.Resource.(*types.AzureInterface)
+	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.Interface) error {
+		iface, ok := interfaceObj.(*types.AzureInterface)
 		if !ok {
 			return fmt.Errorf("invalid interface object")
 		}
@@ -129,7 +129,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *slog.Logger) (a *ipam.AllocationAc
 
 // AllocateIPs performs the Azure IP allocation operation
 func (n *Node) AllocateIPs(ctx context.Context, a *ipam.AllocationAction) error {
-	iface, ok := a.Interface.Resource.(*types.AzureInterface)
+	iface, ok := a.Interface.(*types.AzureInterface)
 	if !ok {
 		return fmt.Errorf("invalid interface object")
 	}
@@ -200,8 +200,8 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	}
 
 	requiredIfaceName := n.k8sObj.Spec.Azure.InterfaceName
-	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.InterfaceRevision) error {
-		iface, ok := interfaceObj.Resource.(*types.AzureInterface)
+	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.Interface) error {
+		iface, ok := interfaceObj.(*types.AzureInterface)
 		if !ok {
 			return fmt.Errorf("invalid interface object")
 		}

--- a/pkg/azure/ipam/node_stats_test.go
+++ b/pkg/azure/ipam/node_stats_test.go
@@ -30,9 +30,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 		State: types.StateSucceeded,
 	}
 	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
-	m.Update("vm1", ipamTypes.InterfaceRevision{
-		Resource: resource.DeepCopy(),
-	})
+	m.Update("vm1", resource.DeepCopy())
 
 	n := &Node{
 		node: mockIPAMNode("vm1"),

--- a/pkg/azure/types/types_test.go
+++ b/pkg/azure/types/types_test.go
@@ -13,18 +13,14 @@ import (
 
 func TestForeachAddresses(t *testing.T) {
 	m := types.NewInstanceMap()
-	m.Update("i-1", types.InterfaceRevision{
-		Resource: &AzureInterface{ID: "1", Addresses: []AzureAddress{
-			{IP: "1.1.1.1"},
-			{IP: "2.2.2.2"},
-		},
-		}})
-	m.Update("i-2", types.InterfaceRevision{
-		Resource: &AzureInterface{ID: "1", Addresses: []AzureAddress{
-			{IP: "3.3.3.3"},
-			{IP: "4.4.4.4"},
-		},
-		}})
+	m.Update("i-1", &AzureInterface{ID: "1", Addresses: []AzureAddress{
+		{IP: "1.1.1.1"},
+		{IP: "2.2.2.2"},
+	}})
+	m.Update("i-2", &AzureInterface{ID: "1", Addresses: []AzureAddress{
+		{IP: "3.3.3.3"},
+		{IP: "4.4.4.4"},
+	}})
 
 	// Iterate over all instances
 	addresses := 0
@@ -44,7 +40,7 @@ func TestForeachAddresses(t *testing.T) {
 
 	// Iterate over all interfaces
 	interfaces := 0
-	m.ForeachInterface("", func(instanceID, interfaceID string, interfaceObj types.InterfaceRevision) error {
+	m.ForeachInterface("", func(instanceID, interfaceID string, interfaceObj types.Interface) error {
 		interfaces++
 		return nil
 	})

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -707,7 +707,7 @@ type AllocationAction struct {
 	InterfaceID string
 
 	// Interface is the interface to allocate IPs on
-	Interface ipamTypes.InterfaceRevision
+	Interface ipamTypes.Interface
 
 	// PoolID is the IPAM pool identifier to allocate the IPs from. This
 	// can correspond to a subnet ID or it can also left blank or set to a

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -476,43 +476,15 @@ type Interface interface {
 	DeepCopyInterface() Interface
 }
 
-// InterfaceRevision is the configurationr revision of a network interface. It
-// consists of a revision hash representing the current configuration version
-// and the resource itself.
-//
-// +k8s:deepcopy-gen=false
-// +deepequal-gen=false
-type InterfaceRevision struct {
-	// Resource is the interface resource
-	Resource Interface
-
-	// Fingerprint is the fingerprint reprsenting the network interface
-	// configuration. It is typically implemented as the result of a hash
-	// function calculated off the resource. This field is optional, not
-	// all IPAM backends make use of fingerprints.
-	Fingerprint string
-}
-
-// DeepCopy returns a deep copy
-func (i *InterfaceRevision) DeepCopy() *InterfaceRevision {
-	if i == nil {
-		return nil
-	}
-	return &InterfaceRevision{
-		Resource:    i.Resource.DeepCopyInterface(),
-		Fingerprint: i.Fingerprint,
-	}
-}
-
 // Instance is the representation of an instance, typically a VM, subject to
 // per-node IPAM logic
 //
 // +k8s:deepcopy-gen=false
 // +deepequal-gen=false
 type Instance struct {
-	// interfaces is a map of all interfaces attached to the instance
+	// Interfaces is a map of all interfaces attached to the instance
 	// indexed by the interface ID
-	Interfaces map[string]InterfaceRevision
+	Interfaces map[string]Interface
 }
 
 // DeepCopy returns a deep copy
@@ -521,10 +493,10 @@ func (i *Instance) DeepCopy() *Instance {
 		return nil
 	}
 	c := &Instance{
-		Interfaces: map[string]InterfaceRevision{},
+		Interfaces: map[string]Interface{},
 	}
 	for k, v := range i.Interfaces {
-		c.Interfaces[k] = *v.DeepCopy()
+		c.Interfaces[k] = v.DeepCopyInterface()
 	}
 	return c
 }
@@ -553,14 +525,14 @@ func (m *InstanceMap) UpdateInstance(instanceID string, instance *Instance) {
 // Update updates the definition of an interface for a particular instance. If
 // the interface is already known, the definition is updated, otherwise the
 // interface is added to the instance.
-func (m *InstanceMap) Update(instanceID string, iface InterfaceRevision) {
+func (m *InstanceMap) Update(instanceID string, iface Interface) {
 	m.mutex.Lock()
 	m.updateLocked(instanceID, iface)
 	m.mutex.Unlock()
 }
 
-func (m *InstanceMap) updateLocked(instanceID string, iface InterfaceRevision) {
-	if iface.Resource == nil {
+func (m *InstanceMap) updateLocked(instanceID string, iface Interface) {
+	if iface == nil {
 		return
 	}
 
@@ -571,10 +543,10 @@ func (m *InstanceMap) updateLocked(instanceID string, iface InterfaceRevision) {
 	}
 
 	if i.Interfaces == nil {
-		i.Interfaces = map[string]InterfaceRevision{}
+		i.Interfaces = map[string]Interface{}
 	}
 
-	i.Interfaces[iface.Resource.InterfaceID()] = iface
+	i.Interfaces[iface.InterfaceID()] = iface
 }
 
 type Address any
@@ -583,8 +555,8 @@ type Address any
 type AddressIterator func(instanceID, interfaceID, ip, poolID string, address Address) error
 
 func foreachAddress(instanceID string, instance *Instance, fn AddressIterator) error {
-	for _, rev := range instance.Interfaces {
-		if err := rev.Resource.ForeachAddress(instanceID, fn); err != nil {
+	for _, iface := range instance.Interfaces {
+		if err := iface.ForeachAddress(instanceID, fn); err != nil {
 			return err
 		}
 	}
@@ -621,11 +593,11 @@ func (m *InstanceMap) ForeachAddress(instanceID string, fn AddressIterator) erro
 }
 
 // InterfaceIterator is the function called by the ForeachInterface iterator
-type InterfaceIterator func(instanceID, interfaceID string, iface InterfaceRevision) error
+type InterfaceIterator func(instanceID, interfaceID string, iface Interface) error
 
 func foreachInterface(instanceID string, instance *Instance, fn InterfaceIterator) error {
-	for _, rev := range instance.Interfaces {
-		if err := fn(instanceID, rev.Resource.InterfaceID(), rev); err != nil {
+	for _, iface := range instance.Interfaces {
+		if err := fn(instanceID, iface.InterfaceID(), iface); err != nil {
 			return err
 		}
 	}
@@ -660,28 +632,27 @@ func (m *InstanceMap) ForeachInterface(instanceID string, fn InterfaceIterator) 
 	return nil
 }
 
-// GetInterface returns returns a particular interface of an instance. The
+// GetInterface returns a particular interface of an instance. The
 // boolean indicates whether the interface was found or not.
-func (m *InstanceMap) GetInterface(instanceID, interfaceID string) (InterfaceRevision, bool) {
+func (m *InstanceMap) GetInterface(instanceID, interfaceID string) (Interface, bool) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
 	if instance := m.data[instanceID]; instance != nil {
-		if rev, ok := instance.Interfaces[interfaceID]; ok {
-			return rev, true
+		if iface, ok := instance.Interfaces[interfaceID]; ok {
+			return iface, true
 		}
 	}
 
-	return InterfaceRevision{}, false
+	return nil, false
 }
 
 // DeepCopy returns a deep copy
 func (m *InstanceMap) DeepCopy() *InstanceMap {
 	c := NewInstanceMap()
-	m.ForeachInterface("", func(instanceID, interfaceID string, rev InterfaceRevision) error {
+	m.ForeachInterface("", func(instanceID, interfaceID string, iface Interface) error {
 		// c is not exposed yet, we can access it without locking it
-		rev.Resource = rev.Resource.DeepCopyInterface()
-		c.updateLocked(instanceID, rev)
+		c.updateLocked(instanceID, iface.DeepCopyInterface())
 		return nil
 	})
 	return c

--- a/pkg/ipam/types/types_test.go
+++ b/pkg/ipam/types/types_test.go
@@ -56,20 +56,16 @@ func (m *mockInterface) ForeachAddress(instanceID string, fn AddressIterator) er
 
 func TestForeachAddresses(t *testing.T) {
 	m := NewInstanceMap()
-	m.Update("i-1", InterfaceRevision{
-		Resource: &mockInterface{
-			id: "intf0",
-			pools: map[string][]net.IP{
-				"s1": {net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")},
-			},
+	m.Update("i-1", &mockInterface{
+		id: "intf0",
+		pools: map[string][]net.IP{
+			"s1": {net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")},
 		},
 	})
-	m.Update("i-2", InterfaceRevision{
-		Resource: &mockInterface{
-			id: "intf0",
-			pools: map[string][]net.IP{
-				"s1": {net.ParseIP("3.3.3.3"), net.ParseIP("4.4.4.4")},
-			},
+	m.Update("i-2", &mockInterface{
+		id: "intf0",
+		pools: map[string][]net.IP{
+			"s1": {net.ParseIP("3.3.3.3"), net.ParseIP("4.4.4.4")},
 		},
 	})
 
@@ -93,7 +89,7 @@ func TestForeachAddresses(t *testing.T) {
 
 	// Iterate over all interfaces
 	interfaces := 0
-	m.ForeachInterface("", func(instanceID, interfaceID string, iface InterfaceRevision) error {
+	m.ForeachInterface("", func(instanceID, interfaceID string, iface Interface) error {
 		interfaces++
 		return nil
 	})
@@ -102,12 +98,10 @@ func TestForeachAddresses(t *testing.T) {
 
 func TestGetInterface(t *testing.T) {
 	m := NewInstanceMap()
-	rev := InterfaceRevision{
-		Resource: &mockInterface{
-			id: "intf0",
-			pools: map[string][]net.IP{
-				"s1": {net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")},
-			},
+	rev := &mockInterface{
+		id: "intf0",
+		pools: map[string][]net.IP{
+			"s1": {net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")},
 		},
 	}
 	m.Update("i-1", rev)
@@ -126,28 +120,22 @@ func TestGetInterface(t *testing.T) {
 
 func TestInstanceMapNumInstances(t *testing.T) {
 	m := NewInstanceMap()
-	m.Update("i-1", InterfaceRevision{
-		Resource: &mockInterface{
-			id: "intf0",
-			pools: map[string][]net.IP{
-				"s1": {net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")},
-			},
+	m.Update("i-1", &mockInterface{
+		id: "intf0",
+		pools: map[string][]net.IP{
+			"s1": {net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2")},
 		},
 	})
-	m.Update("i-2", InterfaceRevision{
-		Resource: &mockInterface{
-			id: "intf0",
-			pools: map[string][]net.IP{
-				"s1": {net.ParseIP("3.3.3.3"), net.ParseIP("4.4.4.4")},
-			},
+	m.Update("i-2", &mockInterface{
+		id: "intf0",
+		pools: map[string][]net.IP{
+			"s1": {net.ParseIP("3.3.3.3"), net.ParseIP("4.4.4.4")},
 		},
 	})
-	m.Update("i-2", InterfaceRevision{
-		Resource: &mockInterface{
-			id: "intf1",
-			pools: map[string][]net.IP{
-				"s1": {net.ParseIP("4.4.4.4"), net.ParseIP("5.5.5.5")},
-			},
+	m.Update("i-2", &mockInterface{
+		id: "intf1",
+		pools: map[string][]net.IP{
+			"s1": {net.ParseIP("4.4.4.4"), net.ParseIP("5.5.5.5")},
 		},
 	})
 


### PR DESCRIPTION
While going through the `pkg/ipam` package, I noticed a typo in a comment that drew my attention to a specific struct definition, `InterfaceRevision`. While reading about its `Fingerprint` field, I got curious about how and where that field was used. After a deeper investigation, I discovered that not only is this `Fingerprint` field currently never set or read, but it has never been ever since its introduction 6 years ago (#10691).

At that point I figured that there is no short or long term plans to start using that field so it can be removed, but since `InterfaceRevision` only had two fields, removing one of them makes it an unnecessary wrapper struct.

So this PR removes the `InterfaceRevision` struct that used to have an `Resource` (`Interface`) and a `Fingerprint` (`string`) fields and replace it with that `Interface`. This eliminates the `.Resource` indirection at every call site.

Also since the whole struct definition is now gone, the typo that started this whole thing is gone as well.