### PR TITLE
bpf: populate ipcache_sec_identity for proxy-upstream packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -112,29 +112,32 @@ static __always_inline __u32
 resolve_srcid_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		   __u32 real_sec_identity, __u32 *ipcache_sec_identity)
 {
-	const struct remote_endpoint_info *info = NULL;
+	const struct remote_endpoint_info *info;
 	union v6addr *src;
 
-	/* Packets from the proxy will already have a real identity. */
-	if (identity_is_reserved(real_sec_identity)) {
-		src = (union v6addr *) &ip6->saddr;
-		info = lookup_ip6_remote_endpoint(src, 0);
-		if (info) {
-			*ipcache_sec_identity = info->sec_identity;
+	/* Always populate ipcache_sec_identity. The host firewall egress
+	 * gate needs to know whether the source IP is a host IP,
+	 * independently of the identity carried in the packet mark.
+	 */
+	src = (union v6addr *) &ip6->saddr;
+	info = lookup_ip6_remote_endpoint(src, 0);
+	if (info)
+		*ipcache_sec_identity = info->sec_identity;
+	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
+		   ((__u32 *)src)[3], *ipcache_sec_identity);
 
-			/* When SNAT is enabled on traffic ingressing
-			 * into Cilium, all traffic from the world will
-			 * have a source IP of the host. It will only
-			 * actually be from the host if "real_sec_identity"
-			 * (passed into this function) reports the src as
-			 * the host. So we can ignore the ipcache if it
-			 * reports the source as HOST_ID.
-			 */
-			if (*ipcache_sec_identity != HOST_ID)
-				real_sec_identity = *ipcache_sec_identity;
-		}
-		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
-			   ((__u32 *)src)[3], real_sec_identity);
+	/* Packets from the proxy will already have a real identity. */
+	if (identity_is_reserved(real_sec_identity) && info) {
+		/* When SNAT is enabled on traffic ingressing
+		 * into Cilium, all traffic from the world will
+		 * have a source IP of the host. It will only
+		 * actually be from the host if "real_sec_identity"
+		 * (passed into this function) reports the src as
+		 * the host. So we can ignore the ipcache if it
+		 * reports the source as HOST_ID.
+		 */
+		if (*ipcache_sec_identity != HOST_ID)
+			real_sec_identity = *ipcache_sec_identity;
 	}
 
 	return real_sec_identity;
@@ -563,27 +566,30 @@ static __always_inline __u32
 resolve_srcid_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
 		   __u32 real_sec_identity, __u32 *ipcache_sec_identity)
 {
-	const struct remote_endpoint_info *info = NULL;
+	const struct remote_endpoint_info *info;
+
+	/* Always populate ipcache_sec_identity. The host firewall egress
+	 * gate needs to know whether the source IP is a host IP,
+	 * independently of the identity carried in the packet mark.
+	 */
+	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+	if (info != NULL)
+		*ipcache_sec_identity = info->sec_identity;
+	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
+		   ip4->saddr, *ipcache_sec_identity);
 
 	/* Packets from the proxy will already have a real identity. */
-	if (identity_is_reserved(real_sec_identity)) {
-		info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
-		if (info != NULL) {
-			*ipcache_sec_identity = info->sec_identity;
-
-			/* When SNAT is enabled on traffic ingressing
-			 * into Cilium, all traffic from the world will
-			 * have a source IP of the host. It will only
-			 * actually be from the host if "real_sec_identity"
-			 * (passed into this function) reports the src as
-			 * the host. So we can ignore the ipcache if it
-			 * reports the source as HOST_ID.
-			 */
-			if (*ipcache_sec_identity != HOST_ID)
-				real_sec_identity = *ipcache_sec_identity;
-		}
-		cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED4 : DBG_IP_ID_MAP_FAILED4,
-			   ip4->saddr, real_sec_identity);
+	if (identity_is_reserved(real_sec_identity) && info != NULL) {
+		/* When SNAT is enabled on traffic ingressing
+		 * into Cilium, all traffic from the world will
+		 * have a source IP of the host. It will only
+		 * actually be from the host if "real_sec_identity"
+		 * (passed into this function) reports the src as
+		 * the host. So we can ignore the ipcache if it
+		 * reports the source as HOST_ID.
+		 */
+		if (*ipcache_sec_identity != HOST_ID)
+			real_sec_identity = *ipcache_sec_identity;
 	}
 
 	return real_sec_identity;

