### PR TITLE
logging: replace pipe-based klog bridge with `klog.SetSlogLogger`

### DIFF
--- a/pkg/logging/klog_bridge.go
+++ b/pkg/logging/klog_bridge.go
@@ -4,20 +4,16 @@
 package logging
 
 import (
-	"bufio"
-	"flag"
-	"fmt"
-	"io"
+	"context"
 	"log/slog"
 	"regexp"
-	"strings"
 
 	"k8s.io/klog/v2"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-var klogErrorOverrides = []logLevelOverride{
+var klogOverrides = []logLevelOverride{
 	{
 		// TODO: We can drop this once bumped to new client-go version which has this at info level:
 		// https://github.com/kubernetes/client-go/commit/ea7a7e7cf9697850f17631f79ef4ef45b95c449e.
@@ -26,157 +22,56 @@ var klogErrorOverrides = []logLevelOverride{
 	},
 }
 
-func initializeKLog(logger *slog.Logger) error {
-	log := logger.With(logfields.LogSubsys, "klog")
-
-	// Create a new flag set and set error handler
-	klogFlags := flag.NewFlagSet("cilium", flag.ExitOnError)
-
-	// Make sure that klog logging variables are initialized so that we can
-	// update them from this file.
-	klog.InitFlags(klogFlags)
-
-	// Make sure klog does not log to stderr as we want it to control the output
-	// of klog so we want klog to log the errors to each writer of each level.
-	klogFlags.Set("logtostderr", "false")
-
-	// Cilium logger already prints the headers
-	klogFlags.Set("skip_headers", "true")
-
-	infoWriter, err := severityOverrideWriter(slog.LevelInfo, log, nil)
-	if err != nil {
-		return fmt.Errorf("failed to setup klog error writer: %w", err)
-	}
-	warnWriter, err := severityOverrideWriter(slog.LevelWarn, log, nil)
-	if err != nil {
-		return fmt.Errorf("failed to setup klog error writer: %w", err)
-	}
-	errWriter, err := severityOverrideWriter(slog.LevelError, log, klogErrorOverrides)
-	if err != nil {
-		return fmt.Errorf("failed to setup klog error writer: %w", err)
-	}
-	fatalWriter, err := severityOverrideWriter(LevelPanic, log, nil)
-	if err != nil {
-		return fmt.Errorf("failed to setup klog error writer: %w", err)
-	}
-
-	klog.SetOutputBySeverity("INFO", infoWriter)
-	klog.SetOutputBySeverity("WARNING", warnWriter)
-	klog.SetOutputBySeverity("ERROR", errWriter)
-	klog.SetOutputBySeverity("FATAL", fatalWriter)
-
-	// Do not repeat log messages on all severities in klog
-	klogFlags.Set("one_output", "true")
-
-	return nil
-}
-
 type logLevelOverride struct {
 	matcher     *regexp.Regexp
 	targetLevel slog.Level
 }
 
-func levelToPrintFunc(log *slog.Logger, level slog.Level) (func(msg string, args ...any), error) {
-	var printFunc func(msg string, args ...any)
-	switch level {
-	case slog.LevelInfo:
-		printFunc = log.Info
-	case slog.LevelWarn:
-		printFunc = log.Warn
-	case slog.LevelError:
-		printFunc = log.Error
-	case LevelPanic:
-		printFunc = func(msg string, args ...any) {
-			Panic(log, msg, args)
-		}
-	case LevelFatal:
-		printFunc = func(msg string, args ...any) {
-			Fatal(log, msg, args)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported log level %q", level)
-	}
-	return printFunc, nil
+// klogOverrideHandler is an slog.Handler that adds a "subsys" attribute and
+// applies log level overrides based on regex patterns matching the log message.
+// It wraps an underlying slog.Handler and delegates all actual output to it.
+type klogOverrideHandler struct {
+	inner     slog.Handler
+	overrides []logLevelOverride
 }
 
-func severityOverrideWriter(level slog.Level, log *slog.Logger, overrides []logLevelOverride) (*io.PipeWriter, error) {
-	printFunc, err := levelToPrintFunc(log, level)
-	if err != nil {
-		return nil, err
-	}
-	reader, writer := io.Pipe()
-
-	for _, override := range overrides {
-		_, err := levelToPrintFunc(log, override.targetLevel)
-		if err != nil {
-			return nil, fmt.Errorf("failed to validate klog matcher level overrides (%s -> %s): %w",
-				override.matcher.String(), level, err)
-		}
-	}
-	go writerScanner(log, reader, printFunc, overrides)
-	return writer, nil
+func (h *klogOverrideHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	// Always return true for levels at or above the minimum override target,
+	// because a message at a higher level might get overridden down to a lower
+	// level that the inner handler still accepts. In practice the inner handler
+	// does the final filtering so this is safe.
+	return h.inner.Enabled(ctx, level)
 }
 
-// writerScanner scans the input from the reader and writes it to the appropriate
-// log print func.
-// In cases where the log message is overridden, that will be emitted via the specified
-// target log level logger function.
-//
-// Based on code from logrus WriterLevel implementation [1]
-//
-// [1] https://github.com/sirupsen/logrus/blob/v1.9.3/writer.go#L66-L97
-func writerScanner(
-	entry *slog.Logger,
-	reader *io.PipeReader,
-	defaultPrintFunc func(msg string, args ...any),
-	overrides []logLevelOverride) {
-
-	defer reader.Close()
-
-	scanner := bufio.NewScanner(reader)
-
-	// Set the buffer size to the maximum token size to avoid buffer overflows
-	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), bufio.MaxScanTokenSize)
-
-	// Define a split function to split the input into chunks of up to 64KB
-	chunkSize := bufio.MaxScanTokenSize // 64KB
-	splitFunc := func(data []byte, atEOF bool) (int, []byte, error) {
-		if len(data) >= chunkSize {
-			return chunkSize, data[:chunkSize], nil
-		}
-
-		return bufio.ScanLines(data, atEOF)
-	}
-
-	// Use the custom split function to split the input
-	scanner.Split(splitFunc)
-
-	// Scan the input and write it to the logger using the specified print function
-	for scanner.Scan() {
-		line := scanner.Text()
-		matched := false
-		for _, override := range overrides {
-			printFn, err := levelToPrintFunc(entry, override.targetLevel)
-			if err != nil {
-				entry.Error("BUG: failed to get printer for klog override matcher",
-					logfields.Error, err,
-					logfields.Matcher, override.matcher,
-				)
-				continue
-			}
-			if override.matcher.FindString(line) != "" {
-				printFn(strings.TrimRight(line, "\r\n"))
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			defaultPrintFunc(strings.TrimRight(scanner.Text(), "\r\n"))
+func (h *klogOverrideHandler) Handle(ctx context.Context, record slog.Record) error {
+	for _, override := range h.overrides {
+		if override.matcher.MatchString(record.Message) {
+			record.Level = override.targetLevel
+			break
 		}
 	}
+	return h.inner.Handle(ctx, record)
+}
 
-	if err := scanner.Err(); err != nil {
-		entry.Error("klog slog override scanner stopped scanning with an error. "+
-			"This may mean that k8s client-go logs will no longer be emitted", logfields.Error, err)
+func (h *klogOverrideHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &klogOverrideHandler{
+		inner:     h.inner.WithAttrs(attrs),
+		overrides: h.overrides,
 	}
+}
+
+func (h *klogOverrideHandler) WithGroup(name string) slog.Handler {
+	return &klogOverrideHandler{
+		inner:     h.inner.WithGroup(name),
+		overrides: h.overrides,
+	}
+}
+
+func initializeKLog(logger *slog.Logger) {
+	log := logger.With(logfields.LogSubsys, "klog")
+	handler := &klogOverrideHandler{
+		inner:     log.Handler(),
+		overrides: klogOverrides,
+	}
+	klog.SetSlogLogger(slog.New(handler))
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -135,12 +135,10 @@ func SetupLogging(loggers []string, logOpts LogOptions, tag string, debug bool) 
 
 	lock.SetLogger(DefaultSlogLogger)
 
-	// Bridge klog to slog. Note that this will open multiple pipes and fork
-	// background goroutines that are not cleaned up.
-	err := initializeKLog(DefaultSlogLogger)
-	if err != nil {
-		return err
-	}
+	// Bridge klog to slog so that all klog output (from client-go, etc.)
+	// flows through Cilium's configured slog handler with proper structured
+	// fields instead of being serialized to text.
+	initializeKLog(DefaultSlogLogger)
 
 	return nil
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -5,12 +5,12 @@ package logging
 
 import (
 	"bytes"
-	"flag"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,52 +60,90 @@ func TestSetDefaultLogLevel(t *testing.T) {
 	require.Equal(t, DefaultLogLevel, GetSlogLevel(DefaultSlogLogger))
 }
 
-func TestSetupLogging2(t *testing.T) {
+func TestKlogBridgeLevelOverrides(t *testing.T) {
 	var out bytes.Buffer
 	logger := slog.New(
-		slog.NewTextHandler(&out,
+		slog.NewJSONHandler(&out,
 			&slog.HandlerOptions{
 				ReplaceAttr: ReplaceAttrFnWithoutTimestamp,
 			},
 		),
 	)
-	log := logger.With(logfields.LogSubsys, "logging-test")
+	log := logger.With(logfields.LogSubsys, "klog")
+
 	overrides := []logLevelOverride{
 		{
 			matcher:     regexp.MustCompile("^please override (this|foo)!$"),
 			targetLevel: slog.LevelInfo,
 		},
 	}
-	errWriter, err := severityOverrideWriter(slog.LevelError, log, overrides)
-	assert.NoError(t, err)
+	handler := &klogOverrideHandler{
+		inner:     log.Handler(),
+		overrides: overrides,
+	}
+	klog.SetSlogLogger(slog.New(handler))
 
-	klogFlags := flag.NewFlagSet("cilium", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-	klogFlags.Set("logtostderr", "false")
-	klogFlags.Set("skip_headers", "true")
-	klogFlags.Set("one_output", "true")
-
-	klog.SetOutputBySeverity("ERROR", errWriter)
-	klog.SetOutputBySeverity("INFO", &out)
-	klog.Error("please do not override this!")
-	klog.Error("please override this!")
-	klog.Error("please override foo!")
-	klog.Error("final log")
+	klog.ErrorS(nil, "please do not override this!")
+	klog.ErrorS(nil, "please override this!")
+	klog.ErrorS(nil, "please override foo!")
+	klog.ErrorS(fmt.Errorf("something failed"), "final log", "key", "value")
 	klog.Flush()
-	var lines []string
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		logout := strings.Trim(out.String(), "\n")
-		lines = strings.Split(logout, "\n")
-		assert.Len(collect, lines, 4)
-	}, time.Second, time.Millisecond*50)
+
+	logout := strings.Trim(out.String(), "\n")
+	lines := strings.Split(logout, "\n")
+	require.Len(t, lines, 4)
+
 	for _, line := range lines {
-		if strings.Contains(line, "please override this!") || strings.Contains(line, "please override foo!") {
-			assert.Contains(t, line, "level=info")
-		} else {
-			assert.Contains(t, line, "level=error")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+
+		msg, _ := entry["msg"].(string)
+		level, _ := entry["level"].(string)
+
+		// Verify subsys is propagated
+		assert.Equal(t, "klog", entry[logfields.LogSubsys])
+
+		switch {
+		case msg == "please override this!" || msg == "please override foo!":
+			assert.Equal(t, "info", level, "overridden messages should be info, got line: %s", line)
+		case msg == "please do not override this!":
+			assert.Equal(t, "error", level, "non-overridden error should stay error, got line: %s", line)
+		case msg == "final log":
+			assert.Equal(t, "error", level, "non-overridden error should stay error, got line: %s", line)
+			assert.Equal(t, "value", entry["key"], "structured key-value pairs should be preserved")
+			assert.Equal(t, "something failed", entry[logfields.Error], "error should be preserved as a structured field")
 		}
 	}
+}
 
+func TestKlogBridgeStructuredFields(t *testing.T) {
+	var out bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(&out,
+			&slog.HandlerOptions{
+				ReplaceAttr: ReplaceAttrFnWithoutTimestamp,
+			},
+		),
+	)
+
+	log := logger.With(logfields.LogSubsys, "klog")
+	handler := &klogOverrideHandler{
+		inner:     log.Handler(),
+		overrides: nil,
+	}
+	klog.SetSlogLogger(slog.New(handler))
+
+	klog.InfoS("test message", "pod", "my-pod", "namespace", "default")
+	klog.Flush()
+
+	logout := strings.Trim(out.String(), "\n")
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(logout), &entry))
+
+	assert.Equal(t, "test message", entry["msg"])
+	assert.Equal(t, "my-pod", entry["pod"])
+	assert.Equal(t, "default", entry["namespace"])
+	assert.Equal(t, "klog", entry[logfields.LogSubsys])
 }
 
 func TestSetupLogging(t *testing.T) {


### PR DESCRIPTION
The current klog bridge uses `SetOutputBySeverity` with `io.Pipe` writers and a line scanner to capture klog text output and feed it to slog.
This has two problems:
* klog's default `stderrThreshold` (`ERROR`) causes `ERROR`/`FATAL` messages to be written directly to `os.Stderr` in raw text format, bypassing slog entirely and producing non-JSON output even when JSON logging is configured.
* All structured key-value pairs from klog's structured logging API (used by `client-go` via `klog.FromContext(ctx)`) get serialized to text by klog's `printS` before reaching the bridge, then passed as a single opaque message string to slog, losing all structure.

Here's what those logs look like today:
```json
"Server rejected event (will not retry!)" err="Too many requests: limit reached on type Server for key " event="&Event{ObjectMeta:{redacted-tester-29605890-hr4lq.18a6e002c2da1804  redacted    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Pod,Namespace:redacted,Name:redacted-tester-29605890-hr4lq,UID:,APIVersion:v1,ResourceVersion:,FieldPath:,},Reason:PacketDrop,Message:Incoming packet dropped (policy_denied) from 10.0.XX.YY TCP/8080. Applied policies: CiliumNetworkPolicy/redacted-tester. Applied clusterwide policies: CiliumClusterwideNetworkPolicy/redacted.,Source:EventSource{Component:cilium,Host:,},FirstTimestamp:2026-04-16 15:30:05.507868676 +0000 UTC m=+56305.633461717,LastTimestamp:2026-04-16 15:30:05.507868676 +0000 UTC m=+56305.633461717,Count:1,Type:Warning,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:,ReportingInstance:,}"
{"time":"2026-04-16T15:30:05.511972567Z","level":"error","msg":"\"Server rejected event (will not retry!)\" err=\"Too many requests: limit reached on type Server for key \" event=\"&Event{ObjectMeta:{redacted-tester-29605890-hr4lq.18a6e002c2da1804  redacted    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Pod,Namespace:redacted,Name:redacted-tester-29605890-hr4lq,UID:,APIVersion:v1,ResourceVersion:,FieldPath:,},Reason:PacketDrop,Message:Incoming packet dropped (policy_denied) from 10.0.XX.YY TCP/8080. Applied policies: CiliumNetworkPolicy/redacted-tester. Applied clusterwide policies: CiliumClusterwideNetworkPolicy/redacted.,Source:EventSource{Component:cilium,Host:,},FirstTimestamp:2026-04-16 15:30:05.507868676 +0000 UTC m=+56305.633461717,LastTimestamp:2026-04-16 15:30:05.507868676 +0000 UTC m=+56305.633461717,Count:1,Type:Warning,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:,ReportingInstance:,}\"","subsys":"klog"}
```

Here's that second log line pretty-printed to show that the klog
attributes are not structured into fields:
```json
{
  "time": "2026-04-16T15:30:05.511972567Z",
  "level": "error",
  "msg": "\"Server rejected event (will not retry!)\" err=\"Too many requests: limit reached on type Server for key \" event=\"&Event{ObjectMeta:{redacted-tester-29605890-hr4lq.18a6e002c2da1804  redacted    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] [] []},InvolvedObject:ObjectReference{Kind:Pod,Namespace:redacted,Name:redacted-tester-29605890-hr4lq,UID:,APIVersion:v1,ResourceVersion:,FieldPath:,},Reason:PacketDrop,Message:Incoming packet dropped (policy_denied) from 10.0.XX.YY TCP/8080. Applied policies: CiliumNetworkPolicy/redacted-tester. Applied clusterwide policies: CiliumClusterwideNetworkPolicy/redacted.,Source:EventSource{Component:cilium,Host:,},FirstTimestamp:2026-04-16 15:30:05.507868676 +0000 UTC m=+56305.633461717,LastTimestamp:2026-04-16 15:30:05.507868676 +0000 UTC m=+56305.633461717,Count:1,Type:Warning,EventTime:0001-01-01 00:00:00 +0000 UTC,Series:nil,Action:,Related:nil,ReportingController:,ReportingInstance:,}\"",
  "subsys": "klog"
}
```

This PR replaces the manual pipe based bridge with klog's [`SetSlogLogger()`](https://pkg.go.dev/k8s.io/klog/v2#SetSlogLogger), which sets an slog-backed `logr.Logger` as klog's global logger with `ContextualLogger(true)`. This makes `klog.FromContext()` return the slog-backed logger directly, so structured calls (`ErrorS`, `InfoS`, `FromContext().Error()`) pass message, error, and key-value pairs as proper slog attributes without any text serialization step. Old-style unstructured calls (`klog.Error()`, etc.) also route through the logger, eliminating the stderr leak.

The log level override mechanism (regex-based level rewriting for specific klog messages) is preserved via a thin `klogOverrideHandler` that wraps the underlying `slog.Handler`.