### PR TITLE
cilium-cli/connectivity: fix static route setup/teardown

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -821,7 +821,14 @@ func (ct *ConnectivityTest) requiresStaticRoutes() bool {
 	return true
 }
 
-func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.Context, verb string) error {
+type ipRouteVerb string
+
+const (
+	verbAdd ipRouteVerb = "add"
+	verbDel ipRouteVerb = "del"
+)
+
+func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.Context, verb ipRouteVerb) error {
 	if !ct.requiresStaticRoutes() {
 		ct.Debugf("Skipping modifying static route on nodes without Cilium, cloud platform has pod connectivity")
 		return nil
@@ -831,13 +838,18 @@ func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.
 		for withoutCilium := range ct.nodesWithoutCilium {
 			pod := ct.hostNetNSPodsByNode[withoutCilium]
 			_, err := ct.client.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, hostNetNSDeploymentNameNonCilium,
-				[]string{"ip", "route", verb, e.CIDR, "via", e.HostIP},
+				[]string{"ip", "route", string(verb), e.CIDR, "via", e.HostIP},
 			)
 			ct.Debugf("Modifying (%s) static route on nodes without Cilium (%v): %v",
 				verb, withoutCilium,
-				[]string{"ip", "route", verb, e.CIDR, "via", e.HostIP},
+				[]string{"ip", "route", string(verb), e.CIDR, "via", e.HostIP},
 			)
 			if err != nil {
+				if verb == verbDel {
+					// Ignore errors when deleting routes, as the route may not exist.
+					ct.Debugf("Ignoring error deleting static route: %v", err)
+					continue
+				}
 				return fmt.Errorf("failed to %s static route: %w", verb, err)
 			}
 		}
@@ -849,12 +861,9 @@ func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.
 // NeedsStaticRoutes checks whether any test requires static ip routes
 // installed.
 func (ct *ConnectivityTest) NeedsStaticRoutes() bool {
-	for _, t := range ct.tests {
-		if t.installIPRoutesFromOutsideToPodCIDRs {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(ct.tests, func(t *Test) bool {
+		return t.installIPRoutesFromOutsideToPodCIDRs
+	})
 }
 
 // SetupStaticRoutes idempotently sets up static routes for nodes without Cilium.
@@ -862,8 +871,8 @@ func (ct *ConnectivityTest) SetupStaticRoutes(ctx context.Context) error {
 	if !ct.NeedsStaticRoutes() {
 		return nil
 	}
-	ct.modifyStaticRoutesForNodesWithoutCilium(ctx, "del")
-	return ct.modifyStaticRoutesForNodesWithoutCilium(ctx, "add")
+	ct.modifyStaticRoutesForNodesWithoutCilium(ctx, verbDel)
+	return ct.modifyStaticRoutesForNodesWithoutCilium(ctx, verbAdd)
 }
 
 // TeardownStaticRoutes tears down static routes for nodes without Cilium.
@@ -871,7 +880,7 @@ func (ct *ConnectivityTest) TeardownStaticRoutes(ctx context.Context) error {
 	if !ct.NeedsStaticRoutes() {
 		return nil
 	}
-	return ct.modifyStaticRoutesForNodesWithoutCilium(ctx, "del")
+	return ct.modifyStaticRoutesForNodesWithoutCilium(ctx, verbDel)
 }
 
 // multiClusterClientLock protects K8S client instantiation (Scheme registration)

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -44,18 +44,6 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 	}
 	junitCollector := check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile, connTests[0].CodeOwners)
 
-	var finalize []func(context.Context)
-	for i := range suiteBuilders {
-		if connTests[i].NeedsStaticRoutes() {
-			connTests[i].SetupStaticRoutes(ctx)
-			finalize = append(finalize, func(ctx context.Context) {
-				if err := connTests[i].TeardownStaticRoutes(ctx); err != nil {
-				}
-			})
-			break
-		}
-	}
-
 	for i := range suiteBuilders {
 		if e := suiteBuilders[i](connTests, extra.AddConnectivityTests); e != nil {
 			return e
@@ -79,10 +67,11 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 			}
 			connTests[j].Cleanup()
 		}
-	}
-
-	for _, f := range finalize {
-		f(ctx)
+		for j := range connTests {
+			if e := connTests[j].TeardownStaticRoutes(ctx); e != nil {
+				err = errors.Join(err, e)
+			}
+		}
 	}
 
 	if err := junitCollector.Write(); err != nil {


### PR DESCRIPTION
Fix two bugs that combined to cause "RTNETLINK answers: File exists" errors in multi-cluster runs following single-cluster steps.

`TeardownStaticRoutes` was never called because the pre-loop checking `NeedsStaticRoutes()` ran before any suite builder, so ct.tests was always empty. Since `host-netns-non-cilium pods` use `HostNetwork: true`, routes survived pod restarts and accumulated across invocations. Fix by removing the dead pre-loop and calling `TeardownStaticRoutes` after each suite iteration.

`modifyStaticRoutesForNodesWithoutCilium` returned immediately on the first `ip route del` error. In multi-cluster mode after a single-cluster run, PodCIDRs contains entries from both clusters but only the source cluster's routes exist. Hence, hitting a remote-cluster CIDR aborted cleanup of local-cluster routes, causing the subsequent `ip route add` to fail with "File exists". Fix by continuing on `ip route del` errors instead of returning early.

While at it, also add a dedicated type for `ip route` verbs and use `slices.ContainsFunc` to simplify `NeedsStaticRoutes`.

Fixes: 01cd65cfc66e ("cli: connectivity tests: only setup/teardown static routes once.")