### PR TITLE
bpf: populate fib lookup L4 tuple for ECMP path selection

### DIFF
--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -7,6 +7,9 @@
 #include <bpf/api.h>
 
 #include "common.h"
+#include "ipfrag.h"
+#include "ipv4.h"
+#include "ipv6.h"
 #include "network_device.h"
 #include "neigh.h"
 #include "l3.h"
@@ -183,6 +186,90 @@ fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 			       ret, *oif, ext_err);
 }
 
+/* fib_set_l4_v4 populates the L4 protocol and port fields of @fib_params for
+ * an IPv4 packet. Uses ipv4_load_l4_ports() to handle fragmented packets: with
+ * fragment tracking enabled, ports are retrieved from the tracking map for
+ * non-first fragments; without tracking, non-first fragments proceed with zero
+ * ports so ECMP hashing falls back to the IP-address tuple rather than
+ * silently reading garbage payload bytes.
+ */
+static __always_inline int
+fib_set_l4_v4(struct __ctx_buff *ctx, int l3_off, struct iphdr *ip4,
+	      struct bpf_fib_lookup_padded *fib_params)
+{
+	struct bpf_fib_lookup *l = &fib_params->l;
+	fraginfo_t fraginfo = ipfrag_encode_ipv4(ip4);
+
+	l->l4_protocol = ip4->protocol;
+	if (ip4->protocol == IPPROTO_TCP || ip4->protocol == IPPROTO_UDP ||
+	    ip4->protocol == IPPROTO_SCTP) {
+		__be16 ports[2] = {};
+		int ret;
+
+		if (ipfrag_has_l4_header(fraginfo) || CONFIG(enable_ipv4_fragments)) {
+			ret = ipv4_load_l4_ports(ctx, ip4, fraginfo,
+						 l3_off + ipv4_hdrlen(ip4),
+						 CT_EGRESS, ports);
+			if (ret < 0)
+				return ret;
+		}
+		l->sport = ports[0];
+		l->dport = ports[1];
+	}
+	return CTX_ACT_OK;
+}
+
+/* fib_set_l4_v6 populates the L4 protocol and port fields of @fib_params for
+ * an IPv6 packet. Walks extension headers to find the true L4 offset and
+ * extract fraginfo, then uses ipv6_load_l4_ports() for the same fragment-aware
+ * port loading as fib_set_l4_v4.
+ */
+static __always_inline int
+fib_set_l4_v6(struct __ctx_buff *ctx, int l3_off, struct ipv6hdr *ip6,
+	      struct bpf_fib_lookup_padded *fib_params)
+{
+	struct bpf_fib_lookup *l = &fib_params->l;
+	__u8 nexthdr = ip6->nexthdr;
+	fraginfo_t fraginfo;
+	int hdrlen;
+
+	hdrlen = ipv6_hdrlen_offset(ctx, l3_off, &nexthdr, &fraginfo);
+	if (hdrlen < 0)
+		return hdrlen;
+
+	l->l4_protocol = nexthdr;
+	if (nexthdr == IPPROTO_TCP || nexthdr == IPPROTO_UDP ||
+	    nexthdr == IPPROTO_SCTP) {
+		__be16 ports[2] = {};
+		int ret;
+
+		if (ipfrag_has_l4_header(fraginfo) || CONFIG(enable_ipv6_fragments)) {
+			ret = ipv6_load_l4_ports(ctx, ip6, fraginfo,
+						 l3_off + hdrlen,
+						 CT_EGRESS, ports);
+			if (ret < 0)
+				return ret;
+		}
+		l->sport = ports[0];
+		l->dport = ports[1];
+	}
+	return CTX_ACT_OK;
+}
+
+/* fib_set_l4_from_tuple populates the L4 fields of @fib_params from an
+ * already-extracted CT tuple, avoiding a packet read.
+ */
+static __always_inline void
+fib_set_l4_from_tuple(struct bpf_fib_lookup_padded *fib_params, __u8 nexthdr,
+		      __be16 sport, __be16 dport)
+{
+	struct bpf_fib_lookup *l = &fib_params->l;
+
+	l->l4_protocol = nexthdr;
+	l->sport = sport;
+	l->dport = dport;
+}
+
 #ifdef ENABLE_IPV6
 /* fib_lookup_v6 will perform a fib lookup with the src and dest addresses
  * provided.
@@ -252,6 +339,13 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		fib_params.l.tbid = tbid;
 		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 	}
+
+	/* Populate L4 flow fields for ECMP multipath hashing. The kernel hashes
+	 * these fields to distribute flows across multiple nexthops.
+	 */
+	ret = fib_set_l4_v6(ctx, l3_off, ip6, &fib_params);
+	if (ret < 0)
+		return ret;
 
 	fib_result = fib_lookup_v6(ctx, &fib_params, &ip6->saddr, &ip6->daddr, flags);
 	switch (fib_result) {
@@ -334,6 +428,13 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		fib_params.l.tbid = tbid;
 		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 	}
