### PR TITLE
egressgw: minor changes for network interface detection

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
@@ -158,6 +159,9 @@ type Manager struct {
 	reconciliationEventsCount atomic.Uint64
 
 	sysctl sysctl.Sysctl
+
+	db          *statedb.DB
+	deviceTable statedb.Table[*tables.Device]
 }
 
 type Params struct {
@@ -175,6 +179,9 @@ type Params struct {
 	Nodes             resource.Resource[*cilium_api_v2.CiliumNode]
 	Endpoints         resource.Resource[*k8sTypes.CiliumEndpoint]
 	Sysctl            sysctl.Sysctl
+
+	DB          *statedb.DB
+	DeviceTable statedb.Table[*tables.Device]
 
 	Lifecycle cell.Lifecycle
 }
@@ -238,6 +245,8 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 		ciliumNodes:                   p.Nodes,
 		endpoints:                     p.Endpoints,
 		sysctl:                        p.Sysctl,
+		db:                            p.DB,
+		deviceTable:                   p.DeviceTable,
 		nodesAddresses2Labels:         make(map[string]map[string]string),
 	}
 

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -22,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -163,6 +166,30 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	policyMap4 := egressmap.CreatePrivatePolicyMap4(lc, nil, egressmap.DefaultPolicyConfig)
 	policyMap6 := egressmap.CreatePrivatePolicyMap6(lc, nil, egressmap.DefaultPolicyConfig)
 
+	var (
+		db          *statedb.DB
+		deviceTable statedb.Table[*tables.Device]
+	)
+
+	// create a hive to provide statedb
+	h := hive.New(
+		cell.Provide(
+			tables.NewDeviceTable,
+		),
+
+		cell.Invoke(func(db_ *statedb.DB,
+			dT statedb.RWTable[*tables.Device]) {
+			db = db_
+			deviceTable = dT
+		}),
+	)
+
+	require.NoError(t, h.Start(logger, context.TODO()))
+
+	t.Cleanup(func() {
+		require.NoError(t, h.Stop(logger, context.TODO()))
+	})
+
 	k.manager, err = newEgressGatewayManager(Params{
 		Logger:            logger,
 		Lifecycle:         lc,
@@ -175,6 +202,8 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 		Nodes:             k.nodes,
 		Endpoints:         k.endpoints,
 		Sysctl:            k.sysctl,
+		DB:                db,
+		DeviceTable:       deviceTable,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, k.manager)

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -71,6 +71,7 @@ type PolicyConfig struct {
 	policyGwConfigs   []policyGatewayConfig
 	gatewayConfigs    []gatewayConfig
 	matchedEndpoints  map[endpointID]*endpointMetadata
+	v4Needed          bool
 	v6Needed          bool
 }
 
@@ -141,7 +142,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 			gwc.gatewayIP = addr
 
 			if node.IsLocal() {
-				err := gwc.deriveFromPolicyGatewayConfig(manager, &policyGwc, config.v6Needed)
+				err := gwc.deriveFromPolicyGatewayConfig(manager, &policyGwc, config.v4Needed, config.v6Needed)
 				if err != nil {
 					manager.logger.Error(
 						"Failed to derive policy gateway configuration",
@@ -174,7 +175,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 
 // deriveFromPolicyGatewayConfig retrieves all the missing gateway configuration
 // data (such as egress IP or interface) given a policy egress gateway config
-func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *policyGatewayConfig, v6Needed bool) error {
+func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *policyGatewayConfig, v4Needed bool, v6Needed bool) error {
 	var err error
 	var egressIP4, egressIP6 netip.Addr
 
@@ -200,9 +201,11 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 			gwc.egressIfindex = uint32(iface.Attrs().Index)
 		}
 
-		egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gc.iface)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+		if v4Needed {
+			egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gc.iface)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+			}
 		}
 
 		if v6Needed {
@@ -236,26 +239,31 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 				return fmt.Errorf("failed to retrieve interface with IPv6 egress IP: %w", err)
 			}
 
-			egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+			if v4Needed {
+				egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+				}
 			}
 		}
 
 	default:
 		// If the gateway config doesn't specify any egress IP or interface, use the
 		// interface with the IPv4 default route
-		iface, err := route.NodeDeviceWithDefaultRoute(manager.logger, true, false)
-		if err != nil {
-			return fmt.Errorf("failed to find interface with IPv4 default route: %w", err)
-		}
 
-		gwc.ifaceName = iface.Attrs().Name
-		gwc.egressIfindex = uint32(iface.Attrs().Index)
+		if v4Needed {
+			iface, err := route.NodeDeviceWithDefaultRoute(manager.logger, true, false)
+			if err != nil {
+				return fmt.Errorf("failed to find interface with IPv4 default route: %w", err)
+			}
 
-		egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+			gwc.ifaceName = iface.Attrs().Name
+			gwc.egressIfindex = uint32(iface.Attrs().Index)
+
+			egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+			}
 		}
 
 		if v6Needed {
@@ -264,7 +272,8 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 				return fmt.Errorf("failed to find interface with IPv6 default route: %w", err)
 			}
 
