### PR TITLE
gateway-api: Move Watch handlers into dedicated module

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -63,19 +63,6 @@ var Cell = cell.Module(
 	cell.Provide(registerSecretSync),
 )
 
-var requiredGVKs = []schema.GroupVersionKind{
-	gatewayv1.SchemeGroupVersion.WithKind(helpers.GatewayClassKind),
-	gatewayv1.SchemeGroupVersion.WithKind(helpers.GatewayKind),
-	gatewayv1.SchemeGroupVersion.WithKind(helpers.HTTPRouteKind),
-	gatewayv1.SchemeGroupVersion.WithKind(helpers.GRPCRouteKind),
-	gatewayv1.SchemeGroupVersion.WithKind(helpers.ReferenceGrantKind),
-}
-
-var optionalGVKs = []schema.GroupVersionKind{
-	gatewayv1.SchemeGroupVersion.WithKind(helpers.TLSRouteKind),
-	mcsapiv1beta1.SchemeGroupVersion.WithKind(helpers.ServiceImportKind),
-}
-
 // gatewayAPIPreconditions holds the result of Gateway API precondition checks.
 // This is provided privately and consumed by both initGatewayAPIController
 // and registerSecretSync to ensure consistent behavior.
@@ -130,8 +117,8 @@ func newGatewayAPIPreconditions(params preconditionParams) (*gatewayAPIPrecondit
 func discoverCRDsWithRetry(ctx context.Context, client k8sClient.Clientset, logger *slog.Logger, health cell.Health) (*gatewayAPIPreconditions, error) {
 	logger.Info(
 		"Checking for required and optional GatewayAPI resources",
-		logfields.RequiredGVK, requiredGVKs,
-		logfields.OptionalGVK, optionalGVKs,
+		logfields.RequiredGVK, helpers.RequiredGVKs,
+		logfields.OptionalGVK, helpers.AllOptionalKinds,
 	)
 
 	// Configure exponential backoff for CRD discovery.
@@ -146,7 +133,7 @@ func discoverCRDsWithRetry(ctx context.Context, client k8sClient.Clientset, logg
 	}
 
 	for {
-		installedKinds, err := checkCRDs(ctx, client, logger, requiredGVKs, optionalGVKs)
+		installedKinds, err := checkCRDs(ctx, client, logger, helpers.RequiredGVKs, helpers.AllOptionalKinds)
 		if err == nil {
 			health.OK("Gateway API CRDs discovered")
 			return &gatewayAPIPreconditions{

--- a/operator/pkg/gateway-api/cell_test.go
+++ b/operator/pkg/gateway-api/cell_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sTesting "k8s.io/client-go/testing"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -118,7 +119,7 @@ func makeGatewayCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResource
 // installRequiredCRDs creates the required Gateway API CRDs in the fake apiextensions client.
 func installRequiredCRDs(t *testing.T, fcs *k8sClient.FakeClientset) {
 	t.Helper()
-	for _, gvk := range requiredGVKs {
+	for _, gvk := range helpers.RequiredGVKs {
 		crd := makeGatewayCRD(gvk)
 		_, err := fcs.APIExtFakeClientset.ApiextensionsV1().CustomResourceDefinitions().Create(
 			t.Context(), crd, metav1.CreateOptions{},
@@ -173,7 +174,7 @@ func TestDiscoverCRDsWithRetry_TransientErrorThenSuccess(t *testing.T) {
 	var callCount atomic.Int32
 	fcs.APIExtFakeClientset.PrependReactor("get", "customresourcedefinitions",
 		func(action k8sTesting.Action) (bool, runtime.Object, error) {
-			if callCount.Add(1) <= int32(len(requiredGVKs)) {
+			if callCount.Add(1) <= int32(len(helpers.RequiredGVKs)) {
 				return true, nil, syscall.ECONNREFUSED
 			}
 			return false, nil, nil
@@ -188,7 +189,7 @@ func TestDiscoverCRDsWithRetry_TransientErrorThenSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.Enabled)
 	assert.Equal(t, cell.StatusOK, simpleHealth.Level)
-	assert.Greater(t, int(callCount.Load()), len(requiredGVKs))
+	assert.Greater(t, int(callCount.Load()), len(helpers.RequiredGVKs))
 }
 
 func TestDiscoverCRDsWithRetry_TransientErrorUntilTimeout(t *testing.T) {

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -45,94 +43,6 @@ func hasMatchingController(ctx context.Context, c client.Client, controllerName 
 
 		return string(gwc.Spec.ControllerName) == controllerName
 	}
-}
-
-func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Object, logger *slog.Logger) []*gatewayv1.Gateway {
-	scopedLog := logger.With(
-		logfields.Resource, obj.GetName(),
-	)
-
-	gwList := &gatewayv1.GatewayList{}
-	if err := c.List(ctx, gwList); err != nil {
-		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
-		return nil
-	}
-
-	var gateways []*gatewayv1.Gateway
-	for _, gw := range gwList.Items {
-		for _, l := range gw.Spec.Listeners {
-			if l.TLS == nil {
-				continue
-			}
-
-			for _, cert := range l.TLS.CertificateRefs {
-				if !helpers.IsSecret(cert) {
-					continue
-				}
-				ns := helpers.NamespaceDerefOr(cert.Namespace, gw.GetNamespace())
-				if string(cert.Name) == obj.GetName() && ns == obj.GetNamespace() {
-					gateways = append(gateways, &gw)
-				}
-			}
-		}
-	}
-	return gateways
-}
-
-func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Object, logger *slog.Logger) []types.NamespacedName {
-	scopedLog := logger.With(
-		logfields.K8sNamespace, ns.GetName(),
-	)
-
-	gwList := &gatewayv1.GatewayList{}
-	if err := c.List(ctx, gwList); err != nil {
-		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
-		return nil
-	}
-
-	var gateways []types.NamespacedName
-	for _, gw := range gwList.Items {
-		for _, l := range gw.Spec.Listeners {
-			if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
-				continue
-			}
-
-			switch *l.AllowedRoutes.Namespaces.From {
-			case gatewayv1.NamespacesFromAll:
-				gateways = append(gateways, client.ObjectKey{
-					Namespace: gw.GetNamespace(),
-					Name:      gw.GetName(),
-				})
-			case gatewayv1.NamespacesFromSame:
-				if ns.GetName() == gw.GetNamespace() {
-					gateways = append(gateways, client.ObjectKey{
-						Namespace: gw.GetNamespace(),
-						Name:      gw.GetName(),
-					})
-				}
-			case gatewayv1.NamespacesFromSelector:
-				if l.AllowedRoutes.Namespaces.Selector == nil {
-					scopedLog.WarnContext(ctx, "AllowedRoutes namespace set to Selector but no selector specified", logfields.Gateway, gw.GetName())
-					continue
-				}
-				nsList := &corev1.NamespaceList{}
-				err := c.List(ctx, nsList, client.MatchingLabels(l.AllowedRoutes.Namespaces.Selector.MatchLabels))
-				if err != nil {
-					scopedLog.WarnContext(ctx, "Unable to list Namespaces", logfields.Error, err)
-					return nil
-				}
-				for _, item := range nsList.Items {
-					if item.GetName() == ns.GetName() {
-						gateways = append(gateways, client.ObjectKey{
-							Namespace: gw.GetNamespace(),
-							Name:      gw.GetName(),
-						})
-					}
-				}
-			}
-		}
-	}
-	return gateways
 }
 
 // onlyStatusChanged returns true if and only if there is status change for underlying objects.

--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -13,12 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,39 +24,7 @@ import (
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
-
-func testScheme() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(ciliumv2.AddToScheme(scheme))
-	utilruntime.Must(ciliumv2alpha1.AddToScheme(scheme))
-	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
-
-	registerGatewayAPITypesToScheme(scheme, optionalGVKs)
-
-	return scheme
-}
-
-func testSchemeNoServiceImport() *runtime.Scheme {
-	scheme := runtime.NewScheme()
-
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(ciliumv2.AddToScheme(scheme))
-	utilruntime.Must(ciliumv2alpha1.AddToScheme(scheme))
-	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
-
-	noMCSGVKs := []schema.GroupVersionKind{
-		gatewayv1.SchemeGroupVersion.WithKind(helpers.TLSRouteKind),
-	}
-
-	registerGatewayAPITypesToScheme(scheme, noMCSGVKs)
-
-	return scheme
-}
 
 var controllerTestFixture = []client.Object{
 	// Cilium Gateway Class
@@ -261,38 +224,9 @@ var controllerTestFixture = []client.Object{
 	},
 }
 
-var namespaceFixtures = []client.Object{
-	&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
-		},
-	},
-	&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "another-namespace",
-		},
-	},
-	&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "namespace-with-allowed-gateway-selector",
-			Labels: map[string]string{
-				"gateway": "allowed",
-			},
-		},
-	},
-	&corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "namespace-with-disallowed-gateway-selector",
-			Labels: map[string]string{
-				"gateway": "disallowed",
-			},
-		},
-	},
-}
-
 func Test_hasMatchingController(t *testing.T) {
 	logger := hivetest.Logger(t)
-	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(controllerTestFixture...).Build()
+	c := fake.NewClientBuilder().WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).WithObjects(controllerTestFixture...).Build()
 	fn := hasMatchingController(t.Context(), c, "io.cilium/gateway-controller", logger)
 
 	t.Run("invalid object", func(t *testing.T) {
@@ -321,7 +255,7 @@ func Test_hasMatchingController(t *testing.T) {
 
 func Test_gatewayReconcilePredicate(t *testing.T) {
 	logger := hivetest.Logger(t)
-	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(controllerTestFixture...).Build()
+	c := fake.NewClientBuilder().WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).WithObjects(controllerTestFixture...).Build()
 	predicate := gatewayOwnedByController(hasMatchingController(t.Context(), c, controllerName, logger))
 
 	t.Run("update keeps handoff reconcile when old gateway matched", func(t *testing.T) {
@@ -365,88 +299,6 @@ func Test_gatewayClassReconcilePredicate(t *testing.T) {
 			},
 		}))
 	})
