### PR TITLE
complexity-diff: Display results on scheduled runs

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -234,6 +234,7 @@ jobs:
   merge-and-diff:
     name: Merge & Diff
     needs: setup-and-test
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout pull request branch (NOT TRUSTED)

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -257,7 +257,7 @@ jobs:
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
         cat ./artifacts/*/verifier-complexity-pull.json | jq -s 'add' > ./artifacts/verifier-complexity-pull.json
-        go run ./tools/complexity-diff ./artifacts/verifier-complexity-base.json ./artifacts/verifier-complexity-pull.json ./artifacts/complexity-diff.json >> $GITHUB_STEP_SUMMARY
+        go run ./tools/complexity-diff -diff-file ./artifacts/complexity-diff.json ./artifacts/verifier-complexity-base.json ./artifacts/verifier-complexity-pull.json >> $GITHUB_STEP_SUMMARY
 
     - name: Remove per-kernel results from workspace
       run: |

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -259,6 +259,11 @@ jobs:
         cat ./artifacts/*/verifier-complexity-pull.json | jq -s 'add' > ./artifacts/verifier-complexity-pull.json
         go run ./tools/complexity-diff -diff-file ./artifacts/complexity-diff.json ./artifacts/verifier-complexity-base.json ./artifacts/verifier-complexity-pull.json >> $GITHUB_STEP_SUMMARY
 
+    - name: Display current state
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      run: |
+        go run ./tools/complexity-diff ./artifacts/verifier-complexity-base.json >> $GITHUB_STEP_SUMMARY
+
     - name: Remove per-kernel results from workspace
       run: |
         rm -Rf ./artifacts/datapath-verifier*

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"maps"
 	"os"
@@ -34,13 +35,20 @@ type verifierComplexityRecord struct {
 }
 
 func main() {
-	if len(os.Args) != 4 {
-		panic("usage: complexity-diff <old> <new> <diff>")
+	diffFile := flag.String("diff-file", "", "File to store the complexity diff")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: go run ./tools/complexity-diff [flags] <old> <new>\n")
+		flag.PrintDefaults()
 	}
 
-	oldFile := os.Args[1]
-	newFile := os.Args[2]
-	diffFile := os.Args[3]
+	flag.Parse()
+	if flag.NArg() < 2 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	oldFile := flag.Arg(0)
+	newFile := flag.Arg(1)
 
 	oldRecords, err := loadRecords(oldFile)
 	if err != nil {
@@ -53,7 +61,9 @@ func main() {
 
 	printDiffRecords(oldRecords, newRecords)
 	printCurrentState(newRecords)
-	dumpDiffRecords(oldRecords, newRecords, diffFile)
+	if *diffFile != "" {
+		dumpDiffRecords(oldRecords, newRecords, *diffFile)
+	}
 }
 
 func printDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord) {

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -51,6 +51,12 @@ func main() {
 		panic(err)
 	}
 
+	printDiffRecords(oldRecords, newRecords)
+	printCurrentState(newRecords)
+	dumpDiffRecords(oldRecords, newRecords, diffFile)
+}
+
+func printDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord) {
 	diffRecords := calcDiffRecords(oldRecords, newRecords, true)
 
 	minMaxInsnsProcessed := calcMinMax(diffRecords, func(r verifierComplexityRecord) int {
@@ -67,28 +73,32 @@ func main() {
 		return r.MapCount
 	})
 	printTop15MinMax("largest differences by map count", minMaxMapCount, percentMapCount, colorRelativeChange)
+}
 
+func printCurrentState(newRecords map[string]verifierComplexityRecord) {
 	var sortedNewRecords []verifierComplexityRecord
 	for _, key := range slices.Sorted(maps.Keys(newRecords)) {
 		sortedNewRecords = append(sortedNewRecords, newRecords[key])
 	}
 
-	minMaxInsnsProcessed = calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
+	minMaxInsnsProcessed := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
 		return r.InsnsProcessed
 	})
 	printTop15MinMax("largest instructions processed", minMaxInsnsProcessed, percentInsnsProcessed, colorAbsoluteValueExponential)
 
-	minMaxStackDepth = calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
+	minMaxStackDepth := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
 		return r.StackDepth
 	})
 	printTop15MinMax("largest stack depth", minMaxStackDepth, percentStackDepth, colorAbsoluteValue)
 
-	minMaxMapCount = calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
+	minMaxMapCount := calcMinMax(sortedNewRecords, func(r verifierComplexityRecord) int {
 		return r.MapCount
 	})
 	printTop15MinMax("largest map count", minMaxMapCount, percentMapCount, colorAbsoluteValue)
+}
 
-	diffRecords = calcDiffRecords(oldRecords, newRecords, false)
+func dumpDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord, diffFile string) {
+	diffRecords := calcDiffRecords(oldRecords, newRecords, false)
 
 	// Sort diff records to be more logically grouped for human consumption, even though its JSON.
 	sort.Slice(diffRecords, func(i, j int) bool {

--- a/tools/complexity-diff/main.go
+++ b/tools/complexity-diff/main.go
@@ -37,33 +37,40 @@ type verifierComplexityRecord struct {
 func main() {
 	diffFile := flag.String("diff-file", "", "File to store the complexity diff")
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: go run ./tools/complexity-diff [flags] <old> <new>\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: go run ./tools/complexity-diff [flags] <old> [new]\n")
 		flag.PrintDefaults()
 	}
 
 	flag.Parse()
-	if flag.NArg() < 2 {
+	if flag.NArg() == 0 {
 		flag.Usage()
 		os.Exit(1)
 	}
 
 	oldFile := flag.Arg(0)
-	newFile := flag.Arg(1)
 
 	oldRecords, err := loadRecords(oldFile)
 	if err != nil {
 		panic(err)
 	}
-	newRecords, err := loadRecords(newFile)
-	if err != nil {
-		panic(err)
-	}
 
-	printDiffRecords(oldRecords, newRecords)
-	printCurrentState(newRecords)
-	if *diffFile != "" {
-		dumpDiffRecords(oldRecords, newRecords, *diffFile)
+	if flag.NArg() == 2 {
+		newFile := flag.Arg(1)
+		newRecords, err := loadRecords(newFile)
+		if err != nil {
+			panic(err)
+		}
+
+		printDiffRecords(oldRecords, newRecords)
+		if *diffFile != "" {
+			dumpDiffRecords(oldRecords, newRecords, *diffFile)
+		}
+
+		// If two files were given, then printCurrentState() should run on the second,
+		// with the new records.
+		oldRecords = newRecords
 	}
+	printCurrentState(oldRecords)
 }
 
 func printDiffRecords(oldRecords, newRecords map[string]verifierComplexityRecord) {


### PR DESCRIPTION
This pull request displays the results from complexity-diff on scheduled runs. In that case, it doesn't actually display a diff, but just the current state.

The first commit also ensures we display the complexity & stack size results even if some of the jobs failed (ex., if bpf-next failed).