### PR TITLE
envoy: allow configuring MaxPendingRequests per cluster

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -398,6 +398,7 @@ cilium-agent [flags]
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-admin-port int                                      Port to serve Envoy admin interface on.
       --proxy-cluster-max-connections uint32                      Maximum number of connections on Envoy clusters (default 1024)
+      --proxy-cluster-max-pending-requests uint32                 Maximum number of pending requests on Envoy clusters (default 1024)
       --proxy-cluster-max-requests uint32                         Maximum number of requests on Envoy clusters (default 1024)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -246,6 +246,7 @@ cilium-agent hive [flags]
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-admin-port int                                      Port to serve Envoy admin interface on.
       --proxy-cluster-max-connections uint32                      Maximum number of connections on Envoy clusters (default 1024)
+      --proxy-cluster-max-pending-requests uint32                 Maximum number of pending requests on Envoy clusters (default 1024)
       --proxy-cluster-max-requests uint32                         Maximum number of requests on Envoy clusters (default 1024)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -251,6 +251,7 @@ cilium-agent hive dot-graph [flags]
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
       --proxy-admin-port int                                      Port to serve Envoy admin interface on.
       --proxy-cluster-max-connections uint32                      Maximum number of connections on Envoy clusters (default 1024)
+      --proxy-cluster-max-pending-requests uint32                 Maximum number of pending requests on Envoy clusters (default 1024)
       --proxy-cluster-max-requests uint32                         Maximum number of requests on Envoy clusters (default 1024)
       --proxy-connect-timeout uint                                Time after which a TCP connect attempt is considered failed unless completed (in seconds) (default 2)
       --proxy-gid uint                                            Group ID for proxy control plane sockets. (default 1337)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1636,6 +1636,10 @@
      - Maximum number of connections on Envoy clusters
      - int
      - ``1024``
+   * - :spelling:ignore:`envoy.clusterMaxPendingRequests`
+     - Maximum number of pending requests on Envoy clusters
+     - int
+     - ``1024``
    * - :spelling:ignore:`envoy.clusterMaxRequests`
      - Maximum number of requests on Envoy clusters
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -459,6 +459,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.baseID | int | `0` |  Set Envoy'--base-id' to use when allocating shared memory regions. Only needs to be changed if multiple Envoy instances will run on the same node and may have conflicts. Supported values: 0 - 4294967295. Defaults to '0' |
 | envoy.bootstrapConfigMap | string | `nil` | ADVANCED OPTION: Bring your own custom Envoy bootstrap ConfigMap. Provide the name of a ConfigMap with a `bootstrap-config.json` key. When specified, Envoy will use this ConfigMap instead of the default provided by the chart. WARNING: Use of this setting has the potential to prevent cilium-envoy from starting up, and can cause unexpected behavior (e.g. due to syntax error or semantically incorrect configuration). Before submitting an issue, please ensure you have disabled this feature, as support cannot be provided for custom Envoy bootstrap configs. @schema type: [null, string] @schema |
 | envoy.clusterMaxConnections | int | `1024` | Maximum number of connections on Envoy clusters |
+| envoy.clusterMaxPendingRequests | int | `1024` | Maximum number of pending requests on Envoy clusters |
 | envoy.clusterMaxRequests | int | `1024` | Maximum number of requests on Envoy clusters |
 | envoy.connectTimeoutSeconds | int | `2` | Time in seconds after which a TCP connection attempt times out |
 | envoy.debug.admin.enabled | bool | `false` | Enable admin interface for cilium-envoy. This is useful for debugging and should not be enabled in production. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1466,6 +1466,7 @@ data:
   proxy-max-concurrent-retries: {{ .Values.envoy.maxConcurrentRetries | quote }}
   proxy-use-original-source-address: {{ .Values.envoy.useOriginalSourceAddress | quote }}
   proxy-cluster-max-connections: {{ .Values.envoy.clusterMaxConnections | quote }}
