### PR TITLE
kpr: Allow users to use VXLAN in LBModeAnnotation mode

### DIFF
--- a/pkg/kpr/initializer/kube_proxy_replacement.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement.go
@@ -127,12 +127,18 @@ func (r *kprInitializer) InitKubeProxyReplacementOptions() error {
 			return fmt.Errorf("XDP acceleration cannot be used with an IPv6 underlay")
 		}
 
-		if option.Config.TunnelingEnabled() && r.tunnelConfig.EncapProtocol() == tunnel.VXLAN &&
-			r.lbConfig.LoadBalancerUsesDSR() {
-			return fmt.Errorf("Node Port %q mode cannot be used with %s tunneling.", r.lbConfig.LBMode, tunnel.VXLAN)
+		if option.Config.TunnelingEnabled() && r.tunnelConfig.EncapProtocol() == tunnel.VXLAN {
+			if r.lbConfig.LBMode != loadbalancer.LBModeSNAT {
+				return fmt.Errorf("Node Port %q mode cannot be used with %s tunneling.", r.lbConfig.LBMode, tunnel.VXLAN)
+			}
+			if r.lbConfig.LBModeAnnotation && r.lbConfig.DSRDispatch != loadbalancer.DSRDispatchIPIP {
+				return fmt.Errorf("Only --%s=%s is supported with %s tunneling when --%s is set",
+					loadbalancer.LoadBalancerDSRDispatchName, loadbalancer.DSRDispatchIPIP,
+					tunnel.VXLAN, loadbalancer.LoadBalancerModeAnnotationName)
+			}
 		}
 
-		if option.Config.TunnelingEnabled() && r.lbConfig.LoadBalancerUsesDSR() &&
+		if option.Config.TunnelingEnabled() && r.lbConfig.LBMode != loadbalancer.LBModeSNAT &&
 			r.lbConfig.DSRDispatch != loadbalancer.DSRDispatchGeneve {
 			return fmt.Errorf("Tunnel routing with Node Port %q mode requires %s dispatch.",
 				r.lbConfig.LBMode, loadbalancer.DSRDispatchGeneve)


### PR DESCRIPTION
The KPR DSR has not been implemented to work with the routing-mode=tunnel and VXLAN [1]. However, some power users might still want to use DSR in Cilium clusters running with VXLAN. For example, DSR with the IP-IP dispatch mode, which is not mutually exclusive with the VXLAN.

\[1\]: https://github.com/cilium/cilium/issues/10114