### PR TITLE
sockets: Avoid pinning BPF maps in TestPrivilegedSocketDestroyers

### DIFF
--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -241,7 +241,7 @@ func newTestBPFSocketDestroyer(tb testing.TB) socketDestroyerTester {
 		maps.MaxSockRevNat4MapEntries,
 		0,
 	)
-	require.NoError(tb, sockRevNat4Map.OpenOrCreate())
+	require.NoError(tb, sockRevNat4Map.CreateUnpinned())
 	sockRevNat6Map := bpf.NewMap(maps.SockRevNat6MapName,
 		ebpf.LRUHash,
 		&maps.SockRevNat6Key{},
@@ -249,7 +249,7 @@ func newTestBPFSocketDestroyer(tb testing.TB) socketDestroyerTester {
 		maps.MaxSockRevNat6MapEntries,
 		0,
 	)
-	require.NoError(tb, sockRevNat6Map.OpenOrCreate())
+	require.NoError(tb, sockRevNat6Map.CreateUnpinned())
 	progs, filterSetter, err := loader.LoadSockTerm(hivetest.Logger(tb), sockRevNat4Map, sockRevNat6Map)
 	require.NoError(tb, err)
 	tb.Cleanup(func() {


### PR DESCRIPTION
The test creates two BPF maps (cilium_lb4_reverse_sk, cilium_lb6_reverse_sk)
and pins them to /sys/fs/bpf/tc/globals/. This races with the loader
test's cleanup which does os.RemoveAll on the same directory. Since
`go test ./...` runs packages in parallel, the loader cleanup can
nuke tc/globals/ between the sockets test's MkdirBPF and Pin calls,
causing ENOENT on the v6 map pin.

The test doesn't need pinned maps. It only needs in-kernel map FDs
which are passed to LoadSockTerm via MapReplacements. Switch to
CreateUnpinned() to avoid the shared filesystem dependency entirely.

Fixes: #44976