### PR TITLE
ci: harden get-runner-ip with trusted endpoints and cross-validation

### DIFF
--- a/.github/actions/get-runner-ip/README.md
+++ b/.github/actions/get-runner-ip/README.md
@@ -58,7 +58,7 @@ This composite action fetches the runner public IP address from a provided `sour
 
 ## Examples
 
-### Parse plain text (recommended)
+### Parse plain text
 
 ```yaml
 - name: Get runner IP

--- a/.github/actions/get-runner-ip/README.md
+++ b/.github/actions/get-runner-ip/README.md
@@ -30,6 +30,18 @@ This composite action fetches the runner public IP address from a provided `sour
   - `data.ip`
   - `data.address`
 
+- **`backup-source`** (optional, default: `https://whatismyip.akamai.com`)
+
+  A backup URL used to cross-validate the IP returned by the primary `source`. If both sources return different IPs, the action fails. Set to an empty string to disable cross-validation.
+
+- **`backup-parsing`** (optional, default: `text`)
+
+  Parsing mode for the backup source response. Same values as `parsing`.
+
+- **`backup-json-key`** (optional)
+
+  Optional JSON key for the backup source when `backup-parsing` is `json`.
+
 ## Outputs
 
 - **`ip`**
@@ -46,14 +58,14 @@ This composite action fetches the runner public IP address from a provided `sour
 
 ## Examples
 
-### Parse plain text
+### Parse plain text (recommended)
 
 ```yaml
 - name: Get runner IP
   id: runner-ip
   uses: ./.github/actions/get-runner-ip
   with:
-    source: https://api.ipify.org
+    source: https://checkip.amazonaws.com
     parsing: text
 
 - name: Print
@@ -63,17 +75,7 @@ This composite action fetches the runner public IP address from a provided `sour
     echo "Runner CIDR: ${{ steps.runner-ip.outputs.cidr }}"
 ```
 
-### Parse JSON using a known key
-
-```yaml
-- name: Get runner IP
-  id: runner-ip
-  uses: ./.github/actions/get-runner-ip
-  with:
-    source: https://httpbin.org/ip
-    parsing: json
-    json-key: origin
-```
+The IP is automatically cross-validated against `https://whatismyip.akamai.com` (the default `backup-source`).
 
 ## Behavior and error handling
 
