### PR TITLE
fix(gateway-api): populate Gateway addresses from Node IPs for non-LB services

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -40,7 +40,7 @@ rules:
   verbs:
    # allow patching of the configmap to set annotations
   - patch
-{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus (include "hasDuration" .Values.operator.endpointGCInterval) }}
+{{- if or .Values.operator.removeNodeTaints .Values.operator.setNodeNetworkStatus (include "hasDuration" .Values.operator.endpointGCInterval) .Values.gatewayAPI.enabled }}
 - apiGroups:
   - ""
   resources:
@@ -393,7 +393,7 @@ rules:
   verbs:
   - get
   - list
-  - watch  
+  - watch
 {{- end }}
 {{- if or .Values.gatewayAPI.enabled .Values.clustermesh.mcsapi.enabled }}
 - apiGroups:

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -263,6 +263,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 	if err := registerReconcilers(
 		params.CtrlRuntimeManager,
 		gatewayAPITranslator,
+		cfg,
 		params.Logger,
 		installedKinds,
 	); err != nil {
@@ -402,12 +403,12 @@ func checkCRDs(ctx context.Context, clientset k8sClient.Clientset, logger *slog.
 
 // registerReconcilers registers Gateway API reconcilers to the controller-runtime library manager.
 // optionalKinds are previously autodetected based on what CRDs are present in the cluster.
-func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) error {
+func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, cfg translation.Config, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger),
-		newGatewayReconciler(mgr, translator, logger, installedCRDs),
+		newGatewayReconciler(mgr, translator, cfg, logger, installedCRDs),
 		newGammaReconciler(mgr, translator, logger),
 		newGatewayClassConfigReconciler(mgr, logger),
 	}

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -46,18 +46,20 @@ type gatewayReconciler struct {
 	client.Client
 	Scheme     *runtime.Scheme
 	translator translation.Translator
+	cfg        translation.Config
 
 	logger        *slog.Logger
 	installedCRDs []schema.GroupVersionKind
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, cfg translation.Config, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		translator:    translator,
+		cfg:           cfg,
 		logger:        scopedLog,
 		installedCRDs: installedCRDs,
 	}
@@ -155,6 +157,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to BackendTLSPolicy
 		Watches(&gatewayv1.BackendTLSPolicy{}, r.enqueueRequestForBackendTLSPolicy()).
 		Watches(&corev1.ConfigMap{}, r.enqueueRequestForBackendTLSPolicyConfigMap()).
+		Watches(&corev1.Node{}, r.enqueueRequestForNode()).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{})
@@ -244,6 +247,52 @@ func (r *gatewayReconciler) enqueueRequestForOwningGatewayClass() handler.EventH
 		}
 		return reqs
 	})
+}
+
+// enqueueRequestForNode returns an event handler that, when a Node changes,
+// enqueues all Cilium-managed Gateways for reconciliation so that address
+// status can be updated for non-LoadBalancer services (hostNetwork/NodePort).
+func (r *gatewayReconciler) enqueueRequestForNode() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		scopedLog := r.logger.With(
+			logfields.LogSubsys, "queue-gw-from-node",
+			logfields.Resource, client.ObjectKeyFromObject(a).String(),
+		)
+
+		gwList, err := r.listAllCiliumGateways(ctx)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list Gateways", logfields.Error, err)
+			return nil
+		}
+
+		reqs := make([]reconcile.Request, 0, len(gwList.Items))
+		for _, gw := range gwList.Items {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: gw.Namespace,
+					Name:      gw.Name,
+				},
+			}
+			reqs = append(reqs, req)
+			scopedLog.DebugContext(ctx,
+				"Enqueued gateway for Node event",
+				logfields.K8sNamespace, gw.GetNamespace(),
+				gateway, gw.GetName(),
+			)
+		}
+		return reqs
+	})
+}
+
+func (r *gatewayReconciler) listAllCiliumGateways(ctx context.Context) (*gatewayv1.GatewayList, error) {
+	gwList := &gatewayv1.GatewayList{}
+	if err := r.Client.List(ctx, gwList, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
+	}); err != nil {
+		return nil, err
+	}
+
+	return gwList, nil
 }
 
 // enqueueRequestForOwningHTTPRoute returns an event handler that, when passed a HTTPRoute, returns reconcile.Requests
