### PR TITLE
Documentation, renovate: regenerate cilium-cli cmdref without cilium-…

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,6 +111,7 @@
     "^make -C install/kubernetes$",
     "^make -C Documentation update-helm-values$",
     "^make -C Documentation update-cmdref$",
+    "^make GO='contrib/scripts/builder.sh go' -C Documentation update-cmdref-cilium-cli$",
     "^make -C Documentation update-requirements$",
     "^make manifests$",
     "^make GO='contrib/scripts/builder.sh go' generate-apis$",
@@ -656,7 +657,7 @@
       ],
       "postUpgradeTasks": {
         "commands": [
-          "make -C Documentation update-cmdref"
+          "make GO='contrib/scripts/builder.sh go' -C Documentation update-cmdref-cilium-cli"
         ],
         "fileFilters": [
           "Documentation/cmdref/cilium_install.md",

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -80,6 +80,19 @@ update-cmdref: cilium-build ## Update the command reference documents (agent, bu
 	-$(QUIET)rm -rf cmdref/cilium*.md
 	$(QUIET)$(DOCKER_RUN) ./update-cmdref.sh
 
+# Lightweight target that regenerates only the cilium-cli command reference
+# files (cmdref/cilium_*.md, e.g. cilium_install.md and cilium_upgrade.md).
+# Unlike `update-cmdref`, this target does not depend on `cilium-build` and
+# therefore does not require building all Cilium binaries inside the
+# cilium-builder docker image. This makes it usable from environments where
+# privileged docker is not available (e.g. Renovate's post-upgrade task
+# sandbox), and it is sufficient for dependency bumps that only affect
+# cilium-cli's embedded helm charts (github.com/cilium/charts).
+.PHONY: update-cmdref-cilium-cli
+update-cmdref-cilium-cli: ## Update the cilium-cli command reference documents only.
+	@$(ECHO_GEN)cmdref-cilium-cli
+	$(QUIET)$(GO) run $(ROOT_DIR)/cilium-cli/cmd/cilium cmdref $(CURDIR)/cmdref
+
 .PHONY: update-feature-metrics
 update-feature-metrics: cilium-build ## Update the observability feature metrics documents (agent, operator).
 	@$(ECHO_GEN)feature-metrics


### PR DESCRIPTION
…build

Renovate's post-upgrade task for github.com/cilium/charts runs 'make -C Documentation update-cmdref' to refresh cmdref/cilium_install.md and cmdref/cilium_upgrade.md. That target depends on 'cilium-build', which spins up the cilium-builder container and runs a full 'make build'. In Renovate's sandbox the container's entrypoint cannot chown /sys (read-only filesystem) and the build aborts with 'chown: changing group of '/sys': Read-only file system', so the chart bump PRs land without the regenerated cmdref pages.

Add a lightweight 'update-cmdref-cilium-cli' target that runs the cilium-cli's built-in cmdref subcommand via 'go run', bypassing cilium-build, and switch the renovate rule for github.com/cilium/charts to invoke it through 'contrib/scripts/builder.sh go', mirroring how generate-apis and generate-k8s-api are run today.