### PR TITLE
bpf: nodeport: enable dynamic SNAT for GENEVE-DSR in XDP path

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -14,6 +14,7 @@ static __always_inline int
 __encap_with_nodeid4(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 		     __be32 tunnel_endpoint,
 		     __u32 seclabel, __u32 dstid, __u32 vni,
+		     void *opt, __u32 opt_len,
 		     enum trace_reason ct_reason, __u32 monitor, int *ifindex,
 		     __be16 proto)
 {
@@ -36,12 +37,14 @@ __encap_with_nodeid4(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			  *ifindex, ct_reason, monitor, proto);
 
 	return ctx_set_encap_info4(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni,
-				   NULL, 0);
+				   opt, opt_len);
 }
 
 static __always_inline int
 __encap_with_nodeid6(struct __ctx_buff *ctx, const union v6addr *tunnel_endpoint,
-		     __u32 seclabel, __u32 dstid, enum trace_reason ct_reason,
+		     __u32 seclabel, __u32 dstid,
+		     void *opt, __u32 opt_len,
+		     enum trace_reason ct_reason,
 		     __u32 monitor, int *ifindex, __be16 proto)
 {
 	/* When encapsulating, a packet originating from the local host is
@@ -60,7 +63,7 @@ __encap_with_nodeid6(struct __ctx_buff *ctx, const union v6addr *tunnel_endpoint
 	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
 			  *ifindex, ct_reason, monitor, proto);
 
-	return ctx_set_encap_info6(ctx, tunnel_endpoint, seclabel, NULL, 0);
+	return ctx_set_encap_info6(ctx, tunnel_endpoint, seclabel, opt, opt_len);
 }
 
 static __always_inline int
@@ -74,12 +77,12 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx,
 
 	if (info->flag_ipv6_tunnel_ep)
 		ret = __encap_with_nodeid6(ctx, &info->tunnel_endpoint.ip6,
-					   seclabel, dstid, trace->reason,
+					   seclabel, dstid, NULL, 0, trace->reason,
 					   trace->monitor, &ifindex, proto);
 	else
 		ret = __encap_with_nodeid4(ctx, 0, 0,
 					   info->tunnel_endpoint.ip4.be32, seclabel,
-					   dstid, vni, trace->reason,
+					   dstid, vni, NULL, 0, trace->reason,
 					   trace->monitor, &ifindex, proto);
 	if (ret != CTX_ACT_REDIRECT)
 		return ret;
@@ -138,62 +141,6 @@ tunnel_gen_src_port_v6(struct ipv6_ct_tuple *tuple __maybe_unused)
 }
 
 #if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int
-__encap_with_nodeid_opt4(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
-			 __u32 tunnel_endpoint,
-			 __u32 seclabel, __u32 dstid, __u32 vni,
-			 void *opt, __u32 opt_len,
-			 enum trace_reason ct_reason,
-			 __u32 monitor, int *ifindex, __be16 proto)
-{
-	/* When encapsulating, a packet originating from the local host is
-	 * being considered as a packet from a remote node as it is being
-	 * received.
-	 */
-	if (seclabel == HOST_ID)
-		seclabel = LOCAL_NODE_ID;
-
-	cilium_dbg(ctx, DBG_ENCAP, tunnel_endpoint, seclabel);
-
-#if __ctx_is == __ctx_skb
-	*ifindex = ENCAP_IFINDEX;
-#else
-	*ifindex = 0;
-#endif
-
-	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
-			  *ifindex, ct_reason, monitor, proto);
-
-	return ctx_set_encap_info4(ctx, src_ip, src_port, tunnel_endpoint, seclabel, vni, opt,
-				   opt_len);
-}
-
-static __always_inline int
-__encap_with_nodeid_opt6(struct __ctx_buff *ctx,
-			 const union v6addr *tunnel_endpoint, __u32 seclabel,
-			 __u32 dstid, void *opt, __u32 opt_len,
-			 enum trace_reason ct_reason, __u32 monitor,
-			 int *ifindex, __be16 proto)
-{
-	/* When encapsulating, a packet originating from the local host is
-	 * being considered as a packet from a remote node as it is being
-	 * received.
-	 */
-	if (seclabel == HOST_ID)
-		seclabel = LOCAL_NODE_ID;
-
-#if __ctx_is == __ctx_skb
-	*ifindex = ENCAP_IFINDEX;
-#else
-	*ifindex = 0;
-#endif
-
-	send_trace_notify(ctx, TRACE_TO_OVERLAY, seclabel, dstid, TRACE_EP_ID_UNKNOWN,
-			  *ifindex, ct_reason, monitor, proto);
-
-	return ctx_set_encap_info6(ctx, tunnel_endpoint, seclabel, opt, opt_len);
-}
-
 static __always_inline void
 set_geneve_dsr_opt4(__be16 port, __be32 addr, struct geneve_dsr_opt4 *gopt)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -181,6 +181,11 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 	/* Let kernel choose the outer source ip */
 	if (ctx_is_skb())
 		src_ip = 0;
