### PR TITLE
cilium-cli: Fix port conflict for `echo-external-node`

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -40,7 +40,7 @@ func newCmdConnectivity(hooks api.Hooks) *cobra.Command {
 }
 
 var params = check.Parameters{
-	ExternalDeploymentPort: 8090,
+	ExternalDeploymentPort: 8190,
 	EchoServerHostPort:     4000,
 	Writer:                 os.Stdout,
 	SysdumpOptions: sysdump.Options{


### PR DESCRIPTION
Commit 018cb7dccba4 ("cilium-cli: Move ExternalDeploymentPort away from node-local-dns health") moved the echo-external-node deployment from TCP/8080 to TCP/8090 to avoid a conflict with `node-local-dns` health checks.

TCP/8090 is the base port and it gets incremented for each new pod, in case multiple pods are deployed on the same node. Unfortunately, TCP/8094 can conflict with a `konnectivity-agent` component on AKS. We thus need to move again.

The conflict wasn't identified when we moved to TCP/8090 because we didn't have the same coverage for AKS at the time. The conflict was identified on GKE instead.

Fixes: https://github.com/cilium/cilium/pull/41713.
Fixes: https://github.com/cilium/cilium/issues/45253.