### PR TITLE
bgp: Introduce --format option to bgp/peers

### DIFF
--- a/pkg/bgp/agent/routermgr.go
+++ b/pkg/bgp/agent/routermgr.go
@@ -65,8 +65,8 @@ type GetPeersResponse struct {
 
 // InstancePeerStates holds peer states for a specific BGP instance.
 type InstancePeerStates struct {
-	Name  string
-	Peers []types.PeerState
+	Name  string            `json:"name,omitempty"`
+	Peers []types.PeerState `json:"peers,omitempty"`
 }
 
 // GetRoutesRequest is a request for GetRoutes method.

--- a/pkg/bgp/commands/peer.go
+++ b/pkg/bgp/commands/peer.go
@@ -4,13 +4,17 @@
 package commands
 
 import (
+	"cmp"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"slices"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/cilium/hive/script"
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/bgp/agent"
@@ -24,6 +28,7 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 			Summary: "List BGP peers on Cilium",
 			Flags: func(fs *pflag.FlagSet) {
 				addOutFileFlag(fs)
+				addFormatFlag(fs)
 				fs.Bool("no-uptime", false, "Do not show Uptime for testing purpose")
 			},
 			Detail: []string{
@@ -36,13 +41,9 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 				if err != nil {
 					return "", "", err
 				}
-
-				tw, buf, f, err := getCmdTabWriter(s)
+				format, err := s.Flags.GetString(formatFlag)
 				if err != nil {
 					return "", "", err
-				}
-				if f != nil {
-					defer f.Close()
 				}
 
 				res, err := bgpMgr.GetPeers(s.Context(), &agent.GetPeersRequest{})
@@ -50,9 +51,25 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					return "", "", err
 				}
 
-				PrintPeerStates(tw, res.Instances, noUptime)
+				w, buf, f, err := getCmdWriter(s)
+				if err != nil {
+					return "", "", err
+				}
+				if f != nil {
+					defer f.Close()
+				}
 
-				tw.Flush()
+				switch format {
+				case "table":
+					tw := getCmdTabWriter(w)
+					PrintPeerStatesTable(tw, res.Instances, noUptime)
+
+					tw.Flush()
+				case "detailed":
+					PrintPeerStatesDetailed(w, res.Instances, noUptime)
+				default:
+					return "", "", fmt.Errorf("unsupported format: %s", format)
+				}
 
 				return buf.String(), "", err
 			}, nil
@@ -60,7 +77,7 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 	)
 }
 
-func PrintPeerStates(tw *tabwriter.Writer, instances []agent.InstancePeerStates, noUptime bool) {
+func PrintPeerStatesTable(tw *tabwriter.Writer, instances []agent.InstancePeerStates, noUptime bool) {
 	type row struct {
 		Instance     string
 		Peer         string
@@ -169,4 +186,231 @@ func PrintPeerStates(tw *tabwriter.Writer, instances []agent.InstancePeerStates,
 			row.Advertised,
 		}, "\t"))
 	}
