### PR TITLE
gateway-api: guard HTTP redirect with X-Forwarded-Proto

### DIFF
--- a/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-scheme/output/cec-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-redirect-scheme/output/cec-echo.yaml
@@ -76,6 +76,12 @@ spec:
       routes:
       - match:
           pathSeparatedPrefix: /scheme-and-host-and-status
+          headers:
+          - invertMatch: true
+            name: X-Forwarded-Proto
+            stringMatch:
+              exact: https
+              ignoreCase: true
         redirect:
           hostRedirect: example.org
           portRedirect: 443
@@ -83,17 +89,35 @@ spec:
           schemeRedirect: https
       - match:
           pathSeparatedPrefix: /scheme-and-status
+          headers:
+          - invertMatch: true
+            name: X-Forwarded-Proto
+            stringMatch:
+              exact: https
+              ignoreCase: true
         redirect:
           portRedirect: 443
           schemeRedirect: https
       - match:
           pathSeparatedPrefix: /scheme-and-host
+          headers:
+          - invertMatch: true
+            name: X-Forwarded-Proto
+            stringMatch:
+              exact: https
+              ignoreCase: true
         redirect:
           hostRedirect: example.org
           portRedirect: 443
           schemeRedirect: https
       - match:
           pathSeparatedPrefix: /scheme
+          headers:
+          - invertMatch: true
+            name: X-Forwarded-Proto
+            stringMatch:
+              exact: https
+              ignoreCase: true
         redirect:
           portRedirect: 443
           schemeRedirect: https

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-port-and-scheme/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-port-and-scheme/output/cec-same-namespace.yaml
@@ -76,18 +76,36 @@ spec:
           routes:
             - match:
                 pathSeparatedPrefix: /scheme-https-and-port-8443
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 hostRedirect: example.org
                 portRedirect: 8443
                 schemeRedirect: https
             - match:
                 pathSeparatedPrefix: /scheme-https-and-port-nil
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 hostRedirect: example.org
                 portRedirect: 443
                 schemeRedirect: https
             - match:
                 pathSeparatedPrefix: /scheme-https-and-port-443
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 hostRedirect: example.org
                 portRedirect: 443

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-scheme/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-redirect-scheme/output/cec-same-namespace.yaml
@@ -76,6 +76,12 @@ spec:
           routes:
             - match:
                 pathSeparatedPrefix: /scheme-and-host-and-status
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 hostRedirect: example.org
                 portRedirect: 443
@@ -83,17 +89,35 @@ spec:
                 schemeRedirect: https
             - match:
                 pathSeparatedPrefix: /scheme-and-status
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 portRedirect: 443
                 schemeRedirect: https
             - match:
                 pathSeparatedPrefix: /scheme-and-host
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 hostRedirect: example.org
                 portRedirect: 443
                 schemeRedirect: https
             - match:
                 pathSeparatedPrefix: /scheme
+                headers:
+                - invertMatch: true
+                  name: X-Forwarded-Proto
+                  stringMatch:
+                    exact: https
+                    ignoreCase: true
               redirect:
                 portRedirect: 443
                 schemeRedirect: https

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -383,6 +383,12 @@ func (r *HTTPRoute) GetMatchKey() string {
 		sb.WriteString("|")
 	}
 
