### PR TITLE
bpf/host: Tail call in `tail_handle_ipv6_from_netdev`

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -470,7 +470,9 @@ tail_handle_ipv6(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 
 	/* TC_ACT_REDIRECT is not an error, but it means we should stop here. */
 	if (ret == CTX_ACT_OK) {
-		bool use_tailcall = is_defined(ENABLE_HOST_FIREWALL);
+		bool use_tailcall = is_defined(ENABLE_HOST_FIREWALL) ||
+				    (!from_host && is_defined(ENABLE_NODEPORT) &&
+				     is_defined(ENABLE_SRV6));
 
 		if (punt_to_stack)
 			return ret;


### PR DESCRIPTION
This commit splits `tail_handle_ipv6_from_netdev` when BPF NodePort is enabled in the datapath, to reduce its complexity. In that case, `handle_ipv6` contains a call to `nodeport_lb6` and it becomes worth splitting `tail_handle_ipv6_from_netdev` into (1) `handle_ipv6` and (2) `handle_ipv6_cont`.

We do the same when the host firewall is enabled, because then handle_ipv6 contains a lot of host firewall logic.