### PR TITLE
daemon: remove deprecated `k8s-api-server` option

### DIFF
--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -699,7 +699,6 @@ been registered with cobra:
       Ⓜ️ infra (Infrastructure):
         Ⓜ️ k8s-client (Kubernetes Client):
              ⚙️ (client.Config) {
-                 K8sAPIServer: (string) "",
                  K8sKubeConfigPath: (string) "",
                  K8sClientQPS: (float32) 0,
                  K8sClientBurst: (int) 0,

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -401,6 +401,9 @@ from Cilium.
   removed in favor of ``--encryption-strict-egress-allow-remote-node-identities``
   (Helm ``encryption.strictMode.egress.allowRemoteNodeIdentities``).
 
+* The previously deprecated ``--k8s-api-server`` agent flag has been removed in
+  favor of ``--k8s-api-server-urls`` (Helm ``k8s.apiServerURLs`` value).
+
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/cilium-dbg/cmd/config.go
+++ b/cilium-dbg/cmd/config.go
@@ -160,7 +160,6 @@ func dumpReadOnlyConfigs(cfgStatus *models.DaemonConfigurationStatus) {
 		fmt.Printf("%-34s: %v\n", k, v)
 	}
 	fmt.Printf("%-34s: %s\n", "k8s-configuration", cfgStatus.K8sConfiguration)
-	fmt.Printf("%-34s: %s\n", "k8s-endpoint", cfgStatus.K8sEndpoint)
 	dumpConfig(cfgStatus.Immutable, false)
 }
 

--- a/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
@@ -63,7 +63,7 @@ func validateCNPs(logger *slog.Logger, clientset k8sClient.Clientset, shutdowner
 
 	if !clientset.IsEnabled() {
 		return fmt.Errorf("Kubernetes client not configured. Please provide configuration via --%s or --%s",
-			option.K8sAPIServer, option.K8sKubeConfigPath)
+			option.K8sAPIServerURLs, option.K8sKubeConfigPath)
 	}
 
 	npValidator, err := v2_validation.NewNPValidator(logger)

--- a/daemon/restapi/config.go
+++ b/daemon/restapi/config.go
@@ -398,7 +398,6 @@ func (h *getConfigHandler) Handle(params daemonapi.GetConfigParams) middleware.R
 	status := &models.DaemonConfigurationStatus{
 		Addressing:       routerNodeAddressing,
 		K8sConfiguration: h.clientset.Config().K8sKubeConfigPath,
-		K8sEndpoint:      h.clientset.Config().K8sAPIServer,
 		NodeMonitor:      h.monitorAgent.State(),
 		KvstoreConfiguration: &models.KVstoreConfiguration{
 			Type:    h.kvstoreConfig.KVStore,

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -28,9 +27,6 @@ type SharedConfig struct {
 
 	// K8sAPIServerURLs is the list of API server instances
 	K8sAPIServerURLs []string
-
-	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
-	K8sAPIServer string
 
 	// K8sKubeConfigPath is the absolute path of the kubernetes kubeconfig file
 	K8sKubeConfigPath string
@@ -68,7 +64,6 @@ func (def ClientParams) Flags(flags *pflag.FlagSet) {
 
 var defaultSharedConfig = SharedConfig{
 	EnableK8s:                    true,
-	K8sAPIServer:                 "",
 	K8sAPIServerURLs:             []string{},
 	K8sKubeConfigPath:            "",
 	K8sClientConnectionTimeout:   30 * time.Second,
@@ -79,8 +74,6 @@ var defaultSharedConfig = SharedConfig{
 
 func (def SharedConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableK8s, def.EnableK8s, "Enable the k8s clientset")
-	flags.String(option.K8sAPIServer, def.K8sAPIServer, "Kubernetes API server URL")
-	flags.MarkDeprecated(option.K8sAPIServer, fmt.Sprintf("use --%s", option.K8sAPIServerURLs))
 	flags.StringSlice(option.K8sAPIServerURLs, def.K8sAPIServerURLs, "Kubernetes API server URLs")
 	flags.String(option.K8sKubeConfigPath, def.K8sKubeConfigPath, "Absolute path of the kubernetes kubeconfig file")
 	flags.Duration(option.K8sClientConnectionTimeout, def.K8sClientConnectionTimeout, "Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0")
@@ -100,8 +93,7 @@ func (cfg Config) IsEnabled() bool {
 	if !cfg.EnableK8s {
 		return false
 	}
-	return cfg.K8sAPIServer != "" ||
-		len(cfg.K8sAPIServerURLs) >= 1 ||
+	return len(cfg.K8sAPIServerURLs) >= 1 ||
 		cfg.K8sKubeConfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 			os.Getenv("KUBERNETES_SERVICE_PORT") != "") ||

--- a/pkg/k8s/client/rest_config_provider.go
+++ b/pkg/k8s/client/rest_config_provider.go
@@ -140,9 +140,7 @@ func (r *restConfigManager) createConfig(cfg Config, userAgent string) (*rest.Co
 		err          error
 		apiServerURL string
 	)
-	if cfg.K8sAPIServer != "" {
-		apiServerURL = cfg.K8sAPIServer
-	} else if len(r.apiServerURLs) > 0 {
+	if len(r.apiServerURLs) > 0 {
 		apiServerURL = r.apiServerURLs[0].String()
 	}
 	kubeCfgPath := cfg.K8sKubeConfigPath
@@ -179,26 +177,6 @@ func (r *restConfigManager) createConfig(cfg Config, userAgent string) (*rest.Co
 }
 
 func (r *restConfigManager) parseConfig(cfg Config) {
-	if cfg.K8sAPIServer != "" {
-		var (
-			serverURL *url.URL
-			err       error
-		)
-		s := cfg.K8sAPIServer
-		if !strings.HasPrefix(s, "http") {
-			s = fmt.Sprintf("http://%s", s) // default to HTTP
-		}
-		serverURL, err = url.Parse(s)
-		if err != nil {
-			r.log.Error("Failed to parse APIServerURL, skipping",
-				logfields.Error, err,
-				logfields.URL, serverURL,
-			)
-			return
-		}
-		r.apiServerURLs = append(r.apiServerURLs, serverURL)
-		return
-	}
 	for _, apiServerURL := range cfg.K8sAPIServerURLs {
 		if apiServerURL == "" {
 			continue

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -174,9 +174,6 @@ const (
 	// Intended for operating cilium with CNI-compatible orchestrators other than Kubernetes. (default is true)
 	EnableK8s = "enable-k8s"
 
-	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
-	K8sAPIServer = "k8s-api-server"
-
 	// K8sAPIServerURLs is the kubernetes api address server url
 	K8sAPIServerURLs = "k8s-api-server-urls"
 


### PR DESCRIPTION
This commit removes the deprecated `k8s-api-server` option from the daemon configuration. This option was previously marked as deprecated in favor of `k8s-api-server-urls` and is no longer supported in the daemon implementation. The code related to this option has been removed from the configuration handling and the tests.

The deprecation was already marked in v1.19, so let's remove this code now (v1.20).