@@ -512,11 +561,8 @@ func (r *gatewayReconciler) updateReconcileRequestsForBackendTLSPolicy(ctx conte
 }
 
 func (r *gatewayReconciler) getAllCiliumGatewaysSet(ctx context.Context) (map[string]struct{}, error) {
-	// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
-	gwList := &gatewayv1.GatewayList{}
-	if err := r.Client.List(ctx, gwList, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
-	}); err != nil {
+	gwList, err := r.listAllCiliumGateways(ctx)
+	if err != nil {
 		return nil, err
 	}
 	// Build a set of all Cilium Gateway full names.

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"slices"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -18,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilsnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +37,8 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	"github.com/cilium/cilium/pkg/annotation"
+	slim_labels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -504,24 +509,36 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 	}
 
 	svc := svcList.Items[0]
-	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		// Potential loadbalancer service isn't ready yet. No need to report as an error, because
-		// reconciliation should be triggered when the loadbalancer services gets updated.
-		return nil
-	}
 
 	var addresses []gatewayv1.GatewayStatusAddress
-	for _, s := range svc.Status.LoadBalancer.Ingress {
-		if len(s.IP) != 0 {
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeLoadBalancer:
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			return nil
+		}
+		for _, s := range svc.Status.LoadBalancer.Ingress {
+			if len(s.IP) != 0 {
+				addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+					Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
+					Value: s.IP,
+				})
+			}
+			if len(s.Hostname) != 0 {
+				addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+					Type:  GatewayAddressTypePtr(gatewayv1.HostnameAddressType),
+					Value: s.Hostname,
+				})
+			}
+		}
+	case corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort:
+		nodeAddresses, err := r.getNodeAddressesForGateway(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get node addresses: %w", err)
+		}
+		for _, addr := range nodeAddresses {
 			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
 				Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
-				Value: s.IP,
-			})
-		}
-		if len(s.Hostname) != 0 {
-			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
-				Type:  GatewayAddressTypePtr(gatewayv1.HostnameAddressType),
-				Value: s.Hostname,
+				Value: addr,
 			})
 		}
 	}
