### PR TITLE
.github: Auto-label PRs related to Gateway API

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,3 +28,9 @@ sig/policy:
     - pkg/identity/**
     - pkg/proxy/dns.go
     - test/**/net_policies.go
+feature/k8s-gateway-api:
+  - changed-files:
+      - Documentation/network/servicemesh/gateway-api/**
+      - operator/pkg/gateway-api/**
+      - operator/pkg/model/**
+      - vendor/sigs.k8s.io/gateway-api/**


### PR DESCRIPTION
Auto-label PRs to these code areas to help contributors track PRs in this area.
