### PR TITLE
ipcache: preserve attributes when reviving shadowed CIDR

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -691,9 +691,13 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	oldK8sMeta := ipc.getK8sMetadata(ip)
 	oldEndpointFlags := ipc.getEndpointFlagsRLocked(ip)
 	var newHostIP net.IP
+	var cidrEncryptKey uint8
 	var oldIdentity *Identity
 	newIdentity := cachedIdentity
 	callbackListeners := true
+	newK8sMeta := oldK8sMeta
+	newEndpointFlags := oldEndpointFlags
+	newEncryptKey := encryptKey
 
 	var err error
 	if cidrCluster, err = cmtypes.ParsePrefixCluster(ip); err == nil {
@@ -714,7 +718,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 		// restore its mapping with the listeners if that was the case.
 		cidrClusterStr := cidrCluster.String()
 		if cidrIdentity, cidrFound := ipc.ipToIdentityCache[cidrClusterStr]; cidrFound {
-			newHostIP, _ = ipc.getHostIPCacheRLocked(cidrClusterStr)
+			newHostIP, cidrEncryptKey = ipc.getHostIPCacheRLocked(cidrClusterStr)
 			if cidrIdentity.ID != cachedIdentity.ID || !oldHostIP.Equal(newHostIP) {
 				ipc.logger.Debug(
 					"Removal of endpoint IP revives shadowed CIDR to identity mapping",
@@ -724,6 +728,12 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 				ipc.ipToIdentityCache[cidrClusterStr] = cidrIdentity
 				oldIdentity = &cachedIdentity
 				newIdentity = cidrIdentity
+				// The revived mapping is the CIDR entry, not the deleted
+				// endpoint IP. Report the CIDR's current metadata/flags/key
+				// to listeners so they don't observe stale pod-scoped data.
+				newK8sMeta = ipc.getK8sMetadata(cidrClusterStr)
+				newEndpointFlags = ipc.getEndpointFlagsRLocked(cidrClusterStr)
+				newEncryptKey = cidrEncryptKey
 			} else {
 				// The endpoint IP and the CIDR were associated with the same
 				// identity and host IP. Nothing changes for the listeners.
@@ -765,7 +775,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	if callbackListeners {
 		for _, listener := range ipc.listeners {
 			listener.OnIPIdentityCacheChange(cacheModification, cidrCluster, oldHostIP, newHostIP,
-				oldIdentity, newIdentity, encryptKey, oldK8sMeta, oldEndpointFlags)
+				oldIdentity, newIdentity, newEncryptKey, newK8sMeta, newEndpointFlags)
 		}
 	}
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -674,12 +674,26 @@ func benchmarkIPCacheUpsert(b *testing.B, num int) {
 
 type dummyListener struct {
 	entries map[string]identityPkg.NumericIdentity
+	events  []recordedChange
 	ipc     *IPCache
+}
+
+type recordedChange struct {
+	modType       CacheModification
+	cidrCluster   cmtypes.PrefixCluster
+	oldHostIP     net.IP
+	newHostIP     net.IP
+	oldID         *Identity
+	newID         Identity
+	encryptKey    uint8
+	k8sMeta       *K8sMetadata
+	endpointFlags uint8
 }
 
 func newDummyListener(ipc *IPCache) *dummyListener {
 	return &dummyListener{
-		ipc: ipc,
+		entries: make(map[string]identityPkg.NumericIdentity),
+		ipc:     ipc,
 	}
 }
 
@@ -693,6 +707,40 @@ func (dl *dummyListener) OnIPIdentityCacheChange(modType CacheModification,
 	default:
 		// Ignore, for simplicity we just clear the cache every time
 	}
+
+	var oldIDCopy *Identity
+	if oldID != nil {
+		copied := *oldID
+		oldIDCopy = &copied
+	}
+
+	var metaCopy *K8sMetadata
+	if k8sMeta != nil {
+		copied := *k8sMeta
+		metaCopy = &copied
+	}
+
+	dl.events = append(dl.events, recordedChange{
+		modType:       modType,
+		cidrCluster:   cidrCluster,
+		oldHostIP:     slices.Clone(oldHostIP),
+		newHostIP:     slices.Clone(newHostIP),
+		oldID:         oldIDCopy,
+		newID:         newID,
+		encryptKey:    encryptKey,
+		k8sMeta:       metaCopy,
+		endpointFlags: endpointFlags,
+	})
+}
+
+func upsertTestEntry(t *testing.T, ipc *IPCache, ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity, endpointFlags uint8) {
+	t.Helper()
+
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+
+	_, err := ipc.upsertLocked(ip, hostIP, hostKey, k8sMeta, newIdentity, endpointFlags, false, false)
+	require.NoError(t, err)
 }
 
 func (dl *dummyListener) ExpectMapping(t *testing.T, targetIP string, targetIdentity identityPkg.NumericIdentity) {
@@ -754,4 +802,67 @@ func TestIPCacheShadowing(t *testing.T) {
 	ipc.Delete(endpointIP, source.KVStore)
 	_, exists := ipc.LookupByPrefix(cidrOverlap)
 	require.False(t, exists)
+}
+
+func TestIPCacheShadowedCIDRRevivalUsesCurrentAttributes(t *testing.T) {
+	t.Parallel()
+	s := setupIPCacheTestSuite(t)
+
+	const (
+		endpointKey   = uint8(7)
+		cidrKey       = uint8(9)
+		endpointFlags = uint8(0x1)
+		cidrFlags     = uint8(0x2)
+	)
+
+	endpointIP := "10.0.0.15"
+	cidrOverlap := "10.0.0.15/32"
+	endpointHostIP := net.ParseIP("192.0.2.10")
+	cidrHostIP := net.ParseIP("192.0.2.20")
+	endpointMeta := &K8sMetadata{
+		Namespace: "default",
+		PodName:   "pod-a",
+	}
+	cidrMeta := &K8sMetadata{
+		Namespace: "cidr-namespace",
+		PodName:   "cidr-entry",
+	}
+	endpointIdentity := Identity{
+		ID:     identityPkg.NumericIdentity(68),
+		Source: source.KVStore,
+	}
+	cidrIdentity := Identity{
+		ID:     identityPkg.NumericIdentity(202),
+		Source: source.Generated,
+	}
+
+	upsertTestEntry(t, s.IPIdentityCache, endpointIP, endpointHostIP, endpointKey, endpointMeta, endpointIdentity, endpointFlags)
+	upsertTestEntry(t, s.IPIdentityCache, cidrOverlap, cidrHostIP, cidrKey, cidrMeta, cidrIdentity, cidrFlags)
+
+	lookedUpIdentity, exists := s.IPIdentityCache.LookupByPrefix(cidrOverlap)
+	require.True(t, exists)
+	require.Equal(t, endpointIdentity.ID, lookedUpIdentity.ID)
+
+	listener := newDummyListener(s.IPIdentityCache)
+	s.IPIdentityCache.AddListener(listener)
+	listener.events = nil
+
+	s.IPIdentityCache.Delete(endpointIP, source.KVStore)
+
+	lookedUpIdentity, exists = s.IPIdentityCache.LookupByPrefix(cidrOverlap)
+	require.True(t, exists)
+	require.Equal(t, cidrIdentity.ID, lookedUpIdentity.ID)
+
+	require.Len(t, listener.events, 1)
+	event := listener.events[0]
+	require.Equal(t, Upsert, event.modType)
+	require.Equal(t, cidrOverlap, event.cidrCluster.String())
+	require.NotNil(t, event.oldID)
+	require.Equal(t, endpointIdentity.ID, event.oldID.ID)
+	require.Equal(t, cidrIdentity.ID, event.newID.ID)
+	require.True(t, endpointHostIP.Equal(event.oldHostIP))
+	require.True(t, cidrHostIP.Equal(event.newHostIP))
+	require.Equal(t, cidrKey, event.encryptKey)
+	require.Equal(t, cidrMeta, event.k8sMeta)
+	require.Equal(t, cidrFlags, event.endpointFlags)
 }


### PR DESCRIPTION
Fix an IPCache listener notification edge case where a shadowed CIDR entry
is revived with stale attributes from the deleted pod-scoped entry.

## Context

This is split out from #45328, which changes egress gateway endpoint
tracking to consume IPCache-backed pod endpoint events instead of watching
`CiliumEndpoint` resources directly.

The broader use case is supporting egress gateway in deployments where
individual `CiliumEndpoint` objects are not the endpoint source:

- clusters with `CiliumEndpointSlice` enabled,
- kvstore identity allocation deployments where CEP objects may be disabled,
- future consumers that need pod endpoint data without knowing whether it came
  from CEP, CES, or another identity source.

The generic approach relies on IPCache as the aggregation point for IP,
identity, and Kubernetes metadata. While validating that approach, I found this
listener correctness issue in IPCache itself.

## Problem

When a pod-scoped IPCache entry is deleted, an overlapping CIDR entry that was
previously shadowed can become visible again.

Before this change, the listener notification for that revived CIDR reused
attributes from the deleted pod-scoped entry. In particular, listeners could
observe stale Kubernetes metadata, endpoint flags, host IP, or encryption key
that belonged to the deleted pod entry rather than the revived CIDR entry.

That is unsafe for an IPCache listener that maintains higher-level endpoint
state. A revived CIDR entry must not look like the deleted pod endpoint.

## Why This Was Not Seen Before

Egress gateway currently watches `CiliumEndpoint` resources directly, so it did
not depend on this IPCache listener path for endpoint lifecycle state.

The bug becomes relevant when building a CEP/CES/kvstore-agnostic endpoint
source on top of IPCache listener events, as proposed in #45328. That consumer
needs the revived mapping to be reported with the revived mapping's attributes,
otherwise stale pod metadata can leak into the derived pod endpoint state.

## Change

When `deleteLocked` revives a shadowed CIDR entry, send listener notifications
using the revived CIDR entry's current attributes instead of the deleted entry's
attributes.

The added test covers:

- host IP,
- encryption key,
- endpoint flags,
- Kubernetes metadata for the revived CIDR entry.

## Risk

This only changes the attributes reported to IPCache listeners for the shadowed
CIDR revival notification. It does not change IPCache lookup semantics or map
contents.

The intended behavior is that the notification reflects the entry that is now
visible, not the entry that was just deleted.

## Testing

- `go test ./pkg/ipcache`

## Release Note

```release-note
Fixed an IPCache notification edge case where deleting a pod IP could cause IPCache consumers to observe stale endpoint attributes for a restored overlapping CIDR entry.
```