### PR TITLE
hubble: remove dead Kafka L7 protocol handling

### DIFF
--- a/pkg/hubble/api/v1/flow.go
+++ b/pkg/hubble/api/v1/flow.go
@@ -26,8 +26,6 @@ func FlowProtocol(flow *pb.Flow) string {
 				return "DNS"
 			case l7.GetHttp() != nil:
 				return "HTTP"
-			case l7.GetKafka() != nil:
-				return "Kafka"
 			}
 		}
 		return "Unknown L7"

--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -82,8 +82,6 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 				subType = "DNS"
 			case l7.GetHttp() != nil:
 				subType = "HTTP"
-			case l7.GetKafka() != nil:
-				subType = "Kafka"
 			}
 		}
 	case monitorAPI.MessageTypeDrop:

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -115,8 +115,6 @@ func (h *policyHandler) ProcessFlowL7(ctx context.Context, flow *flowpb.Flow) er
 			subType = "dns"
 		case l7.GetHttp() != nil:
 			subType = "http"
-		case l7.GetKafka() != nil:
-			subType = "kafka"
 		}
 	}
 	match := fmt.Sprintf("l7/%s", subType)


### PR DESCRIPTION
Kafka policy support was removed from Cilium (see PR #43557). Remove the leftover Kafka case branches from Hubble's flow protocol identification and metrics classification code, as these code paths are now unreachable.

The Kafka message and fields in flow.proto are kept as deprecated for backward compatibility with older Cilium releases.

Fixes: #44551