### PR TITLE
loadbalancer: do not allow service wildcard entries against node IPs

### DIFF
--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -103,6 +103,17 @@ func (fe *Frontend) Clone() *Frontend {
 	return &fe2
 }
 
+// IsWildcardCandidate returns true if the frontend is structurally eligible
+// to parent a wildcard service entry.
+func IsWildcardCandidate(fe *Frontend) bool {
+	switch fe.Type {
+	case SVCTypeLoadBalancer, SVCTypeClusterIP:
+		return fe.Address.Scope() == ScopeExternal
+	default:
+		return false
+	}
+}
+
 func (fe *Frontend) TableHeader() []string {
 	return []string{
 		"Address",

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -707,7 +707,15 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 		return nil
 	}
 
-	if err := ops.updateFrontend(fe); err != nil {
+	isLocalAddr := func(addr netip.Addr) bool {
+		k := tables.NodeAddressKey{Addr: addr}
+		for range ops.nodeAddrs.Prefix(txn, tables.NodeAddressIndex.Query(k)) {
+			return true
+		}
+		return false
+	}
+
+	if err := ops.updateFrontend(fe, isLocalAddr); err != nil {
 		ops.log.Warn("Updating frontend failed", logfields.Error, err)
 		return err
 	}
@@ -742,7 +750,7 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 				fe.Address.Port(),
 				fe.Address.Scope(),
 			)
-			if err := ops.updateFrontend(fe); err != nil {
+			if err := ops.updateFrontend(fe, nil); err != nil {
 				ops.log.Warn("Updating frontend failed",
 					logfields.Error, err,
 					logfields.Address, fe.Address,
@@ -775,7 +783,7 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 	return nil
 }
 
-func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
+func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(netip.Addr) bool) error {
 	// WARNING: This method must be idempotent. Any updates to state must happen only after
 	// the operations that depend on the state have been performed. If this invariant is not
 	// followed then we may leak data due to not retrying a failed operation.
@@ -1058,10 +1066,16 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 	}
 
 	// Upsert wildcard entries such that the data path will have a service entry for any
-	// LoadBalancer or Cluster IP that receives traffic for an unknown protocol/port combination.
+	// traffic for an unknown protocol/port combination.
 	if loadbalancer.IsWildcardCandidate(fe) && ops.isWildcardClass(svc) {
-		if err := ops.upsertWildcard(fe, feID); err != nil {
-			return fmt.Errorf("upsert wildcard: %w", err)
+		if isLocalAddr == nil || !isLocalAddr(fe.Address.Addr()) {
+			if err := ops.upsertWildcard(fe, feID); err != nil {
+				return fmt.Errorf("upsert wildcard: %w", err)
+			}
+		} else {
+			if err := ops.deleteWildcard(fe, feID); err != nil {
+				return fmt.Errorf("delete wildcard: %w", err)
+			}
 		}
 	}
 
@@ -1141,9 +1155,6 @@ func (ops *BPFOps) isWildcardClass(svc *loadbalancer.Service) bool {
 	// The service has a loadBalancerClass, so we only include a wildcard
 	// service entry if it's a class Cilium actively manages, again to avoid
 	// programming wildcard entries for IP addresses we don't manage.
-	//
-	// TODO: improve this in future, perhaps by matching against known
-	// CiliumInternalIPs.
 	return *lbClass == cilium_api_v2alpha1.BGPLoadBalancerClass ||
 		*lbClass == cilium_api_v2alpha1.L2AnnounceLoadBalancerClass
 }
@@ -1305,16 +1316,17 @@ func (ops *BPFOps) updateMaglev(fe *loadbalancer.Frontend, feID loadbalancer.Ser
 // There can be N frontend services to 1 wildcard entry, so we track the relationships via
 // presence of the Frontend ServiceID being present in the wildcardReferences map at the
 // index of the raw Frontend IP Address.
-//
-// This routine will have no effect if the frontend type is not LoadBalancer or ClusterIP, if
-// the Frontend Address scope is not External, or if the Frontend Service ID is already
-// present in the wildcardReferences[] slice.
 func (ops *BPFOps) upsertWildcard(fe *loadbalancer.Frontend, feID loadbalancer.ServiceID) error {
 	// Identify the wildcardReferences slice by Frontend Address. If the Frontend
-	// ServiceID is not present in the slice, we should attempt to program the
-	// data path.
+	// ServiceID is present in the slice, we don't need to do anything. This FE is
+	// already mapped to a wildcard.
 	addr := fe.Address.Addr()
-	if wildRefs := ops.wildcardReferences[addr]; !slices.Contains(wildRefs, feID) {
+	wildRefs := ops.wildcardReferences[addr]
+	if slices.Contains(wildRefs, feID) {
+		return nil
+	}
+
+	if len(wildRefs) == 0 {
 		var wildcardKey maps.ServiceKey
 		var wildcardVal maps.ServiceValue
 
@@ -1337,20 +1349,17 @@ func (ops *BPFOps) upsertWildcard(fe *loadbalancer.Frontend, feID loadbalancer.S
 		})
 		wildcardVal.SetFlags(wildcardFlags.UInt16())
 
-		// Upsert the wildcard service entry
-		ops.log.Debug("Update wildcard service entry for first parent service",
-			logfields.ServiceID, feID,
-			logfields.Type, fe.Type,
-			logfields.Address, fe.Address)
+		// Upsert the wildcard service entry for the first parent.
+		ops.log.Debug("Upsert wildcard service entry for first parent service",
+			logfields.ID, feID)
 		if err := ops.upsertService(wildcardKey, wildcardVal); err != nil {
-			return fmt.Errorf("upsert wildcard: %w", err)
+			return err
 		}
-
-		// Programming was successful, so we append this FE ServiceID into the
-		// wildcardReferences slice to avoid reprogramming the data path if we
-		// get called again.
-		ops.wildcardReferences[addr] = append(wildRefs, feID)
 	}
+
+	// The datapath entry already exists or was successfully programmed above,
+	// so it's now safe to record this frontend as a parent reference.
+	ops.wildcardReferences[addr] = append(wildRefs, feID)
 
 	return nil
 }
@@ -1361,20 +1370,25 @@ func (ops *BPFOps) deleteWildcard(fe *loadbalancer.Frontend, feID loadbalancer.S
 	// Identify the wildcardReferences slice to use by Frontend Address.
 	addr := fe.Address.Addr()
 	wildRefs := ops.wildcardReferences[addr]
+	numParents := len(wildRefs)
 
 	// Scan over the wildRefs slice to look for this Frontend ServiceID. If
 	// found, we need to remove it.
 	for i, parentID := range wildRefs {
-		if parentID == feID {
+		if parentID != feID {
+			continue
+		}
+
+		// If there are multiple parent frontends associated with this wildcard,
+		// we just remove this feID and carry on.
+		if numParents > 1 {
 			wildRefs = append(wildRefs[:i], wildRefs[i+1:]...)
 			ops.wildcardReferences[addr] = wildRefs
-			break
+			return nil
 		}
-	}
 
-	// We use the length of the wildRefs slice to identify if we can remove
-	// the data path entry for this wildcard.
-	if len(wildRefs) == 0 {
+		// This is the last parent entry, so it's safe to attempt to remove it
+		// from the datapath.
 		var wildcardKey maps.ServiceKey
 
 		if addr.Is6() {
@@ -1386,14 +1400,13 @@ func (ops *BPFOps) deleteWildcard(fe *loadbalancer.Frontend, feID loadbalancer.S
 		}
 
 		ops.log.Debug("Delete wildcard service entry for last parent service",
-			logfields.ID, feID,
-			logfields.Type, fe.Type,
-			logfields.Address, fe.Address)
+			logfields.ID, feID)
 		if err := ops.deleteService(wildcardKey); err != nil {
-			return fmt.Errorf("delete wildcard: %w", err)
+			return err
 		}
 
 		delete(ops.wildcardReferences, addr)
+		return nil
 	}
 
 	return nil

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -485,9 +485,11 @@ func (ops *BPFOps) deleteFrontend(fe *loadbalancer.Frontend) error {
 	}
 	delete(ops.prevSourceRanges, fe.Address)
 
-	// Cleanup any wildcard entries this fe might be associated with
-	if err := ops.deleteWildcard(fe, feID); err != nil {
-		return fmt.Errorf("delete wildcard: %w", err)
+	// Cleanup any wildcard entries this fe might be associated with.
+	if loadbalancer.IsWildcardCandidate(fe) && ops.isWildcardClass(fe.Service) {
+		if err := ops.deleteWildcard(fe, feID); err != nil {
+			return fmt.Errorf("delete wildcard: %w", err)
+		}
 	}
 
 	// Decrease the backend reference counts and drop state associated with the frontend.
@@ -1057,8 +1059,10 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend) error {
 
 	// Upsert wildcard entries such that the data path will have a service entry for any
 	// LoadBalancer or Cluster IP that receives traffic for an unknown protocol/port combination.
-	if err := ops.upsertWildcard(fe, feID); err != nil {
-		return fmt.Errorf("upsert wildcard: %w", err)
+	if loadbalancer.IsWildcardCandidate(fe) && ops.isWildcardClass(svc) {
+		if err := ops.upsertWildcard(fe, feID); err != nil {
+			return fmt.Errorf("upsert wildcard: %w", err)
+		}
 	}
 
 	// Calculate the number of existing backend references, so we can cleanup if there there
@@ -1125,34 +1129,23 @@ func (ops *BPFOps) useMaglev(fe *loadbalancer.Frontend) bool {
 	}
 }
 
-func (ops *BPFOps) useWildcard(fe *loadbalancer.Frontend) bool {
-	switch fe.Type {
-	case loadbalancer.SVCTypeLoadBalancer,
-		loadbalancer.SVCTypeClusterIP:
-
-		// Only external scoped entries can parent wildcard entries
-		if fe.Address.Scope() != loadbalancer.ScopeExternal {
-			return false
-		}
-
-		// We only want to program wildcard entries if LB-IPAM has allocated
-		// the VIP, otherwise we risk programming Node internal IPs into the
-		// datapath and causing connectivity faults.
-		lbClass := fe.Service.LoadBalancerClass
-		if lbClass == nil {
-			return ops.extCfg.DefaultLBServiceIPAM == lbipamconfig.DefaultLBClassLBIPAM
-		}
-
-		// The service has a loadBalancerClass, so we only include a wildcard
-		// service entry if it's a class Cilium actively manages, again to avoid
-		// programming wildcard entries for IP addresses we don't manage.
-		//
-		// TODO: improve this in future, perhaps by matching against known
-		// CiliumInternalIPs.
-		return *lbClass == cilium_api_v2alpha1.BGPLoadBalancerClass ||
-			*lbClass == cilium_api_v2alpha1.L2AnnounceLoadBalancerClass
+func (ops *BPFOps) isWildcardClass(svc *loadbalancer.Service) bool {
+	// We only want to program wildcard entries if LB-IPAM has allocated
+	// the VIP, otherwise we risk programming Node internal IPs into the
+	// datapath and causing connectivity faults.
+	lbClass := svc.LoadBalancerClass
+	if lbClass == nil {
+		return ops.extCfg.DefaultLBServiceIPAM == lbipamconfig.DefaultLBClassLBIPAM
 	}
-	return false
+
+	// The service has a loadBalancerClass, so we only include a wildcard
+	// service entry if it's a class Cilium actively manages, again to avoid
+	// programming wildcard entries for IP addresses we don't manage.
+	//
+	// TODO: improve this in future, perhaps by matching against known
+	// CiliumInternalIPs.
+	return *lbClass == cilium_api_v2alpha1.BGPLoadBalancerClass ||
+		*lbClass == cilium_api_v2alpha1.L2AnnounceLoadBalancerClass
 }
 
 func (ops *BPFOps) upsertService(svcKey maps.ServiceKey, svcVal maps.ServiceValue) error {
@@ -1317,11 +1310,6 @@ func (ops *BPFOps) updateMaglev(fe *loadbalancer.Frontend, feID loadbalancer.Ser
 // the Frontend Address scope is not External, or if the Frontend Service ID is already
 // present in the wildcardReferences[] slice.
 func (ops *BPFOps) upsertWildcard(fe *loadbalancer.Frontend, feID loadbalancer.ServiceID) error {
-
-	if !ops.useWildcard(fe) {
-		return nil
-	}
-
 	// Identify the wildcardReferences slice by Frontend Address. If the Frontend
 	// ServiceID is not present in the slice, we should attempt to program the
 	// data path.
@@ -1370,11 +1358,6 @@ func (ops *BPFOps) upsertWildcard(fe *loadbalancer.Frontend, feID loadbalancer.S
 // Delete a wildcard entry based on the deletion of a Frontend.
 // See upsertWildcard() for semantics. This does the reverse.
 func (ops *BPFOps) deleteWildcard(fe *loadbalancer.Frontend, feID loadbalancer.ServiceID) error {
-
-	if !ops.useWildcard(fe) {
-		return nil
-	}
-
 	// Identify the wildcardReferences slice to use by Frontend Address.
 	addr := fe.Address.Addr()
 	wildRefs := ops.wildcardReferences[addr]

--- a/pkg/loadbalancer/tests/testdata/loadbalancer-localaddr-wildcards.txtar
+++ b/pkg/loadbalancer/tests/testdata/loadbalancer-localaddr-wildcards.txtar
@@ -1,0 +1,652 @@
+#! --lb-test-fault-probability=0.0
+
+# Add node addresses
+db/insert node-addresses addrv4.yaml
+db/cmp node-addresses nodeaddrs-initial.table
+
+# Start the test application
+hive start
+
+# Add backend state for one multiprotocol service and one TCP-only service
+k8s/add endpointslice-multi.yaml endpointslice-single.yaml
+db/cmp backends backends.table
+
+# Add the services and verify the desired frontend state
+k8s/add service-multi.yaml service-single.yaml
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# Verify that ClusterIP and LoadBalancer IPs get wildcard ANY entries
+lb/maps-dump lbmaps-initial.actual
+* cmp lbmaps-initial.expected lbmaps-initial.actual
+
+# Add a node-address that clashes with the first LoadBalancer VIP
+# This should suppress the wildcard entry only for 172.16.1.1
+db/insert node-addresses addrv4-eth0.yaml
+db/cmp node-addresses nodeaddrs-clash-1.table
+db/cmp frontends frontends.table
+lb/maps-dump lbmaps-clash-1.actual
+* cmp lbmaps-clash-1.expected lbmaps-clash-1.actual
+
+# Add a second clashing node-address for the other LoadBalancer VIP
+# This should suppress wildcard entries for 172.16.1.2 as well now
+db/insert node-addresses addrv4-eth1.yaml
+db/cmp node-addresses nodeaddrs-clash-both.table
+db/cmp frontends frontends.table
+lb/maps-dump lbmaps-clash-both.actual
+* cmp lbmaps-clash-both.expected lbmaps-clash-both.actual
+
+# Remove the first clashing node-address
+# The first VIP should regain its wildcard entry, while the second should remain suppressed
+db/delete node-addresses addrv4-eth0.yaml
+db/cmp node-addresses nodeaddrs-clash-2.table
+db/cmp frontends frontends.table
+lb/maps-dump lbmaps-clash-2.actual
+* cmp lbmaps-clash-2.expected lbmaps-clash-2.actual
+
+# Remove the second clashing node-address and verify both wildcard entries return
+db/delete node-addresses addrv4-eth1.yaml
+db/cmp node-addresses nodeaddrs-initial.table
+db/cmp frontends frontends.table
+lb/maps-dump lbmaps-restored.actual
+* cmp lbmaps-restored.expected lbmaps-restored.actual
+* cmp lbmaps-initial.actual lbmaps-restored.actual
+
+# Cleanup endpoint state first.
+k8s/delete endpointslice-multi.yaml endpointslice-single.yaml
+* db/empty backends
+
+# Then delete the services and verify the datapath is empty again.
+k8s/delete service-multi.yaml service-single.yaml
+* db/empty services frontends backends
+* lb/maps-empty
+
+#####
+
+-- addrv4.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+
+-- addrv4-eth0.yaml --
+addr: 172.16.1.1
+nodeport: false
+primary: true
+devicename: eth0
+
+-- addrv4-eth1.yaml --
+addr: 172.16.1.2
+nodeport: false
+primary: true
+devicename: eth1
+
+-- nodeaddrs-initial.table --
+Address NodePort Primary DeviceName
+1.1.1.1 true     true    test
+
+-- nodeaddrs-clash-1.table --
+Address     NodePort Primary DeviceName
+1.1.1.1     true     true    test
+172.16.1.1  false    true    eth0
+
+-- nodeaddrs-clash-both.table --
+Address     NodePort Primary DeviceName
+1.1.1.1     true     true    test
+172.16.1.1  false    true    eth0
+172.16.1.2  false    true    eth1
+
+-- nodeaddrs-clash-2.table --
+Address     NodePort Primary DeviceName
+1.1.1.1     true     true    test
+172.16.1.2  false    true    eth1
+
+-- services.table --
+Name               Source   PortNames                      TrafficPolicy   Flags
+test/echo-multi    k8s      dtls=443, http=80, https=443   Cluster
+test/echo-single   k8s      http=80                        Cluster
+
+-- frontends.table --
+Address                Type           ServiceName        PortName   Backends                                 RedirectTo   Status
+0.0.0.0:30781/TCP      NodePort       test/echo-multi    http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
+0.0.0.0:30782/TCP      NodePort       test/echo-multi    https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
+0.0.0.0:30782/UDP      NodePort       test/echo-multi    dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP                Done
+0.0.0.0:30783/TCP      NodePort       test/echo-single   http       10.244.2.1:80/TCP, 10.244.2.2:80/TCP                  Done
+10.96.50.104:80/TCP    ClusterIP      test/echo-multi    http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
+10.96.50.104:443/TCP   ClusterIP      test/echo-multi    https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
+10.96.50.104:443/UDP   ClusterIP      test/echo-multi    dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP                Done
+10.96.50.105:80/TCP    ClusterIP      test/echo-single   http       10.244.2.1:80/TCP, 10.244.2.2:80/TCP                  Done
+172.16.1.1:80/TCP      LoadBalancer   test/echo-multi    http       10.244.1.1:80/TCP, 10.244.1.2:80/TCP                  Done
+172.16.1.1:443/TCP     LoadBalancer   test/echo-multi    https      10.244.1.1:443/TCP, 10.244.1.2:443/TCP                Done
+172.16.1.1:443/UDP     LoadBalancer   test/echo-multi    dtls       10.244.1.1:443/UDP, 10.244.1.2:443/UDP                Done
+172.16.1.2:80/TCP      LoadBalancer   test/echo-single   http       10.244.2.1:80/TCP, 10.244.2.2:80/TCP                  Done
+
+-- backends.table --
+Service            Address             NodeName
+test/echo-multi    10.244.1.1:80/TCP   nodeport-worker1
+test/echo-multi    10.244.1.1:443/TCP  nodeport-worker1
+test/echo-multi    10.244.1.1:443/UDP  nodeport-worker1
+test/echo-multi    10.244.1.2:80/TCP   nodeport-worker2
+test/echo-multi    10.244.1.2:443/TCP  nodeport-worker2
+test/echo-multi    10.244.1.2:443/UDP  nodeport-worker2
+test/echo-single   10.244.2.1:80/TCP   nodeport-worker1
+test/echo-single   10.244.2.2:80/TCP   nodeport-worker2
+
+-- lbmaps-initial.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+BE: ID=5 ADDR=10.244.1.1:443/UDP STATE=active
+BE: ID=6 ADDR=10.244.1.2:443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=172.16.1.1:80
+REV: ID=11 ADDR=172.16.1.1:443
+REV: ID=12 ADDR=172.16.1.1:443
+REV: ID=13 ADDR=0.0.0.0:30783
+REV: ID=14 ADDR=1.1.1.1:30783
+REV: ID=15 ADDR=10.96.50.105:80
+REV: ID=16 ADDR=172.16.1.2:80
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+REV: ID=7 ADDR=10.96.50.104:80
+REV: ID=8 ADDR=10.96.50.104:443
+REV: ID=9 ADDR=10.96.50.104:443
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=10.96.50.105:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=0 ADDR=172.16.1.2:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-clash-1.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+BE: ID=5 ADDR=10.244.1.1:443/UDP STATE=active
+BE: ID=6 ADDR=10.244.1.2:443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=172.16.1.1:80
+REV: ID=11 ADDR=172.16.1.1:443
+REV: ID=12 ADDR=172.16.1.1:443
+REV: ID=13 ADDR=0.0.0.0:30783
+REV: ID=14 ADDR=1.1.1.1:30783
+REV: ID=15 ADDR=10.96.50.105:80
+REV: ID=16 ADDR=172.16.1.2:80
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+REV: ID=7 ADDR=10.96.50.104:80
+REV: ID=8 ADDR=10.96.50.104:443
+REV: ID=9 ADDR=10.96.50.104:443
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=10.96.50.105:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.2:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-clash-both.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+BE: ID=5 ADDR=10.244.1.1:443/UDP STATE=active
+BE: ID=6 ADDR=10.244.1.2:443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=172.16.1.1:80
+REV: ID=11 ADDR=172.16.1.1:443
+REV: ID=12 ADDR=172.16.1.1:443
+REV: ID=13 ADDR=0.0.0.0:30783
+REV: ID=14 ADDR=1.1.1.1:30783
+REV: ID=15 ADDR=10.96.50.105:80
+REV: ID=16 ADDR=172.16.1.2:80
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+REV: ID=7 ADDR=10.96.50.104:80
+REV: ID=8 ADDR=10.96.50.104:443
+REV: ID=9 ADDR=10.96.50.104:443
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=10.96.50.105:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-clash-2.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+BE: ID=5 ADDR=10.244.1.1:443/UDP STATE=active
+BE: ID=6 ADDR=10.244.1.2:443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=172.16.1.1:80
+REV: ID=11 ADDR=172.16.1.1:443
+REV: ID=12 ADDR=172.16.1.1:443
+REV: ID=13 ADDR=0.0.0.0:30783
+REV: ID=14 ADDR=1.1.1.1:30783
+REV: ID=15 ADDR=10.96.50.105:80
+REV: ID=16 ADDR=172.16.1.2:80
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+REV: ID=7 ADDR=10.96.50.104:80
+REV: ID=8 ADDR=10.96.50.104:443
+REV: ID=9 ADDR=10.96.50.104:443
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=10.96.50.105:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-restored.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+BE: ID=5 ADDR=10.244.1.1:443/UDP STATE=active
+BE: ID=6 ADDR=10.244.1.2:443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.1:80/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:80/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=172.16.1.1:80
+REV: ID=11 ADDR=172.16.1.1:443
+REV: ID=12 ADDR=172.16.1.1:443
+REV: ID=13 ADDR=0.0.0.0:30783
+REV: ID=14 ADDR=1.1.1.1:30783
+REV: ID=15 ADDR=10.96.50.105:80
+REV: ID=16 ADDR=172.16.1.2:80
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=0.0.0.0:30782
+REV: ID=6 ADDR=1.1.1.1:30782
+REV: ID=7 ADDR=10.96.50.104:80
+REV: ID=8 ADDR=10.96.50.104:443
+REV: ID=9 ADDR=10.96.50.104:443
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=10.96.50.105:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=0 ADDR=172.16.1.2:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=11 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=12 ADDR=172.16.1.1:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=13 ADDR=0.0.0.0:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=14 ADDR=1.1.1.1:30783/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=15 ADDR=10.96.50.105:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=16 ADDR=172.16.1.2:80/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30782/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=10.96.50.104:443/UDP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- service-multi.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo-multi
+  namespace: test
+  resourceVersion: "741"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    nodePort: 30782
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  - name: dtls
+    nodePort: 30782
+    port: 443
+    protocol: UDP
+    targetPort: 443
+  selector:
+    name: echo-multi
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- service-single.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  name: echo-single
+  namespace: test
+  resourceVersion: "742"
+  uid: a49fe99c-3564-4754-acc4-780f2331a49c
+spec:
+  clusterIP: 10.96.50.105
+  clusterIPs:
+  - 10.96.50.105
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30783
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo-single
+  sessionAffinity: None
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.2
+
+-- endpointslice-multi.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-multi-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo-multi
+  name: echo-multi-kvlm2
+  namespace: test
+  resourceVersion: "797"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker1
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+- name: https
+  port: 443
+  protocol: TCP
+- name: dtls
+  port: 443
+  protocol: UDP
+
+-- endpointslice-single.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  annotations:
+  creationTimestamp: "2022-09-13T11:11:26Z"
+  generateName: echo-single-
+  generation: 3
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: echo-single
+  name: echo-single-kvlm2
+  namespace: test
+  resourceVersion: "798"
+  uid: d1f517f6-ab88-4c76-9bd0-4906a17cdd76
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  nodeName: nodeport-worker1
+- addresses:
+  - 10.244.2.2
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/writer/cell.go
+++ b/pkg/loadbalancer/writer/cell.go
@@ -41,4 +41,8 @@ var Cell = cell.Module(
 	// Register a background job to re-reconcile NodePort and HostPort frontends when
 	// the node addresses change.
 	cell.Invoke(registerNodePortAddressReconciler),
+
+	// Register a background job to re-reconcile wildcard-capable frontends when
+	// the node addresses change.
+	cell.Invoke(registerWildcardAddressReconciler),
 )

--- a/pkg/loadbalancer/writer/wild_addr_reconciler.go
+++ b/pkg/loadbalancer/writer/wild_addr_reconciler.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package writer
+
+import (
+	"context"
+	"log/slog"
+	"net/netip"
+	"slices"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/reconciler"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type wildcardAddressReconcilerParams struct {
+	cell.In
+
+	Lifecycle cell.Lifecycle
+	JobGroup  job.Group
+	Log       *slog.Logger
+
+	DB            *statedb.DB
+	NodeAddresses statedb.Table[tables.NodeAddress]
+	Frontends     statedb.Table[*loadbalancer.Frontend]
+}
+
+func registerWildcardAddressReconciler(p wildcardAddressReconcilerParams) {
+	r := wildcardAddressReconciler{
+		log:       p.Log,
+		db:        p.DB,
+		nodeAddrs: p.NodeAddresses,
+		frontends: p.Frontends.(statedb.RWTable[*loadbalancer.Frontend]),
+	}
+
+	// Grab the initial read transaction synchronously from a start hook so the
+	// initial node-address snapshot is taken after the table has been populated.
+	p.Lifecycle.Append(cell.Hook{
+		OnStart: func(hc cell.HookContext) error {
+			r.initTxn = p.DB.ReadTxn()
+			return nil
+		},
+	})
+
+	p.JobGroup.Add(job.OneShot("wildcard-addr-reconciler", r.wildcardAddressReconcilerLoop))
+}
+
+type wildcardAddressReconciler struct {
+	log       *slog.Logger
+	db        *statedb.DB
+	nodeAddrs statedb.Table[tables.NodeAddress]
+	frontends statedb.RWTable[*loadbalancer.Frontend]
+	initTxn   statedb.ReadTxn
+}
+
+func (r *wildcardAddressReconciler) getAddrs(txn statedb.ReadTxn) ([]netip.Addr, <-chan struct{}) {
+	iter, watch := r.nodeAddrs.AllWatch(txn)
+	addrs := statedb.Collect(statedb.Map(iter, func(addr tables.NodeAddress) netip.Addr {
+		return addr.Addr
+	}))
+	slices.SortFunc(addrs, func(a, b netip.Addr) int {
+		return a.Compare(b)
+	})
+	return slices.Compact(addrs), watch
+}
+
+func (r *wildcardAddressReconciler) wildcardAddressReconcilerLoop(ctx context.Context, health cell.Health) error {
+	// Limit the rate of processing to avoid unnecessary churn, but keep it fast enough for humans.
+	limiter := rate.NewLimiter(time.Second, 1)
+	defer limiter.Stop()
+
+	prevAddrs, watch := r.getAddrs(r.initTxn)
+	r.initTxn = nil
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+
+		wtxn := r.db.WriteTxn(r.frontends)
+		var newAddrs []netip.Addr
+		newAddrs, watch = r.getAddrs(wtxn)
+
+		if !slices.Equal(prevAddrs, newAddrs) {
+			// At the time of writing there's no index on the Frontends table that would let
+			// us gracefully filter frontends by node-addresses. So, we query all frontends and
+			// check if an FE is a wildcard candidate to reduce noise. It's not perfect but can
+			// be improved later if it becomes a bottleneck.
+			for fe := range r.frontends.All(wtxn) {
+				if !loadbalancer.IsWildcardCandidate(fe) {
+					continue
+				}
+
+				fe = fe.Clone()
+				fe.Status = reconciler.StatusPending()
+				_, _, err := r.frontends.Insert(wtxn, fe)
+				if err != nil {
+					r.log.Warn("Could not set wildcard frontend status to pending",
+						logfields.Frontend, fe,
+						logfields.Error, err,
+					)
+				}
+			}
+			prevAddrs = newAddrs
+			wtxn.Commit()
+		} else {
+			wtxn.Abort()
+		}
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -41,10 +41,11 @@ type testParams struct {
 
 	LocalNodeStore *node.LocalNodeStore
 
-	ServiceTable  statedb.Table[*loadbalancer.Service]
-	FrontendTable statedb.Table[*loadbalancer.Frontend]
-	BackendTable  statedb.Table[*loadbalancer.Backend]
-	Nodes         statedb.Table[*node.LocalNode]
+	NodeAddressTable statedb.RWTable[tables.NodeAddress]
+	ServiceTable     statedb.Table[*loadbalancer.Service]
+	FrontendTable    statedb.Table[*loadbalancer.Frontend]
+	BackendTable     statedb.Table[*loadbalancer.Backend]
+	Nodes            statedb.Table[*node.LocalNode]
 }
 
 func fixture(t testing.TB) (p testParams) {
@@ -409,6 +410,81 @@ func TestWriter_Initializers(t *testing.T) {
 	require.NotEmpty(t, p.FrontendTable.PendingInitializers(firstTxn), "expected frontends to be uninitialized")
 	require.NotEmpty(t, p.BackendTable.PendingInitializers(firstTxn), "expected backends to be uninitialized")
 	require.NotEmpty(t, p.ServiceTable.PendingInitializers(firstTxn), "expected services to be uninitialized")
+}
+
+func TestWriter_WildcardAddressReconciler(t *testing.T) {
+	p := fixture(t)
+
+	wildcardName := loadbalancer.NewServiceName("test", "wildcard")
+	otherName := loadbalancer.NewServiceName("test", "other")
+	wildcardAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(200), 2000, loadbalancer.ScopeExternal)
+	otherAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(201), 2001, loadbalancer.ScopeInternal)
+
+	// Add one wildcard-candidate frontend and one non-candidate frontend.
+	wtxn := p.Writer.WriteTxn()
+	require.NoError(t, p.Writer.UpsertServiceAndFrontends(
+		wtxn,
+		&loadbalancer.Service{Name: wildcardName, Source: source.Kubernetes},
+		loadbalancer.FrontendParams{
+			ServiceName: wildcardName,
+			Address:     wildcardAddr,
+			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: wildcardAddr.Port(),
+		},
+	))
+	require.NoError(t, p.Writer.UpsertServiceAndFrontends(
+		wtxn,
+		&loadbalancer.Service{Name: otherName, Source: source.Kubernetes},
+		loadbalancer.FrontendParams{
+			ServiceName: otherName,
+			Address:     otherAddr,
+			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: otherAddr.Port(),
+		},
+	))
+	wtxn.Commit()
+
+	// Mark both frontends as done so the reconciler has to push them back to pending.
+	wtxn = p.Writer.WriteTxn()
+	frontendTable, ok := any(p.FrontendTable).(statedb.RWTable[*loadbalancer.Frontend])
+	require.True(t, ok)
+	wildcardFE, _, found := p.FrontendTable.Get(wtxn, loadbalancer.FrontendByAddress(wildcardAddr))
+	require.True(t, found)
+	otherFE, _, found := p.FrontendTable.Get(wtxn, loadbalancer.FrontendByAddress(otherAddr))
+	require.True(t, found)
+
+	wildcardFE = wildcardFE.Clone()
+	wildcardFE.Status = reconciler.StatusDone()
+	_, _, err := frontendTable.Insert(wtxn, wildcardFE)
+	require.NoError(t, err)
+
+	otherFE = otherFE.Clone()
+	otherFE.Status = reconciler.StatusDone()
+	_, _, err = frontendTable.Insert(wtxn, otherFE)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	// Change the node-address set to trigger the wildcard address reconciler.
+	ntxn := p.DB.WriteTxn(p.NodeAddressTable)
+	_, _, err = p.NodeAddressTable.Insert(ntxn, tables.NodeAddress{
+		Addr:       intToAddr(250).Addr(),
+		Primary:    true,
+		DeviceName: "eth0",
+	})
+	require.NoError(t, err)
+	ntxn.Commit()
+
+	// Verify that only the wildcard candidate gets requeued to pending.
+	require.Eventually(t, func() bool {
+		txn := p.DB.ReadTxn()
+		wildcardFE, _, found := p.FrontendTable.Get(txn, loadbalancer.FrontendByAddress(wildcardAddr))
+		if !found || wildcardFE.Status.Kind != reconciler.StatusKindPending {
+			return false
+		}
+
+		otherFE, _, found := p.FrontendTable.Get(txn, loadbalancer.FrontendByAddress(otherAddr))
+		return found && otherFE.Status.Kind == reconciler.StatusKindDone
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func TestWriter_SetBackends(t *testing.T) {


### PR DESCRIPTION
This PR aims to mitigate scenarios where an LB service wildcard could be programmed for a node-local IP address, causing unintended drops. This has previously happened where LB VIPs are allocated via Node-IPAM. In this case, it's been identified that if a Service IP overlaps with an Egress Gateway egressIP, return traffic is blocked.

Commit 1 is preparatory.

Commit 2 has the main logic update and the log covers it.

<!-- Description of change -->

Fixes: #45408

```release-note
Fix bug that would disrupt node connectivity when ClusterIP/LoadBalancer VIPs overlapped with node-local IP addresses.
```