### PR TITLE
gh: Upload sysdumps also for cancelled jobs

### DIFF
--- a/.github/actions/post-logic/action.yaml
+++ b/.github/actions/post-logic/action.yaml
@@ -40,7 +40,7 @@ runs:
         cilium sysdump --output-filename "cilium-sysdump-${{ inputs.artifacts_suffix }}"
 
     - name: Upload artifacts
-      if: ${{ always() && inputs.job_status == 'failure' }}
+      if: ${{ always() && inputs.job_status != 'success' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "cilium-sysdumps-${{ inputs.artifacts_suffix }}"


### PR DESCRIPTION
Change the run condition of "Upload artifacts" step from == 'failure' to != 'success' so that it also covers cancelled jobs.

Steps may get cancelled due to timeouts, and often the timeouts happen due to sysdump creation taking extra time. Now those sysdumps are lost, and diagnosis is not possible when the same errors can not be reproduced locally. Changing this condition to != 'success' allows the sysdumps that were already produced before the cancellation to be uploaded and thus made avaialble on the action summary page.

Example workflow run with timed-out/cancelled steps that produced sysdumps that were not uploaded: https://github.com/cilium/cilium/actions/runs/24586223717/job/71896434804

Example of a workflow run from a PR with a cherry-pick of this fix: sysdump was uploaded for a conceled step: https://github.com/cilium/cilium/actions/runs/24604295936

```release-note
Sysdumps of cancelled or timed-out GitHub actions are also uploaded.
```
