### PR TITLE
[GH-41867][Part-5][eBPF] Skip SNAT for same subnet traffic in hybrid overlay mode

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -24,6 +24,7 @@
 #include "stubs.h"
 #include "trace.h"
 #include "aux.h"
+#include "subnet.h"
 
 /* Nodeport NAT minimum port value */
 #define NODEPORT_PORT_MIN_NAT CONFIG(nodeport_port_max) + 1
@@ -772,6 +773,18 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 		 * by the remote node if its native dev's
 		 * rp_filter=1.
 		 */
+
+		/* In hybrid routing mode, skip SNAT for traffic within the same
+		 * subnet group. These packets are natively routed and don't need
+		 * masquerading.
+		 */
+		if (CONFIG(hybrid_routing_enabled)) {
+			__u32 src_subnet_id = lookup_ip4_subnet_id(tuple->saddr);
+			__u32 dst_subnet_id = lookup_ip4_subnet_id(tuple->daddr);
+
+			if ((src_subnet_id == dst_subnet_id) && (src_subnet_id != 0))
+				return NAT_PUNT_TO_STACK;
+		}
 
 		if (remote_ep->flag_skip_tunnel)
 			return NAT_PUNT_TO_STACK;
@@ -1760,6 +1773,18 @@ __snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 		}
 		if (!is_defined(TUNNEL_MODE))
 			return NAT_PUNT_TO_STACK;
+
+		/* In hybrid routing mode, skip SNAT for traffic within the same
+		 * subnet group. These packets are natively routed and don't need
+		 * masquerading.
+		 */
+		if (CONFIG(hybrid_routing_enabled)) {
+			__u32 src_subnet_id = lookup_ip6_subnet_id((union v6addr *)&tuple->saddr);
+			__u32 dst_subnet_id = lookup_ip6_subnet_id(&tuple->daddr);
+
+			if ((src_subnet_id == dst_subnet_id) && (src_subnet_id != 0))
+				return NAT_PUNT_TO_STACK;
+		}
 
 		if (remote_ep->flag_skip_tunnel)
 			return NAT_PUNT_TO_STACK;


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

This PR is Part 5 of the hybrid routing mode implementation (CFP-32810).

In hybrid routing mode with overlay routing enabled, pod-to-remote-node
traffic is normally masqueraded before leaving the host. However, when
the source and destination belong to the same subnet topology group,
such traffic is routed natively without tunneling and should preserve
the original source Pod IP.

This patch adds subnet_id checks in the overlay masquerading path for
both IPv4 and IPv6 to skip SNAT when src_subnet_id == dst_subnet_id
(and both are non-zero), allowing same-subnet traffic to retain the
original Pod source IP address.

The subnet_id check is intentionally NOT added in the
enable_remote_node_masquerade=true branch, as that flag represents
user's explicit intent to force SNAT for pod-to-node traffic, which
should not be overridden by automatic subnet-based exclusion.

**Prior PRs (merged):**
- Part 1: #41868 — BPF datapath: LPM trie map, lookup_subnet_id(), tunnel skip logic
- Part 2: #43631 — BPF tests for skip_tunnel flag and subnet-based routing
- Part 3: #43438 — Control plane: SubnetWatcher, dynamic config, StateDB-to-BPF reconciler
- Part 4: #45001 — Core hybrid routing mode support with WireGuard

Fixes:

```release-note
Skip SNAT for same-subnet pod-to-remote-node traffic in hybrid overlay routing mode to preserve original source Pod IP
```