### PR TITLE
cilium-cli: Add log-check-extra-exceptions flag for connectivity test

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -220,6 +220,8 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().MarkHidden("exclude-code-owners")
 	cmd.Flags().StringSliceVar(&params.LogCheckLevels, "log-check-levels", defaults.LogCheckLevels, "Log levels to check for in log messages")
 	cmd.Flags().MarkHidden("log-check-levels")
+	cmd.Flags().StringSliceVar(&params.LogCheckExtraExceptions, "log-check-extra-exceptions", []string{}, "Additional log message substrings to ignore in check-log-errors")
+	cmd.Flags().MarkHidden("log-check-extra-exceptions")
 	cmd.Flags().BoolVar(&params.LogCheckOnlyTestTime, "log-check-only-test-time", false, "Whether logs should only get checked for the duration of the tests")
 
 	cmd.Flags().BoolVar(&params.FlushCT, "flush-ct", false, "Flush conntrack of Cilium on each node")

--- a/cilium-cli/connectivity/builder/check_log_errors.go
+++ b/cilium-cli/connectivity/builder/check_log_errors.go
@@ -19,6 +19,6 @@ func (t checkLogErrors) build(ct *check.ConnectivityTest, _ map[string]string) {
 	}
 	newTest("check-log-errors", ct).
 		WithSysdumpPolicy(check.SysdumpPolicyOnce).
-		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels, ct.Params().ExternalTarget,
-			ct.Params().ExternalOtherTarget, startTime))
+		WithScenarios(tests.NoErrorsInLogs(ct.CiliumVersion, ct.Params().LogCheckLevels, ct.Params().LogCheckExtraExceptions,
+			ct.Params().ExternalTarget, ct.Params().ExternalOtherTarget, startTime))
 }

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -127,11 +127,12 @@ type Parameters struct {
 	ExpectedDropReasons []string
 	ExpectedXFRMErrors  []string
 
-	CodeOwners           []string
-	LogCodeOwners        bool
-	ExcludeCodeOwners    []string
-	LogCheckLevels       []string
-	LogCheckOnlyTestTime bool
+	CodeOwners              []string
+	LogCodeOwners           bool
+	ExcludeCodeOwners       []string
+	LogCheckLevels          []string
+	LogCheckExtraExceptions []string
+	LogCheckOnlyTestTime    bool
 
 	FlushCT               bool
 	SecondaryNetworkIface string

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -48,7 +48,7 @@ func (r regexMatcher) IsMatch(log string) bool {
 // NoErrorsInLogs checks whether there are no error messages in cilium-agent
 // logs. The error messages are defined in badLogMsgsWithExceptions, which key
 // is an error message, while values is a list of ignored messages.
-func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, externalTarget string, externalOtherTarget string, startTime time.Time) check.Scenario {
+func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExceptions []string, externalTarget string, externalOtherTarget string, startTime time.Time) check.Scenario {
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
 	errorLogExceptions := []logMatcher{
@@ -74,6 +74,11 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, external
 	if ciliumVersion.LT(semver.MustParse("1.18.0")) {
 		errorLogExceptions = append(errorLogExceptions, linkNotFound, removeInexistentID)
 		warningLogExceptions = append(warningLogExceptions, linkNotFound, removeInexistentID)
+	}
+
+	for _, exception := range extraExceptions {
+		errorLogExceptions = append(errorLogExceptions, stringMatcher(exception))
+		warningLogExceptions = append(warningLogExceptions, stringMatcher(exception))
 	}
 
 	// The list is adopted from cilium/cilium/test/helper/utils.go

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -32,12 +32,13 @@ time=2025-04-08T14:27:09Z level=error msg="bar" serviceID=2 source=/go/src/githu
 `
 
 	for _, tt := range []struct {
-		levels         []string
-		version        semver.Version
-		wantLen        int
-		wantLogsCount  map[string]int
-		wantExampleLog map[string]set.Set[string]
-		wantFilePath   string
+		levels          []string
+		version         semver.Version
+		extraExceptions []string
+		wantLen         int
+		wantLogsCount   map[string]int
+		wantExampleLog  map[string]set.Set[string]
+		wantFilePath    string
 	}{
 		{
 			levels:  defaults.LogCheckLevels,
@@ -93,9 +94,20 @@ time=2025-04-08T14:27:09Z level=error msg="bar" serviceID=2 source=/go/src/githu
 			// in case of no source file information.
 			wantFilePath: "cilium-cli/connectivity/tests/errors.go",
 		},
+		{
+			levels:          defaults.LogCheckLevels,
+			version:         semver.MustParse("1.17.0"),
+			extraExceptions: []string{"bar", "baz"},
+			wantLen:         2,
+			wantLogsCount: map[string]int{
+				`[error][envoy_bug] envoy bug failure: !Thread::MainThread::isMainOrTestThread()`: 1,
+				`[critical][backtrace] Caught Aborted, suspect faulting address 0xd`:              1,
+			},
+			wantFilePath: "cilium-cli/connectivity/tests/errors.go",
+		},
 	} {
 		var zt time.Time
-		s := NoErrorsInLogs(tt.version, tt.levels, "one.one.one.one", "k8s.io", zt).(*noErrorsInLogs)
+		s := NoErrorsInLogs(tt.version, tt.levels, tt.extraExceptions, "one.one.one.one", "k8s.io", zt).(*noErrorsInLogs)
 		fails, example := s.findUniqueFailures([]byte(errs))
 		assert.Len(t, fails, tt.wantLen)
 		for wantMsg, wantCount := range tt.wantLogsCount {


### PR DESCRIPTION
This allows specifying additional log message exceptions for the check-log-errors test. There are 2 motivations for this flag:

1. Some log messages are expected only in specific scenarios / workflow setups, and we do not want to ignore them for others.

2. Sometimes we may need to add a temporary exception in a workflow without the need for modifying cilium-cli.

