### PR TITLE
vendor,hive: Bump to StateDB v0.8.0 and adapt metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v1.0.1
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260401135853-01f43852f361
-	github.com/cilium/statedb v0.7.0
+	github.com/cilium/statedb v0.8.0
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.4.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9t
 github.com/cilium/lumberjack/v2 v2.4.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20260401135853-01f43852f361 h1:yFMmMnPJeEudjwwBaefqKhYdZTOQydCr/UOhf09Er+4=
 github.com/cilium/proxy v0.0.0-20260401135853-01f43852f361/go.mod h1:EPTdltJDXKIdw2DM58qO2FGPYDlGgea8EotcNU9mMrY=
-github.com/cilium/statedb v0.7.0 h1:bHg2KLIPrTdi7F3D3kJwxZgQwmcl/w0MdgPdZS1rbO8=
-github.com/cilium/statedb v0.7.0/go.mod h1:Dtp96Hmwcw7DJj9kIa2MfkX5Irk4KVyITN40fXyolio=
+github.com/cilium/statedb v0.8.0 h1:Tm3ioI+pjHHmLvY4QTNv0kZHxXlzGQwvV4A/k+wHeLk=
+github.com/cilium/statedb v0.8.0/go.mod h1:Dtp96Hmwcw7DJj9kIa2MfkX5Irk4KVyITN40fXyolio=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.4.0 h1:Tn0e2Ie1THjepOnj5PobkhZ3CLknostEcKRvEGvbY/Y=

--- a/pkg/hive/reconciler_metrics.go
+++ b/pkg/hive/reconciler_metrics.go
@@ -26,6 +26,7 @@ type ReconcilerMetrics struct {
 
 const (
 	labelModuleId  = "module_id"
+	labelName      = "name"
 	labelOperation = "op"
 )
 
@@ -37,7 +38,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Subsystem: "reconciler",
 			Name:      "count",
 			Help:      "Number of reconciliation rounds performed",
-		}, []string{labelModuleId}),
+		}, []string{labelModuleId, labelName}),
 
 		ReconciliationDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			Disabled:  true,
@@ -47,7 +48,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Help:      "Histogram of per-operation duration during reconciliation",
 			// Use buckets in the 0.5ms-1s range.
 			Buckets: []float64{.0005, .001, .0025, .005, .01, .025, .05, 0.1, 0.25, 0.5, 1.0},
-		}, []string{labelModuleId, labelOperation}),
+		}, []string{labelModuleId, labelName, labelOperation}),
 
 		ReconciliationTotalErrors: metric.NewCounterVec(metric.CounterOpts{
 			Disabled:  true,
@@ -55,7 +56,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Subsystem: "reconciler",
 			Name:      "errors_total",
 			Help:      "Total number of errors encountered during reconciliation",
-		}, []string{labelModuleId}),
+		}, []string{labelModuleId, labelName}),
 
 		ReconciliationCurrentErrors: metric.NewGaugeVec(metric.GaugeOpts{
 			Disabled:  true,
@@ -63,7 +64,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Subsystem: "reconciler",
 			Name:      "errors_current",
 			Help:      "The number of objects currently failing to be reconciled",
-		}, []string{labelModuleId}),
+		}, []string{labelModuleId, labelName}),
 
 		PruneCount: metric.NewCounterVec(metric.CounterOpts{
 			Disabled:  true,
@@ -71,7 +72,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Subsystem: "reconciler",
 			Name:      "prune_count",
 			Help:      "Number of prunes performed",
-		}, []string{labelModuleId}),
+		}, []string{labelModuleId, labelName}),
 
 		PruneTotalErrors: metric.NewCounterVec(metric.CounterOpts{
 			Disabled:  true,
@@ -79,7 +80,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Subsystem: "reconciler",
 			Name:      "prune_errors_total",
 			Help:      "Total number of errors encountered during pruning",
-		}, []string{labelModuleId}),
+		}, []string{labelModuleId, labelName}),
 
 		PruneDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			Disabled:  true,