-}
-
-func Test_getGatewaysForSecret(t *testing.T) {
-	c := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(controllerTestFixture...).Build()
-	logger := hivetest.Logger(t)
-
-	t.Run("secret is used in gateway", func(t *testing.T) {
-		gwList := getGatewaysForSecret(t.Context(), c, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "tls-secret",
-				Namespace: "default",
-			},
-		}, logger)
-
-		require.Len(t, gwList, 1)
-		require.Equal(t, "valid-gateway", gwList[0].Name)
-	})
-
-	t.Run("secret is not used in gateway", func(t *testing.T) {
-		gwList := getGatewaysForSecret(t.Context(), c, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "tls-secret-not-used",
-				Namespace: "default",
-			},
-		}, logger)
-
-		require.Empty(t, gwList)
-	})
-}
-
-func Test_getGatewaysForNamespace(t *testing.T) {
-	c := fake.NewClientBuilder().
-		WithScheme(testScheme()).
-		WithObjects(namespaceFixtures...).
-		WithObjects(controllerTestFixture...).
-		Build()
-	logger := hivetest.Logger(t)
-
-	type args struct {
-		namespace string
-	}
-
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "with default namespace",
-			args: args{namespace: "default"},
-			want: []string{"gateway-from-all-namespaces", "gateway-from-same-namespace"},
-		},
-		{
-			name: "with another namespace",
-			args: args{namespace: "another-namespace"},
-			want: []string{"gateway-from-all-namespaces"},
-		},
-		{
-			name: "with namespace-with-allowed-gateway-selector",
-			args: args{namespace: "namespace-with-allowed-gateway-selector"},
-			want: []string{"gateway-from-all-namespaces", "gateway-with-namespaces-selector"},
-		},
-		{
-			name: "with namespace-with-disallowed-gateway-selector",
-			args: args{namespace: "namespace-with-disallowed-gateway-selector"},
-			want: []string{"gateway-from-all-namespaces"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gwList := getGatewaysForNamespace(t.Context(), c, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: tt.args.namespace,
-				},
-			}, logger)
-			names := make([]string, 0, len(gwList))
-			for _, gw := range gwList {
-				names = append(names, gw.Name)
-			}
-			require.ElementsMatch(t, tt.want, names)
-		})
-	}
 }
 
 func Test_success(t *testing.T) {

--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -8,18 +8,13 @@ import (
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -65,127 +60,13 @@ func (r *gammaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch its own resource
 		For(&corev1.Service{}).
 		// Watch HTTPRoute linked to Service
-		Watches(&gatewayv1.HTTPRoute{}, r.enqueueRequestForOwningHTTPRoute(r.logger)).
+		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForGAMMAHTTPRoute(r.Client, r.logger)).
 		// Watch GRPCRoute linked to Service
-		Watches(&gatewayv1.GRPCRoute{}, r.enqueueRequestForOwningGRPCRoute(r.logger)).
+		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForGAMMAGRPCRoute(r.Client, r.logger)).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
+		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForGAMMAReferenceGrant(r.Client, r.logger)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{})
 
 	return gammaBuilder.Complete(r)
-}
-
-// enqueueRequestForOwningHTTPRoute returns an event handler for any changes with HTTP Routes
-// belonging to the given Service
-func (r *gammaReconciler) enqueueRequestForOwningHTTPRoute(logger *slog.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		hr, ok := a.(*gatewayv1.HTTPRoute)
-		if !ok {
-			return nil
-		}
-
-		return getGammaReconcileRequestsForRoute(ctx, r.Client, a, hr.Spec.CommonRouteSpec, logger, hr.Kind)
-	})
-}
-
-// enqueueRequestForOwningGRPCRoute returns an event handler for any changes with GRPC Routes
-// belonging to the given Service
-func (r *gammaReconciler) enqueueRequestForOwningGRPCRoute(logger *slog.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		grpcr, ok := a.(*gatewayv1.GRPCRoute)
-		if !ok {
-			return nil
-		}
-
-		return getGammaReconcileRequestsForRoute(ctx, r.Client, a, grpcr.Spec.CommonRouteSpec, logger, grpcr.Kind)
-	})
-}
-
-func (r *gammaReconciler) enqueueRequestForReferenceGrant() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(r.enqueueAll())
-}
-
-func (r *gammaReconciler) enqueueAll() handler.MapFunc {
-	// TODO(youngnick): This approach will scale poorly with large numbers of
-	// Services; each ReferenceGrant update will trigger reconciliation of _all_ Services.
-	return func(ctx context.Context, o client.Object) []reconcile.Request {
-		scopedLog := r.logger.With(
-			logfields.Resource, client.ObjectKeyFromObject(o),
-		)
-		list := &corev1.ServiceList{}
-
-		if err := r.Client.List(ctx, list, &client.ListOptions{}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to list Service", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		requests := make([]reconcile.Request, 0, len(list.Items))
-		for _, item := range list.Items {
-			svc := client.ObjectKey{
-				Namespace: item.GetNamespace(),
-				Name:      item.GetName(),
-			}
-			requests = append(requests, reconcile.Request{
-				NamespacedName: svc,
-			})
-			scopedLog.InfoContext(ctx, "Enqueued Service for resource", gamma, svc)
-		}
-		return requests
-	}
-}
-
-// getGammaReconcileRequestsForRoute returns a list of GAMMA services to be reconciled based on the supplied route.
-func getGammaReconcileRequestsForRoute(ctx context.Context, c client.Client, object metav1.Object, route gatewayv1.CommonRouteSpec, logger *slog.Logger, objKind string) []reconcile.Request {
-	var reqs []reconcile.Request
-
-	scopedLog := logger.With(
-		logfields.Resource, types.NamespacedName{
-			Namespace: object.GetNamespace(),
-			Name:      object.GetName(),
-		},
-	)
-
-	for _, parent := range route.ParentRefs {
-		if helpers.IsGateway(parent) {
-			continue
-		}
-
-		ns := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
-
-		s := &corev1.Service{}
-		if err := c.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      string(parent.Name),
-		}, s); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				scopedLog.ErrorContext(ctx, "Failed to get Gamma Service", logfields.Error, err)
-			}
-			continue
-		}
-
-		if !isValidGammaService(s) {
-			scopedLog.WarnContext(ctx, "Service referenced as GAMMA parent is not valid")
-			continue
-		}
-
-		scopedLog.InfoContext(ctx, "Enqueued GAMMA Service for Route",
-			logfields.K8sNamespace, ns,
-			logfields.ParentResource, parent.Name,
-			logfields.Kind, objKind,
-			logfields.Route, object.GetName())
-
-		reqs = append(reqs, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: ns,
-				Name:      string(parent.Name),
-			},
-		})
-	}
-
-	return reqs
-}
-
-func isValidGammaService(svc *corev1.Service) bool {
-	return svc.Spec.Type == corev1.ServiceTypeClusterIP
 }

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
@@ -90,7 +91,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 					input := readInputDir(t, fmt.Sprintf("testdata/gamma/%s/input", tt.name))
 
 					c := fake.NewClientBuilder().
-						WithScheme(testScheme()).
+						WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 						WithObjects(append(base, input...)...).
 						WithIndex(&gatewayv1.HTTPRoute{}, indexers.GammaHTTPRouteParentRefsIndex, indexers.IndexHTTPRouteByGammaService).
 						WithIndex(&gatewayv1.GRPCRoute{}, indexers.GammaGRPCRouteParentRefsIndex, indexers.IndexGRPCRouteByGammaService).

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -7,28 +7,21 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
-	"slices"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -134,39 +127,39 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(gatewayOwnedByController(hasMatchingControllerFn))).
 		// Watch GatewayClass resources, which are linked to Gateway
 		Watches(&gatewayv1.GatewayClass{},
-			r.enqueueRequestForOwningGatewayClass(),
+			watchhandlers.EnqueueRequestForOwningGatewayClass(r.Client, *r.logger),
 			builder.WithPredicates(gatewayClassOwnedByController(controllerName))).
 		// Watch related backend Service for status
 		// LB Services are handled by the Owns call later.
-		Watches(&corev1.Service{}, r.enqueueRequestForBackendService()).
+		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, *r.logger)).
 		// Watch HTTPRoute linked to Gateway
-		Watches(&gatewayv1.HTTPRoute{}, r.enqueueRequestForOwningHTTPRoute(r.logger)).
+		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, controllerName)).
 		// Watch GRPCRoute linked to Gateway
-		Watches(&gatewayv1.GRPCRoute{}, r.enqueueRequestForOwningGRPCRoute()).
+		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForOwningGRPCRoute(r.Client, r.logger, controllerName)).
 		// Watch related secrets used to configure TLS
 		Watches(&corev1.Secret{},
-			r.enqueueRequestForTLSSecret(),
+			watchhandlers.EnqueueRequestForTLSSecret(r.Client, r.logger),
 			builder.WithPredicates(predicate.NewPredicateFuncs(r.usedInGateway))).
 		// Watch related namespace in allowed namespaces
 		Watches(&corev1.Namespace{},
-			r.enqueueRequestForAllowedNamespace()).
+			watchhandlers.EnqueueRequestForAllowedNamespace(r.Client, r.logger)).
 		// Watch for changes to Reference Grants
-		Watches(&gatewayv1.ReferenceGrant{}, r.enqueueRequestForReferenceGrant()).
+		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForReferenceGrant(r.Client, r.logger)).
 		// Watch for changes to BackendTLSPolicy
