### PR TITLE
ipam: Migrate `Allocator` and `AllocationResult` to `netip.Addr`

### DIFF
--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -713,7 +713,7 @@ func (r *endpointRestorer) allocateIPsLocked(ep *endpoint.Endpoint) (err error) 
 		// https://github.com/cilium/cilium/pull/15453. Other errors are not
 		// bypassed.
 		case err != nil &&
-			errors.Is(err, ipam.NewIPNotAvailableInPoolError(ep.IPv4.AsSlice())) &&
+			errors.Is(err, ipam.NewIPNotAvailableInPoolError(ep.IPv4)) &&
 			option.Config.BypassIPAvailabilityUponRestore:
 			r.logger.Warn(
 				"Bypassing IP not available error on endpoint restore. This is "+

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -260,14 +260,16 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 	// have been regenerated.
 	result := r.reallocateOldRouterIPs(fromK8s, fromFS)
 	if result == nil {
-		family := ipam.DeriveFamily(family.PrimaryExternal())
+		primaryAddr, _ := netip.AddrFromSlice(family.PrimaryExternal())
+		family := ipam.DeriveFamily(primaryAddr.Unmap())
 		result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(family, "router", ipam.PoolDefault())
 		if err != nil {
 			return nil, fmt.Errorf("unable to allocate router IP for family %s: %w", family, err)
 		}
 	}
 
-	ipfamily := ipam.DeriveFamily(family.PrimaryExternal())
+	primaryAddr, _ := netip.AddrFromSlice(family.PrimaryExternal())
+	ipfamily := ipam.DeriveFamily(primaryAddr.Unmap())
 	masq := (ipfamily == ipam.IPv4 && r.daemonConfig.EnableIPv4Masquerade) ||
 		(ipfamily == ipam.IPv6 && r.daemonConfig.EnableIPv6Masquerade)
 
@@ -305,7 +307,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 		}
 
 		if err = routingInfo.Configure(
-			result.IP,
+			net.IP(result.IP.AsSlice()).To16(),
 			r.mtuManager.GetDeviceMTU(),
 			true,
 		); err != nil {
@@ -344,7 +346,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 		}))
 	}
 
-	return result.IP, nil
+	return net.IP(result.IP.AsSlice()).To16(), nil
 }
 
 func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP net.IP) error {
@@ -372,7 +374,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPv4: %w, see https://cilium.link/ipam-range-full", err)
 			}
-			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = result.IP })
+			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = net.IP(result.IP.AsSlice()).To16() })
 		}
 
 		// Coalescing multiple CIDRs. GH #18868
@@ -422,7 +424,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 				}
 				return fmt.Errorf("unable to allocate health IPv6: %w, see https://cilium.link/ipam-range-full", err)
 			}
-			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6HealthIP = result.IP })
+			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6HealthIP = net.IP(result.IP.AsSlice()).To16() })
 		}
 		r.logger.Debug("Allocated IPv6 health endpoint address", logfields.IPAddr, result.IP)
 	}
@@ -471,8 +473,8 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			}
 		}
 
-		ingressIPv4 = result.IP
-		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = result.IP })
+		ingressIPv4 = net.IP(result.IP.AsSlice()).To16()
+		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = net.IP(result.IP.AsSlice()).To16() })
 		r.logger.Debug("Allocated IPv4 Ingress address", logfields.IPAddr, result.IP)
 
 		// In ENI and AlibabaCloud ENI mode, we require the gateway, CIDRs, and the
@@ -483,7 +485,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 				r.logger.Warn("Unable to allocate ingress information for ENI", logfields.Error, err)
 			} else {
 				if err := ingressRouting.Configure(
-					result.IP,
+					net.IP(result.IP.AsSlice()).To16(),
 					r.mtuManager.GetDeviceMTU(),
 					false,
 				); err != nil {
@@ -535,7 +537,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			}
 		}
 
-		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = result.IP })
+		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = net.IP(result.IP.AsSlice()).To16() })
 		r.logger.Debug("Allocated IPv6 Ingress address", logfields.IPAddr, result.IP)
 	}
 
@@ -669,7 +671,7 @@ func (r *infraIPAllocator) allocateRouterIPs(ctx context.Context, restoredRouter
 }
 
 func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*linuxrouting.RoutingInfo, error) {
-	if result.IP.To4() != nil {
+	if result.IP.Is4() {
 		return linuxrouting.NewRoutingInfo(
 			r.logger,
 			result.GatewayIP,

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -6,6 +6,7 @@ package infraendpoints
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,7 +95,8 @@ func (m *mockIPAllocator) AllocateIPWithoutSyncUpstream(ip net.IP, owner string,
 	if !m.allocCIDR.Contains(ip) {
 		return nil, fmt.Errorf("cannot allocate IP %s", ip)
 	}
-	return &ipam.AllocationResult{IP: ip}, nil
+	addr, _ := netip.AddrFromSlice(ip)
+	return &ipam.AllocationResult{IP: addr.Unmap()}, nil
 }
 
 func (m *mockIPAllocator) AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (result *ipam.AllocationResult, err error) {
@@ -119,6 +121,8 @@ func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 
 	fromFS := net.ParseIP("10.20.30.42")
 	fromK8s := net.ParseIP("10.20.30.41")
+	fromFSAddr := netip.MustParseAddr("10.20.30.42")
+	fromK8sAddr := netip.MustParseAddr("10.20.30.41")
 
 	invalidFromFS := net.ParseIP("172.16.0.42")
 	invalidFromK8s := net.ParseIP("172.16.0.41")
@@ -130,17 +134,17 @@ func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 	// fromK8s if fromFS is not available
 	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, nil)
 	assert.NotNil(t, result)
-	assert.Equal(t, result.IP, fromK8s)
+	assert.Equal(t, result.IP, fromK8sAddr)
 
 	// fromFS if fromK8s is not available
 	result = infraIPAllocator.reallocateOldRouterIPs(nil, fromFS)
 	assert.NotNil(t, result)
-	assert.Equal(t, result.IP, fromFS)
+	assert.Equal(t, result.IP, fromFSAddr)
 
 	// fromFS should be preferred
 	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, fromFS)
 	assert.NotNil(t, result)
-	assert.Equal(t, result.IP, fromFS)
+	assert.Equal(t, result.IP, fromFSAddr)
 
 	// reject restoration if the IP is not in the allocation CIDR
 	result = infraIPAllocator.reallocateOldRouterIPs(invalidFromFS, invalidFromK8s)
@@ -149,12 +153,12 @@ func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 	// fromFS with invalid fromK8s
 	result = infraIPAllocator.reallocateOldRouterIPs(invalidFromK8s, fromFS)
 	assert.NotNil(t, result)
-	assert.Equal(t, result.IP, fromFS)
+	assert.Equal(t, result.IP, fromFSAddr)
 
 	// fromFS with invalid fromK8s
 	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, invalidFromFS)
 	assert.NotNil(t, result)
-	assert.Equal(t, result.IP, fromK8s)
+	assert.Equal(t, result.IP, fromK8sAddr)
 }
 
 func TestPrivilegedRemoveOldRouterState(t *testing.T) {

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 
 	"github.com/google/uuid"
@@ -75,19 +76,25 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 		return
 	}
 
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return nil, fmt.Errorf("invalid IP address: %v", ip)
+	}
+	addr = addr.Unmap()
+
 	family := IPv4
