### PR TITLE
gateway-api: Fix missed version upgrades for stable objects

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
@@ -69,11 +68,11 @@ var requiredGVKs = []schema.GroupVersionKind{
 	gatewayv1.SchemeGroupVersion.WithKind(helpers.GatewayKind),
 	gatewayv1.SchemeGroupVersion.WithKind(helpers.HTTPRouteKind),
 	gatewayv1.SchemeGroupVersion.WithKind(helpers.GRPCRouteKind),
-	gatewayv1beta1.SchemeGroupVersion.WithKind(helpers.ReferenceGrantKind),
+	gatewayv1.SchemeGroupVersion.WithKind(helpers.ReferenceGrantKind),
 }
 
 var optionalGVKs = []schema.GroupVersionKind{
-	gatewayv1alpha2.SchemeGroupVersion.WithKind(helpers.TLSRouteKind),
+	gatewayv1.SchemeGroupVersion.WithKind(helpers.TLSRouteKind),
 	mcsapiv1beta1.SchemeGroupVersion.WithKind(helpers.ServiceImportKind),
 }
 

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -164,9 +163,9 @@ func onlyStatusChanged() predicate.Predicate {
 					return false
 				}
 				return !cmp.Equal(o.Status, n.Status, option)
-			case *gatewayv1alpha2.TLSRoute:
-				o, _ := e.ObjectOld.(*gatewayv1alpha2.TLSRoute)
-				n, ok := e.ObjectNew.(*gatewayv1alpha2.TLSRoute)
+			case *gatewayv1.TLSRoute:
+				o, _ := e.ObjectOld.(*gatewayv1.TLSRoute)
+				n, ok := e.ObjectNew.(*gatewayv1.TLSRoute)
 				if !ok {
 					return false
 				}

