### PR TITLE
bpf: egressgw: allow FIB lookups with custom tbid

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -118,6 +118,8 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		if (egress_gw_snat_needed_hook_v6((union v6addr *)&ip6->saddr,
 						  &daddr, &snat_addr,
 						  &egress_ifindex)) {
+			__u32 tbid = EGRESS_GATEWAY_RT_TBID;
+
 			if (ipv6_addr_equals(&snat_addr, &EGRESS_GATEWAY_NO_EGRESS_IP_V6))
 				return DROP_NO_EGRESS_IP;
 
@@ -130,7 +132,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
 			return egress_gw_fib_lookup_and_redirect_v6(ctx, &snat_addr,
 								    &daddr, egress_ifindex,
-								    ext_err);
+								    tbid, ext_err);
 		}
 	}
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */
@@ -358,6 +360,8 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 		daddr = ip4->daddr;
 		if (egress_gw_snat_needed_hook(ip4->saddr, daddr, &snat_addr,
 					       &egress_ifindex)) {
+			__u32 tbid = EGRESS_GATEWAY_RT_TBID;
+
 			if (snat_addr == EGRESS_GATEWAY_NO_EGRESS_IP)
 				return DROP_NO_EGRESS_IP;
 
@@ -370,7 +374,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 			/* to-netdev@bpf_host handles SNAT, so no need to do it here. */
 			return egress_gw_fib_lookup_and_redirect(ctx, snat_addr,
 								 daddr, egress_ifindex,
-								 ext_err);
+								 tbid, ext_err);
 		}
 	}
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -10,6 +10,10 @@
 #include "encap.h"
 #include "eps.h"
 
+#ifndef EGRESS_GATEWAY_RT_TBID
+#define EGRESS_GATEWAY_RT_TBID	0
+#endif
+
 struct egress_gw_policy_key {
 	struct bpf_lpm_trie_key lpm_key;
 	__be32 saddr;
@@ -79,19 +83,25 @@ struct {
 
 static __always_inline
 int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, __be32 daddr,
-				      __u32 egress_ifindex, __s8 *ext_err)
+				      __u32 egress_ifindex, __u32 tbid, __s8 *ext_err)
 {
 	struct bpf_fib_lookup_padded fib_params = {};
+	int flags = 0;
 	__u32 oif;
 	int ret;
 
 	/* Immediate redirect to egress_ifindex requires L2 resolution.
 	 * Fall back to FIB lookup on older kernels.
 	 */
-	if (egress_ifindex && neigh_resolver_without_nh_available())
+	if (egress_ifindex && !tbid && neigh_resolver_without_nh_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
-	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
+	if (tbid) {
+		fib_params.l.tbid = tbid;
+		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
+	}
+
+	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, flags);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
@@ -395,22 +405,29 @@ static __always_inline
 int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 					 const union v6addr *egress_ip,
 					 const union v6addr *daddr,
-					 __u32 egress_ifindex, __s8 *ext_err)
+					 __u32 egress_ifindex, __u32 tbid,
+					 __s8 *ext_err)
 {
 	struct bpf_fib_lookup_padded *fib_params;
 	int ret, zero = 0;
+	int flags = 0;
 	__u32 oif;
 
-	if (egress_ifindex && neigh_resolver_without_nh_available())
+	if (egress_ifindex && !tbid && neigh_resolver_without_nh_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
 
 	fib_params = map_lookup_elem(&fib_params_storage, &zero);
 	if (!fib_params)
 		return DROP_INVALID;
 
+	if (tbid) {
+		fib_params->l.tbid = tbid;
+		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
+	}
+
 	ret = (__s8)fib_lookup_v6(ctx, fib_params,
 				  (struct in6_addr *)egress_ip,
-				  (struct in6_addr *)daddr, 0);
+				  (struct in6_addr *)daddr, flags);
 
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -129,6 +129,7 @@ struct ipv4_nat_target {
 	__u32 cluster_id;
 	bool needs_ct;
 	__u32 ifindex; /* Obtained from EGW policy */
+	__u32 tbid;
 };
 
 struct {
@@ -714,6 +715,9 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 		if (!local_ep)
 			target->needs_ct = true;
 
+		if (local_ep && local_ep->rt_info)
+			target->tbid = local_ep->rt_info;
+
 		return NAT_NEEDED;
 	}
 #endif
@@ -1267,6 +1271,7 @@ struct ipv6_nat_target {
 	bool needs_ct;
 	bool egress_gateway; /* NAT is needed because of an egress gateway policy */
 	__u32 ifindex; /* Obtained from EGW policy */
+	__u32 tbid;
 };
 
 struct {
@@ -1713,6 +1718,9 @@ __snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 		/* If the endpoint is local, then the connection is already tracked. */
 		if (!local_ep)
 			target->needs_ct = true;
+
+		if (local_ep && local_ep->rt_info)
+			target->tbid = local_ep->rt_info;
 
 		return NAT_NEEDED;
 	}

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -97,7 +97,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		/* Send packet to the correct egress interface, and SNAT it there. */
 		ret = egress_gw_fib_lookup_and_redirect_v6(ctx, &args->target.addr,
 							   &args->tuple.daddr, args->target.ifindex,
-							   ext_err);
+							   args->target.tbid, ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
 	}
