### PR TITLE
connectivity: make conn-disrupt sub-tests independently deployable

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -42,9 +42,15 @@ runs:
           TEST_ARG="${{ inputs.tests }}"
         else
           TEST_ARG="no-interrupted-connections,no-ipsec-xfrm-error"
+          if [[ -n "${{ env.CONN_DISRUPT_EXTRA_TEST }}" ]]; then
+            TEST_ARG="${TEST_ARG},${{ env.CONN_DISRUPT_EXTRA_TEST }}"
+          fi
           EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
           if [[ "${{ inputs.skip-include-conn-disrupt-test-ns-traffic }}" != "true" ]]; then
             EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"
+          fi
+          if [[ -n "${{ env.CONN_DISRUPT_EXTRA_ARG }}" ]]; then
+            EXTRA_ARG="${EXTRA_ARG} ${{ env.CONN_DISRUPT_EXTRA_ARG }}"
           fi
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then

--- a/.github/actions/conn-disrupt-test-setup/action.yaml
+++ b/.github/actions/conn-disrupt-test-setup/action.yaml
@@ -20,6 +20,9 @@ runs:
         if [[ "${{ inputs.include-conn-disrupt-test-l7-traffic }}" == "true" ]]; then
           EXTRA_ARG="--include-conn-disrupt-test-l7-traffic"
         fi
+        if [[ -n "${{ env.CONN_DISRUPT_EXTRA_ARG }}" ]]; then
+          EXTRA_ARG="${EXTRA_ARG} ${{ env.CONN_DISRUPT_EXTRA_ARG }}"
+        fi
 
         # Create pods which establish long lived connections. It will be used by
         # subsequent connectivity tests with --include-conn-disrupt-test to catch any

--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -10,6 +10,8 @@ runs:
         # no prod yet
         echo "QUAY_CHARTS_ORGANIZATION_DEV=cilium-charts-dev" >> $GITHUB_ENV
         echo "EGRESS_GATEWAY_HELM_VALUES=--helm-set=egressGateway.enabled=true" >> $GITHUB_ENV
+        echo "CONN_DISRUPT_EXTRA_ARG=" >> $GITHUB_ENV
+        echo "CONN_DISRUPT_EXTRA_TEST=" >> $GITHUB_ENV
         echo "BGP_CONTROL_PLANE_HELM_VALUES=--helm-set=bgpControlPlane.enabled=true" >> $GITHUB_ENV
         echo "CILIUM_CLI_RELEASE_REPO=cilium/cilium-cli" >> $GITHUB_ENV
         CILIUM_CLI_VERSION=""

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -169,10 +169,10 @@ func GetTestSuites(params check.Parameters) ([]func(connTests []*check.Connectiv
 				return networkPerformanceTests(connTests[0])
 			},
 		}, nil
-	case params.IncludeConnDisruptTest && params.ConnDisruptTestSetup:
+	case params.ConnDisruptTestSetup:
 		// Exit early, as --conn-disrupt-test-setup is only needed to deploy pods which
 		// will be used by another invocation of "cli connectivity test"
