### PR TITLE
policy: resolve egress named ports to per-identity port sets

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -266,39 +266,41 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 			continue
 		}
 
-		pp := newProxyPolicy(l4, policySelectorTuple.Policy.L7Parser, listener, dstPort, dstProto)
-		proxyPort, err, revertFunc := e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e.ID, proxyWaitGroup)
-		if err != nil {
-			// Skip redirects that can not be created or updated.  This
-			// can happen when a listener is missing, for example when
-			// restarting and k8s delivers the CNP before the related
-			// CEC.
-			// Policy is regenerated when listeners are added or removed
-			// to fix this condition when the listener is available.
-			if listener != "" {
-				e.getLogger().Debug(
-					"Redirect rule with missing listener skipped, will be applied once the listener is available",
-					logfields.Error, err,
-					logfields.Listener, listener,
-				)
-			} else {
-				e.getLogger().Error(
-					"Redirect rule with missing listener skipped, policy will drop",
-					logfields.Error, err,
-				)
+		if true {
+			pp := newProxyPolicy(l4, policySelectorTuple.Policy.L7Parser, listener, dstPort, dstProto)
+			proxyPort, err, revertFunc := e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e.ID, proxyWaitGroup)
+			if err != nil {
+				// Skip redirects that can not be created or updated.  This
+				// can happen when a listener is missing, for example when
+				// restarting and k8s delivers the CNP before the related
+				// CEC.
+				// Policy is regenerated when listeners are added or removed
+				// to fix this condition when the listener is available.
+				if listener != "" {
+					e.getLogger().Debug(
+						"Redirect rule with missing listener skipped, will be applied once the listener is available",
+						logfields.Error, err,
+						logfields.Listener, listener,
+					)
+				} else {
+					e.getLogger().Error(
+						"Redirect rule with missing listener skipped, policy will drop",
+						logfields.Error, err,
+					)
 
+				}
+				skipped++
+				continue
 			}
-			skipped++
-			continue
-		}
-		revertStack.Push(revertFunc)
-		desiredRedirects[proxyID] = proxyPort
+			revertStack.Push(revertFunc)
+			desiredRedirects[proxyID] = proxyPort
 
-		// Update the endpoint API model to report that Cilium manages a
-		// redirect for that port.
-		statsKey := policy.ProxyStatsKey(l4.Ingress, string(l4.Protocol), dstPort, proxyPort)
-		proxyStats := e.getProxyStatistics(statsKey, string(policySelectorTuple.Policy.L7Parser), dstPort, l4.Ingress, proxyPort)
-		updatedStats = append(updatedStats, proxyStats)
+			// Update the endpoint API model to report that Cilium manages a
+			// redirect for that port.
+			statsKey := policy.ProxyStatsKey(l4.Ingress, string(l4.Protocol), dstPort, proxyPort)
+			proxyStats := e.getProxyStatistics(statsKey, string(policySelectorTuple.Policy.L7Parser), dstPort, l4.Ingress, proxyPort)
+			updatedStats = append(updatedStats, proxyStats)
+		}
 	}
 
 	// revert function is called with endpoint mutex held

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -247,26 +247,32 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 		// Possible listener name for both the proxy ID and the proxyPolicy below.
 		listener := policySelectorTuple.Policy.GetListener()
 