--- a/bpf/tests/host_proxy.c
+++ b/bpf/tests/host_proxy.c
@@ -8,18 +8,28 @@
 /* Enable code paths under test */
 #define ENABLE_HOST_FIREWALL		1
 #define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
 
 #define NODE_IP				v4_node_one
+#define NODE_IP6			v6_node_one
 #define NODE_PORT			bpf_htons(50000)
 #define NODE_PROXY_PORT			bpf_htons(50001)
+#define PROXY_UPSTREAM_PORT		bpf_htons(50100)
 
 #define TPROXY_PORT			bpf_htons(11111)
 
 #define SERVER_IP			v4_ext_one
 #define SERVER_PORT			bpf_htons(53)
 
+#define BACKEND_IP			v4_ext_two
+#define BACKEND_IP6			v6_ext_node_one
+#define BACKEND_PORT			bpf_htons(80)
+
+#define POD_SEC_IDENTITY		112233
+
 static volatile const __u8 *node_mac = mac_one;
 static volatile const __u8 *server_mac = mac_two;
+static volatile const __u8 *backend_mac = mac_two;
 
 #include "lib/bpf_host.h"
 
@@ -168,6 +178,288 @@ int host_proxy_v4_2_udp_check(const struct __ctx_buff *ctx)
 	assert(ct_entry->packets == 1);
 
 	policy_delete_entry(true, WORLD_ID, IPPROTO_UDP, SERVER_PORT, 0);
