### PR TITLE
fix: improve validator logging and prevent unnecessary watches

### DIFF
--- a/operator/pkg/networkpolicy/cell.go
+++ b/operator/pkg/networkpolicy/cell.go
@@ -82,7 +82,7 @@ func registerPolicyValidator(params PolicyParams) {
 	}
 
 	if !option.Config.EnableCiliumNetworkPolicy && !option.Config.EnableCiliumClusterwideNetworkPolicy {
-		params.Logger.Info(fmt.Sprintf("CNP / CCNP validator doesn't run when CNP and CCNP are disabled (%s=false AND %s=false)", option.EnableCiliumNetworkPolicy, option.EnableCiliumClusterwideNetworkPolicy))
+		params.Logger.Info(fmt.Sprintf("Skipping CNP/CCNP validator registration as both %s and %s are disabled", option.EnableCiliumNetworkPolicy, option.EnableCiliumClusterwideNetworkPolicy))
 		return
 	}
 
@@ -90,17 +90,22 @@ func registerPolicyValidator(params PolicyParams) {
 		params: &params,
 	}
 
-	params.Logger.Info("Registering CNP / CCNP validator")
-	params.JobGroup.Add(job.Observer(
-		"cnp-validation",
-		pv.handleCNPEvent,
-		params.CNPResource,
-	))
-	params.JobGroup.Add(job.Observer(
-		"ccnp-validation",
-		pv.handleCCNPEvent,
-		params.CCNPResource,
-	))
+	if option.Config.EnableCiliumNetworkPolicy {
+		params.Logger.Info("Registering CNP validator")
+		params.JobGroup.Add(job.Observer(
+			"cnp-validation",
+			pv.handleCNPEvent,
+			params.CNPResource,
+		))
+	}
+	if option.Config.EnableCiliumClusterwideNetworkPolicy {
+		params.Logger.Info("Registering CCNP validator")
+		params.JobGroup.Add(job.Observer(
+			"ccnp-validation",
+			pv.handleCCNPEvent,
+			params.CCNPResource,
+		))
+	}
 }
 
 func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Event[*cilium_api_v2.CiliumNetworkPolicy]) error {


### PR DESCRIPTION
- Add explicit log messages when the CNP or CCNP validators are registered individually.
- Improve the log message when skipping registration to clearly state that both options are disabled.
- Ensure observers are only registered for enabled policies, preventing watch errors (e.g., due to missing CRDs) when only one policy type is active.

Fixes: 3b294e9fbdc2515577ed2e0bebb2158334fe30af

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Prevent unnecessary resource watches and potential errors by ensuring that the Cilium Operator only registers validators for enabled network policy types.
```
