### PR TITLE
cilium-cli: propagate --namespace-labels to CCNP helper namespaces

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -946,6 +946,13 @@ func DeployZtunnelTestEnv(ctx context.Context, t *Test, ct *ConnectivityTest) er
 }
 
 func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
+	// Propagate --namespace-labels / --namespace-annotations onto the
+	// CCNP helper namespaces so that cluster-wide policy admission
+	// controllers (e.g. Pod Security admission) treat them the same as
+	// the main test namespace created by deployNamespace. Without this,
+	// the ccnp1/ccnp2 namespaces are created without the caller's
+	// labels and the Pods inside fail to schedule under restrictive
+	// policy (see https://github.com/cilium/cilium-cli/issues/3173).
 	namespaceConfigs := []struct {
 		name string
 		obj  *corev1.Namespace
@@ -954,7 +961,9 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 			name: "cilium-test-ccnp1",
 			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cilium-test-ccnp1",
+					Name:        "cilium-test-ccnp1",
+					Annotations: ct.params.NamespaceAnnotations,
+					Labels:      ct.params.NamespaceLabels,
 				},
 			},
 		},
@@ -962,7 +971,9 @@ func (ct *ConnectivityTest) deployCCNPTestEnv(ctx context.Context) error {
 			name: "cilium-test-ccnp2",
 			obj: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "cilium-test-ccnp2",
+					Name:        "cilium-test-ccnp2",
+					Annotations: ct.params.NamespaceAnnotations,
+					Labels:      ct.params.NamespaceLabels,
 				},
 			},
 		},


### PR DESCRIPTION
Closes [cilium/cilium-cli#3173](https://github.com/cilium/cilium-cli/issues/3173).

## Problem

\`deployCCNPTestEnv\` in \`cilium-cli/connectivity/check/deployment.go\` creates the \`cilium-test-ccnp1\` and \`cilium-test-ccnp2\` helper namespaces with bare \`ObjectMeta\` blocks:

\`\`\`go
{
    name: \"cilium-test-ccnp1\",
    obj: &corev1.Namespace{
        ObjectMeta: metav1.ObjectMeta{
            Name: \"cilium-test-ccnp1\",
        },
    },
},
\`\`\`

\`deployNamespace\` in the same file merges \`ct.params.NamespaceLabels\` (and \`NamespaceAnnotations\`) into the main test namespace. The CCNP helpers don't — so when someone runs

\`\`\`
cilium connectivity test --namespace-labels pod-security.kubernetes.io/enforce=privileged
\`\`\`

only \`cilium-test-1\` gets the label, and cluster-wide Pod Security admission blocks the privileged Pods the test tries to schedule into \`ccnp1\`/\`ccnp2\`. The issue reporter hit this directly.

## Fix

Apply \`ct.params.NamespaceLabels\` and \`ct.params.NamespaceAnnotations\` to the CCNP helper namespace specs, exactly matching the pattern already used by \`deployNamespace\` (line 717). Inline comment explains the rationale and references the issue.

## Verification

- \`go build ./...\` (under \`cilium-cli/\`) — clean.
- \`go vet ./connectivity/check/...\` — clean.
- Scoped to \`cilium-cli/connectivity/check/deployment.go\`; no behavioral change when \`--namespace-labels\`/\`--namespace-annotations\` are unset (nil maps result in empty ObjectMeta fields, same as before).