### PR TITLE
fix(agenthealth): wire config into handler

### DIFF
--- a/daemon/healthz/agenthealth.go
+++ b/daemon/healthz/agenthealth.go
@@ -70,6 +70,7 @@ func registerAgentHealthHTTPService(params agentHealthParams) error {
 
 	handler := &agentHealthHandler{
 		logger:          params.Logger,
+		config:          params.Config,
 		statusCollector: params.StatusCollector,
 	}
 


### PR DESCRIPTION
## Summary

`agentHealthHandler` ignores `--agent-health-require-k8s-connectivity` because the config is not wired, causing `/healthz` to always treat Kubernetes connectivity as optional.

## Fix

Wire `params.Config` into `agentHealthHandler` during initialization.
One-line fix adding the missing config assignment.

```go
handler := &agentHealthHandler{
    logger:          params.Logger,
    config:          params.Config,
    statusCollector: params.StatusCollector,
}
```
