### PR TITLE
contrib: Don't descend into ~/.cache subdirs when chowning in builder.sh

### DIFF
--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -108,7 +108,10 @@ fi
 
 docker exec "$CONTAINER" groupmod -g "$GROUPID" ubuntu
 # usermod fixes UIDs, but GIDs need to be fixed manually.
-docker exec "$CONTAINER" chown -Rhc --from=:1000 :ubuntu /home/ubuntu
+docker exec "$CONTAINER" find /home/ubuntu -xdev \
+   -path /home/ubuntu/.cache/go-build -prune -o \
+   -path /home/ubuntu/.cache/ccache -prune -o \
+   -exec chown -hc --from=:1000 :ubuntu /home/ubuntu {} +
 docker exec "$CONTAINER" usermod -u "$USERID" ubuntu
 docker exec "$CONTAINER" chown -hc ubuntu:ubuntu /home/ubuntu/.cache
 docker exec "${USER_OPTION[@]}" ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"


### PR DESCRIPTION
When Podman is used as Docker's drop-in replacement, it mounts volumes
owned by user inaccessible by root inside the container, and the
recursive chown fails. Don't try to go inside the mountpoints when
fixing the ownership of /home/ubuntu.

Fixes: 65cdb42f3ff6 ("contrib: chown ~/.cache in builder.sh")

```release-note
Follow-up bugfixes for builder.sh.
```
