### PR TITLE
gh: conformance-{aks,eks,gke,kpr}: split out bpf masquerade

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -297,11 +297,16 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set=kubeProxyReplacement=true"
           fi
 
+          BPFMASQV4=$(echo "${EXTRA_ARGS}" | jq -r '.["bpf-masq-v4"] // false')
+          if [[ "${BPFMASQV4}" == "true" ]]; then
+            echo "::notice::BPFMasqV4 enabled - setting {bpf.masquerade=true,enableIPv4Masquerade=true} for all matrix entries"
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
+              --helm-set enableIPv4Masquerade=true"
+          fi
+
           ADV_FEAT=$(echo "${EXTRA_ARGS}" | jq -r '.["advanced-features"] // false')
           if [[ "$ADV_FEAT" == "true" ]]; then
-            CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
-              --helm-set enableIPv4Masquerade=true \
-              --helm-set localRedirectPolicy=true \
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set localRedirectPolicy=true \
               --helm-set egressGateway.enabled=true"
           fi
 

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -353,11 +353,14 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set eni.awsEnablePrefixDelegation=true"
           fi
 
+          if [[ "${{ matrix.bpf-masq-v4 }}" == "true" ]]; then
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
+              --helm-set enableIPv4Masquerade=true"
+          fi
+
           ADV_FEAT=$(echo "${EXTRA_ARGS}" | jq -r '.["advanced-features"] // false')
           if [[ "$ADV_FEAT" == "true" ]]; then
-            CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
-              --helm-set enableIPv4Masquerade=true \
-              --helm-set localRedirectPolicies.enabled=true \
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set localRedirectPolicies.enabled=true \
               --helm-set egressGateway.enabled=true"
           fi
 

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -170,6 +170,7 @@ jobs:
           IPSEC=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["ipsec"] // false')
           WG=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["wireguard"] // false')
           KPR=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["kpr"] // false')
+          BPFMASQV4=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["bpf-masq-v4"] // false')
           ADV_FEAT=$(echo "${EXTRA_ARGS}" | sed 's/^""$/{}/' | jq -r '.["advanced-features"] // false')
 
           # shellcheck disable=SC2193
@@ -197,6 +198,12 @@ jobs:
           if [[ "$KPR" == "true" ]]; then
             echo "::notice::KPR enabled - setting kpr=true for all matrix entries"
             jq '.config |= map(. + {"kpr": true})' /tmp/matrix.json > /tmp/matrix.json.tmp
+            mv /tmp/matrix.json.tmp /tmp/matrix.json
+          fi
+
+          if [[ "${BPFMASQV4}" == "true" ]]; then
+            echo "::notice::BPFMasqV4 enabled - setting bpf.masquerade=true,enableIPv4Masquerade=true for all matrix entries"
+            jq '.config |= map(. + {"bpf-masq-v4": true})' /tmp/matrix.json > /tmp/matrix.json.tmp
             mv /tmp/matrix.json.tmp /tmp/matrix.json
           fi
 
@@ -347,10 +354,13 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set kubeProxyReplacement=true"
           fi
 
-          if [[ "${{ matrix.config.advanced-features }}" == "true" ]]; then
+          if [[ "${{ matrix.config.bpf-masq-v4 }}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
-              --helm-set enableIPv4Masquerade=true \
-              --helm-set localRedirectPolicies.enabled=true \
+              --helm-set enableIPv4Masquerade=true"
+          fi
+
+          if [[ "${{ matrix.config.advanced-features }}" == "true" ]]; then
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set localRedirectPolicies.enabled=true \
               --helm-set egressGateway.enabled=true"
           fi
 

--- a/.github/workflows/conformance-kpr-aks.yaml
+++ b/.github/workflows/conformance-kpr-aks.yaml
@@ -106,7 +106,7 @@ jobs:
       UID: 1
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true}'
 
   conformance-aks-kpr-ipsec:
     name: Conformance AKS with KPR + IPsec
@@ -118,7 +118,7 @@ jobs:
       UID: 2
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "ipsec": true}'
 
   conformance-aks-kpr-wireguard:
     name: Conformance AKS with KPR + WireGuard
@@ -130,7 +130,7 @@ jobs:
       UID: 3
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "wireguard": true}'
 
   merge-upload-and-status:
     name: Merge Upload and Status

--- a/.github/workflows/conformance-kpr-eks.yaml
+++ b/.github/workflows/conformance-kpr-eks.yaml
@@ -106,7 +106,7 @@ jobs:
       UID: 1
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true}'
       test-concurrency: 2
 
   conformance-eks-kpr-ipsec:
@@ -119,7 +119,7 @@ jobs:
       UID: 2
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "ipsec": true}'
       test-concurrency: 2
 
   conformance-eks-kpr-wireguard:
@@ -132,7 +132,7 @@ jobs:
       UID: 3
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "wireguard": true}'
       test-concurrency: 2
 
   merge-upload-and-status:

--- a/.github/workflows/conformance-kpr-gke.yaml
+++ b/.github/workflows/conformance-kpr-gke.yaml
@@ -106,7 +106,7 @@ jobs:
       UID: 1
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true}'
 
   conformance-gke-kpr-ipsec:
     name: Conformance GKE with KPR + IPsec
@@ -118,7 +118,7 @@ jobs:
       UID: 2
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "ipsec": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "ipsec": true}'
 
   conformance-gke-kpr-wireguard:
     name: Conformance GKE with KPR + WireGuard
@@ -130,7 +130,7 @@ jobs:
       UID: 3
       context-ref: ${{ inputs.context-ref || github.sha }}
       SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "advanced-features": true, "wireguard": true}'
+      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "wireguard": true}'
 
   merge-upload-and-status:
     name: Merge Upload and Status


### PR DESCRIPTION
Split out `bpf.masquerade,enableIPv4Masquerade` from conformance testing `"advanced-features"` variable so BPF masq can be enabled independently of LRP/EGW. This will be required to introduce netkit conformance testing in a future commit.