### PR TITLE
contrib: Temporary workaround to run as root

### DIFF
--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -62,6 +62,13 @@ set -u # End workaround for macOS and BASH 3.2.
 trap 'docker rm -f "$CONTAINER"' EXIT
 docker start "$CONTAINER"
 
+if [ "$USERID" -eq 0 ] || [ "$GROUPID" -eq 0 ]; then
+	echo "WARNING: Running with root permissions is discouraged, not supported and insecure!" 1>&2
+	echo "Go cache dirs and ccache dir will be mounted at wrong locations. Don't run as root." 1>&2
+	docker exec ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"
+	exit "$?"
+fi
+
 EXISTING_GROUP=$(docker exec "$CONTAINER" getent group "$GROUPID" || :)
 if [ -n "$EXISTING_GROUP" ] && [ "${EXISTING_GROUP%%:*}" != "ubuntu" ]; then
 	echo "Group exists in the container, trying to reassign ID: $EXISTING_GROUP"


### PR DESCRIPTION
Renovate bot attempts to run make and builder.sh as root and fails [1]. Since commit 2b8a9144df78 ("contrib: Fix UID != 1000 in builder.sh"), running builder.sh as root is not supported, and it attempts to match the UID in the container with the host UID. Commit 74b5841201f8 ("contrib: Remove RUN_AS_ROOT from builder.sh") removed the RUN_AS_ROOT option and fixed the workflows that used it, but Renovate still tries to run commands as root. This is insecure and should be fixed on Renovate side, but in the meanwhile allow running builder.sh as root with a prominent warning. Note that the host cache directories are mounted under /home/ubuntu, and the root user in the container will not use them in this mode.

This mode should be prohibited, once Renovate workflows are fixed.

[1]: https://github.com/cilium/cilium/pull/45389#issuecomment-4251943556

```release-note
Temporary exception to allow running builder.sh as root before Renovate workflows are fixed.
```
