### PR TITLE
api/v1: fix 'occured' -> 'occurred' typos in MapEvent schema descriptions

### DIFF
--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3272,10 +3272,10 @@ definitions:
         type: string
         format: date-time
       key:
-        description: Map key on which the event occured
+        description: Map key on which the event occurred
         type: string
       value:
-        description: Map value on which the event occured
+        description: Map value on which the event occurred
         type: string
       action:
         description: Action type for event


### PR DESCRIPTION
Two `description` fields on the `MapEvent` schema in `api/v1/openapi.yaml` (lines 3275 and 3278) read `Map key/value on which the event occured`. Doc-only OpenAPI change; `yaml.safe_load` parses cleanly.