### PR TITLE
[v1.17] redirectpolicy: refuse addressMatcher override of existing service

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -160,6 +160,7 @@ cilium-agent [flags]
       --enable-l7-proxy                                           Enable L7 proxy for L7 policy enforcement (default true)
       --enable-local-node-route                                   Enable installation of the route which points the allocation prefix of the local node (default true)
       --enable-local-redirect-policy                              Enable Local Redirect Policy
+      --enable-lrp-address-matcher-override                       Re-enable the legacy behavior where a CiliumLocalRedirectPolicy addressMatcher can override an existing Service at the same frontend address. Only available on v1.17; newer releases always refuse an addressMatcher that conflicts with a Service.
       --enable-masquerade-to-route-source                         Masquerade packets to the source IP provided from the routing layer rather than interface address
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-nat46x64-gateway                                   Enable NAT46 and NAT64 gateway

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -291,6 +291,18 @@ communicating via the proxy must reconnect to re-establish connections.
 .. _1.17_upgrade_notes:
 
 
+1.17.16 Upgrade Notes
+---------------------
+
+* ``CiliumLocalRedirectPolicy`` with ``addressMatcher`` will no longer override an
+  existing Service at the same frontend address. Previously, such a policy could
+  hijack traffic intended for the conflicting Service (including across namespaces)
+  and, on deletion, would leave the Service without a service-map entry. Users
+  relying on the legacy behavior should migrate to ``serviceMatcher``. As a
+  transient compatibility knob, setting ``--enable-lrp-address-matcher-override=true``
+  restores the pre-fix behavior; this flag is only available on v1.17, as newer
+  releases always refuse such conflicts.
+
 1.17.4 Upgrade Notes
 --------------------
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -565,6 +565,13 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableLocalRedirectPolicy, false, "Enable Local Redirect Policy")
 	option.BindEnv(vp, option.EnableLocalRedirectPolicy)
 
