### PR TITLE
docs: fix "the the" / "is is" typos in comments

### DIFF
--- a/pkg/datapath/linux/ipsec/types/params.go
+++ b/pkg/datapath/linux/ipsec/types/params.go
@@ -24,13 +24,13 @@ type Parameters struct {
 	// For OUT policies this is the resulting source address of an ESP encrypted
 	// packet.
 	// For IN/FWD this should identify the source SA address of the state which
-	// decrypted the the packet.
+	// decrypted the packet.
 	SourceTunnelIP *net.IP
 	// The destination security gateway IP used to define an IPsec tunnel mode SA
 	// For OUT policies this is the resulting destination address of an ESP encrypted
 	// packet.
 	// For IN/FWD this should identify the destination SA address of the state which
-	// decrypted the the packet.
+	// decrypted the packet.
 	DestTunnelIP *net.IP
 	// The ReqID used for the resulting XFRM policy/state
 	ReqID int

--- a/pkg/datapath/linux/main_test.go
+++ b/pkg/datapath/linux/main_test.go
@@ -13,7 +13,7 @@ func TestMain(m *testing.M) {
 	testutils.GoleakVerifyTestMain(m,
 		// When IPSec is enabled, [linuxNodeHandler] attempts to register IPSec metrics.
 		// Eventually, [metrics.withRegistry] spawns a goroutine to wait for the registry
-		// promise to resolve, but given that it gets never resolved, is is leaked.
+		// promise to resolve, but given that it gets never resolved, it is leaked.
 		testutils.GoleakIgnoreAnyFunction("github.com/cilium/cilium/pkg/metrics.withRegistry.func1"),
 	)
 }

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -65,7 +65,7 @@ func ClusterNameValidator(clusterName string) nodeValidator {
 	}
 }
 
-// NameValidator returns a validator enforcing that the name of the the unmarshaled
+// NameValidator returns a validator enforcing that the name of the unmarshaled
 // node matches the kvstore key.
 func NameValidator() nodeValidator {
 	return func(key string, n *nodeTypes.Node) error {


### PR DESCRIPTION

**Repo:** cilium/cilium (⭐ 19000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Fixes duplicated-word typos in code comments in three files: `pkg/datapath/linux/ipsec/types/params.go` (two occurrences of "decrypted the the packet"), `pkg/datapath/linux/main_test.go` ("is is leaked"), and `pkg/node/store/store.go` ("the name of the the unmarshaled node"). Pure comment changes, no functional impact.

## Why
Small but real readability improvements in comments that future contributors and reviewers will encounter. Duplicated-word typos slipped through review and are trivial to fix without risk.

## Testing
Comment-only changes. Go code semantics are unaffected; no build or test run required. `git diff` confirms only comment lines changed.

## Risk
Low — comment-only edits, no code paths or exports touched.
