### PR TITLE
Extensible verifier complexity testing

### DIFF
--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -8,26 +8,18 @@ import (
 )
 
 var (
-	lxcLoadPermutations       loadPermutationBuilder
-	hostLoadPermutations      loadPermutationBuilder
-	overlayLoadPermutations   loadPermutationBuilder
-	sockLoadPermutations      loadPermutationBuilder
-	wireguardLoadPermutations loadPermutationBuilder
-	xdpLoadPermutations       loadPermutationBuilder
+	lxcLoadPermutations       = baseLXCPermutations()
+	hostLoadPermutations      = baseHostPermutations()
+	overlayLoadPermutations   = baseOverlayPermutations()
+	sockLoadPermutations      = baseSockPermutations()
+	wireguardLoadPermutations = baseWireguardPermutations()
+	xdpLoadPermutations       = baseXDPPermutations()
 )
 
-func init() {
-	baseLXCPermutations()
-	baseHostPermutations()
-	baseOverlayPermutations()
-	baseSockPermutations()
-	baseWireguardPermutations()
-	baseXDPPermutations()
-}
-
-func baseLXCPermutations() {
-	lxcLoadPermutations.addConstructor(func() any { return config.NewBPFLXC(*config.NewNode()) })
-	lxcLoadPermutations.addOptions(
+func baseLXCPermutations() *loadPermutationBuilder {
+	b := new(loadPermutationBuilder)
+	b.addConstructor(func() any { return config.NewBPFLXC(*config.NewNode()) })
+	b.addOptions(
 		Always(func(t *config.BPFLXC, _ bool) {
 			t.Node.TracingIPOptionType = 1
 			t.Node.DebugLB = true
@@ -40,15 +32,17 @@ func baseLXCPermutations() {
 			t.EnableNetkit = false
 		}),
 
-		Permute(func(t *config.BPFLXC, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
-		Permute(func(t *config.BPFLXC, v bool) { t.EnableLRP = v }),
-		Permute(func(t *config.BPFLXC, v bool) { t.HybridRoutingEnabled = v }),
+		Increment(func(t *config.BPFLXC, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
+		Increment(func(t *config.BPFLXC, v bool) { t.HybridRoutingEnabled = v }),
+		IncrementOrPermute(func(t *config.BPFLXC, v bool) { t.EnableLRP = v }),
 	)
+	return b
 }
 
-func baseHostPermutations() {
-	hostLoadPermutations.addConstructor(func() any { return config.NewBPFHost(*config.NewNode()) })
-	hostLoadPermutations.addOptions(
+func baseHostPermutations() *loadPermutationBuilder {
+	b := new(loadPermutationBuilder)
+	b.addConstructor(func() any { return config.NewBPFHost(*config.NewNode()) })
+	b.addOptions(
 		Always(func(t *config.BPFHost, _ bool) {
 			t.Node.TracingIPOptionType = 1
 			t.Node.DebugLB = true
@@ -60,45 +54,51 @@ func baseHostPermutations() {
 			t.EnableL2Announcements = true
 		}),
 
-		Permute(func(t *config.BPFHost, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
-		Permute(func(t *config.BPFHost, v bool) { t.EnableRemoteNodeMasquerade = v }),
-		Permute(func(t *config.BPFHost, v bool) {
+		Increment(func(t *config.BPFHost, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
+		Increment(func(t *config.BPFHost, v bool) { t.EnableRemoteNodeMasquerade = v }),
+		Increment(func(t *config.BPFHost, v bool) {
 			if v {
 				t.EthHeaderLength = 0
 			} else {
 				t.EthHeaderLength = 14
 			}
 		}),
-		Permute(func(t *config.BPFHost, v bool) { t.HybridRoutingEnabled = v }),
+		Increment(func(t *config.BPFHost, v bool) { t.HybridRoutingEnabled = v }),
 	)
+	return b
 }
 
-func baseOverlayPermutations() {
-	overlayLoadPermutations.addConstructor(func() any { return config.NewBPFOverlay(*config.NewNode()) })
-	overlayLoadPermutations.addOptions(
+func baseOverlayPermutations() *loadPermutationBuilder {
+	b := new(loadPermutationBuilder)
+	b.addConstructor(func() any { return config.NewBPFOverlay(*config.NewNode()) })
+	b.addOptions(
 		Always(func(t *config.BPFOverlay, _ bool) {
 			t.Node.TracingIPOptionType = 1
 			t.Node.DebugLB = true
 			t.EnableConntrackAccounting = true
 		}),
 	)
+	return b
 }
 
-func baseSockPermutations() {
-	sockLoadPermutations.addConstructor(func() any { return config.NewBPFSock(*config.NewNode()) })
-	sockLoadPermutations.addOptions(
+func baseSockPermutations() *loadPermutationBuilder {
+	b := new(loadPermutationBuilder)
+	b.addConstructor(func() any { return config.NewBPFSock(*config.NewNode()) })
+	b.addOptions(
 		Always(func(t *config.BPFSock, _ bool) {
 			t.Node.DebugLB = true
 			t.EnableIPv4Fragments = true
 			t.EnableIPv6Fragments = true
 		}),
-		Permute(func(t *config.BPFSock, v bool) { t.EnableLRP = v }),
+		IncrementOrPermute(func(t *config.BPFSock, v bool) { t.EnableLRP = v }),
 	)
+	return b
 }
 
-func baseWireguardPermutations() {
-	wireguardLoadPermutations.addConstructor(func() any { return config.NewBPFWireguard(*config.NewNode()) })
-	wireguardLoadPermutations.addOptions(
+func baseWireguardPermutations() *loadPermutationBuilder {
+	b := new(loadPermutationBuilder)
+	b.addConstructor(func() any { return config.NewBPFWireguard(*config.NewNode()) })
+	b.addOptions(
 		Always(func(t *config.BPFWireguard, _ bool) {
 			t.Node.TracingIPOptionType = 1
 			t.Node.DebugLB = true
@@ -107,11 +107,13 @@ func baseWireguardPermutations() {
 			t.EnableIPv6Fragments = true
 		}),
 	)
+	return b
 }
 
-func baseXDPPermutations() {
-	xdpLoadPermutations.addConstructor(func() any { return config.NewBPFXDP(*config.NewNode()) })
-	xdpLoadPermutations.addOptions(
+func baseXDPPermutations() *loadPermutationBuilder {
+	b := new(loadPermutationBuilder)
+	b.addConstructor(func() any { return config.NewBPFXDP(*config.NewNode()) })
+	b.addOptions(
 		Always(func(t *config.BPFXDP, _ bool) {
 			t.Node.TracingIPOptionType = 1
 			t.Node.DebugLB = true
@@ -119,6 +121,7 @@ func baseXDPPermutations() {
 			t.EnableIPv4Fragments = true
 			t.EnableIPv6Fragments = true
 		}),
-		Permute(func(t *config.BPFXDP, v bool) { t.EnableXDPPrefilter = v }),
+		Increment(func(t *config.BPFXDP, v bool) { t.EnableXDPPrefilter = v }),
 	)
+	return b
 }

--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -4,138 +4,121 @@
 package loader
 
 import (
-	"iter"
-
 	"github.com/cilium/cilium/pkg/datapath/config"
 )
 
-func lxcLoadPermutations() iter.Seq[*config.BPFLXC] {
-	return func(yield func(*config.BPFLXC) bool) {
-		for permutation := range permute(3) {
-			cfg := config.NewBPFLXC(*config.NewNode())
-			cfg.Node.TracingIPOptionType = 1
-			cfg.Node.DebugLB = true
-			cfg.AllowICMPFragNeeded = true
-			cfg.EnableICMPRule = true
-			cfg.EnableConntrackAccounting = true
-			cfg.EnableIPv4Fragments = true
-			cfg.EnableIPv6Fragments = true
-			cfg.EnableNetkit = false
-			cfg.EnableARPResponder = true
+var (
+	lxcLoadPermutations       loadPermutationBuilder
+	hostLoadPermutations      loadPermutationBuilder
+	overlayLoadPermutations   loadPermutationBuilder
+	sockLoadPermutations      loadPermutationBuilder
+	wireguardLoadPermutations loadPermutationBuilder
+	xdpLoadPermutations       loadPermutationBuilder
+)
 
-			cfg.Node.PolicyDenyResponseEnabled = permutation[0]
-			cfg.EnableLRP = permutation[1]
-			cfg.HybridRoutingEnabled = permutation[2]
-
-			if !yield(cfg) {
-				return
-			}
-		}
-	}
+func init() {
+	baseLXCPermutations()
+	baseHostPermutations()
+	baseOverlayPermutations()
+	baseSockPermutations()
+	baseWireguardPermutations()
+	baseXDPPermutations()
 }
 
-func hostLoadPermutations() iter.Seq[*config.BPFHost] {
-	return func(yield func(*config.BPFHost) bool) {
-		for permutation := range permute(3) {
-			cfg := config.NewBPFHost(*config.NewNode())
-			cfg.Node.TracingIPOptionType = 1
-			cfg.Node.DebugLB = true
-			cfg.AllowICMPFragNeeded = true
-			cfg.EnableICMPRule = true
-			cfg.EnableConntrackAccounting = true
-			cfg.EnableIPv4Fragments = true
-			cfg.EnableIPv6Fragments = true
-			cfg.EnableL2Announcements = true
+func baseLXCPermutations() {
+	lxcLoadPermutations.addConstructor(func() any { return config.NewBPFLXC(*config.NewNode()) })
+	lxcLoadPermutations.addOptions(
+		Always(func(t *config.BPFLXC, _ bool) {
+			t.Node.TracingIPOptionType = 1
+			t.Node.DebugLB = true
+			t.AllowICMPFragNeeded = true
+			t.EnableICMPRule = true
+			t.EnableConntrackAccounting = true
+			t.EnableIPv4Fragments = true
+			t.EnableIPv6Fragments = true
+			t.EnableARPResponder = true
+			t.EnableNetkit = false
+		}),
 
-			cfg.EnableRemoteNodeMasquerade = permutation[0]
-			if permutation[1] {
-				cfg.EthHeaderLength = 0
+		Permute(func(t *config.BPFLXC, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
+		Permute(func(t *config.BPFLXC, v bool) { t.EnableLRP = v }),
+		Permute(func(t *config.BPFLXC, v bool) { t.HybridRoutingEnabled = v }),
+	)
+}
+
+func baseHostPermutations() {
+	hostLoadPermutations.addConstructor(func() any { return config.NewBPFHost(*config.NewNode()) })
+	hostLoadPermutations.addOptions(
+		Always(func(t *config.BPFHost, _ bool) {
+			t.Node.TracingIPOptionType = 1
+			t.Node.DebugLB = true
+			t.AllowICMPFragNeeded = true
+			t.EnableICMPRule = true
+			t.EnableConntrackAccounting = true
+			t.EnableIPv4Fragments = true
+			t.EnableIPv6Fragments = true
+			t.EnableL2Announcements = true
+		}),
+
+		Permute(func(t *config.BPFHost, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
+		Permute(func(t *config.BPFHost, v bool) { t.EnableRemoteNodeMasquerade = v }),
+		Permute(func(t *config.BPFHost, v bool) {
+			if v {
+				t.EthHeaderLength = 0
 			} else {
-				cfg.EthHeaderLength = 14
+				t.EthHeaderLength = 14
 			}
-			cfg.HybridRoutingEnabled = permutation[2]
-
-			if !yield(cfg) {
-				return
-			}
-		}
-	}
+		}),
+		Permute(func(t *config.BPFHost, v bool) { t.HybridRoutingEnabled = v }),
+	)
 }
 
-func overlayLoadPermutations() iter.Seq[*config.BPFOverlay] {
-	return func(yield func(*config.BPFOverlay) bool) {
-		cfg := config.NewBPFOverlay(*config.NewNode())
-		cfg.Node.TracingIPOptionType = 1
-		cfg.Node.DebugLB = true
-		cfg.EnableConntrackAccounting = true
-
-		if !yield(cfg) {
-			return
-		}
-	}
+func baseOverlayPermutations() {
+	overlayLoadPermutations.addConstructor(func() any { return config.NewBPFOverlay(*config.NewNode()) })
+	overlayLoadPermutations.addOptions(
+		Always(func(t *config.BPFOverlay, _ bool) {
+			t.Node.TracingIPOptionType = 1
+			t.Node.DebugLB = true
+			t.EnableConntrackAccounting = true
+		}),
+	)
 }
 
-func sockLoadPermutations() iter.Seq[*config.BPFSock] {
-	return func(yield func(*config.BPFSock) bool) {
-		for permutation := range permute(1) {
-			cfg := config.NewBPFSock(*config.NewNode())
-			cfg.Node.DebugLB = true
-			cfg.EnableIPv4Fragments = true
-			cfg.EnableIPv6Fragments = true
-
-			cfg.EnableLRP = permutation[0]
-
-			if !yield(cfg) {
-				return
-			}
-		}
-	}
+func baseSockPermutations() {
+	sockLoadPermutations.addConstructor(func() any { return config.NewBPFSock(*config.NewNode()) })
+	sockLoadPermutations.addOptions(
+		Always(func(t *config.BPFSock, _ bool) {
+			t.Node.DebugLB = true
+			t.EnableIPv4Fragments = true
+			t.EnableIPv6Fragments = true
+		}),
+		Permute(func(t *config.BPFSock, v bool) { t.EnableLRP = v }),
+	)
 }
 
-func wireguardLoadPermutations() iter.Seq[*config.BPFWireguard] {
-	return func(yield func(*config.BPFWireguard) bool) {
-		cfg := config.NewBPFWireguard(*config.NewNode())
-		cfg.Node.TracingIPOptionType = 1
-		cfg.Node.DebugLB = true
-		cfg.EnableConntrackAccounting = true
-		cfg.EnableIPv4Fragments = true
-		cfg.EnableIPv6Fragments = true
-
-		if !yield(cfg) {
-			return
-		}
-	}
+func baseWireguardPermutations() {
+	wireguardLoadPermutations.addConstructor(func() any { return config.NewBPFWireguard(*config.NewNode()) })
+	wireguardLoadPermutations.addOptions(
+		Always(func(t *config.BPFWireguard, _ bool) {
+			t.Node.TracingIPOptionType = 1
+			t.Node.DebugLB = true
+			t.EnableConntrackAccounting = true
+			t.EnableIPv4Fragments = true
+			t.EnableIPv6Fragments = true
+		}),
+	)
 }
 
-func xdpLoadPermutations() iter.Seq[*config.BPFXDP] {
-	return func(yield func(*config.BPFXDP) bool) {
-		for permutation := range permute(1) {
-			cfg := config.NewBPFXDP(*config.NewNode())
-			cfg.Node.TracingIPOptionType = 1
-			cfg.Node.DebugLB = true
-			cfg.EnableConntrackAccounting = true
-			cfg.EnableIPv4Fragments = true
-			cfg.EnableIPv6Fragments = true
-
-			cfg.EnableXDPPrefilter = permutation[0]
-
-			if !yield(cfg) {
-				return
-			}
-		}
-	}
-}
-
-func permute(n int) iter.Seq[[]bool] {
-	permutation := make([]bool, n)
-	return func(yield func([]bool) bool) {
-		for i := range uint64(1 << n) {
-			for j := range n {
-				permutation[j] = (i & (1 << j)) != 0
-			}
-			if !yield(permutation) {
-				return
-			}
-		}
-	}
+func baseXDPPermutations() {
+	xdpLoadPermutations.addConstructor(func() any { return config.NewBPFXDP(*config.NewNode()) })
+	xdpLoadPermutations.addOptions(
+		Always(func(t *config.BPFXDP, _ bool) {
+			t.Node.TracingIPOptionType = 1
+			t.Node.DebugLB = true
+			t.EnableConntrackAccounting = true
+			t.EnableIPv4Fragments = true
+			t.EnableIPv6Fragments = true
+		}),
+		Permute(func(t *config.BPFXDP, v bool) { t.EnableXDPPrefilter = v }),
+	)
 }

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -144,7 +144,7 @@ func TestPrivilegedVerifier(t *testing.T) {
 	})
 }
 
-func compileAndLoad[T any](perm buildPermutation[T], collection, source, output string, build int, records *verifierComplexityRecords) func(t *testing.T) {
+func compileAndLoad(perm buildPermutation, collection, source, output string, build int, records *verifierComplexityRecords) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
@@ -507,13 +507,13 @@ func kernelVersionFromString(s string) (kernelVersion, error) {
 	}
 }
 
-type buildPermutation[T any] struct {
+type buildPermutation struct {
 	options          []string
-	loadPermutations iter.Seq[T]
+	loadPermutations iter.Seq[[]any]
 }
 
-func buildPermutations[T any](progDir string, kernel kernelVersion, loadPerm func() iter.Seq[T]) iter.Seq[buildPermutation[T]] {
-	return func(yield func(buildPermutation[T]) bool) {
+func buildPermutations(progDir string, kernel kernelVersion, loadPerm loadPermutationBuilder) iter.Seq[buildPermutation] {
+	return func(yield func(buildPermutation) bool) {
 		dir := path.Join(*flagCiliumBasePath, "bpf", "complexity-tests", kernel.String(), progDir)
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -529,12 +529,210 @@ func buildPermutations[T any](progDir string, kernel kernelVersion, loadPerm fun
 
 			optionsSlice := strings.Split(string(contents), "\n")
 
-			if !yield(buildPermutation[T]{
+			if !yield(buildPermutation{
 				options:          optionsSlice,
-				loadPermutations: loadPerm(),
+				loadPermutations: loadPerm.build(),
 			}) {
 				return
 			}
+		}
+	}
+}
+
+type loadPermutationBuilder struct {
+	constructors []func() any
+	options      []configOption
+}
+
+func (b *loadPermutationBuilder) addConstructor(constructor func() any) {
+	b.constructors = append(b.constructors, constructor)
+}
+
+func (b *loadPermutationBuilder) addOptions(options ...configOption) {
+	b.options = append(b.options, options...)
+}
+
+// build a sequence of configuration slices from the registered constructors and options.
+func (b *loadPermutationBuilder) build() iter.Seq[[]any] {
+	var alwaysSetters []configSetter
+	var incrementSetters []configSetter
+	var permuteSetters []configSetter
+
+	for _, option := range b.options {
+		switch option.typ {
+		case configAlways:
+			alwaysSetters = append(alwaysSetters, option.fn)
+		case configIncrement:
+			incrementSetters = append(incrementSetters, option.fn)
+		case configPermute:
+			permuteSetters = append(permuteSetters, option.fn)
+		case configIncrementOrPermute:
+			if testing.Short() {
+				incrementSetters = append(incrementSetters, option.fn)
+			} else {
+				permuteSetters = append(permuteSetters, option.fn)
+			}
+		default:
+			panic("unknown option type")
+		}
+	}
+
+	return func(yield func([]any) bool) {
+		// given a number of bools, returns a sequence of all unique permutations of those bools being true or false.
+		// If n=0, then a single empty slice is returned.
+		permute := func(n int) iter.Seq[[]bool] {
+			permutation := make([]bool, n)
+			return func(yield func([]bool) bool) {
+				for i := range uint64(1 << n) {
+					for j := range n {
+						permutation[j] = (i & (1 << j)) != 0
+					}
+					if !yield(permutation) {
+						return
+					}
+				}
+			}
+		}
+
+		// For each permutation of the `Permute` options, or just once if there are none.
+		for permutations := range permute(len(permuteSetters)) {
+			// For each incremental combination of the `Increment` options, or just once if there are none.
+			// it's len + 1, because we always want to yield the configuration with all options disabled, and then
+			// incrementally enable options until all are enabled.
+			for i := range len(incrementSetters) + 1 {
+				// Construct a configuration object from each registered constructor.
+				cfgs := make([]any, len(b.constructors))
+				for j, constructor := range b.constructors {
+					cfgs[j] = constructor()
+				}
+
+				for _, setter := range alwaysSetters {
+					for _, cfg := range cfgs {
+						setter(cfg, true)
+					}
+				}
+
+				for oi, setter := range incrementSetters {
+					for _, cfg := range cfgs {
+						setter(cfg, oi < i)
+					}
+				}
+
+				for oi, setter := range permuteSetters {
+					for _, cfg := range cfgs {
+						setter(cfg, permutations[oi])
+					}
+				}
+
+				if !yield(cfgs) {
+					return
+				}
+			}
+		}
+	}
+}
+
+type configType int
+
+const (
+	configAlways configType = iota
+	configIncrement
+	configPermute
+	configIncrementOrPermute
+)
+
+type configOption struct {
+	typ configType
+	fn  configSetter
+}
+
+type configSetter func(c any, v bool)
+
+func callWithT[T any](fn func(*T, bool)) configSetter {
+	return func(c any, v bool) {
+		if cfg, ok := c.(*T); ok {
+			fn(cfg, v)
+		}
+	}
+}
+
+// Always apply `fn` to the configuration, regardless of the permutation.
+func Always[T any](fn func(*T, bool)) configOption {
+	return configOption{typ: configAlways, fn: callWithT(fn)}
+}
+
+// Apply `fn` to the configuration, incrementally enabling the option for each permutation.
+// `fn` is always invoked, the boolean parameter indicates whether the option should be enabled for this permutation.
+func Increment[T any](fn func(*T, bool)) configOption {
+	return configOption{typ: configIncrement, fn: callWithT(fn)}
+}
+
+// Apply `fn` to the configuration, permuting the option on or off for each permutation.
+// `fn` is always invoked, the boolean parameter indicates whether the option should be enabled for this permutation.
+//
+// Note: permuting options exponentially increases the number of permutations to be checked.
+func Permute[T any](fn func(*T, bool)) configOption {
+	return configOption{typ: configPermute, fn: callWithT(fn)}
+}
+
+// When -short is set, use Increment behavior, otherwise use Permute behavior.
+func IncrementOrPermute[T any](fn func(*T, bool)) configOption {
+	return configOption{typ: configIncrementOrPermute, fn: callWithT(fn)}
+}
+
+func TestTable(t *testing.T) {
+	type configA struct {
+		enableA bool
+		enableB bool
+		enableC bool
+	}
+
+	type configB struct {
+		enableD bool
+		enableE bool
+		enableF bool
+	}
+
+	builder := loadPermutationBuilder{
+		constructors: []func() any{
+			func() any { return &configA{} },
+			func() any { return &configB{} },
+		},
+		options: []configOption{
+			Always(func(c *configA, _ bool) { c.enableA = true }),
+			Increment(func(c *configA, v bool) { c.enableB = v }),
+			Permute(func(c *configA, v bool) { c.enableC = v }),
+			Always(func(c *configB, _ bool) { c.enableD = true }),
+			Increment(func(c *configB, v bool) { c.enableE = v }),
+			Permute(func(c *configB, v bool) { c.enableF = v }),
+		},
+	}
+
+	result := slices.Collect(builder.build())
+	if len(result) != 12 {
+		t.Fatalf("expected 12 configurations, got %d", len(result))
+	}
+	expected := [][]any{
+		{&configA{true, false, false}, &configB{true, false, false}},
+		{&configA{true, true, false}, &configB{true, false, false}},
+		{&configA{true, true, false}, &configB{true, true, false}},
+		{&configA{true, false, true}, &configB{true, false, false}},
+		{&configA{true, true, true}, &configB{true, false, false}},
+		{&configA{true, true, true}, &configB{true, true, false}},
+		{&configA{true, false, false}, &configB{true, false, true}},
+		{&configA{true, true, false}, &configB{true, false, true}},
+		{&configA{true, true, false}, &configB{true, true, true}},
+		{&configA{true, false, true}, &configB{true, false, true}},
+		{&configA{true, true, true}, &configB{true, false, true}},
+		{&configA{true, true, true}, &configB{true, true, true}},
+	}
+	for i, cfg := range result {
+		gotA := cfg[0].(*configA)
+		gotB := cfg[1].(*configB)
+		expA := expected[i][0].(*configA)
+		expB := expected[i][1].(*configB)
+		if *gotA != *expA || *gotB != *expB {
+			t.Errorf("configuration %d does not match expected: got (%+v, %+v), want (%+v, %+v)", i, gotA, gotB, expA, expB)
 		}
 	}
 }

--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -89,56 +89,77 @@ func TestPrivilegedVerifier(t *testing.T) {
 		records.WriteToFile(path)
 	})
 
-	t.Run("LXC", func(t *testing.T) {
-		t.Parallel()
-		i := 1
-		for perm := range buildPermutations("bpf_lxc", kv, lxcLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "lxc", endpointProg, endpointObj, i, &records))
-			i++
-		}
-	})
+	for _, c := range collections {
+		c.Run(t, kv, &records)
+	}
+}
 
-	t.Run("Host", func(t *testing.T) {
-		t.Parallel()
-		i := 1
-		for perm := range buildPermutations("bpf_host", kv, hostLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "host", hostEndpointProg, hostEndpointObj, i, &records))
-			i++
-		}
-	})
+var collections = []collection{
+	{
+		name:             "LXC",
+		progDir:          "bpf_lxc",
+		loadPermutations: lxcLoadPermutations,
+		collection:       "lxc",
+		source:           endpointProg,
+		output:           endpointObj,
+	},
+	{
+		name:             "Host",
+		progDir:          "bpf_host",
+		loadPermutations: hostLoadPermutations,
+		collection:       "host",
+		source:           hostEndpointProg,
+		output:           hostEndpointObj,
+	},
+	{
+		name:             "Overlay",
+		progDir:          "bpf_overlay",
+		loadPermutations: overlayLoadPermutations,
+		collection:       "overlay",
+		source:           overlayProg,
+		output:           overlayObj,
+	},
+	{
+		name:             "Sock",
+		progDir:          "bpf_sock",
+		loadPermutations: sockLoadPermutations,
+		collection:       "sock",
+		source:           socketProg,
+		output:           socketObj,
+	},
+	{
+		name:             "Wireguard",
+		progDir:          "bpf_wireguard",
+		loadPermutations: wireguardLoadPermutations,
+		collection:       "wireguard",
+		source:           wireguardProg,
+		output:           wireguardObj,
+	},
+	{
+		name:             "XDP",
+		progDir:          "bpf_xdp",
+		loadPermutations: xdpLoadPermutations,
+		collection:       "xdp",
+		source:           xdpProg,
+		output:           xdpObj,
+	},
+}
 
-	t.Run("Overlay", func(t *testing.T) {
-		t.Parallel()
-		i := 1
-		for perm := range buildPermutations("bpf_overlay", kv, overlayLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "overlay", overlayProg, overlayObj, i, &records))
-			i++
-		}
-	})
+type collection struct {
+	name             string
+	progDir          string
+	loadPermutations *loadPermutationBuilder
+	collection       string
+	source           string
+	output           string
+}
 
-	t.Run("Sock", func(t *testing.T) {
+func (c *collection) Run(t *testing.T, kv kernelVersion, records *verifierComplexityRecords) {
+	t.Run(c.name, func(t *testing.T) {
 		t.Parallel()
 		i := 1
-		for perm := range buildPermutations("bpf_sock", kv, sockLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "sock", socketProg, socketObj, i, &records))
-			i++
-		}
-	})
-
-	t.Run("Wireguard", func(t *testing.T) {
-		t.Parallel()
-		i := 1
-		for perm := range buildPermutations("bpf_wireguard", kv, wireguardLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "wireguard", wireguardProg, wireguardObj, i, &records))
-			i++
-		}
-	})
-
-	t.Run("XDP", func(t *testing.T) {
-		t.Parallel()
-		i := 1
-		for perm := range buildPermutations("bpf_xdp", kv, xdpLoadPermutations) {
-			t.Run(strconv.Itoa(i), compileAndLoad(perm, "xdp", xdpProg, xdpObj, i, &records))
+		for perm := range buildPermutations(c.progDir, kv, c.loadPermutations) {
+			t.Run(strconv.Itoa(i), compileAndLoad(perm, c.collection, c.source, c.output, i, records))
 			i++
 		}
 	})
@@ -512,7 +533,7 @@ type buildPermutation struct {
 	loadPermutations iter.Seq[[]any]
 }
 
-func buildPermutations(progDir string, kernel kernelVersion, loadPerm loadPermutationBuilder) iter.Seq[buildPermutation] {
+func buildPermutations(progDir string, kernel kernelVersion, loadPerm *loadPermutationBuilder) iter.Seq[buildPermutation] {
 	return func(yield func(buildPermutation) bool) {
 		dir := path.Join(*flagCiliumBasePath, "bpf", "complexity-tests", kernel.String(), progDir)
 		entries, err := os.ReadDir(dir)


### PR DESCRIPTION
In #43479 the loader was made extensible, allowing us to break configuration objects into several pieces and allowing the registration of multiple providers.

This PR updates our verifier test to allow for a similar level of extensibility during testing. We start by introducing a "load permutation builder", to replace the hand crafted iterator building we have done so far. Each collection (LXC, Host, Overlay, ...) gets its own builder object, to which multiple constructors for configuration objects can be registered. Callbacks can also be added to the builder  wrapped with `Always`, `Increment`, `Permute`, and `IncrementOrPermute` to indicate how the callbacks should be applied.

The callbacks in `Always` are always applied, and do not add additional load time config permutations to test.
The callbacks in `Increment` are incrementally enabled. The callbacks in `Permute` cause it to be permuted with every other possible combination. So the amount of load time permutations will be `#loads = (1 + #increment) ^ (1 + #permute)`.

There is also the `IncrementOrPermute` option, which behaves like `Permute` by default and like `Increment` when `-short` is set. In a followup PR we will be able to use this to do a smaller set of tests during PRs, and a larger set of tests when periodically checking complexity.

The build permutations were slightly refactored to now use a global slice that gets looped over. This allows for extensibility on the collection level as well.

Finally, this converts a lot of the permuting options to incremental, since that is the desired behavior in most cases, but we did not have the infra for it, and now we do.

```release-note
Made the verifier complexity tests extensible
```
