### PR TITLE
gateway-api: fetch only referenced Services in reconcilers

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -108,11 +108,78 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	scopedLog.DebugContext(ctx, "Service exists and is a GAMMA Service", relevantHTTPRoutes, len(httpRouteList.Items))
 
-	// TODO(tam): Only list the services / ServiceImports used by accepted Routes
-	servicesList := &corev1.ServiceList{}
-	if err := r.Client.List(ctx, servicesList); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list Services", logfields.Error, err)
-		return controllerruntime.Fail(err)
+	// Collect only the services referenced by route parentRefs (GAMMA parents),
+	// backendRefs, and mirror filters, rather than listing all services in the cluster.
+	svcNames := make(map[types.NamespacedName]struct{})
+	for _, hr := range httpRouteList.Items {
+		// In GAMMA, parentRefs point to Services, not Gateways.
+		for _, parent := range hr.Spec.ParentRefs {
+			if helpers.IsGammaService(parent) {
+				svcNames[types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
+					Name:      string(parent.Name),
+				}] = struct{}{}
+			}
+		}
+		for _, rule := range hr.Spec.Rules {
+			for _, be := range rule.BackendRefs {
+				if helpers.IsService(be.BackendObjectReference) {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(be.Namespace, hr.Namespace),
+						Name:      string(be.Name),
+					}] = struct{}{}
+				}
+			}
+			for _, f := range rule.Filters {
+				if f.Type == gatewayv1.HTTPRouteFilterRequestMirror && f.RequestMirror != nil {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, hr.Namespace),
+						Name:      string(f.RequestMirror.BackendRef.Name),
+					}] = struct{}{}
+				}
+			}
+		}
+	}
+	for _, gr := range grpcRouteList.Items {
+		// In GAMMA, parentRefs point to Services, not Gateways.
+		for _, parent := range gr.Spec.ParentRefs {
+			if helpers.IsGammaService(parent) {
+				svcNames[types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(parent.Namespace, gr.Namespace),
+					Name:      string(parent.Name),
+				}] = struct{}{}
+			}
+		}
+		for _, rule := range gr.Spec.Rules {
+			for _, be := range rule.BackendRefs {
+				if helpers.IsService(be.BackendObjectReference) {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(be.Namespace, gr.Namespace),
+						Name:      string(be.Name),
+					}] = struct{}{}
+				}
+			}
+			for _, f := range rule.Filters {
+				if f.Type == gatewayv1.GRPCRouteFilterRequestMirror && f.RequestMirror != nil {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, gr.Namespace),
+						Name:      string(f.RequestMirror.BackendRef.Name),
+					}] = struct{}{}
+				}
+			}
+		}
+	}
+	services := make([]corev1.Service, 0, len(svcNames))
+	for nsName := range svcNames {
+		svc := &corev1.Service{}
+		if err := r.Client.Get(ctx, nsName, svc); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Unable to get Service", logfields.Error, err)
+				return controllerruntime.Fail(err)
+			}
+			continue
+		}
+		services = append(services, *svc)
 	}
 
 	grants := &gatewayv1beta1.ReferenceGrantList{}
@@ -137,7 +204,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	httpListeners := ingestion.GammaHTTPRoutes(r.logger, ingestion.GammaInput{
 		HTTPRoutes: httpRouteList.Items,
 		GRPCRoutes: grpcRouteList.Items,
-		Services:   servicesList.Items,
+		Services:   services,
 
 		ReferenceGrants: grants.Items,
 	})

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -127,19 +127,101 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	btlspMap := helpers.BuildBackendTLSPolicyLookup(btlspList)
 
