### PR TITLE
lb: remove deprecated `node-port-algorithm` and `node-port-mode`

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -379,6 +379,12 @@ from Cilium.
 
 * The previously deprecated and ignored ``--ces-slice-mode`` operator flag has been removed.
 
+* The previously deprecated ``--node-port-algorithm`` agent flag has been removed
+  in favor of ``--bpf-lb-algorithm`` (``loadBalancer.algorithm`` Helm value).
+
+* The previously deprecated ``--node-port-mode`` agent flag has been removed
+  in favor of the ``--bpf-lb-mode`` (``loadBalancer.mode`` Helm value).
+
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -56,9 +56,6 @@ const (
 
 	LBAlgorithmName = "bpf-lb-algorithm"
 
-	// Deprecated option for setting [LBAlgorithm]
-	NodePortAlgName = "node-port-algorithm"
-
 	// LoadBalancerMode indicates in which mode NodePort implementation should run
 	// ("snat", "dsr" or "hybrid")
 	LoadBalancerModeName = "bpf-lb-mode"
@@ -66,9 +63,6 @@ const (
 	// LoadBalancerModeAnnotation tells whether controller should check service
 	// level annotation for configuring bpf loadbalancing method (snat vs dsr).
 	LoadBalancerModeAnnotationName = "bpf-lb-mode-annotation"
-
-	// Deprecated option for setting [LoadBalancerMode]
-	NodePortModeName = "node-port-mode"
 
 	// LoadBalancerDSRDispatchName is the config option for setting the method for
 	// pushing packets to backends under DSR ("opt", "ipip", "geneve")
@@ -237,7 +231,6 @@ type UserConfig struct {
 // ConfigCell provides the [Config] and [ExternalConfig] configurations.
 var ConfigCell = cell.Group(
 	cell.Config(DefaultUserConfig),
-	cell.Config(DeprecatedConfig{}),
 	cell.Provide(
 		// Bridge options from [option.DaemonConfig] to [loadbalancer.ExternalConfig] to avoid
 		// direct dependency to DaemonConfig
@@ -264,28 +257,6 @@ func (c *Config) LoadBalancerUsesDSR() bool {
 	return c.LBMode == LBModeDSR ||
 		c.LBMode == LBModeHybrid ||
 		c.LBModeAnnotation
-}
-
-type DeprecatedConfig struct {
-	// NodePortAlg indicates which backend selection algorithm is used
-	// ("random" or "maglev")
-	NodePortAlg string `mapstructure:"node-port-algorithm"`
-
-	// NodePortMode indicates in which mode NodePort implementation should run
-	// ("snat", "dsr" or "hybrid")
-	NodePortMode string `mapstructure:"node-port-mode"`
-}
-
-func (DeprecatedConfig) Flags(flags *pflag.FlagSet) {
-	// Deprecated option for setting [LBAlgorithm]
-	flags.String(NodePortAlgName, "", "BPF load balancing algorithm (\"random\", \"maglev\")")
-	flags.MarkHidden(NodePortAlgName)
-	flags.MarkDeprecated(NodePortAlgName, "Use --"+LBAlgorithmName+" instead")
-
-	// Deprecated option for setting [LBMode]
-	flags.String(NodePortModeName, "", "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
-	flags.MarkHidden(NodePortModeName)
-	flags.MarkDeprecated(NodePortAlgName, "Use --"+LoadBalancerModeName+" instead")
 }
 
 func (def UserConfig) Flags(flags *pflag.FlagSet) {
@@ -352,7 +323,7 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 
 // NewConfig takes the user-provided configuration, validates and processes it to produce the final
 // configuration for load-balancing.
-func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig DeprecatedConfig, dcfg *option.DaemonConfig) (cfg Config, err error) {
+func NewConfig(log *slog.Logger, userConfig UserConfig, dcfg *option.DaemonConfig) (cfg Config, err error) {
 	cfg.UserConfig = userConfig
 
 	if cfg.LBMapEntries <= 0 {
@@ -437,21 +408,9 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, deprecatedConfig Depreca
 		return Config{}, fmt.Errorf("Unable to parse min/max port value for NodePort range: %s", NodePortRange)
 	}
 
-	if deprecatedConfig.NodePortAlg != "" {
-		cfg.LBAlgorithm = deprecatedConfig.NodePortAlg
-	}
-
 	if cfg.LBAlgorithm != LBAlgorithmRandom &&
 		cfg.LBAlgorithm != LBAlgorithmMaglev {
 		return Config{}, fmt.Errorf("Invalid value for --%s: %s", LBAlgorithmName, cfg.LBAlgorithm)
-	}
-
-	if deprecatedConfig.NodePortMode != "" {
-		if cfg.LBMode != DefaultUserConfig.LBMode {
-			return Config{}, fmt.Errorf("both --%s and --%s were set. Use --%s instead.",
-				LoadBalancerModeName, NodePortModeName, LoadBalancerModeName)
-		}
-		cfg.LBMode = deprecatedConfig.NodePortMode
 	}
 
 	if cfg.LBMode != LBModeSNAT && cfg.LBMode != LBModeDSR && cfg.LBMode != LBModeHybrid {

--- a/pkg/loadbalancer/config_test.go
+++ b/pkg/loadbalancer/config_test.go
@@ -93,7 +93,7 @@ func TestNewConfig_NodePortRange(t *testing.T) {
 			log := hivetest.Logger(t)
 			ucfg := DefaultUserConfig
 			ucfg.NodePortRange = tt.npRange
-			cfg, err := NewConfig(log, ucfg, DeprecatedConfig{}, &option.DaemonConfig{})
+			cfg, err := NewConfig(log, ucfg, &option.DaemonConfig{})
 
 			if tt.want.wantErr {
 				assert.Error(t, err)

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1244,7 +1244,7 @@ func TestBPFOps(t *testing.T) {
 		EnableNodeIPAM:       false,
 	}
 
-	cfg, _ := loadbalancer.NewConfig(log, loadbalancer.DefaultUserConfig, loadbalancer.DeprecatedConfig{}, &option.DaemonConfig{})
+	cfg, _ := loadbalancer.NewConfig(log, loadbalancer.DefaultUserConfig, &option.DaemonConfig{})
 
 	var lbmaps maps.LBMaps
 	if testutils.IsPrivileged() {

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -277,7 +277,6 @@ func TestPrivilegedSocketTermination_Datapath(t *testing.T) {
 		maglev.Cell,
 		lbmaps.Cell,
 		cell.Config(loadbalancer.DefaultUserConfig),
-		cell.Config(loadbalancer.DeprecatedConfig{}),
 		cell.Provide(
 			loadbalancer.NewBackendsTable,
 			statedb.RWTable[*loadbalancer.Backend].ToTable,

--- a/pkg/loadbalancer/tests/testdata/clusterip-allowed.txtar
+++ b/pkg/loadbalancer/tests/testdata/clusterip-allowed.txtar
@@ -1,4 +1,4 @@
-#! --bpf-lb-external-clusterip=true --node-port-algorithm=maglev
+#! --bpf-lb-external-clusterip=true --bpf-lb-algorithm=maglev
 
 # This test verifies that ClusterIP services are routable (i.e., can be accessed
 # from outside like a nodeWithoutCilium) when bpf-lb-external-clusterip is enabled.

--- a/pkg/loadbalancer/tests/testdata/dualstack-maglev.txtar
+++ b/pkg/loadbalancer/tests/testdata/dualstack-maglev.txtar
@@ -1,4 +1,4 @@
-#! --lb-test-fault-probability=0.0 --node-port-algorithm=maglev --lb-pressure-metrics-interval=100ms --bpf-lb-map-max=1000
+#! --lb-test-fault-probability=0.0 --bpf-lb-algorithm=maglev --lb-pressure-metrics-interval=100ms --bpf-lb-map-max=1000
 
 # NOTE: Fault injection disabled as it leads to non-deterministic id allocation with multiple
 # frontends from single service.

--- a/pkg/loadbalancer/tests/testdata/nodeport-explicit-random.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-explicit-random.txtar
@@ -1,4 +1,4 @@
-#! --bpf-lb-algorithm-annotation --node-port-algorithm=maglev --lb-test-fault-probability=0.0
+#! --bpf-lb-algorithm-annotation --bpf-lb-algorithm=maglev --lb-test-fault-probability=0.0
 
 # Add some node addresses
 db/insert node-addresses addrv4.yaml
@@ -22,7 +22,7 @@ db/cmp services services.table
 db/cmp frontends frontends.table
 
 # Check BPF maps
-# The first service uses default settings, which in this test means maglev due to --node-port-algorithm=maglev, while the second service has an explicit random annotation.
+# The first service uses default settings, which in this test means maglev due to --bpf-lb-algorithm=maglev, while the second service has an explicit random annotation.
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.expected lbmaps.actual
 

--- a/pkg/loadbalancer/tests/testdata/nodeport-maglev.txtar
+++ b/pkg/loadbalancer/tests/testdata/nodeport-maglev.txtar
@@ -1,4 +1,4 @@
-#! --node-port-algorithm=maglev --lb-test-fault-probability=0.0
+#! --bpf-lb-algorithm=maglev --lb-test-fault-probability=0.0
 
 # Add some node addresses
 db/insert node-addresses addrv4.yaml

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -610,7 +610,7 @@ func testMaglev(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) {
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot retrieve service")
 
 	// Flush CT tables so that any entry with src port 6{0,1,2}000
-	// from previous tests with --node-port-algorithm=random
+	// from previous tests with --bpf-lb-algorithm=random
 	// won't interfere the backend selection.
 	for _, label := range []string{helpers.K8s1, helpers.K8s2} {
 		pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)


### PR DESCRIPTION
This commit removes the deprecated `node-port-algorithm` and `node-port-mode` options from the load balancer configuration. These options were previously marked as deprecated and are no longer supported in the load balancer implementation. The code related to these options has been removed from the configuration handling and the tests.

The deprecation was already marked in v1.19, so let's remove this code now (v1.20).