-		Watches(&gatewayv1.BackendTLSPolicy{}, r.enqueueRequestForBackendTLSPolicy()).
-		Watches(&corev1.ConfigMap{}, r.enqueueRequestForBackendTLSPolicyConfigMap()).
+		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger)).
+		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{})
 
 	if tlsRouteEnabled {
 		// Watch TLSRoute linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.TLSRoute{}, r.enqueueRequestForOwningTLSRoute(r.logger))
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, controllerName))
 	}
 
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports
-		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, r.enqueueRequestForBackendServiceImport())
+		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, watchhandlers.EnqueueRequestForBackendServiceImport(r.Client, *r.logger))
 	}
 
 	return gatewayBuilder.Complete(r)
@@ -211,523 +204,6 @@ func gatewayClassOwnedByController(controllerName string) predicate.Predicate {
 	}
 }
 
-// enqueueRequestForOwningGatewayClass returns an event handler that, when given a GatewayClass,
-// returns reconcile.Requests for all Gateway objects belonging to the given GatewayClass.
-func (r *gatewayReconciler) enqueueRequestForOwningGatewayClass() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		scopedLog := r.logger.With(
-			logfields.Resource, client.ObjectKeyFromObject(a).String(),
-		)
-		var reqs []reconcile.Request
-		gwList := &gatewayv1.GatewayList{}
-		if err := r.Client.List(ctx, gwList); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to list Gateways")
-			return nil
-		}
-
-		for _, gw := range gwList.Items {
-			if gw.Spec.GatewayClassName != gatewayv1.ObjectName(a.GetName()) {
-				continue
-			}
-			req := reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: gw.Namespace,
-					Name:      gw.Name,
-				},
-			}
-			reqs = append(reqs, req)
-			scopedLog.InfoContext(ctx,
-				"Queueing gateway",
-				logfields.K8sNamespace, gw.GetNamespace(),
-				gateway, gw.GetName(),
-			)
-		}
-		return reqs
-	})
-}
-
-// enqueueRequestForOwningHTTPRoute returns an event handler that, when passed a HTTPRoute, returns reconcile.Requests
-// for all Cilium-relevant Gateways associated with that HTTPRoute.
-func (r *gatewayReconciler) enqueueRequestForOwningHTTPRoute(logger *slog.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		hr, ok := a.(*gatewayv1.HTTPRoute)
-		if !ok {
-			return nil
-		}
-
-		return getGatewayReconcileRequestsForRoute(context.Background(), r.Client, a, hr.Spec.CommonRouteSpec, logger)
-	})
-}
-
-// enqueueRequestForOwningTLSRoute returns an event handler that, when passed a TLSRoute, returns reconcile.Requests
-// for all Cilium-relevant Gateways associated with that TLSRoute.
-func (r *gatewayReconciler) enqueueRequestForOwningTLSRoute(logger *slog.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		hr, ok := a.(*gatewayv1.TLSRoute)
-		if !ok {
-			return nil
-		}
-
-		return getGatewayReconcileRequestsForRoute(context.Background(), r.Client, a, hr.Spec.CommonRouteSpec, logger)
-	})
-}
-
-// enqueueRequestForOwningGRPCRoute returns an event handler that, when passed a GRPCRoute, returns reconcile.Requests
-// for any Cilium-relevant Gateways associated with that GRPCRoute.
-func (r *gatewayReconciler) enqueueRequestForOwningGRPCRoute() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		gr, ok := a.(*gatewayv1.GRPCRoute)
-		if !ok {
-			return nil
-		}
-
-		return getGatewayReconcileRequestsForRoute(ctx, r.Client, a, gr.Spec.CommonRouteSpec, r.logger)
-	})
-}
-
-// enqueueRequestForBackendService returns an event handler that, when passed a Service, returns reconcile.Requests
-// for all Cilium-relevant Gateways where that Service is used as a backend for a HTTPRoute that is attached to that Gateway.
-func (r *gatewayReconciler) enqueueRequestForBackendService() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		_, ok := o.(*corev1.Service)
-		if !ok {
-			return nil
-		}
-
-		scopedLog := r.logger.With(logfields.LogSubsys, "queue-gw-from-backend-svc")
-
-		// Make a set to hold all reconcile requests
-		reconcileRequests := make(map[reconcile.Request]struct{})
-
-		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
-		hrList := &gatewayv1.HTTPRouteList{}
-
-		if err := r.Client.List(ctx, hrList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceHTTPRouteIndex, client.ObjectKeyFromObject(o).String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		// Then, fetch all TLSRoutes that reference this service, using the backendServiceIndex
-		tlsrList := &gatewayv1.TLSRouteList{}
-
-		if err := r.Client.List(ctx, tlsrList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceTLSRouteIndex, client.ObjectKeyFromObject(o).String()),
-		}); err != nil {
-			scopedLog.Error("Failed to get related HTTPRoutes", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		grpcRouteList := &gatewayv1.GRPCRouteList{}
-		if err := r.Client.List(ctx, grpcRouteList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceGRPCRouteIndex, client.ObjectKeyFromObject(o).String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to list GRPCRoutes", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
-		gwList := &gatewayv1.GatewayList{}
-		if err := r.Client.List(ctx, gwList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		// Build a set of all Cilium Gateway full names.
-		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet := make(map[string]struct{})
-
-		for _, gw := range gwList.Items {
-			gwFullName := types.NamespacedName{
-				Name:      gw.GetName(),
-				Namespace: gw.GetNamespace(),
-			}
-			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
-		}
-
-		// iterate through the HTTPRoutes, update reconcileRequests for each Gateway that is relevant.
-		for _, hr := range hrList.Items {
-			updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
-		}
-
-		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
-		for _, tlsr := range tlsrList.Items {
-			updateReconcileRequestsForParentRefs(tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
-		}
-
-		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
-		for _, grpcr := range grpcRouteList.Items {
-			updateReconcileRequestsForParentRefs(grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
-		}
-
-		// return the keys of the set, since that's the actual reconcile.Requests.
-		return slices.Collect(maps.Keys(reconcileRequests))
-	})
-}
-
-// enqueueRequestForBackendTLSPolicy returns an event handler that, when passed a BackendTLSPolicy, returns reconcile.Requests
-// for all Cilium-relevant Gateways where that BackendTLSPolicy references a Service that is used as a backend for a
-// Route that is attached to that Gateway.
-func (r *gatewayReconciler) enqueueRequestForBackendTLSPolicy() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		scopedLog := r.logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy")
-
-		reconcileRequests := make(map[reconcile.Request]struct{})
-		btlsp, ok := o.(*gatewayv1.BackendTLSPolicy)
-		if !ok {
-			return nil
-		}
-
-		// Build a set of all Cilium Gateway full names.
-		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet, err := r.getAllCiliumGatewaysSet(ctx)
-		if err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		ns := o.GetNamespace()
-		r.updateReconcileRequestsForBackendTLSPolicy(ctx, scopedLog, allCiliumGatewaysSet, reconcileRequests, btlsp, ns)
-
-		recs := slices.Collect(maps.Keys(reconcileRequests))
-		if len(recs) > 0 {
-			scopedLog.Debug("BackendTLSPolicy relevant to Gateways",
-				logfields.Resource, client.ObjectKeyFromObject(o).String(),
-				logfields.Gateway, recs)
-		}
-		return slices.Collect(maps.Keys(reconcileRequests))
-	})
-}
-
-func (r *gatewayReconciler) enqueueRequestForBackendTLSPolicyConfigMap() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		scopedLog := r.logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy-configmap")
-
-		cfgMap, ok := o.(*corev1.ConfigMap)
-		if !ok {
-			return []reconcile.Request{}
-		}
-
-		cfgMapName := types.NamespacedName{
-			Name:      cfgMap.GetName(),
-			Namespace: cfgMap.GetNamespace(),
-		}
-
-		// Fetch all BackendTLSPolicies that reference this ConfigMap
-		btlspList := &gatewayv1.BackendTLSPolicyList{}
-
-		if err := r.Client.List(ctx, btlspList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.BackendTLSPolicyConfigMapIndex, cfgMapName.String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get related BackendTLSPolicies for ConfigMap", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-		// If there are no relevant BackendTLSPolicies, then we can skip this ConfigMap.
-		if len(btlspList.Items) == 0 {
-			return []reconcile.Request{}
-		}
-
-		// Build a set of all Cilium Gateway full names.
-		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet, err := r.getAllCiliumGatewaysSet(ctx)
-		if err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		reconcileRequests := make(map[reconcile.Request]struct{})
-
-		for _, btlsp := range btlspList.Items {
-
-			if len(btlsp.Spec.Validation.CACertificateRefs) == 0 {
-				// There are no ConfigMaps specified in this BackendTLSPolicy,
-				// so this enqueue function doesn't care about it.
-				continue
-			}
-
-			configMapReferenced := false
-
-			for _, caRef := range btlsp.Spec.Validation.CACertificateRefs {
-				if caRef.Group == "" && caRef.Kind == "ConfigMap" && string(caRef.Name) == cfgMap.GetName() {
-					configMapReferenced = true
-				}
-			}
-
-			if !configMapReferenced {
-				// Enqueue only cares about ConfigMaps that are referenced by a BackendTLSPolicy
-				// If there are no references to this ConfigMap, this BackendTLSPolicy is not relevant.
-				continue
-			}
-
-			// This BackendTLSPolicy references the ConfigMap being enqueued, check to see if it's in the
-			// ownership chain any Cilium-relevant Gateways.
-			r.updateReconcileRequestsForBackendTLSPolicy(ctx, scopedLog, allCiliumGatewaysSet, reconcileRequests, &btlsp, cfgMap.GetNamespace())
-
-		}
-		recs := slices.Collect(maps.Keys(reconcileRequests))
-		if len(recs) > 0 {
-			scopedLog.Debug("ConfigMap in BackendTLSPolicy relevant to Gateways",
-				logfields.Resource, client.ObjectKeyFromObject(o).String(),
-				logfields.Gateway, recs)
-		}
-		return recs
-	})
-}
-
-func (r *gatewayReconciler) updateReconcileRequestsForBackendTLSPolicy(ctx context.Context,
-	scopedLog *slog.Logger,
-	allGatewaysSet map[string]struct{},
-	rrSet map[reconcile.Request]struct{},
-	btlsp *gatewayv1.BackendTLSPolicy,
-	ns string,
-) {
-	serviceRefs := []string{}
-	// First, we collect Service references from the TargetRefs
-	for _, target := range btlsp.Spec.TargetRefs {
-		if helpers.IsServiceTargetRef(target) {
-			serviceRefs = append(serviceRefs, ns+"/"+string(target.Name))
-		}
-	}
-	httpRoutes := []gatewayv1.HTTPRoute{}
-
-	for _, svcName := range serviceRefs {
-		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
-		hrList := &gatewayv1.HTTPRouteList{}
-
-		if err := r.Client.List(ctx, hrList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceHTTPRouteIndex, svcName),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
-			return
-		}
-
-		httpRoutes = append(httpRoutes, hrList.Items...)
-	}
-	for _, hr := range httpRoutes {
-		updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, rrSet)
-	}
-}
-
-func (r *gatewayReconciler) getAllCiliumGatewaysSet(ctx context.Context) (map[string]struct{}, error) {
-	// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
-	gwList := &gatewayv1.GatewayList{}
-	if err := r.Client.List(ctx, gwList, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
-	}); err != nil {
-		return nil, err
-	}
-	// Build a set of all Cilium Gateway full names.
-	// This makes sure we only add a reconcile.Request once for each Gateway.
-	allCiliumGatewaysSet := make(map[string]struct{})
-
-	for _, gw := range gwList.Items {
-		gwFullName := types.NamespacedName{
-			Name:      gw.GetName(),
-			Namespace: gw.GetNamespace(),
-		}
-		allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
-	}
-
-	return allCiliumGatewaysSet, nil
-}
-
-// updateReconcileRequestsForParentRefs mutates the passed reconcile.Request set to add all
-func updateReconcileRequestsForParentRefs(parentRefs []gatewayv1.ParentReference, ns string, allGatewaysSet map[string]struct{}, rrSet map[reconcile.Request]struct{}) {
-	for _, parent := range parentRefs {
-		if !helpers.IsGateway(parent) {
-			continue
-		}
-		parentFullName := types.NamespacedName{
-			Name:      string(parent.Name),
-			Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
-		}
-		if _, found := allGatewaysSet[parentFullName.String()]; found {
-			rrSet[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
-		}
-	}
-}
-
-// enqueueRequestForBackendServiceImport makes sure that Gateways are reconciled
-// if a relevant HTTPRoute backend Service Imports are updated.
-func (r *gatewayReconciler) enqueueRequestForBackendServiceImport() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
-		_, ok := o.(*mcsapiv1beta1.ServiceImport)
-		if !ok {
-			return nil
-		}
-
-		scopedLog := r.logger.With(logfields.LogSubsys, "queue-gw-from-backend-svc-import")
-
-		// make a set to hold all reconcile requests
-		reconcileRequests := make(map[reconcile.Request]struct{})
-
-		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
-		hrList := &gatewayv1.HTTPRouteList{}
-
-		if err := r.Client.List(ctx, hrList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceImportHTTPRouteIndex, client.ObjectKeyFromObject(o).String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
-		gwList := &gatewayv1.GatewayList{}
-		if err := r.Client.List(ctx, gwList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		// Build a set of all Cilium Gateway full names.
-		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet := make(map[string]struct{})
-		for _, gw := range gwList.Items {
-			gwFullName := types.NamespacedName{
-				Name:      gw.GetName(),
-				Namespace: gw.GetNamespace(),
-			}
-			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
-		}
-
-		// iterate through the HTTPRoutes, return a reconcile.Request for each Gateways that is relevant.
-		for _, hr := range hrList.Items {
-			for _, parent := range hr.Spec.ParentRefs {
-				if !helpers.IsGateway(parent) {
-					continue
-				}
-				parentFullName := types.NamespacedName{
-					Name:      string(parent.Name),
-					Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
-				}
-				if _, found := allCiliumGatewaysSet[parentFullName.String()]; found {
-					reconcileRequests[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
-				}
-			}
-		}
-
-		// return the keys of the set.
-		return slices.Collect(maps.Keys(reconcileRequests))
-	})
-}
-
-func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, object metav1.Object, route gatewayv1.CommonRouteSpec, logger *slog.Logger) []reconcile.Request {
-	var reqs []reconcile.Request
-
-	scopedLog := logger.With(
-		logfields.Resource, types.NamespacedName{
-			Namespace: object.GetNamespace(),
-			Name:      object.GetName(),
-		},
-	)
-
-	for _, parent := range route.ParentRefs {
-		if !helpers.IsGateway(parent) {
-			continue
-		}
-
-		ns := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
-
-		gw := &gatewayv1.Gateway{}
-		if err := c.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      string(parent.Name),
-		}, gw); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				scopedLog.ErrorContext(ctx, "Failed to get Gateway", logfields.Error, err)
-			}
-			continue
-		}
-
-		if !hasMatchingController(ctx, c, controllerName, logger)(gw) {
-			scopedLog.DebugContext(ctx, "Gateway does not have matching controller, skipping")
-			continue
-		}
-
-		scopedLog.InfoContext(ctx,
-			"Enqueued gateway for Route",
-			logfields.K8sNamespace, ns,
-			logfields.ParentResource, parent.Name,
-			logfields.Route, object.GetName())
-
-		reqs = append(reqs, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: ns,
-				Name:      string(parent.Name),
-			},
-		})
-	}
-
-	return reqs
-}
-
-// enqueueRequestForTLSSecret returns an event handler for any changes with TLS secrets
-func (r *gatewayReconciler) enqueueRequestForTLSSecret() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		gateways := getGatewaysForSecret(ctx, r.Client, a, r.logger)
-		reqs := make([]reconcile.Request, 0, len(gateways))
-		for _, gw := range gateways {
-			reqs = append(reqs, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: gw.GetNamespace(),
-					Name:      gw.GetName(),
-				},
-			})
-		}
-		return reqs
-	})
-}
-
-// enqueueRequestForAllowedNamespace returns an event handler for any changes
-// with allowed namespaces
-func (r *gatewayReconciler) enqueueRequestForAllowedNamespace() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, ns client.Object) []reconcile.Request {
-		gateways := getGatewaysForNamespace(ctx, r.Client, ns, r.logger)
-		reqs := make([]reconcile.Request, 0, len(gateways))
-		for _, gw := range gateways {
-			reqs = append(reqs, reconcile.Request{
-				NamespacedName: gw,
-			})
-		}
-		return reqs
-	})
-}
-
 func (r *gatewayReconciler) usedInGateway(obj client.Object) bool {
-	return len(getGatewaysForSecret(context.Background(), r.Client, obj, r.logger)) > 0
-}
-
-func (r *gatewayReconciler) enqueueRequestForReferenceGrant() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(r.enqueueAll())
-}
-
-func (r *gatewayReconciler) enqueueAll() handler.MapFunc {
-	return func(ctx context.Context, o client.Object) []reconcile.Request {
-		scopedLog := r.logger.With(
-			logfields.Resource, client.ObjectKeyFromObject(o),
-		)
-		list := &gatewayv1.GatewayList{}
-
-		if err := r.Client.List(ctx, list, &client.ListOptions{}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to list Gateway", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		requests := make([]reconcile.Request, 0, len(list.Items))
-		for _, item := range list.Items {
-			gw := client.ObjectKey{
-				Namespace: item.GetNamespace(),
-				Name:      item.GetName(),
-			}
-			requests = append(requests, reconcile.Request{
-				NamespacedName: gw,
-			})
-			scopedLog.InfoContext(ctx, "Enqueued Gateway for resource", gateway, gw)
-		}
-		return requests
-	}
+	return len(helpers.GetGatewaysForSecret(context.Background(), r.Client, obj, r.logger)) > 0
 }

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -303,9 +303,9 @@ func Test_Conformance(t *testing.T) {
 
 			switch tt.disableServiceImport {
 			case true:
-				clientBuilder.WithScheme(testSchemeNoServiceImport())
+				clientBuilder.WithScheme(helpers.TestScheme(helpers.NoMCSOptionalKinds))
 			case false:
-				clientBuilder.WithScheme(testScheme())
+				clientBuilder.WithScheme(helpers.TestScheme(helpers.AllOptionalKinds))
 			}
 
 			// Add any required indexes here
@@ -497,7 +497,7 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 
 			objects := append([]client.Object{gw, svc, cec}, tc.objects...)
 			c := fake.NewClientBuilder().
-				WithScheme(testScheme()).
+				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 				WithObjects(objects...).
 				Build()
 

--- a/operator/pkg/gateway-api/gatewayclass.go
+++ b/operator/pkg/gateway-api/gatewayclass.go
@@ -8,19 +8,16 @@ import (
 	"fmt"
 	"log/slog"
 
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -56,36 +53,8 @@ func (r *gatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.GatewayClass{},
 			builder.WithPredicates(predicate.NewPredicateFuncs(matchesControllerName(controllerName)))).
-		Watches(&v2alpha1.CiliumGatewayClassConfig{}, r.enqueueRequestForCiliumGatewayClassConfig()).
+		Watches(&v2alpha1.CiliumGatewayClassConfig{}, watchhandlers.EnqueueRequestForCiliumGatewayClassConfig(r.Client, r.logger)).
 		Complete(r)
-}
-
-func (r *gatewayClassReconciler) enqueueRequestForCiliumGatewayClassConfig() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(r.enqueueFromIndex(gatewayClassConfigMapIndexName))
-}
-
-func (r *gatewayClassReconciler) enqueueFromIndex(index string) handler.MapFunc {
-	return func(ctx context.Context, o client.Object) []reconcile.Request {
-		scopedLog := r.logger.With(
-			logfields.Resource, client.ObjectKeyFromObject(o),
-		)
-		list := &gatewayv1.GatewayClassList{}
-
-		if err := r.Client.List(ctx, list, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(index, client.ObjectKeyFromObject(o).String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to list related GatewayClass", logfields.Error, err)
-			return []reconcile.Request{}
-		}
-
-		requests := make([]reconcile.Request, 0, len(list.Items))
-		for _, item := range list.Items {
-			c := client.ObjectKeyFromObject(&item)
-			requests = append(requests, reconcile.Request{NamespacedName: c})
-			scopedLog.InfoContext(ctx, "Enqueued GatewayClass for resource", gatewayClass, c)
-		}
-		return requests
-	}
 }
 
 func matchesControllerName(controllerName string) func(object client.Object) bool {

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -19,6 +19,7 @@ import (
 	gwconformanceconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
 	gwconformance "sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
@@ -95,7 +96,7 @@ var (
 
 func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	c := fake.NewClientBuilder().
-		WithScheme(testScheme()).
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 		WithObjects(gwcFixture...).
 		WithObjects(cgwccFixture...).
 		WithStatusSubresource(&gatewayv1.GatewayClass{}).

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
+
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+)
+
+var RequiredGVKs = []schema.GroupVersionKind{
+	gatewayv1.SchemeGroupVersion.WithKind(GatewayClassKind),
+	gatewayv1.SchemeGroupVersion.WithKind(GatewayKind),
+	gatewayv1.SchemeGroupVersion.WithKind(HTTPRouteKind),
+	gatewayv1.SchemeGroupVersion.WithKind(GRPCRouteKind),
+	gatewayv1.SchemeGroupVersion.WithKind(ReferenceGrantKind),
+}
+
+var AllOptionalKinds = []schema.GroupVersionKind{
+	gatewayv1.SchemeGroupVersion.WithKind(TLSRouteKind),
+	mcsapiv1beta1.SchemeGroupVersion.WithKind(ServiceImportKind),
+}
+
+var NoMCSOptionalKinds = []schema.GroupVersionKind{
+	gatewayv1.SchemeGroupVersion.WithKind(TLSRouteKind),
+}
+
+func TestScheme(installedGVKs []schema.GroupVersionKind) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(ciliumv2.AddToScheme(scheme))
+	utilruntime.Must(ciliumv2alpha1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	RegisterGatewayAPITypesToScheme(scheme, installedGVKs)
+
+	return scheme
+}
+
+func RegisterGatewayAPITypesToScheme(scheme *runtime.Scheme, optionalKinds []schema.GroupVersionKind) error {
+	// Autodetection of installed types means we have to add things to the scheme
+	// ourselves for non-Standard GroupVersions, we can't use the generated
+	// functions.
+
+	addToSchema := make(map[fmt.Stringer]func(s *runtime.Scheme) error)
+
+	// We can safely install the GA resources
+	addToSchema[gatewayv1.GroupVersion] = gatewayv1.AddToScheme
+
+	for _, optionalKind := range optionalKinds {
+		// Note that we're using the full GVK as the map key here - this is fine
+		// because the key is just a fmt.Stringer
+		// We need to do this because there needs to be one entry
+		//
+		// Note that these calls are usually done using the package-level
+		// AddToScheme, but we can't use that here because we want to only
+		// enable things on a per-resource basis.
+		addToSchema[optionalKind] = func(s *runtime.Scheme) error {
+			s.AddKnownTypes(optionalKind.GroupVersion(), GetConcreteObject(optionalKind))
+			// We also need to add the List version to the Schema
+			listKind := optionalKind.Kind[:len(optionalKind.Kind)-1] + "lists"
+			optionalKindList := schema.GroupVersionKind{
+				Group:   optionalKind.Group,
+				Version: optionalKind.Version,
+				Kind:    listKind,
+			}
+			s.AddKnownTypes(optionalKind.GroupVersion(), GetConcreteObject(optionalKindList))
+			metav1.AddToGroupVersion(s, optionalKind.GroupVersion())
+			return nil
+		}
+	}
+
+	for gv, f := range addToSchema {
+		if err := f(scheme); err != nil {
+			return fmt.Errorf("failed to add types from %s to scheme: %w", gv, err)
+		}
+	}
+
+	return nil
+}

--- a/operator/pkg/gateway-api/helpers/secrets.go
+++ b/operator/pkg/gateway-api/helpers/secrets.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"context"
+	"log/slog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func GetGatewaysForSecret(ctx context.Context, c client.Client, obj client.Object, logger *slog.Logger) []*gatewayv1.Gateway {
+	scopedLog := logger.With(
+		logfields.Resource, obj.GetName(),
+	)
+
+	gwList := &gatewayv1.GatewayList{}
+	if err := c.List(ctx, gwList); err != nil {
+		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
+		return nil
+	}
+
+	var gateways []*gatewayv1.Gateway
+	for _, gw := range gwList.Items {
+		for _, l := range gw.Spec.Listeners {
+			if l.TLS == nil {
+				continue
+			}
+
+			for _, cert := range l.TLS.CertificateRefs {
+				if !IsSecret(cert) {
+					continue
+				}
+				ns := NamespaceDerefOr(cert.Namespace, gw.GetNamespace())
+				if string(cert.Name) == obj.GetName() && ns == obj.GetNamespace() {
+					gateways = append(gateways, &gw)
+				}
+			}
+		}
+	}
+	return gateways
+}

--- a/operator/pkg/gateway-api/helpers/secrets_test.go
+++ b/operator/pkg/gateway-api/helpers/secrets_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
+)
+
+func Test_getGatewaysForSecret(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(TestScheme(AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...).Build()
+	logger := hivetest.Logger(t)
+
+	t.Run("secret is used in gateway", func(t *testing.T) {
+		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tls-secret",
+				Namespace: "default",
+			},
+		}, logger)
+
+		require.Len(t, gwList, 1)
+		require.Equal(t, "valid-gateway", gwList[0].Name)
+	})
+
+	t.Run("secret is not used in gateway", func(t *testing.T) {
+		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tls-secret-not-used",
+				Namespace: "default",
+			},
+		}, logger)
+
+		require.Empty(t, gwList)
+	})
+}