-		// with include --include-conn-disrupt-test"
+		// with conn-disrupt test flags (e.g. --include-conn-disrupt-test, --include-conn-disrupt-test-egw).
 		return []func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error{
 			func(connTests []*check.ConnectivityTest, _ func(cts ...*check.ConnectivityTest) error) error {
 				return connDisruptTests(connTests[0])
@@ -181,7 +181,7 @@ func GetTestSuites(params check.Parameters) ([]func(connTests []*check.Connectiv
 	case params.TestConcurrency > 1:
 		return []func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error{
 			func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error {
-				if connTests[0].Params().IncludeConnDisruptTest {
+				if connTests[0].ShouldRunConnDisrupt() {
 					if err := connDisruptTests(connTests[0]); err != nil {
 						return err
 					}
@@ -201,7 +201,7 @@ func GetTestSuites(params check.Parameters) ([]func(connTests []*check.Connectiv
 	default: // fallback to the sequential run
 		return []func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error{
 			func(connTests []*check.ConnectivityTest, extraTests func(cts ...*check.ConnectivityTest) error) error {
-				if connTests[0].Params().IncludeConnDisruptTest {
+				if connTests[0].ShouldRunConnDisrupt() {
 					if err := connDisruptTests(connTests[0]); err != nil {
 						return err
 					}

--- a/cilium-cli/connectivity/builder/no_interrupted_connections.go
+++ b/cilium-cli/connectivity/builder/no_interrupted_connections.go
@@ -14,7 +14,7 @@ type noInterruptedConnections struct{}
 
 func (t noInterruptedConnections) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("no-interrupted-connections", ct).
-		WithCondition(func() bool { return ct.Params().IncludeConnDisruptTest }).
+		WithCondition(func() bool { return ct.ShouldRunConnDisrupt() }).
 		WithScenarios(tests.NoInterruptedConnections()).
 		WithFinalizer(func(ctx context.Context) error {
 			// Delete the test-conn-disrupt pods immediately after the test run

--- a/cilium-cli/connectivity/builder/no_ipsec_xfrm_errors.go
+++ b/cilium-cli/connectivity/builder/no_ipsec_xfrm_errors.go
@@ -13,7 +13,7 @@ type noIpsecXfrmErrors struct{}
 
 func (t noIpsecXfrmErrors) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("no-ipsec-xfrm-errors", ct).
-		WithCondition(func() bool { return ct.Params().IncludeConnDisruptTest }).
+		WithCondition(func() bool { return ct.ShouldRunConnDisrupt() }).
 		WithFeatureRequirements(features.RequireMode(features.EncryptionPod, "ipsec")).
 		WithScenarios(tests.NoIPsecXfrmErrors(ct.Params().ExpectedXFRMErrors))
 }

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -1393,6 +1393,13 @@ func (ct *ConnectivityTest) ForEachIPFamily(do func(features.IPFamily)) {
 	}
 }
 
+func (ct *ConnectivityTest) ShouldRunConnDisrupt() bool {
+	return ct.params.IncludeConnDisruptTest ||
+		ct.ShouldRunConnDisruptNSTraffic() ||
+		ct.ShouldRunConnDisruptL7Traffic() ||
+		ct.ShouldRunConnDisruptEgressGateway()
+}
+
 func (ct *ConnectivityTest) ShouldRunConnDisruptNSTraffic() bool {
 	return ct.params.IncludeConnDisruptTestNSTraffic &&
 		ct.Features[features.NodeWithoutCilium].Enabled &&

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1016,15 +1016,17 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 	// Deploy test-conn-disrupt actors (only in the first
 	// test namespace in case of tests concurrent run)
 	if ct.params.ConnDisruptTestSetup && ct.params.TestNamespaceIndex == 0 {
-		if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerDeploymentName, KindTestConnDisrupt, 3,
-			testConnDisruptServiceName, "test-conn-disrupt-server", false, newConnDisruptCNP, ""); err != nil {
-			return err
-		}
+		if ct.params.IncludeConnDisruptTest {
+			if err := ct.createTestConnDisruptServerDeployAndSvc(ctx, testConnDisruptServerDeploymentName, KindTestConnDisrupt, 3,
+				testConnDisruptServiceName, "test-conn-disrupt-server", false, newConnDisruptCNP, ""); err != nil {
+				return err
+			}
 
-		if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientDeploymentName, KindTestConnDisrupt,
-			"test-conn-disrupt-client", fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
-			5, false, nil, ""); err != nil {
-			return err
+			if err := ct.createTestConnDisruptClientDeployment(ctx, testConnDisruptClientDeploymentName, KindTestConnDisrupt,
+				"test-conn-disrupt-client", fmt.Sprintf("test-conn-disrupt.%s.svc.cluster.local.:8000", ct.params.TestNamespace),
+				5, false, nil, ""); err != nil {
+				return err
+			}
 		}
 
 		if ct.ShouldRunConnDisruptNSTraffic() {
@@ -2490,15 +2492,17 @@ func (ct *ConnectivityTest) deploymentList() (srcList []string, dstList []string
 		srcList = append(srcList, client3DeploymentName)
 	}
 
-	if ct.params.IncludeConnDisruptTest && ct.params.TestNamespaceIndex == 0 {
-		// We append the server and client deployment names to two different
-		// lists. This matters when running in multi-cluster mode, because
-		// the server is deployed in the local cluster (targeted by the "src"
-		// client), while the client in the remote one (targeted by the "dst"
-		// client). When running against a single cluster, instead, this does
-		// not matter much, because the two clients are identical.
-		srcList = append(srcList, testConnDisruptServerDeploymentName)
-		dstList = append(dstList, testConnDisruptClientDeploymentName)
+	if ct.params.TestNamespaceIndex == 0 {
+		if ct.params.IncludeConnDisruptTest {
+			// We append the server and client deployment names to two different
+			// lists. This matters when running in multi-cluster mode, because
+			// the server is deployed in the local cluster (targeted by the "src"
+			// client), while the client in the remote one (targeted by the "dst"
+			// client). When running against a single cluster, instead, this does
+			// not matter much, because the two clients are identical.
+			srcList = append(srcList, testConnDisruptServerDeploymentName)
+			dstList = append(dstList, testConnDisruptClientDeploymentName)
+		}
 		if ct.ShouldRunConnDisruptNSTraffic() {
 			srcList = append(srcList, testConnDisruptServerNSTrafficDeploymentName)
 			dstList = append(dstList, ct.testConnDisruptClientNSTrafficDeploymentNames...)

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -50,20 +50,22 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 
 	restartCount := make(map[string]string)
 	for _, client := range ct.Clients() {
-		pods, err := client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisrupt})
-		if err != nil {
-			t.Fatalf("Unable to list test-conn-disrupt pods: %s", err)
-		}
-		if len(pods.Items) == 0 {
-			t.Fatal("No test-conn-disrupt-{client,server} pods found")
-		}
+		if ct.Params().IncludeConnDisruptTest {
+			pods, err := client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisrupt})
+			if err != nil {
+				t.Fatalf("Unable to list test-conn-disrupt pods: %s", err)
+			}
+			if len(pods.Items) == 0 {
+				t.Fatal("No test-conn-disrupt-{client,server} pods found")
+			}
 
-		for _, pod := range pods.Items {
-			restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+			for _, pod := range pods.Items {
+				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+			}
 		}
 
 		if ct.ShouldRunConnDisruptNSTraffic() {
-			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptNSTraffic})
+			pods, err := client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptNSTraffic})
 			if err != nil {
 				t.Fatalf("Unable to list test-conn-disrupt-ns-traffic pods: %s", err)
 			}
@@ -79,7 +81,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		}
 
 		if ct.ShouldRunConnDisruptL7Traffic() {
-			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptL7Traffic})
+			pods, err := client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptL7Traffic})
 			if err != nil {
 				t.Fatalf("Unable to list test-conn-disrupt-l7-traffic pods: %s", err)
 			}
@@ -95,7 +97,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		}
 
 		if ct.ShouldRunConnDisruptEgressGateway() {
-			pods, err = client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptEgressGateway})
+			pods, err := client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisruptEgressGateway})
 			if err != nil {
 				t.Fatalf("Unable to list test-conn-disrupt-egw pods: %s", err)
 			}


### PR DESCRIPTION
Refactor the conn-disrupt test framework so that each sub-test (EW traffic, NS traffic, L7 traffic, EGW) can be deployed and run independently without requiring --include-conn-disrupt-test as a base flag.

Additionally, introduce `CONN_DISRUPT_EXTRA_ARG` and `CONN_DISRUPT_EXTRA_TEST` environment variables in the CI actions to allow injecting additional conn-disrupt flags and test names.

Currently, running a single conn-disrupt sub-test (e.g., EGW only) still requires passing `--include-conn-disrupt-test` which deploys the conn-disrupt Pods for E/W traffic. This makes it difficult to run targeted conn-disrupt tests in downstream or feature-specific CI workflows without unnecessary overhead.