### PR TITLE
l7lb: bpf: load mark from meta data

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1402,8 +1402,11 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 				  bpf_htons(ETH_P_IPV6));
 
 		/* See IPv4 codepath for comments. */
-		if (CONFIG(enable_tproxy) || CONFIG(proxy_redirect_via_cilium_net))
-			return ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
+		if (CONFIG(enable_tproxy) || CONFIG(proxy_redirect_via_cilium_net)) {
+			ret = ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
+			ctx->mark = ctx_load_meta(ctx, CB_PROXY_MAGIC);
+			return ret;
+		}
 
 		cilium_dbg_capture(ctx, DBG_CAPTURE_PROXY_PRE, proxy_port);
 		ctx->mark = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
@@ -2720,9 +2723,11 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 		/* Hairpin the packet through cilium_net when BPF tproxy is enabled
 		 * or when attaching the BPF program to a bridge network device.
 		 */
-		if (CONFIG(enable_tproxy) || CONFIG(proxy_redirect_via_cilium_net))
-			return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
-
+		if (CONFIG(enable_tproxy) || CONFIG(proxy_redirect_via_cilium_net)) {
+			ret = ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
+			ctx->mark = ctx_load_meta(ctx, CB_PROXY_MAGIC);
+			return ret;
+		}
 		/* Pass the packet straight to the proxy, without redirecting via
 		 * cilium_host.
 		 */


### PR DESCRIPTION
see commit message



```release-note
Fixes an issue where L7 LoadBalancer and Ingress traffic would be dropped on certain kernel versions when Cilium is attached to a bridge network device.
```
