### PR TITLE
gateway-api: Fix TLSRoute versions in yaml test data

### DIFF
--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/input/tlsroute-mixed-protocol-listeners.yaml
@@ -32,7 +32,7 @@ spec:
       tls:
         mode: Passthrough
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-mixed

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/tlsroute-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/tlsroute-tlsroute-mixed.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: tlsroute-mixed

--- a/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/Conformance/TLSRouteHostnameIntersection/input-tlsroute.yaml
@@ -1,4 +1,4 @@
-- apiVersion: gateway.networking.k8s.io/v1alpha2
+- apiVersion: gateway.networking.k8s.io/v1
   kind: TLSRoute
   metadata:
     name: tlsroute-exact-hostname-x-4
@@ -30,7 +30,7 @@
         parentRef:
           name: gw-tlsroute-empty-hostname-x-4
           namespace: gateway-conformance-infra
-- apiVersion: gateway.networking.k8s.io/v1alpha2
+- apiVersion: gateway.networking.k8s.io/v1
   kind: TLSRoute
   metadata:
     name: tlsroute-less-specific-wc-hostname-x-4


### PR DESCRIPTION
Integration tests are consistently failing with:

```bash
    --- FAIL: Test_Conformance/tlsroute-mixed-protocol-listeners (0.01s)
        gateway_reconcile_test.go:396:
            	Error Trace:	operator/pkg/gateway-api/gateway_reconcile_test.go:396
            	Error:      	Should be empty, but was   &v1.TLSRoute{
            	            	  	TypeMeta: v1.TypeMeta{
            	            	  		Kind:       "TLSRoute",
            	            	- 		APIVersion: "gateway.networking.k8s.io/v1alpha2",
            	            	+ 		APIVersion: "gateway.networking.k8s.io/v1",
            	            	  	},
            	            	  	ObjectMeta: {Name: "tlsroute-mixed", Namespace: "gateway-conformance-infra"},
            	            	  	Spec:       {CommonRouteSpec: {ParentRefs: {{Name: "gateway-tlsroute-mixed"}}}, Hostnames: {"tls.example.com"}, Rules: {{BackendRefs: {{BackendObjectReference: {Name: "tls-backend", Port: &443}}}}}},
            	            	  	Status:     {RouteStatus: {Parents: {{ParentRef: {Name: "gateway-tlsroute-mixed"}, ControllerName: "io.cilium/gateway-controller", Conditions: {{Type: "Accepted", Status: "True", Reason: "Accepted", Message: "Accepted TLSRoute", ...}, {Type: "ResolvedRefs", Status: "True", Reason: "ResolvedRefs", Message: "Service reference is valid", ...}}}}}},
            	            	  }
            	Test:       	Test_Conformance/tlsroute-mixed-protocol-listeners
FAIL
FAIL	github.com/cilium/cilium/operator/pkg/gateway-api	2.216s
```

Actually changing only `tlsroute-tlsroute-mixed.yaml` would've worked, but from the original deprecation commit (see below) I think adjusting versioning also in other yamls makes sense.

Fixes: https://github.com/cilium/cilium/commit/e4f96757a11eac1766649189c2b13d2fd0efe4ea.