### PR TITLE
wireguard: clamp interface MTU to IPV6_MIN_MTU when IPv6 is enabled

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -295,6 +295,9 @@ const (
 	// MTU is the maximum transmission unit of one interface
 	MTU = "mtu"
 
+	// MinMTU is the minimum MTU allowed for an interface
+	MinMTU = "minMTU"
+
 	// Interface is an interface id/name on the system
 	Interface = "interface"
 

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -65,6 +65,12 @@ const (
 	//      Total extra bytes:         80B
 	WireguardOverhead = 80
 
+	// IPv6MinMTU is the minimum MTU required for IPv6 to function on a
+	// network interface, as defined in RFC 8200 section 5. The Linux kernel
+	// refuses to initialize inet6_dev on interfaces with MTU below this
+	// value, causing all IPv6 packet reception to be silently discarded.
+	IPv6MinMTU = 1280
+
 	// IPIPv4Overhead is the overhead for the IPv4 header used in IPIP devices.
 	// sizeof(struct iphdr)
 	IPIPv4Overhead = 20

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -330,6 +330,14 @@ func (a *Agent) mtuReconciler(ctx context.Context, health cell.Health) error {
 
 			linkMTU := mtuRoute.DeviceMTU - mtu.WireguardOverhead
 
+			if a.config.EnableIPv6 && linkMTU < mtu.IPv6MinMTU {
+				a.logger.Warn("Requested link MTU is below the minimum value, clamping",
+					logfields.MTU, linkMTU,
+					logfields.MinMTU, mtu.IPv6MinMTU,
+				)
+				linkMTU = mtu.IPv6MinMTU
+			}
+
 			if link.Attrs().MTU != linkMTU {
 				if err = netlink.LinkSetMTU(link, linkMTU); err != nil {
 					health.Degraded("failed to set WireGuard link mtu", err)


### PR DESCRIPTION
## Description

When WireGuard encryption is enabled with IPv6, the `mtuReconciler` sets
`cilium_wg0` MTU = `DeviceMTU - WireguardOverhead(80)`. If `DeviceMTU` is
sufficiently low, the resulting MTU falls below 1280 (`IPV6_MIN_MTU` per RFC
8200 section 5).

The Linux kernel's `addrconf` module refuses to initialize `inet6_dev` on
interfaces with MTU < 1280. Without `inet6_dev`, `ipv6_rcv()` silently discards
all received IPv6 packets, incrementing `Ip6InDiscards`. This causes 100%
cross-node packet loss in tunnel+WireGuard mode with IPv6, despite WireGuard
successfully encrypting and decrypting packets.

Clamp the WireGuard interface MTU to `IPv6MinMTU` (1280) when `EnableIPv6` is
true.

Fixes: #45423

Backport PR to v1.19: #45424

```release-note
wireguard: clamp cilium_wg0 MTU to IPV6_MIN_MTU (1280) when IPv6 is enabled, preventing silent packet loss in tunnel+encryption mode with constrained path MTU
```