### PR TITLE
k8s: Allow extensibility of `RemoveCiliumLabels`

### DIFF
--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -197,12 +197,22 @@ type nameLabelsGetter interface {
 	GetLabels() map[string]string
 }
 
+// CiliumOwnedLabelPrefixes contains a list of additional prefixes which are stripped by RemoveCiliumLabels.
+// Vendors might add additional labels to this slices in an init() function.
+var CiliumOwnedLabelPrefixes []string
+
 // RemoveCiliumLabels returns a copy of the given labels map, without the labels owned by Cilium.
 func RemoveCiliumLabels(labels map[string]string) map[string]string {
 	res := map[string]string{}
+nextLabel:
 	for k, v := range labels {
 		if strings.HasPrefix(k, k8sconst.LabelPrefix) {
-			continue
+			continue nextLabel
+		}
+		for _, prefix := range CiliumOwnedLabelPrefixes {
+			if strings.HasPrefix(k, prefix) {
+				continue nextLabel
+			}
 		}
 		res[k] = v
 	}

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"testing"
 
@@ -526,9 +527,12 @@ func TestSanitizePodLabels(t *testing.T) {
 
 func TestStripPodLabels(t *testing.T) {
 	tests := []struct {
-		name   string
-		labels map[string]string
-		want   map[string]string
+		name string
+
+		labels             map[string]string
+		additionalPrefixes []string
+
+		want map[string]string
 	}{
 		{
 			name: "no stripped labels",
@@ -561,10 +565,38 @@ func TestStripPodLabels(t *testing.T) {
 				"app": "foo",
 			},
 		},
+		{
+			name: "Additional owned prefixes unset",
+			labels: map[string]string{
+				"corp.acme.vendor-feature": "qux",
+				"io.cilium.k8s.something":  "cilium internal",
+			},
+			want: map[string]string{
+				"corp.acme.vendor-feature": "qux",
+			},
+		},
+		{
+			name: "Additional owned prefixes provided",
+			labels: map[string]string{
+				"app":                      "foo",
+				"io.cilium.k8s.something":  "cilium internal",
+				"corp.acme.vendor-feature": "qux",
+			},
+			additionalPrefixes: []string{
+				"corp.acme",
+			},
+			want: map[string]string{
+				"app": "foo",
+			},
+		},
 	}
 
+	original := slices.Clone(CiliumOwnedLabelPrefixes)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			CiliumOwnedLabelPrefixes = tt.additionalPrefixes
+			defer func() { CiliumOwnedLabelPrefixes = original }()
+
 			got := StripPodSpecialLabels(tt.labels)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
This commit changes `k8sUtils.RemoveCiliumLabels` to consider an additional list of prefixes when stripping labels from K8s objects.
