### PR TITLE
Documentation: bump Sphinx to 9.1 (and Python to 3.12)

### DIFF
--- a/Documentation/.readthedocs.yaml
+++ b/Documentation/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation with Sphinx
 sphinx:

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,7 +1,7 @@
 # check=error=true
 
 # Python version should match the one in use in Read The Docs
-FROM docker.io/library/python:3.11-alpine3.17 AS docs-base
+FROM docker.io/library/python:3.12-alpine3.17 AS docs-base
 
 LABEL maintainer="maintainer@cilium.io"
 
@@ -35,4 +35,4 @@ ENV MAKE_GIT_REPO_SAFE=1
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
-RUN install -m 0777 -d /usr/local/lib/python3.11/site-packages/versionwarning/_static/data
+RUN install -m 0777 -d /usr/local/lib/python3.12/site-packages/versionwarning/_static/data

--- a/Documentation/requirements-min/requirements.txt
+++ b/Documentation/requirements-min/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==9.0.4
+sphinx==9.1.0
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,9 +1,9 @@
 ## Auto-generated from requirements-min/requirements.txt with "make update-requirements"
-Sphinx==9.0.4
+Sphinx==9.1.0
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@98b0d4664556de6b5ab94e5abcff5d35246a7c46
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@aaa00bd49e9873767577c3d8cab45333b027c32c
 # We use semver to parse Cilium's version in the config file
 semver==3.0.4
 # Sphinx extensions
@@ -24,13 +24,13 @@ annotated-doc==0.0.4
 annotated-types==0.7.0
 attrs==26.1.0
 babel==2.18.0
-certifi==2026.2.25
+certifi==2026.4.22
 charset-normalizer==3.4.7
-click==8.3.2
+click==8.3.3
 colorama==0.4.6
 deepmerge==2.0
 docutils==0.22.4
-idna==3.11
+idna==3.13
 imagesize==2.0.0
 Jinja2==3.1.6
 jsonschema==4.26.0
@@ -41,20 +41,21 @@ MarkupSafe==3.0.3
 mdit-py-plugins==0.5.0
 mdurl==0.1.2
 mistune==3.2.0
-packaging==26.0
-pathspec==1.0.4
+packaging==26.2
+pathspec==1.1.1
 picobox==4.0.0
-pydantic==2.12.5
-pydantic_core==2.41.5
+pydantic==2.13.3
+pydantic_core==2.46.3
 pyenchant==3.3.0
 Pygments==2.20.0
 PyYAML==6.0.3
 referencing==0.37.0
 requests==2.33.1
-rich==14.3.3
+rich==15.0.0
 roman-numerals==4.1.0
 rpds-py==0.30.0
 rstcheck-core==1.2.2
+setuptools==69.0.2
 shellingham==1.5.4
 snowballstemmer==3.0.1
 sphinx_mdinclude==0.6.2
@@ -67,7 +68,8 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 tornado==6.5.5
-typer==0.24.1
+typer==0.25.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
+wheel==0.42.0


### PR DESCRIPTION
Manually do the dependency bump for Sphinx, along with the required bump for Python.