--- a/operator/pkg/gateway-api/helpers/serviceimport.go
+++ b/operator/pkg/gateway-api/helpers/serviceimport.go
@@ -16,7 +16,7 @@ import (
 // and it is expected that it is registered only if the ServiceImport
 // CRD has been installed prior to the client setup.
 func HasServiceImportSupport(scheme *runtime.Scheme) bool {
-	return scheme.Recognizes(mcsapiv1beta1.SchemeGroupVersion.WithKind("ServiceImport"))
+	return scheme.Recognizes(mcsapiv1beta1.SchemeGroupVersion.WithKind(kindServiceImport))
 }
 
 func GetServiceName(svcImport *mcsapiv1beta1.ServiceImport) (string, error) {

--- a/operator/pkg/gateway-api/helpers/testhelpers/doc.go
+++ b/operator/pkg/gateway-api/helpers/testhelpers/doc.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// testhelpers contains functions and fixtures that are helpful for testing multiple
+// parts of the Gateway API code.
+package testhelpers

--- a/operator/pkg/gateway-api/helpers/testhelpers/fixtures.go
+++ b/operator/pkg/gateway-api/helpers/testhelpers/fixtures.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testhelpers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var ControllerTestFixture = []client.Object{
+	// Cilium Gateway Class
+	&gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "io.cilium/gateway-controller",
+		},
+	},
+
+	// Secret used in Gateway
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tls-secret",
+			Namespace: "default",
+		},
+		StringData: map[string]string{
+			"tls.crt": "cert",
+			"tls.key": "key",
+		},
+		Type: corev1.SecretTypeTLS,
+	},
+
+	// Gateway with valid TLS secret
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Hostname: ptr.To[gatewayv1.Hostname]("example.com"),
+					Port:     443,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{
+								Name: "tls-secret",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-gateway-2",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Hostname: ptr.To[gatewayv1.Hostname]("example2.com"),
+					Port:     443,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{},
+					},
+				},
+			},
+		},
+	},
+
+	// Gateway with no TLS listener
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-with-no-tls",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https",
+					Port: 80,
+				},
+			},
+		},
+	},
+
+	// Gateway for TLSRoute
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-tlsroute",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "tls",
+					Protocol: gatewayv1.TLSProtocolType,
+					Port:     443,
+				},
+			},
+		},
+	},
+
+	// Gateway with allowed route in same namespace only
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-from-same-namespace",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https",
+					Port: 80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromSame),
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// Gateway with allowed routes from ALL namespace
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-from-all-namespaces",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https",
+					Port: 80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromAll),
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// Gateway with allowed routes with selector
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-with-namespaces-selector",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https",
+					Port: 80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromSelector),
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"gateway": "allowed",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	// Gateway with allowed routes invalid namespace selector
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-with-invalid-namespaces-selector",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name: "https",
+					Port: 80,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Namespaces: &gatewayv1.RouteNamespaces{
+							From: ptr.To(gatewayv1.NamespacesFromSelector),
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var NamespaceFixtures = []client.Object{
+	&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	},
+	&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "another-namespace",
+		},
+	},
+	&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespace-with-allowed-gateway-selector",
+			Labels: map[string]string{
+				"gateway": "allowed",
+			},
+		},
+	},
+	&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "namespace-with-disallowed-gateway-selector",
+			Labels: map[string]string{
+				"gateway": "disallowed",
+			},
+		},
+	},
+}

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -113,3 +113,7 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 		panic(fmt.Sprintf("Tried to get a concrete type that is not implemented, %s", schemaType.Kind))
 	}
 }