@@ -530,7 +547,6 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 		r.logger.InfoContext(ctx, "At least one valid address, marking gateway programmed", logfields.Resource, client.ObjectKeyFromObject(gw).String())
 		setGatewayProgrammed(gw, metav1.ConditionTrue, "Gateway Programmed", gatewayv1.GatewayReasonProgrammed)
 		for _, l := range gw.Status.Listeners {
-			// Is Listener Accepted?
 			accepted := false
 
 			for _, cond := range l.Conditions {
@@ -556,6 +572,67 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 	return nil
 }
 
+func (r *gatewayReconciler) getNodeAddressesForGateway(ctx context.Context) ([]string, error) {
+	var nodeSelector slim_labels.Selector
+
+	if r.cfg.HostNetworkConfig.Enabled && r.cfg.HostNetworkConfig.NodeLabelSelector != nil {
+		selector, err := slim_metav1.LabelSelectorAsSelector(r.cfg.HostNetworkConfig.NodeLabelSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse node label selector: %w", err)
+		}
+		nodeSelector = selector
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := r.Client.List(ctx, nodeList); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	extIPs := sets.Set[string]{}
+	intIPs := sets.Set[string]{}
+
+	for _, node := range nodeList.Items {
+		if node.DeletionTimestamp != nil && !node.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if nodeSelector != nil && !nodeSelector.Matches(slim_labels.Set(node.Labels)) {
+			continue
+		}
+
+		for _, addr := range node.Status.Addresses {
+			switch addr.Type {
+			case corev1.NodeExternalIP:
+				if isAllowedIPFamily(addr.Address, r.cfg.IPConfig.IPv4Enabled, r.cfg.IPConfig.IPv6Enabled) {
+					extIPs.Insert(addr.Address)
+				}
+			case corev1.NodeInternalIP:
+				if isAllowedIPFamily(addr.Address, r.cfg.IPConfig.IPv4Enabled, r.cfg.IPConfig.IPv6Enabled) {
+					intIPs.Insert(addr.Address)
+				}
+			}
+		}
+	}
+
+	var ips []string
+	if extIPs.Len() > 0 {
+		ips = extIPs.UnsortedList()
+	} else {
+		ips = intIPs.UnsortedList()
+	}
+	slices.Sort(ips)
+	return ips, nil
+}
+
+func isAllowedIPFamily(addr string, ipv4Enabled, ipv6Enabled bool) bool {
+	if ipv4Enabled && utilsnet.IsIPv4String(addr) {
+		return true
+	}
+	if ipv6Enabled && utilsnet.IsIPv6String(addr) {
+		return true
+	}
+	return false
+}
+
 func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {
 	if len(gw.Spec.Addresses) == 0 {
 		return nil
@@ -572,18 +649,30 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	}
 
 	svc := svcList.Items[0]
-	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		// Potential loadbalancer service isn't ready yet. No need to report as an error, because
-		// reconciliation should be triggered when the loadbalancer services gets updated.
-		return nil
-	}
-	addresses := make(map[string]struct{})
-	for _, addr := range svc.Status.LoadBalancer.Ingress {
-		addresses[addr.IP] = struct{}{}
+
+	var addressSet map[string]struct{}
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort:
+		nodeAddresses, err := r.getNodeAddressesForGateway(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get node addresses: %w", err)
+		}
+		addressSet = make(map[string]struct{})
+		for _, ip := range nodeAddresses {
+			addressSet[ip] = struct{}{}
+		}
+	default:
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			return nil
+		}
+		addressSet = make(map[string]struct{})
+		for _, addr := range svc.Status.LoadBalancer.Ingress {
+			addressSet[addr.IP] = struct{}{}
+		}
 	}
 
 	for _, addr := range gw.Spec.Addresses {
-		if _, ok := addresses[addr.Value]; !ok {
+		if _, ok := addressSet[addr.Value]; !ok {
 			return fmt.Errorf("static address %q can't be used", addr.Value)
 		}
 	}

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -41,6 +41,8 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_labels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/shortener"
 )

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -853,7 +853,7 @@ func Test_getNodeAddressesForGateway_HonorsNodeLabelSelectorExpressions(t *testi
 		).
 		Build()
 
-		r := &gatewayReconciler{
+	r := &gatewayReconciler{
 		Client: c,
 		cfg: translation.Config{
 			HostNetworkConfig: translation.HostNetworkConfig{

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -21,12 +21,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/shortener"
 )
 
@@ -56,7 +58,7 @@ var (
 
 func Test_Conformance(t *testing.T) {
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
-	cecTranslator := translation.NewCECTranslator(translation.Config{
+	translatorCfg := translation.Config{
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: true,
 		},
@@ -66,16 +68,14 @@ func Test_Conformance(t *testing.T) {
 		ClusterConfig: translation.ClusterConfig{
 			IdleTimeoutSeconds: 60,
 		},
-	})
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
 		ServiceConfig: translation.ServiceConfig{
 			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
 		},
-	})
-
-	type gwDetails struct {
-		FullName types.NamespacedName
-		wantErr  bool
+	}
+	reconcilerCfg := translation.Config{
+		IPConfig: translation.IPConfig{
+			IPv4Enabled: true,
+		},
 	}
 
 	var (
@@ -284,133 +284,7 @@ func Test_Conformance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			base := readInputDir(t, "testdata/gateway/base")
-			input := readInputDir(t, fmt.Sprintf("testdata/gateway/%s/input", tt.name))
-
-			clientBuilder := fake.NewClientBuilder().
-				WithObjects(append(base, input...)...).
-				WithStatusSubresource(&corev1.Service{}).
-				WithStatusSubresource(&corev1.Namespace{}).
-				WithStatusSubresource(&gatewayv1.GRPCRoute{}).
-				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
-				WithStatusSubresource(&gatewayv1.TLSRoute{}).
-				WithStatusSubresource(&gatewayv1.Gateway{}).
-				WithStatusSubresource(&gatewayv1.GatewayClass{}).
-				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
-
-			switch tt.disableServiceImport {
-			case true:
-				clientBuilder.WithScheme(testSchemeNoServiceImport())
-			case false:
-				clientBuilder.WithScheme(testScheme())
-			}
-
-			// Add any required indexes here
-			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.GatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway)
-			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, fakeIndexHTTPRouteByBackendService)
-			clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, indexers.GatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway)
-			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
-
-			c := clientBuilder.Build()
-
-			r := &gatewayReconciler{
-				Client:     c,
-				translator: gatewayAPITranslator,
-				logger:     logger,
-			}
-
-			// Reconcile all related HTTPRoute objects
-			hrList := &gatewayv1.HTTPRouteList{}
-			err := c.List(t.Context(), hrList)
-			require.NoError(t, err)
-
-			// Reconcile all related TLSRoute objects
-			tlsrList := &gatewayv1.TLSRouteList{}
-			err = c.List(t.Context(), tlsrList)
-			require.NoError(t, err)
-
-			// Reconcile all related GRPCRoute objects
-			grpcrList := &gatewayv1.GRPCRouteList{}
-			err = c.List(t.Context(), grpcrList)
-			require.NoError(t, err)
-
-			// Reconcile all BackendTLSPolicy objects
-			btlspList := &gatewayv1.BackendTLSPolicyList{}
-			err = c.List(t.Context(), btlspList)
-			require.NoError(t, err)
-
-			for _, gwDetail := range tt.gateway {
-				// Reconcile the gateway under test
-				result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: gwDetail.FullName})
-				require.Equal(t, gwDetail.wantErr, err != nil, "Got an unexpected reconciliation error for Gateway %s. want: %t, got: %t", gwDetail.FullName.Name, gwDetail.wantErr, err != nil)
-				require.Equal(t, ctrl.Result{}, result)
-				// Checking the output for Gateway
-				actualGateway := &gatewayv1.Gateway{}
-				err = c.Get(t.Context(), gwDetail.FullName, actualGateway)
-				// TODO(youngnick): controller-runtime has broken something with the fake client
-				// Bypass for now
-				actualGateway.TypeMeta = gatewayTypeMeta
-				require.NoError(t, err)
-				expectedGateway := &gatewayv1.Gateway{}
-				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/%s.yaml", tt.name, gwDetail.FullName.Name), expectedGateway)
-				require.Empty(t, cmp.Diff(expectedGateway, actualGateway, cmpIgnoreFields...))
-				if !gwDetail.wantErr {
-					// Checking the output for CiliumEnvoyConfig
-					actualCEC := &ciliumv2.CiliumEnvoyConfig{}
-					err = c.Get(t.Context(), client.ObjectKey{
-						Namespace: gwDetail.FullName.Namespace,
-						Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gwDetail.FullName.Name),
-					}, actualCEC)
-					require.NoError(t, err, "Could not get CiliumEnvoyConfig and wasn't expecting a reconciliation error")
-					expectedCEC := &ciliumv2.CiliumEnvoyConfig{}
-					readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/cec-%s.yaml", tt.name, gwDetail.FullName.Name), expectedCEC)
-					require.NoError(t, err)
-					require.Empty(t, cmp.Diff(expectedCEC, actualCEC, protocmp.Transform()))
-				}
-
-			}
-			// Checking the output for related HTTPRoute objects
-			for _, hr := range hrList.Items {
-				actualHR := &gatewayv1.HTTPRoute{}
-				err = c.Get(t.Context(), client.ObjectKeyFromObject(&hr), actualHR)
-				// TODO(youngnick): controller-runtime has broken something with the fake client
-				// Bypass for now
-				actualHR.TypeMeta = httpRouteTypeMeta
-				require.NoError(t, err, "error getting HTTPRoute %s/%s: %v", hr.Namespace, hr.Name, err)
-				expectedHR := &gatewayv1.HTTPRoute{}
-				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/httproute-%s.yaml", tt.name, hr.Name), expectedHR)
-				require.Empty(t, cmp.Diff(expectedHR, actualHR, cmpIgnoreFields...))
-			}
-
-			for _, tlsr := range tlsrList.Items {
-				actualTLSR := &gatewayv1.TLSRoute{}
-				err = c.Get(t.Context(), client.ObjectKeyFromObject(&tlsr), actualTLSR)
-				actualTLSR.TypeMeta = tlsRouteTypeMeta
-				require.NoError(t, err, "error getting TLSRoute %s/%s: %v", tlsr.Namespace, tlsr.Name, err)
-				expectedTLSR := &gatewayv1.TLSRoute{}
-				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tlsroute-%s.yaml", tt.name, tlsr.Name), expectedTLSR)
-				require.Empty(t, cmp.Diff(expectedTLSR, actualTLSR, cmpIgnoreFields...))
-			}
-
-			for _, grpcr := range grpcrList.Items {
-				actualGRPCR := &gatewayv1.GRPCRoute{}
-				err = c.Get(t.Context(), client.ObjectKeyFromObject(&grpcr), actualGRPCR)
-				actualGRPCR.TypeMeta = grpcRouteTypeMeta
-				require.NoError(t, err, "error getting GRPCRoute %s/%s: %v", grpcr.Namespace, grpcr.Name, err)
-				expectedGRPCR := &gatewayv1.GRPCRoute{}
-				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/grpcroute-%s.yaml", tt.name, grpcr.Name), expectedGRPCR)
-				require.Empty(t, cmp.Diff(expectedGRPCR, actualGRPCR, cmpIgnoreFields...))
-			}
-
-			for _, btlsp := range btlspList.Items {
-				actualBTLSP := &gatewayv1.BackendTLSPolicy{}
-				err = c.Get(t.Context(), client.ObjectKeyFromObject(&btlsp), actualBTLSP)
-				actualBTLSP.TypeMeta = backendTLSPolicyTypeMeta
-				require.NoError(t, err, "error getting BackendTLSPolicy %s/%s: %v", btlsp.Namespace, btlsp.Name, err)
-				expectedBTLSP := &gatewayv1.BackendTLSPolicy{}
-				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/backendtlspolicy-%s.yaml", tt.name, btlsp.Name), expectedBTLSP)
-				require.Empty(t, cmp.Diff(expectedBTLSP, actualBTLSP, cmpIgnoreFields...))
-			}
+			runGatewayConformanceTest(t, logger, tt.name, tt.gateway, translatorCfg, reconcilerCfg, tt.disableServiceImport)
 		})
 	}
 }
