### PR TITLE
.github: Fix environment.deployment for docs-builder

### DIFF
--- a/.github/workflows/build-images-docs-builder-v1.17.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.17.yaml
@@ -154,7 +154,9 @@ jobs:
     needs: [build-and-push, prepare-update]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     steps:
       - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-docs-builder-v1.18.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.18.yaml
@@ -154,7 +154,9 @@ jobs:
     needs: [build-and-push, prepare-update]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     steps:
       - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-docs-builder-v1.19.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.19.yaml
@@ -154,7 +154,9 @@ jobs:
     needs: [build-and-push, prepare-update]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     steps:
       - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -155,7 +155,9 @@ jobs:
     needs: [build-and-push, prepare-update]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     steps:
       - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Commit 5da1bc45df27e5732ca316210ec21354bbd65d5b ("fix: separate untrusted container run from privileged
push in docs-builder workflows") inadvertently dropped the 'deployment:
false' configuration from the environment when splitting the git push
job into a separate workflow. Fix it.

Fixes: 5da1bc45df27e5732ca316210ec21354bbd65d5b ("fix: separate untrusted container run from privileged push in docs-builder workflows")