+}
+
+func PrintPeerStatesDetailed(w io.Writer, instances []agent.InstancePeerStates, noUptime bool) {
+	slices.SortFunc(instances, func(a, b agent.InstancePeerStates) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	for _, instance := range instances {
+		fmt.Fprintf(w, "Instance: %v\n", instance.Name)
+
+		slices.SortFunc(instance.Peers, func(a, b types.PeerState) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		for _, peer := range instance.Peers {
+			fmt.Fprintf(w, "  Peer: %v\n", peer.Name)
+			fmt.Fprintf(w, "    Address: %v\n", peer.Address)
+			fmt.Fprintf(w, "    Port: %v\n", peer.Port)
+			fmt.Fprintf(w, "    PeerAsn: %v\n", peer.PeerAsn)
+			fmt.Fprintf(w, "    LocalAsn: %v\n", peer.LocalAsn)
+			fmt.Fprintf(w, "    Session State: %v\n", peer.SessionState)
+
+			if !noUptime {
+				fmt.Fprintf(w, "    Uptime: %v\n", peer.Uptime.Truncate(time.Second).String())
+			}
+
+			slices.SortFunc(peer.Families, func(a, b types.PeerFamilyState) int {
+				aStr := fmt.Sprintf("%s/%s", a.Afi, a.Safi)
+				bStr := fmt.Sprintf("%s/%s", b.Afi, b.Safi)
+				return strings.Compare(aStr, bStr)
+			})
+			for i, family := range peer.Families {
+				if i == 0 {
+					fmt.Fprintf(w, "    Address Families:\n")
+				}
+
+				fmt.Fprintf(w, "      %s/%s:\n", family.Afi, family.Safi)
+				fmt.Fprintf(w, "        Received Routes: %v\n", family.ReceivedRoutes)
+				fmt.Fprintf(w, "        Accepted Routes: %v\n", family.AcceptedRoutes)
+				fmt.Fprintf(w, "        Advertised Routes: %v\n", family.AdvertisedRoutes)
+			}
+
+			fmt.Fprintf(w, "    Timers:\n")
+			fmt.Fprintf(w, "      Hold Time:\n")
+			fmt.Fprintf(w, "        Configured: %v\n", peer.Timers.ConfiguredHoldTime.Truncate(time.Second).String())
+			fmt.Fprintf(w, "        Applied: %v\n", peer.Timers.AppliedHoldTime.Truncate(time.Second).String())
+			fmt.Fprintf(w, "      Keep Alive Time:\n")
+			fmt.Fprintf(w, "        Configured: %v\n", peer.Timers.ConfiguredKeepAliveTime.Truncate(time.Second).String())
+			fmt.Fprintf(w, "        Applied: %v\n", peer.Timers.AppliedKeepAliveTime.Truncate(time.Second).String())
+			fmt.Fprintf(w, "      Connect Retry Time: %v\n", peer.Timers.ConnectRetryTime.Truncate(time.Second).String())
+			fmt.Fprintf(w, "    Ebgp Multihop TTL: %v\n", peer.EbgpMultihopTTL)
+			fmt.Fprintf(w, "    Graceful Restart:\n")
+			fmt.Fprintf(w, "      Enabled: %v\n", peer.GracefulRestart.Enabled)
+
+			if peer.GracefulRestart.Enabled {
+				fmt.Fprintf(w, "      Restart Time: %v\n", peer.GracefulRestart.RestartTime.Truncate(time.Second).String())
+			}
+
+			slices.SortFunc(peer.LocalCapabilities, func(a, b bgp.ParameterCapabilityInterface) int {
+				c := cmp.Compare(a.Code(), b.Code())
+				if c != 0 {
+					return c
+				}
+				aByte, _ := a.Serialize()
+				bByte, _ := b.Serialize()
+				return strings.Compare(base64.StdEncoding.EncodeToString(aByte), base64.StdEncoding.EncodeToString(bByte))
+			})
+			for i, capability := range peer.LocalCapabilities {
+				if i == 0 {
+					fmt.Fprintf(w, "    Local Capabilities:\n")
+				}
+
+				if formatter, found := capabilityFormatters[capability.Code()]; found {
+					formatter(w, capability)
+				} else {
+					formatDefaultCap(w, capability)
+				}
+			}
+
+			slices.SortFunc(peer.RemoteCapabilities, func(a, b bgp.ParameterCapabilityInterface) int {
+				return cmp.Compare(a.Code(), b.Code())
+			})
+			for i, capability := range peer.RemoteCapabilities {
+				if i == 0 {
+					fmt.Fprintf(w, "    Remote Capabilities:\n")
+				}
+
+				if formatter, found := capabilityFormatters[capability.Code()]; found {
+					formatter(w, capability)
+				} else {
+					formatDefaultCap(w, capability)
+				}
+			}
+
+			fmt.Fprintf(w, "    TCP Password Enabled: %v\n", peer.TCPPasswordEnabled)
+		}
+	}
+}
+
+// capabilityFormatter defines the function signature for a capability-specific printer.
+type capabilityFormatter func(w io.Writer, cap bgp.ParameterCapabilityInterface)
+
+// capabilityFormatters is a registry mapping BGP capability codes to their specific formatting functions.
+var capabilityFormatters = map[bgp.BGPCapabilityCode]capabilityFormatter{
+	bgp.BGP_CAP_MULTIPROTOCOL:               formatMultiProtocolCap,
+	bgp.BGP_CAP_GRACEFUL_RESTART:            formatGracefulRestartCap,
+	bgp.BGP_CAP_LONG_LIVED_GRACEFUL_RESTART: formatLongLivedGracefulRestartCap,
+	bgp.BGP_CAP_EXTENDED_NEXTHOP:            formatExtendedNexthopCap,
+	bgp.BGP_CAP_ADD_PATH:                    formatAddPathCap,
+	bgp.BGP_CAP_FQDN:                        formatFQDNCap,
+	bgp.BGP_CAP_SOFT_VERSION:                formatSoftwareVersionCap,
+}
+
+func formatMultiProtocolCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s:\n", cap.Code())
+	m := cap.(*bgp.CapMultiProtocol)
+	fmt.Fprintf(w, "        %s\n", m.CapValue)
+}
+
+func formatGracefulRestartCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s", cap.Code())
+	g := cap.(*bgp.CapGracefulRestart)
+	if s := parseGracefulRestartCap(g); len(strings.TrimSpace(s)) > 0 {
+		fmt.Fprintf(w, ":\n%s", s)
+	} else {
+		fmt.Fprintf(w, "\n")
+	}
+}
+
+func formatLongLivedGracefulRestartCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s", cap.Code())
+	g := cap.(*bgp.CapLongLivedGracefulRestart)
+	if s := parseLongLivedGracefulRestartCap(g); len(strings.TrimSpace(s)) > 0 {
+		fmt.Fprintf(w, ":\n%s", s)
+	} else {
+		fmt.Fprintf(w, "\n")
+	}
+}
+
+func formatExtendedNexthopCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s", cap.Code())
+	e := cap.(*bgp.CapExtendedNexthop)
+	if s := parseExtendedNexthopCap(e); len(strings.TrimSpace(s)) > 0 {
+		fmt.Fprintf(w, ":\n%s", s)
+	} else {
+		fmt.Fprintf(w, "\n")
+	}
+}
+
+func formatAddPathCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s:\n", cap.Code())
+	for _, item := range cap.(*bgp.CapAddPath).Tuples {
+		fmt.Fprintf(w, "        %s: %s\n", item.RouteFamily, item.Mode)
+	}
+}
+
+func formatFQDNCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s:\n", cap.Code())
+	fqdn := cap.(*bgp.CapFQDN)
+	fmt.Fprintf(w, "        name: %s\n        domain: %s\n", fqdn.HostName, fqdn.DomainName)
+}
+
+func formatSoftwareVersionCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s: %s\n", cap.Code(), cap.(*bgp.CapSoftwareVersion).SoftwareVersion)
+}
+
+func formatDefaultCap(w io.Writer, cap bgp.ParameterCapabilityInterface) {
+	fmt.Fprintf(w, "      %s\n", cap.Code())
+}
+
+func parseGracefulRestartCap(g *bgp.CapGracefulRestart) string {
+	grStr := "        "
+	if len(g.Tuples) > 0 {
+		grStr += fmt.Sprintf("restart time: %d sec", g.Time)
+	}
+	if g.Flags&0x08 > 0 {
+		if len(strings.TrimSpace(grStr)) > 0 {
+			grStr += ", "
+		}
+		grStr += "restart flag set"
+	}
+	if g.Flags&0x04 > 0 {
+		if len(strings.TrimSpace(grStr)) > 0 {
+			grStr += ", "
+		}
+		grStr += "notification flag set"
+	}
+
+	if len(grStr) > 0 {
+		grStr += "\n"
+	}
+	for _, t := range g.Tuples {
+		grStr += fmt.Sprintf("        %s", bgp.AfiSafiToRouteFamily(t.AFI, t.SAFI))
+		if t.Flags == 0x80 {
+			grStr += ", forward flag set"
+		}
+		grStr += "\n"
+	}
+	return grStr
+}
+
+func parseLongLivedGracefulRestartCap(g *bgp.CapLongLivedGracefulRestart) string {
+	var llgrStr strings.Builder
+	for _, t := range g.Tuples {
+		fmt.Fprintf(&llgrStr, "        %s, restart time %d sec", bgp.AfiSafiToRouteFamily(t.AFI, t.SAFI), t.RestartTime)
+		if t.Flags == 0x80 {
+			llgrStr.WriteString(", forward flag set")
+		}
+		llgrStr.WriteString("\n")
+	}
+	return llgrStr.String()
+}
+
+func parseExtendedNexthopCap(e *bgp.CapExtendedNexthop) string {
+	lines := make([]string, 0, len(e.Tuples))
+	for _, t := range e.Tuples {
+		var nhafi string
+		switch int(t.NexthopAFI) {
+		case bgp.AFI_IP:
+			nhafi = "ipv4"
+		case bgp.AFI_IP6:
+			nhafi = "ipv6"
+		default:
+			nhafi = fmt.Sprintf("%d", t.NexthopAFI)
+		}
+		line := fmt.Sprintf("        nlri: %s, nexthop: %s\n", bgp.AfiSafiToRouteFamily(t.NLRIAFI, uint8(t.NLRISAFI)), nhafi)
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "")
 }