@@ -84,3 +86,4 @@ This composite action fetches the runner public IP address from a provided `sour
   - `parsing: json` is selected but the response is not valid JSON
   - no IP-like value can be extracted
   - the extracted value does not look like an IPv4 or IPv6 address
+  - `backup-source` is set and the backup request fails or returns a different IP than the primary source

--- a/.github/actions/get-runner-ip/action.yml
+++ b/.github/actions/get-runner-ip/action.yml
@@ -29,89 +29,101 @@ runs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
-          const source = `${{ inputs.source }}`.trim();
-          const parsing = `${{ inputs.parsing }}`.trim().toLowerCase();
-          const jsonKey = `${{ inputs['json-key'] }}`.trim();
           const net = require('node:net');
-          if (!source) {
-            core.setFailed("Input 'source' must be a non-empty URL");
-            return;
-          }
+          const timeoutMs = 15000;
+
           const isLikelyIp = (value) => {
             if (typeof value !== 'string') return false;
             const v = value.trim();
             if (!v) return false;
             return net.isIP(v) !== 0;
           };
+
           const getByDotPath = (obj, path) => {
             if (!path) return undefined;
             return path.split('.').reduce((acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined), obj);
           };
-          let response;
-          const timeoutMs = 15000;
-          const controller = new AbortController();
-          const timeout = setTimeout(() => {
-            controller.abort(new Error(`Request timed out after ${timeoutMs}ms`));
-          }, timeoutMs);
-          try {
-            response = await fetch(source, {
-              signal: controller.signal,
-              headers: {
-                'User-Agent': 'actions/github-script get-runner-ip',
-                'Accept': parsing === 'json' ? 'application/json,*/*' : '*/*',
-              },
-            });
-          } catch (e) {
-            core.setFailed(`Failed to fetch '${source}': ${e?.message || e}`);
-            return;
-          } finally {
-            clearTimeout(timeout);
-          }
-          if (!response.ok) {
-            const body = await response.text().catch(() => '');
-            core.setFailed(`Fetch '${source}' failed: HTTP ${response.status} ${response.statusText}${body ? `; body: ${body.slice(0, 200)}` : ''}`);
-            return;
-          }
-          const rawText = await response.text();
-          const trimmed = (rawText || '').trim();
-          let ip;
-          if (parsing === 'text') {
-            ip = trimmed;
-          } else if (parsing === 'json') {
-            let data;
+
+          // Fetch a URL, parse the response, and return a validated IP string.
+          // Returns { ip } on success or { error } on failure.
+          const fetchIp = async (source, parsing, jsonKey) => {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => {
+              controller.abort(new Error(`Request timed out after ${timeoutMs}ms`));
+            }, timeoutMs);
+            let response;
             try {
-              data = JSON.parse(trimmed);
+              response = await fetch(source, {
+                signal: controller.signal,
+                headers: {
+                  'User-Agent': 'actions/github-script get-runner-ip',
+                  'Accept': parsing === 'json' ? 'application/json,*/*' : '*/*',
+                },
+              });
             } catch (e) {
-              core.setFailed(`Failed to parse JSON from '${source}': ${e?.message || e}; body starts with: ${trimmed.slice(0, 200)}`);
-              return;
+              return { error: `Failed to fetch '${source}': ${e?.message || e}` };
+            } finally {
+              clearTimeout(timeout);
             }
-            const candidates = [];
-            if (jsonKey) {
-              candidates.push(getByDotPath(data, jsonKey));
+            if (!response.ok) {
+              const body = await response.text().catch(() => '');
+              return { error: `Fetch '${source}' failed: HTTP ${response.status} ${response.statusText}${body ? `; body: ${body.slice(0, 200)}` : ''}` };
             }
-            // Common response shapes from IP endpoints
-            candidates.push(data?.ip);
-            candidates.push(data?.origin);
-            candidates.push(data?.query);
-            candidates.push(data?.address);
-            candidates.push(data?.data?.ip);
-            candidates.push(data?.data?.address);
-            ip = candidates.find((c) => typeof c === 'string' && c.trim().length > 0);
-            if (typeof ip === 'string') {
-              ip = ip.trim();
+            const rawText = await response.text();
+            const trimmed = (rawText || '').trim();
+            let ip;
+            if (parsing === 'text') {
+              ip = trimmed;
+            } else if (parsing === 'json') {
+              let data;
+              try {
+                data = JSON.parse(trimmed);
+              } catch (e) {
+                return { error: `Failed to parse JSON from '${source}': ${e?.message || e}; body starts with: ${trimmed.slice(0, 200)}` };
+              }
+              const candidates = [];
+              if (jsonKey) {
+                candidates.push(getByDotPath(data, jsonKey));
+              }
+              // Common response shapes from IP endpoints
+              candidates.push(data?.ip);
+              candidates.push(data?.origin);
+              candidates.push(data?.query);
+              candidates.push(data?.address);
+              candidates.push(data?.data?.ip);
+              candidates.push(data?.data?.address);
+              ip = candidates.find((c) => typeof c === 'string' && c.trim().length > 0);
+              if (typeof ip === 'string') {
+                ip = ip.trim();
+              }
+            } else {
+              return { error: `Unsupported parsing mode '${parsing}'. Use 'text' or 'json'.` };
             }
-          } else {
-            core.setFailed(`Unsupported parsing mode '${parsing}'. Use 'text' or 'json'.`);
+            if (!ip || typeof ip !== 'string') {
+              return { error: `No IP address found in response from '${source}'.` };
+            }
+            if (!isLikelyIp(ip)) {
+              return { error: `Parsed value is not a valid IP address: '${ip}'` };
+            }
+            return { ip };
+          };
+
+          const source = `${{ inputs.source }}`.trim();
+          const parsing = `${{ inputs.parsing }}`.trim().toLowerCase();
+          const jsonKey = `${{ inputs['json-key'] }}`.trim();
+
+          if (!source) {
+            core.setFailed("Input 'source' must be a non-empty URL");
             return;
           }
-          if (!ip || typeof ip !== 'string') {
-            core.setFailed(`No IP address found in response from '${source}'.`);
+
+          const result = await fetchIp(source, parsing, jsonKey);
+          if (result.error) {
+            core.setFailed(result.error);
             return;
           }
-          if (!isLikelyIp(ip)) {
-            core.setFailed(`Parsed value is not a valid IP address: '${ip}'`);
-            return;
-          }
+
+          const ip = result.ip;
           core.setOutput('ip', ip);
           const mask = net.isIPv6(ip) ? "128" : "32";
           core.setOutput('mask', mask);

--- a/.github/actions/get-runner-ip/action.yml
+++ b/.github/actions/get-runner-ip/action.yml
@@ -11,6 +11,17 @@ inputs:
   json-key:
     description: Optional JSON key (dot-separated) to extract the IP from when parsing is 'json'. If not set, common keys are tried.
     required: false
+  backup-source:
+    description: Optional backup URL to cross-validate the IP against a second trusted provider. Set to empty string to disable.
+    required: false
+    default: https://whatismyip.akamai.com
+  backup-parsing:
+    description: Parsing mode for the backup source response. Supported values are 'text' and 'json'.
+    required: false
+    default: text
+  backup-json-key:
+    description: Optional JSON key for the backup source when backup-parsing is 'json'.
+    required: false
 outputs:
   ip:
     description: The parsed and validated runner public IP address.
@@ -124,6 +135,25 @@ runs:
           }
 
           const ip = result.ip;
+
+          // Cross-validate against backup source if configured
+          const backupSource = `${{ inputs['backup-source'] }}`.trim();
+          if (backupSource) {
+            const backupParsing = `${{ inputs['backup-parsing'] }}`.trim().toLowerCase() || 'text';
+            const backupJsonKey = `${{ inputs['backup-json-key'] }}`.trim();
+            core.info(`Cross-validating IP against backup source: ${backupSource}`);
+            const backupResult = await fetchIp(backupSource, backupParsing, backupJsonKey);
+            if (backupResult.error) {
+              core.setFailed(`Backup validation failed: ${backupResult.error}`);
+              return;
+            }
+            if (ip !== backupResult.ip) {
+              core.setFailed(`IP mismatch: primary source returned '${ip}' but backup source '${backupSource}' returned '${backupResult.ip}'`);
+              return;
+            }
+            core.info(`Cross-validation passed: both sources agree on IP ${ip}`);
+          }
+
           core.setOutput('ip', ip);
           const mask = net.isIPv6(ip) ? "128" : "32";
           core.setOutput('mask', mask);

--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -30,9 +30,8 @@ runs:
       id: get-runner-ip
       uses: ./.github/actions/get-runner-ip
       with:
-        source: https://whatismyip.azurewebsites.net/json/
-        parsing: json
-        json-key: ip
+        source: https://checkip.amazonaws.com
+        parsing: text
 
     - name: Create AKS cluster
       shell: bash

--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -39,7 +39,7 @@ runs:
       id: get-runner-ip
       uses: ./.github/actions/get-runner-ip
       with:
-        source: https://api.ipify.org
+        source: https://checkip.amazonaws.com
         parsing: text
 
     - id: create-cluster


### PR DESCRIPTION
Replaces third-party IP-check endpoints (api.ipify.org, whatismyip.azurewebsites.net) with AWS's official checkip.amazonaws.com and adds cross-validation against a backup source (whatismyip.akamai.com) to detect service compromise or domain takeover.