+
+	/* Populate L4 flow fields for ECMP multipath hashing. The kernel hashes
+	 * these fields to distribute flows across multiple nexthops.
+	 */
+	ret = fib_set_l4_v4(ctx, l3_off, ip4, &fib_params);
+	if (ret < 0)
+		return ret;
 
 	fib_result = fib_lookup_v4(ctx, &fib_params, ip4->saddr, ip4->daddr, flags);
 	switch (fib_result) {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -751,6 +751,9 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 
 		fib_params.l.ipv4_src = ip4->saddr;
 		fib_params.l.ipv4_dst = ip4->daddr;
+		ret = fib_set_l4_v4(ctx, ETH_HLEN, ip4, &fib_params);
+		if (ret < 0)
+			goto drop_err;
 	} else {
 		if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 			ret = DROP_INVALID;
@@ -761,6 +764,9 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 			       (union v6addr *)&ip6->saddr);
 		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
+		ret = fib_set_l4_v6(ctx, ETH_HLEN, ip6, &fib_params);
+		if (ret < 0)
+			goto drop_err;
 	}
 
 	ret = fib_redirect(ctx, true, &fib_params, false, &ext_err, &oif);
@@ -1070,6 +1076,7 @@ fib_lookup:
 		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
 	}
+	fib_set_l4_from_tuple(&fib_params, tuple.nexthdr, tuple.dport, tuple.sport);
 
 #if (defined(ENABLE_EGRESS_GATEWAY_COMMON) && (defined(IS_BPF_XDP) || defined(IS_BPF_HOST))) ||	\
     defined(TUNNEL_MODE)
@@ -1343,11 +1350,17 @@ fib_ipv4:
 		fib_params->l.ipv4_src = ip4->saddr;
 		fib_params->l.ipv4_dst = ip4->daddr;
 		fib_params->l.family = AF_INET;
+		ret = fib_set_l4_v4(ctx, ETH_HLEN, ip4, fib_params);
+		if (ret < 0)
+			goto drop_err;
 	} else {
 		ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_src,
 			       (union v6addr *)&ip6->saddr);
 		ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
+		ret = fib_set_l4_v6(ctx, ETH_HLEN, ip6, fib_params);
+		if (ret < 0)
+			goto drop_err;
 		fib_params->l.family = AF_INET6;
 	}
 
