### PR TITLE
k8s/utils: Apply `service-proxy-name` filter to `EndpointSlice` lists

### DIFF
--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -46,8 +46,6 @@ var nodeSampleJSON = `{
             "cloud.google.com/gke-nodepool": "default-pool",
             "cloud.google.com/gke-os-distribution": "cos",
             "disktype": "ssd",
-            "failure-domain.beta.kubernetes.io/region": "earth", // Remove after support for 1.17 is dropped
-            "failure-domain.beta.kubernetes.io/zone": "earth", // Remove after support for 1.17 is dropped
             "topology.kubernetes.io/region": "earth",
             "topology.kubernetes.io/zone": "earth",
             "kubernetes.io/hostname": "super-node"

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -305,7 +305,7 @@ func EndpointsResourceWithIndexers(logger *slog.Logger, lc cell.Lifecycle, cfg C
 		return nil, nil
 	}
 
-	endpointSliceOptsModifier, err := utils.GetEndpointSliceListOptionsModifier(cfg.WatchConfig.EnableHeadlessServiceWatch)
+	endpointSliceOptsModifier, err := utils.GetEndpointSliceListOptionsModifier(cfg.Config.K8sServiceProxyName, cfg.WatchConfig.EnableHeadlessServiceWatch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -64,50 +64,12 @@ func GetObjNamespaceName(obj NamespaceNameGetter) string {
 	return ns + "/" + obj.GetName()
 }
 
-// GetEndpointSliceListOptionsModifier returns the options modifier for endpointSlice object list.
-// This methods returns a ListOptions modifier which adds a label selector to
-// select all endpointSlice objects they are not from remote clusters in Cilium cluster mesh.
-// This is mostly the same behavior as kube-proxy except the cluster mesh behavior which is
-// tied to how Cilium internally works with clustermesh endpoints and that this function doesn't ignore
-// headless Services when includeHeadlessServices is true.
-// Given label mirroring from the service objects to endpoint slice objects were introduced in Kubernetes PR 94443,
-// and released as part of Kubernetes v1.20; we can start using GetServiceAndEndpointListOptionsModifier for
-// endpoint slices when dropping support for Kubernetes v1.19 and older. We can do that since the
-// serviceProxyNameLabel label will then be mirrored to endpoint slices for services with that label.
-// We also ignore Kubernetes endpoints coming from other clusters in the Cilium clustermesh here as
-// Cilium does not rely on mirrored Kubernetes EndpointSlice for any of its functionalities.
-func GetEndpointSliceListOptionsModifier(includeHeadlessServices bool) (func(options *v1meta.ListOptions), error) {
-	nonRemoteEndpointSelector, err := labels.NewRequirement(discoveryv1.LabelManagedBy, selection.NotEquals, []string{EndpointSliceMeshControllerName})
-	if err != nil {
-		return nil, err
-	}
-
-	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*nonRemoteEndpointSelector)
-
-	if !includeHeadlessServices {
-		nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
-
-		if err != nil {
-			return nil, err
-		}
-		labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
-	}
-
-	return func(options *v1meta.ListOptions) {
-		options.LabelSelector = labelSelector.String()
-	}, nil
-}
-
-// GetServiceAndEndpointListOptionsModifier returns the options modifier for service and endpoint object lists.
-// This methods returns a ListOptions modifier which adds a label selector to only
-// select services that are in context of Cilium.
-// Unlike kube-proxy Cilium also watches headless services and their endpoint slices when includeHeadlessServices is true.
-// We honor service.kubernetes.io/service-proxy-name label in the service object and only
-// handle services that match our service proxy name. If the service proxy name for Cilium
-// is an empty string, we assume that Cilium is the default service handler in which case
-// we select all services that don't have the above mentioned label.
-func GetServiceAndEndpointListOptionsModifier(k8sServiceProxy string, includeHeadlessServices bool) (func(options *v1meta.ListOptions), error) {
+// serviceListLabelSelector builds the common label selector used to filter
+// Service and EndpointSlice lists. It honors the service.kubernetes.io/service-proxy-name
+// label so that we only handle services matching our service proxy name. If k8sServiceProxy
+// is empty, we assume Cilium is the default service handler and select services without
+// that label. When includeHeadlessServices is false, headless services are also excluded.
+func serviceListLabelSelector(k8sServiceProxy string, includeHeadlessServices bool) (labels.Selector, error) {
 	var (
 		serviceNameSelector *labels.Requirement
 		err                 error
@@ -125,16 +87,59 @@ func GetServiceAndEndpointListOptionsModifier(k8sServiceProxy string, includeHea
 		return nil, err
 	}
 
-	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*serviceNameSelector)
+	labelSelector := labels.NewSelector().Add(*serviceNameSelector)
 
 	if !includeHeadlessServices {
 		nonHeadlessServiceSelector, err := labels.NewRequirement(v1.IsHeadlessService, selection.DoesNotExist, nil)
-
 		if err != nil {
 			return nil, err
 		}
 		labelSelector = labelSelector.Add(*nonHeadlessServiceSelector)
+	}
+
+	return labelSelector, nil
+}
+
+// GetEndpointSliceListOptionsModifier returns the options modifier for endpointSlice object list.
+// This methods returns a ListOptions modifier which adds a label selector to
+// select endpointSlice objects that are in context of Cilium and not from remote clusters
+// in Cilium cluster mesh.
+// The service-proxy-name filter is applied via label mirroring from the parent Service
+// (supported since Kubernetes v1.20). This is mostly the same behavior as kube-proxy except
+// the cluster mesh behavior which is tied to how Cilium internally works with clustermesh
+// endpoints and that this function doesn't ignore headless Services when
+// includeHeadlessServices is true.
+// We ignore Kubernetes endpoints coming from other clusters in the Cilium clustermesh here
+// as Cilium does not rely on mirrored Kubernetes EndpointSlice for any of its functionalities.
+func GetEndpointSliceListOptionsModifier(k8sServiceProxy string, includeHeadlessServices bool) (func(options *v1meta.ListOptions), error) {
+	labelSelector, err := serviceListLabelSelector(k8sServiceProxy, includeHeadlessServices)
+	if err != nil {
+		return nil, err
+	}
+
+	nonRemoteEndpointSelector, err := labels.NewRequirement(discoveryv1.LabelManagedBy, selection.NotEquals, []string{EndpointSliceMeshControllerName})
+	if err != nil {
+		return nil, err
+	}
+	labelSelector = labelSelector.Add(*nonRemoteEndpointSelector)
+
+	return func(options *v1meta.ListOptions) {
+		options.LabelSelector = labelSelector.String()
+	}, nil
+}
+
+// GetServiceAndEndpointListOptionsModifier returns the options modifier for service and endpoint object lists.
+// This methods returns a ListOptions modifier which adds a label selector to only
+// select services that are in context of Cilium.
+// Unlike kube-proxy Cilium also watches headless services and their endpoint slices when includeHeadlessServices is true.
+// We honor service.kubernetes.io/service-proxy-name label in the service object and only
+// handle services that match our service proxy name. If the service proxy name for Cilium
+// is an empty string, we assume that Cilium is the default service handler in which case
+// we select all services that don't have the above mentioned label.
+func GetServiceAndEndpointListOptionsModifier(k8sServiceProxy string, includeHeadlessServices bool) (func(options *v1meta.ListOptions), error) {
+	labelSelector, err := serviceListLabelSelector(k8sServiceProxy, includeHeadlessServices)
+	if err != nil {
+		return nil, err
 	}
 
 	return func(options *v1meta.ListOptions) {

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -116,66 +116,102 @@ func TestEndpointSlices(t *testing.T) {
 	tests := []struct {
 		name                    string
 		includeHeadlessServices bool
+		k8sServiceProxy         string
 		want                    []string
 	}{
 		{
-			name:                    "Headless services are included",
+			name:                    "Headless services are included, proxy is foo",
 			includeHeadlessServices: true,
-			want:                    []string{"test-svc-1", "test-svc-3"},
+			k8sServiceProxy:         "foo",
+			want:                    []string{"test-svc-1", "test-svc-4"},
 		},
 		{
-			name:                    "Headless services are excluded",
+			name:                    "Headless services are included, no proxy",
+			includeHeadlessServices: true,
+			k8sServiceProxy:         "",
+			want:                    []string{"test-svc-3", "test-svc-5"},
+		},
+		{
+			name:                    "Headless services are excluded, proxy is foo",
 			includeHeadlessServices: false,
+			k8sServiceProxy:         "foo",
 			want:                    []string{"test-svc-1"},
+		},
+		{
+			name:                    "Headless services are excluded, no proxy",
+			includeHeadlessServices: false,
+			k8sServiceProxy:         "",
+			want:                    []string{"test-svc-3"},
 		},
 	}
 
 	client := fake.NewSimpleClientset()
+	// test-svc-1: proxy=foo, not headless, not remote -> matches proxy=foo
 	meta1 := &metav1.ObjectMeta{
-		Name:   "test-svc-1",
-		Labels: map[string]string{},
+		Name: "test-svc-1",
+		Labels: map[string]string{
+			serviceProxyNameLabel: "foo",
+		},
 	}
+	// test-svc-2: proxy=bar -> never matches (handled by another proxy)
 	meta2 := &metav1.ObjectMeta{
 		Name: "test-svc-2",
 		Labels: map[string]string{
-			discoveryv1.LabelManagedBy: EndpointSliceMeshControllerName,
+			serviceProxyNameLabel: "bar",
 		},
 	}
+	// test-svc-3: no proxy label, not headless -> matches empty proxy
 	meta3 := &metav1.ObjectMeta{
-		Name: "test-svc-3",
+		Name:   "test-svc-3",
+		Labels: map[string]string{},
+	}
+	// test-svc-4: proxy=foo, headless -> matches when includeHeadlessServices
+	meta4 := &metav1.ObjectMeta{
+		Name: "test-svc-4",
+		Labels: map[string]string{
+			serviceProxyNameLabel:    "foo",
+			corev1.IsHeadlessService: "",
+		},
+	}
+	// test-svc-5: no proxy label, headless -> matches empty proxy when includeHeadlessServices
+	meta5 := &metav1.ObjectMeta{
+		Name: "test-svc-5",
 		Labels: map[string]string{
 			corev1.IsHeadlessService: "",
 		},
 	}
-	meta4 := &metav1.ObjectMeta{
-		Name: "test-svc-4",
+	// test-svc-6: remote clustermesh slice -> never matches
+	meta6 := &metav1.ObjectMeta{
+		Name: "test-svc-6",
+		Labels: map[string]string{
+			discoveryv1.LabelManagedBy: EndpointSliceMeshControllerName,
+		},
+	}
+	// test-svc-7: remote clustermesh slice, headless -> never matches
+	meta7 := &metav1.ObjectMeta{
+		Name: "test-svc-7",
 		Labels: map[string]string{
 			corev1.IsHeadlessService:   "",
 			discoveryv1.LabelManagedBy: EndpointSliceMeshControllerName,
 		},
 	}
 
-	for _, meta := range []*metav1.ObjectMeta{meta1, meta2, meta3, meta4} {
-		ep := &corev1.Endpoints{ObjectMeta: *meta}
-		_, err := client.CoreV1().Endpoints("test-ns").Create(context.TODO(), ep, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("Failed to create endpoint %v: %s", ep, err)
-		}
+	for _, meta := range []*metav1.ObjectMeta{meta1, meta2, meta3, meta4, meta5, meta6, meta7} {
 		epSlice := &discoveryv1.EndpointSlice{ObjectMeta: *meta}
-		_, err = client.DiscoveryV1().EndpointSlices("test-ns").Create(context.TODO(), epSlice, metav1.CreateOptions{})
+		_, err := client.DiscoveryV1().EndpointSlices("test-ns").Create(context.TODO(), epSlice, metav1.CreateOptions{})
 		if err != nil {
-			t.Fatalf("Failed to create endpoint slice %v: %s", ep, err)
+			t.Fatalf("Failed to create endpoint slice %v: %s", epSlice, err)
 		}
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			optMod, _ := GetEndpointSliceListOptionsModifier(tt.includeHeadlessServices)
+			optMod, _ := GetEndpointSliceListOptionsModifier(tt.k8sServiceProxy, tt.includeHeadlessServices)
 			options := metav1.ListOptions{}
 			optMod(&options)
 			epSlices, err := client.DiscoveryV1().EndpointSlices("test-ns").List(context.TODO(), options)
 			if err != nil {
-				t.Fatalf("Failed to list services: %s", err)
+				t.Fatalf("Failed to list endpoint slices: %s", err)
 			}
 
 			got := make([]string, len(epSlices.Items))


### PR DESCRIPTION
Extract the shared service-proxy-name + headless-service label selector into a helper used by both `GetServiceAndEndpointListOptionsModifier` and `GetEndpointSliceListOptionsModifier`. The latter now also takes a `k8sServiceProxy` argument.

The previous split dated from when Cilium still supported Kubernetes v1.19, which did not mirror labels from `Services` onto `EndpointSlices`. Since v1.20, label mirroring is a given, so `EndpointSlices` can be filtered by `service-proxy-name` at the watch level just like `Services`.

Behavior change: `EndpointSlices` whose parent `Service` is handled by a different service-proxy are now excluded from the watch, matching how `Services` themselves are already filtered.

I identified this change while looking for specific code supporting EOLed k8s versions while working on the k8s 1.36 update (#45499).

Note: The current minimum k8s version supported/required by cilium is [1.21](https://github.com/DataDog/cilium/blob/f9a14d6162a3d3bfaa7059c001a935986fc77f8a/install/kubernetes/cilium/Chart.yaml#L7).

```release-note
cilium-agent: when `--k8s-service-proxy-name` is set, `EndpointSlices` are now filtered by the `service.kubernetes.io/service-proxy-name` label at the watch level, matching how `Services` are already filtered, operators with hand-managed `EndpointSlices` must stamp the matching label on those slices.
```