+
+	test_finish();
+}
+
+/* Send a request from cilium_host to a backend, emulating an envoy proxy
+ * upstream socket: the source IP is a host IP but the packet mark carries
+ * a non-reserved pod identity (MARK_MAGIC_PROXY_INGRESS). The host
+ * firewall egress path must still create a CT entry so the reply from
+ * the backend bypasses host ingress policy -- without it, the reply
+ * SYN,ACK misses in ipv4_host_policy_ingress_lookup and default-denies.
+ */
+PKTGEN("tc", "host_proxy_v4_3_upstream_fwd")
+int host_proxy_v4_3_upstream_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *tcp;
+
+	pktgen__init(&builder, ctx);
+
+	tcp = pktgen__push_ipv4_tcp_packet(&builder,
+					   (__u8 *)node_mac, (__u8 *)backend_mac,
+					   NODE_IP, BACKEND_IP,
+					   PROXY_UPSTREAM_PORT, BACKEND_PORT);
+	if (!tcp)
+		return TEST_ERROR;
+
+	tcp->syn = 1;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "host_proxy_v4_3_upstream_fwd")
+int host_proxy_v4_3_upstream_fwd_setup(struct __ctx_buff *ctx)
+{
+	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_PROXY_INGRESS);
+
+	return host_send_packet(ctx);
+}
+
+CHECK("tc", "host_proxy_v4_3_upstream_fwd")
+int host_proxy_v4_3_upstream_fwd_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* The host firewall egress path must have created a CT entry. The
+	 * entry is stored in TUPLE_F_OUT layout with the original
+	 * destination as the tuple's saddr (CT tuple convention).
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = BACKEND_IP,
+		.dport   = BACKEND_PORT,
+		.sport   = PROXY_UPSTREAM_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry created for proxy-upstream forward SYN");
+
+	assert(ct_entry->packets == 1);
+
+	test_finish();
+}
+
+/* Reply SYN,ACK from the backend arriving via the netdev. Without the CT
+ * entry created by the forward test above, the host firewall ingress
+ * lookup would default-deny this packet. Verify that it is accepted and
+ * that the CT entry's packet count is incremented.
+ */
+PKTGEN("tc", "host_proxy_v4_4_upstream_reply")
+int host_proxy_v4_4_upstream_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *tcp;
+
+	pktgen__init(&builder, ctx);
+
+	tcp = pktgen__push_ipv4_tcp_packet(&builder,
+					   (__u8 *)backend_mac, (__u8 *)node_mac,
+					   BACKEND_IP, NODE_IP,
+					   BACKEND_PORT, PROXY_UPSTREAM_PORT);
+	if (!tcp)
+		return TEST_ERROR;
+
+	tcp->syn = 1;
+	tcp->ack = 1;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "host_proxy_v4_4_upstream_reply")
+int host_proxy_v4_4_upstream_reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "host_proxy_v4_4_upstream_reply")
+int host_proxy_v4_4_upstream_reply_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = BACKEND_IP,
+		.dport   = BACKEND_PORT,
+		.sport   = PROXY_UPSTREAM_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found for proxy-upstream flow");
+
+	assert(ct_entry->packets == 2);
+
+	test_finish();
+}
+
+/* IPv6 variant of the proxy-upstream forward test. */
+PKTGEN("tc", "host_proxy_v6_3_upstream_fwd")
+int host_proxy_v6_3_upstream_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *tcp;
+
+	pktgen__init(&builder, ctx);
+
+	tcp = pktgen__push_ipv6_tcp_packet(&builder,
+					   (__u8 *)node_mac, (__u8 *)backend_mac,
+					   (__u8 *)NODE_IP6, (__u8 *)BACKEND_IP6,
+					   PROXY_UPSTREAM_PORT, BACKEND_PORT);
+	if (!tcp)
+		return TEST_ERROR;
+
+	tcp->syn = 1;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "host_proxy_v6_3_upstream_fwd")
+int host_proxy_v6_3_upstream_fwd_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v6_add_entry((union v6addr *)NODE_IP6, 0, 0, ENDPOINT_F_HOST,
+			      HOST_ID, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v6_add_entry((union v6addr *)NODE_IP6, 0, HOST_ID, 0, 0);
+
+	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_PROXY_INGRESS);
+
+	return host_send_packet(ctx);
+}
+
+CHECK("tc", "host_proxy_v6_3_upstream_fwd")
+int host_proxy_v6_3_upstream_fwd_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	struct ipv6_ct_tuple tuple = {
+		.dport   = BACKEND_PORT,
+		.sport   = PROXY_UPSTREAM_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = TUPLE_F_OUT,
+	};
+	ipv6_addr_copy(&tuple.daddr, (union v6addr *)NODE_IP6);
+	ipv6_addr_copy(&tuple.saddr, (union v6addr *)BACKEND_IP6);
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry created for proxy-upstream forward SYN (v6)");
+
+	assert(ct_entry->packets == 1);
+
+	test_finish();
+}
+
+/* IPv6 reply SYN,ACK from the backend, mirroring the v4 reply test. */
+PKTGEN("tc", "host_proxy_v6_4_upstream_reply")
+int host_proxy_v6_4_upstream_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *tcp;
+
+	pktgen__init(&builder, ctx);
+
+	tcp = pktgen__push_ipv6_tcp_packet(&builder,
+					   (__u8 *)backend_mac, (__u8 *)node_mac,
+					   (__u8 *)BACKEND_IP6, (__u8 *)NODE_IP6,
+					   BACKEND_PORT, PROXY_UPSTREAM_PORT);
+	if (!tcp)
+		return TEST_ERROR;
+
+	tcp->syn = 1;
+	tcp->ack = 1;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "host_proxy_v6_4_upstream_reply")
+int host_proxy_v6_4_upstream_reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "host_proxy_v6_4_upstream_reply")
+int host_proxy_v6_4_upstream_reply_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	struct ipv6_ct_tuple tuple = {
+		.dport   = BACKEND_PORT,
+		.sport   = PROXY_UPSTREAM_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags   = TUPLE_F_OUT,
+	};
+	ipv6_addr_copy(&tuple.daddr, (union v6addr *)NODE_IP6);
+	ipv6_addr_copy(&tuple.saddr, (union v6addr *)BACKEND_IP6);
+
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found for proxy-upstream flow (v6)");
+
+	assert(ct_entry->packets == 2);
 
 	test_finish();
 }

