### PR TITLE
cilium-cli: support versioned scenarios

### DIFF
--- a/cilium-cli/connectivity/check/scenario.go
+++ b/cilium-cli/connectivity/check/scenario.go
@@ -32,6 +32,14 @@ type ConditionalScenario interface {
 	Requirements() []features.Requirement
 }
 
+// VersionedScenario is a test scenario which requires a specific Cilium
+// version range. If the running Cilium version does not match the constraint,
+// the test scenario is skipped.
+type VersionedScenario interface {
+	Scenario
+	RequiredCiliumVersion() string
+}
+
 type ScenarioBase struct {
 	filepath string
 }

--- a/cilium-cli/connectivity/check/test.go
+++ b/cilium-cli/connectivity/check/test.go
@@ -204,6 +204,25 @@ func (t *Test) scenarioRequirements(s Scenario) (bool, string) {
 	return t.Context().Features.MatchRequirements(reqs...)
 }
 
+// scenarioVersion returns true if the running Cilium version is within the
+// range specified by a VersionedScenario. Scenarios that do not implement
+// VersionedScenario are always considered in range.
+func (t *Test) scenarioVersion(s Scenario) (bool, string) {
+	vs, ok := s.(VersionedScenario)
+	if !ok {
+		return true, ""
+	}
+	constraint := vs.RequiredCiliumVersion()
+	if constraint == "" {
+		return true, ""
+	}
+	vr := versioncheck.MustCompile(constraint)
+	if !vr(t.Context().CiliumVersion) {
+		return false, fmt.Sprintf("requires Cilium version %s but running %s", constraint, t.Context().CiliumVersion)
+	}
+	return true, ""
+}
+
 // Context returns the enclosing context of the Test.
 func (t *Test) Context() *ConnectivityTest {
 	return t.ctx
@@ -377,6 +396,11 @@ func (t *Test) Run(ctx context.Context, index int) error {
 		}
 
 		if req, reason := t.scenarioRequirements(s); !req {
+			t.skip(s, reason)
+			continue
+		}
+
+		if ver, reason := t.scenarioVersion(s); !ver {
 			t.skip(s, reason)
 			continue
 		}

--- a/cilium-cli/connectivity/tests/ztunnel.go
+++ b/cilium-cli/connectivity/tests/ztunnel.go
@@ -54,12 +54,13 @@ const (
 
 // scenarioConfig defines the configuration for a ztunnel test scenario
 type scenarioConfig struct {
-	name             string
-	clientEnrollment enrollmentStatus
-	serverEnrollment enrollmentStatus
-	location         podLocation
-	sameNamespace    bool
-	expectEncryption bool
+	name                  string
+	clientEnrollment      enrollmentStatus
+	serverEnrollment      enrollmentStatus
+	location              podLocation
+	requiredCiliumVersion string
+	sameNamespace         bool
+	expectEncryption      bool
 }
 
 // ztunnelTestBase provides shared functionality for all ztunnel test scenarios
@@ -138,48 +139,52 @@ func ZTunnelUnenrolledToUnenrolledDifferentNode() check.Scenario {
 // ZTunnelEnrolledToUnenrolledSameNode tests plain traffic from enrolled client to unenrolled server on same node
 func ZTunnelEnrolledToUnenrolledSameNode() check.Scenario {
 	return newZTunnelTest(scenarioConfig{
-		name:             "enrolled-to-unenrolled-same-node",
-		clientEnrollment: enrolled,
-		serverEnrollment: unenrolled,
-		location:         sameNode,
-		sameNamespace:    false,
-		expectEncryption: false,
+		name:                  "enrolled-to-unenrolled-same-node",
+		clientEnrollment:      enrolled,
+		serverEnrollment:      unenrolled,
+		location:              sameNode,
+		sameNamespace:         false,
+		expectEncryption:      false,
+		requiredCiliumVersion: ">=1.20.0",
 	})
 }
 
 // ZTunnelEnrolledToUnenrolledDifferentNode tests plain traffic from enrolled client to unenrolled server on different nodes
 func ZTunnelEnrolledToUnenrolledDifferentNode() check.Scenario {
 	return newZTunnelTest(scenarioConfig{
-		name:             "enrolled-to-unenrolled-different-node",
-		clientEnrollment: enrolled,
-		serverEnrollment: unenrolled,
-		location:         differentNode,
-		sameNamespace:    false,
-		expectEncryption: false,
+		name:                  "enrolled-to-unenrolled-different-node",
+		clientEnrollment:      enrolled,
+		serverEnrollment:      unenrolled,
+		location:              differentNode,
+		sameNamespace:         false,
+		expectEncryption:      false,
+		requiredCiliumVersion: ">=1.20.0",
 	})
 }
 
 // ZTunnelUnenrolledToEnrolledSameNode tests plain traffic from unenrolled client to enrolled server on same node
 func ZTunnelUnenrolledToEnrolledSameNode() check.Scenario {
 	return newZTunnelTest(scenarioConfig{
-		name:             "unenrolled-to-enrolled-same-node",
-		clientEnrollment: unenrolled,
-		serverEnrollment: enrolled,
-		location:         sameNode,
-		sameNamespace:    false,
-		expectEncryption: false,
+		name:                  "unenrolled-to-enrolled-same-node",
+		clientEnrollment:      unenrolled,
+		serverEnrollment:      enrolled,
+		location:              sameNode,
+		sameNamespace:         false,
+		expectEncryption:      false,
+		requiredCiliumVersion: ">=1.20.0",
 	})
 }
 
 // ZTunnelUnenrolledToEnrolledDifferentNode tests plain traffic from unenrolled client to enrolled server on different nodes
 func ZTunnelUnenrolledToEnrolledDifferentNode() check.Scenario {
 	return newZTunnelTest(scenarioConfig{
-		name:             "unenrolled-to-enrolled-different-node",
-		clientEnrollment: unenrolled,
-		serverEnrollment: enrolled,
-		location:         differentNode,
-		sameNamespace:    false,
-		expectEncryption: false,
+		name:                  "unenrolled-to-enrolled-different-node",
+		clientEnrollment:      unenrolled,
+		serverEnrollment:      enrolled,
+		location:              differentNode,
+		sameNamespace:         false,
+		expectEncryption:      false,
+		requiredCiliumVersion: ">=1.20.0",
 	})
 }
 
@@ -217,6 +222,10 @@ func newZTunnelTest(config scenarioConfig) check.Scenario {
 
 func (s *ztunnelTestBase) Name() string {
 	return s.config.name
+}
+
+func (s *ztunnelTestBase) RequiredCiliumVersion() string {
+	return s.config.requiredCiliumVersion
 }
 
 // getNamespaceForEnrollment determines which namespace to use based on enrollment and pod type.


### PR DESCRIPTION
This PR introduces support for versioned scenarios. Currently only whole tests can have a version requirement and with this addition sub scenarios can be added that require newer cilium versions. This is especially useful if new scenarios are added over time.

This problem currently exists for the ztunnel tests, so this PR adds an immediate user of that interface.

Tested this locally running the new cli against a 1.19 cluster and the respective ztunnel tests that require at least 1.20 get skipped.

_AI-Disclosure_: This PR was developed with assistance of Claude Code (Opus 4.6).