### PR TITLE
service: Prune stale backends directly during SyncWithK8sFinished

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1318,6 +1318,43 @@ func (s *Service) SyncWithK8sFinished(localOnly bool, localServices sets.Set[k8s
 				logfields.L3n4Addr:       logfields.Repr(svc.frontend.L3n4Addr),
 				logfields.OrphanBackends: svc.restoredBackendHashes.Len(),
 			}).Info("Service has stale backends: triggering refresh")
+
+			// If we are in the final pass (localOnly = false), we can directly
+			// prune the stale backends if we are not expecting any more updates.
+			// This covers the case where EnsureService() fails to trigger an update
+			// because ServiceCache has no endpoints for this service (e.g., if the
+			// service is only learned via Clustermesh and no update was received
+			// after agent restart because the remote cluster state didn't change).
+			// In that case, correlateEndpoints returns serviceReady = false and
+			// EnsureService skips emitting the event, leaving the stale backends
+			// in BPF maps indefinitely.
+			if !localOnly {
+				validBackends := []*lb.Backend{}
+				staleBackends := []string{}
+				for _, b := range svc.backends {
+					if !svc.restoredBackendHashes.Has(b.L3n4Addr.Hash()) {
+						validBackends = append(validBackends, b.DeepCopy())
+					} else {
+						staleBackends = append(staleBackends, b.L3n4Addr.String())
+					}
+				}
+
+				log.WithFields(logrus.Fields{
+					logfields.ServiceID: svc.frontend.ID,
+					"staleBackends":    staleBackends,
+					"validBackends":    validBackends,
+				}).Info("Pruning stale backends directly")
+
+				svc.restoredBackendHashes = nil
+
+				svcCopy := svc.deepCopyToLBSVC()
+				svcCopy.Backends = validBackends
+
+				if _, _, err := s.upsertService(svcCopy); err != nil {
+					log.WithError(err).Warn("Failed to upsert service during stale backend pruning")
+				}
+				continue
+			}
 		}
 
 		svc.restoredBackendHashes = nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -793,6 +793,62 @@ func TestRestoreServiceWithStaleBackends(t *testing.T) {
 	}
 }
 
+func TestRestoreServiceWithStaleBackends_NoEndpoints(t *testing.T) {
+	backendAddrs := []string{"10.0.0.1", "10.0.0.2"}
+	
+	service := func(ns, name, frontend string, backends ...string) *lb.SVC {
+		var bes []*lb.Backend
+		for _, backend := range backends {
+			bes = append(bes, lb.NewBackend(0, lb.TCP, cmtypes.MustParseAddrCluster(backend), 8080))
+		}
+
+		return &lb.SVC{
+			Frontend:         *lb.NewL3n4AddrID(lb.TCP, cmtypes.MustParseAddrCluster(frontend), 80, lb.ScopeExternal, 0),
+			Backends:         bes,
+			Type:             lb.SVCTypeClusterIP,
+			ExtTrafficPolicy: lb.SVCTrafficPolicyCluster,
+			IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
+			Name:             lb.ServiceName{Name: name, Namespace: ns},
+		}
+	}
+
+	toBackendAddrs := func(backends []*lb.Backend) (addrs []string) {
+		for _, be := range backends {
+			addrs = append(addrs, be.L3n4Addr.AddrCluster.Addr().String())
+		}
+		return
+	}
+
+	lbmap := mockmaps.NewLBMockMap()
+	svc := newService(&FakeMonitorAgent{}, lbmap, nil)
+
+	// 1. Upsert service with 2 backends
+	_, id1, err := svc.upsertService(service("foo", "bar", "172.16.0.1", backendAddrs...))
+	require.NoError(t, err)
+
+	// 2. Restore services
+	svc = newService(&FakeMonitorAgent{}, lbmap, nil)
+	require.NoError(t, svc.RestoreServices())
+
+	// 2.5 Simulate update from Clustermesh with only 1 valid backend
+	// This clears restoredFromDatapath but keeps 10.0.0.2 in restoredBackendHashes
+	_, _, err = svc.upsertService(service("foo", "bar", "172.16.0.1", "10.0.0.1"))
+	require.NoError(t, err)
+
+	// 3. Run SyncWithK8sFinished
+	svcID := k8s.ServiceID{Namespace: "foo", Name: "bar"}
+	stale, err := svc.SyncWithK8sFinished(false, sets.New[k8s.ServiceID]())
+	require.NoError(t, err)
+	
+	// We expect it to be stale because it has restored backends that were not observed
+	require.ElementsMatch(t, stale, []k8s.ServiceID{svcID})
+
+	// 4. Verify that stale backends are PRUNED in lbmap!
+	require.Contains(t, lbmap.ServiceByID, uint16(id1))
+	require.ElementsMatch(t, []string{"10.0.0.1"}, toBackendAddrs(lbmap.ServiceByID[uint16(id1)].Backends))
+	require.ElementsMatch(t, []string{"10.0.0.1"}, toBackendAddrs(maps.Values(lbmap.BackendByID)))
+}
+
 func TestHealthCheckNodePort(t *testing.T) {
 	m := setupManagerTestSuite(t)
 


### PR DESCRIPTION
When a service is learned via Clustermesh and the agent restarts, stale backends that exist in the BPF maps but not in the desired state are not pruned if no update is received for that service from Clustermesh after restart.

This happens because SyncWithK8sFinished returns the service as stale and relies on EnsureService to trigger a refresh. However, if ServiceCache has no endpoints for this service (e.g., if no update was received because the remote cluster state didn't change), EnsureService skips emitting the update event because correlateEndpoints returns serviceReady = false.

Fix this by directly pruning the stale backends in SyncWithK8sFinished during the final pass (localOnly = false) by calling upsertService with only the valid backends.

Also added a unit test TestRestoreServiceWithStaleBackends_NoEndpoints to reproduce and verify the fix.

Fixes: #45441

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #45441

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
