### PR TITLE
hubble-ui: use FQDN for FLOWS_API_ADDR to fix gRPC DNS resolution

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -110,7 +110,7 @@ spec:
           value: "8090"
         {{- if .Values.hubble.relay.tls.server.enabled }}
         - name: FLOWS_API_ADDR
-          value: "hubble-relay:443"
+          value: "hubble-relay.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:443"
         - name: TLS_TO_RELAY_ENABLED
           value: "true"
         - name: TLS_RELAY_SERVER_NAME
@@ -123,7 +123,7 @@ spec:
           value: /var/lib/hubble-ui/certs/client.key
         {{- else }}
         - name: FLOWS_API_ADDR
-          value: "hubble-relay:80"
+          value: "hubble-relay.{{ .Release.Namespace }}.svc.{{ .Values.hubble.peerService.clusterDomain }}:80"
         {{- end }}
         {{- with .Values.hubble.ui.backend.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

The Hubble UI backend uses `hubble-relay:80` (or `:443` with TLS) as the value for `FLOWS_API_ADDR`. gRPC's internal DNS resolver does not apply the Kubernetes search domains from `/etc/resolv.conf` and queries the DNS server for the bare hostname `hubble-relay.` as an absolute name. This returns NXDOMAIN, causing the backend to fail silently — the UI shows no flows and no service map data. 

This PR replaces the hardcoded short names with the FQDN using the release namespace and the existing `hubble.peerService.clusterDomain` value (default: `cluster.local`), which is already used elsewhere in the chart for the same purpose.

Fixes: #45562

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.

```release-note
Fixed Hubble UI showing no flows due to gRPC DNS resolution failure when using short service name for hubble-relay.
```
