### PR TITLE
docs: Extend Azure IPAM documentation

### DIFF
--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -11,10 +11,10 @@ cilium-operator-azure [flags]
 ### Options
 
 ```
-      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,10 +11,10 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
-      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,10 +17,10 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -18,10 +18,10 @@ cilium-operator [flags]
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
       --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -18,10 +18,10 @@ cilium-operator hive [flags]
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
       --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -24,10 +24,10 @@ cilium-operator hive dot-graph [flags]
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
       --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
-      --azure-resource-group string                                Resource group to use for Azure IPAM
+      --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations
-      --azure-user-assigned-identity-id string                     ID of the user assigned identity used to auth with the Azure API
+      --azure-user-assigned-identity-id string                     Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/network/concepts/ipam/azure.rst
+++ b/Documentation/network/concepts/ipam/azure.rst
@@ -12,16 +12,26 @@ Azure IPAM
 
 .. note::
 
-   While still maintained for now, Azure IPAM is considered legacy and is not
-   compatible with AKS clusters created in `Bring your own CNI <https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`_
-   mode. The recommended way to install cilium on AKS are 
-   `Bring your own CNI <https://docs.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`__ or
-   `Azure CNI Powered by Cilium <https://aka.ms/aks/cilium-dataplane>`__.
-   
+   On AKS, the recommended ways to run Cilium are:
+
+   * `Azure CNI Powered by Cilium <https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium>`__: 
+     AKS fully manages Cilium's deployment and configuration. The cluster
+     is created with ``--network-dataplane cilium``. IP allocation is
+     handled by AKS's own controllers via :ref:`azure_delegated_ipam`.
+     See :ref:`aks_install`.
+
+   * `Bring your own CNI <https://learn.microsoft.com/en-us/azure/aks/use-byo-cni?tabs=azure-cli>`__
+     (BYOCNI): the cluster is created with ``--network-plugin=none`` and the
+     administrator self-manages Cilium (via Helm or the cilium-cli)
+     with any Cilium IPAM backend.
+
+   Azure IPAM (this page) is designed for non-AKS self-managed clusters
+   running on Azure VMs or VMSSs.
+
 
 The Azure IPAM allocator is specific to Cilium deployments running in the Azure
 cloud and performs IP allocation based on `Azure Private IP addresses
-<https://docs.microsoft.com/en-us/azure/virtual-network/private-ip-addresses>`__.
+<https://learn.microsoft.com/en-us/azure/virtual-network/private-ip-addresses>`__.
 
 The architecture ensures that only a single operator communicates with the
 Azure API to avoid rate-limiting issues in large clusters. A pre-allocation
@@ -40,7 +50,7 @@ The Azure IPAM allocator builds on top of the CRD-backed allocator. Each node
 creates a ``ciliumnodes.cilium.io`` custom resource matching the node name when
 Cilium starts up for the first time on that node. The Cilium agent running on
 each node will retrieve the Kubernetes ``v1.Node`` resource and extract the
-``.Spec.ProviderID`` field in order to derive the `Azure instance ID <https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids>`__.
+``.Spec.ProviderID`` field in order to derive the `Azure instance ID <https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids>`__.
 Azure allocation parameters are provided as agent configuration option and are
 passed into the custom resource as well.
 
@@ -70,6 +80,56 @@ Configuration
   the option ``--enable-metrics``. See the section :ref:`install_metrics` for
   additional information how to install and run Prometheus including the
   Grafana dashboard.
