### PR TITLE
hubble: correlate policy for audit verdicts and implicit denies

### DIFF
--- a/hubble/pkg/printer/printer.go
+++ b/hubble/pkg/printer/printer.go
@@ -248,6 +248,13 @@ func (p Printer) getVerdict(f *flowpb.Flow) string {
 	case flowpb.Verdict_AUDIT:
 		if f.GetEventType().GetType() == api.MessageTypePolicyVerdict {
 			msg = "AUDITED"
+			if p.opts.policyNames {
+				if f.GetTrafficDirection() == flowpb.TrafficDirection_EGRESS {
+					msg += formatPolicyNames(f.GetEgressDeniedBy())
+				} else if f.GetTrafficDirection() == flowpb.TrafficDirection_INGRESS {
+					msg += formatPolicyNames(f.GetIngressDeniedBy())
+				}
+			}
 		}
 		return p.color.verdictAudit(msg)
 	case flowpb.Verdict_TRACED:

--- a/hubble/pkg/printer/printer_test.go
+++ b/hubble/pkg/printer/printer_test.go
@@ -109,6 +109,15 @@ func TestPrinter_WriteProtoFlow(t *testing.T) {
 	policyAllowed.TrafficDirection = flowpb.TrafficDirection_INGRESS
 	policyAllowed.IngressAllowedBy = []*flowpb.Policy{{Name: "my-policy", Namespace: "my-policy-namespace", Kind: "CiliumNetworkPolicy"}, {Name: "my-policy-2", Kind: "CiliumClusterwideNetworkPolicy"}}
 
+	policyAudited := proto.Clone(&f).(*flowpb.Flow)
+	policyAudited.EventType = &flowpb.CiliumEventType{
+		Type: monitorAPI.MessageTypePolicyVerdict,
+	}
+	policyAudited.Verdict = flowpb.Verdict_AUDIT
+	policyAudited.IsReply = nil
+	policyAudited.TrafficDirection = flowpb.TrafficDirection_EGRESS
+	policyAudited.EgressDeniedBy = []*flowpb.Policy{{Name: "my-policy", Namespace: "my-policy-namespace", Kind: "CiliumNetworkPolicy"}}
+
 	type args struct {
 		f     *flowpb.Flow
 		merge *flowpb.Flow
@@ -263,6 +272,23 @@ Jan  1 00:20:34.567   k8s1   1.1.1.1:31793   2.2.2.2:8080   Policy denied   DROP
 			expected: "Jan  1 00:20:34.567 [k8s1]: " +
 				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (ID:12345) " +
 				"policy-verdict:none INGRESS ALLOWED BY my-policy (CiliumNetworkPolicy), my-policy-2 (CiliumClusterwideNetworkPolicy) (TCP Flags: SYN)\n",
+		},
+		{
+			name: "compact-policy-verdict-audited-with-policy-name",
+			options: []Option{
+				Compact(),
+				WithColor("never"),
+				WithNodeName(),
+				WithPolicyNames(),
+				Writer(&buf),
+			},
+			args: args{
+				f: policyAudited,
+			},
+			wantErr: false,
+			expected: "Jan  1 00:20:34.567 [k8s1]: " +
+				"1.1.1.1:31793 (health) <> 2.2.2.2:8080 (ID:12345) " +
+				"policy-verdict:none EGRESS AUDITED BY my-policy (CiliumNetworkPolicy) (TCP Flags: SYN)\n",
 		},
 		{
 			name: "compact-direction-unknown",

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -28,13 +28,16 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	}
 
 	// We are only interested in flows which are either allowed (i.e. the verdict is either
-	// FORWARDED or REDIRECTED) or explicitly denied (i.e. DROPPED, and matched by a deny policy),
-	// since we cannot usefully annotate the verdict otherwise. (Put differently, which policy
-	// should be listed in {in|e}gress_denied_by for an unmatched flow?)
+	// FORWARDED or REDIRECTED), denied by policy (i.e. DROPPED with a policy deny reason),
+	// or audited (i.e. AUDIT, which represents traffic allowed due to audit mode that would
+	// have been denied otherwise).
 	verdict := f.GetVerdict()
 	allowed := verdict == flowpb.Verdict_FORWARDED || verdict == flowpb.Verdict_REDIRECTED
-	denied := verdict == flowpb.Verdict_DROPPED && f.GetDropReasonDesc() == flowpb.DropReason_POLICY_DENY
-	if !(allowed || denied) {
+	dropReason := f.GetDropReasonDesc()
+	denied := verdict == flowpb.Verdict_DROPPED &&
+		(dropReason == flowpb.DropReason_POLICY_DENY || dropReason == flowpb.DropReason_POLICY_DENIED)
+	audited := verdict == flowpb.Verdict_AUDIT
+	if !(allowed || denied || audited) {
 		return
 	}
 
@@ -76,11 +79,11 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	switch {
 	case direction == trafficdirection.Egress && allowed:
 		f.EgressAllowedBy = rules
-	case direction == trafficdirection.Egress && denied:
+	case direction == trafficdirection.Egress && (denied || audited):
 		f.EgressDeniedBy = rules
 	case direction == trafficdirection.Ingress && allowed:
 		f.IngressAllowedBy = rules
-	case direction == trafficdirection.Ingress && denied:
+	case direction == trafficdirection.Ingress && (denied || audited):
 		f.IngressDeniedBy = rules
 	}
 	// policy log is independent of verdict

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -548,3 +548,293 @@ func TestCorrelatePolicy(t *testing.T) {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 }
+
+func TestCorrelatePolicyAudit(t *testing.T) {
+	localIP := "1.2.3.4"
+	localIdentity := uint32(1234)
+	localID := uint32(12)
+	remoteIP := "5.6.7.8"
+	remoteIdentity := uint32(5678)
+	remoteID := uint32(56)
+	dstPort := uint32(443)
+
+	policyLabel := utils.GetPolicyLabels("foo-namespace", "deny-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
+	expected := []*flowpb.Policy{
+		{
+			Name:      "deny-policy",
+			Namespace: "foo-namespace",
+			Kind:      utils.ResourceTypeCiliumNetworkPolicy,
+			Labels: []string{
+				"k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
+				"k8s:io.cilium.k8s.policy.name=deny-policy",
+				"k8s:io.cilium.k8s.policy.namespace=foo-namespace",
+				"k8s:io.cilium.k8s.policy.uid=1234-5678",
+			},
+			Revision: 1,
+		},
+	}
+
+	policyKey := policy.EgressKey().WithIdentity(identity.NumericIdentity(remoteIdentity)).WithTCPPort(uint16(dstPort))
+	ep := &testutils.FakeEndpointInfo{
+		ID:           uint64(localID),
+		Identity:     identity.NumericIdentity(localIdentity),
+		IPv4:         net.ParseIP(localIP),
+		PodName:      "xwing",
+		PodNamespace: "default",
+		Labels:       []string{"a", "b", "c"},
+		PolicyMap: map[policy.Key]labels.LabelArrayListString{
+			policyKey: labels.LabelArrayList{policyLabel}.ArrayListString(),
+		},
+		PolicyRevision: 1,
+	}
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfoByID: func(id uint16) (endpoint getters.EndpointInfo, ok bool) {
+			if uint64(id) == ep.ID {
+				return ep, true
+			}
+			return nil, false
+		},
+	}
+
+	// Verdict_AUDIT at egress should populate EgressDeniedBy
+	flow := &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
+			Type: monitorAPI.MessageTypePolicyVerdict,
+		},
+		Verdict:          flowpb.Verdict_AUDIT,
+		TrafficDirection: flowpb.TrafficDirection_EGRESS,
+		IP: &flowpb.IP{
+			Source:      localIP,
+			Destination: remoteIP,
+		},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
+			},
+		},
+		Source: &flowpb.Endpoint{
+			ID:       localID,
+			Identity: localIdentity,
+		},
+		Destination: &flowpb.Endpoint{
+			ID:       remoteID,
+			Identity: remoteIdentity,
+		},
+		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+	}
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+
+	require.Nil(t, flow.EgressAllowedBy)
+	require.Nil(t, flow.IngressAllowedBy)
+	require.Nil(t, flow.IngressDeniedBy)
+	if diff := cmp.Diff(expected, flow.EgressDeniedBy, protocmp.Transform()); diff != "" {
+		t.Fatalf("not equal (-want +got):\n%s", diff)
+	}
+
+	// Verdict_AUDIT at ingress should populate IngressDeniedBy
+	policyKey = policy.IngressKey().WithIdentity(identity.NumericIdentity(localIdentity)).WithTCPPort(uint16(dstPort))
+	ep = &testutils.FakeEndpointInfo{
+		ID:           uint64(remoteID),
+		Identity:     identity.NumericIdentity(remoteIdentity),
+		IPv4:         net.ParseIP(remoteIP),
+		PodName:      "xwing",
+		PodNamespace: "default",
+		Labels:       []string{"a", "b", "c"},
+		PolicyMap: map[policy.Key]labels.LabelArrayListString{
+			policyKey: labels.LabelArrayList{policyLabel}.ArrayListString(),
+		},
+		PolicyRevision: 1,
+	}
+	endpointGetter = &testutils.FakeEndpointGetter{
+		OnGetEndpointInfoByID: func(id uint16) (endpoint getters.EndpointInfo, ok bool) {
+			if uint64(id) == ep.ID {
+				return ep, true
+			}
+			return nil, false
+		},
+	}
+
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
+			Type: monitorAPI.MessageTypePolicyVerdict,
+		},
+		Verdict:          flowpb.Verdict_AUDIT,
+		TrafficDirection: flowpb.TrafficDirection_INGRESS,
+		IP: &flowpb.IP{
+			Source:      localIP,
+			Destination: remoteIP,
+		},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
+			},
+		},
+		Source: &flowpb.Endpoint{
+			ID:       localID,
+			Identity: localIdentity,
+		},
+		Destination: &flowpb.Endpoint{
+			ID:       remoteID,
+			Identity: remoteIdentity,
+		},
+		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+	}
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+
+	require.Nil(t, flow.EgressAllowedBy)
+	require.Nil(t, flow.IngressAllowedBy)
+	require.Nil(t, flow.EgressDeniedBy)
+	if diff := cmp.Diff(expected, flow.IngressDeniedBy, protocmp.Transform()); diff != "" {
+		t.Fatalf("not equal (-want +got):\n%s", diff)
+	}
+}
+
+func TestCorrelatePolicyImplicitDeny(t *testing.T) {
+	localIP := "1.2.3.4"
+	localIdentity := uint32(1234)
+	localID := uint32(12)
+	remoteIP := "5.6.7.8"
+	remoteIdentity := uint32(5678)
+	remoteID := uint32(56)
+	dstPort := uint32(443)
+
+	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
+	expected := []*flowpb.Policy{
+		{
+			Name:      "web-policy",
+			Namespace: "foo-namespace",
+			Kind:      utils.ResourceTypeCiliumNetworkPolicy,
+			Labels: []string{
+				"k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
+				"k8s:io.cilium.k8s.policy.name=web-policy",
+				"k8s:io.cilium.k8s.policy.namespace=foo-namespace",
+				"k8s:io.cilium.k8s.policy.uid=1234-5678",
+			},
+			Revision: 1,
+		},
+	}
+
+	// DropReason_POLICY_DENIED (implicit deny, code 133) at egress
+	policyKey := policy.EgressKey().WithIdentity(identity.NumericIdentity(remoteIdentity)).WithTCPPort(uint16(dstPort))
+	ep := &testutils.FakeEndpointInfo{
+		ID:           uint64(localID),
+		Identity:     identity.NumericIdentity(localIdentity),
+		IPv4:         net.ParseIP(localIP),
+		PodName:      "xwing",
+		PodNamespace: "default",
+		Labels:       []string{"a", "b", "c"},
+		PolicyMap: map[policy.Key]labels.LabelArrayListString{
+			policyKey: labels.LabelArrayList{policyLabel}.ArrayListString(),
+		},
+		PolicyRevision: 1,
+	}
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfoByID: func(id uint16) (endpoint getters.EndpointInfo, ok bool) {
+			if uint64(id) == ep.ID {
+				return ep, true
+			}
+			return nil, false
+		},
+	}
+
+	flow := &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
+			Type: monitorAPI.MessageTypePolicyVerdict,
+		},
+		Verdict:          flowpb.Verdict_DROPPED,
+		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+		TrafficDirection: flowpb.TrafficDirection_EGRESS,
+		IP: &flowpb.IP{
+			Source:      localIP,
+			Destination: remoteIP,
+		},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
+			},
+		},
+		Source: &flowpb.Endpoint{
+			ID:       localID,
+			Identity: localIdentity,
+		},
+		Destination: &flowpb.Endpoint{
+			ID:       remoteID,
+			Identity: remoteIdentity,
+		},
+		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+	}
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+
+	require.Nil(t, flow.EgressAllowedBy)
+	require.Nil(t, flow.IngressAllowedBy)
+	require.Nil(t, flow.IngressDeniedBy)
+	if diff := cmp.Diff(expected, flow.EgressDeniedBy, protocmp.Transform()); diff != "" {
+		t.Fatalf("not equal (-want +got):\n%s", diff)
+	}
+
+	// DropReason_POLICY_DENIED at ingress
+	policyKey = policy.IngressKey().WithIdentity(identity.NumericIdentity(localIdentity)).WithTCPPort(uint16(dstPort))
+	ep = &testutils.FakeEndpointInfo{
+		ID:           uint64(remoteID),
+		Identity:     identity.NumericIdentity(remoteIdentity),
+		IPv4:         net.ParseIP(remoteIP),
+		PodName:      "xwing",
+		PodNamespace: "default",
+		Labels:       []string{"a", "b", "c"},
+		PolicyMap: map[policy.Key]labels.LabelArrayListString{
+			policyKey: labels.LabelArrayList{policyLabel}.ArrayListString(),
+		},
+		PolicyRevision: 1,
+	}
+	endpointGetter = &testutils.FakeEndpointGetter{
+		OnGetEndpointInfoByID: func(id uint16) (endpoint getters.EndpointInfo, ok bool) {
+			if uint64(id) == ep.ID {
+				return ep, true
+			}
+			return nil, false
+		},
+	}
+
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
+			Type: monitorAPI.MessageTypePolicyVerdict,
+		},
+		Verdict:          flowpb.Verdict_DROPPED,
+		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
+		TrafficDirection: flowpb.TrafficDirection_INGRESS,
+		IP: &flowpb.IP{
+			Source:      localIP,
+			Destination: remoteIP,
+		},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
+			},
+		},
+		Source: &flowpb.Endpoint{
+			ID:       localID,
+			Identity: localIdentity,
+		},
+		Destination: &flowpb.Endpoint{
+			ID:       remoteID,
+			Identity: remoteIdentity,
+		},
+		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+	}
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+
+	require.Nil(t, flow.EgressAllowedBy)
+	require.Nil(t, flow.IngressAllowedBy)
+	require.Nil(t, flow.EgressDeniedBy)
+	if diff := cmp.Diff(expected, flow.IngressDeniedBy, protocmp.Transform()); diff != "" {
+		t.Fatalf("not equal (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
`CorrelatePolicy` currently handles forwarded/redirected flows and drops with `DropReason_POLICY_DENY`, but misses two categories:

**Audit verdicts** — `Verdict_AUDIT` (code 4) represents traffic that was allowed because the matching policy is in audit mode, but *would have been denied* otherwise. These flows hit the early return and never get correlated, so `hubble observe` shows the audit verdict without any associated policy in the `*DeniedBy` fields.

**Implicit denies** — `DropReason_POLICY_DENIED` (code 133) covers the default-deny case where no allow rule matched. Only `DropReason_POLICY_DENY` (code 181, explicit deny rule) was checked. In practice, most deny-by-default setups produce code 133 drops, and all of those were silently skipped.

This adds `Verdict_AUDIT` as an `audited` flow category that populates `*DeniedBy` (since it represents what would be denied), and extends the `denied` check to cover both `POLICY_DENY` and `POLICY_DENIED` drop reasons.

Tests added for audit flows at both egress/ingress and implicit deny (`POLICY_DENIED`) at both directions.

There is a third aspect to #42044 around `PolicyMatchNone` (match_type 0 for implicit denies where there is genuinely no single rule to point at) — that is a deeper design question around what `lookupPolicyForKey` should return, left for a separate discussion.

Fixes: #42044