### PR TITLE
helm: do not set operator health port as hostPort when hostNetwork is disabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -189,7 +189,9 @@ spec:
         ports:
         - name: health
           containerPort: 9234
+        {{- if .Values.operator.hostNetwork }}
           hostPort: 9234
+        {{- end }}
         {{- if .Values.operator.prometheus.enabled }}
         - name: prometheus
           containerPort: {{ .Values.operator.prometheus.port }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #45385

```release-note
helm: do not set operator health port as hostPort when hostNetwork is disabled
```