-			if iface.Attrs().Name != gwc.ifaceName {
+			// Check that the two default routes point to the same interface
+			if gwc.ifaceName != "" && iface.Attrs().Name != gwc.ifaceName {
 				return fmt.Errorf("IPv6 default route interface doesn't match IPv4 default route interface")
 			}
 
@@ -276,7 +285,9 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 		}
 	}
 
-	gwc.egressIP4 = egressIP4
+	if v4Needed {
+		gwc.egressIP4 = egressIP4
+	}
 	if v6Needed {
 		gwc.egressIP6 = egressIP6
 	}
@@ -362,7 +373,7 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 	var dstCidrList []netip.Prefix
 	var excludedCIDRs []netip.Prefix
 	var policyGwConfigs []policyGatewayConfig
-	var v6Needed bool
+	var v4Needed, v6Needed bool
 
 	allowAllNamespacesRequirement := slim_metav1.LabelSelectorRequirement{
 		Key:      k8sConst.PodNamespaceLabel,
@@ -405,6 +416,8 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 		dstCidrList = append(dstCidrList, cidr)
 		if cidr.Addr().Is6() {
 			v6Needed = true
+		} else {
+			v4Needed = true
 		}
 	}
 
@@ -465,6 +478,7 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 		excludedCIDRs:     excludedCIDRs,
 		matchedEndpoints:  make(map[endpointID]*endpointMetadata),
 		policyGwConfigs:   policyGwConfigs,
+		v4Needed:          v4Needed,
 		v6Needed:          v6Needed,
 		id: types.NamespacedName{
 			Name: name,

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -6,7 +6,6 @@ package egressgateway
 import (
 	"fmt"
 	"hash/fnv"
-	"log/slog"
 	"net/netip"
 	"slices"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/netdevice"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -141,7 +141,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 			gwc.gatewayIP = addr
 
 			if node.IsLocal() {
-				err := gwc.deriveFromPolicyGatewayConfig(manager.logger, &policyGwc, config.v6Needed)
+				err := gwc.deriveFromPolicyGatewayConfig(manager, &policyGwc, config.v6Needed)
 				if err != nil {
 					manager.logger.Error(
 						"Failed to derive policy gateway configuration",
@@ -174,7 +174,7 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 
 // deriveFromPolicyGatewayConfig retrieves all the missing gateway configuration
 // data (such as egress IP or interface) given a policy egress gateway config
-func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc *policyGatewayConfig, v6Needed bool) error {
+func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *policyGatewayConfig, v6Needed bool) error {
 	var err error
 	var egressIP4, egressIP6 netip.Addr
 
@@ -188,12 +188,17 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc 
 		// interface as egress IPs
 		gwc.ifaceName = gc.iface
 
-		iface, err := safenetlink.LinkByName(gwc.ifaceName)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve egress interface %s: %w", gc.iface, err)
-		}
+		dev, _, found := manager.deviceTable.Get(manager.db.ReadTxn(), tables.DeviceNameIndex.Query(gc.iface))
+		if found {
+			gwc.egressIfindex = uint32(dev.Index)
+		} else {
+			iface, err := safenetlink.LinkByName(gwc.ifaceName)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve egress interface %s: %w", gc.iface, err)
+			}
 
-		gwc.egressIfindex = uint32(iface.Attrs().Index)
+			gwc.egressIfindex = uint32(iface.Attrs().Index)
+		}
 
 		egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gc.iface)
 		if err != nil {
@@ -240,7 +245,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc 
 	default:
 		// If the gateway config doesn't specify any egress IP or interface, use the
 		// interface with the IPv4 default route
-		iface, err := route.NodeDeviceWithDefaultRoute(logger, true, false)
+		iface, err := route.NodeDeviceWithDefaultRoute(manager.logger, true, false)
 		if err != nil {
 			return fmt.Errorf("failed to find interface with IPv4 default route: %w", err)
 		}
@@ -254,7 +259,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(logger *slog.Logger, gc 
 		}
 
 		if v6Needed {
-			iface, err := route.NodeDeviceWithDefaultRoute(logger, false, true)
+			iface, err := route.NodeDeviceWithDefaultRoute(manager.logger, false, true)
 			if err != nil {
 				return fmt.Errorf("failed to find interface with IPv6 default route: %w", err)
 			}


### PR DESCRIPTION
Kick off the migration to the Devices table. And bypass the IPv4-related detection logic if a CEGP is pure IPv6, same as we already do for the opposite case.