### PR TITLE
policy: fix policy_change_total outcome label values

### DIFF
--- a/pkg/policy/directory/watcher.go
+++ b/pkg/policy/directory/watcher.go
@@ -269,7 +269,7 @@ func (p *policyWatcher) watchDirectory(ctx context.Context) {
 
 func reportCNPChangeMetrics(op string, err error) {
 	if err != nil {
-		metrics.PolicyChangeTotal.WithLabelValues(string(source.Directory), op, metrics.LabelValueOutcomeFail).Inc()
+		metrics.PolicyChangeTotal.WithLabelValues(string(source.Directory), op, metrics.LabelValueOutcomeFailure).Inc()
 	} else {
 		metrics.PolicyChangeTotal.WithLabelValues(string(source.Directory), op, metrics.LabelValueOutcomeSuccess).Inc()
 	}

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -175,7 +175,7 @@ func addDerivativePolicy(ctx context.Context, logger *slog.Logger, clientset cli
 
 func reportDerivedPolicyChangeMetrics(op string, err error) {
 	if err != nil {
-		metrics.PolicyChangeTotal.WithLabelValues(string(source.Generated), op, metrics.LabelValueOutcomeFail).Inc()
+		metrics.PolicyChangeTotal.WithLabelValues(string(source.Generated), op, metrics.LabelValueOutcomeFailure).Inc()
 	} else {
 		metrics.PolicyChangeTotal.WithLabelValues(string(source.Generated), op, metrics.LabelValueOutcomeSuccess).Inc()
 	}

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -210,7 +210,7 @@ func (p *policyWatcher) registerResourceWithSyncFn(ctx context.Context, resource
 // Cilium Network Policies depending on the operation's success.
 func reportCNPChangeMetrics(op string, err error) {
 	if err != nil {
-		metrics.PolicyChangeTotal.WithLabelValues(string(source.CustomResource), op, metrics.LabelValueOutcomeFail).Inc()
+		metrics.PolicyChangeTotal.WithLabelValues(string(source.CustomResource), op, metrics.LabelValueOutcomeFailure).Inc()
 	} else {
 		metrics.PolicyChangeTotal.WithLabelValues(string(source.CustomResource), op, metrics.LabelValueOutcomeSuccess).Inc()
 	}

--- a/pkg/policy/k8s/cluster_network_policy.go
+++ b/pkg/policy/k8s/cluster_network_policy.go
@@ -23,7 +23,7 @@ func (p *policyWatcher) addK8sClusterNetworkPolicy(k8sCNP *policyv1alpha2.Cluste
 
 	rules, err := k8s.ParseClusterNetworkPolicy(p.log, clusterName, k8sCNP)
 	if err != nil {
-		metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueUpdateOperation, metrics.LabelValueOutcomeFail).Inc()
+		metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueUpdateOperation, metrics.LabelValueOutcomeFailure).Inc()
 		p.log.Error(
 			"Error while parsing k8s kubernetes ClusterNetworkPolicy",
 			logfields.Error, err,

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -21,7 +21,7 @@ func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 
 	rules, err := k8s.ParseNetworkPolicy(p.log, clusterName, k8sNP)
 	if err != nil {
-		metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueUpdateOperation, metrics.LabelValueOutcomeFail).Inc()
+		metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueUpdateOperation, metrics.LabelValueOutcomeFailure).Inc()
 		p.log.Error(
 			"Error while parsing k8s kubernetes NetworkPolicy",
 			logfields.Error, err,


### PR DESCRIPTION
The metric is declared by having the label "outcome" with possible values "success" or "failure". Unfortunately, some instances of the codebase use "fail" instead. This causes a panic when a failure is reported.

Change all instances in the codebase to use "failure".

```release-note
Fixes a very-unlikely panic when an invalid CiliumNetworkPolicy or CiliumClusterwideNetworkPolicy was created.
```
