### PR TITLE
loadbalancer/maps: avoid unnecessary `DeepCopyInto` in `GetPrefix` methods

### DIFF
--- a/pkg/loadbalancer/maps/types.go
+++ b/pkg/loadbalancer/maps/types.go
@@ -1197,9 +1197,7 @@ func (k *SourceRangeKey4) ToHost() SourceRangeKey {
 }
 
 func (k *SourceRangeKey4) GetPrefix() netip.Prefix {
-	var ip types.IPv4
-	k.Address.DeepCopyInto(&ip)
-	return netip.PrefixFrom(ip.Addr(), int(k.PrefixLen)-lpmPrefixLen4)
+	return netip.PrefixFrom(k.Address.Addr(), int(k.PrefixLen)-lpmPrefixLen4)
 }
 
 func (k *SourceRangeKey4) GetRevNATID() loadbalancer.ServiceID {
@@ -1236,9 +1234,7 @@ func (k *SourceRangeKey6) ToHost() SourceRangeKey {
 }
 
 func (k *SourceRangeKey6) GetPrefix() netip.Prefix {
-	var ip types.IPv6
-	k.Address.DeepCopyInto(&ip)
-	return netip.PrefixFrom(ip.Addr(), int(k.PrefixLen)-lpmPrefixLen6)
+	return netip.PrefixFrom(k.Address.Addr(), int(k.PrefixLen)-lpmPrefixLen6)
 }
 
 func (k *SourceRangeKey6) GetRevNATID() loadbalancer.ServiceID {

--- a/pkg/types/ipv4.go
+++ b/pkg/types/ipv4.go
@@ -20,11 +20,6 @@ func (v4 IPv4) String() string {
 	return v4.Addr().String()
 }
 
-// DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
-func (v4 *IPv4) DeepCopyInto(out *IPv4) {
-	copy(out[:], v4[:])
-}
-
 // FromAddr will populate the receiver with the specified address if and only
 // if the provided address is a valid IPv4 address. Any other address,
 // including the "invalid ip" value netip.Addr{} will zero the receiver.

--- a/pkg/types/ipv6.go
+++ b/pkg/types/ipv6.go
@@ -25,11 +25,6 @@ func (v6 IPv6) String() string {
 	return v6.Addr().String()
 }
 
-// DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
-func (v6 *IPv6) DeepCopyInto(out *IPv6) {
-	copy(out[:], v6[:])
-}
-
 // FromAddr will populate the receiver with the specified address if and only
 // if the provided address is a valid IPv6 address. Any other address,
 // including the "invalid ip" value netip.Addr{} will zero the receiver.

--- a/pkg/types/macaddr.go
+++ b/pkg/types/macaddr.go
@@ -3,9 +3,7 @@
 
 package types
 
-import (
-	"net"
-)
+import "net"
 
 // MACAddr is the binary representation for encoding in binary structs.
 type MACAddr [6]byte
@@ -16,9 +14,4 @@ func (addr MACAddr) hardwareAddr() net.HardwareAddr {
 
 func (addr MACAddr) String() string {
 	return addr.hardwareAddr().String()
-}
-
-// DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
-func (addr *MACAddr) DeepCopyInto(out *MACAddr) {
-	copy(out[:], addr[:])
 }


### PR DESCRIPTION
There is no need to deep-copy the address before constructing the prefix, `netip.Addr` that is used to construct the `netip.Prefix` is directly assignable.

This allows to remove the now unused `types.IPv{4,6}.DeepCopyInto` methods along with the already unused `types.MACAddr.DeepCopyInto`.