### PR TITLE
contrib: fix typo in identity_is_node.cocci

### DIFF
--- a/contrib/coccinelle/identity_is_node.cocci
+++ b/contrib/coccinelle/identity_is_node.cocci
@@ -16,7 +16,7 @@ cnt = 0
 
 
 @rule@
-position p1 : script:python() { p2[0].current_element not in ["identity_is_remote_node"] };
+position p1 : script:python() { p1[0].current_element not in ["identity_is_remote_node"] };
 expression e;
 @@
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "<string>", line 3, in <module>
NameError: name 'p2' is not defined. Did you mean: 'p1'? EXN: Failure("Error in Python script, line 19, file \"<snip>/cilium/contrib/coccinelle/identity_is_node.cocci\": Python failure") in ./lib/identity.h

Fixes: b9444865a5ad ("bpf: remove unused identity_is_node()")