### PR TITLE
ipsec: remove deprecated `enable-ipsec-encrypted-overlay` option

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1356,10 +1356,6 @@
      - Enable transparent network encryption.
      - bool
      - ``false``
-   * - :spelling:ignore:`encryption.ipsec.encryptedOverlay`
-     - Enable IPsec encrypted overlay
-     - bool
-     - ``false``
    * - :spelling:ignore:`encryption.ipsec.interface`
      - The interface to use for encrypted traffic.
      - string

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -385,6 +385,9 @@ from Cilium.
 * The previously deprecated ``--node-port-mode`` agent flag has been removed
   in favor of the ``--bpf-lb-mode`` (``loadBalancer.mode`` Helm value).
 
+* The previously deprecated and ignored ``--enable-ipsec-encrypted-overlay`` agent
+  flag (Helm ``encryption.ipsec.encryptedOverlay``) has been removed.
+
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -389,7 +389,6 @@ contributors across the globe, there is almost always someone available to help.
 | enableNonDefaultDenyPolicies | bool | `true` | Enable Non-Default-Deny policies |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
-| encryption.ipsec.encryptedOverlay | bool | `false` | Enable IPsec encrypted overlay |
 | encryption.ipsec.interface | string | `""` | The interface to use for encrypted traffic. |
 | encryption.ipsec.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
 | encryption.ipsec.keyRotationDuration | string | `"5m"` | Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -747,7 +747,6 @@ data:
     {{- if .Values.encryption.ipsec.keyRotationDuration }}
   ipsec-key-rotation-duration: {{ include "validateDuration" .Values.encryption.ipsec.keyRotationDuration | quote }}
     {{- end }}
