### PR TITLE
helm: install ValidatingAdmissionPolicy when GatewayAPI is enabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-gateway-api-validating-admission-policy.yaml
+++ b/install/kubernetes/cilium/templates/cilium-gateway-api-validating-admission-policy.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.gatewayAPI.enabled -}}
+{{- if ( or (eq (.Values.gatewayAPI.gatewayClass.create | toString) "true") (and (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1/GatewayClass") (eq (.Values.gatewayAPI.gatewayClass.create | toString) "auto"))) }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: gateway.cilium.io
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["gateway.networking.k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["gateways"]
+  validations:
+    - expression: "object.spec.gatewayClassName != 'cilium' ||
+        (has(object.spec.listeners)) &&
+        object.spec.listeners.filter(e, has(e.tls) && has(e.tls.mode) && e.tls.mode == 'Terminate').all(e, e.tls.certificateRefs.size() == 1)"
+      message: "cilium GatewayClass requires exactly one certificateRef per listener when tls.mode is Terminate."
+      reason: Invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: gateway.cilium.io
+  {{- with .Values.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  policyName: gateway.cilium.io
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - apiGroups: ["gateway.networking.k8s.io"]
+        apiVersions: ["v1"]
+        resources: ["gateways"]
+        operations: ["CREATE", "UPDATE"]
+{{- end}}
+{{- end}}


### PR DESCRIPTION
The "cilium" GatewayClass only supports using a single certificate reference per Gateway listener. Using multiple certificate refs on a single listener causes Cilium to generate a broken cilium-envoy-config. This meets the requirements for "core" support, but the API allows implementation-specific support for multiple certificate references.

This commit adds a ValidatingAdmissionPolicy to reject Gateways submitted using the "cilium" GatewayClass and containing multiple certificate references on any TLS listener.

Fixes: #41228