### PR TITLE
ipam: Migrate `cidrset` and `CIDRAllocator` to `netip`

### DIFF
--- a/operator/pkg/ipam/podcidroverlap_test.go
+++ b/operator/pkg/ipam/podcidroverlap_test.go
@@ -6,7 +6,7 @@ package ipam
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"sync"
 	"testing"
 	"time"
@@ -47,7 +47,7 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 
 	// Create a new CIDR allocator
 
-	_, cidr, err := net.ParseCIDR("10.129.0.0/16")
+	cidr, err := netip.ParsePrefix("10.129.0.0/16")
 	require.NoError(t, err)
 
 	set, err := cidrset.NewCIDRSet(cidr, 24)

--- a/operator/pkg/multipool/pool.go
+++ b/operator/pkg/multipool/pool.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"net/netip"
 
-	"go4.org/netipx"
-
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"
 )
@@ -24,31 +22,21 @@ func allocFirstFreeCIDR(allocators []cidralloc.CIDRAllocator) (netip.Prefix, err
 			continue
 		}
 
-		ipnet, err := alloc.AllocateNext()
-		if err != nil {
-			return netip.Prefix{}, err
-		}
-
-		prefix, ok := netipx.FromStdIPNet(ipnet)
-		if !ok {
-			return netip.Prefix{}, fmt.Errorf("invalid cidr %s allocated", ipnet)
-		}
-		return prefix, nil
+		return alloc.AllocateNext()
 	}
 
 	return netip.Prefix{}, errPoolEmpty
 }
 
 func occupyCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) error {
-	ipnet := netipx.PrefixIPNet(cidr)
 	for _, alloc := range allocators {
-		if !alloc.InRange(ipnet) {
+		if !alloc.InRange(cidr) {
 			continue
 		}
 		if alloc.IsFull() {
 			return errPoolEmpty
 		}
-		allocated, err := alloc.IsAllocated(ipnet)
+		allocated, err := alloc.IsAllocated(cidr)
 		if err != nil {
 			return err
 		}
@@ -56,20 +44,19 @@ func occupyCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) error {
 			return fmt.Errorf("cidr %s has already been allocated", cidr)
 		}
 
-		return alloc.Occupy(ipnet)
+		return alloc.Occupy(cidr)
 	}
 
 	return fmt.Errorf("cidr %s is not part of the requested pool", cidr)
 }
 
 func releaseCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) error {
-	ipnet := netipx.PrefixIPNet(cidr)
 	for _, alloc := range allocators {
-		if !alloc.InRange(ipnet) {
+		if !alloc.InRange(cidr) {
 			continue
 		}
 
-		allocated, err := alloc.IsAllocated(ipnet)
+		allocated, err := alloc.IsAllocated(cidr)
 		if err != nil {
 			return err
 		}
@@ -77,7 +64,7 @@ func releaseCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) error 
 			return nil // not an error to release a cidr twice
 		}
 
-		return alloc.Release(ipnet)
+		return alloc.Release(cidr)
 	}
 
 	return fmt.Errorf("released cidr %s was not part the pool", cidr)