@@ -385,7 +385,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		/* Send packet to the correct egress interface, and SNAT it there. */
 		ret = egress_gw_fib_lookup_and_redirect(ctx, target.addr,
 							tuple.daddr, target.ifindex,
-							ext_err);
+							target.tbid, ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
 

--- a/bpf/tests/lib/endpoint.h
+++ b/bpf/tests/lib/endpoint.h
@@ -5,7 +5,8 @@
 
 static __always_inline void
 endpoint_add_entry(struct endpoint_key *key, __u32 ifindex, __u16 lxc_id, __u32 flags, __u32 sec_id,
-		   __u32 parent_ifindex, const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
+		   __u32 parent_ifindex, __u32 rt_info,
+		   const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
 {
 	struct endpoint_info value = {
 		.ifindex = ifindex,
@@ -13,6 +14,7 @@ endpoint_add_entry(struct endpoint_key *key, __u32 ifindex, __u16 lxc_id, __u32 
 		.flags = flags,
 		.sec_id = sec_id,
 		.parent_ifindex = parent_ifindex,
+		.rt_info = rt_info,
 	};
 
 	if (ep_mac_addr)
@@ -32,8 +34,23 @@ endpoint_v4_add_entry(__be32 addr, __u32 ifindex, __u16 lxc_id, __u32 flags, __u
 	key.ip4.be32 = addr;
 	key.family = ENDPOINT_KEY_IPV4;
 
-	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, parent_ifindex,
+	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, parent_ifindex, 0,
 			   ep_mac_addr, node_mac_addr);
+}
+
+static __always_inline void
+endpoint_v4_add_entry_with_rt_info(__be32 addr, __u32 ifindex, __u16 lxc_id,
+				   __u32 flags, __u32 sec_id,
+				   __u32 parent_ifindex, __u32 rt_info,
+				   const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
+{
+	struct endpoint_key key __align_stack_8 = {};
+
+	key.ip4.be32 = addr;
+	key.family = ENDPOINT_KEY_IPV4;
+
+	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, parent_ifindex,
+			   rt_info, ep_mac_addr, node_mac_addr);
 }
 
 static __always_inline void
@@ -58,7 +75,22 @@ endpoint_v6_add_entry(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
 
 	memcpy(&key.ip6, addr, sizeof(*addr));
 
-	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, 0,
+	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, 0, 0,
+			   ep_mac_addr, node_mac_addr);
+}
+
+static __always_inline void
+endpoint_v6_add_entry_with_rt_info(const union v6addr *addr, __u32 ifindex, __u16 lxc_id,
+				   __u32 flags, __u32 sec_id, __u32 rt_info,
+				   const __u8 *ep_mac_addr, const __u8 *node_mac_addr)
+{
+	struct endpoint_key key __align_stack_8 = {};
+
+	key.family = ENDPOINT_KEY_IPV6;
+
+	memcpy(&key.ip6, addr, sizeof(*addr));
+
+	endpoint_add_entry(&key, ifindex, lxc_id, flags, sec_id, 0, rt_info,
 			   ep_mac_addr, node_mac_addr);
 }
 

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -15,12 +15,120 @@
 #define ENABLE_HOST_FIREWALL		1
 #define ENCAP_IFINDEX 0
 
+#define RT_TBID				3
+
+#define fib_lookup mock_fib_lookup
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused,
+		const struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused);
+
 #include "lib/bpf_host.h"
 
 #include "lib/egressgw.h"
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/metrics.h"
+
+struct fib_lookup_settings {
+	__u32 tbid;
+	bool fib_lookup_called;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct fib_lookup_settings));
+	__uint(max_entries, 1);
+} fib_lookup_settings_map __section_maps_btf;
+
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused,
+		const struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused)
+{
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (settings) {
+		settings->fib_lookup_called = true;
+
+		if (settings->tbid) {
+			if (flags != (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID))
+				return -1;
+
+			if (params->tbid != settings->tbid)
+				return -2;
+		}
+	}
+
+	return 0;
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program egresses locally, using the endpoint's rt_info.
+ */
+PKTGEN("tc", "tc_egressgw_egress1_rt_info")
+int egressgw_egress1_rt_info_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
+}
+
+SETUP("tc", "tc_egressgw_egress1_rt_info")
+int egressgw_egress1_rt_info_setup(struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+	settings->tbid = RT_TBID;
+
+	endpoint_v4_add_entry_with_rt_info(CLIENT_IP, 0, 0, 0, 0, 0, RT_TBID,
+					   NULL, NULL);
+	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST,
+			      0, 0, NULL, NULL);
+	endpoint_v4_add_entry(EGRESS_IP, 0, 0, ENDPOINT_F_HOST,
+			      0, 0, NULL, NULL);
+
+	create_ct_entry(ctx, client_port(TEST_SNAT1));
+
+	ipcache_v4_add_entry(EGRESS_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
+				  EGRESS_IP);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_egress1_rt_info")
+int egressgw_egress1_rt_info_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_OK,
+	});
+	__u32 key = 0;
+
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || !settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	settings->tbid = 0;
+
+	endpoint_v4_del_entry(CLIENT_IP);
+	endpoint_v4_del_entry(GATEWAY_NODE_IP);
+	endpoint_v4_del_entry(EGRESS_IP);
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+
+	return ret;
+}
 
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program gets redirected to the gateway node.
@@ -200,6 +308,77 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 	endpoint_v4_del_entry(GATEWAY_NODE_IP);
 
 	test_finish();
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program egresses locally, using the endpoint's rt_info.
+ */
+PKTGEN("tc", "tc_egressgw_egress1_rt_info_v6")
+int egressgw_egress1_rt_info_v6_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
+}
+
+SETUP("tc", "tc_egressgw_egress1_rt_info_v6")
+int egressgw_egress1_rt_info_v6_setup(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+	settings->tbid = RT_TBID;
+
+	endpoint_v6_add_entry_with_rt_info(&client_ip, 0, 0, 0, 0, RT_TBID,
+					   NULL, NULL);
+	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST,
+			      0, 0, NULL, NULL);
+	endpoint_v6_add_entry(&egress_ip, 0, 0, ENDPOINT_F_HOST,
+			      0, NULL, NULL);
+
+	create_ct_entry_v6(ctx, client_port(TEST_SNAT1));
+
+	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
+	ipcache_v6_add_world_entry();
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip, 0);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_egress1_rt_info_v6")
+int egressgw_egress1_rt_info_v6_check(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_OK,
+	});
+	__u32 key = 0;
+
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || !settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	settings->tbid = 0;
+
+	endpoint_v6_del_entry(&client_ip);
+	endpoint_v4_del_entry(GATEWAY_NODE_IP);
+	endpoint_v6_del_entry(&egress_ip);
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
 }
 
 /* Test that a packet matching an egress gateway policy on the to-netdev

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_rt_info.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_rt_info.c
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE_IPV4		1
+#define ENABLE_MASQUERADE_IPV6		1
+#define ENCAP_IFINDEX	42
+#define IFACE_IFINDEX	44
+
+#define EGRESS_GATEWAY_RT_TBID		3
+
+#define fib_lookup mock_fib_lookup
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused);
+
+#define skb_get_tunnel_key mock_skb_get_tunnel_key
+static int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
+				   struct bpf_tunnel_key *to,
+				   __maybe_unused __u32 size,
+				   __maybe_unused __u32 flags)
+{
+	to->remote_ipv4 = v4_node_one;
+	/* 0xfffff is the default SECLABEL */
+	to->tunnel_id = 0xfffff;
+	return 0;
+}
+
+#include "lib/bpf_overlay.h"
+
+#include "lib/egressgw.h"
+#include "lib/ipcache.h"
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == IFACE_IFINDEX)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_OK;
+}
+
+struct fib_lookup_settings {
+	bool fib_lookup_called;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct fib_lookup_settings));
+	__uint(max_entries, 1);
+} fib_lookup_settings_map __section_maps_btf;
+
+static __always_inline __maybe_unused long
+mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+		int plen __maybe_unused, __u32 flags __maybe_unused)
+{
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (settings) {
+		settings->fib_lookup_called = true;
+
+		if (flags != (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID))
+			return -1;
+
+		if (params->tbid != EGRESS_GATEWAY_RT_TBID)
+			return -2;
+	}
+
+	params->ifindex = IFACE_IFINDEX;
+	return 0;
+}
+
+/* Test that a packet matching an egress gateway policy on the from-overlay program
+ * gets correctly redirected to the target netdev.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_rt_info")
+int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_egressgw_redirect_from_overlay_with_rt_info")
+int egressgw_redirect_setup(struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
+				  EGRESS_IP);
+
+	return overlay_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_redirect_from_overlay_with_rt_info")
+int egressgw_redirect_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+	__u32 key = 0;
+
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || !settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the from-overlay program
+ * gets correctly redirected to the target netdev for IPv6.
+ */
+PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
+int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+			.redirect = true,
+		});
+}
+
+SETUP("tc", "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
+int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip, 0);
+
+	return overlay_receive_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
+int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
+	__u32 key = 0;
+
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || !settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
+
+	return ret;
+}

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -888,6 +888,7 @@ type SNATV6Args struct {
 		EgressGateway     bool
 		_                 [1]byte
 		IfIndex           uint32
+		Tbid              uint32
 	}
 	Trace struct {
 		_       structs.HostLayout


### PR DESCRIPTION
Wire up an endpoint's rt_info for the FIB lookup in EGW. This enables
endpoints that match an EGW policy and egress on the local node to use
custom routing.

This builds on-top of the changes introduced by https://github.com/cilium/cilium/pull/44319.