### PR TITLE
gateway-api: deduplicate server names in filter chain match

### DIFF
--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 const (
@@ -463,10 +464,13 @@ func toFilterChainMatch(hostNames []string) *envoy_config_listener.FilterChainMa
 	res := &envoy_config_listener.FilterChainMatch{
 		TransportProtocol: tlsTransportProtocol,
 	}
-	// The hostNames slice cannot have duplicates, so we do not need to check for uniqueness.
-	if goslices.Contains(hostNames, "*") {
+	// ServerNames must be sorted and deduplicated. Duplicates arise when
+	// multiple HTTPS listeners share a TLS secret but differ on port.
+	// Envoy rejects "*" as a server name; omit ServerNames to match all SNI.
+	serverNames := slices.SortedUnique(goslices.Clone(hostNames))
+	if goslices.Contains(serverNames, "*") {
 		return res
 	}
-	res.ServerNames = hostNames
+	res.ServerNames = serverNames
 	return res
 }

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -10,10 +10,65 @@ import (
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 )
+
+func Test_toFilterChainMatch(t *testing.T) {
+	tests := []struct {
+		name                string
+		hostNames           []string
+		expectedServerNames []string
+	}{
+		{
+			name:                "nil input",
+			hostNames:           nil,
+			expectedServerNames: nil,
+		},
+		{
+			name:                "single hostname",
+			hostNames:           []string{"foo.example.com"},
+			expectedServerNames: []string{"foo.example.com"},
+		},
+		{
+			name:                "multiple distinct hostnames",
+			hostNames:           []string{"foo.example.com", "bar.example.com"},
+			expectedServerNames: []string{"bar.example.com", "foo.example.com"},
+		},
+		{
+			name:                "wildcard hostname returns empty serverNames",
+			hostNames:           []string{"*"},
+			expectedServerNames: nil,
+		},
+		{
+			name:                "wildcard among others returns empty serverNames",
+			hostNames:           []string{"foo.example.com", "*"},
+			expectedServerNames: nil,
+		},
+		{
+			name:                "duplicate hostnames from multi-port listeners are deduplicated",
+			hostNames:           []string{"*.example.test", "*.example.test"},
+			expectedServerNames: []string{"*.example.test"},
+		},
+		{
+			name:                "triple duplicates are deduplicated",
+			hostNames:           []string{"a.example.com", "b.example.com", "a.example.com"},
+			expectedServerNames: []string{"a.example.com", "b.example.com"},
+		},
+	}
+
+	for _, tC := range tests {
+		t.Run(tC.name, func(t *testing.T) {
+			got := toFilterChainMatch(tC.hostNames)
+			require.NotNil(t, got)
+			assert.Equal(t, "tls", got.TransportProtocol)
+			assert.Equal(t, tC.expectedServerNames, got.ServerNames,
+				"serverNames must be sorted and deduplicated")
+		})
+	}
+}
 
 func Test_getHostNetworkListenerAddresses(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
The Gateway API spec allows two HTTPS listeners to share the same hostname as long as they differ on port. When this happens, TLSSecretsToHostnames groups both listeners under the same TLS secret, producing a hostname slice with duplicates. Writing that slice directly into FilterChainMatch.ServerNames causes Envoy to reject the entire listener config.

Restore the slices.SortedUnique call in toFilterChainMatch so that duplicate server names are eliminated before the filter chain match is built.

This PR was prepared with AIL:3. I personally reviewed each line and also run live traffic tests ([this config](https://github.com/eufriction/k8s-cilium-gapi/tree/main/scenarios/01-simple/http-grpc-split-port)) and regression test scenarios based on this: https://github.com/eufriction/k8s-cilium-gapi/tree/main#test-results-by-version

Fixes: 6292f7d71953 ("gateway-api: Add TLSRoute hostname intersection test")
Fixes: #45623

```release-note
gateway-api: Fix duplicate server names in Envoy config when two listeners with different ports share the same hostname and TLS secret.
```