+
+func IsValidGammaService(svc *corev1.Service) bool {
+	return svc.Spec.Type == corev1.ServiceTypeClusterIP
+}

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -40,4 +40,8 @@ const (
 	// This is then be used by the Service reconciler to only retrieve any GRPCRoutes that have that specific
 	// Service as a parent.
 	GammaGRPCRouteParentRefsIndex = "gammaGRPCRouteParentRefs"
+
+	// Indexes GatewayClassCiliumGatewayClassConfigsIndex indexes GatewayClass by the CiliumGatewayClassConfig
+	// that it refers to.
+	GatewayClassCiliumGatewayClassConfigsIndex = "gatewayClassCiliumGatewayClassConfigsIndex"
 )

--- a/operator/pkg/gateway-api/secretsync.go
+++ b/operator/pkg/gateway-api/secretsync.go
@@ -58,7 +58,7 @@ func EnqueueTLSSecrets(c client.Client, logger *slog.Logger) handler.EventHandle
 }
 
 func IsReferencedByCiliumGateway(ctx context.Context, c client.Client, logger *slog.Logger, obj *corev1.Secret) bool {
-	gateways := getGatewaysForSecret(ctx, c, obj, logger)
+	gateways := helpers.GetGatewaysForSecret(ctx, c, obj, logger)
 	for _, gw := range gateways {
 		if hasMatchingController(ctx, c, controllerName, logger)(gw) {
 			return true

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
@@ -32,7 +32,7 @@ spec:
       tls:
         mode: Passthrough
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-mixed

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/tlsroute-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/tlsroute-tlsroute-mixed.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-mixed

--- a/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
+++ b/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForBackendTLSPolicy returns an event handler that, when passed a BackendTLSPolicy, returns reconcile.Requests
+// for all Cilium-relevant Gateways where that BackendTLSPolicy references a Service that is used as a backend for a
+// Route that is attached to that Gateway.
+func EnqueueRequestForBackendTLSPolicy(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy")
+
+		reconcileRequests := make(map[reconcile.Request]struct{})
+		btlsp, ok := o.(*gatewayv1.BackendTLSPolicy)
+		if !ok {
+			return nil
+		}
+
+		// Build a set of all Cilium Gateway full names.
+		// This makes sure we only add a reconcile.Request once for each Gateway.
+		allCiliumGatewaysSet, err := getAllCiliumGatewaysSet(ctx, c)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		ns := o.GetNamespace()
+		updateReconcileRequestsForBackendTLSPolicy(ctx, c, scopedLog, allCiliumGatewaysSet, reconcileRequests, btlsp, ns)
+
+		recs := slices.Collect(maps.Keys(reconcileRequests))
+		if len(recs) > 0 {
+			scopedLog.Debug("BackendTLSPolicy relevant to Gateways",
+				logfields.Resource, client.ObjectKeyFromObject(o).String(),
+				logfields.Gateway, recs)
+		}
+		return slices.Collect(maps.Keys(reconcileRequests))
+	})
+}
+
+func EnqueueRequestForBackendTLSPolicyConfigMap(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy-configmap")
+
+		cfgMap, ok := o.(*corev1.ConfigMap)
+		if !ok {
+			return []reconcile.Request{}
+		}
+
+		cfgMapName := types.NamespacedName{
+			Name:      cfgMap.GetName(),
+			Namespace: cfgMap.GetNamespace(),
+		}
+
+		// Fetch all BackendTLSPolicies that reference this ConfigMap
+		btlspList := &gatewayv1.BackendTLSPolicyList{}
+
+		if err := c.List(ctx, btlspList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendTLSPolicyConfigMapIndex, cfgMapName.String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get related BackendTLSPolicies for ConfigMap", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+		// If there are no relevant BackendTLSPolicies, then we can skip this ConfigMap.
+		if len(btlspList.Items) == 0 {
+			return []reconcile.Request{}
+		}
+
+		// Build a set of all Cilium Gateway full names.
+		// This makes sure we only add a reconcile.Request once for each Gateway.
+		allCiliumGatewaysSet, err := getAllCiliumGatewaysSet(ctx, c)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		reconcileRequests := make(map[reconcile.Request]struct{})
+
+		for _, btlsp := range btlspList.Items {
+
+			if len(btlsp.Spec.Validation.CACertificateRefs) == 0 {
+				// There are no ConfigMaps specified in this BackendTLSPolicy,
+				// so this enqueue function doesn't care about it.
+				continue
+			}
+
+			configMapReferenced := false
+
+			for _, caRef := range btlsp.Spec.Validation.CACertificateRefs {
+				if caRef.Group == "" && caRef.Kind == "ConfigMap" && string(caRef.Name) == cfgMap.GetName() {
+					configMapReferenced = true
+				}
+			}
+
+			if !configMapReferenced {
+				// Enqueue only cares about ConfigMaps that are referenced by a BackendTLSPolicy
+				// If there are no references to this ConfigMap, this BackendTLSPolicy is not relevant.
+				continue
+			}
+
+			// This BackendTLSPolicy references the ConfigMap being enqueued, check to see if it's in the
+			// ownership chain any Cilium-relevant Gateways.
+			updateReconcileRequestsForBackendTLSPolicy(ctx, c, scopedLog, allCiliumGatewaysSet, reconcileRequests, &btlsp, cfgMap.GetNamespace())
+
+		}
+		recs := slices.Collect(maps.Keys(reconcileRequests))
+		if len(recs) > 0 {
+			scopedLog.Debug("ConfigMap in BackendTLSPolicy relevant to Gateways",
+				logfields.Resource, client.ObjectKeyFromObject(o).String(),
+				logfields.Gateway, recs)
+		}
+		return recs
+	})
+}
+
+func updateReconcileRequestsForBackendTLSPolicy(ctx context.Context,
+	c client.Client,
+	scopedLog *slog.Logger,
+	allGatewaysSet map[string]struct{},
+	rrSet map[reconcile.Request]struct{},
+	btlsp *gatewayv1.BackendTLSPolicy,
+	ns string,
+) {
+	serviceRefs := []string{}
+	// First, we collect Service references from the TargetRefs
+	for _, target := range btlsp.Spec.TargetRefs {
+		if helpers.IsServiceTargetRef(target) {
+			serviceRefs = append(serviceRefs, ns+"/"+string(target.Name))
+		}
+	}
+	httpRoutes := []gatewayv1.HTTPRoute{}
+
+	for _, svcName := range serviceRefs {
+		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
+		hrList := &gatewayv1.HTTPRouteList{}
+
+		if err := c.List(ctx, hrList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceHTTPRouteIndex, svcName),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
+			return
+		}
+
+		httpRoutes = append(httpRoutes, hrList.Items...)
+	}
+	for _, hr := range httpRoutes {
+		updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, rrSet)
+	}
+}

