### PR TITLE
ci: fix gke matrix

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -4,14 +4,13 @@ k8s:
   - version: "1.30"
     zone: us-west2-c
     vmIndex: 1
-    default: true
   - version: "1.31"
     zone: us-west3-a
     vmIndex: 2
-    default: true
   - version: "1.32"
     zone: us-east4-b
     vmIndex: 3
   - version: "1.33"
     zone: us-west1-c
     vmIndex: 4
+    default: true


### PR DESCRIPTION
Forgot to remove the test commit before merging #44557 
faulty commit : https://github.com/cilium/cilium/pull/44557/changes/9a0d030ee0c47ca7a1ffcb5b714b02a6a4b5dfbd
This commit fix the matrix