--- a/pkg/bgp/commands/peer.go
+++ b/pkg/bgp/commands/peer.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"cmp"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"slices"
@@ -65,6 +66,14 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					PrintPeerStatesTable(tw, res.Instances, noUptime)
 
 					tw.Flush()
+				case "json":
+					out, err := json.MarshalIndent(res.Instances, "", "  ")
+					if err != nil {
+						return "", "", fmt.Errorf("json marshal failed: %w", err)
+					}
+					if _, err := w.Write(out); err != nil {
+						return "", "", err
+					}
 				case "detailed":
 					PrintPeerStatesDetailed(w, res.Instances, noUptime)
 				default:

--- a/pkg/bgp/commands/route_polices.go
+++ b/pkg/bgp/commands/route_polices.go
@@ -42,13 +42,14 @@ func BGPRoutePoliciesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					return "", "", err
 				}
 
-				tw, buf, f, err := getCmdTabWriter(s)
+				w, buf, f, err := getCmdWriter(s)
 				if err != nil {
 					return "", "", err
 				}
 				if f != nil {
 					defer f.Close()
 				}
+				tw := getCmdTabWriter(w)
 
 				PrintBGPRoutePoliciesTable(tw, res.Instances)
 				tw.Flush()

--- a/pkg/bgp/commands/routes.go
+++ b/pkg/bgp/commands/routes.go
@@ -72,13 +72,14 @@ func BGPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					return "", "", err
 				}
 
