### PR TITLE
refactor(endpointmanager): use GetEndpointsByNamespace in namespace_u…

### DIFF
--- a/pkg/endpointmanager/namespace_updater.go
+++ b/pkg/endpointmanager/namespace_updater.go
@@ -105,47 +105,44 @@ func (u *namespaceUpdater) update(newNS k8sTables.Namespace) error {
 		return nil
 	}
 
-	eps := u.endpointManager.GetEndpoints()
+	eps := u.endpointManager.GetEndpointsByNamespace(newNS.Name)
 	failed := false
 	ciliumIdentityMaxJitter := option.Config.CiliumIdentityMaxJitter
 	for _, ep := range eps {
-		epNS := ep.GetK8sNamespace()
-		if newNS.Name == epNS {
-			// Handle identity label updates
-			if labelsChanged {
-				err := ep.ModifyIdentityLabels(labels.LabelSourceK8s, newIdtyLabels, oldIdtyLabels, ciliumIdentityMaxJitter)
-				if err != nil {
-					u.log.Warn("unable to update endpoint with new identity labels from namespace labels",
-						logfields.Error, err,
-						logfields.EndpointID, ep.ID)
-					failed = true
-				}
+		// Handle identity label updates
+		if labelsChanged {
+			err := ep.ModifyIdentityLabels(labels.LabelSourceK8s, newIdtyLabels, oldIdtyLabels, ciliumIdentityMaxJitter)
+			if err != nil {
+				u.log.Warn("unable to update endpoint with new identity labels from namespace labels",
+					logfields.Error, err,
+					logfields.EndpointID, ep.ID)
+				failed = true
+			}
+		}
+
+		// Handle SIP permission annotation change - re-evaluate all endpoints in this namespace
+		if sipAllowAnnoChanged {
+			// Get pod annotations from the endpoint's cached pod
+			pod := ep.GetPod()
+			var podAnno map[string]string
+			if pod != nil {
+				podAnno = pod.Annotations
 			}
 
-			// Handle SIP permission annotation change - re-evaluate all endpoints in this namespace
-			if sipAllowAnnoChanged {
-				// Get pod annotations from the endpoint's cached pod
-				pod := ep.GetPod()
-				var podAnno map[string]string
-				if pod != nil {
-					podAnno = pod.Annotations
+			// Re-apply SIP verification setting with new namespace annotations
+			if ep.ApplySourceIPVerificationFromAnnotation(podAnno, newNS.Annotations) {
+				u.log.Info("Namespace DelegateSourceIPVerification annotation changed, regenerating endpoint",
+					logfields.K8sNamespace, newNS.Name,
+					logfields.EndpointID, ep.ID,
+					logfields.Value, newSIPAllowAnno)
+
+				// Trigger datapath regeneration if the setting changed
+				regenMetadata := &regeneration.ExternalRegenerationMetadata{
+					Reason:            "namespace DelegateSourceIPVerification annotation changed",
+					RegenerationLevel: regeneration.RegenerateWithDatapath,
 				}
-
-				// Re-apply SIP verification setting with new namespace annotations
-				if ep.ApplySourceIPVerificationFromAnnotation(podAnno, newNS.Annotations) {
-					u.log.Info("Namespace DelegateSourceIPVerification annotation changed, regenerating endpoint",
-						logfields.K8sNamespace, newNS.Name,
-						logfields.EndpointID, ep.ID,
-						logfields.Value, newSIPAllowAnno)
-
-					// Trigger datapath regeneration if the setting changed
-					regenMetadata := &regeneration.ExternalRegenerationMetadata{
-						Reason:            "namespace DelegateSourceIPVerification annotation changed",
-						RegenerationLevel: regeneration.RegenerateWithDatapath,
-					}
-					if regen, _ := ep.SetRegenerateStateIfAlive(regenMetadata); regen {
-						ep.Regenerate(regenMetadata)
-					}
+				if regen, _ := ep.SetRegenerateStateIfAlive(regenMetadata); regen {
+					ep.Regenerate(regenMetadata)
 				}
 			}
 		}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

  refactor(endpointmanager): use GetEndpointsByNamespace in namespace_updater

  Replace GetEndpoints() + manual namespace filter with
  GetEndpointsByNamespace(newNS.Name) in namespaceUpdater.update().

  The previous code fetched all endpoints and filtered by namespace inside
  the loop. GetEndpointsByNamespace() encapsulates the same logic, making
  the intent explicit and avoiding unnecessary iteration over endpoints
  from other namespaces.

Fixes: #issue-number

```release-note
refactor(endpointmanager): use GetEndpointsByNamespace in namespace_updater
```
