### PR TITLE
agent: add generic prefer-ipv6 flag for health probes and Hubble

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -271,7 +271,6 @@ cilium-agent [flags]
       --hubble-metrics-server-tls-key-file string                 Path to the private key file for the Hubble metrics server. The file must contain PEM encoded data.
       --hubble-monitor-events strings                             Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict trace-sock l7 agent]. By default, Hubble observes all monitor events.
       --hubble-network-policy-correlation-enabled                 Enable network policy correlation of Hubble flows (default true)
-      --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-redact-enabled                                     Hubble redact sensitive information from flows
       --hubble-redact-http-headers-allow strings                  HTTP headers to keep visible in flows
       --hubble-redact-http-headers-deny strings                   HTTP headers to redact from flows
@@ -393,6 +392,7 @@ cilium-agent [flags]
       --pprof-mutex-profile-fraction int                          Enable mutex contention profiling and set the fraction of sampled events (set to 1 to sample all events)
       --pprof-port uint16                                         Port that pprof listens on (default 6060)
       --preallocate-bpf-maps                                      Enable BPF map pre-allocation (default true)
+      --prefer-ipv6                                               Prefer IPv6 addresses over IPv4 when both are available
       --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --procfs string                                             Path to the host's proc filesystem mount (default "/proc")
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -168,7 +168,6 @@ cilium-agent hive [flags]
       --hubble-metrics-server-tls-key-file string                 Path to the private key file for the Hubble metrics server. The file must contain PEM encoded data.
       --hubble-monitor-events strings                             Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict trace-sock l7 agent]. By default, Hubble observes all monitor events.
       --hubble-network-policy-correlation-enabled                 Enable network policy correlation of Hubble flows (default true)
-      --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-redact-enabled                                     Hubble redact sensitive information from flows
       --hubble-redact-http-headers-allow strings                  HTTP headers to keep visible in flows
       --hubble-redact-http-headers-deny strings                   HTTP headers to redact from flows

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -173,7 +173,6 @@ cilium-agent hive dot-graph [flags]
       --hubble-metrics-server-tls-key-file string                 Path to the private key file for the Hubble metrics server. The file must contain PEM encoded data.
       --hubble-monitor-events strings                             Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict trace-sock l7 agent]. By default, Hubble observes all monitor events.
       --hubble-network-policy-correlation-enabled                 Enable network policy correlation of Hubble flows (default true)
-      --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-redact-enabled                                     Hubble redact sensitive information from flows
       --hubble-redact-http-headers-allow strings                  HTTP headers to keep visible in flows
       --hubble-redact-http-headers-deny strings                   HTTP headers to redact from flows

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2245,7 +2245,7 @@
      - int
      - ``4244``
    * - :spelling:ignore:`hubble.preferIpv6`
-     - Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
+     - Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. Deprecated: use top-level preferIpv6 instead.
      - bool
      - ``false``
    * - :spelling:ignore:`hubble.redact`
@@ -3616,6 +3616,10 @@
      - Configure pprof listen port for cilium-agent
      - int
      - ``6060``
+   * - :spelling:ignore:`preferIpv6`
+     - Prefer IPv6 addresses over IPv4 when both are available for health probes and Hubble peer communication.
+     - bool
+     - ``false``
    * - :spelling:ignore:`preflight.affinity`
      - Affinity for cilium-preflight
      - object

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -351,7 +351,10 @@ The following options have been deprecated in this version of Cilium. A future
 version of Cilium will remove these options, so if you use these options then
 you may need to take action to migrate to an alternative.
 
-* TODO
+* The ``hubble.preferIpv6`` Helm value and ``--hubble-prefer-ipv6`` agent flag
+  have been deprecated and will be removed in Cilium 1.20. Use the top-level
+  ``preferIpv6`` Helm value and ``--prefer-ipv6`` agent flag instead, which
+  apply to both health probes and Hubble peer communication.
 
 Removed Options
 ###############

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -670,6 +670,7 @@ pre
 preconfigured
 prefilter
 preflight
+preferIpv
 preload
 preloaded
 preloading

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -207,6 +207,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPv6Name, defaults.EnableIPv6, "Enable IPv6 support")
 	option.BindEnv(vp, option.EnableIPv6Name)
 
+	flags.Bool(option.PreferIpv6Name, defaults.PreferIpv6, "Prefer IPv6 addresses over IPv4 when both are available")
+	option.BindEnv(vp, option.PreferIpv6Name)
+
 	flags.Bool(option.EnableNat46X64Gateway, false, "Enable NAT46 and NAT64 gateway")
 	option.BindEnv(vp, option.EnableNat46X64Gateway)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -611,7 +611,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.networkPolicyCorrelation | object | `{"enabled":true}` | Enables network policy correlation of Hubble flows, i.e. populating `egress_allowed_by`, `ingress_denied_by` fields with policy information. |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
-| hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
+| hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. Deprecated: use top-level preferIpv6 instead. |
 | hubble.redact | object | `{"enabled":false,"http":{"headers":{"allow":[],"deny":[]},"urlQuery":false,"userInfo":true}}` | Enables redacting sensitive information present in Layer 7 flows. |
 | hubble.redact.http.headers.allow | list | `[]` | List of HTTP headers to allow: headers not matching will be redacted. Note: `allow` and `deny` lists cannot be used both at the same time, only one can be present. Example:   redact:     enabled: true     http:       headers:         allow:           - traceparent           - tracestate           - Cache-Control  You can specify the options from the helm CLI:   --set hubble.redact.enabled="true"   --set hubble.redact.http.headers.allow="traceparent,tracestate,Cache-Control" |
 | hubble.redact.http.headers.deny | list | `[]` | List of HTTP headers to deny: matching headers will be redacted. Note: `allow` and `deny` lists cannot be used both at the same time, only one can be present. Example:   redact:     enabled: true     http:       headers:         deny:           - Authorization           - Proxy-Authorization  You can specify the options from the helm CLI:   --set hubble.redact.enabled="true"   --set hubble.redact.http.headers.deny="Authorization,Proxy-Authorization" |
@@ -954,6 +954,7 @@ contributors across the globe, there is almost always someone available to help.
 | pprof.enabled | bool | `false` | Enable pprof for cilium-agent |
 | pprof.mutexProfileFraction | int | `0` | Enable mutex contention profiling for cilium-agent and set the fraction of sampled events (set to 1 to sample all events) |
 | pprof.port | int | `6060` | Configure pprof listen port for cilium-agent |
+| preferIpv6 | bool | `false` | Prefer IPv6 addresses over IPv4 when both are available for health probes and Hubble peer communication. |
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.annotations | object | `{}` | Annotations to be added to all top-level preflight objects (resources under templates/cilium-preflight) |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -335,6 +335,10 @@ data:
   # address.
   enable-ipv6: {{ .Values.ipv6.enabled | quote }}
 
+{{- if eq .Values.preferIpv6 true }}
+  prefer-ipv6: "true"
+{{- end }}
+
 {{- if .Values.cleanState }}
   # If a serious issue occurs during Cilium startup, this
   # invasive option may be set to true to remove all persistent
@@ -1153,7 +1157,7 @@ data:
   hubble-drop-events-interval: {{ .Values.hubble.dropEventEmitter.interval | quote }}
   hubble-drop-events-reasons: {{ .Values.hubble.dropEventEmitter.reasons | join " " | quote }}
 {{- end }}
-{{- if or (eq .Values.hubble.preferIpv6 true) (eq .Values.ipv4.enabled false) }}
+{{- if or (eq .Values.hubble.preferIpv6 true) (eq .Values.preferIpv6 true) (eq .Values.ipv4.enabled false) }}
   hubble-prefer-ipv6: "true"
 {{- end }}
 {{- if (not (kindIs "invalid" .Values.hubble.skipUnknownCGroupIDs)) }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5584,6 +5584,9 @@
       },
       "type": "object"
     },
