### PR TITLE
renovate: add dependency cooldown

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -121,6 +121,11 @@
   "assignAutomerge": true,
   "packageRules": [
     {
+      // Dependency cooldown: skip versions published less than 5 days ago
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "minimumReleaseAge": "5 days"
+    },
+    {
       "matchPackageNames": [
         "bufbuild/buf", // Protocol buffer toolkit
         "docker.io/alpine/socat", // Alpine socat package


### PR DESCRIPTION
Adds a 5-day `minimumReleaseAge` to Renovate package rules to mitigate supply chain attacks.
 
Renovate will skip any package version published less than 5 days ago, giving the security community time to detect and flag compromised releases before they enter our builds.