@@ -87,7 +88,7 @@ func NewStateDBReconcilerMetrics() ReconcilerMetrics {
 			Subsystem: "reconciler",
 			Name:      "prune_duration_seconds",
 			Help:      "Histogram of pruning duration",
-		}, []string{labelModuleId}),
+		}, []string{labelModuleId, labelName}),
 	}
 	return m
 }
@@ -101,30 +102,33 @@ type reconcilerMetricsImpl struct {
 }
 
 // PruneDuration implements reconciler.Metrics.
-func (m *reconcilerMetricsImpl) PruneDuration(moduleID cell.FullModuleID, duration time.Duration) {
-	m.m.PruneDuration.WithLabelValues(moduleID.String()).
+func (m *reconcilerMetricsImpl) PruneDuration(moduleID cell.FullModuleID, name string, duration time.Duration) {
+	m.m.PruneDuration.WithLabelValues(moduleID.String(), name).
 		Observe(duration.Seconds())
 }
 
 // FullReconciliationErrors implements reconciler.Metrics.
-func (m *reconcilerMetricsImpl) PruneError(moduleID cell.FullModuleID, err error) {
-	m.m.PruneCount.WithLabelValues(moduleID.String()).Inc()
+func (m *reconcilerMetricsImpl) PruneError(moduleID cell.FullModuleID, name string, err error) {
+	mod := moduleID.String()
+	m.m.PruneCount.WithLabelValues(mod, name).Inc()
 	if err != nil {
-		m.m.PruneTotalErrors.WithLabelValues(moduleID.String()).Add(1)
+		m.m.PruneTotalErrors.WithLabelValues(mod, name).Add(1)
 	}
 }
 
 // ReconciliationDuration implements reconciler.Metrics.
-func (m *reconcilerMetricsImpl) ReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration) {
-	m.m.ReconciliationCount.WithLabelValues(moduleID.String()).Inc()
-	m.m.ReconciliationDuration.WithLabelValues(moduleID.String(), operation).
+func (m *reconcilerMetricsImpl) ReconciliationDuration(moduleID cell.FullModuleID, name string, operation string, duration time.Duration) {
+	mod := moduleID.String()
+	m.m.ReconciliationCount.WithLabelValues(mod, name).Inc()
+	m.m.ReconciliationDuration.WithLabelValues(mod, name, operation).
 		Observe(duration.Seconds())
 }
 
 // ReconciliationErrors implements reconciler.Metrics.
-func (m *reconcilerMetricsImpl) ReconciliationErrors(moduleID cell.FullModuleID, new, current int) {
-	m.m.ReconciliationCurrentErrors.WithLabelValues(moduleID.String()).Set(float64(current))
-	m.m.ReconciliationCurrentErrors.WithLabelValues(moduleID.String()).Add(float64(new))
+func (m *reconcilerMetricsImpl) ReconciliationErrors(moduleID cell.FullModuleID, name string, new, current int) {
+	mod := moduleID.String()
+	m.m.ReconciliationCurrentErrors.WithLabelValues(mod, name).Set(float64(current))
+	m.m.ReconciliationCurrentErrors.WithLabelValues(mod, name).Add(float64(new))
 }
 
 var _ reconciler.Metrics = &reconcilerMetricsImpl{}

--- a/vendor/github.com/cilium/statedb/reconciler/builder.go
+++ b/vendor/github.com/cilium/statedb/reconciler/builder.go
@@ -91,6 +91,14 @@ func Register[Obj comparable](
 // Option for the reconciler
 type Option func(opts *options)
 
+// WithName sets the name of this reconciler instance.
+// This name is passed to the configured [Metrics] implementation.
+func WithName(name string) Option {
+	return func(opts *options) {
+		opts.Name = name
+	}
+}
+
 // WithMetrics sets the [Metrics] instance to use with this reconciler.
 // The metrics capture the duration of operations during incremental and
 // full reconcilation and the errors that occur during either.

--- a/vendor/github.com/cilium/statedb/reconciler/config.go
+++ b/vendor/github.com/cilium/statedb/reconciler/config.go
@@ -10,6 +10,7 @@ import (
 
 func defaultOptions() options {
 	return options{
+		Name:    "",
 		Metrics: nil, // use DefaultMetrics
 
 		// Refresh objects every 30 minutes at a rate of 100 per second.
@@ -31,6 +32,11 @@ func defaultOptions() options {
 }
 
 type options struct {
+	// Name identifies this reconciler instance within the hive module.
+	// This is passed to the configured metrics implementation and is useful
+	// when a single module registers multiple reconcilers.
+	Name string
+
 	// Metrics to use with this reconciler. The metrics capture the duration
 	// of operations during incremental and full reconcilation and the errors
 	// that occur during either.

--- a/vendor/github.com/cilium/statedb/reconciler/incremental.go
+++ b/vendor/github.com/cilium/statedb/reconciler/incremental.go
@@ -17,6 +17,7 @@ import (
 type incremental[Obj comparable] struct {
 	metrics        Metrics
 	moduleID       cell.FullModuleID
+	name           string
 	config         *config[Obj]
 	retries        *retries
 	primaryIndexer statedb.Indexer[Obj]
@@ -68,7 +69,7 @@ func (incr *incremental[Obj]) run(ctx context.Context, txn statedb.ReadTxn, chan
 	// queue which includes both errors occurred in this round and the old
 	// errors.
 	errs = incr.retries.errors()
-	incr.metrics.ReconciliationErrors(incr.moduleID, newErrors, len(errs))
+	incr.metrics.ReconciliationErrors(incr.moduleID, incr.name, newErrors, len(errs))
 
 	// Prepare for next round.
 	incr.numReconciled = 0
@@ -148,6 +149,7 @@ func (incr *incremental[Obj]) batch(ctx context.Context, txn statedb.ReadTxn, ch
 		ops.DeleteBatch(ctx, txn, deleteBatch)
 		incr.metrics.ReconciliationDuration(
 			incr.moduleID,
+			incr.name,
 			OpDelete,
 			time.Since(start),
 		)
@@ -165,6 +167,7 @@ func (incr *incremental[Obj]) batch(ctx context.Context, txn statedb.ReadTxn, ch
 		ops.UpdateBatch(ctx, txn, updateBatch)
 		incr.metrics.ReconciliationDuration(
 			incr.moduleID,
+			incr.name,
 			OpUpdate,
 			time.Since(start),
 		)
@@ -218,7 +221,7 @@ func (incr *incremental[Obj]) processSingle(ctx context.Context, txn statedb.Rea
 		status := incr.config.GetObjectStatus(obj)
 		incr.results[obj] = opResult{original: orig, id: status.ID, rev: rev, err: err}
 	}
-	incr.metrics.ReconciliationDuration(incr.moduleID, op, time.Since(start))
+	incr.metrics.ReconciliationDuration(incr.moduleID, incr.name, op, time.Since(start))
 
 	if err == nil {
 		incr.retries.Clear(obj)

--- a/vendor/github.com/cilium/statedb/reconciler/metrics.go
+++ b/vendor/github.com/cilium/statedb/reconciler/metrics.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Metrics interface {
-	ReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration)
-	ReconciliationErrors(moduleID cell.FullModuleID, new, current int)
+	ReconciliationDuration(moduleID cell.FullModuleID, name, operation string, duration time.Duration)
+	ReconciliationErrors(moduleID cell.FullModuleID, name string, new, current int)
 
-	PruneError(moduleID cell.FullModuleID, err error)
-	PruneDuration(moduleID cell.FullModuleID, duration time.Duration)
+	PruneError(moduleID cell.FullModuleID, name string, err error)
+	PruneDuration(moduleID cell.FullModuleID, name string, duration time.Duration)
 }
 
 const (
@@ -37,32 +37,41 @@ type ExpVarMetrics struct {
 	PruneCurrentErrorsVar *expvar.Map
 }
 
-func (m *ExpVarMetrics) PruneDuration(moduleID cell.FullModuleID, duration time.Duration) {
-	m.PruneDurationVar.AddFloat(moduleID.String(), duration.Seconds())
+func metricKey(moduleID cell.FullModuleID, name string) string {
+	if name == "" {
+		return moduleID.String()
+	}
+	return moduleID.String() + "/" + name
 }
 
-func (m *ExpVarMetrics) PruneError(moduleID cell.FullModuleID, err error) {
-	m.PruneCountVar.Add(moduleID.String(), 1)
+func (m *ExpVarMetrics) PruneDuration(moduleID cell.FullModuleID, name string, duration time.Duration) {
+	m.PruneDurationVar.AddFloat(metricKey(moduleID, name), duration.Seconds())
+}
+
+func (m *ExpVarMetrics) PruneError(moduleID cell.FullModuleID, name string, err error) {
+	key := metricKey(moduleID, name)
+	m.PruneCountVar.Add(key, 1)
 
 	var intVar expvar.Int
 	if err != nil {
-		m.PruneTotalErrorsVar.Add(moduleID.String(), 1)
+		m.PruneTotalErrorsVar.Add(key, 1)
 		intVar.Set(1)
 	}
-	m.PruneCurrentErrorsVar.Set(moduleID.String(), &intVar)
+	m.PruneCurrentErrorsVar.Set(key, &intVar)
 }
 
-func (m *ExpVarMetrics) ReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration) {
-	m.ReconciliationDurationVar.AddFloat(moduleID.String()+"/"+operation, duration.Seconds())
+func (m *ExpVarMetrics) ReconciliationDuration(moduleID cell.FullModuleID, name, operation string, duration time.Duration) {
+	m.ReconciliationDurationVar.AddFloat(metricKey(moduleID, name)+"/"+operation, duration.Seconds())
 }
 
-func (m *ExpVarMetrics) ReconciliationErrors(moduleID cell.FullModuleID, new, current int) {
-	m.ReconciliationCountVar.Add(moduleID.String(), 1)
-	m.ReconciliationTotalErrorsVar.Add(moduleID.String(), int64(new))
+func (m *ExpVarMetrics) ReconciliationErrors(moduleID cell.FullModuleID, name string, new, current int) {
+	key := metricKey(moduleID, name)
+	m.ReconciliationCountVar.Add(key, 1)
+	m.ReconciliationTotalErrorsVar.Add(key, int64(new))
 
 	var intVar expvar.Int
 	intVar.Set(int64(current))
-	m.ReconciliationCurrentErrorsVar.Set(moduleID.String(), &intVar)
+	m.ReconciliationCurrentErrorsVar.Set(key, &intVar)
 }
 
 var _ Metrics = &ExpVarMetrics{}

--- a/vendor/github.com/cilium/statedb/reconciler/reconciler.go
+++ b/vendor/github.com/cilium/statedb/reconciler/reconciler.go
@@ -59,6 +59,7 @@ func (r *reconciler[Obj]) reconcileLoop(ctx context.Context, health cell.Health)
 
 	incremental := incremental[Obj]{
 		moduleID:       r.ModuleID,
+		name:           r.config.Name,
 		metrics:        r.config.Metrics,
 		config:         &r.config,
 		retries:        r.retries,
@@ -136,8 +137,8 @@ func (r *reconciler[Obj]) prune(ctx context.Context, txn statedb.ReadTxn) error 
 		r.Log.Warn("Reconciler: failed to prune objects", "error", err, "pruneInterval", r.config.PruneInterval)
 		err = fmt.Errorf("prune: %w", err)
 	}
-	r.config.Metrics.PruneDuration(r.ModuleID, time.Since(start))
-	r.config.Metrics.PruneError(r.ModuleID, err)
+	r.config.Metrics.PruneDuration(r.ModuleID, r.config.Name, time.Since(start))
+	r.config.Metrics.PruneError(r.ModuleID, r.config.Name, err)
 	return err
 }
 

--- a/vendor/github.com/cilium/statedb/script.go
+++ b/vendor/github.com/cilium/statedb/script.go
@@ -340,6 +340,7 @@ func CompareCmd(db *DB) script.Cmd {
 			}
 
 			tableName := args[0]
+			fileName := args[1]
 
 			txn := db.ReadTxn()
 			meta := db.GetTable(txn, tableName)
@@ -349,16 +350,16 @@ func CompareCmd(db *DB) script.Cmd {
 			tbl := AnyTable{Meta: meta}
 			header := tbl.TableHeader()
 
-			data, err := os.ReadFile(s.Path(args[1]))
+			data, err := os.ReadFile(s.Path(fileName))
 			if err != nil {
-				return nil, fmt.Errorf("ReadFile(%s): %w", args[1], err)
+				return nil, fmt.Errorf("ReadFile(%s): %w", fileName, err)
 			}
 			lines := strings.Split(s.ExpandEnv(string(data), false), "\n")
 			lines = slices.DeleteFunc(lines, func(line string) bool {
 				return strings.TrimSpace(line) == ""
 			})
 			if len(lines) < 1 {
-				return nil, fmt.Errorf("%q missing header line, e.g. %q", args[1], strings.Join(header, " "))
+				return nil, fmt.Errorf("%q missing header line, e.g. %q", fileName, strings.Join(header, " "))
 			}
 
 			columnNames, columnPositions := splitHeaderLine(lines[0])
@@ -370,6 +371,7 @@ func CompareCmd(db *DB) script.Cmd {
 			lines = lines[1:]
 			origLines := lines
 			timeoutChan := time.After(timeout)
+			var lastActual string
 
 			for {
 				lines = origLines
@@ -378,7 +380,10 @@ func CompareCmd(db *DB) script.Cmd {
 				equal := true
 				var diff bytes.Buffer
 				w := newTabWriter(&diff)
-				fmt.Fprintf(w, "  %s\n", joinByPositions(columnNames, columnPositions, false))
+				joined := joinByPositions(columnNames, columnPositions, false)
+				fmt.Fprintf(w, "  %s\n", joined)
+				var actual strings.Builder
+				fmt.Fprintf(&actual, "  %s\n", joined)
 
 				objs, watch := tbl.AllWatch(db.ReadTxn())
 				for obj := range objs {
@@ -387,6 +392,7 @@ func CompareCmd(db *DB) script.Cmd {
 					if grepRe != nil && !grepRe.Match([]byte(row)) {
 						continue
 					}
+					fmt.Fprintf(&actual, "%s\n", row)
 
 					if len(lines) == 0 {
 						equal = false
@@ -409,6 +415,7 @@ func CompareCmd(db *DB) script.Cmd {
 					fmt.Fprintf(w, "+ %s\n", line)
 					equal = false
 				}
+				lastActual = actual.String()
 				if equal {
 					return nil, nil
 				}
@@ -419,6 +426,10 @@ func CompareCmd(db *DB) script.Cmd {
 					return nil, s.Context().Err()
 
 				case <-timeoutChan:
+					if s.DoUpdate {
+						s.FileUpdates[fileName] = lastActual
+						return nil, nil
+					}
 					return nil, fmt.Errorf("table mismatch:\n%s", diff.String())
 
 				case <-watch:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -352,7 +352,7 @@ github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20260401135853-01f43852f361
 ## explicit; go 1.25.0
 github.com/cilium/proxy/go/cilium/api
-# github.com/cilium/statedb v0.7.0
+# github.com/cilium/statedb v0.8.0
 ## explicit; go 1.25
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
Bump to StateDB v0.8.0. This changes the [reconciler.Metrics] to include the reconciler name. Add this as a "name" label to reconciler related metrics. If the [reconciler.WithName] is not used the label value will be the empty string.

With this change we can have multiple reconcilers in a single hive module without the metrics colliding.

This has no impact on existing metrics since [reconciler.WithName] is not yet used.