+	if r.RequestRedirect != nil && r.RequestRedirect.Scheme != nil {
+		sb.WriteString("redirect:")
+		sb.WriteString("true")
+		sb.WriteString("|")
+	}
+
 	return sb.String()
 }
 

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -237,6 +237,9 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 		}
 
 		if hRoutes[0].RequestRedirect != nil {
+			if hRoutes[0].RequestRedirect.Scheme != nil {
+				route.Match.Headers = append(route.Match.Headers, getRouteRedirectMatch(*hRoutes[0].RequestRedirect.Scheme))
+			}
 			route.Action = getRouteRedirect(hRoutes[0].RequestRedirect, listenerPort)
 		} else {
 			route.Action = getRouteAction(&r, backends, r.BackendHTTPFilters, r.Rewrite, r.RequestMirrors)
@@ -499,6 +502,21 @@ func getRouteRedirect(redirect *model.HTTPRequestRedirectFilter, listenerPort ui
 
 	return &envoy_config_route_v3.Route_Redirect{
 		Redirect: redirectAction,
+	}
+}
+
+func getRouteRedirectMatch(match string) *envoy_config_route_v3.HeaderMatcher {
+	return &envoy_config_route_v3.HeaderMatcher{
+		Name: "X-Forwarded-Proto",
+		HeaderMatchSpecifier: &envoy_config_route_v3.HeaderMatcher_StringMatch{
+			StringMatch: &envoy_type_matcher_v3.StringMatcher{
+				MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+					Exact: match,
+				},
+				IgnoreCase: true,
+			},
+		},
+		InvertMatch: true,
 	}
 }
 

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -660,3 +660,49 @@ func Test_retryMutation(t *testing.T) {
 		require.Equal(t, int64(20), res.Route.RetryPolicy.RetryBackOff.MaxInterval.Seconds)
 	})
 }
+
+func Test_envoyHTTPRoutes(t *testing.T) {
+	t.Run("redirect with x-forwarded-proto and backend", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				Name:      "Redirect",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				RequestRedirect: &model.HTTPRequestRedirectFilter{
+					Scheme:     ptr.To("https"),
+					Port:       ptr.To(int32(443)),
+					StatusCode: ptr.To(302),
+				},
+			},
+			{
+				Name:      "Backend",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				Backends: []model.Backend{
+					{
+						Name:      "backend",
+						Namespace: "default",
+						Port:      &model.BackendPort{Port: 31337},
+					},
+				},
+			},
+		}
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80)
+		require.Len(t, res, 2)
+		// Redirect Route
+		require.NotNil(t, res[0])
+		require.Equal(t, "/", res[0].Match.GetPrefix())
+		require.Len(t, res[0].Match.GetHeaders(), 1)
+		require.Equal(t, "X-Forwarded-Proto", res[0].Match.GetHeaders()[0].Name)
+		require.True(t, res[0].Match.GetHeaders()[0].InvertMatch)
+		require.Equal(t, "https", res[0].Match.GetHeaders()[0].GetStringMatch().GetExact())
+		require.NotNil(t, res[0].GetRedirect())
+		require.Equal(t, "https", res[0].GetRedirect().GetSchemeRedirect())
+		require.Equal(t, uint32(443), res[0].GetRedirect().PortRedirect)
+		require.Equal(t, envoy_config_route_v3.RedirectAction_FOUND, res[0].GetRedirect().ResponseCode)
+		// Backend Route
+		require.NotNil(t, res[1])
+		require.Equal(t, "/", res[1].Match.GetPrefix())
+		require.Empty(t, res[1].Match.GetHeaders())
+		require.NotNil(t, res[1].GetRoute())
+		require.Equal(t, "default:backend:31337", res[1].GetRoute().GetCluster())
+	})
+}


### PR DESCRIPTION
### Description

Add a guard around the HTTP redirect logic using the X-Forwarded-Proto header. The redirect is only performed if the header value does not match the scheme defined in the HTTPRoute resource.

This prevents infinite redirect loops in scenarios where a front proxy or load balancer terminates TLS and passes unencrypted traffic to Envoy. By checking this header, Envoy can distinguish between redirected traffic and traffic that originally started as a secure connection.

The `--gateway-api-xff-num-trusted-hops` flag must be set to the desired number of trusted hops in order for Envoy to rely on the X-Forwarded-Proto header.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #34539

```release-note
Fix infinite HTTP redirect loops by honoring the X-Forwarded-Proto header to detect TLS termination at external load balancers.
```