+    "preferIpv6": {
+      "type": "boolean"
+    },
     "preflight": {
       "properties": {
         "affinity": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1334,6 +1334,9 @@ eni:
 gke:
   # -- Enable Google Kubernetes Engine integration
   enabled: false
+# -- Prefer IPv6 addresses over IPv4 when both are available for health probes
+# and Hubble peer communication.
+preferIpv6: false
 # -- Enable connectivity health checking.
 healthChecking: true
 # -- TCP port for the agent health API. This is not the port for cilium-health.
@@ -1626,6 +1629,7 @@ hubble:
   # Hubble is listening on port 4244.
   listenAddress: ":4244"
   # -- Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
+  # Deprecated: use top-level preferIpv6 instead.
   preferIpv6: false
   # @schema
   # type: [null, boolean]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1346,6 +1346,9 @@ eni:
 gke:
   # -- Enable Google Kubernetes Engine integration
   enabled: false
+# -- Prefer IPv6 addresses over IPv4 when both are available for health probes
+# and Hubble peer communication.
+preferIpv6: false
 # -- Enable connectivity health checking.
 healthChecking: true
 # -- TCP port for the agent health API. This is not the port for cilium-health.
@@ -1640,6 +1643,7 @@ hubble:
   # Hubble is listening on port 4244.
   listenAddress: ":4244"
   # -- Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
+  # Deprecated: use top-level preferIpv6 instead.
   preferIpv6: false
   # @schema
   # type: [null, boolean]

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -192,6 +192,10 @@ const (
 	// EnableIPv6 is the default value for IPv6 enablement
 	EnableIPv6 = true
 
+	// PreferIpv6 is the default value for preferring IPv6 addresses
+	// over IPv4 when both are available.
+	PreferIpv6 = false
+
 	// EnableIPv6NDP is the default value for IPv6 NDP support enablement
 	EnableIPv6NDP = false
 

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -268,7 +268,9 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		info.Addressing.IPv4 = healthIPv4.String()
 		info.Addressing.IPv4PoolName = ipam.PoolDefault().String()
 		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
-		healthIP = healthIPv4
+		if !option.Config.PreferIpv6 {
+			healthIP = healthIPv4
+		}
 	}
 
 	if option.Config.EnableEndpointRoutes {

--- a/pkg/health/server/node.go
+++ b/pkg/health/server/node.go
@@ -9,35 +9,51 @@ import (
 
 type healthNode struct {
 	*models.NodeElement
+	preferPrimaryIPv6 bool
 }
 
 // NewHealthNode creates a new node structure based on the specified model.
-func NewHealthNode(elem *models.NodeElement) healthNode {
+func NewHealthNode(elem *models.NodeElement, preferPrimaryIPv6 bool) healthNode {
 	return healthNode{
-		NodeElement: elem,
+		NodeElement:       elem,
+		preferPrimaryIPv6: preferPrimaryIPv6,
 	}
 }
 
-// PrimaryIP returns the primary IP address of the node.
-func (n *healthNode) PrimaryIP() string {
-	if n.NodeElement.PrimaryAddress.IPv4.Enabled {
-		return n.NodeElement.PrimaryAddress.IPv4.IP
+// preferAddr returns the IP from the preferred address family, falling back
+// to the other if the preferred one is not enabled.
+func preferAddr(preferIPv6 bool, ipv4, ipv6 *models.NodeAddressingElement) string {
+	primary, secondary := ipv4, ipv6
+	if preferIPv6 {
+		primary, secondary = ipv6, ipv4
 	}
-	return n.NodeElement.PrimaryAddress.IPv6.IP
+	if primary.Enabled {
+		return primary.IP
+	}
+	return secondary.IP
+}
+
+// PrimaryIP returns the primary IP address of the node. When
+// preferPrimaryIPv6 is set, IPv6 is preferred over IPv4.
+func (n *healthNode) PrimaryIP() string {
+	return preferAddr(n.preferPrimaryIPv6, n.PrimaryAddress.IPv4, n.PrimaryAddress.IPv6)
 }
 
 // SecondaryIPs return a list of IP addresses corresponding to secondary addresses
-// of the node. If both IPv4 and IPv6 is enabled then primary IPv6 is also
-// returned in the list, since in that case we assume that IPv4 is the primary
-// address of the node, see the above function PrimaryIP().
+// of the node. If both IPv4 and IPv6 are enabled then the non-primary address
+// family is also returned in the list.
 func (n *healthNode) SecondaryIPs() []string {
 	var addresses []string
 
-	if n.NodeElement.PrimaryAddress.IPv4.Enabled && n.NodeElement.PrimaryAddress.IPv6.Enabled {
-		addresses = append(addresses, n.NodeElement.PrimaryAddress.IPv6.IP)
+	if n.PrimaryAddress.IPv4.Enabled && n.PrimaryAddress.IPv6.Enabled {
+		if n.preferPrimaryIPv6 {
+			addresses = append(addresses, n.PrimaryAddress.IPv4.IP)
+		} else {
+			addresses = append(addresses, n.PrimaryAddress.IPv6.IP)
+		}
 	}
 
-	for _, addr := range n.NodeElement.SecondaryAddresses {
+	for _, addr := range n.SecondaryAddresses {
 		if addr.Enabled {
 			addresses = append(addresses, addr.IP)
 		}
@@ -47,27 +63,27 @@ func (n *healthNode) SecondaryIPs() []string {
 }
 
 // HealthIP returns the IP address of the health endpoint for the node.
+// When preferPrimaryIPv6 is set, IPv6 is preferred over IPv4.
 func (n *healthNode) HealthIP() string {
-	if n.NodeElement.HealthEndpointAddress == nil {
+	if n.HealthEndpointAddress == nil {
 		return ""
 	}
-	if n.NodeElement.HealthEndpointAddress.IPv4.Enabled {
-		return n.NodeElement.HealthEndpointAddress.IPv4.IP
-	}
-	return n.NodeElement.HealthEndpointAddress.IPv6.IP
+	return preferAddr(n.preferPrimaryIPv6, n.HealthEndpointAddress.IPv4, n.HealthEndpointAddress.IPv6)
 }
 
 // SecondaryHealthIPs return a list of IP addresses corresponding to secondary
 // addresses of the health endpoint. In the current implementation, this
-// is the IPv6 IP if both IPv4 and IPv6 are enabled (IPv4 remains the primary
-// health IP in such a scenario)
+// is the non-primary address family IP if both IPv4 and IPv6 are enabled.
 func (n *healthNode) SecondaryHealthIPs() []string {
-	if n.NodeElement.HealthEndpointAddress == nil {
+	if n.HealthEndpointAddress == nil {
 		return nil
 	}
 
-	if n.NodeElement.HealthEndpointAddress.IPv4.Enabled && n.NodeElement.HealthEndpointAddress.IPv6.Enabled {
-		return []string{n.NodeElement.HealthEndpointAddress.IPv6.IP}
+	if n.HealthEndpointAddress.IPv4.Enabled && n.HealthEndpointAddress.IPv6.Enabled {
+		if n.preferPrimaryIPv6 {
+			return []string{n.HealthEndpointAddress.IPv4.IP}
+		}
+		return []string{n.HealthEndpointAddress.IPv6.IP}
 	}
 
 	return nil

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -111,34 +111,34 @@ func (s *Server) getNodes() (nodeMap, nodeMap, error) {
 	}
 	s.RWMutex.Unlock()
 
-	nodesAdded := nodeElementSliceToNodeMap(resp.Payload.NodesAdded)
-	nodesRemoved := nodeElementSliceToNodeMap(resp.Payload.NodesRemoved)
+	nodesAdded := nodeElementSliceToNodeMap(resp.Payload.NodesAdded, option.Config.PreferIpv6)
+	nodesRemoved := nodeElementSliceToNodeMap(resp.Payload.NodesRemoved, option.Config.PreferIpv6)
 
 	return nodesAdded, nodesRemoved, nil
 }
 
 // nodeElementSliceToNodeMap returns a slice of models.NodeElement into a
 // nodeMap.
-func nodeElementSliceToNodeMap(nodeElements []*models.NodeElement) nodeMap {
+func nodeElementSliceToNodeMap(nodeElements []*models.NodeElement, preferIpv6 bool) nodeMap {
 	nodes := make(nodeMap)
 	for _, n := range nodeElements {
 		if n.PrimaryAddress != nil {
 			if n.PrimaryAddress.IPv4 != nil {
-				nodes[ipString(n.PrimaryAddress.IPv4.IP)] = NewHealthNode(n)
+				nodes[ipString(n.PrimaryAddress.IPv4.IP)] = NewHealthNode(n, preferIpv6)
 			}
 			if n.PrimaryAddress.IPv6 != nil {
-				nodes[ipString(n.PrimaryAddress.IPv6.IP)] = NewHealthNode(n)
+				nodes[ipString(n.PrimaryAddress.IPv6.IP)] = NewHealthNode(n, preferIpv6)
 			}
 		}
 		for _, addr := range n.SecondaryAddresses {
-			nodes[ipString(addr.IP)] = NewHealthNode(n)
+			nodes[ipString(addr.IP)] = NewHealthNode(n, preferIpv6)
 		}
 		if n.HealthEndpointAddress != nil {
 			if n.HealthEndpointAddress.IPv4 != nil {
-				nodes[ipString(n.HealthEndpointAddress.IPv4.IP)] = NewHealthNode(n)
+				nodes[ipString(n.HealthEndpointAddress.IPv4.IP)] = NewHealthNode(n, preferIpv6)
 			}
 			if n.HealthEndpointAddress.IPv6 != nil {
-				nodes[ipString(n.HealthEndpointAddress.IPv6.IP)] = NewHealthNode(n)
+				nodes[ipString(n.HealthEndpointAddress.IPv6.IP)] = NewHealthNode(n, preferIpv6)
 			}
 		}
 	}

--- a/pkg/hubble/cell/config.go
+++ b/pkg/hubble/cell/config.go
@@ -77,6 +77,7 @@ func (def config) Flags(flags *pflag.FlagSet) {
 	// Hubble TCP server configuration
 	flags.String("hubble-listen-address", def.ListenAddress, `An additional address for Hubble server to listen to, e.g. ":4244"`)
 	flags.Bool("hubble-prefer-ipv6", def.PreferIpv6, "Prefer IPv6 addresses for announcing nodes when both address types are available.")
+	flags.MarkDeprecated("hubble-prefer-ipv6", "Use --prefer-ipv6 instead. Will be removed in v1.20.")
 }
 
 func (cfg *config) normalize() {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -597,6 +597,9 @@ const (
 	// EnableIPv6Name is the name of the option to enable IPv6 support
 	EnableIPv6Name = "enable-ipv6"
 
+	// PreferIpv6Name is the name of the option to prefer IPv6 addresses
+	PreferIpv6Name = "prefer-ipv6"
+
 	// EnableIPv6NDPName is the name of the option to enable IPv6 NDP support
 	EnableIPv6NDPName = "enable-ipv6-ndp"
 
@@ -1381,6 +1384,10 @@ type DaemonConfig struct {
 	// EnableIPv6 is true when IPv6 is enabled
 	EnableIPv6 bool
 
+	// PreferIpv6 is true when IPv6 addresses should be preferred over
+	// IPv4 when both are available.
+	PreferIpv6 bool
+
 	// EnableNat46X64Gateway is true when L3 based NAT46 and NAT64 translation is enabled
 	EnableNat46X64Gateway bool
 
@@ -1908,6 +1915,7 @@ var (
 		HealthCheckICMPFailureThreshold: defaults.HealthCheckICMPFailureThreshold,
 		EnableIPv4:                      defaults.EnableIPv4,
 		EnableIPv6:                      defaults.EnableIPv6,
+		PreferIpv6:                      defaults.PreferIpv6,
 		EnableIPv6NDP:                   defaults.EnableIPv6NDP,
 		EnableSCTP:                      defaults.EnableSCTP,
 		EnableL7Proxy:                   defaults.EnableL7Proxy,
@@ -2439,6 +2447,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.DebugVerbose = vp.GetStringSlice(DebugVerbose)
 	c.EnableIPv4 = vp.GetBool(EnableIPv4Name)
 	c.EnableIPv6 = vp.GetBool(EnableIPv6Name)
+	c.PreferIpv6 = vp.GetBool(PreferIpv6Name)
 	c.EnableIPv6NDP = vp.GetBool(EnableIPv6NDPName)
 	c.EnableSRv6 = vp.GetBool(EnableSRv6)
 	c.EnableFibTableIDAnnotation = vp.GetBool(EnableFibTableIDAnnotation)


### PR DESCRIPTION
## Description

When both IPv4 and IPv6 are enabled, `cilium-health` unconditionally prefers IPv4 for address selection. In clusters where IPv4 addresses are unroutable across sites but IPv6 is globally routable (e.g., Geneve tunnels with `underlayProtocol: ipv6`), this causes permanently degraded health status (`1/2 reachable`).

This PR adds a generic `prefer-ipv6` agent-level flag following the same pattern as `EnableIPv4`/`EnableIPv6` in `DaemonConfig`.

### Changes

- **Agent flag**: `--prefer-ipv6` / `PreferIpv6` in `DaemonConfig`, default `false`
- **Health probes**: New `preferAddr()` helper simplifies `PrimaryIP()` and `HealthIP()` to 2 return statements each. When `preferPrimaryIPv6` is set, IPv6 is chosen as primary.
- **Hubble**: The ConfigMap template cascades `preferIpv6` → `hubble-prefer-ipv6: "true"` so Hubble picks it up automatically. No Hubble agent code changes needed.
- **Deprecation**: `hubble.preferIpv6` Helm value and `--hubble-prefer-ipv6` agent flag are deprecated in favor of the top-level `preferIpv6` / `--prefer-ipv6`. Both deprecated options compose via OR semantics with the new flag for backward compatibility and will be removed in Cilium 1.20.

### Helm value
- **Top-level**: `preferIpv6: false` — generic agent-wide preference
- **`hubble.preferIpv6`**: Deprecated, kept for backward compatibility. Both can still be set independently (OR semantics).

Closes: #44561

```release-note
Add generic `preferIpv6` Helm value / `--prefer-ipv6` agent flag to prefer IPv6 addresses for health probes and Hubble peer communication when both address families are available. The `hubble.preferIpv6` Helm value and `--hubble-prefer-ipv6` agent flag are deprecated in favor of the new top-level `preferIpv6` and will be removed in Cilium 1.20.
```