+	flags.Bool(option.EnableLRPAddressMatcherOverride, false,
+		"Re-enable the legacy behavior where a CiliumLocalRedirectPolicy "+
+			"addressMatcher can override an existing Service at the same frontend "+
+			"address. Only available on v1.17; newer releases always refuse an "+
+			"addressMatcher that conflicts with a Service.")
+	option.BindEnv(vp, option.EnableLRPAddressMatcherOverride)
+
 	flags.Bool(option.EnableMKE, false, "Enable BPF kube-proxy replacement for MKE environments")
 	flags.MarkHidden(option.EnableMKE)
 	option.BindEnv(vp, option.EnableMKE)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -330,6 +330,13 @@ const (
 	// EnableLocalRedirectPolicy enables support for local redirect policy
 	EnableLocalRedirectPolicy = "enable-local-redirect-policy"
 
+	// EnableLRPAddressMatcherOverride re-enables the legacy behavior where a
+	// CiliumLocalRedirectPolicy addressMatcher can override an existing
+	// service at the given frontend address. This is unsafe (allows cross-
+	// namespace traffic hijacking and corrupts the service map on delete)
+	// and is provided only as a transient compatibility knob.
+	EnableLRPAddressMatcherOverride = "enable-lrp-address-matcher-override"
+
 	// EnableMKE enables MKE specific 'chaining' for kube-proxy replacement
 	EnableMKE = "enable-mke"
 
@@ -1947,6 +1954,12 @@ type DaemonConfig struct {
 	// EnableLocalRedirectPolicy enables redirect policies to redirect traffic within nodes
 	EnableLocalRedirectPolicy bool
 
+	// EnableLRPAddressMatcherOverride re-enables the legacy behavior where a
+	// CiliumLocalRedirectPolicy addressMatcher can override an existing
+	// service at the given frontend address. Unsafe; provided for backwards
+	// compatibility only.
+	EnableLRPAddressMatcherOverride bool
+
 	// NodePortMin is the minimum port address for the NodePort range
 	NodePortMin int
 
@@ -2914,6 +2927,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.CgroupPathMKE = vp.GetString(CgroupPathMKE)
 	c.EnableHostFirewall = vp.GetBool(EnableHostFirewall)
 	c.EnableLocalRedirectPolicy = vp.GetBool(EnableLocalRedirectPolicy)
+	c.EnableLRPAddressMatcherOverride = vp.GetBool(EnableLRPAddressMatcherOverride)
 	c.EncryptInterface = vp.GetStringSlice(EncryptInterface)
 	c.EncryptNode = vp.GetBool(EncryptNode)
 	c.IdentityChangeGracePeriod = vp.GetDuration(IdentityChangeGracePeriod)

--- a/pkg/redirectpolicy/manager.go
+++ b/pkg/redirectpolicy/manager.go
@@ -44,6 +44,9 @@ var (
 type svcManager interface {
 	DeleteService(frontend lb.L3n4Addr) (bool, error)
 	UpsertService(*lb.SVC) (bool, lb.ID, error)
+	UpsertServiceWithCheck(params *lb.SVC,
+		check func(existingType lb.SVCType) bool,
+	) (bool, lb.ID, error)
 	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr)
 }
 
@@ -780,7 +783,25 @@ func (rpm *Manager) upsertService(config *LRPConfig, frontendMapping *feMapping)
 		LoadBalancerAlgorithm: loadBalancerAlgorithm,
 	}
 
-	if _, _, err := rpm.svcManager.UpsertService(p); err != nil {
+	var err error
+	if config.lrpType == lrpConfigTypeAddr && !option.Config.EnableLRPAddressMatcherOverride {
+		_, _, err = rpm.svcManager.UpsertServiceWithCheck(p,
+			func(existingType lb.SVCType) bool {
+				if existingType == lb.SVCTypeLocalRedirect {
+					return true
+				}
+				log.WithFields(logrus.Fields{
+					logfields.LRPName:      config.id.Name,
+					logfields.K8sNamespace: config.id.Namespace,
+					logfields.ServiceType:  existingType,
+					logfields.LRPFrontends: frontendMapping.feAddr,
+				}).Warn("LocalRedirectPolicy addressMatcher matches an address owned by an existing service; refusing to override")
+				return false
+			})
+	} else {
+		_, _, err = rpm.svcManager.UpsertService(p)
+	}
+	if err != nil {
 		if errors.Is(err, service.NewErrLocalRedirectServiceExists(p.Frontend, p.Name)) {
 			log.WithError(err).Debug("Error while inserting service in LB map")
 		} else {

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -87,6 +87,9 @@ func setupManagerSuite(tb testing.TB) *ManagerSuite {
 type fakeSvcManager struct {
 	upsertEvents            chan *lb.SVC
 	destroyConnectionEvents chan lb.L3n4Addr
+	// existingFrontendTypes returns the SVCType registered for a given
+	// frontend address. A nil map means no frontends are registered.
+	existingFrontendTypes map[string]lb.SVCType
 }
 
 func (f *fakeSvcManager) DeleteService(lb.L3n4Addr) (bool, error) {
@@ -98,6 +101,17 @@ func (f *fakeSvcManager) UpsertService(s *lb.SVC) (bool, lb.ID, error) {
 		f.upsertEvents <- s
 	}
 	return true, 1, nil
+}
+
+func (f *fakeSvcManager) UpsertServiceWithCheck(s *lb.SVC,
+	check func(existingType lb.SVCType) bool,
+) (bool, lb.ID, error) {
+	if existingType, ok := f.existingFrontendTypes[s.Frontend.Hash()]; ok {
+		if !check(existingType) {
+			return false, 0, nil
+		}
+	}
+	return f.UpsertService(s)
 }
 
 func (f *fakeSvcManager) TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr) {
@@ -366,6 +380,126 @@ func TestManager_AddRedirectPolicy_AddrMatcherDuplicateConfig(t *testing.T) {
 
 	require.False(t, added)
 	require.Error(t, err)
+}
+
+// Tests that upsertService skips the UpsertService call for an addressMatcher
+// policy when the frontend is already owned by another service (e.g. a
+// Kubernetes Service's ClusterIP). This guards against cross-namespace traffic
+// hijacking and the service-state corruption on deletion
+func TestManager_UpsertService_AddrMatcherFrontendOwnedByAnotherService(t *testing.T) {
+	m := setupManagerSuite(t)
+
+	upsertEvents := make(chan *lb.SVC, 1)
+	m.rpm.svcManager = &fakeSvcManager{
+		upsertEvents: upsertEvents,
+		existingFrontendTypes: map[string]lb.SVCType{
+			fe1.Hash(): lb.SVCTypeClusterIP,
+		},
+	}
+
+	feM := &feMapping{
+		feAddr: fe1,
+		fePort: portName1,
+		podBackends: []backend{{
+			L3n4Addr: lb.L3n4Addr{
+				AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+				L4Addr:      beP1.l4Addr,
+			},
+			podID: pod1ID,
+		}},
+	}
+
+	m.rpm.upsertService(&configAddrType, feM)
+
+	select {
+	case svc := <-upsertEvents:
+		t.Fatalf("UpsertService should not have been called; got %v", svc)
+	default:
+	}
+}
+
+// Tests that the EnableLRPAddressMatcherOverride compatibility flag restores
+// the legacy behavior: when set, upsertService proceeds to override an
+// existing service frontend.
+func TestManager_UpsertService_AddrMatcherOverrideFlag(t *testing.T) {
+	m := setupManagerSuite(t)
+
+	prev := option.Config.EnableLRPAddressMatcherOverride
+	option.Config.EnableLRPAddressMatcherOverride = true
+	t.Cleanup(func() { option.Config.EnableLRPAddressMatcherOverride = prev })
+
+	upsertEvents := make(chan *lb.SVC, 1)
+	m.rpm.svcManager = &fakeSvcManager{
+		upsertEvents: upsertEvents,
+		existingFrontendTypes: map[string]lb.SVCType{
+			fe1.Hash(): lb.SVCTypeClusterIP,
+		},
+	}
+
+	feM := &feMapping{
+		feAddr: fe1,
+		fePort: portName1,
+		podBackends: []backend{{
+			L3n4Addr: lb.L3n4Addr{
+				AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+				L4Addr:      beP1.l4Addr,
+			},
+			podID: pod1ID,
+		}},
+	}
+
+	m.rpm.upsertService(&configAddrType, feM)
+
+	select {
+	case svc := <-upsertEvents:
+		require.Equal(t, lb.SVCTypeLocalRedirect, svc.Type)
+		require.Equal(t, lb.ServiceName{
+			Name:      configAddrType.id.Name + localRedirectSvcStr,
+			Namespace: configAddrType.id.Namespace,
+		}, svc.Name)
+	default:
+		t.Fatal("UpsertService should have been called when override flag is set")
+	}
+}
+
+// Tests that upsertService proceeds for an addressMatcher policy when the
+// frontend is already owned by the policy's own LocalRedirect pseudo-service
+// (e.g. re-processing on pod events).
+func TestManager_UpsertService_AddrMatcherFrontendOwnedBySelf(t *testing.T) {
+	m := setupManagerSuite(t)
+
+	upsertEvents := make(chan *lb.SVC, 1)
+	m.rpm.svcManager = &fakeSvcManager{
+		upsertEvents: upsertEvents,
+		existingFrontendTypes: map[string]lb.SVCType{
+			fe1.Hash(): lb.SVCTypeLocalRedirect,
+		},
+	}
+
+	feM := &feMapping{
+		feAddr: fe1,
+		fePort: portName1,
+		podBackends: []backend{{
+			L3n4Addr: lb.L3n4Addr{
+				AddrCluster: cmtypes.MustParseAddrCluster("10.0.0.1"),
+				L4Addr:      beP1.l4Addr,
+			},
+			podID: pod1ID,
+		}},
+	}
+
+	m.rpm.upsertService(&configAddrType, feM)
+
+	select {
+	case svc := <-upsertEvents:
+		require.Equal(t, lb.SVCTypeLocalRedirect, svc.Type)
+		require.Equal(t, lb.ServiceName{
+			Name:      configAddrType.id.Name + localRedirectSvcStr,
+			Namespace: configAddrType.id.Namespace,
+		}, svc.Name)
+	default:
+		t.Fatal("UpsertService should have been called")
+	}
 }
 
 // Tests if duplicate svcMatcher configs are not added.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -699,6 +699,34 @@ func (s *Service) UpsertService(params *lb.SVC) (bool, lb.ID, error) {
 	return s.upsertService(params)
 }
 
+// UpsertServiceWithCheck upserts the given service. If a service is already
+// registered at the frontend, `check` is called with its SVCType and the
+// upsert proceeds only if it returns true. When the frontend is unused the
+// upsert proceeds unconditionally. The check and the upsert run under the
+// service manager's write lock, so no concurrent upsert can interleave
+// between the decision and the update.
+func (s *Service) UpsertServiceWithCheck(params *lb.SVC,
+	check func(existingType lb.SVCType) bool,
+) (bool, lb.ID, error) {
+	s.Lock()
+	defer s.Unlock()
+	// Mirror createSVCInfoIfNotExist's lookup: first consult the protocol-
+	// agnostic ("ANY") entry for backwards compatibility with services
+	// persisted prior to protocol differentiation, falling back to the
+	// protocol-specific entry. Deep-copy the frontend so we don't mutate
+	// the caller's params.
+	fe := params.Frontend.DeepCopy()
+	fe.L3n4Addr.L4Addr.Protocol = "ANY"
+	existing, found := s.svcByHash[fe.Hash()]
+	if !found {
+		existing, found = s.svcByHash[params.Frontend.Hash()]
+	}
+	if found && !check(existing.svcType) {
+		return false, lb.ID(0), nil
+	}
+	return s.upsertService(params)
+}
+
 // reUpsertServicesByName upserts a service again to update it's internal state after
 // changes for L7 service redirection.
 // Write lock on 's' must be held.

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -81,6 +81,16 @@ type ServiceManager interface {
 	// UpsertService inserts or updates the given service.
 	UpsertService(*lb.SVC) (bool, lb.ID, error)
 
+	// UpsertServiceWithCheck upserts the given service. If a service is
+	// already registered at the frontend, `check` is called with its
+	// SVCType and the upsert proceeds only if it returns true. When the
+	// frontend is unused the upsert proceeds unconditionally. The check
+	// and the upsert run under a single write lock, so the decision is
+	// atomic with respect to concurrent upserts.
+	UpsertServiceWithCheck(params *lb.SVC,
+		check func(existingType lb.SVCType) bool,
+	) (bool, lb.ID, error)
+
 	// TerminateUDPConnectionsToBackend terminates UDP connections to the passed
 	// backend with address when socket-LB is enabled.
 	TerminateUDPConnectionsToBackend(l3n4Addr *lb.L3n4Addr)


### PR DESCRIPTION
A CiliumLocalRedirectPolicy using addressMatcher with an existing Service's ClusterIP installs a LocalRedirect pseudo-service at the same frontend and overwrites the ClusterIP entry in the service map. This bypasses the namespace-scoping that serviceMatcher enforces and lets a policy in one namespace hijack traffic for a Service in another. On policy deletion the original ClusterIP is not restored (unlike serviceMatcher, which calls svcCache.EnsureService), so the Service is left with no map entry and service translation breaks entirely.

Before upserting the LocalRedirect, look up the service type at the target frontend and skip the upsert if a non-LocalRedirect service already owns it. The LRP always installs a LocalRedirect-type entry, so a re-upsert of the same LRP (pod events, re-sync) still succeeds via type match.

For backwards compatibility, add `--enable-lrp-address-matcher-override` flag (default false) that restores the pre-fix behavior.


```release-note
CiliumLocalRedirectPolicy addressMatcher now refuses to override an existing Service's frontend (prevents cross-namespace traffic hijacking and service-map corruption on policy delete); set `--enable-lrp-address-matcher-override=true` to restore the legacy behavior. 
```