--- a/operator/pkg/gateway-api/watch-handlers/doc.go
+++ b/operator/pkg/gateway-api/watch-handlers/doc.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// watchhandlers holds functions that return closures that are used as
+// handler.TypedEventHandler[client.Object, reconcile.Request]
+// in controller-runtime Watch() calls. Each type of object has up to one watchhandler per
+// reconciler it's used in.
+//
+// # The watchhandler closures all have the signature
+//
+// ```
+// func(ctx context.Context, a client.Object) []reconcile.Request
+// ```
+//
+// and take a single client.Object that's been changed (added, deleted or updated), and
+// figure out what, if any of the reconciled objects are relevant, and return a reconcile.Request
+// for each reconciled object that needs to be rereconcilied.
+//
+// In this way, for example, an update in a HTTPRoute can be traced back to the Gateway
+// that HTTPRoute is a child of, and, if that Gateway is relevant to Cilium, we trigger
+// reconciliation for that Gateway (which will update config for the HTTPRoute we just saw
+// as well as any other relevant config that's changed since last time).
+//
+// The watchhandler functions that generate the closures should generally take a Kubernetes client and an slog logger, and
+// may take other parameters (like the name of an index to look up or similar). Indexing via the
+// `indexers` package happens _before_ the watches get checked (actually, before the object enters
+// the controller-runtime cache), so it's okay to use indexes in these functions. Index names should
+// be stored as constants in the `indexers` package as well.
+//
+// It's expected that the watchhandler functions will be called, and the _closure_ function stored by
+// the caller so that we can programmatically build out the list of Watch calls for a reconciler.
+package watchhandlers