-		// proxyID() returns also the destination port for the policy,
-		// which may be resolved from a named port
-		proxyID, dstPort, dstProto := e.proxyID(l4, listener, selectorPolicy.GetSelectorSnapshot())
-		if proxyID == "" {
+		// proxyIDs() returns also the destination ports for the policy,
+		// which may be resolved from a named port.
+		proxyIDs := e.proxyIDs(l4, listener, selectorPolicy.GetSelectorSnapshot())
+		if len(proxyIDs) == 0 {
 			// Skip redirects for which a proxyID cannot be created.
 			// This may happen due to the named port mapping not
-			// existing or multiple PODs defining the same port name
-			// with different port values. The redirect will be created
-			// when the mapping is available or when the port name
-			// conflicts have been resolved in POD specs.
+			// existing. The redirect will be created when the mapping is
+			// available.
 			skipped++
 			continue
 		}
-		// desiredRedirects starts out empty, so we can use it check
-		// if the redirect has already been updated on this round.
-		if desiredRedirects[proxyID] != 0 {
+		allRedirectsDesired := true
+		for _, resolved := range proxyIDs {
+			if desiredRedirects[resolved.id] == 0 {
+				allRedirectsDesired = false
+				break
+			}
+		}
+		// desiredRedirects starts out empty, so we can use it to check if all
+		// redirects for this filter have already been updated on this round.
+		if allRedirectsDesired {
 			continue
 		}
+		for _, resolved := range proxyIDs {
+			proxyID, dstPort, dstProto := resolved.id, resolved.port, resolved.proto
 
-		if true {
 			pp := newProxyPolicy(l4, policySelectorTuple.Policy.L7Parser, listener, dstPort, dstProto)
 			proxyPort, err, revertFunc := e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e.ID, proxyWaitGroup)
 			if err != nil {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -25,7 +25,7 @@ import (
 	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
 	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/eventqueue"
-	identityPkg "github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -784,7 +784,9 @@ func TestProxyID(t *testing.T) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
 	e.UpdateLogger(nil)
 
-	id, port, proto := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
+	resolved := e.proxyIDs(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
+	require.Len(t, resolved, 1)
+	id, port, proto := resolved[0].id, resolved[0].port, resolved[0].proto
 	require.NotEmpty(t, id)
 	require.Equal(t, uint16(8080), port)
 	require.Equal(t, u8proto.TCP, proto)
@@ -797,7 +799,9 @@ func TestProxyID(t *testing.T) {
 	require.Empty(t, listener)
 	require.NoError(t, err)
 
-	id, port, proto = e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "test-listener", policy.SelectorSnapshot{})
+	resolved = e.proxyIDs(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true}, "test-listener", policy.SelectorSnapshot{})
+	require.Len(t, resolved, 1)
+	id, port, proto = resolved[0].id, resolved[0].port, resolved[0].proto
 	require.NotEmpty(t, id)
 	require.Equal(t, uint16(8080), port)
 	require.Equal(t, u8proto.TCP, proto)
@@ -810,10 +814,49 @@ func TestProxyID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Undefined named port
-	id, port, proto = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
-	require.Empty(t, id)
-	require.Equal(t, uint16(0), port)
-	require.Equal(t, u8proto.ANY, proto)
+	resolved = e.proxyIDs(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
+	require.Empty(t, resolved)
+
+	resolved = e.proxyIDs(&policy.L4Filter{Protocol: api.ProtoTCP, Ingress: true}, "", policy.SelectorSnapshot{})
+	require.Empty(t, resolved)
+
+	npm := ciliumTypes.NewNamedPortMultiMap()
+	require.True(t, npm.Update(identity.NumericIdentity(101), nil, ciliumTypes.NamedPortMap{
+		"http": {Proto: u8proto.TCP, Port: 8080},
+	}))
+	require.True(t, npm.Update(identity.NumericIdentity(102), nil, ciliumTypes.NamedPortMap{
+		"http": {Proto: u8proto.TCP, Port: 9090},
+	}))
+	e.namedPortsGetter = testNamedPortsGetter{npm: npm}
+	e.SetK8sMetadata([]corev1.ContainerPort{{
+		Name:          "http",
+		ContainerPort: 7070,
+		Protocol:      corev1.ProtocolTCP,
+	}})
+	backendSelector, selectorSnapshot := endpointCachedSelectorForIdentities(t, "id=backend", 101, 102)
+	defer selectorSnapshot.Invalidate()
+	resolved = e.proxyIDs(&policy.L4Filter{
+		PortName: "http",
+		Protocol: api.ProtoTCP,
+		U8Proto:  u8proto.TCP,
+		PerSelectorPolicies: policy.L7DataMap{
+			backendSelector: nil,
+		},
+	}, "", selectorSnapshot)
+	require.Len(t, resolved, 2)
+	require.Equal(t, uint16(8080), resolved[0].port)
+	require.Equal(t, uint16(9090), resolved[1].port)
+}
+
+func endpointCachedSelectorForIdentities(t testing.TB, selectorLabel string, identities ...identity.NumericIdentity) (policy.CachedSelector, policy.SelectorSnapshot) {
+	identityMap := make(identity.IdentityMap, len(identities))
+	for _, nid := range identities {
+		identityMap[nid] = labels.ParseLabelArray(selectorLabel)
+	}
+
+	selectorCache := policy.NewSelectorCache(hivetest.Logger(t), identityMap)
+	selector, _ := selectorCache.AddIdentitySelectorForTest(&testpolicy.DummySelectorCacheUser{}, api.NewESFromLabels(labels.ParseSelectLabel(selectorLabel)))
+	return selector, selectorCache.GetSelectorSnapshot()
 }
 
 type testNamedPortsGetter struct {
@@ -826,7 +869,7 @@ func (g testNamedPortsGetter) GetNamedPorts() ciliumTypes.NamedPortMultiMap {
 
 func TestGetEgressNamedPorts(t *testing.T) {
 	namedPorts := ciliumTypes.NewNamedPortMultiMap()
-	nid := identityPkg.NumericIdentity(101)
+	nid := identity.NumericIdentity(101)
 	require.True(t, namedPorts.Update(nid, nil, ciliumTypes.NamedPortMap{
 		"http": ciliumTypes.PortProto{Port: 8080, Proto: u8proto.TCP},
 	}))
@@ -838,22 +881,22 @@ func TestGetEgressNamedPorts(t *testing.T) {
 		namedPortsGetter: testNamedPortsGetter{npm: namedPorts},
 	}
 
-	portsByNID := map[identityPkg.NumericIdentity][]uint16{}
-	for destID, port := range e.GetEgressNamedPorts("http", u8proto.TCP, slices.Values([]identityPkg.NumericIdentity{nid, 102})) {
+	portsByNID := map[identity.NumericIdentity][]uint16{}
+	for destID, port := range e.GetEgressNamedPorts("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid, 102})) {
 		portsByNID[destID] = append(portsByNID[destID], port)
 	}
-	require.Equal(t, map[identityPkg.NumericIdentity][]uint16{
+	require.Equal(t, map[identity.NumericIdentity][]uint16{
 		nid: {8080, 9090},
 	}, portsByNID)
 
-	portsByNID = map[identityPkg.NumericIdentity][]uint16{}
-	for destID, port := range e.GetEgressNamedPorts("http", u8proto.UDP, slices.Values([]identityPkg.NumericIdentity{nid})) {
+	portsByNID = map[identity.NumericIdentity][]uint16{}
+	for destID, port := range e.GetEgressNamedPorts("http", u8proto.UDP, slices.Values([]identity.NumericIdentity{nid})) {
 		portsByNID[destID] = append(portsByNID[destID], port)
 	}
 	require.Empty(t, portsByNID)
 
-	portsByNID = map[identityPkg.NumericIdentity][]uint16{}
-	for destID, port := range e.GetEgressNamedPorts("http", u8proto.TCP, slices.Values([]identityPkg.NumericIdentity{102})) {
+	portsByNID = map[identity.NumericIdentity][]uint16{}
+	for destID, port := range e.GetEgressNamedPorts("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{102})) {
 		portsByNID[destID] = append(portsByNID[destID], port)
 	}
 	require.Empty(t, portsByNID)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
 	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -44,6 +46,7 @@ import (
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
 )
@@ -811,6 +814,49 @@ func TestProxyID(t *testing.T) {
 	require.Empty(t, id)
 	require.Equal(t, uint16(0), port)
 	require.Equal(t, u8proto.ANY, proto)
+}
+
+type testNamedPortsGetter struct {
+	npm ciliumTypes.NamedPortMultiMap
+}
+
+func (g testNamedPortsGetter) GetNamedPorts() ciliumTypes.NamedPortMultiMap {
+	return g.npm
+}
+
+func TestGetEgressNamedPorts(t *testing.T) {
+	namedPorts := ciliumTypes.NewNamedPortMultiMap()
+	nid := identityPkg.NumericIdentity(101)
+	require.True(t, namedPorts.Update(nid, nil, ciliumTypes.NamedPortMap{
+		"http": ciliumTypes.PortProto{Port: 8080, Proto: u8proto.TCP},
+	}))
+	require.True(t, namedPorts.Update(nid, nil, ciliumTypes.NamedPortMap{
+		"http": ciliumTypes.PortProto{Port: 9090, Proto: u8proto.TCP},
+	}))
+
+	e := &Endpoint{
+		namedPortsGetter: testNamedPortsGetter{npm: namedPorts},
+	}
+
+	portsByNID := map[identityPkg.NumericIdentity][]uint16{}
+	for destID, port := range e.GetEgressNamedPorts("http", u8proto.TCP, slices.Values([]identityPkg.NumericIdentity{nid, 102})) {
+		portsByNID[destID] = append(portsByNID[destID], port)
+	}
+	require.Equal(t, map[identityPkg.NumericIdentity][]uint16{
+		nid: {8080, 9090},
+	}, portsByNID)
+
+	portsByNID = map[identityPkg.NumericIdentity][]uint16{}
+	for destID, port := range e.GetEgressNamedPorts("http", u8proto.UDP, slices.Values([]identityPkg.NumericIdentity{nid})) {
+		portsByNID[destID] = append(portsByNID[destID], port)
+	}
+	require.Empty(t, portsByNID)
+
+	portsByNID = map[identityPkg.NumericIdentity][]uint16{}
+	for destID, port := range e.GetEgressNamedPorts("http", u8proto.TCP, slices.Values([]identityPkg.NumericIdentity{102})) {
+		portsByNID[destID] = append(portsByNID[destID], port)
+	}
+	require.Empty(t, portsByNID)
 }
 
 func TestEndpoint_GetK8sPodLabels(t *testing.T) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -87,12 +87,17 @@ func (e *Endpoint) GetEgressNamedPorts(name string, proto u8proto.U8proto, destI
 	return e.namedPortsGetter.GetNamedPorts().GetNamedPorts(name, proto, destIdentities)
 }
 
-// proxyID returns a unique string to identify a proxy mapping,
-// and the resolved destination port number, if any.
-// For port ranges the proxy is identified by the first port in
-// the range, as overlapping proxy port ranges are not supported.
-// Must be called with e.mutex held.
-func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string, scSnapshot policy.SelectorSnapshot) (string, uint16, u8proto.U8proto) {
+type resolvedProxyID struct {
+	id    string
+	port  uint16
+	proto u8proto.U8proto
+}
+
+// proxyIDs returns unique strings to identify proxy mappings, and the resolved
+// destination port numbers, if any. For port ranges the proxy is identified by
+// the first port in the range, as overlapping proxy port ranges are not
+// supported. Must be called with e.mutex held.
+func (e *Endpoint) proxyIDs(l4 *policy.L4Filter, listener string, scSnapshot policy.SelectorSnapshot) []resolvedProxyID {
 	port := l4.Port
 	protocol := l4.U8Proto
 	// Calculate protocol if it is 0 (default) and
@@ -101,14 +106,35 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter, listener string, scSnapshot poli
 		proto, _ := u8proto.ParseProtocol(string(l4.Protocol))
 		protocol = proto
 	}
-	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPort(l4.Ingress, l4.PortName, protocol, l4.Identities(scSnapshot))
-		if port == 0 {
-			return "", 0, 0
+
+	proxyIDForPort := func(port uint16) resolvedProxyID {
+		return resolvedProxyID{
+			id:    policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port, listener),
+			port:  port,
+			proto: protocol,
 		}
 	}
 
-	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port, listener), port, protocol
+	if port == 0 {
+		if l4.PortName == "" {
+			return nil
+		}
+		port = e.GetNamedPort(l4.Ingress, l4.PortName, protocol, l4.Identities(scSnapshot))
+	}
+	if port != 0 {
+		return []resolvedProxyID{proxyIDForPort(port)}
+	}
+	if l4.Ingress {
+		return nil
+	}
+
+	// egress named port with possibly many ports
+	ports := e.GetEgressNamedPorts(l4.PortName, protocol, l4.Identities(scSnapshot)).Ports()
+	proxyIDs := make([]resolvedProxyID, 0, len(ports))
+	for _, port := range ports {
+		proxyIDs = append(proxyIDs, proxyIDForPort(port))
+	}
+	return proxyIDs
 }
 
 // setNextPolicyRevision updates the desired policy revision field

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -50,44 +50,41 @@ func (e *Endpoint) PreviousMapState() *policy.MapState {
 	return e.desiredPolicy.GetMapState()
 }
 
-// GetNamedPort returns the port for the given name.
+// GetNamedPort returns one port for the given name.
 func (e *Endpoint) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, idents iter.Seq[identity.NumericIdentity]) uint16 {
-	if ingress {
-		// Ingress only needs the ports of the POD itself
-		return e.getNamedPortIngress(e.GetK8sPorts(), name, proto)
-	}
-	// egress needs named ports of the destination pods
-	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto, idents)
-}
+	var port uint16
+	var err error
+	var dir string
 
-func (e *Endpoint) getNamedPortIngress(npMap types.NamedPortMap, name string, proto u8proto.U8proto) uint16 {
-	port, err := npMap.GetNamedPort(name, proto)
+	if ingress {
+		dir = "ingress"
+		// Ingress only needs the ports of the POD itself
+		port, err = e.GetK8sPorts().GetNamedPort(name, proto)
+	} else {
+		dir = "egress"
+		// egress needs named ports of the destination security identities
+		port, err = e.namedPortsGetter.GetNamedPorts().GetNamedPort(name, proto, idents)
+		// Skip logging for ErrUnknownNamedPort on egress, as the destination POD with the
+		// port name is likely not scheduled yet.
+		if err != nil && errors.Is(err, types.ErrUnknownNamedPort) {
+			err = nil
+		}
+	}
 	if err != nil && e.logLimiter.Allow() {
 		e.getLogger().Warn(
 			"Skipping named port",
 			logfields.Error, err,
 			logfields.PortName, name,
 			logfields.Protocol, proto,
-			logfields.TrafficDirection, "ingress",
+			logfields.TrafficDirection, dir,
 		)
 	}
 	return port
 }
 
-func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string, proto u8proto.U8proto, idents iter.Seq[identity.NumericIdentity]) uint16 {
-	port, err := npMap.GetNamedPort(name, proto, idents)
-	// Skip logging for ErrUnknownNamedPort on egress, as the destination POD with the port name
-	// is likely not scheduled yet.
-	if err != nil && !errors.Is(err, types.ErrUnknownNamedPort) && e.logLimiter.Allow() {
-		e.getLogger().Warn(
-			"Skipping named port",
-			logfields.Error, err,
-			logfields.PortName, name,
-			logfields.Protocol, proto,
-			logfields.TrafficDirection, "egress",
-		)
-	}
-	return port
+// GetEgressNamedPorts returns destination ports for the given name scoped to destIdentities.
+func (e *Endpoint) GetEgressNamedPorts(name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) types.NidPortSeq {
+	return e.namedPortsGetter.GetNamedPorts().GetNamedPorts(name, proto, destIdentities)
 }
 
 // proxyID returns a unique string to identify a proxy mapping,

--- a/pkg/envoy/test/updater_mock.go
+++ b/pkg/envoy/test/updater_mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -38,6 +39,10 @@ func (m *ProxyUpdaterMock) GetIPv6Address() string { return m.Ipv6 }
 
 func (m *ProxyUpdaterMock) GetNamedPort(bool, string, u8proto.U8proto, iter.Seq[identity.NumericIdentity]) uint16 {
 	return 0
+}
+
+func (m *ProxyUpdaterMock) GetEgressNamedPorts(string, u8proto.U8proto, iter.Seq[identity.NumericIdentity]) types.NidPortSeq {
+	return func(func(identity.NumericIdentity, uint16) bool) {}
 }
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1629,9 +1629,10 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 			ports := []uint16{l4.Port}
 			if l4.Port == 0 && l4.PortName != "" {
 				ports = nil
-				port := ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto, l4.Identities(selectors))
-				if port != 0 {
+				if port := ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto, l4.Identities(selectors)); port != 0 {
 					ports = []uint16{port}
+				} else if !l4.Ingress {
+					ports = ep.GetEgressNamedPorts(l4.PortName, l4.U8Proto, l4.Identities(selectors)).Ports()
 				}
 			}
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1626,40 +1626,121 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 				continue
 			}
 
-			port := l4.Port
-			if port == 0 && l4.PortName != "" {
-				port = ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto, l4.Identities(selectors))
+			ports := []uint16{l4.Port}
+			if l4.Port == 0 && l4.PortName != "" {
+				ports = nil
+				port := ep.GetNamedPort(l4.Ingress, l4.PortName, l4.U8Proto, l4.Identities(selectors))
+				if port != 0 {
+					ports = []uint16{port}
+				}
 			}
 
-			// Skip if a named port can not be resolved (yet)
-			// wildcard port already taken care of above
-			if port == 0 {
-				continue
-			}
+			for _, port := range ports {
+				// Skip if a named port can not be resolved (yet)
+				// wildcard port already taken care of above
+				if port == 0 {
+					continue
+				}
 
-			rules := make([]*cilium.PortNetworkPolicyRule, 0, len(l4.PerSelectorPolicies))
+				rules := make([]*cilium.PortNetworkPolicyRule, 0, len(l4.PerSelectorPolicies))
 
-			// Assume none of the rules have side-effects so that rule evaluation can be
-			// stopped as soon as the first allowing rule is found. Values are added to
-			// 'cantShortCircuit' for each precedence for which this is not true.
-			cantShortCircuit := make(map[uint32]struct{})
+				// Assume none of the rules have side-effects so that rule evaluation can be
+				// stopped as soon as the first allowing rule is found. Values are added to
+				// 'cantShortCircuit' for each precedence for which this is not true.
+				cantShortCircuit := make(map[uint32]struct{})
 
-			// port-specific wildcard selector rules, if any, only for the highest
-			// precedence rules.
-			var allowAllPrecedence uint32
-			var allowAllRule *cilium.PortNetworkPolicyRule
-			var denyAllPrecedence uint32
-			var denyAllRule *cilium.PortNetworkPolicyRule
+				// port-specific wildcard selector rules, if any, only for the highest
+				// precedence rules.
+				var allowAllPrecedence uint32
+				var allowAllRule *cilium.PortNetworkPolicyRule
+				var denyAllPrecedence uint32
+				var denyAllRule *cilium.PortNetworkPolicyRule
 
-			for sel, psp := range l4.PerSelectorPolicies {
-				precedence := psp.GetPrecedence()
+				for sel, psp := range l4.PerSelectorPolicies {
+					precedence := psp.GetPrecedence()
 
-				if precedence < wildcardSelectorPrecedence ||
-					wildcardSelectorPrecedence.IsDeny() && precedence == wildcardSelectorPrecedence {
+					if precedence < wildcardSelectorPrecedence ||
+						wildcardSelectorPrecedence.IsDeny() && precedence == wildcardSelectorPrecedence {
+						if debugEnabled {
+							s.logger.Debug("PortNetworkPolicyRule skipping rule due to higher precedence wildcard port rule",
+								logfields.EndpointID, ep.GetID(),
+								logfields.Version, selectors,
+								logfields.TrafficDirection, dir,
+								logfields.Port, port,
+							)
+						}
+						continue
+					}
+
+					rule, csc := s.getPortNetworkPolicyRule(ep, selectors, sel, psp,
+						tierBasePriority, tierLastPriority,
+						useFullTLSContext, useSDS, policySecretsNamespace)
+					if rule == nil {
+						continue
+					}
+					if !csc {
+						cantShortCircuit[rule.Precedence] = struct{}{}
+					}
+
 					if debugEnabled {
-						s.logger.Debug("PortNetworkPolicyRule skipping rule due to higher precedence wildcard port rule",
+						s.logger.Debug("PortNetworkPolicyRule matching remote IDs",
 							logfields.EndpointID, ep.GetID(),
 							logfields.Version, selectors,
+							logfields.TrafficDirection, dir,
+							logfields.Port, port,
+							logfields.ProxyPort, rule.ProxyId,
+							logfields.PolicyID, rule.RemotePolicies,
+							logfields.ServerNames, rule.ServerNames,
+						)
+					}
+
+					if len(rule.RemotePolicies) == 0 {
+						if rule.GetDeny() {
+							if rule.Precedence > denyAllPrecedence {
+								denyAllRule = rule
+								denyAllPrecedence = rule.Precedence
+							}
+						} else if isEmptyRuleButPrecedence(rule) {
+							if rule.Precedence > allowAllPrecedence {
+								allowAllRule = rule
+								allowAllPrecedence = rule.Precedence
+							}
+						}
+					}
+
+					rules = append(rules, rule)
+				}
+
+				// prune out rules due to wildcard rules on this port, if any
+				if denyAllRule != nil || allowAllRule != nil {
+					nRules := len(rules)
+					rules = slices.DeleteFunc(rules, func(rule *cilium.PortNetworkPolicyRule) bool {
+						_, found := cantShortCircuit[rule.Precedence]
+						canShortCircuit := !found
+
+						return denyAllRule != nil && rule != denyAllRule && rule.Precedence <= denyAllRule.Precedence ||
+							allowAllRule != nil && rule != allowAllRule &&
+								(rule.Precedence < allowAllRule.Precedence ||
+									canShortCircuit && rule.Precedence == allowAllRule.Precedence)
+					})
+
+					if len(rules) < nRules && debugEnabled {
+						s.logger.Debug("Pruned rules due to wildcard rules on the port ",
+							logfields.EndpointID, ep.GetID(),
+							logfields.TrafficDirection, dir,
+							logfields.Port, port,
+							logfields.Count, nRules-len(rules),
+						)
+					}
+				}
+
+				// No rule for this port matches any remote identity.
+				// In this case, just don't generate any PortNetworkPolicy for this
+				// port.
+				if len(rules) == 0 {
+					if debugEnabled {
+						s.logger.Debug("Skipping PortNetworkPolicy due to no matching remote identities",
+							logfields.EndpointID, ep.GetID(),
 							logfields.TrafficDirection, dir,
 							logfields.Port, port,
 						)
@@ -1667,96 +1748,21 @@ func (s *xdsServer) getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, selec
 					continue
 				}
 
-				rule, csc := s.getPortNetworkPolicyRule(ep, selectors, sel, psp,
-					tierBasePriority, tierLastPriority,
-					useFullTLSContext, useSDS, policySecretsNamespace)
-				if rule == nil {
-					continue
-				}
-				if !csc {
-					cantShortCircuit[rule.Precedence] = struct{}{}
+				if len(rules) > 1 {
+					envoypolicy.SortPortNetworkPolicyRules(rules)
+				} else if len(rules) == 1 && isEmptyRule(rules[0]) {
+					rules = nil
 				}
 
-				if debugEnabled {
-					s.logger.Debug("PortNetworkPolicyRule matching remote IDs",
-						logfields.EndpointID, ep.GetID(),
-						logfields.Version, selectors,
-						logfields.TrafficDirection, dir,
-						logfields.Port, port,
-						logfields.ProxyPort, rule.ProxyId,
-						logfields.PolicyID, rule.RemotePolicies,
-						logfields.ServerNames, rule.ServerNames,
-					)
+				// NPDS supports port ranges.
+				portPolicy := &cilium.PortNetworkPolicy{
+					Port:     uint32(port),
+					EndPort:  uint32(l4.EndPort),
+					Protocol: protocol,
+					Rules:    rules,
 				}
-
-				if len(rule.RemotePolicies) == 0 {
-					if rule.GetDeny() {
-						if rule.Precedence > denyAllPrecedence {
-							denyAllRule = rule
-							denyAllPrecedence = rule.Precedence
-						}
-					} else if isEmptyRuleButPrecedence(rule) {
-						if rule.Precedence > allowAllPrecedence {
-							allowAllRule = rule
-							allowAllPrecedence = rule.Precedence
-						}
-					}
-				}
-
-				rules = append(rules, rule)
+				PerPortPolicies = append(PerPortPolicies, portPolicy)
 			}
-
-			// prune out rules due to wildcard rules on this port, if any
-			if denyAllRule != nil || allowAllRule != nil {
-				nRules := len(rules)
-				rules = slices.DeleteFunc(rules, func(rule *cilium.PortNetworkPolicyRule) bool {
-					_, found := cantShortCircuit[rule.Precedence]
-					canShortCircuit := !found
-
-					return denyAllRule != nil && rule != denyAllRule && rule.Precedence <= denyAllRule.Precedence ||
-						allowAllRule != nil && rule != allowAllRule &&
-							(rule.Precedence < allowAllRule.Precedence ||
-								canShortCircuit && rule.Precedence == allowAllRule.Precedence)
-				})
-
-				if len(rules) < nRules && debugEnabled {
-					s.logger.Debug("Pruned rules due to wildcard rules on the port ",
-						logfields.EndpointID, ep.GetID(),
-						logfields.TrafficDirection, dir,
-						logfields.Port, port,
-						logfields.Count, nRules-len(rules),
-					)
-				}
-			}
-
-			// No rule for this port matches any remote identity.
-			// In this case, just don't generate any PortNetworkPolicy for this
-			// port.
-			if len(rules) == 0 {
-				if debugEnabled {
-					s.logger.Debug("Skipping PortNetworkPolicy due to no matching remote identities",
-						logfields.EndpointID, ep.GetID(),
-						logfields.TrafficDirection, dir,
-						logfields.Port, port,
-					)
-				}
-				continue
-			}
-
-			if len(rules) > 1 {
-				envoypolicy.SortPortNetworkPolicyRules(rules)
-			} else if len(rules) == 1 && isEmptyRule(rules[0]) {
-				rules = nil
-			}
-
-			// NPDS supports port ranges.
-			portPolicy := &cilium.PortNetworkPolicy{
-				Port:     uint32(port),
-				EndPort:  uint32(l4.EndPort),
-				Protocol: protocol,
-				Rules:    rules,
-			}
-			PerPortPolicies = append(PerPortPolicies, portPolicy)
 		}
 
 		// Skip remaining tiers if there is a wildcard port/selector rule and no pass

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -30,6 +30,16 @@ type IPCacheTestSuite struct {
 	Allocator       *testidentity.MockIdentityAllocator
 }
 
+func getNamedPorts(npm types.NamedPortMultiMap, name string, proto u8proto.U8proto, nid identityPkg.NumericIdentity) []uint16 {
+	var ports []uint16
+	for resultNID, port := range npm.GetNamedPorts(name, proto, slices.Values([]identityPkg.NumericIdentity{nid})) {
+		if resultNID == nid {
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}
+
 func setupIPCacheTestSuite(tb testing.TB) *IPCacheTestSuite {
 	s := &IPCacheTestSuite{
 		Allocator:     testidentity.NewMockIdentityAllocator(nil),
@@ -497,6 +507,55 @@ func TestIPCacheNamedPorts(t *testing.T) {
 		ips = s.IPIdentityCache.LookupByIdentity(identities[index])
 		require.Nil(t, ips)
 	}
+
+	// Test GetNamedPorts returning multiple concrete ports for the same named
+	// port and numeric identity.
+	multiNID := identityPkg.NumericIdentity(88)
+	multiIdentity := Identity{
+		ID:     multiNID,
+		Source: source.Kubernetes,
+	}
+	multiIP1 := "10.2.0.1"
+	multiIP2 := "10.2.0.2"
+	multiMeta1 := K8sMetadata{
+		Namespace: "default",
+		PodName:   "multi-1",
+		NamedPorts: types.NamedPortMap{
+			"http-alt": types.PortProto{Port: 8080, Proto: u8proto.TCP},
+		},
+	}
+	multiMeta2 := K8sMetadata{
+		Namespace: "default",
+		PodName:   "multi-2",
+		NamedPorts: types.NamedPortMap{
+			"http-alt": types.PortProto{Port: 9090, Proto: u8proto.TCP},
+		},
+	}
+	namedPortsChanged, err = s.IPIdentityCache.Upsert(multiIP1, nil, 0, &multiMeta1, multiIdentity)
+	require.NoError(t, err)
+	require.True(t, namedPortsChanged)
+	namedPortsChanged, err = s.IPIdentityCache.Upsert(multiIP2, nil, 0, &multiMeta2, multiIdentity)
+	require.NoError(t, err)
+	require.True(t, namedPortsChanged)
+
+	npm = s.IPIdentityCache.GetNamedPorts()
+	require.NotNil(t, npm)
+	ports := getNamedPorts(npm, "http-alt", u8proto.TCP, multiNID)
+	require.Equal(t, []uint16{8080, 9090}, ports)
+
+	namedPortsChanged = s.IPIdentityCache.Delete(multiIP1, source.Kubernetes)
+	require.True(t, namedPortsChanged)
+	npm = s.IPIdentityCache.GetNamedPorts()
+	require.NotNil(t, npm)
+	ports = getNamedPorts(npm, "http-alt", u8proto.TCP, multiNID)
+	require.Equal(t, []uint16{9090}, ports)
+
+	namedPortsChanged = s.IPIdentityCache.Delete(multiIP2, source.Kubernetes)
+	require.True(t, namedPortsChanged)
+	npm = s.IPIdentityCache.GetNamedPorts()
+	require.NotNil(t, npm)
+	ports = getNamedPorts(npm, "http-alt", u8proto.TCP, multiNID)
+	require.Nil(t, ports)
 
 	require.Len(t, s.IPIdentityCache.ipToIdentityCache, 1)
 	require.Len(t, s.IPIdentityCache.identityToIPCache, 1)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -688,8 +688,13 @@ func (l4 *L4Filter) makeMapStateEntry(logger *slog.Logger, p *EndpointPolicy, po
 }
 
 // Identities extracts the set of identities corresponding to selectors.
+// If the filter has a wildcard selector, only the wildcard identity (0) is yielded.
 func (l4 *L4Filter) Identities(txn SelectorSnapshot) iter.Seq[identity.NumericIdentity] {
 	return func(yield func(identity.NumericIdentity) bool) {
+		if l4.wildcard != nil {
+			yield(0)
+			return
+		}
 		for cs := range l4.PerSelectorPolicies {
 			if cs == nil {
 				continue

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -217,6 +217,24 @@ func (a *PerSelectorPolicy) Equal(b *PerSelectorPolicy) bool {
 		a.L7Rules.DeepEqual(&b.L7Rules)
 }
 
+// datapathEquivalent returns true if 'a' and 'b' would produce the same
+// datapath verdict for a concrete port in the same L4 filter.
+func (a *PerSelectorPolicy) datapathEquivalent(b *PerSelectorPolicy) bool {
+	aParser, bParser := ParserTypeNone, ParserTypeNone
+	if a != nil {
+		aParser = a.L7Parser
+	}
+	if b != nil {
+		bParser = b.L7Parser
+	}
+
+	// GetPrecedence encodes verdict, priority, and listener priority
+	return a.GetPrecedence() == b.GetPrecedence() &&
+		aParser == bParser &&
+		a.GetListener() == b.GetListener() &&
+		a.getAuthRequirement() == b.getAuthRequirement()
+}
+
 // GetListener returns the listener of the PerSelectorPolicy.
 func (a *PerSelectorPolicy) GetListener() string {
 	if a == nil {
@@ -644,17 +662,11 @@ func (c *ChangeState) Size() int {
 	return len(c.Adds) - deleteLen
 }
 
-// generateWildcardMapStateEntry creates map state entry for wildcard selector in the filter.
-func (l4 *L4Filter) generateWildcardMapStateEntry(logger *slog.Logger, p *EndpointPolicy, port uint16, tierPriority, nextTierPriority types.Priority) mapStateEntry {
-	if l4.wildcard != nil {
-		currentRule := l4.PerSelectorPolicies[l4.wildcard]
-		cs := l4.wildcard
-
-		return l4.makeMapStateEntry(logger, p, port, cs, currentRule, tierPriority, nextTierPriority)
+func (l4 *L4Filter) selectorCoveredByWildcard(cs CachedSelector, currentRule *PerSelectorPolicy, wildcardPort bool) bool {
+	if l4.wildcard == nil || cs == l4.wildcard || wildcardPort {
+		return false
 	}
-
-	return makeInvalidEntry()
-
+	return currentRule.datapathEquivalent(l4.PerSelectorPolicies[l4.wildcard])
 }
 
 // makeMapStateEntry creates a mapStateEntry for the given selector and policy for the Endpoint.
@@ -735,66 +747,90 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, tierPriority, nextTierPriori
 		)
 	}
 
-	// resolve named port
+	// resolve named port if any
+	egressNamedPort := false
 	if port == 0 && l4.PortName != "" {
 		port = p.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto, l4.Identities(p.selectors))
 		if port == 0 {
-			return // nothing to be done for undefined named port
+			if l4.Ingress {
+				return // nothing to be done for undefined ingress named port
+			}
+			// egress named port is resolved separately for each selector
+			egressNamedPort = true
 		}
 	}
 
 	tierMaxPrecedence := tierPriority.ToDenyPrecedence()
 
+	// compute keys to insert, identities will be filled in later
+	key := KeyForDirection(direction).WithPortProto(proto, port)
 	var keysToAdd []Key
-	for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
-		keysToAdd = append(keysToAdd,
-			KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+	if port != 0 && l4.EndPort > port {
+		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
+			keysToAdd = append(keysToAdd, key.WithPortPrefix(mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+		}
+	} else {
+		// single key for singular (named) port
+		keysToAdd = []Key{key}
 	}
 
-	// Compute the wildcard entry, if present.
-	wildcardEntry := l4.generateWildcardMapStateEntry(scopedLog, p, port, tierPriority, nextTierPriority)
-	haveWildcard := wildcardEntry.IsValid() || wildcardEntry.IsPassEntry()
+	logEntry := func(entry *mapStateEntry, cs CachedSelector, idents identity.NumericIdentitySlice) {
+		if entry.IsDeny() {
+			scopedLog.Debug(
+				"ToMapState: Denied remote IDs",
+				logfields.Version, p.selectors,
+				logfields.EndpointSelector, cs,
+				logfields.PolicyID, idents,
+			)
+		} else {
+			scopedLog.Debug(
+				"ToMapState: Allowed remote IDs",
+				logfields.Version, p.selectors,
+				logfields.EndpointSelector, cs,
+				logfields.PolicyID, idents,
+			)
+		}
+	}
 
-	var idents identity.NumericIdentitySlice
-	var entry mapStateEntry
 	for cs, currentRule := range l4.PerSelectorPolicies {
-		// is this wildcard? If so, we already created it above
-		if haveWildcard && cs == l4.wildcard {
-			entry = wildcardEntry
-			// wildcard identity
+		var idents identity.NumericIdentitySlice
+
+		if cs == l4.wildcard {
 			idents = identity.NumericIdentitySlice{0}
 		} else {
-			entry = l4.makeMapStateEntry(logger, p, port, cs, currentRule, tierPriority, nextTierPriority)
-			if !entry.IsValid() && !entry.IsPassEntry() {
-				continue
-			}
-
-			// If this entry is identical to the wildcard's entry, we can elide it.
-			// Do not elide for port wildcards. TODO: This is probably too
-			// conservative, determine if it's safe to elide l3 entry when no l4 specifier is present.
-			if wildcardEntry.IsValid() && port != 0 && entry.MapStateEntry == wildcardEntry.MapStateEntry {
+			wildcardPort := port == 0 && !egressNamedPort
+			if l4.selectorCoveredByWildcard(cs, currentRule, wildcardPort) {
 				scopedLog.Debug("ToMapState: Skipping L3/L4 key due to existing identical L4-only key", logfields.EndpointSelector, cs)
 				continue
 			}
 			idents = cs.GetSelectionsAt(p.selectors)
 		}
 
-		if option.Config.Debug {
-			if entry.IsDeny() {
-				scopedLog.Debug(
-					"ToMapState: Denied remote IDs",
-					logfields.Version, p.selectors,
-					logfields.EndpointSelector, cs,
-					logfields.PolicyID, idents,
-				)
-			} else {
-				scopedLog.Debug(
-					"ToMapState: Allowed remote IDs",
-					logfields.Version, p.selectors,
-					logfields.EndpointSelector, cs,
-					logfields.PolicyID, idents,
-				)
+		if egressNamedPort {
+			// Egress named ports can map to multiple ports that can be different for
+			// each selector.
+			// Port ranges are not supported with named ports.
+			for id, port := range p.PolicyOwner.GetEgressNamedPorts(l4.PortName, proto, slices.Values(idents)) {
+				entry := l4.makeMapStateEntry(logger, p, port, cs, currentRule, tierPriority, nextTierPriority)
+				if !entry.IsValid() && !entry.IsPassEntry() {
+					continue // Skip unrealized redirects
+				}
+				if option.Config.Debug {
+					logEntry(&entry, cs, idents)
+				}
+				keyToAdd := key.WithIdentity(id).WithPort(port)
+				p.policyMapState.insertWithChanges(tierMaxPrecedence, keyToAdd, entry, features, changes)
 			}
+			continue
+		}
+
+		// single port case, may be wildcard port
+		entry := l4.makeMapStateEntry(logger, p, port, cs, currentRule, tierPriority, nextTierPriority)
+		if !entry.IsValid() && !entry.IsPassEntry() {
+			continue // Skip unrealized redirects
+		}
+		if option.Config.Debug {
+			logEntry(&entry, cs, idents)
 		}
 		for _, id := range idents {
 			for _, keyToAdd := range keysToAdd {
@@ -803,6 +839,7 @@ func (l4 *L4Filter) toMapState(logger *slog.Logger, tierPriority, nextTierPriori
 			}
 		}
 	}
+
 	if option.Config.Debug {
 		scopedLog.Debug(
 			"ToMapChange changes",
@@ -827,10 +864,11 @@ func (l4 *L4Filter) IdentitySelectionUpdated(logger *slog.Logger, cs types.Cache
 		logfields.DeletedPolicyID, deleted,
 	)
 
-	// Skip updates on wildcard selectors, as datapath and L7
-	// proxies do not need enumeration of all ids for L3 wildcard.
+	// Skip updates on wildcard selectors on specific ports, as datapath does not need
+	// enumeration of all ids for L3 wildcard.
+	// Updates with a named port may be needed, as a new identity may map to a different port.
 	// This mirrors the per-selector logic in toMapState().
-	if cs.IsWildcard() {
+	if cs.IsWildcard() && l4.PortName == "" {
 		return
 	}
 
@@ -1136,6 +1174,9 @@ func (l4 *L4Filter) attach(ctx PolicyContext, l4Policy *L4Policy) (policyFeature
 	// proxy redirection for the Host, when we should accept everything from host, then
 	// wildcard Host at L7 (which is taken care of at the mapstate level).
 
+	if l4.PortName != "" {
+		features.setFeature(namedPortRules)
+	}
 	for cs, sp := range l4.PerSelectorPolicies {
 		if sp != nil {
 			// collect redirect types (if any)
@@ -1437,6 +1478,7 @@ const (
 	orderedRules
 	authRules
 	passRules
+	namedPortRules
 
 	// if any of the precedenceFeatures is set, then we need to scan for policy overrides due to
 	// precedence differences between rules.
@@ -1618,7 +1660,17 @@ func (l4 *L4Policy) removeUser(user *EndpointPolicy) {
 // The caller is responsible for making sure the same identity is not
 // present in both 'adds' and 'deletes'.
 func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter, cs CachedSelector, adds, deletes []identity.NumericIdentity) {
+	perSelectorPolicy := l4.PerSelectorPolicies[cs]
 	port := uint16(l4.Port)
+
+	wildcardPort := port == 0 && l4.PortName == ""
+	if l4.selectorCoveredByWildcard(cs, perSelectorPolicy, wildcardPort) {
+		logger.Debug(
+			"AccumulateMapChanges: Skipping L3/L4 key due to existing identical L4-only key",
+			logfields.EndpointSelector, cs)
+		return
+	}
+
 	proto := l4.U8Proto
 	derivedFrom := l4.RuleOrigin[cs]
 
@@ -1628,7 +1680,7 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 		direction = trafficdirection.Ingress
 		directionPolicy = &l4Policy.Ingress
 	}
-	perSelectorPolicy := l4.PerSelectorPolicies[cs]
+
 	redirect := perSelectorPolicy.IsRedirect()
 	listener := perSelectorPolicy.GetListener()
 	listenerPriority := perSelectorPolicy.GetListenerPriority()
@@ -1642,67 +1694,39 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 		nextTierPriority = directionPolicy.tierBasePriority[tier+1]
 	}
 
-	// Can hold rlock here as neither GetNamedPort() nor LookupRedirectPort() no longer
+	// Can hold rlock here as neither named port lookup nor LookupRedirectPort()
 	// takes the Endpoint lock below.
 	// SelectorCache may not be called into while holding this lock!
 	l4Policy.mutex.RLock()
 	defer l4Policy.mutex.RUnlock()
 
-	idents := slices.Values(append(adds, deletes...))
-	for epPolicy := range l4Policy.users {
-		// resolve named port
-		if port == 0 && l4.PortName != "" {
-			port = epPolicy.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto, idents)
-			if port == 0 {
-				continue
+	lookupProxyPort := func(ep *EndpointPolicy, port uint16) (proxyPort uint16) {
+		var err error
+		proxyPort, err = ep.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port, listener)
+		if err != nil {
+			logArgs := []any{
+				logfields.EndpointSelector, cs,
+				logfields.Port, port,
+				logfields.Protocol, proto,
+				logfields.TrafficDirection, direction,
+				logfields.Priority, priority,
+				logfields.IsRedirect, redirect,
+				logfields.Listener, listener,
+				logfields.ListenerPriority, listenerPriority,
+			}
+			// If the redirect is configured through a listener, it is possible
+			// that listener configuration is in progress. Policy will be
+			// automatically regenerated once the listener is programmed.
+			if len(listener) != 0 {
+				logger.Info("AccumulateMapChanges: Missing redirect.", logArgs...)
+			} else {
+				logger.Warn("AccumulateMapChanges: Missing redirect.", logArgs...)
 			}
 		}
-		var proxyPort uint16
-		if redirect {
-			var err error
-			proxyPort, err = epPolicy.LookupRedirectPort(l4.Ingress, string(l4.Protocol), port, listener)
-			if err != nil {
-				logArgs := []any{
-					logfields.EndpointSelector, cs,
-					logfields.Port, port,
-					logfields.Protocol, proto,
-					logfields.TrafficDirection, direction,
-					logfields.Priority, priority,
-					logfields.IsRedirect, redirect,
-					logfields.Listener, listener,
-					logfields.ListenerPriority, listenerPriority,
-				}
-				// If the redirect is configured through a listener, it is possible that listener
-				// configuration is in progress. Policy will be automatically regenerated once
-				// the listener is programmed.
-				if len(listener) != 0 {
-					logger.Info("AccumulateMapChanges: Missing redirect.", logArgs...)
-				} else {
-					logger.Warn("AccumulateMapChanges: Missing redirect.", logArgs...)
-				}
+		return proxyPort
+	}
 
-				continue
-			}
-		}
-		var keysToAdd []Key
-		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
-			keysToAdd = append(keysToAdd,
-				KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
-		}
-
-		value := newMapStateEntry(priority, tierPriority, nextTierPriority, derivedFrom, proxyPort, listenerPriority, verdict, authReq)
-
-		// If the entry is identical to wildcard map entry, we can elide it.
-		// See comment in L4Filter.toMapState()
-		wildcardMapEntry := l4.generateWildcardMapStateEntry(logger, epPolicy, port, tierPriority, nextTierPriority)
-
-		if wildcardMapEntry.IsValid() && port != 0 && value.MapStateEntry == wildcardMapEntry.MapStateEntry {
-			logger.Debug(
-				"AccumulateMapChanges: Skipping L3/L4 key due to existing identical L4-only key",
-				logfields.EndpointSelector, cs)
-			continue
-		}
-
+	debugLog := func(port uint16) {
 		if option.Config.Debug {
 			authString := "default"
 			if authReq.IsExplicit() {
@@ -1725,6 +1749,75 @@ func (l4Policy *L4Policy) AccumulateMapChanges(logger *slog.Logger, l4 *L4Filter
 				logfields.Priority, priority,
 			)
 		}
+	}
+
+	// Named ports are handled separately
+	if port == 0 && l4.PortName != "" {
+		for epPolicy := range l4Policy.users {
+			// named port deletes are done by ID
+			if len(deletes) > 0 {
+				epPolicy.policyMapChanges.AccumulateMapDeletesByID(tier, tierPriority, deletes)
+			}
+			if len(adds) == 0 {
+				continue // nothing more to do
+			}
+
+			idents := slices.Values(adds)
+			resolvedPort := epPolicy.PolicyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto, idents)
+			// default to same port for all nids
+			idPorts := func(yield func(identity.NumericIdentity, uint16) bool) {
+				for _, nid := range adds {
+					if !yield(nid, resolvedPort) {
+						return
+					}
+				}
+			}
+			if resolvedPort == 0 {
+				if l4.Ingress {
+					continue // skip unresolved ingress port
+				}
+				// multiple different ports
+				idPorts = epPolicy.PolicyOwner.GetEgressNamedPorts(l4.PortName, proto, slices.Values(adds))
+			}
+
+			for nid, port := range idPorts {
+				var proxyPort uint16
+				if redirect {
+					proxyPort = lookupProxyPort(epPolicy, port)
+					if proxyPort == 0 {
+						continue
+					}
+				}
+				key := KeyForDirection(direction).WithPortProto(proto, port)
+				value := newMapStateEntry(priority, tierPriority, nextTierPriority, derivedFrom, proxyPort, listenerPriority, verdict, authReq)
+
+				debugLog(port)
+
+				epPolicy.policyMapChanges.AccumulateMapChanges(tier, tierPriority, identity.NumericIdentitySlice{nid}, nil, []Key{key}, value)
+			}
+		}
+		return
+	}
+
+	for epPolicy := range l4Policy.users {
+		var proxyPort uint16
+		if redirect {
+			proxyPort = lookupProxyPort(epPolicy, port)
+			if proxyPort == 0 {
+				continue
+			}
+		}
+
+		var keysToAdd []Key
+		for _, mp := range PortRangeToMaskedPorts(port, l4.EndPort) {
+			keysToAdd = append(keysToAdd,
+				KeyForDirection(direction).WithPortProtoPrefix(proto, mp.port, uint8(bits.LeadingZeros16(^mp.mask))))
+		}
+
+		value := newMapStateEntry(priority, tierPriority, nextTierPriority, derivedFrom, proxyPort, listenerPriority, verdict, authReq)
+
+		debugLog(port)
+
 		epPolicy.policyMapChanges.AccumulateMapChanges(tier, tierPriority, adds, deletes, keysToAdd, value)
 	}
 }

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -16,10 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	pkgTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -29,6 +33,194 @@ func perSelectorPolicyToString(psp *PerSelectorPolicy) string {
 		return err.Error()
 	}
 	return string(b)
+}
+
+type namedPortPolicyOwner struct {
+	DummyOwner
+	egressPorts map[identity.NumericIdentity][]uint16
+}
+
+func (o namedPortPolicyOwner) egressPortsFor(destID identity.NumericIdentity) []uint16 {
+	if destID != 0 {
+		return o.egressPorts[destID]
+	}
+
+	portSet := map[uint16]struct{}{}
+	for _, ports := range o.egressPorts {
+		for _, port := range ports {
+			portSet[port] = struct{}{}
+		}
+	}
+	ports := make([]uint16, 0, len(portSet))
+	for port := range portSet {
+		ports = append(ports, port)
+	}
+	slices.Sort(ports)
+	return ports
+}
+
+func (o namedPortPolicyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIDs iter.Seq[identity.NumericIdentity]) uint16 {
+	if ingress {
+		return o.DummyOwner.GetNamedPort(ingress, name, proto, destIDs)
+	}
+	var port uint16
+	for destID := range destIDs {
+		for _, destPort := range o.egressPortsFor(destID) {
+			if port != 0 && port != destPort {
+				return 0
+			}
+			port = destPort
+		}
+	}
+	return port
+}
+
+func (o namedPortPolicyOwner) GetEgressNamedPorts(name string, proto u8proto.U8proto, destIDs iter.Seq[identity.NumericIdentity]) pkgTypes.NidPortSeq {
+	return func(yield func(identity.NumericIdentity, uint16) bool) {
+		for destID := range destIDs {
+			for _, port := range o.egressPortsFor(destID) {
+				if !yield(destID, port) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func TestEgressNamedPortToMapStateUnion(t *testing.T) {
+	logger := hivetest.Logger(t)
+	cs := newTestCachedSelector("backend", false, 101, 102)
+	owner := namedPortPolicyOwner{
+		DummyOwner: DummyOwner{logger: logger},
+		egressPorts: map[identity.NumericIdentity][]uint16{
+			101: {8080, 9090},
+			102: {9090},
+		},
+	}
+	epPolicy := &EndpointPolicy{
+		PolicyOwner:    owner,
+		policyMapState: newMapState(logger, nil, namedPortRules),
+		selectors:      types.MockSelectorSnapshot(),
+	}
+	filter := &L4Filter{
+		PortName: "http",
+		Protocol: api.ProtoTCP,
+		U8Proto:  u8proto.TCP,
+		PerSelectorPolicies: L7DataMap{
+			cs: nil,
+		},
+	}
+
+	filter.toMapState(logger, types.HighestPriority, types.LowestPriority, epPolicy, namedPortRules, ChangeState{})
+
+	for _, key := range []Key{
+		EgressKey().WithIdentity(101).WithTCPPort(8080),
+		EgressKey().WithIdentity(101).WithTCPPort(9090),
+		EgressKey().WithIdentity(102).WithTCPPort(9090),
+	} {
+		_, ok := epPolicy.policyMapState.Get(key)
+		require.True(t, ok, "missing key %s", key)
+	}
+	_, ok := epPolicy.policyMapState.Get(EgressKey().WithIdentity(102).WithTCPPort(8080))
+	require.False(t, ok)
+}
+
+func TestEgressNamedPortWildcardOptimization(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ws := newTestCachedSelector("wildcard", true, 101, 102)
+	filter := &L4Filter{
+		PortName: "http",
+		Protocol: api.ProtoTCP,
+		U8Proto:  u8proto.TCP,
+		wildcard: ws,
+		PerSelectorPolicies: L7DataMap{
+			ws: nil,
+		},
+	}
+
+	t.Run("agreed ports use wildcard identity", func(t *testing.T) {
+		owner := namedPortPolicyOwner{
+			DummyOwner: DummyOwner{logger: logger},
+			egressPorts: map[identity.NumericIdentity][]uint16{
+				101: {8080},
+				102: {8080},
+			},
+		}
+		epPolicy := &EndpointPolicy{
+			PolicyOwner:    owner,
+			policyMapState: newMapState(logger, nil, namedPortRules),
+			selectors:      types.MockSelectorSnapshot(),
+		}
+
+		filter.toMapState(logger, types.HighestPriority, types.LowestPriority, epPolicy, namedPortRules, ChangeState{})
+
+		_, ok := epPolicy.policyMapState.Get(EgressKey().WithIdentity(0).WithTCPPort(8080))
+		require.True(t, ok)
+		_, ok = epPolicy.policyMapState.Get(EgressKey().WithIdentity(101).WithTCPPort(8080))
+		require.False(t, ok)
+	})
+
+	t.Run("disagreed ports use wildcard identity for all ports", func(t *testing.T) {
+		owner := namedPortPolicyOwner{
+			DummyOwner: DummyOwner{logger: logger},
+			egressPorts: map[identity.NumericIdentity][]uint16{
+				101: {8080, 9090},
+				102: {9090},
+			},
+		}
+		epPolicy := &EndpointPolicy{
+			PolicyOwner:    owner,
+			policyMapState: newMapState(logger, nil, namedPortRules),
+			selectors:      types.MockSelectorSnapshot(),
+		}
+
+		filter.toMapState(logger, types.HighestPriority, types.LowestPriority, epPolicy, namedPortRules, ChangeState{})
+
+		_, ok := epPolicy.policyMapState.Get(EgressKey().WithIdentity(0).WithTCPPort(8080))
+		require.True(t, ok)
+		_, ok = epPolicy.policyMapState.Get(EgressKey().WithIdentity(0).WithTCPPort(9090))
+		require.True(t, ok)
+		for _, key := range []Key{
+			EgressKey().WithIdentity(101).WithTCPPort(8080),
+			EgressKey().WithIdentity(101).WithTCPPort(9090),
+			EgressKey().WithIdentity(102).WithTCPPort(9090),
+		} {
+			_, ok := epPolicy.policyMapState.Get(key)
+			require.False(t, ok, "unexpected key %s", key)
+		}
+	})
+}
+
+func TestNamedPortRulesDeleteByID(t *testing.T) {
+	logger := hivetest.Logger(t)
+	epPolicy := &EndpointPolicy{
+		PolicyOwner:    DummyOwner{logger: logger},
+		policyMapState: newMapState(logger, nil, namedPortRules),
+	}
+	require.NotNil(t, epPolicy.policyMapState.byId)
+
+	entry := newMapStateEntry(0, types.HighestPriority, types.LowestPriority, NilRuleOrigin, 0, 0, types.Allow, NoAuthRequirement)
+	for _, key := range []Key{
+		EgressKey().WithIdentity(101).WithTCPPort(8080),
+		EgressKey().WithIdentity(101).WithTCPPort(9090),
+		EgressKey().WithIdentity(102).WithTCPPort(9090),
+	} {
+		epPolicy.policyMapState.insertWithChanges(types.HighestPriority.ToDenyPrecedence(), key, entry, namedPortRules, ChangeState{})
+	}
+
+	changes := MapChanges{logger: logger}
+	changes.AccumulateMapDeletesByID(0, types.HighestPriority, []identity.NumericIdentity{101})
+	changes.SyncMapChanges(types.MockSelectorSnapshot())
+	_, changeState := changes.consumeMapChanges(epPolicy, namedPortRules)
+
+	_, ok := epPolicy.policyMapState.Get(EgressKey().WithIdentity(101).WithTCPPort(8080))
+	require.False(t, ok)
+	_, ok = epPolicy.policyMapState.Get(EgressKey().WithIdentity(101).WithTCPPort(9090))
+	require.False(t, ok)
+	_, ok = epPolicy.policyMapState.Get(EgressKey().WithIdentity(102).WithTCPPort(9090))
+	require.True(t, ok)
+	require.Contains(t, changeState.Deletes, EgressKey().WithIdentity(101).WithTCPPort(8080))
+	require.Contains(t, changeState.Deletes, EgressKey().WithIdentity(101).WithTCPPort(9090))
 }
 
 func TestRedirectType(t *testing.T) {

--- a/pkg/policy/lookup.go
+++ b/pkg/policy/lookup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/spanstat"
+	pkgTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -119,12 +120,7 @@ func (ei *endpointInfo) GetID() uint64 {
 	return ei.ID
 }
 
-// GetNamedPort determines the named port of the *destination*. So, if ingress
-// is false, then this looks up the peer.
-func (ei *endpointInfo) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16 {
-	if !ingress && ei.remoteEndpoint != nil {
-		return ei.remoteEndpoint.GetNamedPort(true, name, proto, destIdentities)
-	}
+func (ei *endpointInfo) getNamedPort(name string, proto u8proto.U8proto) uint16 {
 	switch {
 	case proto == u8proto.TCP && ei.TCPNamedPorts != nil:
 		return ei.TCPNamedPorts[name]
@@ -133,6 +129,33 @@ func (ei *endpointInfo) GetNamedPort(ingress bool, name string, proto u8proto.U8
 	}
 
 	return 0
+}
+
+func (ei *endpointInfo) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, _ iter.Seq[identity.NumericIdentity]) uint16 {
+	if ingress {
+		return ei.getNamedPort(name, proto)
+	}
+	if ei.remoteEndpoint == nil {
+		return 0
+	}
+	return ei.remoteEndpoint.getNamedPort(name, proto)
+}
+
+func (ei *endpointInfo) GetEgressNamedPorts(name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) pkgTypes.NidPortSeq {
+	return func(yield func(identity.NumericIdentity, uint16) bool) {
+		if ei.remoteEndpoint == nil {
+			return
+		}
+		port := ei.remoteEndpoint.getNamedPort(name, proto)
+		if port == 0 {
+			return
+		}
+		for destID := range destIdentities {
+			if !yield(destID, port) {
+				return
+			}
+		}
+	}
 }
 
 func (ei *endpointInfo) PolicyDebug(msg string, attrs ...any) {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -713,7 +713,7 @@ func newMapState(logger *slog.Logger, old *mapState, features policyFeatures) ma
 		trie:    bitlpm.NewTrie[types.LPMKey, IDSet](types.MapStatePrefixLen),
 	}
 
-	if features&passRules != 0 {
+	if features&(passRules|namedPortRules) != 0 {
 		if old == nil {
 			ms.byId = make(map[identity.NumericIdentity]LPMKeys)
 		} else {
@@ -850,10 +850,15 @@ func (ms mapState) String() (res string) {
 	return res
 }
 
-// Equal returns true of two entries are equal.
-// This is used for testing only via mapState.Equal and mapState.Diff.
+// Equal returns true if two entries are fully equal, including rule origin
+// metadata used for labels and logging.
 func (e mapStateEntry) Equal(o mapStateEntry) bool {
-	return e.MapStateEntry == o.MapStateEntry && e.derivedFromRules == o.derivedFromRules &&
+	return e.VerdictEqual(o) && e.derivedFromRules == o.derivedFromRules
+}
+
+// VerdictEqual returns true if two entries have equal datapath and PASS semantics.
+func (e mapStateEntry) VerdictEqual(o mapStateEntry) bool {
+	return e.MapStateEntry == o.MapStateEntry &&
 		(e.passes == o.passes || (e.passes != nil && o.passes != nil &&
 			slices.Equal(*e.passes, *o.passes)))
 }
@@ -1609,6 +1614,23 @@ type mapChange struct {
 	TierMaxPrecedence types.Precedence
 	Key               Key
 	Value             mapStateEntry
+}
+
+// AccumulateMapDeletesByID accumulates identity-wide deletes. This is used when
+// the exact keys are intentionally not reconstructed, such as egress named port
+// deletes whose concrete ports may no longer be available.
+func (mc *MapChanges) AccumulateMapDeletesByID(tier types.Tier, basePriority types.Priority, deletes []identity.NumericIdentity) {
+	tierMaxPrecedence := basePriority.ToDenyPrecedence()
+	mc.mutex.Lock()
+	defer mc.mutex.Unlock()
+	for _, id := range deletes {
+		mc.changes = append(mc.changes, mapChange{
+			Add:               false,
+			Tier:              tier,
+			TierMaxPrecedence: tierMaxPrecedence,
+			Key:               Key{Identity: id},
+		})
+	}
 }
 
 type MapChange struct {

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/time"
+	pkgTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -269,7 +270,8 @@ func (p *EndpointPolicy) CopyMapStateFrom(m MapStateMap) {
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64
-	GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16
+	GetNamedPort(ingress bool, name string, proto u8proto.U8proto, idents iter.Seq[identity.NumericIdentity]) uint16
+	GetEgressNamedPorts(name string, proto u8proto.U8proto, destIdents iter.Seq[identity.NumericIdentity]) pkgTypes.NidPortSeq
 	PolicyDebug(msg string, attrs ...any)
 	IsHost() bool
 	PreviousMapState() *MapState

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	pkgTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -183,6 +184,16 @@ func (d DummyOwner) CreateRedirects(*L4Filter) {
 
 func (d DummyOwner) GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16 {
 	return 80
+}
+
+func (d DummyOwner) GetEgressNamedPorts(name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) pkgTypes.NidPortSeq {
+	return func(yield func(identity.NumericIdentity, uint16) bool) {
+		for destID := range destIdentities {
+			if !yield(destID, 80) {
+				return
+			}
+		}
+	}
 }
 
 func (d DummyOwner) GetID() uint64 {

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -19,6 +20,7 @@ type EndpointInfoSource interface {
 	GetIPv4Address() string
 	GetIPv6Address() string
 	GetNamedPort(ingress bool, name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) uint16
+	GetEgressNamedPorts(name string, proto u8proto.U8proto, destIdentities iter.Seq[identity.NumericIdentity]) types.NidPortSeq
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/types/portmap.go
+++ b/pkg/types/portmap.go
@@ -34,7 +34,7 @@ type PortProto struct {
 // NamedPortMap maps port names to port numbers and protocols.
 type NamedPortMap map[string]PortProto
 
-// PortProtoSet maps PortProto to a map of endpoint IDs to their reference counts.
+// PortProtoSet maps PortProto to a map of numeric identities to their reference counts.
 type PortProtoSet map[PortProto]map[identity.NumericIdentity]int
 
 // Equal returns true if the PortProtoSets are equal.
@@ -48,8 +48,8 @@ func (pps PortProtoSet) Equal(other PortProtoSet) bool {
 		if !exists || len(epCounts) != len(otherEpCounts) {
 			return false
 		}
-		for epID, count := range epCounts {
-			otherCount, epExists := otherEpCounts[epID]
+		for nid, count := range epCounts {
+			otherCount, epExists := otherEpCounts[nid]
 			if !epExists || count != otherCount {
 				return false
 			}
@@ -58,25 +58,25 @@ func (pps PortProtoSet) Equal(other PortProtoSet) bool {
 	return true
 }
 
-// Add increments the reference count for the epID associated with the PortProto.
-// Returns true if the epID was not previously in the map (count was 0).
-func (pps PortProtoSet) Add(pp PortProto, epID identity.NumericIdentity) bool {
+// Add increments the reference count for the numeric identity associated with the PortProto.
+// Returns true if the numeric identity was not previously in the map (count was 0).
+func (pps PortProtoSet) Add(pp PortProto, nid identity.NumericIdentity) bool {
 	epCounts, ok := pps[pp]
 	if !ok {
 		epCounts = make(map[identity.NumericIdentity]int)
 		pps[pp] = epCounts
 	}
-	return counter.Counter[identity.NumericIdentity](epCounts).Add(epID)
+	return counter.Counter[identity.NumericIdentity](epCounts).Add(nid)
 }
 
-// Delete decrements the reference count for the epID associated with the PortProto.
-// It returns true if the epID was deleted.
-func (pps PortProtoSet) Delete(pp PortProto, epID identity.NumericIdentity) bool {
+// Delete decrements the reference count for the numeric identity associated with the PortProto.
+// It returns true if the numeric identity was deleted.
+func (pps PortProtoSet) Delete(pp PortProto, nid identity.NumericIdentity) bool {
 	epCounts, ok := pps[pp]
 	if !ok {
 		return false
 	}
-	deleted := counter.Counter[identity.NumericIdentity](epCounts).Delete(epID)
+	deleted := counter.Counter[identity.NumericIdentity](epCounts).Delete(nid)
 	if deleted && len(epCounts) == 0 {
 		delete(pps, pp)
 	}
@@ -87,7 +87,7 @@ func (pps PortProtoSet) Delete(pp PortProto, epID identity.NumericIdentity) bool
 // define the same name with different values.
 type NamedPortMultiMap interface {
 	// GetNamedPort returns the port number for the named port, if any.
-	GetNamedPort(name string, proto u8proto.U8proto, epIDs iter.Seq[identity.NumericIdentity]) (uint16, error)
+	GetNamedPort(name string, proto u8proto.U8proto, nids iter.Seq[identity.NumericIdentity]) (uint16, error)
 
 	// Len returns the number of Name->PortProtoSet mappings known.
 	Len() int
@@ -113,7 +113,7 @@ func (npm *namedPortMultiMap) Len() int {
 }
 
 // Update applies potential changes in named ports, and returns whether there were any.
-func (npm *namedPortMultiMap) Update(epID identity.NumericIdentity, old, new NamedPortMap) (namedPortsChanged bool) {
+func (npm *namedPortMultiMap) Update(nid identity.NumericIdentity, old, new NamedPortMap) (namedPortsChanged bool) {
 	npm.Lock()
 	defer npm.Unlock()
 
@@ -122,7 +122,7 @@ func (npm *namedPortMultiMap) Update(epID identity.NumericIdentity, old, new Nam
 		newPP, exists := new[name]
 		if !exists || oldPP != newPP {
 			if pps, ok := npm.m[name]; ok {
-				if deleted := pps.Delete(oldPP, epID); deleted {
+				if deleted := pps.Delete(oldPP, nid); deleted {
 					namedPortsChanged = true
 				}
 			}
@@ -145,7 +145,7 @@ func (npm *namedPortMultiMap) Update(epID identity.NumericIdentity, old, new Nam
 				pps = make(PortProtoSet)
 				npm.m[name] = pps
 			}
-			if pps.Add(newPP, epID) {
+			if pps.Add(newPP, nid) {
 				namedPortsChanged = true
 			}
 		}
@@ -218,7 +218,7 @@ func (npm NamedPortMap) GetNamedPort(name string, proto u8proto.U8proto) (uint16
 }
 
 // GetNamedPort returns the port number for the named port, if any.
-func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto, epIDs iter.Seq[identity.NumericIdentity]) (uint16, error) {
+func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto, nids iter.Seq[identity.NumericIdentity]) (uint16, error) {
 	if npm == nil {
 		return 0, ErrNilMap
 	}
@@ -233,20 +233,21 @@ func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto, e
 		// and it is likely the destination POD with the port name is simply not scheduled yet.
 		return 0, ErrUnknownNamedPort
 	}
-	// Find if there is a single port that has no proto conflict and no zero port value
+	// Find if there is a single port that has no proto conflict and no zero port value.
+	// Numeric identities that have no named port mapping are skipped.
 	port := uint16(0)
 	err := ErrUnknownNamedPort
-	for pp, epSet := range pps {
-		// Check if this PortProto is defined by any of the target endpoint IDs
-		validEp := false
-		for epID := range epIDs {
-			if _, exists := epSet[epID]; exists {
-				validEp = true
+	for pp, nidSet := range pps {
+		// Check if this PortProto is defined by any of the target numeric identities
+		validNID := false
+		for nid := range nids {
+			if _, exists := nidSet[nid]; exists {
+				validNID = true
 				break
 			}
 		}
-		if !validEp {
-			continue // Skip if PortProto is not from the target endpoints
+		if !validNID {
+			continue // Skip if PortProto is not from the target identities
 		}
 
 		if pp.Proto != 0 && proto != pp.Proto {

--- a/pkg/types/portmap.go
+++ b/pkg/types/portmap.go
@@ -4,10 +4,14 @@
 package types
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
 	"strings"
+	"unique"
+	"unsafe"
 
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/iana"
@@ -83,11 +87,21 @@ func (pps PortProtoSet) Delete(pp PortProto, nid identity.NumericIdentity) bool 
 	return deleted
 }
 
+type NidPortSeq iter.Seq2[identity.NumericIdentity, uint16]
+
+func emptyNidPortSeq(func(identity.NumericIdentity, uint16) bool) {}
+
 // NamedPortMultiMap may have multiple entries for a name if multiple PODs
 // define the same name with different values.
 type NamedPortMultiMap interface {
 	// GetNamedPort returns the port number for the named port, if any.
+	// Wildcard identity gets the named port defined for any other identity.
 	GetNamedPort(name string, proto u8proto.U8proto, nids iter.Seq[identity.NumericIdentity]) (uint16, error)
+
+	// GetNamedPorts returns the port numbers for the named port, if any, by
+	// numeric identity.
+	// Wildcard identity gets the named ports defined for all other identities.
+	GetNamedPorts(name string, proto u8proto.U8proto, nids iter.Seq[identity.NumericIdentity]) NidPortSeq
 
 	// Len returns the number of Name->PortProtoSet mappings known.
 	Len() int
@@ -95,7 +109,8 @@ type NamedPortMultiMap interface {
 
 func NewNamedPortMultiMap() *namedPortMultiMap {
 	return &namedPortMultiMap{
-		m: make(map[string]PortProtoSet),
+		m:     make(map[string]PortProtoSet),
+		ports: make(map[namedPortCacheKey]map[identity.NumericIdentity]unique.Handle[namedPortSet]),
 	}
 }
 
@@ -104,7 +119,21 @@ func NewNamedPortMultiMap() *namedPortMultiMap {
 type namedPortMultiMap struct {
 	lock.RWMutex
 	m map[string]PortProtoSet
+	// ports caches the port set by numeric identity, nid 0 caches ports for all identities.
+	ports map[namedPortCacheKey]map[identity.NumericIdentity]unique.Handle[namedPortSet]
 }
+
+type namedPortCacheKey struct {
+	name  string
+	proto u8proto.U8proto
+}
+
+// namedPortSet is an interned, sorted, deduplicated set of uint16 ports encoded
+// as native-endian bytes. It must only be constructed from sorted []uint16 via
+// makeNamedPortSet(), and its bytes must be treated as immutable.
+type namedPortSet string
+
+var zeroNamedPortSet unique.Handle[namedPortSet]
 
 func (npm *namedPortMultiMap) Len() int {
 	npm.RLock()
@@ -117,6 +146,8 @@ func (npm *namedPortMultiMap) Update(nid identity.NumericIdentity, old, new Name
 	npm.Lock()
 	defer npm.Unlock()
 
+	touchedNames := map[string]struct{}{}
+
 	// Handle removals: Ports in old but not in new, or changed.
 	for name, oldPP := range old {
 		newPP, exists := new[name]
@@ -124,6 +155,7 @@ func (npm *namedPortMultiMap) Update(nid identity.NumericIdentity, old, new Name
 			if pps, ok := npm.m[name]; ok {
 				if deleted := pps.Delete(oldPP, nid); deleted {
 					namedPortsChanged = true
+					touchedNames[name] = struct{}{}
 				}
 			}
 		}
@@ -147,10 +179,27 @@ func (npm *namedPortMultiMap) Update(nid identity.NumericIdentity, old, new Name
 			}
 			if pps.Add(newPP, nid) {
 				namedPortsChanged = true
+				touchedNames[name] = struct{}{}
 			}
 		}
 	}
+	for name := range touchedNames {
+		npm.invalidateNamedPorts(name, nid)
+	}
 	return namedPortsChanged
+}
+
+// invalidateNamedPorts invalidates cached portsets for the given identity and the wildcard identity
+func (npm *namedPortMultiMap) invalidateNamedPorts(name string, nid identity.NumericIdentity) {
+	for key, byNID := range npm.ports {
+		if key.name == name {
+			delete(byNID, 0)
+			delete(byNID, nid)
+			if len(byNID) == 0 {
+				delete(npm.ports, key)
+			}
+		}
+	}
 }
 
 // ValidatePortName checks that the port name conforms to the IANA Service Names spec
@@ -218,6 +267,9 @@ func (npm NamedPortMap) GetNamedPort(name string, proto u8proto.U8proto) (uint16
 }
 
 // GetNamedPort returns the port number for the named port, if any.
+// Numeric identities that have no named port mapping are skipped.
+// Wildcard identity gets the named port defined for any other identity.
+// Callers that need stricter per-identity semantics can fall back to GetNamedPorts().
 func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto, nids iter.Seq[identity.NumericIdentity]) (uint16, error) {
 	if npm == nil {
 		return 0, ErrNilMap
@@ -234,37 +286,152 @@ func (npm *namedPortMultiMap) GetNamedPort(name string, proto u8proto.U8proto, n
 		return 0, ErrUnknownNamedPort
 	}
 	// Find if there is a single port that has no proto conflict and no zero port value.
-	// Numeric identities that have no named port mapping are skipped.
-	port := uint16(0)
-	err := ErrUnknownNamedPort
-	for pp, nidSet := range pps {
-		// Check if this PortProto is defined by any of the target numeric identities
-		validNID := false
-		for nid := range nids {
-			if _, exists := nidSet[nid]; exists {
-				validNID = true
-				break
-			}
-		}
-		if !validNID {
-			continue // Skip if PortProto is not from the target identities
-		}
-
-		if pp.Proto != 0 && proto != pp.Proto {
-			err = ErrIncompatibleProtocol
-			continue // conflicting proto
-		}
-		if pp.Port == 0 {
-			err = ErrNamedPortIsZero
-			continue // zero port
-		}
-		if port != 0 && pp.Port != port {
+	var ports []uint16
+	for nid := range nids {
+		ports = collectNamedPorts(pps, proto, nid, ports)
+		if len(ports) > 1 {
 			return 0, ErrDuplicateNamedPorts
 		}
-		port = pp.Port
 	}
-	if port == 0 {
-		return 0, err
+	if len(ports) == 0 {
+		return 0, ErrUnknownNamedPort
 	}
-	return port, nil
+	return ports[0], nil
+}
+
+// GetNamedPorts returns the port numbers for the named port, if any.
+func (npm *namedPortMultiMap) GetNamedPorts(name string, proto u8proto.U8proto, nids iter.Seq[identity.NumericIdentity]) NidPortSeq {
+	if npm == nil {
+		return emptyNidPortSeq
+	}
+	npm.Lock()
+	if npm.m == nil {
+		npm.Unlock()
+		return emptyNidPortSeq
+	}
+	if npm.ports == nil {
+		npm.ports = make(map[namedPortCacheKey]map[identity.NumericIdentity]unique.Handle[namedPortSet])
+	}
+	key := namedPortCacheKey{name: name, proto: proto}
+	byNID, ok := npm.ports[key]
+	if !ok || byNID == nil {
+		byNID = make(map[identity.NumericIdentity]unique.Handle[namedPortSet])
+		npm.ports[key] = byNID
+	}
+	pps := npm.m[name]
+	var resultNIDs []identity.NumericIdentity
+	var resultPorts []uint16
+	for nid := range nids {
+		if portSet, ok := byNID[nid]; ok {
+			if portSet != zeroNamedPortSet {
+				resultNIDs, resultPorts = appendNamedPorts(resultNIDs, resultPorts, nid, portSet)
+			}
+			continue
+		}
+
+		// cache miss, collect the ports for this numeric identity
+		ports := collectNamedPorts(pps, proto, nid, nil)
+		if len(ports) == 0 {
+			byNID[nid] = zeroNamedPortSet
+			continue
+		}
+		slices.Sort(ports)
+		portSet := makeNamedPortSet(ports)
+		byNID[nid] = portSet
+		resultNIDs, resultPorts = appendNamedPorts(resultNIDs, resultPorts, nid, portSet)
+	}
+	npm.Unlock()
+
+	return func(yield func(identity.NumericIdentity, uint16) bool) {
+		for i, nid := range resultNIDs {
+			if !yield(nid, resultPorts[i]) {
+				return
+			}
+		}
+	}
+}
+
+func (s NidPortSeq) Ports() []uint16 {
+	portSet := map[uint16]struct{}{}
+	var port uint16
+	for _, port = range s {
+		portSet[port] = struct{}{}
+	}
+	if len(portSet) == 0 {
+		return nil
+	}
+	if len(portSet) == 1 {
+		return []uint16{port}
+	}
+
+	ports := make([]uint16, 0, len(portSet))
+	for port := range portSet {
+		ports = append(ports, port)
+	}
+	slices.Sort(ports)
+	return ports
+}
+
+// collectNamedPorts collects named ports registered for the given numeric identity.
+// For a wildcard identity (0) named ports registered for all identities are returned.
+func collectNamedPorts(pps PortProtoSet, proto u8proto.U8proto, nid identity.NumericIdentity, ports []uint16) []uint16 {
+	for pp, nidCounts := range pps {
+		if nid != 0 {
+			if _, exists := nidCounts[nid]; !exists {
+				continue
+			}
+		}
+		if pp.Proto != 0 && proto != pp.Proto {
+			continue
+		}
+		if pp.Port == 0 {
+			continue
+		}
+		if !slices.Contains(ports, pp.Port) {
+			ports = append(ports, pp.Port)
+		}
+	}
+	return ports
+}
+
+func makeNamedPortSet(ports []uint16) unique.Handle[namedPortSet] {
+	if len(ports) == 0 {
+		return zeroNamedPortSet
+	}
+	// SAFETY: ports is sorted, deduplicated, and not mutated after this point.
+	// unsafe.String aliases ports only for the duration of unique.Make(). The
+	// unique package clones string values before retaining new canonical values;
+	// if the value is already interned, the temporary string is not retained.
+	portSet := namedPortSet(unsafe.String(
+		(*byte)(unsafe.Pointer(unsafe.SliceData(ports))),
+		len(ports)*2,
+	))
+	return unique.Make(portSet)
+}
+
+func appendNamedPorts(resultNIDs []identity.NumericIdentity, resultPorts []uint16, nid identity.NumericIdentity, portSet unique.Handle[namedPortSet]) ([]identity.NumericIdentity, []uint16) {
+	portSet.Value().forEachPort(func(port uint16) bool {
+		resultNIDs = append(resultNIDs, nid)
+		resultPorts = append(resultPorts, port)
+		return true
+	})
+	return resultNIDs, resultPorts
+}
+
+func (ps namedPortSet) forEachPort(yield func(uint16) bool) bool {
+	if len(ps) == 0 {
+		return true
+	}
+	// SAFETY: namedPortSet values are created from []uint16 native-endian bytes
+	// and are immutable after interning. We read as bytes rather than casting
+	// back to []uint16 because unique.Make clones strings, so the cloned string
+	// backing storage is not guaranteed to have uint16 alignment.
+	portBytes := unsafe.Slice(unsafe.StringData(string(ps)), len(ps))
+	for len(portBytes) >= 2 {
+		if !yield(binary.NativeEndian.Uint16(portBytes[:2])) {
+			return false
+		}
+		portBytes = portBytes[2:]
+	}
+	return true
 }

--- a/pkg/types/portmap_test.go
+++ b/pkg/types/portmap_test.go
@@ -197,11 +197,11 @@ func TestPolicyNamedPortMultiMap(t *testing.T) {
 	require.Equal(t, uint16(0), port)
 
 	port, err = a.GetNamedPort("http", u8proto.UDP, id1)
-	require.Equal(t, ErrIncompatibleProtocol, err)
+	require.Equal(t, ErrUnknownNamedPort, err)
 	require.Equal(t, uint16(0), port)
 
 	port, err = a.GetNamedPort("zero", u8proto.TCP, id0)
-	require.Equal(t, ErrNamedPortIsZero, err)
+	require.Equal(t, ErrUnknownNamedPort, err)
 	require.Equal(t, uint16(0), port)
 
 	port, err = a.GetNamedPort("none", u8proto.TCP, id0)
@@ -236,6 +236,263 @@ func TestPolicyNamedPortMultiMap(t *testing.T) {
 	port, err = b.GetNamedPort("dns", u8proto.UDP, id0)
 	require.NoError(t, err)
 	require.Equal(t, uint16(53), port)
+}
+
+func TestPolicyNamedPortMultiMapGetNamedPortIgnoresMissingNumericIdentity(t *testing.T) {
+	nid1 := identity.NumericIdentity(1)
+	npm := &namedPortMultiMap{
+		m: map[string]PortProtoSet{
+			"http": {
+				PortProto{Port: 80, Proto: u8proto.TCP}: {nid1: 1},
+			},
+		},
+	}
+
+	port, err := npm.GetNamedPort("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid1, 42}))
+	require.NoError(t, err)
+	require.Equal(t, uint16(80), port)
+}
+
+func TestPolicyNamedPortMultiMapGetNamedPortWildcardIdentity(t *testing.T) {
+	nid0 := identity.NumericIdentity(0)
+	nid1 := identity.NumericIdentity(1)
+	nid2 := identity.NumericIdentity(2)
+	npm := &namedPortMultiMap{
+		m: map[string]PortProtoSet{
+			"http": {
+				PortProto{Port: 80, Proto: u8proto.TCP}: {nid1: 1, nid2: 1},
+			},
+			"multi": {
+				PortProto{Port: 80, Proto: u8proto.TCP}:   {nid1: 1},
+				PortProto{Port: 8080, Proto: u8proto.TCP}: {nid2: 1},
+			},
+			"proto": {
+				PortProto{Port: 53, Proto: u8proto.TCP}:   {nid1: 1},
+				PortProto{Port: 53, Proto: u8proto.UDP}:   {nid2: 1},
+				PortProto{Port: 5353, Proto: u8proto.UDP}: {nid2: 1},
+			},
+			"zero": {
+				PortProto{Port: 0, Proto: u8proto.TCP}: {nid1: 1},
+			},
+		},
+	}
+
+	port, err := npm.GetNamedPort("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid0}))
+	require.NoError(t, err)
+	require.Equal(t, uint16(80), port)
+
+	port, err = npm.GetNamedPort("multi", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid0}))
+	require.Equal(t, ErrDuplicateNamedPorts, err)
+	require.Equal(t, uint16(0), port)
+
+	port, err = npm.GetNamedPort("proto", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid0}))
+	require.NoError(t, err)
+	require.Equal(t, uint16(53), port)
+
+	port, err = npm.GetNamedPort("proto", u8proto.UDP, slices.Values([]identity.NumericIdentity{nid0}))
+	require.Equal(t, ErrDuplicateNamedPorts, err)
+	require.Equal(t, uint16(0), port)
+
+	port, err = npm.GetNamedPort("zero", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid0}))
+	require.Equal(t, ErrUnknownNamedPort, err)
+	require.Equal(t, uint16(0), port)
+}
+
+func getNamedPorts(npm NamedPortMultiMap, name string, proto u8proto.U8proto, nid identity.NumericIdentity) []uint16 {
+	var result []uint16
+	for resultNID, port := range npm.GetNamedPorts(name, proto, slices.Values([]identity.NumericIdentity{nid})) {
+		if resultNID == nid {
+			result = append(result, port)
+		}
+	}
+	return result
+}
+
+func TestPolicyNamedPortMultiMapGetNamedPorts(t *testing.T) {
+	nid1 := identity.NumericIdentity(1)
+	nid2 := identity.NumericIdentity(2)
+	a := &namedPortMultiMap{
+		m: map[string]PortProtoSet{
+			"http": {
+				PortProto{Port: 80, Proto: u8proto.TCP}:   {nid1: 1},
+				PortProto{Port: 8080, Proto: u8proto.TCP}: {nid2: 1},
+			},
+			"web": {
+				PortProto{Port: 80, Proto: u8proto.TCP}: {nid1: 1},
+			},
+			"multi": {
+				PortProto{Port: 80, Proto: u8proto.TCP}:  {nid1: 1},
+				PortProto{Port: 443, Proto: u8proto.TCP}: {nid1: 1},
+			},
+			"multi2": {
+				PortProto{Port: 443, Proto: u8proto.TCP}: {nid1: 1},
+				PortProto{Port: 80, Proto: u8proto.TCP}:  {nid1: 1},
+			},
+			"https": {
+				PortProto{Port: 443, Proto: u8proto.TCP}: {nid1: 1},
+			},
+			"zero": {
+				PortProto{Port: 0, Proto: u8proto.TCP}: {nid1: 1},
+			},
+			"none": {},
+			"dns": {
+				PortProto{Port: 53, Proto: u8proto.UDP}: {nid1: 1},
+				PortProto{Port: 53, Proto: u8proto.TCP}: {nid1: 1},
+			},
+		},
+	}
+	b := &namedPortMultiMap{
+		m: map[string]PortProtoSet{
+			"http": {
+				PortProto{Port: 80, Proto: u8proto.TCP}:   {nid1: 1},
+				PortProto{Port: 8080, Proto: u8proto.TCP}: {nid2: 1},
+			},
+			"https": {
+				PortProto{Port: 443, Proto: u8proto.TCP}: {nid1: 1},
+			},
+			"zero": {
+				PortProto{Port: 0, Proto: u8proto.TCP}: {nid1: 1},
+			},
+			"none": {},
+			"dns": {
+				PortProto{Port: 53, Proto: 0}: {nid1: 1},
+			},
+		},
+	}
+
+	ports := getNamedPorts(a, "http", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80}, ports)
+	ports = getNamedPorts(a, "http", u8proto.TCP, nid2)
+	require.Equal(t, []uint16{8080}, ports)
+
+	portsByNID := map[identity.NumericIdentity][]uint16{}
+	for resultNID, resultPort := range a.GetNamedPorts("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid1, 42, nid2})) {
+		portsByNID[resultNID] = append(portsByNID[resultNID], resultPort)
+	}
+	require.Equal(t, map[identity.NumericIdentity][]uint16{
+		nid1: {80},
+		nid2: {8080},
+	}, portsByNID)
+	cachedByNID, found := a.ports[namedPortCacheKey{name: "http", proto: u8proto.TCP}]
+	require.True(t, found)
+	cached, found := cachedByNID[42]
+	require.True(t, found)
+	require.Equal(t, zeroNamedPortSet, cached)
+
+	ports = getNamedPorts(a, "web", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80}, ports)
+	require.Equal(t, a.ports[namedPortCacheKey{name: "http", proto: u8proto.TCP}][nid1], a.ports[namedPortCacheKey{name: "web", proto: u8proto.TCP}][nid1])
+
+	ports = getNamedPorts(a, "multi", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80, 443}, ports)
+	ports = getNamedPorts(a, "multi2", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80, 443}, ports)
+	require.Equal(t, a.ports[namedPortCacheKey{name: "multi", proto: u8proto.TCP}][nid1], a.ports[namedPortCacheKey{name: "multi2", proto: u8proto.TCP}][nid1])
+
+	ports = getNamedPorts(a, "http", u8proto.UDP, nid2)
+	require.Nil(t, ports)
+
+	ports = getNamedPorts(a, "zero", u8proto.TCP, nid1)
+	require.Nil(t, ports)
+
+	ports = getNamedPorts(a, "none", u8proto.TCP, nid1)
+	require.Nil(t, ports)
+
+	ports = getNamedPorts(a, "unknown", u8proto.TCP, nid1)
+	require.Nil(t, ports)
+
+	var nilvalued *namedPortMultiMap
+	ports = getNamedPorts(NamedPortMultiMap(nilvalued), "unknown", u8proto.TCP, nid1)
+	require.Nil(t, ports)
+
+	ports = getNamedPorts(a, "https", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{443}, ports)
+
+	ports = getNamedPorts(a, "dns", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{53}, ports)
+
+	ports = getNamedPorts(b, "dns", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{53}, ports)
+
+	ports = getNamedPorts(a, "dns", u8proto.UDP, nid1)
+	require.Equal(t, []uint16{53}, ports)
+
+	ports = getNamedPorts(b, "dns", u8proto.UDP, nid1)
+	require.Equal(t, []uint16{53}, ports)
+}
+
+func TestPolicyNamedPortMultiMapGetNamedPortsWildcardIdentity(t *testing.T) {
+	nid0 := identity.NumericIdentity(0)
+	nid1 := identity.NumericIdentity(1)
+	nid2 := identity.NumericIdentity(2)
+	nid3 := identity.NumericIdentity(3)
+	npm := &namedPortMultiMap{
+		m: map[string]PortProtoSet{
+			"http": {
+				PortProto{Port: 80, Proto: u8proto.TCP}:   {nid1: 1, nid3: 1},
+				PortProto{Port: 8080, Proto: u8proto.TCP}: {nid2: 1},
+				PortProto{Port: 53, Proto: u8proto.UDP}:   {nid2: 1},
+				PortProto{Port: 0, Proto: u8proto.TCP}:    {nid1: 1},
+			},
+			"same": {
+				PortProto{Port: 443, Proto: u8proto.TCP}: {nid1: 1, nid2: 1},
+			},
+		},
+	}
+
+	ports := getNamedPorts(npm, "http", u8proto.TCP, nid0)
+	require.Equal(t, []uint16{80, 8080}, ports)
+	ports = getNamedPorts(npm, "http", u8proto.UDP, nid0)
+	require.Equal(t, []uint16{53}, ports)
+	ports = getNamedPorts(npm, "same", u8proto.TCP, nid0)
+	require.Equal(t, []uint16{443}, ports)
+
+	portsByNID := map[identity.NumericIdentity][]uint16{}
+	for resultNID, resultPort := range npm.GetNamedPorts("http", u8proto.TCP, slices.Values([]identity.NumericIdentity{nid0, nid1})) {
+		portsByNID[resultNID] = append(portsByNID[resultNID], resultPort)
+	}
+	require.Equal(t, map[identity.NumericIdentity][]uint16{
+		nid0: {80, 8080},
+		nid1: {80},
+	}, portsByNID)
+
+	cachedByNID, found := npm.ports[namedPortCacheKey{name: "http", proto: u8proto.TCP}]
+	require.True(t, found)
+	require.NotEqual(t, zeroNamedPortSet, cachedByNID[nid0])
+	require.NotEqual(t, zeroNamedPortSet, cachedByNID[nid1])
+}
+
+func TestPolicyNamedPortMultiMapGetNamedPortsWildcardIdentityUpdate(t *testing.T) {
+	nid0 := identity.NumericIdentity(0)
+	nid1 := identity.NumericIdentity(1)
+	nid2 := identity.NumericIdentity(2)
+	npm := NewNamedPortMultiMap()
+
+	nid1Ports := NamedPortMap{"http": {Proto: u8proto.TCP, Port: 80}}
+	nid2Ports := NamedPortMap{"http": {Proto: u8proto.TCP, Port: 8080}}
+	require.True(t, npm.Update(nid1, nil, nid1Ports))
+	require.True(t, npm.Update(nid2, nil, nid2Ports))
+
+	ports := getNamedPorts(npm, "http", u8proto.TCP, nid0)
+	require.Equal(t, []uint16{80, 8080}, ports)
+
+	key := namedPortCacheKey{name: "http", proto: u8proto.TCP}
+	cachedByNID, found := npm.ports[key]
+	require.True(t, found)
+	wildcardPortSet := cachedByNID[nid0]
+	require.NotEqual(t, zeroNamedPortSet, wildcardPortSet)
+
+	nid2UpdatedPorts := NamedPortMap{"http": {Proto: u8proto.TCP, Port: 9090}}
+	require.True(t, npm.Update(nid2, nid2Ports, nid2UpdatedPorts))
+	cachedByNID, found = npm.ports[key]
+	if found {
+		_, found = cachedByNID[nid0]
+		require.False(t, found)
+	}
+
+	ports = getNamedPorts(npm, "http", u8proto.TCP, nid0)
+	require.Equal(t, []uint16{80, 9090}, ports)
+	require.NotEqual(t, wildcardPortSet, npm.ports[key][nid0])
 }
 
 func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
@@ -288,4 +545,62 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	port, err = npm.GetNamedPort("http", u8proto.UDP, nids2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(8080), port)
+}
+
+func TestPolicyNamedPortMultiMapGetNamedPortsUpdate(t *testing.T) {
+	npm := NewNamedPortMultiMap()
+	nid1 := identity.NumericIdentity(1)
+	nid2 := identity.NumericIdentity(2)
+
+	// Insert http=80/TCP from pod1 with nid1
+	pod1PortsOld := map[string]PortProto{}
+	pod1PortsNew := map[string]PortProto{
+		"http": {u8proto.TCP, 80},
+	}
+	changed := npm.Update(nid1, pod1PortsOld, pod1PortsNew)
+	require.True(t, changed)
+
+	// No changes
+	changed = npm.Update(nid1, pod1PortsNew, pod1PortsNew)
+	require.False(t, changed)
+
+	// Assert http=80/TCP
+	ports := getNamedPorts(npm, "http", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80}, ports)
+
+	// Insert 9090 from a peer with the same numeric identity
+	peerPortsOld := map[string]PortProto{}
+	peerPortsNew := map[string]PortProto{
+		"http": {u8proto.TCP, 9090},
+	}
+	changed = npm.Update(nid1, peerPortsOld, peerPortsNew)
+	require.True(t, changed)
+
+	// Assert both are returned
+	ports = getNamedPorts(npm, "http", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80, 9090}, ports)
+
+	// Insert http=8080/UDP from pod2 with nid2
+	pod2PortsOld := map[string]PortProto{}
+	pod2PortsNew := map[string]PortProto{
+		"http": {u8proto.UDP, 8080},
+	}
+	changed = npm.Update(nid2, pod2PortsOld, pod2PortsNew)
+	require.True(t, changed)
+
+	ports = getNamedPorts(npm, "http", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{80, 9090}, ports)
+	ports = getNamedPorts(npm, "http", u8proto.UDP, nid2)
+	require.Equal(t, []uint16{8080}, ports)
+
+	// Delete http=80/TCP from pod1
+	pod1PortsOld = pod1PortsNew
+	pod1PortsNew = map[string]PortProto{}
+	changed = npm.Update(nid1, pod1PortsOld, pod1PortsNew)
+	require.True(t, changed)
+
+	ports = getNamedPorts(npm, "http", u8proto.UDP, nid2)
+	require.Equal(t, []uint16{8080}, ports)
+	ports = getNamedPorts(npm, "http", u8proto.TCP, nid1)
+	require.Equal(t, []uint16{9090}, ports)
 }

--- a/pkg/types/portmap_test.go
+++ b/pkg/types/portmap_test.go
@@ -240,40 +240,40 @@ func TestPolicyNamedPortMultiMap(t *testing.T) {
 
 func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	npm := NewNamedPortMultiMap()
-	id1 := slices.Values([]identity.NumericIdentity{1})
-	id2 := slices.Values([]identity.NumericIdentity{2})
+	nid1 := identity.NumericIdentity(1)
+	nid2 := identity.NumericIdentity(2)
+	nids1 := slices.Values([]identity.NumericIdentity{nid1})
+	nids2 := slices.Values([]identity.NumericIdentity{nid2})
 
+	// Insert http=80/TCP from pod1 with nid1
 	pod1PortsOld := map[string]PortProto{}
 	pod1PortsNew := map[string]PortProto{
 		"http": {u8proto.TCP, 80},
 	}
-
-	// Insert http=80/TCP from pod1
-	changed := npm.Update(identity.NumericIdentity(1), pod1PortsOld, pod1PortsNew)
+	changed := npm.Update(nid1, pod1PortsOld, pod1PortsNew)
 	require.True(t, changed)
 
 	// No changes
-	changed = npm.Update(identity.NumericIdentity(1), pod1PortsNew, pod1PortsNew)
+	changed = npm.Update(nid1, pod1PortsNew, pod1PortsNew)
 	require.False(t, changed)
 
 	// Assert http=80/TCP
-	port, err := npm.GetNamedPort("http", u8proto.TCP, id1)
+	port, err := npm.GetNamedPort("http", u8proto.TCP, nids1)
 	require.NoError(t, err)
 	require.Equal(t, uint16(80), port)
 
+	// Insert http=8080/UDP from pod2 with nid2
 	pod2PortsOld := map[string]PortProto{}
 	pod2PortsNew := map[string]PortProto{
 		"http": {u8proto.UDP, 8080},
 	}
-
-	// Insert http=8080/UDP from pod2, retain http=80/TCP from pod1
-	changed = npm.Update(identity.NumericIdentity(2), pod2PortsOld, pod2PortsNew)
+	changed = npm.Update(nid2, pod2PortsOld, pod2PortsNew)
 	require.True(t, changed)
 
-	port, err = npm.GetNamedPort("http", u8proto.TCP, id1)
+	port, err = npm.GetNamedPort("http", u8proto.TCP, nids1)
 	require.NoError(t, err)
 	require.Equal(t, uint16(80), port)
-	port, err = npm.GetNamedPort("http", u8proto.UDP, id2)
+	port, err = npm.GetNamedPort("http", u8proto.UDP, nids2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(8080), port)
 
@@ -282,10 +282,10 @@ func TestPolicyNamedPortMultiMapUpdate(t *testing.T) {
 	pod1PortsNew = map[string]PortProto{}
 
 	// Delete http=80/TCP from pod1
-	changed = npm.Update(identity.NumericIdentity(1), pod1PortsOld, pod1PortsNew)
+	changed = npm.Update(nid1, pod1PortsOld, pod1PortsNew)
 	require.True(t, changed)
 
-	port, err = npm.GetNamedPort("http", u8proto.UDP, id2)
+	port, err = npm.GetNamedPort("http", u8proto.UDP, nids2)
 	require.NoError(t, err)
 	require.Equal(t, uint16(8080), port)
 }


### PR DESCRIPTION
Egress named-port policy resolution has been identity-scoped since PR #44429, commit 234112b0e058b74e84cea0b9615a190749063cb5 ("policy: Resolve named ports for egress policies by destination identities"). That change still contains a correctness gap when multiple backends sharing the same security identity define the same named port with different concrete port numbers: policy generation could only install one of the possible ports.

Change egress named-port resolution to return a sequence of numerical identity / concrete port pairs for a given name/protocol for a selector. Ingress named ports remain endpoint-local and still resolve to a single port.

Key changes:
* Handle wildcard identity in `NamedPortMultiMap.GetNamedPort()`
* Add new `NamedPortMultiMap.GetNamedPorts()` that returns an iterator for <numeric identity, port>. This allows for multiple and different ports per identity.
* Expand egress named-port L4 filters into multiple policy map keys as needed.
* Transform wildcard elision logic to operate on the L4Filter contents alone, without requiring wildcard entries to be created first.
* Handle incremental deletes for named ports via mapState byId index so that all relevant keys can be deleted without reconstructing named-port mappings (that may no longer be available).
* Expand proxy redirect creation and Envoy network policy generation across all resolved concrete named-port values.

This keeps the datapath and public policy API unchanged. The resulting semantics are still identity-granular: if identity X has backends defining http as both 8080 and 9090, an egress allow to named port http installs allow entries for both X:8080 and X:9090.

This PR has been created with Codex (AIL:3). The implementation has been completely revised after initial Codex output. Unit tests are pretty close to original Codex output.

Fixes: #44429

```release-note
Different named port numbers for a name from multiple pods are now honored in policy enforcement.
```
