### PR TITLE
Use extra power github runner if available for multi-pool CI workflow

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -135,7 +135,7 @@ jobs:
     name: Install and Connectivity Test
     env:
       job_name: "Install and Connectivity Test"
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 120
     steps:
       - name: Set commit status to pending


### PR DESCRIPTION
Successful run: https://github.com/cilium/cilium/actions/runs/24798351780