### PR TITLE
helm: Support ipFamilyPolicy and ipFamilies for dual-stack in ingressController service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2835,7 +2835,7 @@
    * - :spelling:ignore:`ingressController.service`
      - Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources.
      - object
-     - ``{"allocateLoadBalancerNodePorts":null,"annotations":{},"externalTrafficPolicy":"Cluster","insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
+     - ``{"allocateLoadBalancerNodePorts":null,"annotations":{},"externalTrafficPolicy":"Cluster","insecureNodePort":null,"ipFamilies":null,"ipFamilyPolicy":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
    * - :spelling:ignore:`ingressController.service.allocateLoadBalancerNodePorts`
      - Configure if node port allocation is required for LB service ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
      - string
@@ -2850,6 +2850,14 @@
      - ``"Cluster"``
    * - :spelling:ignore:`ingressController.service.insecureNodePort`
      - Configure a specific nodePort for insecure HTTP traffic on the shared LB service
+     - string
+     - ``nil``
+   * - :spelling:ignore:`ingressController.service.ipFamilies`
+     - Configure specific ipFamilies on the shared LB service
+     - string
+     - ``nil``
+   * - :spelling:ignore:`ingressController.service.ipFamilyPolicy`
+     - Configure a specific ipFamilyPolicy on the shared LB service
      - string
      - ``nil``
    * - :spelling:ignore:`ingressController.service.labels`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -758,11 +758,13 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |
 | ingressController.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
-| ingressController.service | object | `{"allocateLoadBalancerNodePorts":null,"annotations":{},"externalTrafficPolicy":"Cluster","insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
+| ingressController.service | object | `{"allocateLoadBalancerNodePorts":null,"annotations":{},"externalTrafficPolicy":"Cluster","insecureNodePort":null,"ipFamilies":null,"ipFamilyPolicy":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
 | ingressController.service.allocateLoadBalancerNodePorts | string | `nil` | Configure if node port allocation is required for LB service ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation |
 | ingressController.service.annotations | object | `{}` | Annotations to be added for the shared LB service |
 | ingressController.service.externalTrafficPolicy | string | `"Cluster"` | Control how traffic from external sources is routed to the LoadBalancer Kubernetes Service for Cilium Ingress in shared mode. Valid values are "Cluster" and "Local". ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy |
 | ingressController.service.insecureNodePort | string | `nil` | Configure a specific nodePort for insecure HTTP traffic on the shared LB service |
+| ingressController.service.ipFamilies | string | `nil` | Configure specific ipFamilies on the shared LB service |
+| ingressController.service.ipFamilyPolicy | string | `nil` | Configure a specific ipFamilyPolicy on the shared LB service |
 | ingressController.service.labels | object | `{}` | Labels to be added for the shared LB service |
 | ingressController.service.loadBalancerClass | string | `nil` | Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+) |
 | ingressController.service.loadBalancerIP | string | `nil` | Configure a specific loadBalancerIP on the shared LB service |

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -48,4 +48,11 @@ spec:
   {{- if and .Values.ingressController.service.externalTrafficPolicy (not .Values.ingressController.hostNetwork.enabled) }}
   externalTrafficPolicy: {{ .Values.ingressController.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.ingressController.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.ingressController.service.ipFamilyPolicy }}
+  {{- end }}
+  {{ if .Values.ingressController.service.ipFamilies }}
+  ipFamilies:
+    {{ toYaml .Values.ingressController.service.ipFamilies | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4383,6 +4383,18 @@
                 "integer"
               ]
             },
+            "ipFamilies": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "ipFamilyPolicy": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "labels": {
               "type": "object"
             },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1053,6 +1053,16 @@ ingressController:
     # Valid values are "Cluster" and "Local".
     # ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
     externalTrafficPolicy: Cluster
+    # @schema
+    # type: [null, string]
+    # @schema
+    # -- Configure a specific ipFamilyPolicy on the shared LB service
+    ipFamilyPolicy: ~
+    # @schema
+    # type: [null, array]
+    # @schema
+    # -- Configure specific ipFamilies on the shared LB service
+    ipFamilies: ~
   # Host Network related configuration
   hostNetwork:
     # -- Configure whether the Envoy listeners should be exposed on the host network.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1061,6 +1061,16 @@ ingressController:
     # Valid values are "Cluster" and "Local".
     # ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#external-traffic-policy
     externalTrafficPolicy: Cluster
+    # @schema
+    # type: [null, string]
+    # @schema
+    # -- Configure a specific ipFamilyPolicy on the shared LB service
+    ipFamilyPolicy: ~
+    # @schema
+    # type: [null, array]
+    # @schema
+    # -- Configure specific ipFamilies on the shared LB service
+    ipFamilies: ~
   # Host Network related configuration
   hostNetwork:
     # -- Configure whether the Envoy listeners should be exposed on the host network.


### PR DESCRIPTION
This extension of the Helm chart allows setting `ipFamilyPolicy` and `ipFamilies` for the LoadBalancer service when using shared mode.

This makes it possible to create a shared dual-stack LoadBalancer service with the following Helm values:

```yaml
ingressController:
  enabled: true
  loadbalancerMode: shared
  service:
    ipFamilies:
    - IPv4
    - IPv6
    ipFamilyPolicy: RequireDualStack
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!