### PR TITLE
operator/ztunnel: fix flaky enrollment reconciler Start tests

### DIFF
--- a/operator/pkg/ztunnel/reconciler/reconciler_test.go
+++ b/operator/pkg/ztunnel/reconciler/reconciler_test.go
@@ -319,8 +319,9 @@ func TestEnrollmentReconciler_Start_UpsertOnSACreate(t *testing.T) {
 	select {
 	case id := <-upserted:
 		require.Equal(t, "enrolled-ns/sa1", id)
-		require.Equal(t, float64(1),
-			getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeSuccess))
+		require.Eventually(t, func() bool {
+			return getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeSuccess) == 1
+		}, 5*time.Second, 10*time.Millisecond)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upsert")
 	}
@@ -393,8 +394,9 @@ func TestEnrollmentReconciler_Start_DeleteOnSARemove(t *testing.T) {
 	select {
 	case id := <-deleted:
 		require.Equal(t, "enrolled-ns/sa1", id)
-		require.Equal(t, float64(1),
-			getMetric(ops.metrics, LabelValueMethodDelete, LabelValueOutcomeSuccess))
+		require.Eventually(t, func() bool {
+			return getMetric(ops.metrics, LabelValueMethodDelete, LabelValueOutcomeSuccess) == 1
+		}, 5*time.Second, 10*time.Millisecond)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for delete")
 	}
@@ -420,13 +422,15 @@ func TestEnrollmentReconciler_Start_ErrorMetricsAndRequeue(t *testing.T) {
 
 	select {
 	case <-upsertCalled:
-		require.Equal(t, float64(1),
-			getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeFail))
+		require.Eventually(t, func() bool {
+			return getMetric(ops.metrics, LabelValueMethodUpsert, LabelValueOutcomeFail) == 1
+		}, 5*time.Second, 10*time.Millisecond)
 
 		// Verify the namespace was requeued to pending for re-reconciliation.
-		ns, _, found := enrolledTbl.Get(db.ReadTxn(), table.EnrolledNamespacesNameIndex.Query("enrolled-ns"))
-		require.True(t, found)
-		require.Equal(t, reconciler.StatusKindPending, ns.Status.Kind)
+		require.Eventually(t, func() bool {
+			ns, _, found := enrolledTbl.Get(db.ReadTxn(), table.EnrolledNamespacesNameIndex.Query("enrolled-ns"))
+			return found && ns.Status.Kind == reconciler.StatusKindPending
+		}, 5*time.Second, 10*time.Millisecond)
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for upsert call")
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fix the flake reported in #45420 in the ztunnel enrollment reconciler
`Start_*` unit tests:

```
reconciler_test.go:396:
    Error: Not equal: expected: 1, actual: 0
    Test:  TestEnrollmentReconciler_Start_DeleteOnSARemove
```

The tests assert on metric counters (and on the enrolled-namespace
requeue status in one case) immediately after the mock `SpireClient`
callback unblocks them via a channel send. The reconciler goroutine
records those side effects after the mock returns, so the test can
observe them before the reconciler applies them.

Wrap the post-channel assertions in `require.Eventually` in all three
`TestEnrollmentReconciler_Start_*` tests. The channel still proves the
mock was invoked; `Eventually` covers the ordering gap to the
observable side effects. Applied to all three `Start_*` tests, since
the same pattern is latent in the two that hadn't flaked yet.

Reproduces reliably with the race detector before the fix (fails
within the first few iterations). After the fix, 500 iterations pass
cleanly:

```bash
CGO_ENABLED=1 go test -race -count=500 \
    -run TestEnrollmentReconciler_Start \
    ./operator/pkg/ztunnel/reconciler
```

Fixes: #45420