### PR TITLE
[v1.19] ipam: fix data race in MultiPoolManager node update

### DIFF
--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -560,7 +560,8 @@ func (m *multiPoolManager) updateLocalNodeStore(newNode *ciliumv2.CiliumNode) {
 
 func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
 	m.mutex.Lock()
-	newNode := m.node.DeepCopy()
+	currentNode := m.node.DeepCopy()
+	newNode := currentNode.DeepCopy()
 	requested := []types.IPAMPoolRequest{}
 	allocated := []types.IPAMPoolAllocation{}
 
@@ -629,7 +630,7 @@ func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
 
 	m.mutex.Unlock()
 
-	if !newNode.Spec.IPAM.DeepEqual(&m.node.Spec.IPAM) {
+	if !newNode.Spec.IPAM.DeepEqual(&currentNode.Spec.IPAM) {
 		_, err := m.nodeUpdater.Update(ctx, newNode, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to update node spec: %w", err)


### PR DESCRIPTION
Related to #44869.
Backport of #45383.

## Summary
- snapshot `m.node` under `m.mutex` in `updateLocalNode()`
- derive `newNode` from that snapshot
- compare against the immutable snapshot after unlocking instead of the shared field

## Details
`ciliumNodeUpdated()` can replace `m.node` from the event loop while `updateLocalNode()` is preparing an update. In the `v1.19` code path, `updateLocalNode()` unlocked and then compared `newNode.Spec.IPAM` against `m.node.Spec.IPAM`, which races with concurrent writes from `ciliumNodeUpdated()`.

This keeps the existing behavior but closes the race by taking a `DeepCopy()` snapshot while the lock is held and using that snapshot for the post-unlock comparison.

## Testing
- `go test ./pkg/ipam -run '^Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc$' -count=100 -race -timeout 60s`
- `go test ./pkg/ipam -run '^Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc$' -count=200 -timeout 60s`
