### PR TITLE
operator/lbipam: prevent IP stealing during pool shrink via two-phase revalidation

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1584,43 +1584,7 @@ func (ipam *LBIPAM) handlePoolModified(ctx context.Context, pool *cilium_api_v2.
 }
 
 func (ipam *LBIPAM) revalidateAllServices(ctx context.Context) error {
-	revalidate := func(sv *ServiceView) error {
-		err := ipam.stripInvalidAllocations(sv)
-		if err != nil {
-			return fmt.Errorf("stripInvalidAllocations: %w", err)
-		}
-
-		// Check for each ingress, if its IP has been allocated by us. If it isn't check if we can allocate that IP.
-		// If we can't, strip the ingress from the service.
-		svModifiedStatus, err := ipam.stripOrImportIngresses(sv)
-		if err != nil {
-			return fmt.Errorf("stripOrImportIngresses: %w", err)
-		}
-
-		// Attempt to satisfy this service in particular now. We do this now instead of relying on
-		// ipam.satisfyServices to avoid updating the service twice in quick succession.
-		if !sv.isSatisfied() {
-			modified, err := ipam.satisfyService(sv)
-			if err != nil {
-				return fmt.Errorf("satisfyService: %w", err)
-			}
-			if modified {
-				svModifiedStatus = true
-			}
-		}
-
-		// If any of the steps above changed the service object, update the object.
-		if svModifiedStatus {
-			err := ipam.patchSvcStatus(ctx, sv)
-			if err != nil {
-				return fmt.Errorf("patchSvcStatus: %w", err)
-			}
-		}
-
-		ipam.serviceStore.Upsert(sv)
-
-		return nil
-	}
+	serviceViews := make([]*ServiceView, 0, len(ipam.serviceStore.satisfied)+len(ipam.serviceStore.unsatisfied))
 
 	// We want to first revalidate all satisfied services.
 	// This helps in case when pool's CIDR was widened
@@ -1628,15 +1592,54 @@ func (ipam *LBIPAM) revalidateAllServices(ctx context.Context) error {
 	// In this case, we want to revalidate satisfied services first,
 	// so that we can reallocate the same IPs from the newly widened CIDR.
 	for _, sv := range ipam.serviceStore.satisfied {
-		if err := revalidate(sv); err != nil {
-			return fmt.Errorf("revalidate: %w", err)
-		}
+		serviceViews = append(serviceViews, sv)
 	}
 
 	for _, sv := range ipam.serviceStore.unsatisfied {
-		if err := revalidate(sv); err != nil {
-			return fmt.Errorf("revalidate: %w", err)
+		serviceViews = append(serviceViews, sv)
+	}
+
+	statusModified := make(map[*ServiceView]bool, len(serviceViews))
+
+	// Re-import any still-valid ingresses for all services before allocating fresh IPs.
+	// This prevents services with removed IPs from stealing addresses that are still valid
+	// for other services during pool shrink or similar range updates.
+	for _, sv := range serviceViews {
+		err := ipam.stripInvalidAllocations(sv)
+		if err != nil {
+			return fmt.Errorf("revalidate: stripInvalidAllocations: %w", err)
 		}
+
+		modified, err := ipam.stripOrImportIngresses(sv)
+		if err != nil {
+			return fmt.Errorf("revalidate: stripOrImportIngresses: %w", err)
+		}
+		if modified {
+			statusModified[sv] = true
+		}
+
+		ipam.serviceStore.Upsert(sv)
+	}
+
+	for _, sv := range serviceViews {
+		if !sv.isSatisfied() {
+			modified, err := ipam.satisfyService(sv)
+			if err != nil {
+				return fmt.Errorf("revalidate: satisfyService: %w", err)
+			}
+			if modified {
+				statusModified[sv] = true
+			}
+		}
+
+		if statusModified[sv] {
+			err := ipam.patchSvcStatus(ctx, sv)
+			if err != nil {
+				return fmt.Errorf("revalidate: patchSvcStatus: %w", err)
+			}
+		}
+
+		ipam.serviceStore.Upsert(sv)
 	}
 
 	return nil

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -2092,6 +2092,92 @@ func TestPoolExtendWithPendingServices(t *testing.T) {
 	}
 }
 
+// TestPoolShrinkWithPendingServices tests that shrinking a pool does not reassign an IP
+// that is still valid for a service with pending requests.
+func TestPoolShrinkWithPendingServices(t *testing.T) {
+	poolA := &cilium_api_v2.CiliumLoadBalancerIPPool{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:              "pool-a",
+			UID:               poolAUID,
+			CreationTimestamp: meta_v1.Date(2022, 10, 16, 12, 00, 00, 0, time.UTC),
+		},
+		Spec: cilium_api_v2.CiliumLoadBalancerIPPoolSpec{
+			Blocks: []cilium_api_v2.CiliumLoadBalancerIPPoolIPBlock{
+				{
+					Start: "10.0.10.10",
+					Stop:  "10.0.10.11",
+				},
+			},
+		},
+	}
+	fixture := mkTestFixture(t, true, true)
+	fixture.UpsertPool(t, poolA)
+
+	svcA := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-a",
+			Namespace: "default",
+			UID:       serviceAUID,
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type: slim_core_v1.ServiceTypeLoadBalancer,
+		},
+	}
+	fixture.UpsertSvc(t, svcA)
+	svcA = fixture.GetSvc("default", "service-a")
+	if len(svcA.Status.LoadBalancer.Ingress) != 1 {
+		t.Fatal("Expected service A to receive exactly one ingress IP")
+	}
+
+	preferDualStack := slim_core_v1.IPFamilyPolicyPreferDualStack
+	svcB := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-b",
+			Namespace: "default",
+			UID:       serviceBUID,
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type:           slim_core_v1.ServiceTypeLoadBalancer,
+			IPFamilyPolicy: &preferDualStack,
+			IPFamilies: []slim_core_v1.IPFamily{
+				slim_core_v1.IPv4Protocol,
+				slim_core_v1.IPv6Protocol,
+			},
+		},
+	}
+	fixture.UpsertSvc(t, svcB)
+	svcB = fixture.GetSvc("default", "service-b")
+	if len(svcB.Status.LoadBalancer.Ingress) != 1 {
+		t.Fatal("Expected service B to receive exactly one ingress IP")
+	}
+
+	serviceBIP := svcB.Status.LoadBalancer.Ingress[0].IP
+
+	poolA = fixture.GetPool("pool-a")
+	poolA.Spec.Blocks = []cilium_api_v2.CiliumLoadBalancerIPPoolIPBlock{
+		{
+			Start: serviceBIP,
+			Stop:  serviceBIP,
+		},
+	}
+	fixture.UpsertPool(t, poolA)
+
+	svcA = fixture.GetSvc("default", "service-a")
+	svcB = fixture.GetSvc("default", "service-b")
+
+	if len(svcA.Status.LoadBalancer.Ingress) != 0 {
+		t.Fatal("Expected service A to lose its ingress after its IP was removed from the pool")
+	}
+
+	if len(svcB.Status.LoadBalancer.Ingress) != 1 {
+		t.Fatal("Expected service B to keep exactly one ingress IP")
+	}
+
+	if svcB.Status.LoadBalancer.Ingress[0].IP != serviceBIP {
+		t.Fatalf("Expected service B to keep ingress IP %q, got %q", serviceBIP, svcB.Status.LoadBalancer.Ingress[0].IP)
+	}
+}
+
 // TestLBIPAM_serviceIPFamilyRequest tests that the correct IP address families are requested in the different
 // combinations of service spec fields and enabled families in the cluster.
 func TestLBIPAM_serviceIPFamilyRequest(t *testing.T) {


### PR DESCRIPTION
Fixes #41458

When a pool shrink removes one service's allocation but leaves another service's ingress IP valid, `revalidateAllServices()` currently processes cleanup, ingress import, and fresh allocation in a single pass. That lets the now-unsatisfied service allocate first and claim an address that should have been preserved for the service whose ingress is still valid.

This change splits revalidation into two phases:

1. Phase 1 drops invalid allocations and re-imports still-valid ingresses for every service, so existing valid addresses are locked back into the allocator before any new allocation happens.
2. Phase 2 only allocates fresh addresses for services that are still unsatisfied after the import pass.

That keeps pool shrink handling deterministic and prevents a service with a removed IP from stealing an address that should remain attached to another service.

A deterministic regression test, `TestPoolShrinkWithPendingServices`, covers the shrink scenario that triggered the reassignment.

Testing:
- `go test ./operator/pkg/lbipam -run TestPoolShrinkWithPendingServices -count=20`
- `go test ./operator/pkg/lbipam -count=1`
- `make lint`