-	if ip.To4() != nil {
+	if addr.Is4() {
 		if ipam.ipv4Allocator == nil {
 			err = ErrIPv4Disabled
 			return
 		}
 
 		if needSyncUpstream {
-			if result, err = ipam.ipv4Allocator.Allocate(ip, owner, pool); err != nil {
+			if result, err = ipam.ipv4Allocator.Allocate(addr, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if result, err = ipam.ipv4Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
+			if result, err = ipam.ipv4Allocator.AllocateWithoutSyncUpstream(addr, owner, pool); err != nil {
 				return
 			}
 		}
@@ -104,11 +111,11 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 		}
 
 		if needSyncUpstream {
-			if result, err = ipam.ipv6Allocator.Allocate(ip, owner, pool); err != nil {
+			if result, err = ipam.ipv6Allocator.Allocate(addr, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if result, err = ipam.ipv6Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
+			if result, err = ipam.ipv6Allocator.AllocateWithoutSyncUpstream(addr, owner, pool); err != nil {
 				return
 			}
 		}
@@ -188,14 +195,15 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 			result.IPPoolName = PoolDefault()
 		}
 
-		if _, ok := ipam.isIPExcluded(result.IP, pool); !ok {
+		resultIP := result.IP.AsSlice()
+		if _, ok := ipam.isIPExcluded(resultIP, pool); !ok {
 			ipam.logger.Debug(
 				"Allocated random IP",
 				logfields.IPAddr, result.IP,
 				logfields.PoolName, result.IPPoolName,
 				logfields.Owner, owner,
 			)
-			ipam.registerIPOwner(result.IP, owner, pool)
+			ipam.registerIPOwner(resultIP, owner, pool)
 			metrics.IPAMEvent.WithLabelValues(metricAllocate, string(family)).Inc()
 			return
 		}
@@ -203,7 +211,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 		// The allocated IP is excluded, do not use it. The excluded IP
 		// is now allocated so it won't be allocated in the next
 		// iteration.
-		ipam.registerIPOwner(result.IP, fmt.Sprintf("%s (excluded)", owner), pool)
+		ipam.registerIPOwner(resultIP, fmt.Sprintf("%s (excluded)", owner), pool)
 	}
 }
 
@@ -245,7 +253,7 @@ func (ipam *IPAM) AllocateNext(family, owner string, pool Pool) (ipv4Result, ipv
 		ipv4Result, err = ipam.AllocateNextFamily(IPv4, owner, pool)
 		if err != nil {
 			if ipv6Result != nil {
-				ipam.ReleaseIP(ipv6Result.IP, ipv6Result.IPPoolName)
+				ipam.ReleaseIP(ipv6Result.IP.AsSlice(), ipv6Result.IPPoolName)
 			}
 			return
 		}
@@ -266,13 +274,13 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, ti
 	if timeout != time.Duration(0) {
 		for _, result := range []*AllocationResult{ipv4Result, ipv6Result} {
 			if result != nil {
-				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, result.IPPoolName, timeout)
+				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP.AsSlice(), result.IPPoolName, timeout)
 				if err != nil {
 					if ipv4Result != nil {
-						ipam.ReleaseIP(ipv4Result.IP, ipv4Result.IPPoolName)
+						ipam.ReleaseIP(ipv4Result.IP.AsSlice(), ipv4Result.IPPoolName)
 					}
 					if ipv6Result != nil {
-						ipam.ReleaseIP(ipv6Result.IP, ipv6Result.IPPoolName)
+						ipam.ReleaseIP(ipv6Result.IP.AsSlice(), ipv6Result.IPPoolName)
 					}
 					return
 				}
@@ -288,13 +296,19 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 		return fmt.Errorf("no IPAM pool provided for IP release of %s", ip)
 	}
 
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return fmt.Errorf("invalid IP address: %v", ip)
+	}
+	addr = addr.Unmap()
+
 	family := IPv4
-	if ip.To4() != nil {
+	if addr.Is4() {
 		if ipam.ipv4Allocator == nil {
 			return ErrIPv4Disabled
 		}
 
-		ipam.ipv4Allocator.Release(ip, pool)
+		ipam.ipv4Allocator.Release(addr, pool)
 		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
 			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv4Allocator.Capacity()))
 		} else {
@@ -306,7 +320,7 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 			return ErrIPv6Disabled
 		}
 
-		ipam.ipv6Allocator.Release(ip, pool)
+		ipam.ipv6Allocator.Release(addr, pool)
 		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
 			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv6Allocator.Capacity()))
 		} else {

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -184,24 +184,24 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv4.IP.AsSlice(), "foo", PoolDefault())
 	require.Error(t, err)
 	// IPv6 address must be in use
-	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.IP.AsSlice(), "foo", PoolDefault())
 	require.Error(t, err)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be available again
-	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv4.IP.AsSlice(), "foo", PoolDefault())
 	require.NoError(t, err)
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.IP.AsSlice(), "foo", PoolDefault())
 	require.NoError(t, err)
 	// Release IPs
-	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
+	err = ipam.ReleaseIP(ipv4.IP.AsSlice(), PoolDefault())
 	require.NoError(t, err)
-	err = ipam.ReleaseIP(ipv6.IP, PoolDefault())
+	err = ipam.ReleaseIP(ipv6.IP.AsSlice(), PoolDefault())
 	require.NoError(t, err)
 
 	// Allocate IPs again and test stopping the expiration timer
@@ -209,18 +209,18 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stop expiration timer for IPv4 address
-	err = ipam.StopExpirationTimer(ipv4.IP, PoolDefault(), ipv4.ExpirationUUID)
+	err = ipam.StopExpirationTimer(ipv4.IP.AsSlice(), PoolDefault(), ipv4.ExpirationUUID)
 	require.NoError(t, err)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv4.IP.AsSlice(), "foo", PoolDefault())
 	require.Error(t, err)
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.IP.AsSlice(), "foo", PoolDefault())
 	require.NoError(t, err)
 	// Release IPv4 address
-	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
+	err = ipam.ReleaseIP(ipv4.IP.AsSlice(), PoolDefault())
 	require.NoError(t, err)
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"net/netip"
 	"reflect"
 	"strconv"
 	"sync"