@@ -500,6 +374,7 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 
 			r := &gatewayReconciler{
 				Client: c,
+				cfg:    translation.Config{IPConfig: translation.IPConfig{IPv4Enabled: true}},
 				logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
 			}
 
@@ -738,4 +613,264 @@ func fakeIndexHTTPRouteByBackendService(rawObj client.Object) []string {
 		}
 	}
 	return backendServices
+}
+
+type gwDetails struct {
+	FullName types.NamespacedName
+	wantErr  bool
+}
+
+func runGatewayConformanceTest(t *testing.T, logger *slog.Logger, testName string, gateways []gwDetails, translatorCfg, reconcilerCfg translation.Config, disableServiceImport bool) {
+	t.Helper()
+
+	cecTranslator := translation.NewCECTranslator(translatorCfg)
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translatorCfg)
+	c := newGatewayConformanceClient(t, testName, disableServiceImport)
+	r := &gatewayReconciler{
+		Client:     c,
+		translator: gatewayAPITranslator,
+		cfg:        reconcilerCfg,
+		logger:     logger,
+	}
+
+	hrList := &gatewayv1.HTTPRouteList{}
+	require.NoError(t, c.List(t.Context(), hrList))
+
+	tlsrList := &gatewayv1alpha2.TLSRouteList{}
+	require.NoError(t, c.List(t.Context(), tlsrList))
+
+	grpcrList := &gatewayv1.GRPCRouteList{}
+	require.NoError(t, c.List(t.Context(), grpcrList))
+
+	btlspList := &gatewayv1.BackendTLSPolicyList{}
+	require.NoError(t, c.List(t.Context(), btlspList))
+
+	for _, gwDetail := range gateways {
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: gwDetail.FullName})
+		require.Equal(t, gwDetail.wantErr, err != nil, "Got an unexpected reconciliation error for Gateway %s. want: %t, got: %t", gwDetail.FullName.Name, gwDetail.wantErr, err != nil)
+		require.Equal(t, ctrl.Result{}, result)
+
+		assertGatewayOutput(t, c, testName, gwDetail)
+		if !gwDetail.wantErr {
+			assertCECOutput(t, c, testName, gwDetail)
+		}
+	}
+
+	assertHTTPRoutesOutput(t, c, testName, hrList)
+	assertTLSRoutesOutput(t, c, testName, tlsrList)
+	assertGRPCRoutesOutput(t, c, testName, grpcrList)
+	assertBackendTLSPoliciesOutput(t, c, testName, btlspList)
+}
+
+func newGatewayConformanceClient(t *testing.T, testName string, disableServiceImport bool) client.Client {
+	t.Helper()
+
+	base := readInputDir(t, "testdata/gateway/base")
+	input := readInputDir(t, fmt.Sprintf("testdata/gateway/%s/input", testName))
+
+	clientBuilder := fake.NewClientBuilder().
+		WithObjects(append(base, input...)...).
+		WithStatusSubresource(&corev1.Service{}).
+		WithStatusSubresource(&corev1.Namespace{}).
+		WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		WithStatusSubresource(&gatewayv1alpha2.TLSRoute{}).
+		WithStatusSubresource(&gatewayv1.Gateway{}).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}).
+		WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
+
+	if disableServiceImport {
+		clientBuilder.WithScheme(testSchemeNoServiceImport())
+	} else {
+		clientBuilder.WithScheme(testScheme())
+	}
+
+	clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.GatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway)
+	clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, fakeIndexHTTPRouteByBackendService)
+	clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, indexers.GatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway)
+	clientBuilder.WithIndex(&gatewayv1alpha2.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
+
+	return clientBuilder.Build()
+}
+
+func assertGatewayOutput(t *testing.T, c client.Client, testName string, gwDetail gwDetails) {
+	t.Helper()
+
+	actualGateway := &gatewayv1.Gateway{}
+	err := c.Get(t.Context(), gwDetail.FullName, actualGateway)
+	actualGateway.TypeMeta = gatewayTypeMeta
+	require.NoError(t, err)
+
+	expectedGateway := &gatewayv1.Gateway{}
+	readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/%s.yaml", testName, gwDetail.FullName.Name), expectedGateway)
+	require.Empty(t, cmp.Diff(expectedGateway, actualGateway, cmpIgnoreFields...))
+}
+
+func assertCECOutput(t *testing.T, c client.Client, testName string, gwDetail gwDetails) {
+	t.Helper()
+
+	actualCEC := &ciliumv2.CiliumEnvoyConfig{}
+	err := c.Get(t.Context(), client.ObjectKey{
+		Namespace: gwDetail.FullName.Namespace,
+		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gwDetail.FullName.Name),
+	}, actualCEC)
+	require.NoError(t, err, "Could not get CiliumEnvoyConfig and wasn't expecting a reconciliation error")
+
+	expectedCEC := &ciliumv2.CiliumEnvoyConfig{}
+	readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/cec-%s.yaml", testName, gwDetail.FullName.Name), expectedCEC)
+	require.Empty(t, cmp.Diff(expectedCEC, actualCEC, protocmp.Transform()))
+}
+
+func assertHTTPRoutesOutput(t *testing.T, c client.Client, testName string, hrList *gatewayv1.HTTPRouteList) {
+	t.Helper()
+
+	for _, hr := range hrList.Items {
+		actualHR := &gatewayv1.HTTPRoute{}
+		err := c.Get(t.Context(), client.ObjectKeyFromObject(&hr), actualHR)
+		actualHR.TypeMeta = httpRouteTypeMeta
+		require.NoError(t, err, "error getting HTTPRoute %s/%s: %v", hr.Namespace, hr.Name, err)
+
+		expectedHR := &gatewayv1.HTTPRoute{}
+		readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/httproute-%s.yaml", testName, hr.Name), expectedHR)
+		require.Empty(t, cmp.Diff(expectedHR, actualHR, cmpIgnoreFields...))
+	}
+}
+
+func assertTLSRoutesOutput(t *testing.T, c client.Client, testName string, tlsrList *gatewayv1alpha2.TLSRouteList) {
+	t.Helper()
+
+	for _, tlsr := range tlsrList.Items {
+		actualTLSR := &gatewayv1alpha2.TLSRoute{}
+		err := c.Get(t.Context(), client.ObjectKeyFromObject(&tlsr), actualTLSR)
+		actualTLSR.TypeMeta = tlsRouteTypeMeta
+		require.NoError(t, err, "error getting TLSRoute %s/%s: %v", tlsr.Namespace, tlsr.Name, err)
+
+		expectedTLSR := &gatewayv1alpha2.TLSRoute{}
+		readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tlsroute-%s.yaml", testName, tlsr.Name), expectedTLSR)
+		require.Empty(t, cmp.Diff(expectedTLSR, actualTLSR, cmpIgnoreFields...))
+	}
+}
+
+func assertGRPCRoutesOutput(t *testing.T, c client.Client, testName string, grpcrList *gatewayv1.GRPCRouteList) {
+	t.Helper()
+
+	for _, grpcr := range grpcrList.Items {
+		actualGRPCR := &gatewayv1.GRPCRoute{}
+		err := c.Get(t.Context(), client.ObjectKeyFromObject(&grpcr), actualGRPCR)
+		actualGRPCR.TypeMeta = grpcRouteTypeMeta
+		require.NoError(t, err, "error getting GRPCRoute %s/%s: %v", grpcr.Namespace, grpcr.Name, err)
+
+		expectedGRPCR := &gatewayv1.GRPCRoute{}
+		readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/grpcroute-%s.yaml", testName, grpcr.Name), expectedGRPCR)
+		require.Empty(t, cmp.Diff(expectedGRPCR, actualGRPCR, cmpIgnoreFields...))
+	}
+}
+
+func assertBackendTLSPoliciesOutput(t *testing.T, c client.Client, testName string, btlspList *gatewayv1.BackendTLSPolicyList) {
+	t.Helper()
+
+	for _, btlsp := range btlspList.Items {
+		actualBTLSP := &gatewayv1.BackendTLSPolicy{}
+		err := c.Get(t.Context(), client.ObjectKeyFromObject(&btlsp), actualBTLSP)
+		actualBTLSP.TypeMeta = backendTLSPolicyTypeMeta
+		require.NoError(t, err, "error getting BackendTLSPolicy %s/%s: %v", btlsp.Namespace, btlsp.Name, err)
+
+		expectedBTLSP := &gatewayv1.BackendTLSPolicy{}
+		readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/backendtlspolicy-%s.yaml", testName, btlsp.Name), expectedBTLSP)
+		require.Empty(t, cmp.Diff(expectedBTLSP, actualBTLSP, cmpIgnoreFields...))
+	}
+}
+
+func Test_HostNetwork_Conformance(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	hostNetworkCfg := translation.Config{
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
+		},
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		HostNetworkConfig: translation.HostNetworkConfig{
+			Enabled: true,
+		},
+		IPConfig: translation.IPConfig{
+			IPv4Enabled: true,
+		},
+	}
+
+	reconcilerCfg := hostNetworkCfg
+
+	tests := []struct {
+		name    string
+		gateway []gwDetails
+	}{
+		{name: "hostnetwork-node-addresses", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}}}},
+		{name: "hostnetwork-all-nodes", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}}}},
+		{name: "hostnetwork-internal-ip-fallback", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runGatewayConformanceTest(t, logger, tt.name, tt.gateway, hostNetworkCfg, reconcilerCfg, false)
+		})
+	}
+}
+
+func Test_getNodeAddressesForGateway_HonorsNodeLabelSelectorExpressions(t *testing.T) {
+	t.Parallel()
+
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "worker-1",
+					Labels: map[string]string{"role": "gateway", "zone": "a"},
+				},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "203.0.113.1"}}},
+			},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "worker-2",
+					Labels: map[string]string{"role": "gateway", "zone": "b"},
+				},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "203.0.113.2"}}},
+			},
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "worker-3",
+					Labels: map[string]string{"role": "other", "zone": "a"},
+				},
+				Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "203.0.113.3"}}},
+			},
+		).
+		Build()
+
+		r := &gatewayReconciler{
+		Client: c,
+		cfg: translation.Config{
+			HostNetworkConfig: translation.HostNetworkConfig{
+				Enabled: true,
+				NodeLabelSelector: &slim_metav1.LabelSelector{
+					MatchExpressions: []slim_metav1.LabelSelectorRequirement{{
+						Key:      "role",
+						Operator: slim_metav1.LabelSelectorOpIn,
+						Values:   []string{"gateway"},
+					}},
+				},
+			},
+			IPConfig: translation.IPConfig{IPv4Enabled: true},
+		},
+	}
+
+	ips, err := r.getNodeAddressesForGateway(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"203.0.113.1", "203.0.113.2"}, ips)
 }

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -122,6 +122,10 @@ func readInput(t *testing.T, file string) []client.Object {
 			obj := &gatewayv1.BackendTLSPolicy{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
+		case "Node":
+			obj := &corev1.Node{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
 		}
 	}
 

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/input/hostnetwork-excluded-nodes.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/input/hostnetwork-excluded-nodes.yaml
@@ -1,0 +1,36 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+  labels:
+    node.kubernetes.io/exclude-from-external-load-balancers: ""
+status:
+  addresses:
+    - type: ExternalIP
+      address: "203.0.113.1"
+    - type: InternalIP
+      address: "10.0.0.1"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-2
+status:
+  addresses:
+    - type: ExternalIP
+      address: "203.0.113.2"
+    - type: InternalIP
+      address: "10.0.0.2"

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/output/cec-same-namespace.yaml
@@ -1,0 +1,118 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+  - name: infra-backend-v1
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 80
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8080
+    name: gateway-conformance-infra:infra-backend-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - name: cilium-gateway-same-namespace
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/output/httproute-gateway-conformance-infra-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/output/httproute-gateway-conformance-infra-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-04-21T15:20:45Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-21T15:20:45Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-all-nodes/output/same-namespace.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+status:
+  addresses:
+  - type: IPAddress
+    value: 203.0.113.1
+  - type: IPAddress
+    value: 203.0.113.2
+  conditions:
+  - lastTransitionTime: "2026-04-21T15:20:45Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-04-21T15:20:45Z"
+    message: Gateway Programmed
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-04-21T15:20:45Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-04-21T15:20:45Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-21T15:20:45Z"
+      message: Listener Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/input/hostnetwork-internal-ip-fallback.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/input/hostnetwork-internal-ip-fallback.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+status:
+  addresses:
+    - type: InternalIP
+      address: "10.0.0.1"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-2
+status:
+  addresses:
+    - type: InternalIP
+      address: "10.0.0.2"

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/output/cec-same-namespace.yaml
@@ -1,0 +1,118 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+  - name: infra-backend-v1
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 80
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8080
+    name: gateway-conformance-infra:infra-backend-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - name: cilium-gateway-same-namespace
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/output/httproute-gateway-conformance-infra-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/output/httproute-gateway-conformance-infra-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-04-21T15:18:38Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-21T15:18:38Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-internal-ip-fallback/output/same-namespace.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+status:
+  addresses:
+  - type: IPAddress
+    value: 10.0.0.1
+  - type: IPAddress
+    value: 10.0.0.2
+  conditions:
+  - lastTransitionTime: "2026-04-21T15:18:38Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-04-21T15:18:38Z"
+    message: Gateway Programmed
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-04-21T15:18:38Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-04-21T15:18:38Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-21T15:18:38Z"
+      message: Listener Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/input/hostnetwork-node-addresses.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/input/hostnetwork-node-addresses.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+status:
+  addresses:
+    - type: ExternalIP
+      address: "203.0.113.1"
+    - type: InternalIP
+      address: "10.0.0.1"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-2
+status:
+  addresses:
+    - type: ExternalIP
+      address: "203.0.113.2"
+    - type: InternalIP
+      address: "10.0.0.2"

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/output/cec-same-namespace.yaml
@@ -1,0 +1,118 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+  - name: infra-backend-v1
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    address:
+      socketAddress:
+        address: 0.0.0.0
+        portValue: 80
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8080
+    name: gateway-conformance-infra:infra-backend-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - name: cilium-gateway-same-namespace
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/output/httproute-gateway-conformance-infra-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/output/httproute-gateway-conformance-infra-test.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-04-21T15:16:13Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-21T15:16:13Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostnetwork-node-addresses/output/same-namespace.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+status:
+  addresses:
+  - type: IPAddress
+    value: 203.0.113.1
+  - type: IPAddress
+    value: 203.0.113.2
+  conditions:
+  - lastTransitionTime: "2026-04-21T15:16:13Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-04-21T15:16:13Z"
+    message: Gateway Programmed
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-04-21T15:16:13Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-04-21T15:16:13Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-04-21T15:16:13Z"
+      message: Listener Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute


### PR DESCRIPTION
## Description

When `gateway-api-hostnetwork-enabled` is true, the gateway service is created as `ClusterIP` instead of `LoadBalancer`, so `status.loadBalancer.ingress` is never populated. This causes `setAddressStatus()` to never populate gateway addresses, leaving the Gateway stuck in `Programmed=False` with `AddressNotAssigned`.

This PR populates Gateway addresses from **Node IPs directly** when the service type is `ClusterIP` or `NodePort`. This is the semantically correct approach — in hostNetwork mode, the Gateway IS reachable at node IPs. This works without LB IPAM at all and also handles NodePort services.

**This is a functional bug, not cosmetic** — the empty addresses break external-dns DNS record generation (services unreachable by hostname), violate Gateway API spec conformance (`Programmed` should be True when Envoy is serving traffic), and cause monitoring false positives. See #42786 and #45485 for full analysis.

Related: #42786
Fixes: #45485

## Changes

- **`gateway_reconcile.go`**: In `setAddressStatus()`, switch on service type. For `ClusterIP`/`NodePort`, call `getNodeAddressesForGateway()` which lists Node objects and collects IPs. Same for `setStaticAddressStatus()`.
- **`gateway.go`**: Add `Watches(&corev1.Node{}, ...)` so Gateways are re-reconciled when nodes change. Pass `translation.Config` to the reconciler for access to `HostNetworkConfig` and `IPConfig`.
- **`cell.go`**: Wire `translation.Config` through to `newGatewayReconciler`.
- **`gateway_status_test.go`**: Remove old LB IPAM annotation test (replaced by correct approach).
- **`helper_test.go`**: Add `Node` kind support for testdata YAML parsing (for future reconciler tests).

## Key design decisions

- **Node IPs, not LB IPAM annotation**: Reading from the annotation was the previous approach in this PR. The maintainer (@youngnick, see #42786) specified that the correct fix reads Node IPs directly. This works without LB IPAM at all.
- **NodeLabelSelector respected**: When `gateway-api-hostnetwork-nodelabelselector` is configured, only matching nodes are used for addresses.
- **Node exclusion**: Nodes with `node.kubernetes.io/exclude-from-external-load-balancers` label or pending deletion are skipped.
- **ExternalIP preferred**: ExternalIPs are preferred over InternalIPs, with fallback.
- **IP family filtering**: Only IPs matching the configured IP families (IPv4/IPv6) are included.
- **No RBAC changes**: The operator ClusterRole already has `nodes` and `nodes/status` access.

## Risk

Low. The change is scoped to the `ClusterIP`/`NodePort` branches only. `LoadBalancer` services follow the exact same code path as before (reading from `status.loadBalancer.ingress`). The `getNodeAddressesForGateway()` method uses the existing controller-runtime client cache.

```release-note
Fix Gateway Programmed status stuck at False when gateway-api hostNetwork mode is enabled
```