@@ -93,9 +80,8 @@ func hasCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) bool {
 }
 
 func containsCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) bool {
-	ipnet := netipx.PrefixIPNet(cidr)
 	for _, alloc := range allocators {
-		if alloc.InRange(ipnet) {
+		if alloc.InRange(cidr) {
 			return true
 		}
 	}

--- a/operator/pkg/multipool/pool_allocator.go
+++ b/operator/pkg/multipool/pool_allocator.go
@@ -13,8 +13,6 @@ import (
 	"slices"
 	"sort"
 
-	"go4.org/netipx"
-
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"
 	"github.com/cilium/cilium/pkg/ipam/types"
@@ -217,11 +215,10 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 				}
 
 				for cidr := range cidrs {
-					ipnet := netipx.PrefixIPNet(cidr)
-					if !oldCIDR.InRange(ipnet) {
+					if !oldCIDR.InRange(cidr) {
 						continue
 					}
-					allocated, err := oldCIDR.IsAllocated(ipnet)
+					allocated, err := oldCIDR.IsAllocated(cidr)
 					if err != nil {
 						errs = append(errs, err)
 						continue

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -13,7 +13,6 @@ import (
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
 	"github.com/google/uuid"
-	"go4.org/netipx"
 	"golang.org/x/time/rate"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
@@ -63,20 +62,19 @@ type API struct {
 	pdAllocator    *cidrset.CidrSet
 	limiter        *rate.Limiter
 	delaySim       *helpers.DelaySimulator
-	pdSubnet       *net.IPNet
+	pdSubnet       netip.Prefix
 }
 
 // NewAPI returns a new mocked EC2 API
 func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, securityGroups []*types.SecurityGroup, routeTables []*ipamTypes.RouteTable) *API {
 
 	// Start with base CIDR 10.0.0.0/16
-	_, baseCidr, _ := net.ParseCIDR("10.10.0.0/16")
+	basePrefix := netip.MustParsePrefix("10.10.0.0/16")
 
 	// Use 10.10.0.0/17 for IP allocations
-	cidrSet, _ := cidrset.NewCIDRSet(baseCidr, 17)
+	cidrSet, _ := cidrset.NewCIDRSet(basePrefix, 17)
 	podCidr, _ := cidrSet.AllocateNext()
-	podCidrPrefix, _ := netipx.FromStdIPNet(podCidr)
-	podCidrRange := ipallocator.NewCIDRRange(podCidrPrefix)
+	podCidrRange := ipallocator.NewCIDRRange(podCidr)
 
 	// Use 10.10.128.0/17 for prefix allocations
 	pdCidr, _ := cidrSet.AllocateNext()
@@ -592,11 +590,11 @@ func (e *API) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []
 	addresses := make([]string, 0)
 	// Convert prefixes to IP addresses and release prefix from pd allocator
 	for _, prefix := range prefixes {
-		_, ipNet, err := net.ParseCIDR(prefix)
+		pfx, err := netip.ParsePrefix(prefix)
 		if err != nil {
 			return fmt.Errorf("Invalid CIDR block %s", prefix)
 		}
-		e.pdAllocator.Release(ipNet)
+		e.pdAllocator.Release(pfx)
 		ips, _ := ip.PrefixToIps(prefix, 0)
 		addresses = append(addresses, ips...)
 	}

--- a/pkg/aws/ec2/mock/mock_test.go
+++ b/pkg/aws/ec2/mock/mock_test.go
@@ -5,7 +5,7 @@ package mock
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -123,7 +123,7 @@ func TestSetLimiter(t *testing.T) {
 }
 
 func TestGetNextSubnet(t *testing.T) {
-	_, cidrTest, _ := net.ParseCIDR("10.0.0.0/8")
+	cidrTest := netip.MustParsePrefix("10.0.0.0/8")
 	cidrSet, _ := cidrset.NewCIDRSet(cidrTest, 9)
 	subnet, err := cidrSet.AllocateNext()
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestGetNextSubnet(t *testing.T) {
 }
 
 func TestPrefixToIps(t *testing.T) {
-	_, cidrTest, _ := net.ParseCIDR("10.128.0.0/9")
+	cidrTest := netip.MustParsePrefix("10.128.0.0/9")
 	cidrSet, _ := cidrset.NewCIDRSet(cidrTest, 28)
 	subnet, err := cidrSet.AllocateNext()
 	require.NoError(t, err)

--- a/pkg/ipam/allocator/clusterpool/cidralloc/cidralloc.go
+++ b/pkg/ipam/allocator/clusterpool/cidralloc/cidralloc.go
@@ -5,22 +5,20 @@ package cidralloc
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam/cidrset"
 )
 
 type CIDRAllocator interface {
 	fmt.Stringer
 
-	Occupy(cidr *net.IPNet) error
-	AllocateNext() (*net.IPNet, error)
-	Release(cidr *net.IPNet) error
-	IsAllocated(cidr *net.IPNet) (bool, error)
+	Occupy(prefix netip.Prefix) error
+	AllocateNext() (netip.Prefix, error)
+	Release(prefix netip.Prefix) error
+	IsAllocated(prefix netip.Prefix) (bool, error)
 	IsFull() bool
-	InRange(cidr *net.IPNet) bool
+	InRange(prefix netip.Prefix) bool
 	IsClusterCIDR(prefix netip.Prefix) bool
 	Prefix() netip.Prefix
 }
@@ -45,13 +43,13 @@ func (e *ErrCIDRCollision) Is(target error) bool {
 func NewCIDRSets(isV6 bool, strCIDRs []string, maskSize int) ([]CIDRAllocator, error) {
 	cidrAllocators := make([]CIDRAllocator, 0, len(strCIDRs))
 	for _, strCIDR := range strCIDRs {
-		addr, cidr, err := net.ParseCIDR(strCIDR)
+		prefix, err := netip.ParsePrefix(strCIDR)
 		if err != nil {
 			return nil, err
 		}
 		// Check if CIDRs collide with each other.
 		for _, cidrAllocator := range cidrAllocators {
-			if cidrAllocator.InRange(cidr) {
+			if cidrAllocator.InRange(prefix) {
 				return nil, &ErrCIDRCollision{
 					cidr:      strCIDR,
 					allocator: cidrAllocator,
@@ -59,13 +57,14 @@ func NewCIDRSets(isV6 bool, strCIDRs []string, maskSize int) ([]CIDRAllocator, e
 			}
 		}
 
+		addr := prefix.Addr()
 		switch {
-		case isV6 && ip.IsIPv4(addr):
-			return nil, fmt.Errorf("CIDR is not v6 family: %s", cidr)
-		case !isV6 && !ip.IsIPv4(addr):
-			return nil, fmt.Errorf("CIDR is not v4 family: %s", cidr)
+		case isV6 && addr.Is4():
+			return nil, fmt.Errorf("CIDR is not v6 family: %s", prefix)
+		case !isV6 && !addr.Is4():
+			return nil, fmt.Errorf("CIDR is not v4 family: %s", prefix)
 		}
-		cidrSet, err := cidrset.NewCIDRSet(cidr, maskSize)
+		cidrSet, err := cidrset.NewCIDRSet(prefix, maskSize)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 
+	"go4.org/netipx"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/pkg/cidr"
@@ -580,11 +581,12 @@ func (n *NodesPodCIDRManager) releaseCIDRs(cidrAllocators []cidralloc.CIDRAlloca
 		return
 	}
 	for _, ipNet := range cidrsToRelease {
+		prefix, _ := netipx.FromStdIPNet(ipNet)
 		for _, clusterCIDR := range cidrAllocators {
-			if !clusterCIDR.InRange(ipNet) {
+			if !clusterCIDR.InRange(prefix) {
 				continue
 			}
-			err := clusterCIDR.Release(ipNet)
+			err := clusterCIDR.Release(prefix)
 			if err != nil {
 				n.logger.Error("failed to release cidr",
 					logfields.Error, err,
@@ -795,11 +797,12 @@ func allocateIPNet(allType allocatorType, cidrSets []cidralloc.CIDRAllocator, ne
 	// available. 'err' will keep the error that should be returned at the end
 	// of the loop iterations.
 	for _, newCIDR := range newCidrs {
+		newPrefix, _ := netipx.FromStdIPNet(newCIDR)
 		var isAllocated bool
 		for _, cidrSet := range cidrSets {
 			// Do not even try to allocate if the cidrSet is full or if the
 			// newCIDR does not belong to the cidrSet.
-			if !cidrSet.InRange(newCIDR) {
+			if !cidrSet.InRange(newPrefix) {
 				err = fmt.Errorf("allocator not configured for the requested CIDR %s", newCIDR)
 				continue
 			}
@@ -809,7 +812,7 @@ func allocateIPNet(allType allocatorType, cidrSets []cidralloc.CIDRAllocator, ne
 				err = fmt.Errorf("allocator %s full", cidrSet)
 				return nil, err
 			}
-			isAllocated, err = cidrSet.IsAllocated(newCIDR)
+			isAllocated, err = cidrSet.IsAllocated(newPrefix)
 			if err != nil {
 				return nil, err
 			}
@@ -819,13 +822,13 @@ func allocateIPNet(allType allocatorType, cidrSets []cidralloc.CIDRAllocator, ne
 				}
 			}
 			// Try to allocate this new CIDR
-			err = cidrSet.Occupy(newCIDR)
+			err = cidrSet.Occupy(newPrefix)
 			if err != nil {
 				return nil, err
 			}
 			revertStack.Push(func() error {
 				// In case of a follow up error release this new allocated CIDR.
-				return cidrSet.Release(newCIDR)
+				return cidrSet.Release(newPrefix)
 			})
 			break
 		}
@@ -940,12 +943,13 @@ func allocateFirstFreeCIDR(cidrAllocators []cidralloc.CIDRAllocator) (revertFunc
 	if firstFreeAllocator == nil {
 		return nil, nil, &ErrAllocatorFull{}
 	}
-	cidr, err = (*firstFreeAllocator).AllocateNext()
+	prefix, err := (*firstFreeAllocator).AllocateNext()
 	if err != nil {
 		return nil, nil, err
 	}
+	cidr = netipx.PrefixIPNet(prefix)
 	revertStack.Push(func() error {
-		return (*firstFreeAllocator).Release(cidr)
+		return (*firstFreeAllocator).Release(prefix)
 	})
 	return revertStack.Revert, cidr, err
 }

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -51,42 +51,42 @@ func mustNewTrigger(f func(), minInterval time.Duration) *trigger.Trigger {
 }
 
 type mockCIDRAllocator struct {
-	OnOccupy       func(cidr *net.IPNet) error
-	OnAllocateNext func() (*net.IPNet, error)
-	OnRelease      func(cidr *net.IPNet) error
-	OnIsAllocated  func(cidr *net.IPNet) (bool, error)
+	OnOccupy       func(prefix netip.Prefix) error
+	OnAllocateNext func() (netip.Prefix, error)
+	OnRelease      func(prefix netip.Prefix) error
+	OnIsAllocated  func(prefix netip.Prefix) (bool, error)
 	OnIsFull       func() bool
-	OnInRange      func(cidr *net.IPNet) bool
+	OnInRange      func(prefix netip.Prefix) bool
 }
 
 func (d *mockCIDRAllocator) String() string {
 	return "clusterCIDR: 10.0.0.0/24, nodeMask: 24"
 }
 
-func (d *mockCIDRAllocator) Occupy(cidr *net.IPNet) error {
+func (d *mockCIDRAllocator) Occupy(prefix netip.Prefix) error {
 	if d.OnOccupy != nil {
-		return d.OnOccupy(cidr)
+		return d.OnOccupy(prefix)
 	}
 	panic("d.Occupy should not have been called!")
 }
 
-func (d *mockCIDRAllocator) AllocateNext() (*net.IPNet, error) {
+func (d *mockCIDRAllocator) AllocateNext() (netip.Prefix, error) {
 	if d.OnAllocateNext != nil {
 		return d.OnAllocateNext()
 	}
 	panic("d.AllocateNext should not have been called!")
 }
 
-func (d *mockCIDRAllocator) Release(cidr *net.IPNet) error {
+func (d *mockCIDRAllocator) Release(prefix netip.Prefix) error {
 	if d.OnRelease != nil {
-		return d.OnRelease(cidr)
+		return d.OnRelease(prefix)
 	}
 	panic("d.Release should not have been called!")
 }
 
-func (d *mockCIDRAllocator) IsAllocated(cidr *net.IPNet) (bool, error) {
+func (d *mockCIDRAllocator) IsAllocated(prefix netip.Prefix) (bool, error) {
 	if d.OnIsAllocated != nil {
-		return d.OnIsAllocated(cidr)
+		return d.OnIsAllocated(prefix)
 	}
 	panic("d.IsAllocated should not have been called!")
 }
@@ -98,9 +98,9 @@ func (d *mockCIDRAllocator) IsFull() bool {
 	panic("d.IsFull should not have been called!")
 }
 
-func (d *mockCIDRAllocator) InRange(cidr *net.IPNet) bool {
+func (d *mockCIDRAllocator) InRange(prefix netip.Prefix) bool {
 	if d.OnInRange != nil {
-		return d.OnInRange(cidr)
+		return d.OnInRange(prefix)
 	}
 	panic("d.InRange should not have been called!")
 }
@@ -178,12 +178,12 @@ func TestNodesPodCIDRManager_Delete(t *testing.T) {
 					canAllocateNodes: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnRelease: func(cidr *net.IPNet) error {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnRelease: func(cidr netip.Prefix) error {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 						},
@@ -331,8 +331,8 @@ func TestNodesPodCIDRManager_Upsert(t *testing.T) {
 					canAllocateNodes: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnAllocateNext: func() (ipNet *net.IPNet, err error) {
-								return mustNewCIDRs("10.10.0.0/24")[0], nil
+							OnAllocateNext: func() (prefix netip.Prefix, err error) {
+								return netip.MustParsePrefix("10.10.0.0/24"), nil
 							},
 							OnIsFull: func() bool {
 								return false
@@ -386,8 +386,8 @@ func TestNodesPodCIDRManager_Upsert(t *testing.T) {
 					canAllocateNodes: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnAllocateNext: func() (ipNet *net.IPNet, err error) {
-								return nil, fmt.Errorf("Allocator full!")
+							OnAllocateNext: func() (prefix netip.Prefix, err error) {
+								return netip.Prefix{}, fmt.Errorf("Allocator full!")
 							},
 							OnIsFull: func() bool {
 								return false
@@ -437,8 +437,8 @@ func TestNodesPodCIDRManager_Upsert(t *testing.T) {
 					canAllocateNodes: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnAllocateNext: func() (ipNet *net.IPNet, err error) {
-								return nil, fmt.Errorf("Allocator full!")
+							OnAllocateNext: func() (prefix netip.Prefix, err error) {
+								return netip.Prefix{}, fmt.Errorf("Allocator full!")
 							},
 							OnIsFull: func() bool {
 								return false
@@ -619,18 +619,18 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					canAllocatePodCIDRs: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnOccupy: func(cidr *net.IPNet) error {
+							OnOccupy: func(cidr netip.Prefix) error {
 								onOccupyCallsv4++
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return nil
 							},
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv4++
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return false, nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 							OnIsFull: func() bool {
@@ -640,18 +640,18 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					},
 					v6ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnOccupy: func(cidr *net.IPNet) error {
+							OnOccupy: func(cidr netip.Prefix) error {
 								onOccupyCallsv6++
-								require.Equal(t, mustNewCIDRs("fd00::/80")[0], cidr)
+								require.Equal(t, netip.MustParsePrefix("fd00::/80"), cidr)
 								return nil
 							},
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv6++
-								require.Equal(t, mustNewCIDRs("fd00::/80")[0], cidr)
+								require.Equal(t, netip.MustParsePrefix("fd00::/80"), cidr)
 								return false, nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("fd00::/80")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("fd00::/80"), cidr)
 								return true
 							},
 							OnIsFull: func() bool {
@@ -699,23 +699,23 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					canAllocatePodCIDRs: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv4++
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return false, nil
 							},
-							OnOccupy: func(cidr *net.IPNet) error {
+							OnOccupy: func(cidr netip.Prefix) error {
 								onOccupyCallsv4++
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return nil
 							},
-							OnRelease: func(cidr *net.IPNet) error {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnRelease: func(cidr netip.Prefix) error {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								releaseCallsv4++
 								return nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 							OnIsFull: func() bool {
@@ -725,8 +725,8 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					},
 					v6ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("fd00::/80")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("fd00::/80"), cidr)
 								return true
 							},
 							OnIsFull: func() bool {
@@ -834,9 +834,9 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 							OnIsFull: func() bool {
 								return false
 							},
-							OnAllocateNext: func() (*net.IPNet, error) {
+							OnAllocateNext: func() (netip.Prefix, error) {
 								onAllocateNextv6++
-								return mustNewCIDRs("fd00::/80")[0], nil
+								return netip.MustParsePrefix("fd00::/80"), nil
 							},
 						},
 					},
@@ -877,15 +877,15 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					canAllocatePodCIDRs: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv4++
 								return false, nil
 							},
-							OnOccupy: func(cidr *net.IPNet) error {
+							OnOccupy: func(cidr netip.Prefix) error {
 								onOccupyCallsv4++
 								return nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
+							OnInRange: func(cidr netip.Prefix) bool {
 								return true
 							},
 							OnIsFull: func() bool {
@@ -895,11 +895,11 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					},
 					v6ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv6++
 								return true, nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
+							OnInRange: func(cidr netip.Prefix) bool {
 								return true
 							},
 							OnIsFull: func() bool {
@@ -941,11 +941,11 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					canAllocatePodCIDRs: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv4++
 								return true, nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
+							OnInRange: func(cidr netip.Prefix) bool {
 								return true
 							},
 							OnIsFull: func() bool {
@@ -955,15 +955,15 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					},
 					v6ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv6++
 								return false, nil
 							},
-							OnOccupy: func(cidr *net.IPNet) error {
+							OnOccupy: func(cidr netip.Prefix) error {
 								onOccupyCallsv6++
 								return nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
+							OnInRange: func(cidr netip.Prefix) bool {
 								return true
 							},
 							OnIsFull: func() bool {
@@ -1005,11 +1005,11 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					canAllocatePodCIDRs: true,
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv4++
 								return true, nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
+							OnInRange: func(cidr netip.Prefix) bool {
 								return true
 							},
 							OnIsFull: func() bool {
@@ -1019,11 +1019,11 @@ func TestNodesPodCIDRManager_allocateIPNets(t *testing.T) {
 					},
 					v6ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+							OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 								onIsAllocatedCallsv6++
 								return true, nil
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
+							OnInRange: func(cidr netip.Prefix) bool {
 								return true
 							},
 							OnIsFull: func() bool {
@@ -1135,30 +1135,30 @@ func TestNodesPodCIDRManager_allocateNext(t *testing.T) {
 				return &fields{
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnAllocateNext: func() (ipNet *net.IPNet, err error) {
+							OnAllocateNext: func() (prefix netip.Prefix, err error) {
 								allocateNextCallsv4++
-								return mustNewCIDRs("10.10.0.0/24")[0], nil
+								return netip.MustParsePrefix("10.10.0.0/24"), nil
 							},
 							OnIsFull: func() bool {
 								return false
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 						},
 					},
 					v6ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnAllocateNext: func() (ipNet *net.IPNet, err error) {
+							OnAllocateNext: func() (prefix netip.Prefix, err error) {
 								allocateNextCallsv6++
-								return mustNewCIDRs("fd00::/80")[0], nil
+								return netip.MustParsePrefix("fd00::/80"), nil
 							},
 							OnIsFull: func() bool {
 								return false
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 						},
@@ -1194,20 +1194,20 @@ func TestNodesPodCIDRManager_allocateNext(t *testing.T) {
 				return &fields{
 					v4ClusterCIDRs: []cidralloc.CIDRAllocator{
 						&mockCIDRAllocator{
-							OnAllocateNext: func() (ipNet *net.IPNet, err error) {
+							OnAllocateNext: func() (prefix netip.Prefix, err error) {
 								allocateNextCallsv4++
-								return mustNewCIDRs("10.10.0.0/24")[0], nil
+								return netip.MustParsePrefix("10.10.0.0/24"), nil
 							},
-							OnRelease: func(cidr *net.IPNet) error {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnRelease: func(cidr netip.Prefix) error {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								releaseCallsv4++
 								return nil
 							},
 							OnIsFull: func() bool {
 								return false
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 						},
@@ -1217,8 +1217,8 @@ func TestNodesPodCIDRManager_allocateNext(t *testing.T) {
 							OnIsFull: func() bool {
 								return true
 							},
-							OnInRange: func(cidr *net.IPNet) bool {
-								require.Equal(t, mustNewCIDRs("10.10.0.0/24")[0], cidr)
+							OnInRange: func(cidr netip.Prefix) bool {
+								require.Equal(t, netip.MustParsePrefix("10.10.0.0/24"), cidr)
 								return true
 							},
 						},
@@ -1313,13 +1313,13 @@ func TestNodesPodCIDRManager_releaseIPNets(t *testing.T) {
 				onReleaseCalls = 0
 				cidrSet := []cidralloc.CIDRAllocator{
 					&mockCIDRAllocator{
-						OnRelease: func(cidr *net.IPNet) error {
+						OnRelease: func(cidr netip.Prefix) error {
 							onReleaseCalls++
-							require.Equal(t, mustNewCIDRs("10.0.0.0/16")[0], cidr)
+							require.Equal(t, netip.MustParsePrefix("10.0.0.0/16"), cidr)
 							return nil
 						},
-						OnInRange: func(cidr *net.IPNet) bool {
-							require.Equal(t, mustNewCIDRs("10.0.0.0/16")[0], cidr)
+						OnInRange: func(cidr netip.Prefix) bool {
+							require.Equal(t, netip.MustParsePrefix("10.0.0.0/16"), cidr)
 							return true
 						},
 					},
@@ -1348,13 +1348,13 @@ func TestNodesPodCIDRManager_releaseIPNets(t *testing.T) {
 				onReleaseCalls = 0
 				cidrSet := []cidralloc.CIDRAllocator{
 					&mockCIDRAllocator{
-						OnRelease: func(cidr *net.IPNet) error {
+						OnRelease: func(cidr netip.Prefix) error {
 							onReleaseCalls++
-							require.Equal(t, mustNewCIDRs("fd00::/80")[0], cidr)
+							require.Equal(t, netip.MustParsePrefix("fd00::/80"), cidr)
 							return nil
 						},
-						OnInRange: func(cidr *net.IPNet) bool {
-							require.Equal(t, mustNewCIDRs("fd00::/80")[0], cidr)
+						OnInRange: func(cidr netip.Prefix) bool {
+							require.Equal(t, netip.MustParsePrefix("fd00::/80"), cidr)
 							return true
 						},
 					},
@@ -1955,14 +1955,14 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 	// v4 pool: Node A gets .0.0/24, Node B gets .1.0/24, Node C gets .2.0/24.
 	// Before the fix (see commit), Node B's .1.0/24 was freed and given to
 	// Node C.
-	v4Pool := []*net.IPNet{
-		mustNewCIDRs("10.10.0.0/24")[0],
-		mustNewCIDRs("10.10.1.0/24")[0],
-		mustNewCIDRs("10.10.2.0/24")[0],
+	v4Pool := []netip.Prefix{
+		netip.MustParsePrefix("10.10.0.0/24"),
+		netip.MustParsePrefix("10.10.1.0/24"),
+		netip.MustParsePrefix("10.10.2.0/24"),
 	}
 
 	v4Allocator := &mockCIDRAllocator{
-		OnInRange: func(cidr *net.IPNet) bool {
+		OnInRange: func(cidr netip.Prefix) bool {
 			for _, p := range v4Pool {
 				if cidr.String() == p.String() {
 					return true
@@ -1973,37 +1973,37 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 		OnIsFull: func() bool {
 			return len(v4Occupied) >= len(v4Pool)
 		},
-		OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+		OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 			return v4Occupied[cidr.String()], nil
 		},
-		OnOccupy: func(cidr *net.IPNet) error {
+		OnOccupy: func(cidr netip.Prefix) error {
 			v4Occupied[cidr.String()] = true
 			return nil
 		},
-		OnRelease: func(cidr *net.IPNet) error {
+		OnRelease: func(cidr netip.Prefix) error {
 			delete(v4Occupied, cidr.String())
 			return nil
 		},
-		OnAllocateNext: func() (*net.IPNet, error) {
+		OnAllocateNext: func() (netip.Prefix, error) {
 			for _, p := range v4Pool {
 				if !v4Occupied[p.String()] {
 					v4Occupied[p.String()] = true
 					return p, nil
 				}
 			}
-			return nil, fmt.Errorf("v4 allocator full")
+			return netip.Prefix{}, fmt.Errorf("v4 allocator full")
 		},
 	}
 
 	// v6 pool: fd00::/80 is the duplicate shared by Node A and Node B.
 	// fd01::/80 exists for fresh allocations i.e. for Node C.
-	v6Pool := []*net.IPNet{
-		mustNewCIDRs("fd00::/80")[0],
-		mustNewCIDRs("fd01::/80")[0],
+	v6Pool := []netip.Prefix{
+		netip.MustParsePrefix("fd00::/80"),
+		netip.MustParsePrefix("fd01::/80"),
 	}
 
 	v6Allocator := &mockCIDRAllocator{
-		OnInRange: func(cidr *net.IPNet) bool {
+		OnInRange: func(cidr netip.Prefix) bool {
 			for _, p := range v6Pool {
 				if cidr.String() == p.String() {
 					return true
@@ -2014,25 +2014,25 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 		OnIsFull: func() bool {
 			return len(v6Occupied) >= len(v6Pool)
 		},
-		OnIsAllocated: func(cidr *net.IPNet) (bool, error) {
+		OnIsAllocated: func(cidr netip.Prefix) (bool, error) {
 			return v6Occupied[cidr.String()], nil
 		},
-		OnOccupy: func(cidr *net.IPNet) error {
+		OnOccupy: func(cidr netip.Prefix) error {
 			v6Occupied[cidr.String()] = true
 			return nil
 		},
-		OnRelease: func(cidr *net.IPNet) error {
+		OnRelease: func(cidr netip.Prefix) error {
 			delete(v6Occupied, cidr.String())
 			return nil
 		},
-		OnAllocateNext: func() (*net.IPNet, error) {
+		OnAllocateNext: func() (netip.Prefix, error) {
 			for _, p := range v6Pool {
 				if !v6Occupied[p.String()] {
 					v6Occupied[p.String()] = true
 					return p, nil
 				}
 			}
-			return nil, fmt.Errorf("v6 allocator full")
+			return netip.Prefix{}, fmt.Errorf("v6 allocator full")
 		},
 	}
 

--- a/pkg/ipam/cidrset/cidr_set.go
+++ b/pkg/ipam/cidrset/cidr_set.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/bits"
-	"net"
 	"net/netip"
 
 	"go4.org/netipx"
@@ -22,15 +21,9 @@ import (
 // be allocated from.
 type CidrSet struct {
 	lock.Mutex
-	// clusterCIDR is the CIDR assigned to the cluster
-	clusterCIDR *net.IPNet
-	// clusterMaskSize is the mask size, in bits, assigned to the cluster
-	// caches the mask size to avoid the penalty of calling clusterCIDR.Mask.Size()
-	clusterMaskSize int
-	// nodeMask is the network mask assigned to the nodes
-	nodeMask net.IPMask
-	// nodeMaskSize is the mask size, in bits,assigned to the nodes
-	// caches the mask size to avoid the penalty of calling nodeMask.Size()
+	// clusterPrefix is the CIDR assigned to the cluster.
+	clusterPrefix netip.Prefix
+	// nodeMaskSize is the mask size, in bits, assigned to the nodes
 	nodeMaskSize int
 	// maxCIDRs is the maximum number of CIDRs that can be allocated
 	maxCIDRs int
@@ -49,8 +42,10 @@ const (
 	// Due to this limitation the subnet mask for IPv6 cluster cidr needs to be >= 48
 	// as default mask size for IPv6 is 64.
 	clusterSubnetMaxDiff = 16
-	// halfIPv6Len is the half of the IPv6 length
-	halfIPv6Len = net.IPv6len / 2
+	// halfIPv6Bytes is the half of the IPv6 byte length.
+	halfIPv6Bytes = 8
+	// ipv6Bits is the total number of bits in an IPv6 address.
+	ipv6Bits = 128
 	// the default subnet mask should be lower or equal to the max ipv4 netmask
 	maxSubNetMaskSizeIPv4 = 32
 	// the default subnet mask should be lower or equal to the max ipv6 netmask
@@ -74,11 +69,11 @@ var (
 )
 
 // NewCIDRSet creates a new CidrSet.
-func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
-	clusterMask := clusterCIDR.Mask
-	clusterMaskSize, bits := clusterMask.Size()
+func NewCIDRSet(clusterPrefix netip.Prefix, subNetMaskSize int) (*CidrSet, error) {
+	clusterPrefix = clusterPrefix.Masked()
+	clusterMaskSize := clusterPrefix.Bits()
 
-	if clusterCIDR.IP.To4() == nil {
+	if clusterPrefix.Addr().Is6() {
 		if subNetMaskSize > maxSubNetMaskSizeIPv6 {
 			return nil, ErrSubNetMaskSizeInvalid
 		}
@@ -90,63 +85,54 @@ func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
 	}
 	maxCIDRs := 1 << uint32(subNetMaskSize-clusterMaskSize)
 	return &CidrSet{
-		clusterCIDR:     clusterCIDR,
-		nodeMask:        net.CIDRMask(subNetMaskSize, bits),
-		clusterMaskSize: clusterMaskSize,
-		maxCIDRs:        maxCIDRs,
-		nodeMaskSize:    subNetMaskSize,
+		clusterPrefix: clusterPrefix,
+		maxCIDRs:      maxCIDRs,
+		nodeMaskSize:  subNetMaskSize,
 	}, nil
 }
 
 func (s *CidrSet) String() string {
-	return fmt.Sprintf("clusterCIDR: %s, nodeMask: %d", s.clusterCIDR.String(), s.nodeMaskSize)
+	return fmt.Sprintf("clusterCIDR: %s, nodeMask: %d", s.clusterPrefix, s.nodeMaskSize)
 }
 
-func (s *CidrSet) indexToCIDRBlock(index int) *net.IPNet {
-	var ip []byte
-	switch /*v4 or v6*/ {
-	case s.clusterCIDR.IP.To4() != nil:
-		{
-			j := uint32(index) << uint32(32-s.nodeMaskSize)
-			ipInt := (binary.BigEndian.Uint32(s.clusterCIDR.IP)) | j
-			ip = make([]byte, net.IPv4len)
-			binary.BigEndian.PutUint32(ip, ipInt)
-		}
-	case s.clusterCIDR.IP.To16() != nil:
-		{
-			// leftClusterIP      |     rightClusterIP
-			// 2001:0DB8:1234:0000:0000:0000:0000:0000
-			const v6NBits = 128
-			const halfV6NBits = v6NBits / 2
-			leftClusterIP := binary.BigEndian.Uint64(s.clusterCIDR.IP[:halfIPv6Len])
-			rightClusterIP := binary.BigEndian.Uint64(s.clusterCIDR.IP[halfIPv6Len:])
+func (s *CidrSet) indexToCIDRBlock(index int) netip.Prefix {
+	if s.clusterPrefix.Addr().Is4() {
+		clusterBytes := s.clusterPrefix.Addr().As4()
+		j := uint32(index) << uint32(32-s.nodeMaskSize)
+		ipInt := binary.BigEndian.Uint32(clusterBytes[:]) | j
+		var ipBytes [4]byte
+		binary.BigEndian.PutUint32(ipBytes[:], ipInt)
+		return netip.PrefixFrom(netip.AddrFrom4(ipBytes), s.nodeMaskSize)
+	}
 
-			ip = make([]byte, net.IPv6len)
+	// leftClusterIP      |     rightClusterIP
+	// 2001:0DB8:1234:0000:0000:0000:0000:0000
+	const halfV6NBits = ipv6Bits / 2
+	clusterBytes := s.clusterPrefix.Addr().As16()
+	leftClusterIP := binary.BigEndian.Uint64(clusterBytes[:halfIPv6Bytes])
+	rightClusterIP := binary.BigEndian.Uint64(clusterBytes[halfIPv6Bytes:])
 
-			if s.nodeMaskSize <= halfV6NBits {
-				// We only care about left side IP
-				leftClusterIP |= uint64(index) << uint(halfV6NBits-s.nodeMaskSize)
-			} else {
-				if s.clusterMaskSize < halfV6NBits {
-					// see how many bits are needed to reach the left side
-					btl := uint(s.nodeMaskSize - halfV6NBits)
-					indexMaxBit := uint(64 - bits.LeadingZeros64(uint64(index)))
-					if indexMaxBit > btl {
-						leftClusterIP |= uint64(index) >> btl
-					}
-				}
-				// the right side will be calculated the same way either the
-				// subNetMaskSize affects both left and right sides
-				rightClusterIP |= uint64(index) << uint(v6NBits-s.nodeMaskSize)
+	if s.nodeMaskSize <= halfV6NBits {
+		// We only care about left side IP
+		leftClusterIP |= uint64(index) << uint(halfV6NBits-s.nodeMaskSize)
+	} else {
+		if s.clusterPrefix.Bits() < halfV6NBits {
+			// see how many bits are needed to reach the left side
+			btl := uint(s.nodeMaskSize - halfV6NBits)
+			indexMaxBit := uint(64 - bits.LeadingZeros64(uint64(index)))
+			if indexMaxBit > btl {
+				leftClusterIP |= uint64(index) >> btl
 			}
-			binary.BigEndian.PutUint64(ip[:halfIPv6Len], leftClusterIP)
-			binary.BigEndian.PutUint64(ip[halfIPv6Len:], rightClusterIP)
 		}
+		// the right side will be calculated the same way either the
+		// subNetMaskSize affects both left and right sides
+		rightClusterIP |= uint64(index) << uint(ipv6Bits-s.nodeMaskSize)
 	}
-	return &net.IPNet{
-		IP:   ip,
-		Mask: s.nodeMask,
-	}
+
+	var ipBytes [16]byte
+	binary.BigEndian.PutUint64(ipBytes[:halfIPv6Bytes], leftClusterIP)
+	binary.BigEndian.PutUint64(ipBytes[halfIPv6Bytes:], rightClusterIP)
+	return netip.PrefixFrom(netip.AddrFrom16(ipBytes), s.nodeMaskSize)
 }
 
 // IsFull returns true if CidrSet does not have any more available CIDRs.
@@ -158,12 +144,12 @@ func (s *CidrSet) IsFull() bool {
 
 // AllocateNext allocates the next free CIDR range. This will set the range
 // as occupied and return the allocated range.
-func (s *CidrSet) AllocateNext() (*net.IPNet, error) {
+func (s *CidrSet) AllocateNext() (netip.Prefix, error) {
 	s.Lock()
 	defer s.Unlock()
 
 	if s.allocatedCIDRs == s.maxCIDRs {
-		return nil, ErrCIDRRangeNoCIDRsRemaining
+		return netip.Prefix{}, ErrCIDRRangeNoCIDRsRemaining
 	}
 	candidate := s.nextCandidate
 	for range s.maxCIDRs {
@@ -180,60 +166,41 @@ func (s *CidrSet) AllocateNext() (*net.IPNet, error) {
 	return s.indexToCIDRBlock(candidate), nil
 }
 
-// InRange returns true if the given CIDR is inside the range of the allocatable
+// InRange returns true if the given prefix is inside the range of the allocatable
 // CidrSet.
-func (s *CidrSet) InRange(cidr *net.IPNet) bool {
-	return s.clusterCIDR.Contains(cidr.IP.Mask(s.clusterCIDR.Mask)) || cidr.Contains(s.clusterCIDR.IP.Mask(cidr.Mask))
+func (s *CidrSet) InRange(prefix netip.Prefix) bool {
+	return s.clusterPrefix.Contains(prefix.Addr()) || prefix.Contains(s.clusterPrefix.Addr())
 }
 
-// IsClusterCIDR returns true if the given CIDR is equal to this CidrSet's cluster CIDR.
-func (s *CidrSet) IsClusterCIDR(cidr netip.Prefix) bool {
-	clusterPrefix, _ := netipx.FromStdIPNet(s.clusterCIDR)
-	return cidr == clusterPrefix
+// IsClusterCIDR returns true if the given prefix is equal to this CidrSet's cluster CIDR.
+func (s *CidrSet) IsClusterCIDR(prefix netip.Prefix) bool {
+	return prefix == s.clusterPrefix
 }
 
 // Prefix returns the CidrSet's prefix.
 func (s *CidrSet) Prefix() netip.Prefix {
-	prefix, _ := netipx.FromStdIPNet(s.clusterCIDR)
-	return prefix
+	return s.clusterPrefix
 }
 
-func (s *CidrSet) getBeginningAndEndIndices(cidr *net.IPNet) (begin, end int, err error) {
-	if cidr == nil {
-		return -1, -1, fmt.Errorf("error getting indices for cluster cidr %v, cidr is nil", s.clusterCIDR)
-	}
+func (s *CidrSet) getBeginningAndEndIndices(prefix netip.Prefix) (begin, end int, err error) {
 	begin, end = 0, s.maxCIDRs-1
-	cidrMask := cidr.Mask
-	maskSize, _ := cidrMask.Size()
-	var ipSize int
 
-	if !s.InRange(cidr) {
-		return -1, -1, fmt.Errorf("cidr %v is out the range of cluster cidr %v", cidr, s.clusterCIDR)
+	if !s.InRange(prefix) {
+		return -1, -1, fmt.Errorf("cidr %v is out the range of cluster cidr %v", prefix, s.clusterPrefix)
 	}
 
-	if s.clusterMaskSize < maskSize {
-
-		ipSize = net.IPv4len
-		if cidr.IP.To4() == nil {
-			ipSize = net.IPv6len
-		}
-		begin, err = s.getIndexForIP(cidr.IP.Mask(s.nodeMask))
+	if s.clusterPrefix.Bits() < prefix.Bits() {
+		// Align the prefix start to node-level granularity.
+		beginAddr := netip.PrefixFrom(prefix.Addr(), s.nodeMaskSize).Masked().Addr()
+		begin, err = s.getIndexForAddr(beginAddr)
 		if err != nil {
 			return -1, -1, err
 		}
-		ip := make([]byte, ipSize)
-		if cidr.IP.To4() != nil {
-			ipInt := binary.BigEndian.Uint32(cidr.IP) | (^binary.BigEndian.Uint32(cidr.Mask))
-			binary.BigEndian.PutUint32(ip, ipInt)
-		} else {
-			// ipIntLeft          |         ipIntRight
-			// 2001:0DB8:1234:0000:0000:0000:0000:0000
-			ipIntLeft := binary.BigEndian.Uint64(cidr.IP[:net.IPv6len/2]) | (^binary.BigEndian.Uint64(cidr.Mask[:net.IPv6len/2]))
-			ipIntRight := binary.BigEndian.Uint64(cidr.IP[net.IPv6len/2:]) | (^binary.BigEndian.Uint64(cidr.Mask[net.IPv6len/2:]))
-			binary.BigEndian.PutUint64(ip[:net.IPv6len/2], ipIntLeft)
-			binary.BigEndian.PutUint64(ip[net.IPv6len/2:], ipIntRight)
-		}
-		end, err = s.getIndexForIP(net.IP(ip).Mask(s.nodeMask))
+
+		// Compute the last address of the prefix, then align to node-level.
+		endAddr := netipx.PrefixLastIP(prefix)
+		endAddr = netip.PrefixFrom(endAddr, s.nodeMaskSize).Masked().Addr()
+		end, err = s.getIndexForAddr(endAddr)
 		if err != nil {
 			return -1, -1, err
 		}
@@ -241,9 +208,9 @@ func (s *CidrSet) getBeginningAndEndIndices(cidr *net.IPNet) (begin, end int, er
 	return begin, end, nil
 }
 
-// IsAllocated verifies if the given CIDR is allocated
-func (s *CidrSet) IsAllocated(cidr *net.IPNet) (bool, error) {
-	begin, end, err := s.getBeginningAndEndIndices(cidr)
+// IsAllocated verifies if the given prefix is allocated.
+func (s *CidrSet) IsAllocated(prefix netip.Prefix) (bool, error) {
+	begin, end, err := s.getBeginningAndEndIndices(prefix)
 	if err != nil {
 		return false, err
 	}
@@ -257,9 +224,9 @@ func (s *CidrSet) IsAllocated(cidr *net.IPNet) (bool, error) {
 	return true, nil
 }
 
-// Release releases the given CIDR range.
-func (s *CidrSet) Release(cidr *net.IPNet) error {
-	begin, end, err := s.getBeginningAndEndIndices(cidr)
+// Release releases the given prefix range.
+func (s *CidrSet) Release(prefix netip.Prefix) error {
+	begin, end, err := s.getBeginningAndEndIndices(prefix)
 	if err != nil {
 		return err
 	}
@@ -276,10 +243,10 @@ func (s *CidrSet) Release(cidr *net.IPNet) error {
 	return nil
 }
 
-// Occupy marks the given CIDR range as used. Occupy succeeds even if the CIDR
+// Occupy marks the given prefix range as used. Occupy succeeds even if the prefix
 // range was previously used.
-func (s *CidrSet) Occupy(cidr *net.IPNet) (err error) {
-	begin, end, err := s.getBeginningAndEndIndices(cidr)
+func (s *CidrSet) Occupy(prefix netip.Prefix) (err error) {
+	begin, end, err := s.getBeginningAndEndIndices(prefix)
 	if err != nil {
 		return err
 	}
@@ -297,24 +264,24 @@ func (s *CidrSet) Occupy(cidr *net.IPNet) (err error) {
 	return nil
 }
 
-func (s *CidrSet) getIndexForIP(ip net.IP) (int, error) {
-	if ip.To4() != nil {
-		cidrIndex := (binary.BigEndian.Uint32(s.clusterCIDR.IP) ^ binary.BigEndian.Uint32(ip.To4())) >> uint32(32-s.nodeMaskSize)
+func (s *CidrSet) getIndexForAddr(addr netip.Addr) (int, error) {
+	if addr.Is4() {
+		clusterBytes := s.clusterPrefix.Addr().As4()
+		addrBytes := addr.As4()
+		cidrIndex := (binary.BigEndian.Uint32(clusterBytes[:]) ^ binary.BigEndian.Uint32(addrBytes[:])) >> uint32(32-s.nodeMaskSize)
 		if cidrIndex >= uint32(s.maxCIDRs) {
-			return 0, fmt.Errorf("CIDR: %v/%v is out of the range of CIDR allocator", ip, s.nodeMaskSize)
+			return 0, fmt.Errorf("CIDR: %v/%v is out of the range of CIDR allocator", addr, s.nodeMaskSize)
 		}
 		return int(cidrIndex), nil
 	}
-	if ip.To16() != nil {
-		bigIP := big.NewInt(0).SetBytes(s.clusterCIDR.IP)
-		bigIP = bigIP.Xor(bigIP, big.NewInt(0).SetBytes(ip))
-		cidrIndexBig := bigIP.Rsh(bigIP, uint(net.IPv6len*8-s.nodeMaskSize))
-		cidrIndex := cidrIndexBig.Uint64()
-		if cidrIndex >= uint64(s.maxCIDRs) {
-			return 0, fmt.Errorf("CIDR: %v/%v is out of the range of CIDR allocator", ip, s.nodeMaskSize)
-		}
-		return int(cidrIndex), nil
+	clusterBytes := s.clusterPrefix.Addr().As16()
+	addrBytes := addr.As16()
+	bigIP := big.NewInt(0).SetBytes(clusterBytes[:])
+	bigIP = bigIP.Xor(bigIP, big.NewInt(0).SetBytes(addrBytes[:]))
+	cidrIndexBig := bigIP.Rsh(bigIP, uint(ipv6Bits-s.nodeMaskSize))
+	cidrIndex := cidrIndexBig.Uint64()
+	if cidrIndex >= uint64(s.maxCIDRs) {
+		return 0, fmt.Errorf("CIDR: %v/%v is out of the range of CIDR allocator", addr, s.nodeMaskSize)
 	}
-
-	return 0, fmt.Errorf("invalid IP: %v", ip)
+	return int(cidrIndex), nil
 }

--- a/pkg/ipam/cidrset/cidr_set_test.go
+++ b/pkg/ipam/cidrset/cidr_set_test.go
@@ -6,7 +6,7 @@ package cidrset
 
 import (
 	"math/big"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,8 +33,8 @@ func TestCIDRSetFullyAllocated(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
-		a, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+		clusterPrefix := netip.MustParsePrefix(tc.clusterCIDRStr)
+		a, err := NewCIDRSet(clusterPrefix, tc.subNetMaskSize)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
@@ -184,8 +184,8 @@ func TestIndexToCIDRBlock(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
-		a, err := NewCIDRSet(clusterCIDR, tc.subnetMaskSize)
+		clusterPrefix := netip.MustParsePrefix(tc.clusterCIDRStr)
+		a, err := NewCIDRSet(clusterPrefix, tc.subnetMaskSize)
 		if err != nil {
 			t.Fatalf("error for %v ", tc.description)
 		}
@@ -211,13 +211,13 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
-		a, err := NewCIDRSet(clusterCIDR, 24)
+		clusterPrefix := netip.MustParsePrefix(tc.clusterCIDRStr)
+		a, err := NewCIDRSet(clusterPrefix, 24)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
 		// allocate all the CIDRs
-		var cidrs []*net.IPNet
+		var cidrs []netip.Prefix
 
 		for range 256 {
 			if c, err := a.AllocateNext(); err == nil {
@@ -238,7 +238,7 @@ func TestCIDRSet_RandomishAllocation(t *testing.T) {
 		}
 
 		// allocate the CIDRs again
-		var rcidrs []*net.IPNet
+		var rcidrs []netip.Prefix
 		for i := range 256 {
 			if c, err := a.AllocateNext(); err == nil {
 				rcidrs = append(rcidrs, c)
@@ -270,13 +270,13 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
-		a, err := NewCIDRSet(clusterCIDR, 24)
+		clusterPrefix := netip.MustParsePrefix(tc.clusterCIDRStr)
+		a, err := NewCIDRSet(clusterPrefix, 24)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
 		// allocate all the CIDRs
-		var cidrs []*net.IPNet
+		var cidrs []netip.Prefix
 		var numCIDRs = 256
 
 		for range numCIDRs {
@@ -302,7 +302,7 @@ func TestCIDRSet_AllocationOccupied(t *testing.T) {
 		}
 
 		// allocate the first 128 CIDRs again
-		var rcidrs []*net.IPNet
+		var rcidrs []netip.Prefix
 		for i := range numCIDRs / 2 {
 			if c, err := a.AllocateNext(); err == nil {
 				rcidrs = append(rcidrs, c)
@@ -445,21 +445,21 @@ func TestGetBitforCIDR(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
+		clusterPrefix, err := netip.ParsePrefix(tc.clusterCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
-		cs, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+		cs, err := NewCIDRSet(clusterPrefix, tc.subNetMaskSize)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
-		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
+		subnetPrefix, err := netip.ParsePrefix(tc.subNetCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
-		got, err := cs.getIndexForIP(subnetCIDR.IP)
+		got, err := cs.getIndexForAddr(subnetPrefix.Addr())
 		if err == nil && tc.expectErr {
 			t.Errorf("expected error but got null for %v", tc.description)
 			continue
@@ -615,22 +615,22 @@ func TestOccupy(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
+		clusterPrefix, err := netip.ParsePrefix(tc.clusterCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
-		cs, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+		cs, err := NewCIDRSet(clusterPrefix, tc.subNetMaskSize)
 		if err != nil {
 			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
 		}
 
-		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
+		subnetPrefix, err := netip.ParsePrefix(tc.subNetCIDRStr)
 		if err != nil {
 			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
-		err = cs.Occupy(subnetCIDR)
+		err = cs.Occupy(subnetPrefix)
 		if err == nil && tc.expectErr {
 			t.Errorf("expected error but got none for %v", tc.description)
 			continue
@@ -684,10 +684,10 @@ func TestCIDRSetv6(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
-			a, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+			clusterPrefix := netip.MustParsePrefix(tc.clusterCIDRStr)
+			a, err := NewCIDRSet(clusterPrefix, tc.subNetMaskSize)
 			if gotErr := err != nil; gotErr != tc.expectErr {
-				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterCIDR, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
+				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterPrefix, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
 			}
 			if a == nil {
 				return
@@ -700,7 +700,7 @@ func TestCIDRSetv6(t *testing.T) {
 				t.Errorf("a.AllocateNext() = %+v, want no error", err)
 			}
 			if !tc.expectErr {
-				if p != nil && p.String() != tc.expectedCIDR {
+				if p.IsValid() && p.String() != tc.expectedCIDR {
 					t.Fatalf("a.AllocateNext() got %+v, want %+v", p.String(), tc.expectedCIDR)
 				}
 			}
@@ -712,7 +712,7 @@ func TestCIDRSetv6(t *testing.T) {
 				t.Errorf("a.AllocateNext() = %+v, want no error", err)
 			}
 			if !tc.expectErr {
-				if p2 != nil && p2.String() != tc.expectedCIDR2 {
+				if p2.IsValid() && p2.String() != tc.expectedCIDR2 {
 					t.Fatalf("a.AllocateNext() got %+v, want %+v", p2.String(), tc.expectedCIDR)
 				}
 			}
@@ -754,10 +754,10 @@ func TestInvalidSubNetMaskSize(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
-			a, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+			clusterPrefix := netip.MustParsePrefix(tc.clusterCIDRStr)
+			a, err := NewCIDRSet(clusterPrefix, tc.subNetMaskSize)
 			if gotErr := err != nil; gotErr != tc.expectErr {
-				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterCIDR, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
+				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterPrefix, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
 			}
 		})
 	}


### PR DESCRIPTION
Relates to #24246

Followup to #45395

Switch `cidrset.CidrSet` and the `cidralloc.CIDRAllocator` interface from `net.IPNet` to `netip.Prefix`.

The operator's `multipool` package loses its round-trip conversions now that the allocator speaks `netip.Prefix` natively.

Callers in `podcidr.NodesPodCIDRManager` still carry `net.IPNet` internally and convert at the boundary.