--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -344,6 +344,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{
 		hostFirewallIngress{},
 		hostFirewallEgress{},
+		hostFirewallL7Ingress{},
 		clientEgressL7TlsDenyWithoutHeaders{},
 		clientEgressL7TlsHeaders{},
 		egresstoSpecificNamespace{},

--- a/cilium-cli/connectivity/builder/host_firewall_l7_ingress.go
+++ b/cilium-cli/connectivity/builder/host_firewall_l7_ingress.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/host-firewall-l7-ingress.yaml
+var hostFirewallL7IngressPolicyYAML string
+
+type hostFirewallL7Ingress struct{}
+
+// build verifies that an L7-proxied connection to a pod on a remote node
+// completes successfully when the host firewall is enabled and host
+// ingress is default-deny. The forward leg is redirected to envoy on the
+// destination node; the upstream socket envoy opens to the local pod is
+// sourced from the cilium_host IP. Without per-flow CT installed for that
+// upstream connection, the reply SYN,ACK from the backend hits the host's
+// default-deny ingress and is dropped, causing the curl to fail.
+//
+// Regression test for https://github.com/cilium/cilium/issues/45565.
+func (t hostFirewallL7Ingress) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("host-firewall-l7-ingress", ct).
+		WithUnsafeTests().
+		WithFeatureRequirements(
+			features.RequireEnabled(features.HostFirewall),
+			features.RequireEnabled(features.L7Proxy),
+		).
+		WithCiliumClusterwidePolicy(hostFirewallL7IngressPolicyYAML).
+		WithCiliumPolicy(echoIngressL7HTTPPolicyYAML).
+		WithScenarios(
+			tests.PodToPod(
+				tests.WithSourceLabelsOption(client2Label),
+				tests.WithDestinationLabelsOption(map[string]string{"name": "echo-other-node"}),
+			),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			egress = check.ResultOK
+			egress.HTTP = check.HTTP{Method: "GET"}
+			return egress, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/host-firewall-l7-ingress.yaml
+++ b/cilium-cli/connectivity/builder/manifests/host-firewall-l7-ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-firewall-l7-ingress"
+spec:
+  nodeSelector: {}
+  ingress:
+  - fromEntities:
+    - health
+    - kube-apiserver
+    - remote-node
+    - world


### PR DESCRIPTION
`resolve_srcid_ipv{4,6}` only populated `ipcache_sec_identity` when the mark-carried identity was reserved. Proxy upstream packets (`MARK_MAGIC_PROXY_{INGRESS,EGRESS}`) carry a pod identity instead, so `ipcache_sec_identity` stayed `0` and `ipv{4,6}_host_policy_egress_lookup` short-circuited out. The reply SYN,ACK from the backend then missed CT at host ingress and hit default-deny when the host firewall was enabled.

Always populate `ipcache_sec_identity` from the packet source IP so the egress gate correctly detects host-sourced packets.

Fixes: #45565

AIL:4. Reviewed manually (although without too deep understanding of Cilium BPF code) and tested against my repro of the issue https://github.com/jaakkonen/cilium-issue-repro manually.

<!-- Description of change -->

```release-note
Fixes bug where replies to proxy would be dropped when using L7 rules with host firewall enabled
```