### PR TITLE
clustermesh: fix eplicesync missing err check

### DIFF
--- a/pkg/clustermesh/endpointslicesync/client.go
+++ b/pkg/clustermesh/endpointslicesync/client.go
@@ -130,7 +130,10 @@ func (c meshClientEndpointSlice) List(ctx context.Context, opts metav1.ListOptio
 }
 func (c meshClientEndpointSlice) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	watchInterface, err := c.EndpointSliceInterface.Watch(ctx, opts)
-	return NewMeshEndpointSliceWatcher(watchInterface), err
+	if err != nil {
+		return nil, err
+	}
+	return NewMeshEndpointSliceWatcher(watchInterface), nil
 }
 
 // Pretty much a copy of watch.Streamwatcher but simplified to have another Streamwatcher


### PR DESCRIPTION
Before this commit we could be calling `NewMeshEndpointSliceWatcher` while `c.EndpointSliceInterface.Watch` was returning an error which could trigger a crash because `NewMeshEndpointSliceWatcher` trigger a goroutine that depends on the watchInterface being set.

Fixes #45396

```release-note
clustermesh: fails gracefully instead of crashing when EndpointSliceSync is not able to setup the EndpointSlice watch
```
