### PR TITLE
[v1.17] ipam: fix data race in MultiPoolManager node update

### DIFF
--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -477,7 +477,8 @@ func (m *multiPoolManager) isRestoreFinishedLocked(family Family) bool {
 
 func (m *multiPoolManager) updateCiliumNode(ctx context.Context) error {
 	m.mutex.Lock()
-	newNode := m.node.DeepCopy()
+	currentNode := m.node.DeepCopy()
+	newNode := currentNode.DeepCopy()
 	requested := []types.IPAMPoolRequest{}
 	allocated := []types.IPAMPoolAllocation{}
 
@@ -546,7 +547,7 @@ func (m *multiPoolManager) updateCiliumNode(ctx context.Context) error {
 
 	m.mutex.Unlock()
 
-	if !newNode.Spec.IPAM.DeepEqual(&m.node.Spec.IPAM) {
+	if !newNode.Spec.IPAM.DeepEqual(&currentNode.Spec.IPAM) {
 		_, err := m.nodeUpdater.Update(ctx, newNode, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to update node spec: %w", err)


### PR DESCRIPTION
Fixes #44869

## Summary
- avoid reading `m.node` after `updateCiliumNode()` releases `m.mutex`
- take a `DeepCopy()` snapshot of the current node while the lock is held
- compare and publish updates from that snapshot instead of the shared field

## Details
`ciliumNodeUpdated()` can replace `m.node` from the event loop while `updateCiliumNode()` is still preparing an update. In the `v1.17` code path, `updateCiliumNode()` released the lock and then compared `newNode.Spec.IPAM` against `m.node.Spec.IPAM`, which races with concurrent writes from `ciliumNodeUpdated()`.

This change snapshots `m.node` under lock using `DeepCopy()`, derives `newNode` from that snapshot, and performs the post-unlock comparison against the immutable snapshot instead of the shared field. The behavior stays the same, but the data race is removed.

## Testing
- `go test ./pkg/ipam -run '^Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc$' -count=200 -timeout 60s`
- `go test ./pkg/ipam -run '^Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc$' -count=50 -race -timeout 60s`
- `go test ./pkg/ipam -run '^Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc$' -count=10 -race -timeout 60s`
- `make lint`
