### PR TITLE
driftchecker: wait for DynamicConfig table initialization before checking

### DIFF
--- a/pkg/driftchecker/checker.go
+++ b/pkg/driftchecker/checker.go
@@ -65,16 +65,11 @@ func Register(params checkerParams) {
 func (c checker) watchTableChanges(ctx context.Context) error {
 	// Wait for all config source reflectors to complete their initial
 	// listing before computing deltas.
-	for {
-		initialized, initWatch := c.dct.Initialized(c.db.ReadTxn())
-		if initialized {
-			break
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-initWatch:
-		}
+	_, initWatch := c.dct.Initialized(c.db.ReadTxn())
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-initWatch:
 	}
 
 	for {

--- a/pkg/driftchecker/checker.go
+++ b/pkg/driftchecker/checker.go
@@ -63,17 +63,22 @@ func Register(params checkerParams) {
 }
 
 func (c checker) watchTableChanges(ctx context.Context) error {
+	// Wait for all config source reflectors to complete their initial
+	// listing before computing deltas.
+	for {
+		initialized, initWatch := c.dct.Initialized(c.db.ReadTxn())
+		if initialized {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-initWatch:
+		}
+	}
+
 	for {
 		tableKeys, channel := dynamicconfig.WatchAllKeys(c.db.ReadTxn(), c.dct)
-		// Wait for table initialization
-		if len(tableKeys) == 0 {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-channel:
-				continue
-			}
-		}
 
 		deltas := c.computeDelta(tableKeys, c.cla)
 		c.publishMetrics(deltas)

--- a/pkg/driftchecker/checker_test.go
+++ b/pkg/driftchecker/checker_test.go
@@ -148,6 +148,88 @@ func TestComputeDelta(t *testing.T) {
 	}
 }
 
+// Regression test: the drift checker must wait for all config source
+// reflectors to initialize before computing deltas. Otherwise, it may
+// report spurious mismatches when a higher-priority source (e.g.
+// CiliumNodeConfig) hasn't populated the table yet.
+func TestWatchTableChangesWaitsForInitialization(t *testing.T) {
+	var (
+		db    *statedb.DB
+		table statedb.RWTable[dynamicconfig.DynamicConfig]
+		m     Metrics
+	)
+
+	var initDone func(statedb.WriteTxn)
+
+	h := hive.New(
+		k8sClient.FakeClientCell(),
+		metrics.Metric(MetricsProvider),
+		cell.Provide(
+			dynamicconfig.NewConfigTable,
+			func(table statedb.RWTable[dynamicconfig.DynamicConfig]) statedb.Table[dynamicconfig.DynamicConfig] {
+				return table
+			},
+			func() config {
+				return config{EnableDriftChecker: true}
+			},
+			func() dynamicconfig.Config {
+				return dynamicconfig.Config{EnableDynamicConfig: true}
+			},
+		),
+		cell.Invoke(
+			func(params checkerParams) {
+				params.CellAllSettings = map[string]any{"datapath-mode": "veth"}
+				Register(params)
+			},
+			func(t statedb.RWTable[dynamicconfig.DynamicConfig], db_ *statedb.DB, c *k8sClient.FakeClientset, metrics_ Metrics) error {
+				table = t
+				db = db_
+				m = metrics_
+
+				txn := db.WriteTxn(table)
+				initDone = table.RegisterInitializer(txn, "cnc-reflector")
+				txn.Commit()
+				return nil
+			},
+		),
+	)
+
+	ctx := context.Background()
+	tLog := hivetest.Logger(t)
+	if err := h.Start(tLog, ctx); err != nil {
+		t.Fatalf("starting hive: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Stop(tLog, ctx); err != nil {
+			t.Fatalf("stopping hive: %s", err)
+		}
+	})
+
+	// Simulate the ConfigMap reflector populating first with a value that
+	// differs from what the agent is running (veth vs netkit).
+	upsertEntryWithSource(db, table, "datapath-mode", "netkit", "cilium-config", 2)
+
+	// Give the drift checker time to (incorrectly) react. If the drift
+	// checker fires before initialization, it would see the ConfigMap
+	// mismatch and set the metric to 1.
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(m.DriftCheckerConfigDelta),
+		"drift checker should not compute deltas before table is initialized")
+
+	// Complete initialization without inserting the CNC override. The drift
+	// checker should now unblock and report the mismatch.
+	txn := db.WriteTxn(table)
+	initDone(txn)
+	txn.Commit()
+
+	if err := testutils.WaitUntil(func() bool {
+		return prometheustestutil.ToFloat64(m.DriftCheckerConfigDelta) == 1
+	}, 5*time.Second); err != nil {
+		t.Fatal("drift checker did not report the expected mismatch after initialization")
+	}
+}
+
 func newDynamicConfig(key string, value string) dynamicconfig.DynamicConfig {
 	return dynamicconfig.DynamicConfig{
 		Key: dynamicconfig.Key{
@@ -160,10 +242,14 @@ func newDynamicConfig(key string, value string) dynamicconfig.DynamicConfig {
 }
 
 func upsertEntry(db *statedb.DB, table statedb.RWTable[dynamicconfig.DynamicConfig], k string, v string) {
+	upsertEntryWithSource(db, table, k, v, "kube-system", 0)
+}
+
+func upsertEntryWithSource(db *statedb.DB, table statedb.RWTable[dynamicconfig.DynamicConfig], k, v, source string, priority int) {
 	txn := db.WriteTxn(table)
 	defer txn.Commit()
 
-	entry := dynamicconfig.DynamicConfig{Key: dynamicconfig.Key{Name: k, Source: "kube-system"}, Value: v, Priority: 0}
+	entry := dynamicconfig.DynamicConfig{Key: dynamicconfig.Key{Name: k, Source: source}, Value: v, Priority: priority}
 	_, _, _ = table.Insert(txn, entry)
 }
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->


We are using CiliumNodeConfig's more and more, and I've noticed a lot of noise in the logs from the drift-checker. For example, if we setup a CiliumNodeConfig with:

```yaml
spec:
  nodeSelector:
    matchLabels:
      really-old-nodes: "super-old"
  defaults:
    datapath-mode: "veth"
    enable-bpf-clock-probe: "false"
```

and then configure the agent's config to have:
```yaml
  datapath-mode: "netkit"
```

On startup, the agent logs:
```json
{"time":"2026-04-14T19:21:17.575022659Z","level":"warn","msg":"Mismatch found","module":"agent.controlplane.config-drift-checker","key":"datapath-mode","actual":"veth","expectedValue":"netkit","expectedSource":{"Name":"datapath-mode","Source":"cilium-config"}}
```

The code was just looking for `tableKeys` to have any entry. Instead this patch has it wait until all of the configs are initialized. There's a new test to highlight this behavior too by configuring an entry, waiting 200ms for the metric to incorrectly flag the issue. I wasn't super sure on how to approach the test so lemme know if that seems off. I looked to see if there were any open issues mentioning this but didn't find one. 

```release-note
driftchecker: wait for DynamicConfig table initialization before checking for drift
```