--- a/operator/pkg/gateway-api/watch-handlers/gamma.go
+++ b/operator/pkg/gateway-api/watch-handlers/gamma.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForGAMMAHTTPRoute returns an event handler for any changes with HTTP Routes
+// belonging to the given Service
+func EnqueueRequestForGAMMAHTTPRoute(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		hr, ok := a.(*gatewayv1.HTTPRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGammaReconcileRequestsForRoute(ctx, c, a, hr.Spec.CommonRouteSpec, logger, hr.Kind)
+	})
+}
+
+// EnqueueRequestForGAMMAGRPCRoute returns an event handler for any changes with GRPC Routes
+// belonging to the given Service
+func EnqueueRequestForGAMMAGRPCRoute(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		grpcr, ok := a.(*gatewayv1.GRPCRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGammaReconcileRequestsForRoute(ctx, c, a, grpcr.Spec.CommonRouteSpec, logger, grpcr.Kind)
+	})
+}
+
+// getGammaReconcileRequestsForRoute returns a list of GAMMA services to be reconciled based on the supplied route.
+func getGammaReconcileRequestsForRoute(ctx context.Context, c client.Client, object metav1.Object, route gatewayv1.CommonRouteSpec, logger *slog.Logger, objKind string) []reconcile.Request {
+	var reqs []reconcile.Request
+
+	scopedLog := logger.With(
+		logfields.Resource, types.NamespacedName{
+			Namespace: object.GetNamespace(),
+			Name:      object.GetName(),
+		},
+	)
+
+	for _, parent := range route.ParentRefs {
+		if helpers.IsGateway(parent) {
+			continue
+		}
+
+		ns := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
+
+		s := &corev1.Service{}
+		if err := c.Get(ctx, types.NamespacedName{
+			Namespace: ns,
+			Name:      string(parent.Name),
+		}, s); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Failed to get Gamma Service", logfields.Error, err)
+			}
+			continue
+		}
+
+		if !helpers.IsValidGammaService(s) {
+			scopedLog.WarnContext(ctx, "Service referenced as GAMMA parent is not valid")
+			continue
+		}
+
+		scopedLog.InfoContext(ctx, "Enqueued GAMMA Service for Route",
+			logfields.K8sNamespace, ns,
+			logfields.ParentResource, parent.Name,
+			logfields.Kind, objKind,
+			logfields.Route, object.GetName())
+
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: ns,
+				Name:      string(parent.Name),
+			},
+		})
+	}
+
+	return reqs
+}
+
+func EnqueueRequestForGAMMAReferenceGrant(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(enqueueAllServices(c, logger))
+}
+
+func enqueueAllServices(c client.Client, logger *slog.Logger) handler.MapFunc {
+	// TODO(youngnick): This approach will scale poorly with large numbers of
+	// Services; each ReferenceGrant update will trigger reconciliation of _all_ Services.
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := logger.With(
+			logfields.Resource, client.ObjectKeyFromObject(o),
+		)
+		list := &corev1.ServiceList{}
+
+		if err := c.List(ctx, list, &client.ListOptions{}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to list Service", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		requests := make([]reconcile.Request, 0, len(list.Items))
+		for _, item := range list.Items {
+			svc := client.ObjectKey{
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: svc,
+			})
+			scopedLog.InfoContext(ctx, "Enqueued Service for resource", logfields.GammaService, svc)
+		}
+		return requests
+	}
+}

--- a/operator/pkg/gateway-api/watch-handlers/gatewayclass.go
+++ b/operator/pkg/gateway-api/watch-handlers/gatewayclass.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -49,4 +51,32 @@ func EnqueueRequestForOwningGatewayClass(c client.Client, logger slog.Logger) ha
 		}
 		return reqs
 	})
+}
+
+func EnqueueRequestForCiliumGatewayClassConfig(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(enqueueGatewayClassFromIndex(c, logger, indexers.GatewayClassCiliumGatewayClassConfigsIndex))
+}
+
+func enqueueGatewayClassFromIndex(c client.Client, logger *slog.Logger, index string) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := logger.With(
+			logfields.Resource, client.ObjectKeyFromObject(o),
+		)
+		list := &gatewayv1.GatewayClassList{}
+
+		if err := c.List(ctx, list, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(index, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to list related GatewayClass", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		requests := make([]reconcile.Request, 0, len(list.Items))
+		for _, item := range list.Items {
+			c := client.ObjectKeyFromObject(&item)
+			requests = append(requests, reconcile.Request{NamespacedName: c})
+			scopedLog.InfoContext(ctx, "Enqueued GatewayClass for resource", logfields.GatewayClass, c)
+		}
+		return requests
+	}
 }

--- a/operator/pkg/gateway-api/watch-handlers/gatewayclass.go
+++ b/operator/pkg/gateway-api/watch-handlers/gatewayclass.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// enqueueRequestForOwningGatewayClass returns an event handler that, when given a GatewayClass,
+// returns reconcile.Requests for all Gateway objects belonging to the given GatewayClass.
+func EnqueueRequestForOwningGatewayClass(c client.Client, logger slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		scopedLog := logger.With(
+			logfields.Resource, client.ObjectKeyFromObject(a).String(),
+		)
+		var reqs []reconcile.Request
+		gwList := &gatewayv1.GatewayList{}
+		if err := c.List(ctx, gwList); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list Gateways")
+			return nil
+		}
+
+		for _, gw := range gwList.Items {
+			if gw.Spec.GatewayClassName != gatewayv1.ObjectName(a.GetName()) {
+				continue
+			}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: gw.Namespace,
+					Name:      gw.Name,
+				},
+			}
+			reqs = append(reqs, req)
+			scopedLog.InfoContext(ctx,
+				"Queueing gateway",
+				logfields.K8sNamespace, gw.GetNamespace(),
+				logfields.Gateway, gw.GetName(),
+			)
+		}
+		return reqs
+	})
+}

--- a/operator/pkg/gateway-api/watch-handlers/helpers.go
+++ b/operator/pkg/gateway-api/watch-handlers/helpers.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// updateReconcileRequestsForParentRefs mutates the passed reconcile.Request set to add all
+func updateReconcileRequestsForParentRefs(parentRefs []gatewayv1.ParentReference, ns string, allGatewaysSet map[string]struct{}, rrSet map[reconcile.Request]struct{}) {
+	for _, parent := range parentRefs {
+		if !helpers.IsGateway(parent) {
+			continue
+		}
+		parentFullName := types.NamespacedName{
+			Name:      string(parent.Name),
+			Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
+		}
+		if _, found := allGatewaysSet[parentFullName.String()]; found {
+			rrSet[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
+		}
+	}
+}
+
+func hasMatchingController(ctx context.Context, c client.Client, controllerName string, logger *slog.Logger) func(object client.Object) bool {
+	return func(obj client.Object) bool {
+		scopedLog := logger.With(
+			logfields.Resource, obj.GetName(),
+		)
+		gw, ok := obj.(*gatewayv1.Gateway)
+		if !ok {
+			return false
+		}
+
+		gwc := &gatewayv1.GatewayClass{}
+		key := types.NamespacedName{Name: string(gw.Spec.GatewayClassName)}
+		if err := c.Get(ctx, key, gwc); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to get GatewayClass", logfields.Error, err)
+			return false
+		}
+
+		return string(gwc.Spec.ControllerName) == controllerName
+	}
+}
+
+func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, object metav1.Object, route gatewayv1.CommonRouteSpec, logger *slog.Logger, controllerName string) []reconcile.Request {
+	var reqs []reconcile.Request
+
+	scopedLog := logger.With(
+		logfields.Resource, types.NamespacedName{
+			Namespace: object.GetNamespace(),
+			Name:      object.GetName(),
+		},
+	)
+
+	for _, parent := range route.ParentRefs {
+		if !helpers.IsGateway(parent) {
+			continue
+		}
+
+		ns := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
+
+		gw := &gatewayv1.Gateway{}
+		if err := c.Get(ctx, types.NamespacedName{
+			Namespace: ns,
+			Name:      string(parent.Name),
+		}, gw); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Failed to get Gateway", logfields.Error, err)
+			}
+			continue
+		}
+
+		if !hasMatchingController(ctx, c, controllerName, logger)(gw) {
+			scopedLog.DebugContext(ctx, "Gateway does not have matching controller, skipping")
+			continue
+		}
+
+		scopedLog.InfoContext(ctx,
+			"Enqueued gateway for Route",
+			logfields.K8sNamespace, ns,
+			logfields.ParentResource, parent.Name,
+			logfields.Route, object.GetName())
+
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: ns,
+				Name:      string(parent.Name),
+			},
+		})
+	}
+
+	return reqs
+}
+
+func getAllCiliumGatewaysSet(ctx context.Context, c client.Client) (map[string]struct{}, error) {
+	// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
+	gwList := &gatewayv1.GatewayList{}
+	if err := c.List(ctx, gwList, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
+	}); err != nil {
+		return nil, err
+	}
+	// Build a set of all Cilium Gateway full names.
+	// This makes sure we only add a reconcile.Request once for each Gateway.
+	allCiliumGatewaysSet := make(map[string]struct{})
+
+	for _, gw := range gwList.Items {
+		gwFullName := types.NamespacedName{
+			Name:      gw.GetName(),
+			Namespace: gw.GetNamespace(),
+		}
+		allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
+	}
+
+	return allCiliumGatewaysSet, nil
+}

--- a/operator/pkg/gateway-api/watch-handlers/namespaces.go
+++ b/operator/pkg/gateway-api/watch-handlers/namespaces.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForAllowedNamespace returns an event handler for any changes
+// with allowed namespaces
+func EnqueueRequestForAllowedNamespace(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, ns client.Object) []reconcile.Request {
+		gateways := getGatewaysForNamespace(ctx, c, ns, logger)
+		reqs := make([]reconcile.Request, 0, len(gateways))
+		for _, gw := range gateways {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: gw,
+			})
+		}
+		return reqs
+	})
+}
+
+func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Object, logger *slog.Logger) []types.NamespacedName {
+	scopedLog := logger.With(
+		logfields.K8sNamespace, ns.GetName(),
+	)
+
+	gwList := &gatewayv1.GatewayList{}
+	if err := c.List(ctx, gwList); err != nil {
+		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
+		return nil
+	}
+
+	var gateways []types.NamespacedName
+	for _, gw := range gwList.Items {
+		for _, l := range gw.Spec.Listeners {
+			if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
+				continue
+			}
+
+			switch *l.AllowedRoutes.Namespaces.From {
+			case gatewayv1.NamespacesFromAll:
+				gateways = append(gateways, client.ObjectKey{
+					Namespace: gw.GetNamespace(),
+					Name:      gw.GetName(),
+				})
+			case gatewayv1.NamespacesFromSame:
+				if ns.GetName() == gw.GetNamespace() {
+					gateways = append(gateways, client.ObjectKey{
+						Namespace: gw.GetNamespace(),
+						Name:      gw.GetName(),
+					})
+				}
+			case gatewayv1.NamespacesFromSelector:
+				if l.AllowedRoutes.Namespaces.Selector == nil {
+					scopedLog.WarnContext(ctx, "AllowedRoutes namespace set to Selector but no selector specified", logfields.Gateway, gw.GetName())
+					continue
+				}
+				nsList := &corev1.NamespaceList{}
+				err := c.List(ctx, nsList, client.MatchingLabels(l.AllowedRoutes.Namespaces.Selector.MatchLabels))
+				if err != nil {
+					scopedLog.WarnContext(ctx, "Unable to list Namespaces", logfields.Error, err)
+					return nil
+				}
+				for _, item := range nsList.Items {
+					if item.GetName() == ns.GetName() {
+						gateways = append(gateways, client.ObjectKey{
+							Namespace: gw.GetNamespace(),
+							Name:      gw.GetName(),
+						})
+					}
+				}
+			}
+		}
+	}
+	return gateways
+}

