### PR TITLE
cilium: Fix incorrect IPv6 BIG TCP display

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -463,12 +463,12 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 		fmt.Fprintf(w, "IPv4 BIG TCP:\t%s\n", status)
 	}
 
-	if sr.IPv4BigTCP != nil {
+	if sr.IPv6BigTCP != nil {
 		status := "Disabled"
-		if sr.IPv4BigTCP.Enabled {
-			max := fmt.Sprintf("[%d]", sr.IPv4BigTCP.MaxGSO)
-			if sr.IPv4BigTCP.MaxGRO != sr.IPv4BigTCP.MaxGSO {
-				max = fmt.Sprintf("[%d, %d]", sr.IPv4BigTCP.MaxGRO, sr.IPv4BigTCP.MaxGSO)
+		if sr.IPv6BigTCP.Enabled {
+			max := fmt.Sprintf("[%d]", sr.IPv6BigTCP.MaxGSO)
+			if sr.IPv6BigTCP.MaxGRO != sr.IPv6BigTCP.MaxGSO {
+				max = fmt.Sprintf("[%d, %d]", sr.IPv6BigTCP.MaxGRO, sr.IPv6BigTCP.MaxGSO)
 			}
 			status = fmt.Sprintf("Enabled\t%s", max)
 		}


### PR DESCRIPTION
André fixed up Renovate's commit in 40b523eec7bd ("chore(deps): update quay.io/goswagger/swagger docker tag to v0.33.2") and introduced a small error that leads to the IPv4 BIG TCP status being displayed instead of the IPv6 one.

Fixes: https://github.com/cilium/cilium/pull/44926.
Fixes: https://github.com/cilium/cilium/issues/45513.