### PR TITLE
api: fix typo 'event occured' -> 'event occurred' in map_event

### DIFF
--- a/api/v1/models/map_event.go
+++ b/api/v1/models/map_event.go
@@ -28,7 +28,7 @@ type MapEvent struct {
 	// Enum: ["ok","insert","delete"]
 	DesiredAction string `json:"desired-action,omitempty"`
 
-	// Map key on which the event occured
+	// Map key on which the event occurred
 	Key string `json:"key,omitempty"`
 
 	// Last error seen while performing desired action
@@ -38,7 +38,7 @@ type MapEvent struct {
 	// Format: date-time
 	Timestamp strfmt.DateTime `json:"timestamp,omitempty"`
 
-	// Map value on which the event occured
+	// Map value on which the event occurred
 	Value string `json:"value,omitempty"`
 }
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3272,10 +3272,10 @@ definitions:
         type: string
         format: date-time
       key:
-        description: Map key on which the event occured
+        description: Map key on which the event occurred
         type: string
       value:
-        description: Map value on which the event occured
+        description: Map value on which the event occurred
         type: string
       action:
         description: Action type for event

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3880,7 +3880,7 @@ func init() {
           ]
         },
         "key": {
-          "description": "Map key on which the event occured",
+          "description": "Map key on which the event occurred",
           "type": "string"
         },
         "last-error": {
@@ -3893,7 +3893,7 @@ func init() {
           "format": "date-time"
         },
         "value": {
-          "description": "Map value on which the event occured",
+          "description": "Map value on which the event occurred",
           "type": "string"
         }
       }
@@ -9651,7 +9651,7 @@ func init() {
           ]
         },
         "key": {
-          "description": "Map key on which the event occured",
+          "description": "Map key on which the event occurred",
           "type": "string"
         },
         "last-error": {
@@ -9664,7 +9664,7 @@ func init() {
           "format": "date-time"
         },
         "value": {
-          "description": "Map value on which the event occured",
+          "description": "Map value on which the event occurred",
           "type": "string"
         }
       }


### PR DESCRIPTION
The Cilium API describes map events with "Map key on which the event **occured**" / "Map value on which the event **occured**". "occured" is a misspelling of "occurred".

### Changes

The fix is applied consistently to:

- `api/v1/openapi.yaml` — the source descriptions
- `api/v1/models/map_event.go` — generated model
- `api/v1/server/embedded_spec.go` — embedded copy

This keeps the generated code in sync with the spec. No behavioral change.