+
+Operator scope: subscription, resource group, identity
+======================================================
+
+The operator talks to Azure using three pieces of context. Each can be
+auto-detected from the `Azure Instance Metadata Service (IMDS)
+<https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service>`__
+or set explicitly via the ``--azure-*`` :doc:`operator flags </cmdref/cilium-operator-azure>`.
+
+Subscription (``--azure-subscription-id``)
+   All Azure SDK clients are bound to a single subscription. If unset, the
+   operator detects the subscription of the node it runs on via its IMDS.
+
+Resource group (``--azure-resource-group``)
+   Scopes per-resource-group API calls such as listing interfaces, VMSS, and
+   Public IP Prefixes. This must be the resource group of the cluster
+   nodes. If unset, the operator detects the resource group of the node it runs
+   on via its IMDS, which is only correct when the operator pod runs on a node in
+   the same resource group as the rest of the cluster's nodes. Set this flag
+   explicitly when worker VMs/VMSS live in a different resource group (for
+   example, self-managed Azure VM clusters that split control-plane and
+   worker pools across resource groups).
+
+VNet / subnet resource group
+   The operator derives the VNet and subnet resource group from each
+   interface's subnet ID at runtime, there is no flag for it. When VNets live
+   in a shared networking resource group, the operator's identity needs to have
+   read access there.
+
+Authentication
+==============
+
+The operator authenticates using the Azure Identity SDK. Two modes are
+supported:
+
+Default credential chain (no flag set)
+   When ``--azure-user-assigned-identity-id`` is empty, the operator calls
+   `DefaultAzureCredential
+   <https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication>`__,
+   which tries, in order: environment variables, workload identity (projected
+   token), system-assigned managed identity, then Azure CLI. This is the
+   recommended path for AKS clusters using `Azure AD Workload Identity
+   <https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview>`__.
+
+User-assigned managed identity (``--azure-user-assigned-identity-id``)
+   When set, the operator authenticates as a specific user-assigned managed
+   identity. The value must be the identity's client ID (a UUID), not its
+   full Azure resource ID (``/subscriptions/.../userAssignedIdentities/...``).
+   The client ID is visible in the identity's overview blade in the Azure portal
+   or via ``az identity show -g <resource-group> -n <name> --query clientId -o tsv``.
 
 Custom Azure IPAM Configuration
 ===============================
@@ -247,7 +307,7 @@ criteria:
  * The interface has addresses associated which are not yet used or the number of
    addresses associated with the interface is lesser than `maximum number of
    addresses
-   <https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#networking-limits>`__
+   <https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#networking-limits>`__
    that can be associated to an interface.
 
  * The subnet associated with the interface has IPs available for allocation
@@ -322,30 +382,105 @@ Masquerading is supported via the eBPF :ref:`ip-masq-agent <concepts_masqueradin
 Required Privileges
 *******************
 
-The following Azure API calls are being performed by the Cilium operator. The
-Service Principal provided must have privileges to perform these within the
-scope of the AKS cluster node resource group:
+The identity used by the operator (managed identity, service principal, or
+workload identity federation) needs Azure RBAC permissions on two or three
+scopes depending on topology:
 
- * `Network Interfaces - Create Or Update <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterfaces/createorupdate>`__
- * `NetworkInterface In VMSS - List Virtual Machine Scale Set Network Interfaces <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/networkinterface%20in%20vmss/listvirtualmachinescalesetnetworkinterfaces>`__
- * `Virtual Networks - List <https://docs.microsoft.com/en-us/rest/api/virtualnetwork/virtualnetworks/list>`__
- * `Virtual Machine Scale Sets - List All <https://docs.microsoft.com/en-us/rest/api/compute/virtualmachinescalesets/listall>`__
+Node resource group
+   Grants read on VMSS, and the writes needed to attach IP configurations
+   to node NICs. On VMSS this is a write on the VMSS instance's VM model,
+   on standalone VMs it is a write on the network interface itself (see
+   the ``Actions`` breakdown below for the exact permissions). This is the
+   resource group passed via ``--azure-resource-group`` (or auto-detected
+   from IMDS when the operator is collocated with the nodes).
 
-When using static public IP allocation with Public IP Prefixes, the following additional privileges are required:
+VNet / subnet resource group
+   Grants read on the VNet and subnets, and the ``subnets/join/action`` used
+   when attaching new private IPs. Often the same as the node resource
+   group, but can be a separate networking resource group.
 