--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -56,7 +55,7 @@ func testSchemeNoServiceImport() *runtime.Scheme {
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	noMCSGVKs := []schema.GroupVersionKind{
-		gatewayv1alpha2.SchemeGroupVersion.WithKind(helpers.TLSRouteKind),
+		gatewayv1.SchemeGroupVersion.WithKind(helpers.TLSRouteKind),
 	}
 
 	registerGatewayAPITypesToScheme(scheme, noMCSGVKs)
@@ -800,8 +799,8 @@ func Test_onlyStatusChanged(t *testing.T) {
 			name: "no change in TLSRoute status",
 			args: args{
 				evt: event.UpdateEvent{
-					ObjectOld: &gatewayv1alpha2.TLSRoute{},
-					ObjectNew: &gatewayv1alpha2.TLSRoute{},
+					ObjectOld: &gatewayv1.TLSRoute{},
+					ObjectNew: &gatewayv1.TLSRoute{},
 				},
 			},
 			expected: false,
@@ -810,9 +809,9 @@ func Test_onlyStatusChanged(t *testing.T) {
 			name: "change in TLSRoute status",
 			args: args{
 				evt: event.UpdateEvent{
-					ObjectOld: &gatewayv1alpha2.TLSRoute{},
-					ObjectNew: &gatewayv1alpha2.TLSRoute{
-						Status: gatewayv1alpha2.TLSRouteStatus{
+					ObjectOld: &gatewayv1.TLSRoute{},
+					ObjectNew: &gatewayv1.TLSRoute{
+						Status: gatewayv1.TLSRouteStatus{
 							RouteStatus: gatewayv1.RouteStatus{
 								Parents: []gatewayv1.RouteParentStatus{
 									{
@@ -842,8 +841,8 @@ func Test_onlyStatusChanged(t *testing.T) {
 			name: "only change LastTransitionTime in TLSRoute status",
 			args: args{
 				evt: event.UpdateEvent{
-					ObjectOld: &gatewayv1alpha2.TLSRoute{
-						Status: gatewayv1alpha2.TLSRouteStatus{
+					ObjectOld: &gatewayv1.TLSRoute{
+						Status: gatewayv1.TLSRouteStatus{
 							RouteStatus: gatewayv1.RouteStatus{
 								Parents: []gatewayv1.RouteParentStatus{
 									{
@@ -865,8 +864,8 @@ func Test_onlyStatusChanged(t *testing.T) {
 							},
 						},
 					},
-					ObjectNew: &gatewayv1alpha2.TLSRoute{
-						Status: gatewayv1alpha2.TLSRouteStatus{
+					ObjectNew: &gatewayv1.TLSRoute{
+						Status: gatewayv1.TLSRouteStatus{
 							RouteStatus: gatewayv1.RouteStatus{
 								Parents: []gatewayv1.RouteParentStatus{
 									{

--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
@@ -70,7 +69,7 @@ func (r *gammaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch GRPCRoute linked to Service
 		Watches(&gatewayv1.GRPCRoute{}, r.enqueueRequestForOwningGRPCRoute(r.logger)).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1beta1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
+		Watches(&gatewayv1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{})
 

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -115,7 +114,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return controllerruntime.Fail(err)
 	}
 
-	grants := &gatewayv1beta1.ReferenceGrantList{}
+	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to list ReferenceGrants", logfields.Error, err)
 		return controllerruntime.Fail(err)
@@ -167,7 +166,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	return controllerruntime.Success()
 }
 
-func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
+func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1.ReferenceGrantList) error {
 	gammaLogger.DebugContext(ctx, "Updating HTTPRoute statuses for GAMMA Service", numRoutes, len(httpRoutes.Items))
 	for httpRouteIndex, original := range httpRoutes.Items {
 
@@ -269,7 +268,7 @@ func (r *gammaReconciler) filterGRPCRoutesByService(ctx context.Context, gammaSe
 	return filtered
 }
 
-func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, grpcRoutes *gatewayv1.GRPCRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
+func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, grpcRoutes *gatewayv1.GRPCRouteList, grants *gatewayv1.ReferenceGrantList) error {
 	gammaLogger.DebugContext(ctx, "Updating GRPCRoute statuses for GAMMA Service", numRoutes, len(grpcRoutes.Items))
 	for grpcRouteIndex, original := range grpcRoutes.Items {
 

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -25,8 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -108,7 +106,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			indexers.BackendServiceTLSRouteIndex: indexers.GenerateIndexerTLSRoutebyBackendService(r.Client, r.logger),
 			indexers.GatewayTLSRouteIndex:        indexers.IndexTLSRouteByGateway,
 		} {
-			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.TLSRoute{}, indexName, indexerFunc); err != nil {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexName, indexerFunc); err != nil {
 				return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
 			}
 		}
@@ -153,7 +151,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Namespace{},
 			r.enqueueRequestForAllowedNamespace()).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1beta1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
+		Watches(&gatewayv1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
 		// Watch for changes to BackendTLSPolicy
 		Watches(&gatewayv1.BackendTLSPolicy{}, r.enqueueRequestForBackendTLSPolicy()).
 		Watches(&corev1.ConfigMap{}, r.enqueueRequestForBackendTLSPolicyConfigMap()).
@@ -163,7 +161,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if tlsRouteEnabled {
 		// Watch TLSRoute linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1alpha2.TLSRoute{}, r.enqueueRequestForOwningTLSRoute(r.logger))
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.TLSRoute{}, r.enqueueRequestForOwningTLSRoute(r.logger))
 	}
 
 	if serviceImportEnabled {
@@ -265,7 +263,7 @@ func (r *gatewayReconciler) enqueueRequestForOwningHTTPRoute(logger *slog.Logger
 // for all Cilium-relevant Gateways associated with that TLSRoute.
 func (r *gatewayReconciler) enqueueRequestForOwningTLSRoute(logger *slog.Logger) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		hr, ok := a.(*gatewayv1alpha2.TLSRoute)
+		hr, ok := a.(*gatewayv1.TLSRoute)
 		if !ok {
 			return nil
 		}
@@ -312,7 +310,7 @@ func (r *gatewayReconciler) enqueueRequestForBackendService() handler.EventHandl
 		}
 
 		// Then, fetch all TLSRoutes that reference this service, using the backendServiceIndex
-		tlsrList := &gatewayv1alpha2.TLSRouteList{}
+		tlsrList := &gatewayv1.TLSRouteList{}
 
 		if err := r.Client.List(ctx, tlsrList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceTLSRouteIndex, client.ObjectKeyFromObject(o).String()),

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -23,8 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
@@ -125,7 +123,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	tlsRouteList := &gatewayv1alpha2.TLSRouteList{}
+	tlsRouteList := &gatewayv1.TLSRouteList{}
 	if helpers.HasTLSRouteSupport(r.Client.Scheme()) {
 		if err := r.Client.List(ctx, tlsRouteList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayTLSRouteIndex, client.ObjectKeyFromObject(original).String()),
@@ -157,7 +155,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	grants := &gatewayv1beta1.ReferenceGrantList{}
+	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to list ReferenceGrants", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
@@ -468,8 +466,8 @@ func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route
 	return false
 }
 
-func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TLSRoute) []gatewayv1alpha2.TLSRoute {
-	var filtered []gatewayv1alpha2.TLSRoute
+func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
+	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) &&
 			len(computeHosts(gw, route.Spec.Hostnames, nil)) > 0 {
@@ -479,8 +477,8 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 	return filtered
 }
 
-func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TLSRoute) []gatewayv1alpha2.TLSRoute {
-	var filtered []gatewayv1alpha2.TLSRoute
+func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
+	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
@@ -593,8 +591,8 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	return nil
 }
 
-func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1alpha2.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList) (bool, error) {
-	grants := &gatewayv1beta1.ReferenceGrantList{}
+func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList) (bool, error) {
+	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
 	}
@@ -895,7 +893,7 @@ func (r *gatewayReconciler) parentIsMatchingGateway(parent gatewayv1.ParentRefer
 	return hasMatchingControllerFn(gw)
 }
 
-func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
+func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1.ReferenceGrantList) error {
 	scopedLog.DebugContext(ctx, "Updating HTTPRoute statuses for Gateway", numRoutes, len(httpRoutes.Items))
 	for httpRouteIndex, original := range httpRoutes.Items {
 
@@ -934,7 +932,7 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 	return nil
 }
 
-func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx context.Context, tlsRoutes *gatewayv1alpha2.TLSRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
+func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx context.Context, tlsRoutes *gatewayv1.TLSRouteList, grants *gatewayv1.ReferenceGrantList) error {
 	scopedLog.Debug("Updating TLSRoute statuses for Gateway", numRoutes, len(tlsRoutes.Items))
 	for tlsRouteIndex, original := range tlsRoutes.Items {
 
@@ -968,7 +966,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 	return nil
 }
 
-func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx context.Context, grpcRoutes *gatewayv1.GRPCRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
+func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx context.Context, grpcRoutes *gatewayv1.GRPCRouteList, grants *gatewayv1.ReferenceGrantList) error {
 	scopedLog.Debug("Updating GRPCRoute statuses for Gateway", numRoutes, len(grpcRoutes.Items))
 	for grpcRouteIndex, original := range grpcRoutes.Items {
 
@@ -1268,14 +1266,14 @@ func (r *gatewayReconciler) updateHTTPRouteStatus(ctx context.Context, scopedLog
 	return r.Client.Status().Update(ctx, new)
 }
 
-func (r *gatewayReconciler) handleTLSRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1alpha2.TLSRoute, modified *gatewayv1alpha2.TLSRoute) error {
+func (r *gatewayReconciler) handleTLSRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1.TLSRoute, modified *gatewayv1.TLSRoute) error {
 	if err := r.updateTLSRouteStatus(ctx, scopedLog, original, modified); err != nil {
 		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
 	}
 	return nil
 }
 
-func (r *gatewayReconciler) updateTLSRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1alpha2.TLSRoute, new *gatewayv1alpha2.TLSRoute) error {
+func (r *gatewayReconciler) updateTLSRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1.TLSRoute, new *gatewayv1.TLSRoute) error {
 	oldStatus := original.Status.DeepCopy()
 	newStatus := new.Status.DeepCopy()
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -21,7 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
@@ -32,9 +31,8 @@ import (
 )
 
 var (
-	gatewayv1APIVersion       = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
-	gatewayv1alpha2APIVersion = gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version
-	gatewayTypeMeta           = metav1.TypeMeta{
+	gatewayv1APIVersion = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
+	gatewayTypeMeta     = metav1.TypeMeta{
 		Kind:       "Gateway",
 		APIVersion: gatewayv1APIVersion,
 	}
@@ -48,7 +46,7 @@ var (
 	}
 	tlsRouteTypeMeta = metav1.TypeMeta{
 		Kind:       "TLSRoute",
-		APIVersion: gatewayv1alpha2APIVersion,
+		APIVersion: gatewayv1APIVersion,
 	}
 	backendTLSPolicyTypeMeta = metav1.TypeMeta{
 		Kind:       "BackendTLSPolicy",
@@ -295,7 +293,7 @@ func Test_Conformance(t *testing.T) {
 				WithStatusSubresource(&corev1.Namespace{}).
 				WithStatusSubresource(&gatewayv1.GRPCRoute{}).
 				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
-				WithStatusSubresource(&gatewayv1alpha2.TLSRoute{}).
+				WithStatusSubresource(&gatewayv1.TLSRoute{}).
 				WithStatusSubresource(&gatewayv1.Gateway{}).
 				WithStatusSubresource(&gatewayv1.GatewayClass{}).
 				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
@@ -311,7 +309,7 @@ func Test_Conformance(t *testing.T) {
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.GatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway)
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, fakeIndexHTTPRouteByBackendService)
 			clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, indexers.GatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway)
-			clientBuilder.WithIndex(&gatewayv1alpha2.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
+			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
 
 			c := clientBuilder.Build()
 
@@ -327,7 +325,7 @@ func Test_Conformance(t *testing.T) {
 			require.NoError(t, err)
 
 			// Reconcile all related TLSRoute objects
-			tlsrList := &gatewayv1alpha2.TLSRouteList{}
+			tlsrList := &gatewayv1.TLSRouteList{}
 			err = c.List(t.Context(), tlsrList)
 			require.NoError(t, err)
 
@@ -385,11 +383,11 @@ func Test_Conformance(t *testing.T) {
 			}
 
 			for _, tlsr := range tlsrList.Items {
-				actualTLSR := &gatewayv1alpha2.TLSRoute{}
+				actualTLSR := &gatewayv1.TLSRoute{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&tlsr), actualTLSR)
 				actualTLSR.TypeMeta = tlsRouteTypeMeta
 				require.NoError(t, err, "error getting TLSRoute %s/%s: %v", tlsr.Namespace, tlsr.Name, err)
-				expectedTLSR := &gatewayv1alpha2.TLSRoute{}
+				expectedTLSR := &gatewayv1.TLSRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tlsroute-%s.yaml", tt.name, tlsr.Name), expectedTLSR)
 				require.Empty(t, cmp.Diff(expectedTLSR, actualTLSR, cmpIgnoreFields...))
 			}

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -14,8 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 	k8syaml "sigs.k8s.io/yaml"
 )
@@ -97,7 +95,7 @@ func readInput(t *testing.T, file string) []client.Object {
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "TLSRoute":
-			obj := &gatewayv1alpha2.TLSRoute{}
+			obj := &gatewayv1.TLSRoute{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "GRPCRoute":
@@ -113,7 +111,7 @@ func readInput(t *testing.T, file string) []client.Object {
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "ReferenceGrant":
-			obj := &gatewayv1beta1.ReferenceGrant{}
+			obj := &gatewayv1.ReferenceGrant{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "ServiceImport":

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -140,7 +140,7 @@ func isKindAllowed(listener gatewayv1.Listener, route metav1.Object) bool {
 		if (kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName) &&
 			kind.Kind == kindHTTPRoute && routeKind == kindHTTPRoute {
 			return true
-		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1alpha2.GroupName) &&
+		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName) &&
 			kind.Kind == kindTLSRoute && routeKind == kindTLSRoute {
 			return true
 		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName) &&
@@ -188,7 +188,7 @@ func getSupportedRouteKinds(protocol gatewayv1.ProtocolType) []gatewayv1.RouteGr
 	case gatewayv1.TLSProtocolType:
 		return []gatewayv1.RouteGroupKind{
 			{
-				Group: GroupPtr(gatewayv1alpha2.GroupName),
+				Group: GroupPtr(gatewayv1.GroupName),
 				Kind:  kindTLSRoute,
 			},
 		}
@@ -217,7 +217,7 @@ func getGatewayKindForObject(obj metav1.Object) gatewayv1.Kind {
 		return kindHTTPRoute
 	case *gatewayv1.GRPCRoute:
 		return kindGRPCRoute
-	case *gatewayv1alpha2.TLSRoute:
+	case *gatewayv1.TLSRoute:
 		return kindTLSRoute
 	case *gatewayv1alpha2.UDPRoute:
 		return kindUDPRoute

--- a/operator/pkg/gateway-api/helpers/referencegrants.go
+++ b/operator/pkg/gateway-api/helpers/referencegrants.go
@@ -7,12 +7,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 // IsBackendReferenceAllowed returns true if the backend reference is allowed by the reference grant.
-func IsBackendReferenceAllowed(originatingNamespace string, be gatewayv1.BackendRef, gvk schema.GroupVersionKind, grants []gatewayv1beta1.ReferenceGrant) bool {
+func IsBackendReferenceAllowed(originatingNamespace string, be gatewayv1.BackendRef, gvk schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
 	if IsService(be.BackendObjectReference) {
 		return isReferenceAllowed(originatingNamespace, string(be.Name), be.Namespace, gvk, corev1.SchemeGroupVersion.WithKind("Service"), grants)
 	}
@@ -24,11 +23,11 @@ func IsBackendReferenceAllowed(originatingNamespace string, be gatewayv1.Backend
 }
 
 // IsSecretReferenceAllowed returns true if the secret reference is allowed by the reference grant.
-func IsSecretReferenceAllowed(originatingNamespace string, sr gatewayv1.SecretObjectReference, gvk schema.GroupVersionKind, grants []gatewayv1beta1.ReferenceGrant) bool {
+func IsSecretReferenceAllowed(originatingNamespace string, sr gatewayv1.SecretObjectReference, gvk schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
 	return isReferenceAllowed(originatingNamespace, string(sr.Name), sr.Namespace, gvk, corev1.SchemeGroupVersion.WithKind("Secret"), grants)
 }
 
-func isReferenceAllowed(originatingNamespace, name string, namespace *gatewayv1.Namespace, fromGVK, toGVK schema.GroupVersionKind, grants []gatewayv1beta1.ReferenceGrant) bool {
+func isReferenceAllowed(originatingNamespace, name string, namespace *gatewayv1.Namespace, fromGVK, toGVK schema.GroupVersionKind, grants []gatewayv1.ReferenceGrant) bool {
 	ns := NamespaceDerefOr(namespace, originatingNamespace)
 	if originatingNamespace == ns {
 		return true // same namespace is always allowed

--- a/operator/pkg/gateway-api/helpers/tlsroute.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute.go
@@ -5,7 +5,7 @@ package helpers
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // HasTLSRouteSupport returns if the TLSRoute CRD is supported.
@@ -13,5 +13,5 @@ import (
 // and it is expected that it is registered only if the TLSRoute
 // CRD has been installed prior to the client setup.
 func HasTLSRouteSupport(scheme *runtime.Scheme) bool {
-	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute"))
+	return scheme.Recognizes(gatewayv1.SchemeGroupVersion.WithKind("TLSRoute"))
 }

--- a/operator/pkg/gateway-api/helpers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/helpers/tlsroute_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
@@ -16,11 +17,11 @@ func TestHasTLSRouteSupport(t *testing.T) {
 	assert.False(t, HasTLSRouteSupport(scheme1), "Should be false when group is not registered")
 
 	scheme2 := runtime.NewScheme()
-	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TCPRoute{})
+	scheme2.AddKnownTypes(gatewayv1.SchemeGroupVersion, &gatewayv1alpha2.TCPRoute{})
 	assert.False(t, HasTLSRouteSupport(scheme2), "Should be false when group is registered but TLSRoute kind is not")
 
 	scheme3 := runtime.NewScheme()
-	err := gatewayv1alpha2.AddToScheme(scheme3)
+	err := gatewayv1.AddToScheme(scheme3)
 	assert.NoError(t, err)
 	assert.True(t, HasTLSRouteSupport(scheme3), "Should be true when TLSRoute kind is registered")
 }

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
@@ -102,9 +101,9 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 
 	switch kind {
 	case TLSRouteKind:
-		return &gatewayv1alpha2.TLSRoute{}
+		return &gatewayv1.TLSRoute{}
 	case TLSRouteListKind:
-		return &gatewayv1alpha2.TLSRouteList{}
+		return &gatewayv1.TLSRouteList{}
 	case ServiceImportKind:
 		return &mcsapiv1beta1.ServiceImport{}
 	case ServiceImportListKind:

--- a/operator/pkg/gateway-api/helpers/types_test.go
+++ b/operator/pkg/gateway-api/helpers/types_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestIsGammaService(t *testing.T) {
@@ -273,20 +272,20 @@ func TestGetConcreteObject(t *testing.T) {
 		{
 			name: "TLSRoute",
 			gvk: schema.GroupVersionKind{
-				Group:   gatewayv1alpha2.GroupVersion.Group,
-				Version: gatewayv1alpha2.GroupVersion.Version,
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
 				Kind:    TLSRouteKind,
 			},
-			want: &gatewayv1alpha2.TLSRoute{},
+			want: &gatewayv1.TLSRoute{},
 		},
 		{
 			name: "TLSRouteList",
 			gvk: schema.GroupVersionKind{
-				Group:   gatewayv1alpha2.GroupVersion.Group,
-				Version: gatewayv1alpha2.GroupVersion.Version,
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
 				Kind:    TLSRouteListKind,
 			},
-			want: &gatewayv1alpha2.TLSRouteList{},
+			want: &gatewayv1.TLSRouteList{},
 		},
 	}
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/helpers_test.go
+++ b/operator/pkg/gateway-api/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func Test_isKindAllowed(t *testing.T) {
@@ -48,7 +47,7 @@ func Test_isKindAllowed(t *testing.T) {
 		},
 		{
 			name:     "TLSRoute is not allowed",
-			route:    &gatewayv1alpha2.TLSRoute{},
+			route:    &gatewayv1.TLSRoute{},
 			expected: false,
 		},
 	}

--- a/operator/pkg/gateway-api/indexers/tlsroute.go
+++ b/operator/pkg/gateway-api/indexers/tlsroute.go
@@ -8,7 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -18,7 +18,7 @@ import (
 // to add to the relevant index.
 func GenerateIndexerTLSRoutebyBackendService(c client.Client, logger *slog.Logger) client.IndexerFunc {
 	return func(rawObj client.Object) []string {
-		route := rawObj.(*gatewayv1alpha2.TLSRoute)
+		route := rawObj.(*gatewayv1.TLSRoute)
 		var backendServices []string
 
 		for _, rule := range route.Spec.Rules {
@@ -50,7 +50,7 @@ func GenerateIndexerTLSRoutebyBackendService(c client.Client, logger *slog.Logge
 //
 // Note that this does _not_ filter to only Cilium-relevant Gateways.
 func IndexTLSRouteByGateway(rawObj client.Object) []string {
-	route := rawObj.(*gatewayv1alpha2.TLSRoute)
+	route := rawObj.(*gatewayv1.TLSRoute)
 	var gateways []string
 	for _, parent := range route.Spec.ParentRefs {
 		if !helpers.IsGateway(parent) {

--- a/operator/pkg/gateway-api/indexers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/indexers/tlsroute_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestIndexTLSRouteByGateway(t *testing.T) {
@@ -22,12 +21,12 @@ func TestIndexTLSRouteByGateway(t *testing.T) {
 	}{
 		{
 			name: "parentRef is Gateway",
-			obj: &gatewayv1alpha2.TLSRoute{
+			obj: &gatewayv1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-gateway",
 					Namespace: "default",
 				},
-				Spec: gatewayv1alpha2.TLSRouteSpec{
+				Spec: gatewayv1.TLSRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
 						ParentRefs: []gatewayv1.ParentReference{
 							{
@@ -44,12 +43,12 @@ func TestIndexTLSRouteByGateway(t *testing.T) {
 		},
 		{
 			name: "parentRef is a Gateway, nil namespace",
-			obj: &gatewayv1alpha2.TLSRoute{
+			obj: &gatewayv1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-gateway",
 					Namespace: "default",
 				},
-				Spec: gatewayv1alpha2.TLSRouteSpec{
+				Spec: gatewayv1.TLSRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
 						ParentRefs: []gatewayv1.ParentReference{
 							{
@@ -65,12 +64,12 @@ func TestIndexTLSRouteByGateway(t *testing.T) {
 		},
 		{
 			name: "parentRef is not a Gateway",
-			obj: &gatewayv1alpha2.TLSRoute{
+			obj: &gatewayv1.TLSRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-parent",
 					Namespace: "default",
 				},
-				Spec: gatewayv1alpha2.TLSRouteSpec{
+				Spec: gatewayv1.TLSRouteSpec{
 					CommonRouteSpec: gatewayv1.CommonRouteSpec{
 						ParentRefs: []gatewayv1.ParentReference{
 							{

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -28,7 +28,7 @@ type GRPCRouteInput struct {
 	Ctx       context.Context
 	Logger    *slog.Logger
 	Client    client.Client
-	Grants    *gatewayv1beta1.ReferenceGrantList
+	Grants    *gatewayv1.ReferenceGrantList
 	GRPCRoute *gatewayv1.GRPCRoute
 
 	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
@@ -84,7 +84,7 @@ func (g *GRPCRouteInput) GetGVK() schema.GroupVersionKind {
 	return gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute")
 }
 
-func (g *GRPCRouteInput) GetGrants() []gatewayv1beta1.ReferenceGrant {
+func (g *GRPCRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
 	return g.Grants.Items
 }
 

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
@@ -27,7 +25,7 @@ type HTTPRouteInput struct {
 	Ctx       context.Context
 	Logger    *slog.Logger
 	Client    client.Client
-	Grants    *gatewayv1beta1.ReferenceGrantList
+	Grants    *gatewayv1.ReferenceGrantList
 	HTTPRoute *gatewayv1.HTTPRoute
 
 	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
@@ -56,7 +54,7 @@ func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
 	}
 }
 
-func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
+func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range h.HTTPRoute.Status.RouteStatus.Parents {
 		if reflect.DeepEqual(parent.ParentRef, parentRef) {
@@ -68,14 +66,14 @@ func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentR
 		h.HTTPRoute.Status.RouteStatus.Parents[index].Conditions = helpers.MergeConditions(h.HTTPRoute.Status.RouteStatus.Parents[index].Conditions, updates...)
 		return
 	}
-	h.HTTPRoute.Status.RouteStatus.Parents = append(h.HTTPRoute.Status.RouteStatus.Parents, gatewayv1alpha2.RouteParentStatus{
+	h.HTTPRoute.Status.RouteStatus.Parents = append(h.HTTPRoute.Status.RouteStatus.Parents, gatewayv1.RouteParentStatus{
 		ParentRef:      parentRef,
 		ControllerName: controllerName,
 		Conditions:     updates,
 	})
 }
 
-func (h *HTTPRouteInput) GetGrants() []gatewayv1beta1.ReferenceGrant {
+func (h *HTTPRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
 	return h.Grants.Items
 }
 

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const (
@@ -30,7 +29,7 @@ type Input interface {
 	GetClient() client.Client
 	GetContext() context.Context
 	GetGVK() schema.GroupVersionKind
-	GetGrants() []gatewayv1beta1.ReferenceGrant
+	GetGrants() []gatewayv1.ReferenceGrant
 	GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error)
 	GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error)
 	GetHostnames() []gatewayv1.Hostname

--- a/operator/pkg/gateway-api/routechecks/route_checks.go
+++ b/operator/pkg/gateway-api/routechecks/route_checks.go
@@ -45,7 +45,7 @@ func CheckBackend(input Input, parentRef gatewayv1.ParentReference) (bool, error
 		for _, be := range rule.GetBackendRefs() {
 			if !helpers.IsService(be.BackendObjectReference) && !helpers.IsServiceImport(be.BackendObjectReference) {
 				input.SetParentCondition(parentRef, metav1.Condition{
-					Type:    string(gatewayv1alpha2.RouteConditionResolvedRefs),
+					Type:    string(gatewayv1.RouteConditionResolvedRefs),
 					Status:  metav1.ConditionFalse,
 					Reason:  string(gatewayv1.RouteReasonInvalidKind),
 					Message: "Unsupported backend kind " + string(*be.Kind),

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
@@ -27,8 +25,8 @@ type TLSRouteInput struct {
 	Ctx      context.Context
 	Logger   *slog.Logger
 	Client   client.Client
-	Grants   *gatewayv1beta1.ReferenceGrantList
-	TLSRoute *gatewayv1alpha2.TLSRoute
+	Grants   *gatewayv1.ReferenceGrantList
+	TLSRoute *gatewayv1.TLSRoute
 
 	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
 }
@@ -55,7 +53,7 @@ func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
 	}
 }
 
-func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
+func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TLSRoute.Status.RouteStatus.Parents {
 		if reflect.DeepEqual(parent.ParentRef, parentRef) {
@@ -67,14 +65,14 @@ func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentRe
 		t.TLSRoute.Status.RouteStatus.Parents[index].Conditions = helpers.MergeConditions(t.TLSRoute.Status.RouteStatus.Parents[index].Conditions, updates...)
 		return
 	}
-	t.TLSRoute.Status.RouteStatus.Parents = append(t.TLSRoute.Status.RouteStatus.Parents, gatewayv1alpha2.RouteParentStatus{
+	t.TLSRoute.Status.RouteStatus.Parents = append(t.TLSRoute.Status.RouteStatus.Parents, gatewayv1.RouteParentStatus{
 		ParentRef:      parentRef,
 		ControllerName: controllerName,
 		Conditions:     updates,
 	})
 }
 
-func (t *TLSRouteInput) GetGrants() []gatewayv1beta1.ReferenceGrant {
+func (t *TLSRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
 	return t.Grants.Items
 }
 
@@ -83,7 +81,7 @@ func (t *TLSRouteInput) GetNamespace() string {
 }
 
 func (t *TLSRouteInput) GetGVK() schema.GroupVersionKind {
-	return gatewayv1alpha2.SchemeGroupVersion.WithKind("TLSRoute")
+	return gatewayv1.SchemeGroupVersion.WithKind("TLSRoute")
 }
 
 func (t *TLSRouteInput) GetRules() []GenericRule {
@@ -104,7 +102,7 @@ func (t *TLSRouteInput) GetContext() context.Context {
 
 // TLSRouteRule is used to implement the GenericRule interface for TLSRoute
 type TLSRouteRule struct {
-	Rule gatewayv1alpha2.TLSRouteRule
+	Rule gatewayv1.TLSRouteRule
 }
 
 func (t *TLSRouteRule) GetBackendRefs() []gatewayv1.BackendRef {

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-invalid-reference-grant/input/gateway-secret-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-invalid-reference-grant/input/gateway-secret-invalid-reference-grant.yaml
@@ -19,7 +19,7 @@ spec:
             name: certificate
             namespace: gateway-conformance-web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-namespace
@@ -34,7 +34,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-group
@@ -49,7 +49,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-kind
@@ -64,7 +64,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-namespace
@@ -79,7 +79,7 @@ spec:
       kind: Secret
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-group
@@ -94,7 +94,7 @@ spec:
       kind: Secret
       name: not-the-certificate-youre-looking-for
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-kind
@@ -109,7 +109,7 @@ spec:
       kind: Service
       name: certificate
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-name

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-all-in-namespace/input/gateway-secret-reference-grant-all-in-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-all-in-namespace/input/gateway-secret-reference-grant-all-in-namespace.yaml
@@ -19,7 +19,7 @@ spec:
             name: all-certificate
             namespace: gateway-conformance-web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-all-in-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-specific/input/gateway-secret-reference-grant-specific.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-secret-reference-grant-specific/input/gateway-secret-reference-grant-specific.yaml
@@ -19,7 +19,7 @@ spec:
             name: specific-certificate
             namespace: gateway-conformance-web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-specific

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-reference-grant/input/httproute-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-invalid-reference-grant/input/httproute-invalid-reference-grant.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-namespace
@@ -14,7 +14,7 @@ spec:
       kind: Service
       name: web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-group
@@ -29,7 +29,7 @@ spec:
       kind: Service
       name: web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-kind
@@ -44,7 +44,7 @@ spec:
       kind: Service
       name: web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-namespace
@@ -59,7 +59,7 @@ spec:
       kind: Service
       name: web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-group
@@ -74,7 +74,7 @@ spec:
       kind: Service
       name: web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-kind
@@ -89,7 +89,7 @@ spec:
       kind: Secret
       name: web-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-name

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-partially-invalid-via-invalid-reference-grant/input/httproute-partially-invalid-via-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-partially-invalid-via-invalid-reference-grant/input/httproute-partially-invalid-via-invalid-reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: invalid-reference-grant

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-reference-grant/input/httproute-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-reference-grant/input/httproute-reference-grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/input/tlsroute-hostname-intersection.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/input/tlsroute-hostname-intersection.yaml
@@ -77,7 +77,7 @@ spec:
       tls:
         mode: Passthrough
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-more-specific-wc-hostname-x-1
@@ -93,7 +93,7 @@ spec:
         - name: tls-backend
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-exact-hostname-x-2
@@ -109,7 +109,7 @@ spec:
         - name: tls-backend
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-less-specific-wc-hostname-x-2
@@ -125,7 +125,7 @@ spec:
         - name: tls-backend-2
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-exact-hostname-x-3
@@ -141,7 +141,7 @@ spec:
         - name: tls-backend
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-more-specific-wc-hostname-x-3
@@ -157,7 +157,7 @@ spec:
         - name: tls-backend-2
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-exact-hostname-x-4
@@ -173,7 +173,7 @@ spec:
         - name: tls-backend
           port: 443
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-less-specific-wc-hostname-x-4

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-exact-hostname-x-2

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-3.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-exact-hostname-x-3

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-exact-hostname-x-4.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-exact-hostname-x-4

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-less-specific-wc-hostname-x-2

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-less-specific-wc-hostname-x-4.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-less-specific-wc-hostname-x-4

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-1.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-more-specific-wc-hostname-x-1

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/tlsroute-tlsroute-more-specific-wc-hostname-x-3.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-more-specific-wc-hostname-x-3

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-no-matching-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-no-matching-section-name.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-no-matching-section-name

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-http.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-http.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-not-allowed-protocol-http

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-https.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-not-allowed-protocol-https

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/input/tlsroute-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/input/tlsroute-invalid-reference-grant.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-namespace
@@ -14,7 +14,7 @@ spec:
       kind: Service
       name: tls-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-group
@@ -29,7 +29,7 @@ spec:
       kind: Service
       name: tls-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-kind
@@ -44,7 +44,7 @@ spec:
       kind: Service
       name: tls-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-from-namespace
@@ -59,7 +59,7 @@ spec:
       kind: Service
       name: tls-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-group
@@ -74,7 +74,7 @@ spec:
       kind: Service
       name: tls-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-kind
@@ -89,7 +89,7 @@ spec:
       kind: Secret
       name: tls-backend
 ---
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: ReferenceGrant
 metadata:
   name: reference-grant-wrong-to-name
@@ -104,7 +104,7 @@ spec:
       kind: Service
       name: not-the-service-youre-looking-for
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: gateway-conformance-infra-test

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/output/tlsroute-gateway-conformance-infra-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/output/tlsroute-gateway-conformance-infra-test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: gateway-conformance-infra-test

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/input/tlsroute-simple-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/input/tlsroute-simple-same-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: gateway-conformance-infra-test

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/tlsroute-gateway-conformance-infra-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/tlsroute-gateway-conformance-infra-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: gateway-conformance-infra-test

--- a/operator/pkg/model/ingestion/gamma.go
+++ b/operator/pkg/model/ingestion/gamma.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -22,7 +21,7 @@ import (
 type GammaInput struct {
 	HTTPRoutes      []gatewayv1.HTTPRoute
 	GRPCRoutes      []gatewayv1.GRPCRoute
-	ReferenceGrants []gatewayv1beta1.ReferenceGrant
+	ReferenceGrants []gatewayv1.ReferenceGrant
 	Services        []corev1.Service
 }
 
@@ -59,7 +58,7 @@ func toGammaHTTPRoutes(
 	parentServices map[types.NamespacedName]model.FullyQualifiedResource,
 	input []gatewayv1.HTTPRoute,
 	services []corev1.Service,
-	grants []gatewayv1beta1.ReferenceGrant,
+	grants []gatewayv1.ReferenceGrant,
 ) []model.HTTPListener {
 	var resHTTP []model.HTTPListener
 
@@ -203,7 +202,7 @@ func toGammaGRPCRoutes(
 	parentServices map[types.NamespacedName]model.FullyQualifiedResource,
 	input []gatewayv1.GRPCRoute,
 	services []corev1.Service,
-	grants []gatewayv1beta1.ReferenceGrant,
+	grants []gatewayv1.ReferenceGrant,
 ) []model.HTTPListener {
 	var resGRPC []model.HTTPListener
 

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -35,9 +35,9 @@ type Input struct {
 
 	Gateway             gatewayv1.Gateway
 	HTTPRoutes          []gatewayv1.HTTPRoute
-	TLSRoutes           []gatewayv1alpha2.TLSRoute
+	TLSRoutes           []gatewayv1.TLSRoute
 	GRPCRoutes          []gatewayv1.GRPCRoute
-	ReferenceGrants     []gatewayv1beta1.ReferenceGrant
+	ReferenceGrants     []gatewayv1.ReferenceGrant
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
 	BackendTLSPolicyMap helpers.BackendTLSPolicyServiceMap
@@ -174,7 +174,7 @@ func toHTTPRoutes(log *slog.Logger,
 	input []gatewayv1.HTTPRoute,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
-	grants []gatewayv1beta1.ReferenceGrant,
+	grants []gatewayv1.ReferenceGrant,
 	btlspMap helpers.BackendTLSPolicyServiceMap,
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
@@ -247,7 +247,7 @@ func extractRoutes(logger *slog.Logger,
 	hr gatewayv1.HTTPRoute,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
-	grants []gatewayv1beta1.ReferenceGrant,
+	grants []gatewayv1.ReferenceGrant,
 	btlspMap helpers.BackendTLSPolicyServiceMap,
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
@@ -531,7 +531,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	input []gatewayv1.GRPCRoute,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
-	grants []gatewayv1beta1.ReferenceGrant,
+	grants []gatewayv1.ReferenceGrant,
 ) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
 	for _, r := range input {
@@ -562,7 +562,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	return grpcRoutes
 }
 
-func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1beta1.ReferenceGrant) []model.HTTPRoute {
+func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
 	for _, rule := range grpcr.Spec.Rules {
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
@@ -654,7 +654,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 	return grpcRoutes
 }
 
-func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1alpha2.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1beta1.ReferenceGrant) []model.TLSPassthroughRoute {
+func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
 	for _, r := range input {
 		isListener := false
@@ -1019,7 +1019,7 @@ func toQueryMatch(match gatewayv1.HTTPRouteMatch) []model.KeyValueMatch {
 	return res
 }
 
-func toTLS(tls *gatewayv1.ListenerTLSConfig, grants []gatewayv1beta1.ReferenceGrant, defaultNamespace string) []model.TLSSecret {
+func toTLS(tls *gatewayv1.ListenerTLSConfig, grants []gatewayv1.ReferenceGrant, defaultNamespace string) []model.TLSSecret {
 	if tls == nil {
 		return nil
 	}


### PR DESCRIPTION
This commit fixes some version changes I missed when upgrading to Gateway API v1.5, along with upgrading TLSRoute and ReferenceGrant to `v1`.

This removes all references to gatewayv1alpha2.TLSRoute and gatewayv1beta1.ReferenceGrant, and moves them to the correct gatewayv1 versions, along with some other structs I missed earlier.
