### PR TITLE
loadbalancer/reflectors: Filter `EndpointSlice` watch by service labels

### DIFF
--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -884,8 +884,15 @@ type replaceEndpointsEvent struct {
 
 func (replaceEndpointsEvent) isEvent() {}
 
-func endpointsEvents(log *slog.Logger, c client.Clientset) stream.Observable[event] {
-	lw := k8sUtils.ListerWatcherFromTyped(c.Slim().DiscoveryV1().EndpointSlices(""))
+func endpointsEvents(log *slog.Logger, c client.Clientset, cfg k8s.ConfigParams) (stream.Observable[event], error) {
+	optsModifier, err := utils.GetEndpointSliceListOptionsModifier(cfg.Config.K8sServiceProxyName, cfg.WatchConfig.EnableHeadlessServiceWatch)
+	if err != nil {
+		return nil, err
+	}
+	lw := k8sUtils.ListerWatcherWithModifiers(
+		k8sUtils.ListerWatcherFromTyped(c.Slim().DiscoveryV1().EndpointSlices("")),
+		optsModifier,
+	)
 	return stream.Map(
 		k8s.ListerWatcherToObservable(lw),
 		func(ev k8s.CacheStoreEvent) event {
@@ -909,7 +916,7 @@ func endpointsEvents(log *slog.Logger, c client.Clientset) stream.Observable[eve
 			default:
 				panic(fmt.Sprintf("unexpected k8s.CacheStoreEventKind: %#v", ev.Kind))
 			}
-		})
+		}), nil
 }
 
 func serviceEvents(cs client.Clientset, cfg k8s.ConfigParams) (stream.Observable[event], error) {
@@ -953,9 +960,13 @@ func newEventStream(log *slog.Logger, cs client.Clientset, cfg k8s.ConfigParams)
 	if err != nil {
 		return nil, err
 	}
+	epsEvents, err := endpointsEvents(log, cs, cfg)
+	if err != nil {
+		return nil, err
+	}
 	return joinObservables(
 		svcEvents,
-		endpointsEvents(log, cs),
+		epsEvents,
 	), nil
 }
 


### PR DESCRIPTION
`endpointsEvents` feeds the loadbalancer's service/backend tables, but its `ListerWatcher` is constructed with no `ListOptions` modifier. As a result Cilium reflects every `EndpointSlice` in the cluster regardless of the `service.kubernetes.io/service-proxy-name` or `service.kubernetes.io/headless` labels, even though the sibling `serviceEvents` already applies those filters to the Service watch.

This PR threads `k8s.ConfigParams` into `endpointsEvents` and applies `GetEndpointSliceListOptionsModifier` (extended in #45504 to cover `service-proxy-name`) so both watches share the same selector.

I identified this while working on the k8s 1.36 upgrade in #45499 with the updated upstream end 2 end test that fails without this change (see kubernetes/kubernetes#134321 and kubernetes/kubernetes#134623). That test now labels the `EndpointSlice` rather than the `Service`. Without this PR, cilium keeps routing to the labelled `EndpointSlice`'s backends and the test times out waiting for the service to go down.