### PR TITLE
ces: remove deprecated `ces-slice-mode` option

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -372,6 +372,8 @@ from Cilium.
   ``hubble-redact-kafka-apikey`` agent flag have been removed as part of
   dropping Kafka support.
 
+* The previously deprecated and ignored ``--ces-slice-mode`` operator flag has been removed.
+
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -15,9 +15,6 @@ const (
 	// a CiliumEndpointSlice resource.
 	CESMaxCEPsInCES = "ces-max-ciliumendpoints-per-ces"
 
-	// CESSlicingMode instructs how CEPs are grouped in a CES.
-	CESSlicingMode = "ces-slice-mode"
-
 	// CESRateLimits can be used to configure a custom, stepped dynamic rate limit based on cluster size.
 	CESRateLimits = "ces-rate-limits"
 
@@ -38,22 +35,18 @@ var Cell = cell.Module(
 
 type Config struct {
 	CESMaxCEPsInCES           int    `mapstructure:"ces-max-ciliumendpoints-per-ces"`
-	CESSlicingMode            string `mapstructure:"ces-slice-mode"`
 	CESDynamicRateLimitConfig string `mapstructure:"ces-rate-limits"`
 	CESControllerMode         string `mapstructure:"ces-controller-mode"`
 }
 
 var defaultConfig = Config{
 	CESMaxCEPsInCES:           100,
-	CESSlicingMode:            fcfsMode,
 	CESDynamicRateLimitConfig: "[{\"nodes\":0,\"limit\":10,\"burst\":20}]",
 	CESControllerMode:         defaultMode,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Int(CESMaxCEPsInCES, def.CESMaxCEPsInCES, "Maximum number of CiliumEndpoints allowed in a CES")
-	flags.String(CESSlicingMode, def.CESSlicingMode, "Slicing mode defines how CiliumEndpoints are grouped into CES: either batched by their Identity (\"identity\") or batched on a \"First Come, First Served\" basis (\"fcfs\")")
-	flags.MarkDeprecated(CESSlicingMode, "Slicing mode defaults to the FCFS mode and is now deprecated option. It does not have a functional effect")
 
 	flags.String(CESRateLimits, def.CESDynamicRateLimitConfig, "Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string.")
 	flags.String(CESControllerMode, def.CESControllerMode, "CES controller operation mode. Can be 'default' or 'slim'")

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -38,11 +38,6 @@ const (
 	// dropped out of the queue.
 	maxRetries = 15
 
-	// CEPs are batched into a CES, based on its Identity
-	identityMode = "identity"
-	// CEPs are inserted into the largest, non-empty CiliumEndpointSlice
-	fcfsMode = "fcfs"
-
 	// Default CES Synctime, multiple consecutive syncs with k8s-apiserver are
 	// batched and synced together after a short delay.
 	DefaultCESSyncTime = 500 * time.Millisecond

--- a/operator/pkg/ciliumendpointslice/rate_limit_test.go
+++ b/operator/pkg/ciliumendpointslice/rate_limit_test.go
@@ -35,7 +35,6 @@ func TestSingleDynamicRateLimit(t *testing.T) {
 		Logger: hivetest.Logger(t),
 		Cfg: Config{
 			CESMaxCEPsInCES:           100,
-			CESSlicingMode:            identityMode,
 			CESDynamicRateLimitConfig: "[{\"nodes\": 5, \"limit\": 15.0, \"burst\": 30}]",
 			CESControllerMode:         defaultMode,
 		},
@@ -74,7 +73,6 @@ func TestMultipleUnsortedDynamicRateLimit(t *testing.T) {
 		Logger: hivetest.Logger(t),
 		Cfg: Config{
 			CESMaxCEPsInCES:           100,
-			CESSlicingMode:            identityMode,
 			CESDynamicRateLimitConfig: string(rlJson),
 			CESControllerMode:         defaultMode,
 		},


### PR DESCRIPTION
This commit removes the deprecated `ces-slice-mode` option, which was previously used to configure how CiliumEndpoints (CEPs) are grouped into CiliumEndpointSlices (CESs). The option was marked as deprecated already in v1.19 in favor of always behave `fcfs` (first come first served). Let's then cleanup this code.