### PR TITLE
Helm: fixes typo: commonLabels and clustermesh.annotations are both scoped at .Values

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml
@@ -5,11 +5,11 @@ kind: Certificate
 metadata:
   name: clustermesh-apiserver-server-cert
   namespace: {{ include "cilium.namespace" . }}
-  {{- with .Values.clustermesh.annotations }}
   {{- with .Values.commonLabels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.clustermesh.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
When setting `clustermesh.apiserver.tls.auto.method: certmanager` and setting any anntoations, the Helm fails with the following error:
```
[debug] template: cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml:9:18: executing "cilium/templates/clustermesh-apiserver/tls-certmanager/server-secret.yaml" at <.Values.commonLabels>: nil pointer evaluating interface {}.commonLabels

```
it appears that `.Values.commonLabels` was improperly nested inside `{{- with .Values.clustermesh.annotations }}`.

…

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #45577

```release-note
clustermesh: Fix Helm typo preventing to add annotations when setting `clustermesh.apiserver.tls.auto.method: certmanager`
```
