### PR TITLE
ci-gwapi-conformance: adding longer polling time

### DIFF
--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -72,12 +72,11 @@ func TestConformance(t *testing.T) {
 			})
 		}
 	}
-	// TODO: Run MeshGRPCRouteWeight once it is deflaked upstream. See
-	//       GH-42456 for details.
-	skipTests = append(skipTests, "MeshGRPCRouteWeight")
-	skipTests = append(skipTests, "MeshHTTPRouteMatching")  // same here
-	skipTests = append(skipTests, "MeshHTTPRouteNamedRule") // same here
-	options.TimeoutConfig.DefaultPollInterval = 1 * time.Second
+	// TODO: @xtineskim - Monitor the flakiness of the ci of the following tests after pr-45553 is merged
+	//skipTests = append(skipTests, "MeshGRPCRouteWeight")
+	//skipTests = append(skipTests, "MeshHTTPRouteMatching")  // same here
+	//skipTests = append(skipTests, "MeshHTTPRouteNamedRule") // same here
+	options.TimeoutConfig.DefaultPollInterval = 3 * time.Second
 	options.UnusableNetworkAddresses = unusableNetworkAddresses
 	options.UsableNetworkAddresses = usableNetworkAddresses
 	options.SkipTests = append(options.SkipTests, skipTests...)


### PR DESCRIPTION
<!-- Description of change -->
Increasing the polling time for the gateway api conformance test to be 3 seconds. This is because the Mesh tests don't have enough time to ensure the pods are ready in time.
I believe the resources getting provisioned are just a bit slow, I don't run into the timing issue when running the conformance tests locally. 

Will monitor gateway api test results when they are run to track the flaki-ness of the tests after this is merged.