+#ifdef ENABLE_IPV4
+	else
+		/* no-op if failure, no need for capturing results */
+		fib_lookup_src_v4(ctx, &src_ip, info->tunnel_endpoint.ip4.be32);
+#endif /* ENABLE_IPV4 */
 
 	/* Append L2 hdr before redirecting to tunnel netdev.
 	 * Otherwise, the kernel will drop such request in

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -135,43 +135,6 @@ nodeport_dsr_lookup_v6_nat_entry(const struct ipv6_ct_tuple *nat_tuple)
 
 #ifdef HAVE_ENCAP
 static __always_inline int
-nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
-			  const struct remote_endpoint_info *info,
-			  __u32 src_sec_identity, enum trace_reason ct_reason,
-			  __u32 monitor, int *ifindex, __be16 proto)
-{
-	/* Let kernel choose the outer source ip */
-	if (ctx_is_skb())
-		src_ip = 0;
-#ifdef ENABLE_IPV4
-	else
-		/* no-op if failure, no need for capturing results */
-		fib_lookup_src_v4(ctx, &src_ip, info->tunnel_endpoint.ip4.be32);
-#endif /* ENABLE_IPV4 */
-
-	/* Append L2 hdr before redirecting to tunnel netdev.
-	 * Otherwise, the kernel will drop such request in
-	 * https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/net/core/filter.c?h=v6.7.4#n2147
-	 */
-	if (THIS_IS_L3_DEV) {
-		int ret;
-
-		ret = add_l2_hdr(ctx);
-		if (ret != 0)
-			return ret;
-	}
-
-	if (info->flag_ipv6_tunnel_ep)
-		return __encap_with_nodeid6(ctx, &info->tunnel_endpoint.ip6,
-					    src_sec_identity, info->sec_identity,
-					    ct_reason, monitor, ifindex, proto);
-	return __encap_with_nodeid4(ctx, src_ip, src_port, info->tunnel_endpoint.ip4.be32,
-				    src_sec_identity, info->sec_identity, NOT_VTEP_DST,
-				    ct_reason, monitor, ifindex, proto);
-}
-
-# if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-static __always_inline int
 nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
 			      const struct remote_endpoint_info *info,
 			      __u32 src_sec_identity, void *opt, __u32 opt_len,
@@ -200,15 +163,27 @@ nodeport_add_tunnel_encap_opt(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_p
 	}
 
 	if (info->flag_ipv6_tunnel_ep)
-		return __encap_with_nodeid_opt6(ctx, &info->tunnel_endpoint.ip6,
-						src_sec_identity, info->sec_identity,
-						opt, opt_len, ct_reason, monitor,
-						ifindex, proto);
-	return __encap_with_nodeid_opt4(ctx, src_ip, src_port, info->tunnel_endpoint.ip4.be32,
-					src_sec_identity, info->sec_identity, NOT_VTEP_DST,
-					opt, opt_len, ct_reason, monitor, ifindex, proto);
+		return __encap_with_nodeid6(ctx, &info->tunnel_endpoint.ip6,
+					    src_sec_identity, info->sec_identity,
+					    opt, opt_len, ct_reason, monitor,
+					    ifindex, proto);
+	return __encap_with_nodeid4(ctx, src_ip, src_port, info->tunnel_endpoint.ip4.be32,
+				    src_sec_identity, info->sec_identity, NOT_VTEP_DST,
+				    opt, opt_len, ct_reason, monitor, ifindex, proto);
 }
-# endif
+
+static __always_inline int
+nodeport_add_tunnel_encap(struct __ctx_buff *ctx, __u32 src_ip, __be16 src_port,
+			  const struct remote_endpoint_info *info,
+			  __u32 src_sec_identity,
+			  enum trace_reason ct_reason, __u32 monitor,
+			  int *ifindex, __be16 proto)
+{
+	return nodeport_add_tunnel_encap_opt(ctx, src_ip, src_port, info,
+					     src_sec_identity, NULL, 0,
+					     ct_reason, monitor, ifindex,
+					     proto);
+}
 #endif /* HAVE_ENCAP */
 
 static __always_inline bool dsr_fail_needs_reply(int code __maybe_unused)


### PR DESCRIPTION
```
When manually adding tunnel headers for GENEVE-DSR packets in XDP mode, we
currently always use IPV4_DIRECT_ROUTING as source IP. Add a call to
fib_lookup_src_v4(), matching what nodeport_add_tunnel_encap() does.
```

Also clean up some duplicated encap helpers while at it.