### PR TITLE
bpf: host: fix source identity for IPsec trace in to-netdev

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1326,6 +1326,18 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 	int ret = CTX_ACT_OK;
 	__s8 ext_err = 0;
 
+	/* Load the ethertype just once: */
+	validate_ethertype(ctx, &proto);
+
+	/* Trace before clearing skb->cb */
+#ifdef ENABLE_IPSEC
+	if (magic == MARK_MAGIC_ENCRYPT)
+		send_trace_notify(ctx, TRACE_FROM_STACK,
+				  get_encrypt_identity_meta(ctx), UNKNOWN_ID,
+				  TRACE_EP_ID_UNKNOWN, ctx->ingress_ifindex,
+				  TRACE_REASON_ENCRYPTED, 0, proto);
+#endif /* ENABLE_IPSEC */
+
 	bpf_clear_meta(ctx);
 	check_and_store_ip_trace_id(ctx);
 
@@ -1339,17 +1351,6 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 	else if (magic == MARK_MAGIC_EGW_DONE)
 		src_sec_identity = get_identity(ctx);
 #endif
-
-	/* Load the ethertype just once: */
-	validate_ethertype(ctx, &proto);
-
-#ifdef ENABLE_IPSEC
-	if (magic == MARK_MAGIC_ENCRYPT)
-		send_trace_notify(ctx, TRACE_FROM_STACK,
-				  get_encrypt_identity_meta(ctx), UNKNOWN_ID,
-				  TRACE_EP_ID_UNKNOWN, ctx->ingress_ifindex,
-				  TRACE_REASON_ENCRYPTED, 0, proto);
-#endif /* ENABLE_IPSEC */
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 */


### PR DESCRIPTION
The blamed commit added a IPsec-specific trace notification in the to-netdev path. This uses get_encrypt_identity_meta() to obtain the original source identity of the encrypted packet, accessing skb->cb.

But we also call bpf_clear_meta() at the very beginning of the program, and thus the identity has been cleared already.

Fix this by moving the send_trace_notify() up, before the skb->cb gets cleared.

Fixes: 06cf4dc147f3 ("bpf: host: trace encrypted IPsec traffic in to-netdev")