### PR TITLE
cilium-cli: Deploy FRR daemonset only once per node

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -324,9 +324,14 @@ func newConnectivityTests(
 	}
 
 	connTests := make([]*check.ConnectivityTest, 0, params.TestConcurrency)
+	sharedNamespace := ""
 	for i := range params.TestConcurrency {
 		params := params
 		params.TestNamespace = fmt.Sprintf("%s-%d", params.TestNamespace, i+1)
+		if sharedNamespace == "" {
+			sharedNamespace = params.TestNamespace // use the first test ns for shared resources
+		}
+		params.SharedTestNamespace = sharedNamespace
 		params.TestNamespaceIndex = i
 		if params.ExternalTargetCANamespace == "" {
 			params.ExternalTargetCANamespace = params.TestNamespace

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -52,6 +52,7 @@ type Parameters struct {
 	AssumeCiliumVersion       string
 	CiliumNamespace           string
 	TestNamespace             string
+	SharedTestNamespace       string
 	TestNamespaceIndex        int
 	TestConcurrency           int
 	SingleNode                bool

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1647,8 +1647,11 @@ func (ct *ConnectivityTest) deploy(ctx context.Context) error {
 		}
 	}
 
-	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled {
-		_, err = ct.clients.src.GetDaemonSet(ctx, ct.params.TestNamespace, frrDaemonSetNameName, metav1.GetOptions{})
+	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled &&
+		ct.params.TestNamespace == ct.params.SharedTestNamespace {
+		// NOTE: FRR daemonset should be deployed only once per node as it is running in the host network namespace,
+		// and multiple deployments could cause issues with binding to the same ports - so deploy it in the SharedTestNamespace.
+		_, err = ct.clients.src.GetDaemonSet(ctx, ct.params.SharedTestNamespace, frrDaemonSetNameName, metav1.GetOptions{})
 		if err != nil {
 			ct.Logf("✨ [%s] Deploying %s daemonset...", ct.clients.src.ClusterName(), frrDaemonSetNameName)
 			ds := NewFRRDaemonSet(ct.params)
@@ -2851,10 +2854,10 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 	}
 
 	if ct.Features[features.BGPControlPlane].Enabled && ct.Features[features.NodeWithoutCilium].Enabled {
-		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.Params().TestNamespace, frrDaemonSetNameName); err != nil {
+		if err := WaitForDaemonSet(ctx, ct, ct.clients.src, ct.params.SharedTestNamespace, frrDaemonSetNameName); err != nil {
 			return err
 		}
-		frrPods, err := ct.clients.dst.ListPods(ctx, ct.params.TestNamespace, metav1.ListOptions{LabelSelector: "name=" + frrDaemonSetNameName})
+		frrPods, err := ct.clients.dst.ListPods(ctx, ct.params.SharedTestNamespace, metav1.ListOptions{LabelSelector: "name=" + frrDaemonSetNameName})
 		if err != nil {
 			return fmt.Errorf("unable to list FRR pods: %w", err)
 		}


### PR DESCRIPTION
After switching to concurrent test runs in https://github.com/cilium/cilium/commit/c705af018ff0de811faeacca29bfa0fcb381caec we are now deploying FRR daemonset in each concurrency namespace. 

However, FRR daemonset used by the BGP tests should not be deployed multiple times per node, as it is running in the host network namespace and multiple daemonset per node causes issues with binding to the same ports.

This introduces a new `SharedTestNamespace` test param that can be used to deploy such resources only once even for TestConcurrency > 1 and deploys the FRR daemonset in it.
