### PR TITLE
pkg/endpoint: skip logger rebuild on policy revision updates

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2421,9 +2421,11 @@ func (e *Endpoint) setPolicyRevision(rev uint64) {
 
 	now := time.Now()
 	e.policyRevision = rev
-	e.UpdateLogger(map[string]any{
-		logfields.DatapathPolicyRevision: e.policyRevision,
-	})
+	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
+		e.UpdateLogger(map[string]any{
+			logfields.DatapathPolicyRevision: e.policyRevision,
+		})
+	}
 	for ps := range e.policyRevisionSignals {
 		select {
 		case <-ps.ctx.Done():

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -90,8 +90,6 @@ func (e *Endpoint) UpdateLogger(fields map[string]any) {
 		e.loggerAttrs.Store(logfields.EndpointID, e.ID)
 		e.loggerAttrs.Store(logfields.ContainerID, e.GetShortContainerID())
 		e.loggerAttrs.Store(logfields.ContainerInterface, e.containerIfName)
-		e.loggerAttrs.Store(logfields.DatapathPolicyRevision, e.policyRevision)
-		e.loggerAttrs.Store(logfields.DesiredPolicyRevision, e.nextPolicyRevision)
 		e.loggerAttrs.Store(logfields.IPv4, e.GetIPv4Address())
 		e.loggerAttrs.Store(logfields.IPv6, e.GetIPv6Address())
 		e.loggerAttrs.Store(logfields.K8sPodName, e.GetK8sNamespaceAndPodName())

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -118,9 +118,11 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string, scSnapshot poli
 // Must be called with the endpoint lock held for at least reading
 func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 	e.nextPolicyRevision = revision
-	e.UpdateLogger(map[string]any{
-		logfields.DesiredPolicyRevision: e.nextPolicyRevision,
-	})
+	if e.Options != nil && e.Options.IsEnabled(option.Debug) {
+		e.UpdateLogger(map[string]any{
+			logfields.DesiredPolicyRevision: e.nextPolicyRevision,
+		})
+	}
 }
 
 type policyGenerateResult struct {


### PR DESCRIPTION
When upgrading from 1.17 to 1.18 we found that there is a significant amount of time now spent in `Endpoint.UpdateLogger()` attributed to rebuilding the logger in order to bump the policy revision field.

This got more expensive when migrating to slog in
https://github.com/cilium/cilium/pull/39135. See below pprof extracts from high-churn workloads where the revisions are changing frequently:

    1.17 pprof:
      setPolicyRevision   0.06s  1.58% (cum)
      UpdateLogger        0.06s  1.58% (cum)

    1.18 pprof:
      setPolicyRevision   0.57s  11.03% (cum)
      UpdateLogger        0.54s  10.44% (cum)
      slog.Logger.With    0.45s   8.70% (cum)

This creates significantly more allocations per second and puts pressure on go GC ultimately resulting in more CPU usage.

Having the policy revision likely isn't information we want in info logs so am gating this behaviour behind debug being enabled to avoid the codepath in normal operation.

