### PR TITLE
ci: add drop monitor for GKE conformance tests

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -497,12 +497,48 @@ jobs:
         run: |
           mkdir -p cilium-junits
 
+      - name: Start drop monitor (flake hunt for cilium/cilium#44131)
+        run: |
+          mkdir -p drop-monitor
+          for pod in $(kubectl -n kube-system get pod -l k8s-app=cilium -o jsonpath='{.items[*].metadata.name}'); do
+            kubectl -n kube-system exec "$pod" -c cilium-agent -- cilium-dbg monitor --type drop -j > "drop-monitor/${pod}.jsonl" 2> "drop-monitor/${pod}.stderr" &
+            touch "drop-monitor/$!.pid"
+          done
+          sleep 2
+
       - name: Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})
         id: run-tests
         run: |
           cilium connectivity test ${{ steps.vars-conn.outputs.connectivity_test_defaults }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
+
+      - name: Stop drop monitor
+        if: always()
+        run: |
+          # term drop monitors so stdout flushes to files.
+          for pidf in drop-monitor/*.pid; do
+            [ -f "$pidf" ] || continue
+            pid="${pidf##*/}"; pid="${pid%.pid}"
+            kill -TERM "$pid" 2>/dev/null || true
+          done
+          sleep 2
+          # kill any monitors who failed to stop after two seconds.
+          for pidf in drop-monitor/*.pid; do
+            [ -f "$pidf" ] || continue
+            pid="${pidf##*/}"; pid="${pid%.pid}"
+            kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+            rm -f "$pidf"
+          done
+
+      - name: Upload drop monitor artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drop-events-gke-${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ matrix.config.type }}, ${{ inputs.UID }})
+          path: drop-monitor/
+          retention-days: 30
+          if-no-files-found: ignore
 
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}


### PR DESCRIPTION
Temporarily log drop events from cilium monitor to a log file that is
uploaded as an artifact.

This is in pursuit of tracking down flake #44131.

In all examples of flake #44131 both Hubble and the in-memory monitor
queue do not contain the drop, since many more flows are seen between.

However, in all examples of the flake there is only a single drop.
Therefore, use cilium monitor to filter for drops and log this to
a file. This will provide further insight into the condition causing the
flake.

```release-note
CI: add cilium monitor drop logging to GKE conformance tests
```