@@ -437,8 +438,8 @@ func (n *nodeStore) updateLocalNodeResource(node *ciliumv2.CiliumNode) {
 		// Retrieve the appropriate allocator
 		var allocator *crdAllocator
 		var ipFamily Family
-		if ipAddr := net.ParseIP(ip); ipAddr != nil {
-			ipFamily = DeriveFamily(ipAddr)
+		if parsedAddr, err := netip.ParseAddr(ip); err == nil {
+			ipFamily = DeriveFamily(parsedAddr)
 		}
 		if ipFamily == "" {
 			continue
@@ -541,7 +542,7 @@ func (n *nodeStore) addAllocator(allocator *crdAllocator) {
 }
 
 // allocate checks if a particular IP can be allocated or return an error
-func (n *nodeStore) allocate(ip net.IP) (*ipamTypes.AllocationIP, error) {
+func (n *nodeStore) allocate(addr netip.Addr) (*ipamTypes.AllocationIP, error) {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
@@ -553,13 +554,13 @@ func (n *nodeStore) allocate(ip net.IP) (*ipamTypes.AllocationIP, error) {
 		return nil, fmt.Errorf("No IPs available")
 	}
 
-	if n.isIPInReleaseHandshake(ip.String()) {
+	if n.isIPInReleaseHandshake(addr.String()) {
 		return nil, fmt.Errorf("IP not available, marked or ready for release")
 	}
 
-	ipInfo, ok := n.ownNode.Spec.IPAM.Pool[ip.String()]
+	ipInfo, ok := n.ownNode.Spec.IPAM.Pool[addr.String()]
 	if !ok {
-		return nil, NewIPNotAvailableInPoolError(ip)
+		return nil, NewIPNotAvailableInPoolError(addr)
 	}
 
 	return &ipInfo, nil
@@ -579,31 +580,31 @@ func (n *nodeStore) isIPInReleaseHandshake(ip string) bool {
 }
 
 // allocateNext allocates the next available IP or returns an error
-func (n *nodeStore) allocateNext(allocated ipamTypes.AllocationMap, family Family, owner string) (net.IP, *ipamTypes.AllocationIP, error) {
+func (n *nodeStore) allocateNext(allocated ipamTypes.AllocationMap, family Family, owner string) (netip.Addr, *ipamTypes.AllocationIP, error) {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
 	if n.ownNode == nil {
-		return nil, nil, fmt.Errorf("CiliumNode for own node is not available")
+		return netip.Addr{}, nil, fmt.Errorf("CiliumNode for own node is not available")
 	}
 
 	// Check if IP has a custom owner (only supported in manual CRD mode)
 	if n.conf.IPAMMode() == ipamOption.IPAMCRD && len(owner) != 0 {
 		for ip, ipInfo := range n.ownNode.Spec.IPAM.Pool {
 			if ipInfo.Owner == owner {
-				parsedIP := net.ParseIP(ip)
-				if parsedIP == nil {
+				parsedAddr, err := netip.ParseAddr(ip)
+				if err != nil {
 					n.logger.Warn(
 						"Unable to parse IP in CiliumNode custom resource",
 						fieldName, n.ownNode.Name,
 						logfields.IPAddr, ip,
 					)
-					return nil, nil, fmt.Errorf("invalid custom ip %s for %s. ", ip, owner)
+					return netip.Addr{}, nil, fmt.Errorf("invalid custom ip %s for %s. ", ip, owner)
 				}
-				if DeriveFamily(parsedIP) != family {
+				if DeriveFamily(parsedAddr) != family {
 					continue
 				}
-				return parsedIP, &ipInfo, nil
+				return parsedAddr, &ipInfo, nil
 			}
 		}
 	}
@@ -619,8 +620,8 @@ func (n *nodeStore) allocateNext(allocated ipamTypes.AllocationMap, family Famil
 			if ipInfo.Owner != "" {
 				continue // IP is used by another
 			}
-			parsedIP := net.ParseIP(ip)
-			if parsedIP == nil {
+			parsedAddr, err := netip.ParseAddr(ip)
+			if err != nil {
 				n.logger.Warn(
 					"Unable to parse IP in CiliumNode custom resource",
 					fieldName, n.ownNode.Name,
@@ -629,11 +630,11 @@ func (n *nodeStore) allocateNext(allocated ipamTypes.AllocationMap, family Famil
 				continue
 			}
 
-			if DeriveFamily(parsedIP) != family {
+			if DeriveFamily(parsedAddr) != family {
 				continue
 			}
 
-			return parsedIP, &ipInfo, nil
+			return parsedAddr, &ipInfo, nil
 		}
 	}
 
@@ -643,7 +644,7 @@ func (n *nodeStore) allocateNext(allocated ipamTypes.AllocationMap, family Famil
 	} else {
 		msg += "once Cilium Operator allocates more IPs"
 	}
-	return nil, nil, errors.New(msg)
+	return netip.Addr{}, nil, errors.New(msg)
 }
 
 // totalPoolSize returns the total size of the allocation pool
@@ -715,8 +716,8 @@ func deriveGatewayIP(logger *slog.Logger, cidr string, index int) string {
 	return gw.String()
 }
 
-func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.AllocationIP) (result *AllocationResult, err error) {
-	result = &AllocationResult{IP: ip}
+func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.AllocationIP) (result *AllocationResult, err error) {
+	result = &AllocationResult{IP: addr}
 
 	a.store.mutex.RLock()
 	defer a.store.mutex.RUnlock()
@@ -728,7 +729,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 	switch a.conf.IPAMMode() {
 
 	case ipamOption.IPAMENI:
-		return buildENIAllocationResult(a.logger, ip, a.store.ownNode, a.conf, a.ipMasqAgent)
+		return buildENIAllocationResult(a.logger, addr, a.store.ownNode, a.conf, a.ipMasqAgent)
 
 	// In Azure mode, the Resource points to the azure interface so we can
 	// derive the master interface
@@ -748,9 +749,9 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 				if a.conf.EnableIPMasqAgent {
 					nonMasqCidrs := a.ipMasqAgent.NonMasqCIDRsFromConfig()
 					for _, prefix := range nonMasqCidrs {
-						if ip.To4() != nil && prefix.Addr().Is4() {
+						if addr.Is4() && prefix.Addr().Is4() {
 							result.CIDRs = append(result.CIDRs, prefix.String())
-						} else if ip.To4() == nil && prefix.Addr().Is6() {
+						} else if !addr.Is4() && prefix.Addr().Is6() {
 							result.CIDRs = append(result.CIDRs, prefix.String())
 						}
 					}
@@ -797,27 +798,27 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 // allocate it if it is available. If the IP is unavailable or already
 // allocated, an error is returned. The custom resource will be updated to
 // reflect the newly allocated IP.
-func (a *crdAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+func (a *crdAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	if _, ok := a.allocated[ip.String()]; ok {
+	if _, ok := a.allocated[addr.String()]; ok {
 		return nil, fmt.Errorf("IP already in use")
 	}
 
-	ipInfo, err := a.store.allocate(ip)
+	ipInfo, err := a.store.allocate(addr)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := a.buildAllocationResult(ip, ipInfo)
+	result, err := a.buildAllocationResult(addr, ipInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", addr, err)
 	}
 
-	a.markAllocated(ip, owner, *ipInfo)
+	a.markAllocated(addr, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
-	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
+	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", addr))
 
 	return result, nil
 }
@@ -826,25 +827,25 @@ func (a *crdAllocator) Allocate(ip net.IP, owner string, pool Pool) (*Allocation
 // custom resource and allocate it if it is available. If the IP is
 // unavailable or already allocated, an error is returned. The custom resource
 // will not be updated.
-func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+func (a *crdAllocator) AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	if _, ok := a.allocated[ip.String()]; ok {
+	if _, ok := a.allocated[addr.String()]; ok {
 		return nil, fmt.Errorf("IP already in use")
 	}
 
-	ipInfo, err := a.store.allocate(ip)
+	ipInfo, err := a.store.allocate(addr)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := a.buildAllocationResult(ip, ipInfo)
+	result, err := a.buildAllocationResult(addr, ipInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", addr, err)
 	}
 
-	a.markAllocated(ip, owner, *ipInfo)
+	a.markAllocated(addr, owner, *ipInfo)
 
 	return result, nil
 }
@@ -852,25 +853,25 @@ func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool
 // Release will release the specified IP or return an error if the IP has not
 // been allocated before. The custom resource will be updated to reflect the
 // released IP.
-func (a *crdAllocator) Release(ip net.IP, pool Pool) error {
+func (a *crdAllocator) Release(addr netip.Addr, pool Pool) error {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	if _, ok := a.allocated[ip.String()]; !ok {
-		return fmt.Errorf("IP %s is not allocated", ip.String())
+	if _, ok := a.allocated[addr.String()]; !ok {
+		return fmt.Errorf("IP %s is not allocated", addr.String())
 	}
 
-	delete(a.allocated, ip.String())
+	delete(a.allocated, addr.String())
 	// Update custom resource to reflect the newly released IP.
-	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("release of IP %s", ip.String()))
+	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("release of IP %s", addr.String()))
 
 	return nil
 }
 
 // markAllocated marks a particular IP as allocated
-func (a *crdAllocator) markAllocated(ip net.IP, owner string, ipInfo ipamTypes.AllocationIP) {
+func (a *crdAllocator) markAllocated(addr netip.Addr, owner string, ipInfo ipamTypes.AllocationIP) {
 	ipInfo.Owner = owner
-	a.allocated[ip.String()] = ipInfo
+	a.allocated[addr.String()] = ipInfo
 }
 
 // AllocateNext allocates the next available IP as offered by the custom
@@ -880,19 +881,19 @@ func (a *crdAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult,
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	ip, ipInfo, err := a.store.allocateNext(a.allocated, a.family, owner)
+	addr, ipInfo, err := a.store.allocateNext(a.allocated, a.family, owner)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := a.buildAllocationResult(ip, ipInfo)
+	result, err := a.buildAllocationResult(addr, ipInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", addr, err)
 	}
 
-	a.markAllocated(ip, owner, *ipInfo)
+	a.markAllocated(addr, owner, *ipInfo)
 	// Update custom resource to reflect the newly allocated IP.
-	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", ip.String()))
+	a.store.refreshTrigger.TriggerWithReason(fmt.Sprintf("allocation of IP %s", addr.String()))
 
 	return result, nil
 }
@@ -904,17 +905,17 @@ func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
-	ip, ipInfo, err := a.store.allocateNext(a.allocated, a.family, owner)
+	addr, ipInfo, err := a.store.allocateNext(a.allocated, a.family, owner)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := a.buildAllocationResult(ip, ipInfo)
+	result, err := a.buildAllocationResult(addr, ipInfo)
 	if err != nil {
-		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", ip, err)
+		return nil, fmt.Errorf("failed to associate IP %s inside CiliumNode: %w", addr, err)
 	}
 
-	a.markAllocated(ip, owner, *ipInfo)
+	a.markAllocated(addr, owner, *ipInfo)
 
 	return result, nil
 }
@@ -948,18 +949,18 @@ func (a *crdAllocator) RestoreFinished() {
 
 // NewIPNotAvailableInPoolError returns an error resprenting the given IP not
 // being available in the IPAM pool.
-func NewIPNotAvailableInPoolError(ip net.IP) error {
-	return &ErrIPNotAvailableInPool{ip: ip}
+func NewIPNotAvailableInPoolError(addr netip.Addr) error {
+	return &ErrIPNotAvailableInPool{addr: addr}
 }
 
 // ErrIPNotAvailableInPool represents an error when an IP is not available in
 // the pool.
 type ErrIPNotAvailableInPool struct {
-	ip net.IP
+	addr netip.Addr
 }
 
 func (e *ErrIPNotAvailableInPool) Error() string {
-	return fmt.Sprintf("IP %s is not available", e.ip.String())
+	return fmt.Sprintf("IP %s is not available", e.addr)
 }
 
 // Is provides this error type with the logic for use with errors.Is.
@@ -974,5 +975,5 @@ func (e *ErrIPNotAvailableInPool) Is(target error) bool {
 	if t == nil {
 		return false
 	}
-	return t.ip.Equal(e.ip)
+	return t.addr == e.addr
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/netip"
 	"testing"
 	"time"
@@ -34,37 +33,37 @@ import (
 )
 
 func TestIPNotAvailableInPoolError(t *testing.T) {
-	err := NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
-	err2 := NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err := NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))
+	err2 := NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))
 	assert.Equal(t, err, err2)
 	assert.ErrorIs(t, err, err2)
 
-	err = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
-	err2 = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err = NewIPNotAvailableInPoolError(netip.MustParseAddr("2.1.1.1"))
+	err2 = NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))
 	assert.NotEqual(t, err, err2)
 	assert.NotErrorIs(t, err, err2)
 
-	err = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err = NewIPNotAvailableInPoolError(netip.MustParseAddr("2.1.1.1"))
 	err2 = errors.New("another error")
 	assert.NotEqual(t, err, err2)
 	assert.NotErrorIs(t, err, err2)
 
 	err = errors.New("another error")
-	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err2 = NewIPNotAvailableInPoolError(netip.MustParseAddr("2.1.1.1"))
 	assert.NotEqual(t, err, err2)
 	assert.NotErrorIs(t, err, err2)
 
-	err = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err = NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))
 	err2 = nil
 	assert.NotErrorIs(t, err, err2)
 
 	err = nil
-	err2 = NewIPNotAvailableInPoolError(net.ParseIP("1.1.1.1"))
+	err2 = NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))
 	assert.NotErrorIs(t, err, err2)
 
 	// We don't match against strings. It must be the sentinel value.
 	err = errors.New("IP 2.1.1.1 is not available")
-	err2 = NewIPNotAvailableInPoolError(net.ParseIP("2.1.1.1"))
+	err2 = NewIPNotAvailableInPoolError(netip.MustParseAddr("2.1.1.1"))
 	assert.NotEqual(t, err, err2)
 	assert.NotErrorIs(t, err, err2)
 }
@@ -125,7 +124,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	// Allocate the first 3 IPs
 	for i := 1; i <= 3; i++ {
 		epipv4 := netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))
-		_, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault())
+		_, err := ipam.ipv4Allocator.Allocate(epipv4, fmt.Sprintf("test%d", i), PoolDefault())
 		require.NoError(t, err)
 	}
 
@@ -133,7 +132,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
 	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
 	epipv4 := netip.MustParseAddr("1.1.1.4")
-	_, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault())
+	_, err := ipam.ipv4Allocator.Allocate(epipv4, "test", PoolDefault())
 	require.Error(t, err)
 	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
 	sharedNodeStore.updateLocalNodeResource(cn)
@@ -210,7 +209,7 @@ func TestIPMasq(t *testing.T) {
 	ipam.ConfigureAllocator()
 
 	epipv4 := netip.MustParseAddr("10.1.1.226")
-	result, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), "test1", PoolDefault())
+	result, err := ipam.ipv4Allocator.Allocate(epipv4, "test1", PoolDefault())
 	require.NoError(t, err)
 	// The resulting CIDRs should contain the VPC CIDRs and the default ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
 	require.ElementsMatch(
@@ -283,7 +282,7 @@ func TestAzureIPMasq(t *testing.T) {
 	ipam.ConfigureAllocator()
 
 	epipv4 := netip.MustParseAddr("10.10.1.5")
-	result, err := ipam.ipv4Allocator.Allocate(epipv4.AsSlice(), "test1", PoolDefault())
+	result, err := ipam.ipv4Allocator.Allocate(epipv4, "test1", PoolDefault())
 	require.NoError(t, err)
 	// The resulting CIDRs should contain the Azure interface CIDR and the default ip-masq-agent CIDRs
 	require.ElementsMatch(

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 	"slices"
 	"strconv"
 
@@ -336,18 +337,18 @@ func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sy
 // owns the given IP.
 func buildENIAllocationResult(
 	logger *slog.Logger,
-	allocatedIP net.IP,
+	allocatedAddr netip.Addr,
 	node *ciliumv2.CiliumNode,
 	conf *option.DaemonConfig,
 	ipMasqAgent *ipmasq.IPMasqAgent,
 ) (*AllocationResult, error) {
 	for _, eni := range node.Status.ENI.ENIs {
-		if !eniContainsIP(eni, allocatedIP) {
+		if !eniContainsIP(eni, allocatedAddr) {
 			continue
 		}
 
 		result := &AllocationResult{
-			IP:         allocatedIP,
+			IP:         allocatedAddr,
 			PrimaryMAC: eni.MAC,
 			CIDRs:      []string{eni.VPC.PrimaryCIDR},
 		}
@@ -363,9 +364,9 @@ func buildENIAllocationResult(
 		// ip-masq-agent configuration changes.
 		if conf.EnableIPMasqAgent {
 			for _, prefix := range ipMasqAgent.NonMasqCIDRsFromConfig() {
-				if allocatedIP.To4() != nil && prefix.Addr().Is4() {
+				if allocatedAddr.Is4() && prefix.Addr().Is4() {
 					result.CIDRs = append(result.CIDRs, prefix.String())
-				} else if allocatedIP.To4() == nil && prefix.Addr().Is6() {
+				} else if !allocatedAddr.Is4() && prefix.Addr().Is6() {
 					result.CIDRs = append(result.CIDRs, prefix.String())
 				}
 			}
@@ -381,26 +382,26 @@ func buildENIAllocationResult(
 		return result, nil
 	}
 
-	return nil, fmt.Errorf("unable to find ENI for IP %s", allocatedIP)
+	return nil, fmt.Errorf("unable to find ENI for IP %s", allocatedAddr)
 }
 
 // eniContainsIP returns true if the given IP belongs to the ENI: either as the
 // primary IP, a secondary address, or within one of its delegated prefixes.
-func eniContainsIP(eni eniTypes.ENI, ip net.IP) bool {
-	ipStr := ip.String()
-	if eni.IP == ipStr {
+func eniContainsIP(eni eniTypes.ENI, addr netip.Addr) bool {
+	addrStr := addr.String()
+	if eni.IP == addrStr {
 		return true
 	}
-	if slices.Contains(eni.Addresses, ipStr) {
+	if slices.Contains(eni.Addresses, addrStr) {
 		return true
 	}
 
 	for _, prefix := range eni.Prefixes {
-		_, cidr, err := net.ParseCIDR(prefix)
+		parsed, err := netip.ParsePrefix(prefix)
 		if err != nil {
 			continue
 		}
-		if cidr.Contains(ip) {
+		if parsed.Contains(addr) {
 			return true
 		}
 	}

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -4,7 +4,7 @@
 package ipam
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -266,7 +266,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	t.Run("secondary IP on eni-1", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.10"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), node, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
@@ -276,7 +276,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	})
 
 	t.Run("secondary IP on eni-2", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, net.ParseIP("10.3.1.20"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.3.1.20"), node, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:02", result.PrimaryMAC)
 		require.Equal(t, "2", result.InterfaceNumber)
@@ -284,7 +284,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 	})
 
 	t.Run("unknown IP returns error", func(t *testing.T) {
-		_, err := buildENIAllocationResult(logger, net.ParseIP("10.99.99.99"), node, conf, nil)
+		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.99.99.99"), node, conf, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unable to find ENI for IP")
 	})
@@ -293,7 +293,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 		confWithNative := &option.DaemonConfig{
 			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.0.0.0/8"),
 		}
-		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.10"), node, confWithNative, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), node, confWithNative, nil)
 		require.NoError(t, err)
 		require.Contains(t, result.CIDRs, "10.0.0.0/8")
 	})
@@ -323,20 +323,20 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	t.Run("IP in first prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.5"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.5"), node, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
 	})
 
 	t.Run("IP in second prefix", func(t *testing.T) {
-		result, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.20"), node, conf, nil)
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.20"), node, conf, nil)
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 	})
 
 	t.Run("IP outside all prefixes", func(t *testing.T) {
-		_, err := buildENIAllocationResult(logger, net.ParseIP("10.1.1.32"), node, conf, nil)
+		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), node, conf, nil)
 		require.Error(t, err)
 	})
 }
@@ -349,18 +349,18 @@ func TestEniContainsIP(t *testing.T) {
 	}
 
 	// Primary IP match
-	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.0.100")))
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.0.100")))
 
 	// Secondary address match
-	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.0.1")))
-	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.0.2")))
-	require.False(t, eniContainsIP(eni, net.ParseIP("10.0.0.3")))
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.0.1")))
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.0.2")))
+	require.False(t, eniContainsIP(eni, netip.MustParseAddr("10.0.0.3")))
 
 	// Prefix match
-	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.1.0")))
-	require.True(t, eniContainsIP(eni, net.ParseIP("10.0.1.15")))
-	require.False(t, eniContainsIP(eni, net.ParseIP("10.0.1.16")))
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.1.0")))
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.1.15")))
+	require.False(t, eniContainsIP(eni, netip.MustParseAddr("10.0.1.16")))
 
 	// Empty ENI
-	require.False(t, eniContainsIP(eniTypes.ENI{}, net.ParseIP("10.0.0.1")))
+	require.False(t, eniContainsIP(eniTypes.ENI{}, netip.MustParseAddr("10.0.0.1")))
 }

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -5,7 +5,6 @@ package ipam
 
 import (
 	"fmt"
-	"net"
 	"net/netip"
 
 	"go4.org/netipx"
@@ -19,47 +18,31 @@ type hostScopeAllocator struct {
 	allocator *ipallocator.Range
 }
 
-func newHostScopeAllocator(n *net.IPNet) Allocator {
-	prefix, ok := netipx.FromStdIPNet(n)
-	if !ok {
-		panic(fmt.Sprintf("invalid IPNet: %v", n))
-	}
+func newHostScopeAllocator(prefix netip.Prefix) Allocator {
 	return &hostScopeAllocator{
 		allocCIDR: prefix,
 		allocator: ipallocator.NewCIDRRange(prefix),
 	}
 }
 
-func (h *hostScopeAllocator) Allocate(ipAddr net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	addr, ok := netip.AddrFromSlice(ipAddr)
-	if !ok {
-		return nil, fmt.Errorf("invalid IP address: %v", ipAddr)
-	}
-	if err := h.allocator.Allocate(addr.Unmap()); err != nil {
+func (h *hostScopeAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	if err := h.allocator.Allocate(addr); err != nil {
 		return nil, err
 	}
 
-	return &AllocationResult{IP: ipAddr}, nil
+	return &AllocationResult{IP: addr}, nil
 }
 
-func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(ipAddr net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	addr, ok := netip.AddrFromSlice(ipAddr)
-	if !ok {
-		return nil, fmt.Errorf("invalid IP address: %v", ipAddr)
-	}
-	if err := h.allocator.Allocate(addr.Unmap()); err != nil {
+func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	if err := h.allocator.Allocate(addr); err != nil {
 		return nil, err
 	}
 
-	return &AllocationResult{IP: ipAddr}, nil
+	return &AllocationResult{IP: addr}, nil
 }
 
-func (h *hostScopeAllocator) Release(ipAddr net.IP, pool Pool) error {
-	addr, ok := netip.AddrFromSlice(ipAddr)
-	if !ok {
-		return nil
-	}
-	h.allocator.Release(addr.Unmap())
+func (h *hostScopeAllocator) Release(addr netip.Addr, pool Pool) error {
+	h.allocator.Release(addr)
 	return nil
 }
 
@@ -69,7 +52,7 @@ func (h *hostScopeAllocator) AllocateNext(owner string, pool Pool) (*AllocationR
 		return nil, err
 	}
 
-	return &AllocationResult{IP: net.IP(addr.AsSlice()).To16()}, nil
+	return &AllocationResult{IP: addr}, nil
 }
 
 func (h *hostScopeAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
@@ -78,7 +61,7 @@ func (h *hostScopeAllocator) AllocateNextWithoutSyncUpstream(owner string, pool 
 		return nil, err
 	}
 
-	return &AllocationResult{IP: net.IP(addr.AsSlice()).To16()}, nil
+	return &AllocationResult{IP: addr}, nil
 }
 
 func (h *hostScopeAllocator) Dump() (map[Pool]map[string]string, string) {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
+	"go4.org/netipx"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
@@ -33,8 +35,8 @@ const (
 )
 
 // DeriveFamily derives the address family of an IP
-func DeriveFamily(ip net.IP) Family {
-	if ip.To4() == nil {
+func DeriveFamily(addr netip.Addr) Family {
+	if addr.Is6() {
 		return IPv6
 	}
 	return IPv4
@@ -130,11 +132,19 @@ func (ipam *IPAM) ConfigureAllocator() {
 		)
 
 		if ipam.config.IPv6Enabled() {
-			ipam.ipv6Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet)
+			prefix, ok := netipx.FromStdIPNet(ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet)
+			if !ok {
+				logging.Fatal(ipam.logger, "Invalid IPv6 allocation CIDR")
+			}
+			ipam.ipv6Allocator = newHostScopeAllocator(prefix)
 		}
 
 		if ipam.config.IPv4Enabled() {
-			ipam.ipv4Allocator = newHostScopeAllocator(ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet)
+			prefix, ok := netipx.FromStdIPNet(ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet)
+			if !ok {
+				logging.Fatal(ipam.logger, "Invalid IPv4 allocation CIDR")
+			}
+			ipam.ipv4Allocator = newHostScopeAllocator(prefix)
 		}
 	case ipamOption.IPAMMultiPool:
 		ipam.logger.Info("Initializing MultiPool IPAM")

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -6,7 +6,6 @@ package ipam
 import (
 	"fmt"
 	"maps"
-	"net"
 	"net/netip"
 	"strings"
 	"testing"
@@ -49,21 +48,21 @@ type fakePoolAllocator struct {
 func newFakePoolAllocator(poolMap map[string]string) *fakePoolAllocator {
 	pools := make(map[Pool]Allocator, len(poolMap))
 	for name, cidr := range poolMap {
-		_, ipnet, err := net.ParseCIDR(cidr)
+		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
 			panic(fmt.Sprintf("failed to parse test cidr %s for pool %s", cidr, name))
 		}
-		pools[Pool(name)] = newHostScopeAllocator(ipnet)
+		pools[Pool(name)] = newHostScopeAllocator(prefix)
 	}
 	return &fakePoolAllocator{pools: pools}
 }
 
-func (f *fakePoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+func (f *fakePoolAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	alloc, ok := f.pools[pool]
 	if !ok {
 		return nil, fmt.Errorf("unknown pool %s", pool)
 	}
-	result, err := alloc.Allocate(ip, owner, pool)
+	result, err := alloc.Allocate(addr, owner, pool)
 	if err != nil {
 		return nil, err
 	}
@@ -71,16 +70,16 @@ func (f *fakePoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*Alloc
 	return result, nil
 }
 
-func (f fakePoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	return f.Allocate(ip, owner, pool)
+func (f fakePoolAllocator) AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	return f.Allocate(addr, owner, pool)
 }
 
-func (f fakePoolAllocator) Release(ip net.IP, pool Pool) error {
+func (f fakePoolAllocator) Release(addr netip.Addr, pool Pool) error {
 	alloc, ok := f.pools[pool]
 	if !ok {
 		return fmt.Errorf("unknown pool %s", pool)
 	}
-	return alloc.Release(ip, pool)
+	return alloc.Release(addr, pool)
 }
 
 func (f fakePoolAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
@@ -142,13 +141,13 @@ func TestLock(t *testing.T) {
 	ipv6 = ipv6.Next()
 
 	// Forcefully release possible allocated IPs
-	ipam.ipv4Allocator.Release(ipv4.AsSlice(), PoolDefault())
-	ipam.ipv6Allocator.Release(ipv6.AsSlice(), PoolDefault())
+	ipam.ipv4Allocator.Release(ipv4, PoolDefault())
+	ipam.ipv6Allocator.Release(ipv6, PoolDefault())
 
 	// Let's allocate the IP first so we can see the tests failing
-	result, err := ipam.ipv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault())
+	result, err := ipam.ipv4Allocator.Allocate(ipv4, "test", PoolDefault())
 	require.NoError(t, err)
-	require.Equal(t, net.IP(ipv4.AsSlice()), result.IP)
+	require.Equal(t, ipv4, result.IP)
 }
 
 func TestExcludeIP(t *testing.T) {
@@ -189,8 +188,8 @@ func TestExcludeIP(t *testing.T) {
 }
 
 func TestDeriveFamily(t *testing.T) {
-	require.Equal(t, IPv4, DeriveFamily(net.ParseIP("1.1.1.1")))
-	require.Equal(t, IPv6, DeriveFamily(net.ParseIP("f00d::1")))
+	require.Equal(t, IPv4, DeriveFamily(netip.MustParseAddr("1.1.1.1")))
+	require.Equal(t, IPv6, DeriveFamily(netip.MustParseAddr("f00d::1")))
 }
 
 func TestIPAMMetadata(t *testing.T) {
@@ -235,18 +234,18 @@ func TestIPAMMetadata(t *testing.T) {
 	})
 
 	// Checks AllocateIP
-	specialIP := net.ParseIP("172.18.19.20")
-	_, err := ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "")
+	specialIP := netip.MustParseAddr("172.18.19.20")
+	_, err := ipam.AllocateIPWithoutSyncUpstream(specialIP.AsSlice(), "special/wants-special-ip", "")
 	require.Error(t, err) // pool required
-	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "special")
+	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(specialIP.AsSlice(), "special/wants-special-ip", "special")
 	require.NoError(t, err)
 	require.Equal(t, Pool("special"), resIPv4.IPPoolName)
-	require.True(t, resIPv4.IP.Equal(specialIP))
+	require.Equal(t, specialIP, resIPv4.IP)
 
 	// Checks ReleaseIP
-	err = ipam.ReleaseIP(specialIP, "")
+	err = ipam.ReleaseIP(specialIP.AsSlice(), "")
 	require.Error(t, err) // pool required
-	err = ipam.ReleaseIP(specialIP, "special")
+	err = ipam.ReleaseIP(specialIP.AsSlice(), "special")
 	require.NoError(t, err)
 
 	// Checks if pool metadata is used if pool is empty

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
@@ -91,16 +91,16 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 		}
 }
 
-func (c *multiPoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	return c.manager.allocateIP(ip, owner, pool, c.family, true)
+func (c *multiPoolAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	return c.manager.allocateIP(addr, owner, pool, c.family, true)
 }
 
-func (c *multiPoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
-	return c.manager.allocateIP(ip, owner, pool, c.family, false)
+func (c *multiPoolAllocator) AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
+	return c.manager.allocateIP(addr, owner, pool, c.family, false)
 }
 
-func (c *multiPoolAllocator) Release(ip net.IP, pool Pool) error {
-	return c.manager.releaseIP(ip, pool, c.family, true)
+func (c *multiPoolAllocator) Release(addr netip.Addr, pool Pool) error {
+	return c.manager.releaseIP(addr, pool, c.family, true)
 }
 
 func (c *multiPoolAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"net"
 	"net/netip"
 	"slices"
 	"sort"
@@ -43,15 +42,14 @@ const (
 type ErrPoolNotReadyYet struct {
 	poolName Pool
 	family   Family
-	ip       net.IP
+	addr     netip.Addr
 }
 
 func (e *ErrPoolNotReadyYet) Error() string {
-	if e.ip == nil {
+	if !e.addr.IsValid() {
 		return fmt.Sprintf("unable to allocate from pool %q (family %s): pool not (yet) available", e.poolName, e.family)
-	} else {
-		return fmt.Sprintf("unable to reserve IP %s from pool %q (family %s): pool not (yet) available", e.ip, e.poolName, e.family)
 	}
+	return fmt.Sprintf("unable to reserve IP %s from pool %q (family %s): pool not (yet) available", e.addr, e.poolName, e.family)
 }
 
 func (e *ErrPoolNotReadyYet) Is(err error) bool {
@@ -725,10 +723,10 @@ func (m *multiPoolManager) allocateNext(owner string, poolName Pool, family Fami
 	}
 
 	m.pendingIPsPerPool.markAsAllocated(poolName, owner, family)
-	return &AllocationResult{IP: addr.AsSlice(), IPPoolName: poolName, SkipMasquerade: skipMasq}, nil
+	return &AllocationResult{IP: addr, IPPoolName: poolName, SkipMasquerade: skipMasq}, nil
 }
 
-func (m *multiPoolManager) allocateIP(ip net.IP, owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
+func (m *multiPoolManager) allocateIP(addr netip.Addr, owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
 	m.poolsMutex.Lock()
 	defer m.poolsMutex.Unlock()
 
@@ -741,36 +739,29 @@ func (m *multiPoolManager) allocateIP(ip net.IP, owner string, poolName Pool, fa
 	pool := m.poolByFamilyLocked(poolName, family)
 	if pool == nil {
 		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
-		return nil, &ErrPoolNotReadyYet{poolName: poolName, family: family, ip: ip}
+		return nil, &ErrPoolNotReadyYet{poolName: poolName, family: family, addr: addr}
 	}
 
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return nil, fmt.Errorf("invalid IP address: %v", ip)
-	}
-	err := pool.allocate(addr.Unmap())
+	err := pool.allocate(addr)
 	if err != nil {
 		m.pendingIPsPerPool.upsertPendingAllocation(poolName, owner, family)
 		return nil, err
 	}
 
 	m.pendingIPsPerPool.markAsAllocated(poolName, owner, family)
-	return &AllocationResult{IP: ip, IPPoolName: poolName}, nil
+	return &AllocationResult{IP: addr, IPPoolName: poolName}, nil
 }
 
-func (m *multiPoolManager) releaseIP(ip net.IP, poolName Pool, family Family, upstreamSync bool) error {
+func (m *multiPoolManager) releaseIP(addr netip.Addr, poolName Pool, family Family, upstreamSync bool) error {
 	m.poolsMutex.Lock()
 	defer m.poolsMutex.Unlock()
 
 	pool := m.poolByFamilyLocked(poolName, family)
 	if pool == nil {
-		return fmt.Errorf("unable to release IP %s of unknown pool %q (family %s)", ip, poolName, family)
+		return fmt.Errorf("unable to release IP %s of unknown pool %q (family %s)", addr, poolName, family)
 	}
 
-	addr, ok := netip.AddrFromSlice(ip)
-	if ok {
-		pool.release(addr.Unmap())
-	}
+	pool.release(addr)
 	if upstreamSync {
 		m.k8sUpdater.Trigger()
 	}

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -195,12 +195,12 @@ func Test_MultiPoolManager(t *testing.T) {
 	c.waitForAllPools()
 
 	// test allocation in default pool
-	defaultAllocation, err := c.allocateIP(net.ParseIP("10.0.22.1"), "default-pod-1", "default", IPv4, false)
+	defaultAllocation, err := c.allocateIP(netip.MustParseAddr("10.0.22.1"), "default-pod-1", "default", IPv4, false)
 	assert.NoError(t, err)
-	assert.Equal(t, defaultAllocation.IP, net.ParseIP("10.0.22.1"))
+	assert.Equal(t, netip.MustParseAddr("10.0.22.1"), defaultAllocation.IP)
 
 	// cannot allocate the same IP twice
-	faultyAllocation, err := c.allocateIP(net.ParseIP("10.0.22.1"), "default-pod-1", "default", IPv4, false)
+	faultyAllocation, err := c.allocateIP(netip.MustParseAddr("10.0.22.1"), "default-pod-1", "default", IPv4, false)
 	assert.ErrorIs(t, err, ipallocator.ErrAllocated)
 	assert.Nil(t, faultyAllocation)
 
@@ -208,7 +208,7 @@ func Test_MultiPoolManager(t *testing.T) {
 	jupiterIPv4CIDR := cidr.MustParseCIDR("192.168.1.0/16")
 	juptierIPv6CIDR := cidr.MustParseCIDR("fc00:33::/96")
 
-	faultyAllocation, err = c.allocateIP(net.ParseIP("192.168.1.1"), "jupiter-pod-0", "jupiter", IPv4, false)
+	faultyAllocation, err = c.allocateIP(netip.MustParseAddr("192.168.1.1"), "jupiter-pod-0", "jupiter", IPv4, false)
 	assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
 	assert.Nil(t, faultyAllocation)
 	faultyAllocation, err = c.allocateNext("jupiter-pod-1", "jupiter", IPv6, false)
@@ -292,13 +292,13 @@ func Test_MultiPoolManager(t *testing.T) {
 	c.waitForPool(t.Context(), IPv6, "jupiter")
 
 	// Allocations should now succeed
-	jupiterIP0 := net.ParseIP("192.168.1.1")
+	jupiterIP0 := netip.MustParseAddr("192.168.1.1")
 	allocatedJupiterIP0, err := c.allocateIP(jupiterIP0, "jupiter-pod-0", "jupiter", IPv4, false)
 	assert.NoError(t, err)
-	assert.True(t, jupiterIP0.Equal(allocatedJupiterIP0.IP))
+	assert.Equal(t, jupiterIP0, allocatedJupiterIP0.IP)
 	allocatedJupiterIP1, err := c.allocateNext("jupiter-pod-1", "jupiter", IPv6, false)
 	assert.NoError(t, err)
-	assert.True(t, juptierIPv6CIDR.Contains(allocatedJupiterIP1.IP))
+	assert.True(t, juptierIPv6CIDR.Contains(allocatedJupiterIP1.IP.AsSlice()))
 
 	// Release IPs from jupiter pool. This should fully remove it from both
 	// "requested" and "allocated"
@@ -346,13 +346,13 @@ func Test_MultiPoolManager(t *testing.T) {
 	}, currentNode.Spec.IPAM.Pools)
 
 	// exhaust mars ipv4 pool (/27 contains 30 IPs)
-	allocatedMarsIPs := []net.IP{}
+	allocatedMarsIPs := []netip.Addr{}
 	numMarsIPs := 30
 	for i := range numMarsIPs {
 		// set upstreamSync to true for last allocation, to ensure we only get one upsert event
 		ar, err := c.allocateNext(fmt.Sprintf("mars-pod-%d", i), "mars", IPv4, i == numMarsIPs-1)
 		assert.NoError(t, err)
-		assert.True(t, marsIPv4CIDR1.Contains(ar.IP))
+		assert.True(t, marsIPv4CIDR1.Contains(ar.IP.AsSlice()))
 		allocatedMarsIPs = append(allocatedMarsIPs, ar.IP)
 	}
 	_, err = c.allocateNext("mars-pod-overflow", "mars", IPv4, false)
@@ -409,11 +409,11 @@ func Test_MultiPoolManager(t *testing.T) {
 	// Should now be able to allocate from mars pool again
 	marsAllocation, err := c.allocateNext("mars-pod-overflow", "mars", IPv4, false)
 	assert.NoError(t, err)
-	assert.True(t, marsIPv4CIDR2.Contains(marsAllocation.IP))
+	assert.True(t, marsIPv4CIDR2.Contains(marsAllocation.IP.AsSlice()))
 
 	// Deallocate all other IPs from mars pool. This should release the old CIDR
-	for i, ip := range allocatedMarsIPs {
-		err = c.releaseIP(ip, "mars", IPv4, i == numMarsIPs-1)
+	for i, addr := range allocatedMarsIPs {
+		err = c.releaseIP(addr, "mars", IPv4, i == numMarsIPs-1)
 		assert.NoError(t, err)
 	}
 	assert.Equal(t, "upsert", <-events)
@@ -542,11 +542,11 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 	<-events // first upsert (initial node)
 
 	// Allocate one IPv4 and one IPv6 IP
-	ipInCIDR1 := net.ParseIP("10.0.10.0")
+	ipInCIDR1 := netip.MustParseAddr("10.0.10.0")
 	_, err = mgr.allocateIP(ipInCIDR1, "pod-a", "default", IPv4, false)
 	assert.NoError(t, err)
 
-	ipInCIDRv61 := net.ParseIP("fd00:10::")
+	ipInCIDRv61 := netip.MustParseAddr("fd00:10::")
 	_, err = mgr.allocateIP(ipInCIDRv61, "pod-a", "default", IPv6, false)
 	assert.NoError(t, err)
 
@@ -664,11 +664,11 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 
 	// Allocate 5 IPv4 and 5 IPv6 IPs
 	for i := range 5 {
-		ip4 := net.ParseIP(fmt.Sprintf("10.0.100.%d", i))
+		ip4 := netip.MustParseAddr(fmt.Sprintf("10.0.100.%d", i))
 		_, err := mgr.allocateIP(ip4, fmt.Sprintf("pod4-%d", i), "default", IPv4, false)
 		assert.NoError(t, err)
 
-		ip6 := net.ParseIP(fmt.Sprintf("fd00:100::%d", i))
+		ip6 := netip.MustParseAddr(fmt.Sprintf("fd00:100::%d", i))
 		_, err = mgr.allocateIP(ip6, fmt.Sprintf("pod6-%d", i), "default", IPv6, false)
 		assert.NoError(t, err)
 	}

--- a/pkg/ipam/noop_allocator.go
+++ b/pkg/ipam/noop_allocator.go
@@ -5,7 +5,7 @@ package ipam
 
 import (
 	"errors"
-	"net"
+	"net/netip"
 )
 
 var errNotSupported = errors.New("Operation not supported")
@@ -15,15 +15,15 @@ var errNotSupported = errors.New("Operation not supported")
 // without relying on the cilium daemon or operator.
 type noOpAllocator struct{}
 
-func (n *noOpAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+func (n *noOpAllocator) Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	return nil, errNotSupported
 }
 
-func (n *noOpAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+func (n *noOpAllocator) AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	return nil, errNotSupported
 }
 
-func (n *noOpAllocator) Release(ip net.IP, pool Pool) error {
+func (n *noOpAllocator) Release(addr netip.Addr, pool Pool) error {
 	return errNotSupported
 }
 

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -5,7 +5,7 @@ package ipam
 
 import (
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -27,7 +27,7 @@ import (
 // AllocationResult is the result of an allocation
 type AllocationResult struct {
 	// IP is the allocated IP
-	IP net.IP
+	IP netip.Addr
 
 	// IPPoolName is the IPAM pool from which the above IP was allocated from
 	IPPoolName Pool
@@ -64,14 +64,14 @@ type AllocationResult struct {
 // Allocator is the interface for an IP allocator implementation
 type Allocator interface {
 	// Allocate allocates a specific IP or fails
-	Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error)
+	Allocate(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error)
 
 	// AllocateWithoutSyncUpstream allocates a specific IP without syncing
 	// upstream or fails
-	AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error)
+	AllocateWithoutSyncUpstream(addr netip.Addr, owner string, pool Pool) (*AllocationResult, error)
 
 	// Release releases a previously allocated IP or fails
-	Release(ip net.IP, pool Pool) error
+	Release(addr netip.Addr, pool Pool) error
 
 	// AllocateNext allocates the next available IP or fails if no more IPs
 	// are available


### PR DESCRIPTION
Relates to #24246

Followup to #45508 #45495 #45395 #45260

Switch the IPAM [`Allocator`](https://github.com/cilium/cilium/blob/e6ff2e7e2b60a6b7ec9d3dc157f75e73c0b3b4bb/pkg/ipam/types.go#L64-L95) interface and the [`AllocationResult.IP`](https://github.com/cilium/cilium/blob/e6ff2e7e2b60a6b7ec9d3dc157f75e73c0b3b4bb/pkg/ipam/types.go#L30) field from `net.IP` to `netip.Addr`. All four implementations of this interface get updated as well, with conversions at the boundary:
* `hostScopeAllocator`
* `multiPoolAllocator`
* `crdAllocator`
* `noOpAllocator`