@@ -2381,6 +2394,7 @@ redirect:
 
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
+	fib_set_l4_from_tuple(&fib_params, tuple.nexthdr, tuple.dport, tuple.sport);
 
 	ret = ipv4_l3(ctx, l3_off, NULL, NULL, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
@@ -2683,6 +2697,13 @@ skip_source_lookup:
 
 	fib_params.l.ipv4_src = ip4->saddr;
 	fib_params.l.ipv4_dst = ip4->daddr;
+	/* Populate L4 flow fields for ECMP multipath hashing. Use
+	 * post-SNAT addresses and ports for consistent hashing with
+	 * the return path.
+	 */
+	ret = fib_set_l4_v4(ctx, ETH_HLEN, ip4, &fib_params);
+	if (ret < 0)
+		goto drop_err;
 
 	ret = fib_redirect(ctx, true, &fib_params, false, &ext_err, &oif);
 	if (fib_ok(ret)) {

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -199,6 +199,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 		       &nat_info.address);
 	ipv6_addr_copy((union v6addr *)fib_params.l.ipv6_dst,
 		       &tuple.daddr);
+	fib_set_l4_from_tuple(&fib_params, tuple.nexthdr, tuple.dport, tuple.sport);
 
 	ret = nodeport_fib_lookup_and_redirect(ctx, &fib_params, ext_err);
 	if (ret != CTX_ACT_OK)
@@ -499,6 +500,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, bool *snat_done,
 	fib_params.l.ifindex = ctx_get_ifindex(ctx);
 	fib_params.l.ipv4_src = nat_info.address;
 	fib_params.l.ipv4_dst = tuple.daddr;
+	fib_set_l4_from_tuple(&fib_params, tuple.nexthdr, tuple.dport, tuple.sport);
 
 	ret = nodeport_fib_lookup_and_redirect(ctx, &fib_params, ext_err);
 	if (ret != CTX_ACT_OK)

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -40,20 +40,29 @@ long mock_redirect_neigh(__maybe_unused int ifindex,
 
 struct fib_lookup_recorder {
 	__u32 flags;
+	__u8 l4_protocol;
+	__be16 sport;
+	__be16 dport;
 } fib_lookup_recorder = {0};
 
 void reset_fib_lookup_recorder(struct fib_lookup_recorder *r)
 {
 	r->flags = 0;
+	r->l4_protocol = 0;
+	r->sport = 0;
+	r->dport = 0;
 }
 
 #define fib_lookup mock_fib_lookup
 
 long mock_fib_lookup(void *ctx __maybe_unused,
-		     struct bpf_fib_lookup *params __maybe_unused,
+		     const struct bpf_fib_lookup *params __maybe_unused,
 		     int plen __maybe_unused, __u32 flags __maybe_unused)
 {
 	fib_lookup_recorder.flags = flags;
+	fib_lookup_recorder.l4_protocol = params->l4_protocol;
+	fib_lookup_recorder.sport = params->sport;
+	fib_lookup_recorder.dport = params->dport;
 	return 0;
 }
 
@@ -202,7 +211,7 @@ int test2_check(struct __ctx_buff *ctx)
 	});
 
 	TEST("fib_redirect_v4", {
-		struct iphdr hdr = { 0 };
+		struct iphdr hdr = { .protocol = IPPROTO_TCP };
 		int oif = 0;
 		__s8 ext_err;
 
@@ -216,11 +225,16 @@ int test2_check(struct __ctx_buff *ctx)
 				   BPF_FIB_LOOKUP_SKIP_NEIGH,
 				   fib_lookup_recorder.flags);
 
+		if (fib_lookup_recorder.l4_protocol != IPPROTO_TCP)
+			test_fatal("expected l4_protocol %d, got %d",
+				   IPPROTO_TCP,
+				   fib_lookup_recorder.l4_protocol);
+
 		reset_fib_lookup_recorder(&fib_lookup_recorder);
 	});
 
 	TEST("fib_redirect_v6", {
-		struct ipv6hdr hdr6 = { 0 };
+		struct ipv6hdr hdr6 = { .nexthdr = IPPROTO_UDP };
 		int oif = 0;
 		__s8 ext_err;
 
@@ -233,6 +247,11 @@ int test2_check(struct __ctx_buff *ctx)
 			test_fatal("expected flags %x, got %d",
 				   BPF_FIB_LOOKUP_SKIP_NEIGH,
 				   fib_lookup_recorder.flags);
+
+		if (fib_lookup_recorder.l4_protocol != IPPROTO_UDP)
+			test_fatal("expected l4_protocol %d, got %d",
+				   IPPROTO_UDP,
+				   fib_lookup_recorder.l4_protocol);
 
 		reset_fib_lookup_recorder(&fib_lookup_recorder);
 	});


### PR DESCRIPTION
In the current context, Cilium native routing mode with ebpf host routing only uses a single NIC. This patch intends to leverage on multiple NICs to aggregate throughput.

In my understanding, there were two issues previously.
Firstly, ENABLE_SKIP_FIB bypassed bpf_fib_lookup() entirely — fib_redirect_v4(), fib_redirect_v6(), and fib_redirect() would skip the kernel FIB and hard-redirect to CONFIG(direct_routing_dev_ifindex) — a single device. ECMP was impossible.
(This was addressed in #43277.)

Secondly, L4 fields left as zeros — even when bpf_fib_lookup() was called (e.g. the nodeport.h paths didn't use ENABLE_SKIP_FIB), the sport/dport/l4_protocol fields were zero. With fib_multipath_hash_policy=1, all flows between the same pod pair produce identical hashes → same nexthop → single NIC.

This patch populates l4_protocol, sport, and dport in BPF FIB lookups so ECMP has per-flow entropy instead of hashing only identical L3 inputs.

This complements the ENABLE_SKIP_FIB removal by ensuring bpf_fib_lookup() can actually distribute same src/dst flows across ECMP nexthops.



Fixes: #39121 

```
Leveraging on multiple NICs  for ebpf host routing
```

