### PR TITLE
ci: add strict-mode-ingress WireGuard to both stable and newest config

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -343,6 +343,7 @@ jobs:
           encryption: ${{ matrix.encryption }}
           encryption-node: ${{ matrix.encryption-node }}
           encryption-strict-egress: ${{ matrix.encryption-strict-egress }}
+          encryption-strict-ingress: ${{ matrix.encryption-strict-ingress }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           mutual-auth: false


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/39239 landed already in v1.19, so it makes sense to add the strict-mode-ingress WireGuard configuration to both stable and newest CI configurations, so that we start testing upgrade/downgrade scenarios with this enabled as well.