### PR TITLE
bpf: let `device_mac` return zero MAC in case of missing device

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -1181,7 +1181,6 @@ here.
 | DROP_EP_NOT_READY | 203 | A BPF program wants to tail call some endpoint&#39;s policy program in cilium_call_policy, but the program is not available. |
 | DROP_NO_EGRESS_IP | 204 | An Egress Gateway node matched a packet against an Egress Gateway policy that didn&#39;t select a valid Egress IP. |
 | DROP_PUNT_PROXY | 205 | Punt packet to a user space proxy. |
-| DROP_NO_DEVICE | 206 | A BPF program failed to look up information for a network device. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -652,8 +652,6 @@ const (
 	DropReason_DROP_NO_EGRESS_IP DropReason = 204
 	// Punt packet to a user space proxy.
 	DropReason_DROP_PUNT_PROXY DropReason = 205
-	// A BPF program failed to look up information for a network device.
-	DropReason_DROP_NO_DEVICE DropReason = 206
 )
 
 // Enum value maps for DropReason.
@@ -735,7 +733,6 @@ var (
 		203: "DROP_EP_NOT_READY",
 		204: "DROP_NO_EGRESS_IP",
 		205: "DROP_PUNT_PROXY",
-		206: "DROP_NO_DEVICE",
 	}
 	DropReason_value = map[string]int32{
 		"DROP_REASON_UNKNOWN":                                   0,
@@ -814,7 +811,6 @@ var (
 		"DROP_EP_NOT_READY":                                     203,
 		"DROP_NO_EGRESS_IP":                                     204,
 		"DROP_PUNT_PROXY":                                       205,
-		"DROP_NO_DEVICE":                                        206,
 	}
 )
 
@@ -5920,7 +5916,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
 	"\x06TRACED\x10\x06\x12\x0e\n" +
 	"\n" +
-	"TRANSLATED\x10\a*\xda\x11\n" +
+	"TRANSLATED\x10\a*\xc5\x11\n" +
 	"\n" +
 	"DropReason\x12\x17\n" +
 	"\x13DROP_REASON_UNKNOWN\x10\x00\x12\x1b\n" +
@@ -6001,8 +5997,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x13DROP_HOST_NOT_READY\x10\xca\x01\x12\x16\n" +
 	"\x11DROP_EP_NOT_READY\x10\xcb\x01\x12\x16\n" +
 	"\x11DROP_NO_EGRESS_IP\x10\xcc\x01\x12\x14\n" +
-	"\x0fDROP_PUNT_PROXY\x10\xcd\x01\x12\x13\n" +
-	"\x0eDROP_NO_DEVICE\x10\xce\x01*J\n" +
+	"\x0fDROP_PUNT_PROXY\x10\xcd\x01*J\n" +
 	"\x10TrafficDirection\x12\x1d\n" +
 	"\x19TRAFFIC_DIRECTION_UNKNOWN\x10\x00\x12\v\n" +
 	"\aINGRESS\x10\x01\x12\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -524,8 +524,6 @@ enum DropReason {
     DROP_NO_EGRESS_IP = 204;
     // Punt packet to a user space proxy.
     DROP_PUNT_PROXY = 205;
-    // A BPF program failed to look up information for a network device.
-    DROP_NO_DEVICE = 206;
 }
 
 enum TrafficDirection {

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -211,7 +211,6 @@ const DropReason_DROP_HOST_NOT_READY = flow.DropReason_DROP_HOST_NOT_READY
 const DropReason_DROP_EP_NOT_READY = flow.DropReason_DROP_EP_NOT_READY
 const DropReason_DROP_NO_EGRESS_IP = flow.DropReason_DROP_NO_EGRESS_IP
 const DropReason_DROP_PUNT_PROXY = flow.DropReason_DROP_PUNT_PROXY
-const DropReason_DROP_NO_DEVICE = flow.DropReason_DROP_NO_DEVICE
 
 var DropReason_name = flow.DropReason_name
 var DropReason_value = flow.DropReason_value

--- a/bpf/lib/drop_reasons.h
+++ b/bpf/lib/drop_reasons.h
@@ -86,4 +86,3 @@
 #define DROP_EP_NOT_READY	-203
 #define DROP_NO_EGRESS_IP	-204
 #define DROP_PUNT_PROXY		-205 /* Mapped as drop code, though drop not necessary. */
-#define DROP_NO_DEVICE		-206

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -66,7 +66,6 @@ static __always_inline bool fib_ok(int ret)
   *
   * Returns:
   *   - result of BPF redirect
-  *   - DROP_NO_DEVICE when SMAC couldn't be resolved
   *   - DROP_NO_FIB when DMAC couldn't be resolved
   *   - other DROP reasons
   *
@@ -128,9 +127,6 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	} else {
 		const union macaddr *smac = device_mac(oif);
 		const union macaddr *dmac = NULL;
-
-		if (!smac)
-			return DROP_NO_DEVICE;
 
 		if (allow_neigh_map) {
 			/* The neigh_record_ip{4,6} locations are mainly from

--- a/bpf/lib/network_device.h
+++ b/bpf/lib/network_device.h
@@ -29,6 +29,7 @@ struct {
 	__type(value, struct device_state);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 512);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } cilium_devices __section_maps_btf;
 
 static __always_inline const struct device_state *
@@ -49,6 +50,7 @@ static __always_inline const union macaddr *
 device_mac(__u32 ifindex)
 {
 	const struct device_state *state = device_state_lookup(ifindex);
+	static union macaddr __zero_mac = {};
 
-	return state ? &state->mac : NULL;
+	return state ? &state->mac : &__zero_mac;
 }

--- a/pkg/datapath/maps/maps_generated.go
+++ b/pkg/datapath/maps/maps_generated.go
@@ -285,7 +285,7 @@ func newCiliumDevicesSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  16,
 		Value:      anyTypeByName(btf, "device_state"),
 		MaxEntries: 512,
-		Flags:      0,
+		Flags:      unix.BPF_F_NO_PREALLOC,
 		Pinning:    ebpf.PinByName,
 	}
 }


### PR DESCRIPTION
After the switch of the `cilium_devices` map from array to hash map in commit fffae2c8a1f1 ("maps/netdev: switch cilium_devices from array to hash map"), `device_mac` will return `NULL` if the device is not present in the map whereas before, it would always return a zero MAC and thus the `NULL` check in `fib_do_redirect` would never hit. This is also consistent with the behavior before commit 585e63f7e965 ("datapath: move device metadata to cilium_devices map") switched device metadata from macros to the `cilium_devices` map. There, `NATIVE_DEV_MAC_BY_IFINDEX` would also return a zero MAC if no device was found for a given ifindex lookup.

Restore that behavior by letting `device_mac` return a zero MAC in case the ifindex isn't present in `cilium_devices`. This also allows to drop the now unused `DROP_NO_DEVICE` drop reason. Since it was never part of a released version (just on `main` branch), this can be done without breaking API.

Fixes: fffae2c8a1f1 ("maps/netdev: switch cilium_devices from array to hash map")