-  enable-ipsec-encrypted-overlay: {{ .Values.encryption.ipsec.encryptedOverlay | quote }}
   {{- else if eq .Values.encryption.type "wireguard" }}
   enable-wireguard: {{ .Values.encryption.enabled | quote }}
     {{- if .Values.encryption.wireguard.persistentKeepalive }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1934,9 +1934,6 @@
         },
         "ipsec": {
           "properties": {
-            "encryptedOverlay": {
-              "type": "boolean"
-            },
             "interface": {
               "type": "string"
             },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1169,8 +1169,6 @@ encryption:
     # -- Maximum duration of the IPsec key rotation. The previous key will be
     # removed after that delay.
     keyRotationDuration: "5m"
-    # -- Enable IPsec encrypted overlay
-    encryptedOverlay: false
   wireguard:
     # -- Controls WireGuard PersistentKeepalive option. Set 0s to disable.
     persistentKeepalive: 0s

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1180,8 +1180,6 @@ encryption:
     # -- Maximum duration of the IPsec key rotation. The previous key will be
     # removed after that delay.
     keyRotationDuration: "5m"
-    # -- Enable IPsec encrypted overlay
-    encryptedOverlay: false
   wireguard:
     # -- Controls WireGuard PersistentKeepalive option. Set 0s to disable.
     persistentKeepalive: 0s

--- a/pkg/datapath/linux/ipsec/cell.go
+++ b/pkg/datapath/linux/ipsec/cell.go
@@ -97,7 +97,6 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableIPsecKeyWatcher, def.EnableIPsecKeyWatcher, "Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations.")
 	flags.Bool(option.EnableIPSecXfrmStateCaching, def.EnableIPsecXfrmStateCaching, "Enable XfrmState cache for IPSec. Significantly reduces CPU usage in large clusters.")
 	flags.MarkHidden(option.EnableIPSecXfrmStateCaching)
-	flags.MarkDeprecated(option.EnableIPSecEncryptedOverlay, "Encrypted overlay is the default behavior for IPsec.")
 	flags.Bool(option.UseCiliumInternalIPForIPsec, def.UseCiliumInternalIPForIPsec, "Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation")
 	flags.MarkHidden(option.UseCiliumInternalIPForIPsec)
 	flags.Bool(option.DNSProxyInsecureSkipTransparentModeCheck, def.DNSProxyInsecureSkipTransparentModeCheck, "Allows DNS proxy transparent mode to be disabled even if encryption is enabled. Enabling this flag and disabling DNS proxy transparent mode will cause proxied DNS traffic to leave the node unencrypted.")

--- a/pkg/datapath/linux/ipsec/fake/ipsec.go
+++ b/pkg/datapath/linux/ipsec/fake/ipsec.go
@@ -53,7 +53,6 @@ func (a *Agent) Enabled() bool {
 
 type Config struct {
 	EnableIPsec                              bool
-	EncryptedOverlay                         bool
 	UseCiliumInternalIPForIPsec              bool
 	DNSProxyInsecureSkipTransparentModeCheck bool
 }

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -135,10 +135,6 @@ const (
 	// ReservedIdentityWorldIPv6 represents any endpoint outside of the cluster
 	// for IPv6 address only.
 	ReservedIdentityWorldIPv6
-
-	// ReservedEncryptedOverlay represents overlay traffic which must be IPSec
-	// encrypted before it leaves the host
-	ReservedEncryptedOverlay
 )
 
 // Special identities for well-known cluster components
@@ -367,17 +363,16 @@ func GetMaximumAllocationIdentity(clusterID uint32) NumericIdentity {
 
 var (
 	reservedIdentities = map[string]NumericIdentity{
-		labels.IDNameHost:             ReservedIdentityHost,
-		labels.IDNameWorld:            ReservedIdentityWorld,
-		labels.IDNameWorldIPv4:        ReservedIdentityWorldIPv4,
-		labels.IDNameWorldIPv6:        ReservedIdentityWorldIPv6,
-		labels.IDNameUnmanaged:        ReservedIdentityUnmanaged,
-		labels.IDNameHealth:           ReservedIdentityHealth,
-		labels.IDNameInit:             ReservedIdentityInit,
-		labels.IDNameRemoteNode:       ReservedIdentityRemoteNode,
-		labels.IDNameKubeAPIServer:    ReservedIdentityKubeAPIServer,
-		labels.IDNameIngress:          ReservedIdentityIngress,
-		labels.IDNameEncryptedOverlay: ReservedEncryptedOverlay,
+		labels.IDNameHost:          ReservedIdentityHost,
+		labels.IDNameWorld:         ReservedIdentityWorld,
+		labels.IDNameWorldIPv4:     ReservedIdentityWorldIPv4,
+		labels.IDNameWorldIPv6:     ReservedIdentityWorldIPv6,
+		labels.IDNameUnmanaged:     ReservedIdentityUnmanaged,
+		labels.IDNameHealth:        ReservedIdentityHealth,
+		labels.IDNameInit:          ReservedIdentityInit,
+		labels.IDNameRemoteNode:    ReservedIdentityRemoteNode,
+		labels.IDNameKubeAPIServer: ReservedIdentityKubeAPIServer,
+		labels.IDNameIngress:       ReservedIdentityIngress,
 	}
 	reservedIdentityNames = map[NumericIdentity]string{
 		IdentityUnknown:               "unknown",

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -58,16 +58,6 @@ const (
 	// with IDNameHost if the kube-apiserver is running on the local host.
 	IDNameKubeAPIServer = "kube-apiserver"
 
-	// IDNameEncryptedOverlay is the label used to identify encrypted overlay
-	// traffic.
-	//
-	// It is part of the reserved identity 11 and signals that overlay traffic
-	// with this identity must be IPSec encrypted before leaving the host.
-	//
-	// This identity should never be seen on the wire and is used only on the
-	// local host.
-	IDNameEncryptedOverlay = "overlay-to-encrypt"
-
 	// IDNameIngress is the label used to identify Ingress proxies. It is part
 	// of the reserved identity 8.
 	IDNameIngress = "ingress"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1117,12 +1117,6 @@ const (
 	// IPSecKeyFile is the name of the option for ipsec key file
 	IPSecKeyFile = "ipsec-key-file"
 
-	// EnableIPSecEncryptedOverlay is the name of the option which enables
-	// the EncryptedOverlay feature.
-	//
-	// This feature will encrypt overlay traffic before it leaves the cluster.
-	EnableIPSecEncryptedOverlay = "enable-ipsec-encrypted-overlay"
-
 	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
 	UseCiliumInternalIPForIPsec = "use-cilium-internal-ip-for-ipsec"
 )


### PR DESCRIPTION
This is not used anymore. From Cilium >v1.18, all overlay traffic gets automatically encrypted before leaving the host without needing any agent/daemon/helm flags.