-	// TODO(tam): Only list the services / ServiceImports used by accepted Routes
-	servicesList := &corev1.ServiceList{}
-	if err := r.Client.List(ctx, servicesList); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list Services", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
-	}
-
 	serviceImportsList := &mcsapiv1alpha1.ServiceImportList{}
 	if helpers.HasServiceImportSupport(r.Client.Scheme()) {
 		if err := r.Client.List(ctx, serviceImportsList); err != nil {
 			scopedLog.ErrorContext(ctx, "Unable to list ServiceImports", logfields.Error, err)
 			return controllerruntime.Fail(err)
 		}
+	}
+
+	// Collect only the services referenced by route backendRefs and mirror filters,
+	// rather than listing all services in the cluster.
+	svcNames := make(map[types.NamespacedName]struct{})
+	for _, hr := range httpRouteList.Items {
+		for _, rule := range hr.Spec.Rules {
+			for _, be := range rule.BackendRefs {
+				if helpers.IsService(be.BackendObjectReference) {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(be.Namespace, hr.Namespace),
+						Name:      string(be.Name),
+					}] = struct{}{}
+				} else if helpers.IsServiceImport(be.BackendObjectReference) {
+					if svcName, err := helpers.GetDerivedServiceName(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), serviceImportsList.Items); err == nil {
+						svcNames[types.NamespacedName{
+							Namespace: helpers.NamespaceDerefOr(be.Namespace, hr.Namespace),
+							Name:      svcName,
+						}] = struct{}{}
+					}
+				}
+			}
+			for _, f := range rule.Filters {
+				if f.Type == gatewayv1.HTTPRouteFilterRequestMirror && f.RequestMirror != nil {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, hr.Namespace),
+						Name:      string(f.RequestMirror.BackendRef.Name),
+					}] = struct{}{}
+				}
+			}
+		}
+	}
+	for _, gr := range grpcRouteList.Items {
+		for _, rule := range gr.Spec.Rules {
+			for _, be := range rule.BackendRefs {
+				if helpers.IsService(be.BackendObjectReference) {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(be.Namespace, gr.Namespace),
+						Name:      string(be.Name),
+					}] = struct{}{}
+				} else if helpers.IsServiceImport(be.BackendObjectReference) {
+					if svcName, err := helpers.GetDerivedServiceName(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, gr.Namespace), serviceImportsList.Items); err == nil {
+						svcNames[types.NamespacedName{
+							Namespace: helpers.NamespaceDerefOr(be.Namespace, gr.Namespace),
+							Name:      svcName,
+						}] = struct{}{}
+					}
+				}
+			}
+			for _, f := range rule.Filters {
+				if f.Type == gatewayv1.GRPCRouteFilterRequestMirror && f.RequestMirror != nil {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, gr.Namespace),
+						Name:      string(f.RequestMirror.BackendRef.Name),
+					}] = struct{}{}
+				}
+			}
+		}
+	}
+	for _, tr := range tlsRouteList.Items {
+		for _, rule := range tr.Spec.Rules {
+			for _, be := range rule.BackendRefs {
+				if helpers.IsService(be.BackendObjectReference) {
+					svcNames[types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(be.Namespace, tr.Namespace),
+						Name:      string(be.Name),
+					}] = struct{}{}
+				} else if helpers.IsServiceImport(be.BackendObjectReference) {
+					if svcName, err := helpers.GetDerivedServiceName(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, tr.Namespace), serviceImportsList.Items); err == nil {
+						svcNames[types.NamespacedName{
+							Namespace: helpers.NamespaceDerefOr(be.Namespace, tr.Namespace),
+							Name:      svcName,
+						}] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	services := make([]corev1.Service, 0, len(svcNames))
+	for nsName := range svcNames {
+		svc := &corev1.Service{}
+		if err := r.Client.Get(ctx, nsName, svc); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Unable to get Service", logfields.Error, err)
+				return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+			}
+			continue
+		}
+		services = append(services, *svc)
 	}
 
 	grants := &gatewayv1beta1.ReferenceGrantList{}
@@ -189,7 +271,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		HTTPRoutes:          httpRoutes,
 		TLSRoutes:           tlsRoutes,
 		GRPCRoutes:          grpcRoutes,
-		Services:            servicesList.Items,
+		Services:            services,
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
 		BackendTLSPolicyMap: btlspMap,

--- a/operator/pkg/gateway-api/helpers/serviceimport.go
+++ b/operator/pkg/gateway-api/helpers/serviceimport.go
@@ -30,3 +30,14 @@ func GetServiceName(svcImport *mcsapiv1alpha1.ServiceImport) (string, error) {
 
 	return backendServiceName, nil
 }
+
+// GetDerivedServiceName finds a ServiceImport by name and namespace in the given list,
+// then returns the derived service name from its annotation.
+func GetDerivedServiceName(name, namespace string, serviceImports []mcsapiv1alpha1.ServiceImport) (string, error) {
+	for _, si := range serviceImports {
+		if si.GetName() == name && si.GetNamespace() == namespace {
+			return GetServiceName(&si)
+		}
+	}
+	return "", fmt.Errorf("ServiceImport %s/%s not found", namespace, name)
+}


### PR DESCRIPTION
Previously, the Gateway and GAMMA reconcilers called r.Client.List() to fetch every Service in the cluster on each reconcile, then passed the entire list into the ingestion package. The ingestion code only uses the few Services actually referenced by route backendRefs, making the vast majority of fetched Services unnecessary. In large clusters with thousands of Services, this wastes memory and CPU on every reconcile cycle.

Replace the unfiltered List call with targeted Get calls for only the Services actually referenced by routes. The referenced service names are extracted from:

 - HTTPRoute, GRPCRoute, and TLSRoute spec.rules[].backendRefs
 - RequestMirror filter backends in spec.rules[].filters
 - ServiceImport backendRefs (resolved via the derived-service annotation)
 - GAMMA parentRef Services (since GAMMA routes attach to Services)

Each unique Service is fetched individually via r.Client.Get(), which is an O(1) informer cache lookup. The resulting small slice is passed into the ingestion Input struct. No changes to the ingestion package are needed.

Also adds a GetDerivedServiceName() helper in the helpers package to look up a ServiceImport by name/namespace and return its derived service name.

Fixes: #45377