### PR TITLE
ci: set minimum for helm chart git digest in print-chart-version.sh

### DIFF
--- a/contrib/scripts/print-chart-version.sh
+++ b/contrib/scripts/print-chart-version.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 VERSION="$(cat "$SCRIPT_DIR/../../VERSION")"
 GIT_COMMIT_COUNT="$(git rev-list --count "$(git log --follow -1 --pretty=%H VERSION)"..HEAD)"
-GIT_HASH="$(git rev-parse --short HEAD)"
+GIT_HASH="$(git -c core.abbrev=12 rev-parse --short HEAD)"
 CHART_VERSION_PRERELEASE_PREFIX=dev
 CHART_VERSION_DEV="${VERSION}-${CHART_VERSION_PRERELEASE_PREFIX}.${GIT_COMMIT_COUNT}-${GIT_HASH}"
 # Using an OCI repository for helm means versions are stored as OCI tags, which cannot contain +.


### PR DESCRIPTION
Small improvement on dev helm chart identifier. Depending on the tree checked out the result of `git rev-parse --short` might be different, makes it difficult to use this script to pick the dev helm chart version in our workflows when it's different.