### PR TITLE
endpoint: remove endpoint base64 string in .h file

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -38,16 +38,11 @@ import (
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
-	"github.com/cilium/cilium/pkg/version"
 )
 
 const (
 	// EndpointGenerationTimeout specifies timeout for proxy completion context
 	EndpointGenerationTimeout = 330 * time.Second
-
-	// ciliumCHeaderPrefix is the prefix using when printing/writing an endpoint in a
-	// base64 form.
-	ciliumCHeaderPrefix = "CILIUM_BASE64_"
 )
 
 var (
@@ -84,7 +79,7 @@ func (e *Endpoint) callsMapPath() string {
 }
 
 // writeInformationalComments writes annotations to the specified writer,
-// including a base64 encoding of the endpoint object, and human-readable
+// including information about the endpoint, and human-readable
 // strings describing the configuration of the datapath.
 //
 // For configuration of actual datapath behavior, see WriteEndpointConfig().
@@ -95,22 +90,6 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 
 	fmt.Fprint(fw, "/*\n")
 	fmt.Fprintln(fw, " * This file is not using during compilation of endpoint programs.")
-
-	epStr64, err := e.base64()
-	if err == nil {
-		var verBase64 string
-		verBase64, err = version.Base64()
-		if err == nil {
-			// Current versions ignore the comment, but we need to retain it
-			// so that downgrades work.
-			fmt.Fprintln(fw, " * The line below is retained for backwards compatibility only.")
-			fmt.Fprintf(fw, " * %s%s:%s\n * \n", ciliumCHeaderPrefix,
-				verBase64, epStr64)
-		}
-	}
-	if err != nil {
-		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
-	}
 
 	if cid := e.GetContainerID(); cid == "" {
 		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.dockerNetworkID)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -5,7 +5,6 @@ package endpoint
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -941,15 +940,6 @@ func (e *Endpoint) SetDefaultOpts(opts *option.IntOptions) {
 		}
 	}
 	e.UpdateLogger(nil)
-}
-
-// base64 returns the endpoint in a base64 format.
-func (e *Endpoint) base64() (string, error) {
-	jsonBytes, err := e.MarshalJSON()
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(jsonBytes), nil
 }
 
 // FilterEPDir returns a list of directories' names that possible belong to an endpoint.

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -4,14 +4,10 @@
 package endpoint
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/netip"
 	"os"
@@ -78,7 +74,7 @@ func ReadEPsFromDirNames(ctx context.Context, logger *slog.Logger, parser Endpoi
 			logfields.Path, epDir,
 		)
 
-		state, err := findEndpointState(scopedLogger, epDir)
+		state, err := findEndpointState(epDir)
 		if err != nil {
 			scopedLogger.Warn("Couldn't find state, ignoring endpoint", logfields.Error, err)
 			failed++
@@ -113,51 +109,8 @@ func ReadEPsFromDirNames(ctx context.Context, logger *slog.Logger, parser Endpoi
 
 // findEndpointState finds the JSON representation of an endpoint's state in
 // a directory.
-//
-// It prefers reading from the endpoint state JSON file and falls back to
-// reading from the header.
-func findEndpointState(logger *slog.Logger, dir string) ([]byte, error) {
-	state, err := os.ReadFile(filepath.Join(dir, common.EndpointStateFileName))
-	if err == nil {
-		logger.Debug("Restore from JSON file")
-		return state, nil
-	}
-	if !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	}
-
-	// Fall back to reading state from the C header.
-	// Remove this at some point in the far future.
-	f, err := os.Open(filepath.Join(dir, common.CHeaderFileName))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	logger.Debug("Restore from C header file")
-
-	br := bufio.NewReader(f)
-	var line []byte
-	for {
-		b, err := br.ReadBytes('\n')
-		if errors.Is(err, io.EOF) {
-			return nil, os.ErrNotExist
-		}
-		if err != nil {
-			return nil, err
-		}
-		if bytes.Contains(b, []byte(ciliumCHeaderPrefix)) {
-			line = b
-			break
-		}
-	}
-
-	epSlice := bytes.Split(line, []byte{':'})
-	if len(epSlice) != 2 {
-		return nil, fmt.Errorf("invalid format %q. Should contain a single ':'", line)
-	}
-
-	return base64.StdEncoding.AppendDecode(nil, epSlice[1])
+func findEndpointState(dir string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(dir, common.EndpointStateFileName))
 }
 
 // partitionEPDirNamesByRestoreStatus partitions the provided list of directory

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,8 +4,6 @@
 package version
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"runtime"
@@ -70,15 +68,6 @@ func FromString(versionString string) CiliumVersion {
 var GetCiliumVersion = sync.OnceValue(func() CiliumVersion {
 	return FromString(Version)
 })
-
-// Base64 returns the version in a base64 format.
-func Base64() (string, error) {
-	jsonBytes, err := json.Marshal(Version)
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(jsonBytes), nil
-}
 
 // ParseKernelVersion converts a version string to semver.Version.
 func ParseKernelVersion(ver string) (semver.Version, error) {


### PR DESCRIPTION
In v1.16 the new json file was introduced in 169e53c14 ("endpoint: store state in ep_config.json") and by that point it was both written and read by default. Now, two years later, there are no longer any supported versions of cilium that default to using this file/format.

This also resulted in two JSON marshallings of the same endpoint data during endpoint state dumps, causing more cpu time spent, as well as resulting in more allocations.

There is a benchmark called `BenchmarkWriteHeaderfile` but its pretty much broken testing at scale (aka. it fills up your machines memory) so I'll fix that in a separate PR. As expected this would naturally reduce the allocs in that test significantly since the output is now effectively `O(1)` rather than having eg. `O(|number of identities in dns rules| x |number of ports for dns rules| x |number of protos for dns rules|)`, `O(|dns rules|)` or `O(|dns history|).

This does also remove the base64 encoded version string as well, but we could keep that as a non-base64 version. I still struggle to justify it, so curious if there are other thoughts.