--- a/operator/pkg/gateway-api/watch-handlers/namespaces_test.go
+++ b/operator/pkg/gateway-api/watch-handlers/namespaces_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
+)
+
+func Test_getGatewaysForNamespace(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(testhelpers.NamespaceFixtures...).
+		WithObjects(testhelpers.ControllerTestFixture...).
+		Build()
+	logger := hivetest.Logger(t)
+
+	type args struct {
+		namespace string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "with default namespace",
+			args: args{namespace: "default"},
+			want: []string{"gateway-from-all-namespaces", "gateway-from-same-namespace"},
+		},
+		{
+			name: "with another namespace",
+			args: args{namespace: "another-namespace"},
+			want: []string{"gateway-from-all-namespaces"},
+		},
+		{
+			name: "with namespace-with-allowed-gateway-selector",
+			args: args{namespace: "namespace-with-allowed-gateway-selector"},
+			want: []string{"gateway-from-all-namespaces", "gateway-with-namespaces-selector"},
+		},
+		{
+			name: "with namespace-with-disallowed-gateway-selector",
+			args: args{namespace: "namespace-with-disallowed-gateway-selector"},
+			want: []string{"gateway-from-all-namespaces"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gwList := getGatewaysForNamespace(t.Context(), c, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.args.namespace,
+				},
+			}, logger)
+			names := make([]string, 0, len(gwList))
+			for _, gw := range gwList {
+				names = append(names, gw.Name)
+			}
+			require.ElementsMatch(t, tt.want, names)
+		})
+	}
+}

--- a/operator/pkg/gateway-api/watch-handlers/referencegrant.go
+++ b/operator/pkg/gateway-api/watch-handlers/referencegrant.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// TODO(youngnick): Fix this so it doesn't just enqueue all Gateways whenever a ReferenceGrant
+// is updated.
+
+func EnqueueRequestForReferenceGrant(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(enqueueAll(c, logger))
+}
+
+func enqueueAll(c client.Client, logger *slog.Logger) handler.MapFunc {
+	return func(ctx context.Context, o client.Object) []reconcile.Request {
+		scopedLog := logger.With(
+			logfields.Resource, client.ObjectKeyFromObject(o),
+		)
+		list := &gatewayv1.GatewayList{}
+
+		if err := c.List(ctx, list, &client.ListOptions{}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to list Gateway", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		requests := make([]reconcile.Request, 0, len(list.Items))
+		for _, item := range list.Items {
+			gw := client.ObjectKey{
+				Namespace: item.GetNamespace(),
+				Name:      item.GetName(),
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: gw,
+			})
+			scopedLog.InfoContext(ctx, "Enqueued Gateway for resource", logfields.Gateway, gw)
+		}
+		return requests
+	}
+}

--- a/operator/pkg/gateway-api/watch-handlers/routes.go
+++ b/operator/pkg/gateway-api/watch-handlers/routes.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// EnqueueRequestForOwningHTTPRoute returns an event handler that, when passed a HTTPRoute, returns reconcile.Requests
+// for all Cilium-relevant Gateways associated with that HTTPRoute.
+func EnqueueRequestForOwningHTTPRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		hr, ok := a.(*gatewayv1.HTTPRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(context.Background(), c, a, hr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}
+
+// EnqueueRequestForOwningTLSRoute returns an event handler that, when passed a TLSRoute, returns reconcile.Requests
+// for all Cilium-relevant Gateways associated with that TLSRoute.
+func EnqueueRequestForOwningTLSRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		hr, ok := a.(*gatewayv1alpha2.TLSRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(context.Background(), c, a, hr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}
+
+// EnqueueRequestForOwningGRPCRoute returns an event handler that, when passed a GRPCRoute, returns reconcile.Requests
+// for any Cilium-relevant Gateways associated with that GRPCRoute.
+func EnqueueRequestForOwningGRPCRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		gr, ok := a.(*gatewayv1.GRPCRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(ctx, c, a, gr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}

--- a/operator/pkg/gateway-api/watch-handlers/secrets.go
+++ b/operator/pkg/gateway-api/watch-handlers/secrets.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+// EnqueueRequestForTLSSecret returns an event handler for any changes with TLS secrets
+func EnqueueRequestForTLSSecret(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		gateways := helpers.GetGatewaysForSecret(ctx, c, a, logger)
+		reqs := make([]reconcile.Request, 0, len(gateways))
+		for _, gw := range gateways {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: gw.GetNamespace(),
+					Name:      gw.GetName(),
+				},
+			})
+		}
+		return reqs
+	})
+}

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForBackendService returns an event handler that, when passed a Service, returns reconcile.Requests
+// for all Cilium-relevant Gateways where that Service is used as a backend for a HTTPRoute that is attached to that Gateway.
+func EnqueueRequestForBackendService(c client.Client, logger slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		_, ok := o.(*corev1.Service)
+		if !ok {
+			return nil
+		}
+
+		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backend-svc")
+
+		// Make a set to hold all reconcile requests
+		reconcileRequests := make(map[reconcile.Request]struct{})
+
+		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
+		hrList := &gatewayv1.HTTPRouteList{}
+
+		if err := c.List(ctx, hrList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceHTTPRouteIndex, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		// Then, fetch all TLSRoutes that reference this service, using the backendServiceIndex
+		tlsrList := &gatewayv1alpha2.TLSRouteList{}
+
+		if err := c.List(ctx, tlsrList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceTLSRouteIndex, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.Error("Failed to get related HTTPRoutes", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		grpcRouteList := &gatewayv1.GRPCRouteList{}
+		if err := c.List(ctx, grpcRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceGRPCRouteIndex, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list GRPCRoutes", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
+		gwList := &gatewayv1.GatewayList{}
+		if err := c.List(ctx, gwList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		// Build a set of all Cilium Gateway full names.
+		// This makes sure we only add a reconcile.Request once for each Gateway.
+		allCiliumGatewaysSet := make(map[string]struct{})
+
+		for _, gw := range gwList.Items {
+			gwFullName := types.NamespacedName{
+				Name:      gw.GetName(),
+				Namespace: gw.GetNamespace(),
+			}
+			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
+		}
+
+		// iterate through the HTTPRoutes, update reconcileRequests for each Gateway that is relevant.
+		for _, hr := range hrList.Items {
+			updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+		}
+
+		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
+		for _, tlsr := range tlsrList.Items {
+			updateReconcileRequestsForParentRefs(tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+		}
+
+		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
+		for _, grpcr := range grpcRouteList.Items {
+			updateReconcileRequestsForParentRefs(grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+		}
+
+		// return the keys of the set, since that's the actual reconcile.Requests.
+		return slices.Collect(maps.Keys(reconcileRequests))
+	})
+}
+
+// EnqueueRequestForBackendServiceImport makes sure that Gateways are reconciled
+// if a relevant HTTPRoute backend Service Imports are updated.
+func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		_, ok := o.(*mcsapiv1beta1.ServiceImport)
+		if !ok {
+			return nil
+		}
+
+		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backend-svc-import")
+
+		// make a set to hold all reconcile requests
+		reconcileRequests := make(map[reconcile.Request]struct{})
+
+		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
+		hrList := &gatewayv1.HTTPRouteList{}
+
+		if err := c.List(ctx, hrList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceImportHTTPRouteIndex, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get related HTTPRoutes", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
+		gwList := &gatewayv1.GatewayList{}
+		if err := c.List(ctx, gwList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		// Build a set of all Cilium Gateway full names.
+		// This makes sure we only add a reconcile.Request once for each Gateway.
+		allCiliumGatewaysSet := make(map[string]struct{})
+		for _, gw := range gwList.Items {
+			gwFullName := types.NamespacedName{
+				Name:      gw.GetName(),
+				Namespace: gw.GetNamespace(),
+			}
+			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
+		}
+
+		// iterate through the HTTPRoutes, return a reconcile.Request for each Gateways that is relevant.
+		for _, hr := range hrList.Items {
+			for _, parent := range hr.Spec.ParentRefs {
+				if !helpers.IsGateway(parent) {
+					continue
+				}
+				parentFullName := types.NamespacedName{
+					Name:      string(parent.Name),
+					Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
+				}
+				if _, found := allCiliumGatewaysSet[parentFullName.String()]; found {
+					reconcileRequests[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
+				}
+			}
+		}
+
+		// return the keys of the set.
+		return slices.Collect(maps.Keys(reconcileRequests))
+	})
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1160,6 +1160,8 @@ const (
 
 	Gateway = "gateway"
 
+	GammaService = "gammaService"
+
 	Kind = "kind"
 
 	RequiredGVK = "requiredGVK"

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1162,6 +1162,8 @@ const (
 
 	GammaService = "gammaService"
 
+	GatewayClass = "GatewayClass"
+
 	Kind = "kind"
 
 	RequiredGVK = "requiredGVK"


### PR DESCRIPTION
This PR moves the `Watch()` event handler functions away from being methods on the relevant reconciler to being functions in their own package. This will mean that we can add testing to these functions at a later date.

This is part of a series of changes aimed at making adding resources to the various reconcilers more straightforward.

Please review by commits.
