### PR TITLE
 envoy: reuse shared circuit breaker thresholds for xDS bootstrap

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.yaml
@@ -252,6 +252,11 @@ staticResources:
   - name: "xds-grpc-cilium"
     type: "STATIC"
     connectTimeout: "{{ .Values.envoy.connectTimeoutSeconds }}s"
+    circuitBreakers:
+      thresholds:
+      - maxRetries: {{ .Values.envoy.maxConcurrentRetries }}
+        maxConnections: {{ .Values.envoy.clusterMaxConnections }}
+        maxRequests: {{ .Values.envoy.clusterMaxRequests }}
     loadAssignment:
       clusterName: "xds-grpc-cilium"
       endpoints:

--- a/pkg/envoy/standalone_envoy.go
+++ b/pkg/envoy/standalone_envoy.go
@@ -505,6 +505,7 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) er
 						}},
 					},
 					TypedExtensionProtocolOptions: http2ProtocolOptions,
+					CircuitBreakers:               clusterRetryLimits,
 				},
 				{
 					Name:                 adminClusterName,


### PR DESCRIPTION
PR #43049 made Envoy circuit breaker settings configurable, but the xds-grpc-cilium cluster was not included. Reuse the existing retry, connection, and request thresholds for that cluster too, and apply the same limits in standalone Envoy bootstrap generation.

```release-note
envoy: reuse the circuit breaker thresholds configuration for Envoy xDS clusters
```
