### PR TITLE
daemon: fall back to API server when pod is missing from cache during restore

### DIFF
--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/vishvananda/netlink"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/daemon/cmd/legacy"
 	"github.com/cilium/cilium/pkg/datapath/connector"
@@ -98,10 +99,16 @@ type endpointRestorerParams struct {
 	ConnectorConfig     connector.Config
 }
 
+type k8sWatcher interface {
+	WaitForCacheSync(resourceNames ...string)
+	GetCachedPod(namespace, name string) (*slim_corev1.Pod, error)
+}
+
 type endpointRestorer struct {
+	ctx                 context.Context
 	logger              *slog.Logger
 	stateDir            string
-	k8sWatcher          *watchers.K8sWatcher
+	k8sWatcher          k8sWatcher
 	clientset           k8sClient.Clientset
 	endpointCreator     endpointcreator.EndpointCreator
 	endpointManager     endpointmanager.EndpointManager
@@ -161,6 +168,7 @@ func newEndpointRestorer(params endpointRestorerParams) *endpointRestorer {
 
 	params.Lifecycle.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
+			restorer.ctx = ctx
 			if err := restorer.clearStaleCiliumEndpointVeths(); err != nil {
 				// log and continue
 				params.Logger.Warn("Unable to clean stale endpoint interfaces", logfields.Error, err)
@@ -357,8 +365,19 @@ func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
 	r.k8sWatcher.WaitForCacheSync(resources.K8sAPIGroupPodV1Core)
 	pod, err = r.k8sWatcher.GetCachedPod(ep.K8sNamespace, ep.K8sPodName)
 	if err != nil && k8serrors.IsNotFound(err) {
-		return fmt.Errorf("Kubernetes pod %s/%s does not exist", ep.K8sNamespace, ep.K8sPodName)
-	} else if err == nil && pod.Spec.NodeName != nodeTypes.GetName() {
+		// Fall back to fetching from the API server to avoid race conditions
+		// where the informer cache has not yet synced the pod.
+		pod, err = r.clientset.Slim().CoreV1().Pods(ep.K8sNamespace).Get(r.ctx, ep.K8sPodName, metav1.GetOptions{})
+		if err != nil && k8serrors.IsNotFound(err) {
+			return fmt.Errorf("Kubernetes pod %s/%s does not exist", ep.K8sNamespace, ep.K8sPodName)
+		} else if err != nil {
+			return fmt.Errorf("failed to get pod %s/%s from API server: %w", ep.K8sNamespace, ep.K8sPodName, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to get pod %s/%s from cache: %w", ep.K8sNamespace, ep.K8sPodName, err)
+	}
+
+	if pod.Spec.NodeName != nodeTypes.GetName() {
 		// if flag CiliumEndpointCRD is disabled,
 		// `GetCachedPod` may return endpoint has moved to another node.
 		return fmt.Errorf("Kubernetes pod %s/%s is not owned by this agent", ep.K8sNamespace, ep.K8sPodName)

--- a/daemon/cmd/endpoint_restore_test.go
+++ b/daemon/cmd/endpoint_restore_test.go
@@ -4,13 +4,23 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/endpoint"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
@@ -43,5 +53,133 @@ func TestPrivilegedRemoveStaleEPIfaces(t *testing.T) {
 		assert.Error(t, err)
 
 		return nil
+	})
+}
+
+type fakeK8sWatcher struct {
+	pod *slim_corev1.Pod
+	err error
+}
+
+func (f *fakeK8sWatcher) WaitForCacheSync(resourceNames ...string) {}
+
+func (f *fakeK8sWatcher) GetCachedPod(namespace, name string) (*slim_corev1.Pod, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.pod == nil {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Group: "core", Resource: "pod"}, name)
+	}
+	return f.pod, nil
+}
+
+func TestGetPodForEndpoint(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "node-1"
+	ep := &endpoint.Endpoint{
+		K8sPodName:   "pod-1",
+		K8sNamespace: "ns-1",
+	}
+	nodeTypes.SetName(nodeName)
+
+	t.Run("Pod found in cache", func(t *testing.T) {
+		pod := &slim_corev1.Pod{
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name:      "pod-1",
+				Namespace: "ns-1",
+			},
+			Spec: slim_corev1.PodSpec{
+				NodeName: nodeName,
+			},
+		}
+		watcher := &fakeK8sWatcher{pod: pod}
+		_, clientset := k8sClient.NewFakeClientset(hivetest.Logger(t))
+
+		restorer := &endpointRestorer{
+			ctx:        ctx,
+			k8sWatcher: watcher,
+			clientset:  clientset,
+		}
+
+		err := restorer.getPodForEndpoint(ep)
+		require.NoError(t, err)
+	})
+
+	t.Run("Pod not in cache, found in API server", func(t *testing.T) {
+		pod := &slim_corev1.Pod{
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name:      "pod-1",
+				Namespace: "ns-1",
+			},
+			Spec: slim_corev1.PodSpec{
+				NodeName: nodeName,
+			},
+		}
+		watcher := &fakeK8sWatcher{}
+		fc, clientset := k8sClient.NewFakeClientset(hivetest.Logger(t))
+		fc.SlimFakeClientset.Tracker().Add(pod)
+
+		restorer := &endpointRestorer{
+			ctx:        ctx,
+			k8sWatcher: watcher,
+			clientset:  clientset,
+		}
+
+		err := restorer.getPodForEndpoint(ep)
+		require.NoError(t, err)
+	})
+
+	t.Run("Pod not found in cache nor API server", func(t *testing.T) {
+		watcher := &fakeK8sWatcher{}
+		_, clientset := k8sClient.NewFakeClientset(hivetest.Logger(t))
+
+		restorer := &endpointRestorer{
+			ctx:        ctx,
+			k8sWatcher: watcher,
+			clientset:  clientset,
+		}
+
+		err := restorer.getPodForEndpoint(ep)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("Pod in cache but not owned by this node", func(t *testing.T) {
+		pod := &slim_corev1.Pod{
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name:      "pod-1",
+				Namespace: "ns-1",
+			},
+			Spec: slim_corev1.PodSpec{
+				NodeName: "node-2",
+			},
+		}
+		watcher := &fakeK8sWatcher{pod: pod}
+		_, clientset := k8sClient.NewFakeClientset(hivetest.Logger(t))
+
+		restorer := &endpointRestorer{
+			ctx:        ctx,
+			k8sWatcher: watcher,
+			clientset:  clientset,
+		}
+
+		err := restorer.getPodForEndpoint(ep)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is not owned by this agent")
+	})
+
+	t.Run("Unexpected error in GetCachedPod is returned", func(t *testing.T) {
+		watcher := &fakeK8sWatcher{err: errors.New("unexpected error")}
+		_, clientset := k8sClient.NewFakeClientset(hivetest.Logger(t))
+
+		restorer := &endpointRestorer{
+			ctx:        ctx,
+			k8sWatcher: watcher,
+			clientset:  clientset,
+		}
+
+		err := restorer.getPodForEndpoint(ep)
+		require.Error(t, err)
+		require.Equal(t, "unexpected error", err.Error())
 	})
 }


### PR DESCRIPTION
During agent restarts or rolling updates, the pod informer cache can experience eventual consistency delays when pulling data from the API server's internal watch cache. This occasionally causes `getPodForEndpoint` to fail cache lookups for valid pods, skipping endpoint restoration. The orphaned endpoints are subsequently deleted by the
`stale-endpoint-cleanup` routine.

This commit prevents premature endpoint drops by modifying `getPodForEndpoint` to fall back to a direct Kubernetes API server query if a pod cache miss occurs.

To enable testing of this workflow without spinning up a heavy daemon:
- Converted `endpointRestorer.k8sWatcher` into a lightweight internal interface.
- Added unit tests in `endpoint_restore_test.go` isolating the fallback logic.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #29716

```release-note
NONE
```
