### PR TITLE
bpf/lxc: Tail call in `cil_lxc_policy` when IPv4/6-only

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2144,8 +2144,7 @@ out:
 
 TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_INGRESS_POLICY_ONLY,
 		tail_ipv6_ct_ingress_policy_only, CT_INGRESS,
-		(is_defined(ENABLE_IPV4) && is_defined(ENABLE_IPV6)),
-		CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY, tail_ipv6_policy)
+		1, CILIUM_CALL_IPV6_TO_LXC_POLICY_ONLY, tail_ipv6_policy)
 
 TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_INGRESS, tail_ipv6_ct_ingress, CT_INGRESS,
 		1, CILIUM_CALL_IPV6_TO_ENDPOINT, tail_ipv6_to_endpoint)
@@ -2465,7 +2464,7 @@ out:
 
 TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_INGRESS_POLICY_ONLY,
 		tail_ipv4_ct_ingress_policy_only, CT_INGRESS,
-		(is_defined(ENABLE_IPV4) && is_defined(ENABLE_IPV6)),
+		1,
 		CILIUM_CALL_IPV4_TO_LXC_POLICY_ONLY, tail_ipv4_policy)
 
 TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_INGRESS, tail_ipv4_ct_ingress, CT_INGRESS,


### PR DESCRIPTION
When IPv4 is disabled, program `cil_lxc_policy` includes both the ct lookup and the actual policy enforcement. As a result, its stack size culminates at 488 bytes, the largest of all our programs.

The commit splits `cil_lxc_policy` with a tail even when only one of IPv4 or IPv6 is enabled. As a result, when IPv6 is disabled, `cil_lxc_policy`'s stack size drops to 168 bytes. The additional BPF program, `tail_ipv6_policy`, has a stack size of 384 bytes.

This change also has a small impact on the complexity when IPv4 is disabled, reducing the complexity of `cil_lxc_policy` by ~3%.