- * `Network Interfaces - Get <https://learn.microsoft.com/en-us/rest/api/virtualnetwork/network-interfaces/get>`__ (for standalone VMs only)
- * `Public IP Prefixes - List All <https://learn.microsoft.com/en-us/rest/api/virtualnetwork/public-ip-prefixes/list-all>`__
- * `Virtual Machine Scale Set VMs - Get <https://learn.microsoft.com/en-us/rest/api/compute/virtual-machine-scale-set-vms/get>`__
- * `Virtual Machine Scale Set VMs - Update <https://learn.microsoft.com/en-us/rest/api/compute/virtual-machine-scale-set-vms/update>`__
- * `Virtual Machines - Get <https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/get>`__ (for standalone VMs only)
+Subscription (optional)
+   Only required if you want VNet discovery to work across multiple resource
+   groups from a single role assignment. ``List`` calls filter by RBAC, so
+   subscription-wide Reader is not mandatory, scoping the same actions to
+   each relevant resource group is sufficient.
+
+Minimum ``Actions`` for a custom role
+=====================================
+
+The set of required ``Actions`` depends on the node type (VMSS instances
+vs. standalone VMs) and on whether static public IP allocation is enabled.
+
+Common to every deployment:
+
+.. code-block:: text
+
+   Microsoft.Network/networkInterfaces/read
+   Microsoft.Network/virtualNetworks/read
+   Microsoft.Network/virtualNetworks/subnets/read
+   Microsoft.Network/virtualNetworks/subnets/join/action
+   Microsoft.Compute/virtualMachineScaleSets/read
+
+For VMSS-based clusters, add:
+
+.. code-block:: text
+
+   Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read
+   Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write
+
+For standalone-VM clusters, add:
+
+.. code-block:: text
+
+   Microsoft.Network/networkInterfaces/write
+
+When using static public IP allocation with Public IP Prefixes, add:
+
+.. code-block:: text
+
+   Microsoft.Network/publicIPPrefixes/read
+   Microsoft.Network/publicIPPrefixes/join/action
+   Microsoft.Compute/virtualMachines/read
+
+.. note::
+
+   ``Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write`` is a
+   broad permission, it authorizes any PATCH on the instance's VM model,
+   not just NIC changes. But it is necessary for VMSS topologies. On
+   VMSS, per-instance NIC configurations are part of the instance model
+   itself (``Properties.NetworkProfileConfiguration``), and there is no
+   narrower RBAC action that permits editing only the NIC block. The
+   operator uses this permission solely to add or remove IP configurations
+   on existing NICs. It does not issue VMSS instance lifecycle operations.
+   Standalone-VM deployments don't have this issue because NICs are first-class
+   resources edited via ``Microsoft.Network/networkInterfaces/write``.
 
 .. note::
 
    The node resource group is *not* the resource group of the AKS cluster. A
    single resource group may hold multiple AKS clusters, but each AKS cluster
    regroups all resources in an automatically managed secondary resource group.
-   See `Why are two resource groups created with AKS? <https://docs.microsoft.com/en-us/azure/aks/faq#why-are-two-resource-groups-created-with-aks>`__
+   See `Why are two resource groups created with AKS? <https://learn.microsoft.com/en-us/azure/aks/faq#why-are-two-resource-groups-created-with-aks->`__
    for more details.
+
+Troubleshooting
+===============
+
+``AuthorizationFailed`` on ``Microsoft.Network/virtualNetworks/read``
+   The operator's identity does not have read access on the resource group
+   that owns the VNet. Add a role assignment scoped to the VNet resource
+   group (which may differ from the node resource group).
+
+``spec.ipam.available`` stays empty and no allocations happen
+   ``--azure-resource-group`` is pointing at the wrong resource group.
+   Verify that the value matches the resource group containing the actual
+   VMs or VMSS, not the operator's own resource group, and not the AKS
+   cluster resource group.
+
+``ManagedIdentityCredential authentication failed``
+   ``--azure-user-assigned-identity-id`` was set to the full resource ID
+   (``/subscriptions/.../userAssignedIdentities/<name>``). Pass the identity's
+   client ID (a UUID) instead.
 
 *******
 Metrics

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -138,8 +138,11 @@ Twilio
 Uncompress
 Uncordon
 VM
+VMSS
+VMs
 VMware
 VNet
+VNets
 VPC
 Vagrantcloud
 Vagrantfile

--- a/operator/pkg/ipam/azure.go
+++ b/operator/pkg/ipam/azure.go
@@ -49,8 +49,8 @@ var azureDefaultConfig = AzureConfig{
 
 func (cfg AzureConfig) Flags(flags *pflag.FlagSet) {
 	flags.String(operatorOption.AzureSubscriptionID, azureDefaultConfig.AzureSubscriptionID, "Subscription ID to access Azure API")
-	flags.String(operatorOption.AzureResourceGroup, azureDefaultConfig.AzureResourceGroup, "Resource group to use for Azure IPAM")
-	flags.String(operatorOption.AzureUserAssignedIdentityID, azureDefaultConfig.AzureUserAssignedIdentityID, "ID of the user assigned identity used to auth with the Azure API")
+	flags.String(operatorOption.AzureResourceGroup, azureDefaultConfig.AzureResourceGroup, "Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)")
+	flags.String(operatorOption.AzureUserAssignedIdentityID, azureDefaultConfig.AzureUserAssignedIdentityID, "Client ID (UUID) of the user-assigned managed identity used to auth with the Azure API")
 	flags.Bool(operatorOption.AzureUsePrimaryAddress, azureDefaultConfig.AzureUsePrimaryAddress, "Use Azure IP address from interface's primary IPConfigurations")
 }
 


### PR DESCRIPTION
Update Azure IPAM documentation to add more details around:
* required IAM permissions
* authentication modes (in particular the `--azure-user-assigned-identity-id` flag)
* troubleshooting common failure modes

The goal of this PR is to address the points raised in #16164.

Closes #16164