+  proxy-cluster-max-pending-requests: {{ .Values.envoy.clusterMaxPendingRequests | quote }}
   proxy-cluster-max-requests: {{ .Values.envoy.clusterMaxRequests | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
   http-stream-idle-timeout: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2444,6 +2444,9 @@
         "clusterMaxConnections": {
           "type": "integer"
         },
+        "clusterMaxPendingRequests": {
+          "type": "integer"
+        },
         "clusterMaxRequests": {
           "type": "integer"
         },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2750,6 +2750,8 @@ envoy:
   maxConcurrentRetries: 128
   # -- Maximum number of connections on Envoy clusters
   clusterMaxConnections: 1024
+  # -- Maximum number of pending requests on Envoy clusters
+  clusterMaxPendingRequests: 1024
   # -- Maximum number of requests on Envoy clusters
   clusterMaxRequests: 1024
   # -- Maximum number of global downstream connections

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2779,6 +2779,8 @@ envoy:
   maxConcurrentRetries: 128
   # -- Maximum number of connections on Envoy clusters
   clusterMaxConnections: 1024
+  # -- Maximum number of pending requests on Envoy clusters
+  clusterMaxPendingRequests: 1024
   # -- Maximum number of requests on Envoy clusters
   clusterMaxRequests: 1024
   # -- Maximum number of global downstream connections

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -67,6 +67,7 @@ type CECResourceParser struct {
 	defaultMaxConcurrentRetries uint32
 	defaultMaxConnections       uint32
 	defaultMaxRequests          uint32
+	defaultMaxPendingRequests   uint32
 	httpLingerConfig            int
 	accessLogPath               string
 }
@@ -92,6 +93,7 @@ func newCECResourceParser(params parserParams) *CECResourceParser {
 		defaultMaxConcurrentRetries: params.EnvoyConfig.ProxyMaxConcurrentRetries,
 		defaultMaxConnections:       params.EnvoyConfig.ProxyClusterMaxConnections,
 		defaultMaxRequests:          params.EnvoyConfig.ProxyClusterMaxRequests,
+		defaultMaxPendingRequests:   params.EnvoyConfig.ProxyClusterMaxPendingRequests,
 		httpLingerConfig:            params.EnvoyConfig.EnvoyHTTPUpstreamLingerTimeout,
 	}
 	if params.EnvoyConfig.EnvoyAccessLogEnabled {
@@ -343,7 +345,7 @@ func (r *CECResourceParser) ParseResources(cecNamespace string, cecName string, 
 
 			fillInTransportSocketXDS(cecNamespace, cecName, cluster.TransportSocket)
 
-			fillInCircuitBreakers(cluster, r.defaultMaxConcurrentRetries, r.defaultMaxConnections, r.defaultMaxRequests)
+			fillInCircuitBreakers(cluster, r.defaultMaxConcurrentRetries, r.defaultMaxConnections, r.defaultMaxRequests, r.defaultMaxPendingRequests)
 
 			// Fill in EDS config source if unset
 			if enum := cluster.GetType(); enum == envoy_config_cluster.Cluster_EDS {
@@ -988,13 +990,14 @@ func fillInTransportSocketXDS(cecNamespace string, cecName string, ts *envoy_con
 	}
 }
 
-func fillInCircuitBreakers(cluster *envoy_config_cluster.Cluster, defaultConcurrentRetries uint32, defaultMaxConnections uint32, defaultRequests uint32) {
+func fillInCircuitBreakers(cluster *envoy_config_cluster.Cluster, defaultConcurrentRetries, defaultMaxConnections, defaultRequests, defaultPendingRequests uint32) {
 	if cluster.CircuitBreakers == nil {
 		cluster.CircuitBreakers = &envoy_config_cluster.CircuitBreakers{
 			Thresholds: []*envoy_config_cluster.CircuitBreakers_Thresholds{{
-				MaxRetries:     &wrapperspb.UInt32Value{Value: defaultConcurrentRetries},
-				MaxConnections: &wrapperspb.UInt32Value{Value: defaultMaxConnections},
-				MaxRequests:    &wrapperspb.UInt32Value{Value: defaultRequests},
+				MaxRetries:         &wrapperspb.UInt32Value{Value: defaultConcurrentRetries},
+				MaxConnections:     &wrapperspb.UInt32Value{Value: defaultMaxConnections},
+				MaxRequests:        &wrapperspb.UInt32Value{Value: defaultRequests},
+				MaxPendingRequests: &wrapperspb.UInt32Value{Value: defaultPendingRequests},
 			}},
 		}
 	}

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -480,6 +480,9 @@ clusters:default/cilium-ingress-default-basic-ingress/default:details:9080:
       max_connections: {
         value: 1024
       }
+      max_pending_requests: {
+        value: 1024
+      }
       max_requests: {
         value: 1024
       }
@@ -549,6 +552,9 @@ clusters:default/cilium-ingress-default-basic-ingress/default:productpage:9080:
   circuit_breakers: {
     thresholds: {
       max_connections: {
+        value: 1024
+      }
+      max_pending_requests: {
         value: 1024
       }
       max_requests: {

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -232,6 +232,9 @@ clusters:test/listener-a/test:echo:80:
       max_connections: {
         value: 1024
       }
+      max_pending_requests: {
+        value: 1024
+      }
       max_requests: {
         value: 1024
       }
@@ -276,6 +279,9 @@ clusters:test/listener-b/test:echo:80:
   circuit_breakers: {
     thresholds: {
       max_connections: {
+        value: 1024
+      }
+      max_pending_requests: {
         value: 1024
       }
       max_requests: {
@@ -373,6 +379,9 @@ clusters:test/listener-b/test:echo:80:
   circuit_breakers: {
     thresholds: {
       max_connections: {
+        value: 1024
+      }
+      max_pending_requests: {
         value: 1024
       }
       max_requests: {

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -149,6 +149,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 			maxConcurrentRetries:           params.EnvoyProxyConfig.ProxyMaxConcurrentRetries,
 			maxConnections:                 params.EnvoyProxyConfig.ProxyClusterMaxConnections,
 			maxRequests:                    params.EnvoyProxyConfig.ProxyClusterMaxRequests,
+			maxPendingRequests:             params.EnvoyProxyConfig.ProxyClusterMaxPendingRequests,
 			localNodeStore:                 params.LocalNodeStore,
 		}, nil
 	}

--- a/pkg/envoy/config/config.go
+++ b/pkg/envoy/config/config.go
@@ -29,6 +29,7 @@ type ProxyConfig struct {
 	ProxyMaxConcurrentRetries           uint32
 	ProxyClusterMaxConnections          uint32
 	ProxyClusterMaxRequests             uint32
+	ProxyClusterMaxPendingRequests      uint32
 	HTTPNormalizePath                   bool
 	HTTPRequestTimeout                  uint
 	HTTPIdleTimeout                     uint
@@ -65,6 +66,7 @@ func (r ProxyConfig) Flags(flags *pflag.FlagSet) {
 	flags.Uint32("proxy-max-concurrent-retries", 128, "Maximum number of concurrent retries on Envoy clusters")
 	flags.Uint32("proxy-cluster-max-connections", 1024, "Maximum number of connections on Envoy clusters")
 	flags.Uint32("proxy-cluster-max-requests", 1024, "Maximum number of requests on Envoy clusters")
+	flags.Uint32("proxy-cluster-max-pending-requests", 1024, "Maximum number of pending requests on Envoy clusters")
 	flags.Bool("http-normalize-path", true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
 	flags.Uint("http-request-timeout", 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
 	flags.Uint("http-idle-timeout", 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")

--- a/pkg/envoy/standalone_envoy.go
+++ b/pkg/envoy/standalone_envoy.go
@@ -115,6 +115,7 @@ type standaloneEnvoyConfig struct {
 	maxConcurrentRetries           uint32
 	maxConnections                 uint32
 	maxRequests                    uint32
+	maxPendingRequests             uint32
 }
 
 // startStandaloneEnvoyInternal starts an Envoy proxy instance.
@@ -151,6 +152,7 @@ func (o *onDemandXdsStarter) startStandaloneEnvoyInternal(config standaloneEnvoy
 		maxConcurrentRetries:           config.maxConcurrentRetries,
 		maxConnections:                 config.maxConnections,
 		maxRequests:                    config.maxRequests,
+		maxPendingRequests:             config.maxPendingRequests,
 		nodeLocalityEnabled:            config.nodeLocalityEnabled,
 	})
 	if err != nil {
@@ -378,6 +380,7 @@ type bootstrapConfig struct {
 	maxConcurrentRetries           uint32
 	maxConnections                 uint32
 	maxRequests                    uint32
+	maxPendingRequests             uint32
 	nodeLocalityEnabled            bool
 }
 
@@ -425,9 +428,10 @@ func (o *onDemandXdsStarter) writeBootstrapConfigFile(config bootstrapConfig) er
 
 	clusterRetryLimits := &envoy_config_cluster.CircuitBreakers{
 		Thresholds: []*envoy_config_cluster.CircuitBreakers_Thresholds{{
-			MaxRetries:     &wrapperspb.UInt32Value{Value: config.maxConcurrentRetries},
-			MaxConnections: &wrapperspb.UInt32Value{Value: config.maxConnections},
-			MaxRequests:    &wrapperspb.UInt32Value{Value: config.maxRequests},
+			MaxRetries:         &wrapperspb.UInt32Value{Value: config.maxConcurrentRetries},
+			MaxConnections:     &wrapperspb.UInt32Value{Value: config.maxConnections},
+			MaxRequests:        &wrapperspb.UInt32Value{Value: config.maxRequests},
+			MaxPendingRequests: &wrapperspb.UInt32Value{Value: config.maxPendingRequests},
 		}},
 	}
 

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -35,6 +35,7 @@ type onDemandXdsStarter struct {
 	maxConcurrentRetries           uint32
 	maxConnections                 uint32
 	maxRequests                    uint32
+	maxPendingRequests             uint32
 	localNodeStore                 *node.LocalNodeStore
 
 	envoyOnce sync.Once
@@ -92,6 +93,7 @@ func (o *onDemandXdsStarter) startStandaloneEnvoy(wg *completion.WaitGroup) erro
 			maxConcurrentRetries:           o.maxConcurrentRetries,
 			maxConnections:                 o.maxConnections,
 			maxRequests:                    o.maxRequests,
+			maxPendingRequests:             o.maxPendingRequests,
 		})
 
 		// Add Prometheus listener if the port is (properly) configured


### PR DESCRIPTION
Adds `envoy.clusterMaxPendingRequests` for configuring Envoy cluster circuit breakers.

```
❱ kubectl -n kube-system exec ds/cilium -- cilium-dbg envoy admin clusters | grep default/echo::default_priority::max_pending_requests
default/echo::default_priority::max_pending_requests::4096
```

```release-note
Support configuring Envoy cluster default max pending requests via `envoy.clusterMaxPendingRequests` helm value or cilium-agent `--proxy-cluster-max-connections` command-line arg
```