-				tw, buf, f, err := getCmdTabWriter(s)
+				w, buf, f, err := getCmdWriter(s)
 				if err != nil {
 					return "", "", err
 				}
 				if f != nil {
 					defer f.Close()
 				}
+				tw := getCmdTabWriter(w)
 
 				res, err := bgpMgr.GetRoutes(s.Context(), req)
 				if err != nil {

--- a/pkg/bgp/commands/utils.go
+++ b/pkg/bgp/commands/utils.go
@@ -17,6 +17,8 @@ import (
 const (
 	outFileFlag       = "out"
 	outFileFlagShort  = "o"
+	formatFlag        = "format"
+	formatFlagShort   = "f"
 	instanceFlag      = "instance"
 	instanceFlagShort = "i"
 
@@ -29,7 +31,11 @@ func addOutFileFlag(fs *pflag.FlagSet) {
 	fs.StringP(outFileFlag, outFileFlagShort, "", "File to write to instead of stdout")
 }
 
-func getCmdTabWriter(s *script.State) (tw *tabwriter.Writer, buf *strings.Builder, f *os.File, err error) {
+func addFormatFlag(fs *pflag.FlagSet) {
+	fs.StringP(formatFlag, formatFlagShort, "table", "Format to write in (table or detailed)")
+}
+
+func getCmdWriter(s *script.State) (writer io.Writer, buf *strings.Builder, f *os.File, err error) {
 	fileName := ""
 	fileName, err = s.Flags.GetString(outFileFlag)
 	if err != nil {
@@ -37,7 +43,6 @@ func getCmdTabWriter(s *script.State) (tw *tabwriter.Writer, buf *strings.Builde
 	}
 
 	buf = &strings.Builder{}
-	var writer io.Writer
 	if fileName == "" {
 		// will write to string buffer
 		writer = buf
@@ -51,6 +56,9 @@ func getCmdTabWriter(s *script.State) (tw *tabwriter.Writer, buf *strings.Builde
 		writer = f
 	}
 
-	tw = tabwriter.NewWriter(writer, tabMinWidth, 0, tabPadding, tabPaddingChar, 0)
 	return
+}
+
+func getCmdTabWriter(writer io.Writer) *tabwriter.Writer {
+	return tabwriter.NewWriter(writer, tabMinWidth, 0, tabPadding, tabPaddingChar, 0)
 }

--- a/pkg/bgp/commands/utils.go
+++ b/pkg/bgp/commands/utils.go
@@ -32,7 +32,7 @@ func addOutFileFlag(fs *pflag.FlagSet) {
 }
 
 func addFormatFlag(fs *pflag.FlagSet) {
-	fs.StringP(formatFlag, formatFlagShort, "table", "Format to write in (table or detailed)")
+	fs.StringP(formatFlag, formatFlagShort, "table", "Format to write in (table, json or detailed)")
 }
 
 func getCmdWriter(s *script.State) (writer io.Writer, buf *strings.Builder, f *os.File, err error) {

--- a/pkg/bgp/gobgp/conversions.go
+++ b/pkg/bgp/gobgp/conversions.go
@@ -455,7 +455,16 @@ func toAgentSessionState(s gobgp.PeerState_SessionState) types.SessionState {
 	}
 }
 
-func toAgentCap(s []*anypb.Any) []*models.BgpCapabilities {
+func toAgentCap(s []*anypb.Any) []bgp.ParameterCapabilityInterface {
+	caps, err := apiutil.UnmarshalCapabilities(s)
+	if err != nil {
+		return nil
+	}
+
+	return caps
+}
+
+func toAgentCapLegacy(s []*anypb.Any) []*models.BgpCapabilities {
 	caps, err := apiutil.UnmarshalCapabilities(s)
 	if err != nil {
 		return nil

--- a/pkg/bgp/gobgp/state.go
+++ b/pkg/bgp/gobgp/state.go
@@ -75,10 +75,17 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context, req *types.GetPeerStateR
 			state.Address = addr
 			state.LocalAsn = int64(peer.Conf.LocalAsn)
 			state.PeerAsn = int64(peer.Conf.PeerAsn)
+			state.TCPPasswordEnabled = peer.Conf.AuthPassword != ""
 		}
 
 		if peer.State != nil {
+			if peer.Conf.PeerAsn == 0 { // if peerAsn is not set, use peer state peerAsn
+				state.PeerAsn = int64(peer.State.PeerAsn)
+			}
+
 			state.SessionState = toAgentSessionState(peer.State.SessionState)
+			state.LocalCapabilities = toAgentCap(peer.State.LocalCap)
+			state.RemoteCapabilities = toAgentCap(peer.State.RemoteCap)
 
 			// Uptime is time since session got established. It is
 			// calculated by difference in time from uptime
@@ -93,6 +100,36 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context, req *types.GetPeerStateR
 				continue
 			}
 			state.Families = append(state.Families, toAgentAfiSafiState(afiSafi.State))
+		}
+
+		if peer.EbgpMultihop != nil && peer.EbgpMultihop.Enabled {
+			state.EbgpMultihopTTL = int64(peer.EbgpMultihop.MultihopTtl)
+		} else {
+			state.EbgpMultihopTTL = int64(v2.DefaultBGPEBGPMultihopTTL) // defaults to 1 if not enabled
+		}
+
+		if peer.Timers != nil {
+			tConfig := peer.Timers.Config
+			tState := peer.Timers.State
+			if tConfig != nil {
+				state.Timers.ConnectRetryTime = time.Duration(tConfig.ConnectRetry) * time.Second
+				state.Timers.ConfiguredHoldTime = time.Duration(tConfig.HoldTime) * time.Second
+				state.Timers.ConfiguredKeepAliveTime = time.Duration(tConfig.KeepaliveInterval) * time.Second
+			}
+			if tState != nil {
+				if tState.NegotiatedHoldTime != 0 {
+					state.Timers.AppliedHoldTime = time.Duration(tState.NegotiatedHoldTime) * time.Second
+				}
+				if tState.KeepaliveInterval != 0 {
+					state.Timers.AppliedKeepAliveTime = time.Duration(tState.KeepaliveInterval) * time.Second
+				}
+			}
+		}
+
+		state.GracefulRestart = types.BgpGracefulRestart{}
+		if peer.GracefulRestart != nil {
+			state.GracefulRestart.Enabled = peer.GracefulRestart.Enabled
+			state.GracefulRestart.RestartTime = time.Duration(peer.GracefulRestart.RestartTime) * time.Second
 		}
 
 		res.Peers = append(res.Peers, state)
@@ -156,8 +193,8 @@ func (g *GoBGPServer) GetPeerStateLegacy(ctx context.Context) (types.GetPeerStat
 			}
 
 			peerState.SessionState = toAgentSessionState(peer.State.SessionState).String()
-			peerState.LocalCapabilities = toAgentCap(peer.State.LocalCap)
-			peerState.RemoteCapabilities = toAgentCap(peer.State.RemoteCap)
+			peerState.LocalCapabilities = toAgentCapLegacy(peer.State.LocalCap)
+			peerState.RemoteCapabilities = toAgentCapLegacy(peer.State.RemoteCap)
 
 			// Uptime is time since session got established.
 			// It is calculated by difference in time from uptime timestamp till now.

--- a/pkg/bgp/test/testdata/README.md
+++ b/pkg/bgp/test/testdata/README.md
@@ -43,7 +43,7 @@ message about duplicate IPs across the tests.
 To observe / assert the state Cilium BGP Control Plane, use the `bgp/*` commands:
 
 ```
-bgp/peers [-o] [--out=string]
+bgp/peers [-fo] [--format=string] [--no-uptime] [--out=string] 
 	List BGP peers on Cilium
 bgp/route-policies [-io] [--instance=string] [--out=string] 
 	List BGP route policies on Cilium

--- a/pkg/bgp/test/testdata/commands.txtar
+++ b/pkg/bgp/test/testdata/commands.txtar
@@ -38,6 +38,12 @@ gobgp/wait-state -s server3 fd00:10:99:7::6 ESTABLISHED
 bgp/peers --no-uptime -o bgp-peers.actual
 * cmp bgp-peers.expected bgp-peers.actual
 
+# Test peers detailed
+bgp/peers --no-uptime -f detailed -o bgp-peers-detailed.actual
+sed 'name:.*' 'name: <redacted>' bgp-peers-detailed.actual
+sed 'software-version:.*' 'software-version: <redacted>' bgp-peers-detailed.actual
+* cmp bgp-peers-detailed.expected bgp-peers-detailed.actual
+
 # Test route-policies
 bgp/route-policies -o bgp-route-policies.actual
 * cmp bgp-route-policies.expected bgp-route-policies.actual
@@ -160,6 +166,237 @@ instance1   peer0   established     -        ipv4-unicast   1          1        
                                              ipv6-unicast   1          1          1
             peer1   established     -        ipv4-unicast   1          1          1
                                              ipv6-unicast   1          1          1
+-- bgp-peers-detailed.expected --
+Instance: instance0
+  Peer: peer0
+    Address: fd00:10:99:7::1
+    Port: 1790
+    PeerAsn: 65000
+    LocalAsn: 65000
+    Session State: established
+    Address Families:
+      ipv4/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+      ipv6/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+    Timers:
+      Hold Time:
+        Configured: 1m30s
+        Applied: 1m30s
+      Keep Alive Time:
+        Configured: 30s
+        Applied: 30s
+      Connect Retry Time: 1s
+    Ebgp Multihop TTL: 1
+    Graceful Restart:
+      Enabled: false
+    Local Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      4-octet-as
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    Remote Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      graceful-restart
+      4-octet-as
+      add-path:
+        ipv4-unicast: receive
+        ipv6-unicast: receive
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    TCP Password Enabled: false
+  Peer: peer1
+    Address: fd00:10:99:7::2
+    Port: 1790
+    PeerAsn: 65000
+    LocalAsn: 65000
+    Session State: established
+    Address Families:
+      ipv4/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+      ipv6/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+    Timers:
+      Hold Time:
+        Configured: 1m30s
+        Applied: 1m30s
+      Keep Alive Time:
+        Configured: 30s
+        Applied: 30s
+      Connect Retry Time: 1s
+    Ebgp Multihop TTL: 1
+    Graceful Restart:
+      Enabled: false
+    Local Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      4-octet-as
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    Remote Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      graceful-restart
+      4-octet-as
+      add-path:
+        ipv4-unicast: receive
+        ipv6-unicast: receive
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    TCP Password Enabled: false
+Instance: instance1
+  Peer: peer0
+    Address: fd00:10:99:7::3
+    Port: 1790
+    PeerAsn: 65001
+    LocalAsn: 65001
+    Session State: established
+    Address Families:
+      ipv4/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+      ipv6/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+    Timers:
+      Hold Time:
+        Configured: 1m30s
+        Applied: 1m30s
+      Keep Alive Time:
+        Configured: 30s
+        Applied: 30s
+      Connect Retry Time: 1s
+    Ebgp Multihop TTL: 1
+    Graceful Restart:
+      Enabled: false
+    Local Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      4-octet-as
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    Remote Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      graceful-restart
+      4-octet-as
+      add-path:
+        ipv4-unicast: receive
+        ipv6-unicast: receive
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    TCP Password Enabled: false
+  Peer: peer1
+    Address: fd00:10:99:7::4
+    Port: 1790
+    PeerAsn: 65001
+    LocalAsn: 65001
+    Session State: established
+    Address Families:
+      ipv4/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+      ipv6/unicast:
+        Received Routes: 1
+        Accepted Routes: 1
+        Advertised Routes: 1
+    Timers:
+      Hold Time:
+        Configured: 1m30s
+        Applied: 1m30s
+      Keep Alive Time:
+        Configured: 30s
+        Applied: 30s
+      Connect Retry Time: 1s
+    Ebgp Multihop TTL: 1
+    Graceful Restart:
+      Enabled: false
+    Local Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      4-octet-as
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    Remote Capabilities:
+      multiprotocol:
+        ipv4-unicast
+      multiprotocol:
+        ipv6-unicast
+      route-refresh
+      extended-nexthop:
+        nlri: ipv4-unicast, nexthop: ipv6
+      graceful-restart
+      4-octet-as
+      add-path:
+        ipv4-unicast: receive
+        ipv6-unicast: receive
+      fqdn:
+        name: <redacted>
+        domain: 
+      software-version: <redacted>
+    TCP Password Enabled: false
 -- bgp-route-policies.expected --
 Instance    Policy Name          Type     Match Peers       Match Families   Match Prefixes (Min..Max Len)   RIB Action   Path Actions
 instance0   allow-local          import                                                                      accept       

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -148,16 +148,16 @@ type PeerState struct {
 	// Address of the peer
 	Address netip.Addr
 
-	// Local AS Number
-	LocalAsn int64
-
-	// Peer AS Number
-	PeerAsn int64
-
 	// TCP port number of peer
 	// Maximum: 65535
 	// Minimum: 1
 	Port int64
+
+	// Peer AS Number
+	PeerAsn int64
+
+	// Local AS Number
+	LocalAsn int64
 
 	// BGP peer state
 	SessionState SessionState
@@ -169,6 +169,52 @@ type PeerState struct {
 
 	// BGP peer address family states. All configured address families are present here.
 	Families []PeerFamilyState
+
+	// Contains information for peer timers settings.
+	Timers PeerTimers
+
+	// Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.
+	// 1 implies that eBGP multi-hop feature is disabled (only a single hop is allowed).
+	//
+	EbgpMultihopTTL int64
+
+	// Graceful restart capability
+	GracefulRestart BgpGracefulRestart
+
+	// Capabilities announced by the local peer
+	LocalCapabilities []bgp.ParameterCapabilityInterface
+
+	// Capabilities announced by the remote peer
+	RemoteCapabilities []bgp.ParameterCapabilityInterface
+
+	// Set when a TCP password is configured for communications with this peer
+	TCPPasswordEnabled bool
+}
+
+// PeerTimers contains information for peer timers settings.
+type PeerTimers struct {
+	// Applied initial value for the BGP HoldTimer (RFC 4271, Section 4.2)
+	// The applied value holds the value that is in effect on the current BGP session.
+	//
+	AppliedHoldTime time.Duration
+
+	// Applied initial value for the BGP KeepaliveTimer (RFC 4271, Section 8)
+	// The applied value holds the value that is in effect on the current BGP session.
+	//
+	AppliedKeepAliveTime time.Duration
+
+	// Configured initial value for the BGP HoldTimer (RFC 4271, Section 4.2)
+	// The configured value will be used for negotiation with the peer during the BGP session establishment.
+	//
+	ConfiguredHoldTime time.Duration
+
+	// Configured initial value for the BGP KeepaliveTimer (RFC 4271, Section 8)
+	// The applied value may be different than the configured value, as it depends on the negotiated hold time interval.
+	//
+	ConfiguredKeepAliveTime time.Duration
+
+	// Initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8)
+	ConnectRetryTime time.Duration
 }
 
 // PeerFamilyState contains status information for a specific address family.
@@ -177,6 +223,18 @@ type PeerFamilyState struct {
 	ReceivedRoutes   uint64
 	AcceptedRoutes   uint64
 	AdvertisedRoutes uint64
+}
+
+// BgpGracefulRestart BGP graceful restart parameters negotiated with the peer.
+type BgpGracefulRestart struct {
+	// When set, graceful restart capability is negotiated for all AFI/SAFIs of
+	// this peer.
+	Enabled bool
+
+	// This is the time advertised to peer for the BGP session to be re-established
+	// after a restart. After this period, peer will remove stale routes.
+	// (RFC 4724 section 4.2)
+	RestartTime time.Duration
 }
 
 // PathRequest contains parameters for advertising or withdrawing a Path

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -143,52 +143,52 @@ type ResetAllNeighborsRequest struct {
 // PeerState contains status information for a BGP peer
 type PeerState struct {
 	// Name of the peer
-	Name string
+	Name string `json:"name,omitempty"`
 
 	// Address of the peer
-	Address netip.Addr
+	Address netip.Addr `json:"peer-address,omitempty"`
 
 	// TCP port number of peer
 	// Maximum: 65535
 	// Minimum: 1
-	Port int64
+	Port int64 `json:"peer-port,omitempty"`
 
 	// Peer AS Number
-	PeerAsn int64
+	PeerAsn int64 `json:"peer-asn,omitempty"`
 
 	// Local AS Number
-	LocalAsn int64
+	LocalAsn int64 `json:"local-asn,omitempty"`
 
 	// BGP peer state
-	SessionState SessionState
+	SessionState SessionState `json:"session-state,omitempty"`
 
 	// The rest of the fields are only valid if SessionState is Established
 
 	// Time since the BGP session was established
-	Uptime time.Duration
+	Uptime time.Duration `json:"uptime-nanoseconds,omitempty"`
 
 	// BGP peer address family states. All configured address families are present here.
-	Families []PeerFamilyState
+	Families []PeerFamilyState `json:"families"`
 
 	// Contains information for peer timers settings.
-	Timers PeerTimers
+	Timers PeerTimers `json:"timers"`
 
 	// Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.
 	// 1 implies that eBGP multi-hop feature is disabled (only a single hop is allowed).
 	//
-	EbgpMultihopTTL int64
+	EbgpMultihopTTL int64 `json:"ebgp-multihop-ttl,omitempty"`
 
 	// Graceful restart capability
-	GracefulRestart BgpGracefulRestart
+	GracefulRestart BgpGracefulRestart `json:"graceful-restart,omitempty"`
 
 	// Capabilities announced by the local peer
-	LocalCapabilities []bgp.ParameterCapabilityInterface
+	LocalCapabilities []bgp.ParameterCapabilityInterface `json:"local-capabilities"`
 
 	// Capabilities announced by the remote peer
-	RemoteCapabilities []bgp.ParameterCapabilityInterface
+	RemoteCapabilities []bgp.ParameterCapabilityInterface `json:"remote-capabilities"`
 
 	// Set when a TCP password is configured for communications with this peer
-	TCPPasswordEnabled bool
+	TCPPasswordEnabled bool `json:"tcp-password-enabled,omitempty"`
 }
 
 // PeerTimers contains information for peer timers settings.
@@ -196,45 +196,45 @@ type PeerTimers struct {
 	// Applied initial value for the BGP HoldTimer (RFC 4271, Section 4.2)
 	// The applied value holds the value that is in effect on the current BGP session.
 	//
-	AppliedHoldTime time.Duration
+	AppliedHoldTime time.Duration `json:"applied-hold-nanoseconds,omitempty"`
 
 	// Applied initial value for the BGP KeepaliveTimer (RFC 4271, Section 8)
 	// The applied value holds the value that is in effect on the current BGP session.
 	//
-	AppliedKeepAliveTime time.Duration
+	AppliedKeepAliveTime time.Duration `json:"applied-keep-alive-nanoseconds,omitempty"`
 
 	// Configured initial value for the BGP HoldTimer (RFC 4271, Section 4.2)
 	// The configured value will be used for negotiation with the peer during the BGP session establishment.
 	//
-	ConfiguredHoldTime time.Duration
+	ConfiguredHoldTime time.Duration `json:"configured-hold-nanoseconds,omitempty"`
 
 	// Configured initial value for the BGP KeepaliveTimer (RFC 4271, Section 8)
 	// The applied value may be different than the configured value, as it depends on the negotiated hold time interval.
 	//
-	ConfiguredKeepAliveTime time.Duration
+	ConfiguredKeepAliveTime time.Duration `json:"configured-keep-alive-nanoseconds,omitempty"`
 
 	// Initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8)
-	ConnectRetryTime time.Duration
+	ConnectRetryTime time.Duration `json:"connect-retry-nanoseconds,omitempty"`
 }
 
 // PeerFamilyState contains status information for a specific address family.
 type PeerFamilyState struct {
 	Family
-	ReceivedRoutes   uint64
-	AcceptedRoutes   uint64
-	AdvertisedRoutes uint64
+	ReceivedRoutes   uint64 `json:"received,omitempty"`
+	AcceptedRoutes   uint64 `json:"accepted,omitempty"`
+	AdvertisedRoutes uint64 `json:"advertised,omitempty"`
 }
 
 // BgpGracefulRestart BGP graceful restart parameters negotiated with the peer.
 type BgpGracefulRestart struct {
 	// When set, graceful restart capability is negotiated for all AFI/SAFIs of
 	// this peer.
-	Enabled bool
+	Enabled bool `json:"enabled,omitempty"`
 
 	// This is the time advertised to peer for the BGP session to be re-established
 	// after a restart. After this period, peer will remove stale routes.
 	// (RFC 4724 section 4.2)
-	RestartTime time.Duration
+	RestartTime time.Duration `json:"restart-time-nanoseconds,omitempty"`
 }
 
 // PathRequest contains parameters for advertising or withdrawing a Path
@@ -543,8 +543,8 @@ type ServerParameters struct {
 //
 // +deepequal-gen=true
 type Family struct {
-	Afi  Afi
-	Safi Safi
+	Afi  Afi  `json:"afi,omitempty"`
+	Safi Safi `json:"safi,omitempty"`
 }
 
 func (f Family) String() string {

--- a/pkg/bgp/types/conversions.go
+++ b/pkg/bgp/types/conversions.go
@@ -44,6 +44,14 @@ func (s SessionState) String() string {
 	}
 }
 
+func (s SessionState) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + s.String() + "\""), nil
+}
+
+func (s SessionState) MarshalYAML() (any, error) {
+	return s.String(), nil
+}
+
 // Afi is address family identifier
 type Afi uint32
 


### PR DESCRIPTION
Update the bgp/peers command to support multiple output formats (table, json, and detailed).

- Updated commands.BGPPeersCmd to handle the new format options.
- Added JSON tags to agent.InstancePeerStates, types.PeerState, types.PeerFamilyState, and types.Family.
- Added necessary attributes to types.PeerState to support the detailed output view.
- Updated types.PeerState LocalCapabilities and RemoteCapabilities to use	bgp.ParameterCapabilityInterface.
- Added formatter functions to produce human readable output of bgp.ParameterCapabilityInterface for detailed format.
- Added unit tests to verify the output of the detailed format.

```release-note
bgp: add --format option to the bgp/peers command to support table, json, and detailed output formats
```
