### PR TITLE
gha fix: typo eks-cluster-delete.yaml that skips cluster delete

### DIFF
--- a/.github/workflows/eks-cluster-delete.yaml
+++ b/.github/workflows/eks-cluster-delete.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           eksctl utils update-cluster-vpc-config --cluster "${{ inputs.cluster_name }}" \
             --public-access-cidrs="${{ steps.get-runner-ip.outputs.cidr }}" \
-            --public-access=true --private-access=true --approve || \
+            --public-access=true --private-access=true --approve && \
           eksctl delete cluster --name "${{ inputs.cluster_name }}" --region ${{ inputs.region }}
         shell: bash {0} # Disable default fail-fast behaviour
 


### PR DESCRIPTION
`||` allowed for cluster cleanup to fail after acl has been successfully configured. changing to `&&` so that cleanup can be properly handled.

