### PR TITLE
endpoint: Remove network policy unconditionally

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1310,6 +1310,11 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 		}
 	}
 
+	// Endpoint's network policy must be released even if the identity is not released.
+	// Remove network policy before (possibly) releasing identity so proxy cleanup
+	// can still observe the endpoint exactly as it was published.
+	e.removeNetworkPolicy()
+
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
 		if e.identitySet {
 			// Restored endpoint may be created with a reserved identity of 5
@@ -1326,7 +1331,6 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 				errs = append(errs, fmt.Errorf("unable to release identity: %w", err))
 			}
 		}
-		e.removeNetworkPolicy()
 		e.SecurityIdentity = nil
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -23,6 +23,7 @@ import (
 	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
 	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	fqdnrestore "github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -39,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	proxyendpoint "github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
@@ -521,6 +523,24 @@ func TestWaitForPolicyRevision(t *testing.T) {
 	require.Empty(t, e.policyRevisionSignals)
 }
 
+func TestDeleteRemovesNetworkPolicyWhenIdentityReleaseIsSkipped(t *testing.T) {
+	p := createTestEndpointParams(t)
+	proxy := &recordingRemoveNetworkPolicyProxy{}
+
+	ep, err := NewEndpointFromChangeModel(p, noopDNSRulesAPI{}, proxy, newTestEndpointModel(1234, StateReady), nil)
+	require.NoError(t, err)
+
+	ep.Start(uint16(ep.ID))
+
+	errs := ep.Delete(DeleteConfig{
+		NoIdentityRelease: true,
+		NoIPRelease:       true,
+	})
+	require.Empty(t, errs)
+	require.Equal(t, 1, proxy.calls)
+	require.Equal(t, uint64(ep.ID), proxy.lastEndpointID)
+}
+
 func TestProxyID(t *testing.T) {
 	setupEndpointSuite(t)
 
@@ -834,6 +854,23 @@ func newTestEndpointModel(id int, state State) *models.EndpointChangeRequest {
 			PropertyFakeEndpoint: true,
 		},
 	}
+}
+
+type noopDNSRulesAPI struct{}
+
+func (noopDNSRulesAPI) GetDNSRules(uint16) fqdnrestore.DNSRules { return nil }
+
+func (noopDNSRulesAPI) RemoveRestoredDNSRules(uint16) {}
+
+type recordingRemoveNetworkPolicyProxy struct {
+	FakeEndpointProxy
+	calls          int
+	lastEndpointID uint64
+}
+
+func (p *recordingRemoveNetworkPolicyProxy) RemoveNetworkPolicy(ep proxyendpoint.EndpointInfoSource) {
+	p.calls++
+	p.lastEndpointID = ep.GetID()
 }
 
 //TODODODODO


### PR DESCRIPTION
Endpoint's network policy must be removed on delete even if the identity would not be released.  This prevents stale endpoint policies remaining and later causing IP collisions since IP addresses can be reused for new endpoints after endpoint deletion.

Fixes: #36433

```release-note
Network policies of stale un-restored endpoints are now removed properly.
```
