### PR TITLE
ztunnel: split CA server into its own package

### DIFF
--- a/pkg/ztunnel/ca/ca_server.go
+++ b/pkg/ztunnel/ca/ca_server.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ca
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"os"
+	"strings"
+
+	"google.golang.org/grpc/credentials"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/ztunnel/pb"
+)
+
+const (
+	// bootstrapKeyPath is the private key used to bootstrap the ztunnel to
+	// CA TLS connection.
+	bootstrapKeyPath = "/etc/ztunnel/bootstrap-private.key"
+	// bootstrapCertPath is the certificate used to bootstrap the ztunnel to
+	// CA TLS connection.
+	bootstrapCertPath = "/etc/ztunnel/bootstrap-root.crt"
+	// caKeyPath is the private key used to sign client certificates.
+	caKeyPath = "/etc/ztunnel/ca-private.key"
+	// caCertPath is the root certificate trust anchor for issued client
+	// certificates.
+	caCertPath = "/etc/ztunnel/ca-root.crt"
+)
+
+var _ pb.IstioCertificateServiceServer = (*Server)(nil)
+
+// Server is the built-in certificate authority for the stand-alone ztunnel
+// proxy. It signs CSRs submitted by ztunnel and returns workload identity
+// certificates.
+//
+// Server does not own a listener or a *grpc.Server; the caller (the xDS
+// server) is responsible for registering a Server on its own gRPC server via
+// pb.RegisterIstioCertificateServiceServer.
+type Server struct {
+	log       *slog.Logger
+	epManager endpointmanager.EndpointManager
+	caCert    *x509.Certificate
+	// caCertPEM caches the PEM encoded certificate; it is returned as the
+	// trust anchor on ztunnel certificate creation requests.
+	caCertPEM string
+	caKey     *rsa.PrivateKey
+	pb.UnimplementedIstioCertificateServiceServer
+}
+
+// NewServer initializes the built-in CA server by loading the CA certificate
+// and private key from disk.
+func NewServer(log *slog.Logger, epManager endpointmanager.EndpointManager) (*Server, error) {
+	s := &Server{
+		log:       log,
+		epManager: epManager,
+	}
+	if err := s.init(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// LoadServerTLSCredentials loads the bootstrap TLS credentials used by the
+// gRPC server that hosts the certificate signing service.
+func LoadServerTLSCredentials() (credentials.TransportCredentials, error) {
+	return credentials.NewServerTLSFromFile(bootstrapCertPath, bootstrapKeyPath)
+}
+
+// init loads the CA certificate and private key from disk.
+func (s *Server) init() error {
+	// caCertPath will be a PEM encoded certificate, we need to decode this
+	// to DER to parse as an x509.Certificate and also cache the PEM string.
+	certFile, err := os.OpenFile(caCertPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open CA certificate file %s: %w", caCertPath, err)
+	}
+	defer func() {
+		err := certFile.Close()
+		if err != nil {
+			s.log.Error("failed to close CA certificate file",
+				logfields.Path,
+				caCertPath,
+				logfields.Error,
+				err)
+		}
+	}()
+
+	buf, err := safeio.ReadAllLimit(certFile, safeio.MB)
+	if err != nil {
+		return fmt.Errorf("failed to read CA certificate file %s: %w", caCertPath, err)
+	}
+
+	s.caCertPEM = string(buf)
+
+	block, _ := pem.Decode(buf)
+	if block.Type != "CERTIFICATE" {
+		return fmt.Errorf("CA certificate file %s is not a valid PEM encoded certificate", caCertPath)
+	}
+
+	s.caCert, err = x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse CA certificate file %s: %w", caCertPath, err)
+	}
+
+	// caKeyPath will be a PEM encoded certificate. We can parse this into an
+	// rsa.PrivateKey.
+	keyFile, err := os.OpenFile(caKeyPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open CA private key file %s: %w",
+			caKeyPath,
+			err)
+	}
+	defer func() {
+		err := keyFile.Close()
+		if err != nil {
+			s.log.Error("failed to close CA private key file",
+				logfields.Path,
+				caKeyPath,
+				logfields.Error,
+				err)
+		}
+	}()
+
+	buf, err = safeio.ReadAllLimit(keyFile, safeio.MB)
+	if err != nil {
+		return fmt.Errorf("failed to read CA private key file %s: %w", caKeyPath, err)
+	}
+
+	block, _ = pem.Decode(buf)
+	if block.Type != "PRIVATE KEY" {
+		return fmt.Errorf("CA private key file %s is not a valid PEM encoded RSA private key", caKeyPath)
+	}
+
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
+		}
+
+		// only support RSA keys for now.
+		var ok bool
+		if s.caKey, ok = key.(*rsa.PrivateKey); !ok {
+			return fmt.Errorf("CA private key file %s is not a valid RSA private key", caKeyPath)
+		}
+	case "RSA PRIVATE KEY":
+		// this block type parses directly to an RSA private key.
+		s.caKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
+		}
+
+	default:
+		return fmt.Errorf("CA private key file %s is not a valid PEM encoded RSA private key, got %q", caKeyPath, block.Type)
+	}
+
+	return nil
+}
+
+// createCertificate will generate a certificate given a CSR and return the
+// PEM encoded string.
+func (s *Server) createCertificate(req *x509.CertificateRequest) (string, error) {
+	// generate the certificate serial
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	certTemplate := &x509.Certificate{
+		SerialNumber:   serial,
+		Subject:        req.Subject,
+		URIs:           req.URIs,
+		DNSNames:       req.DNSNames,
+		IPAddresses:    req.IPAddresses,
+		EmailAddresses: req.EmailAddresses,
+		NotBefore:      time.Now(),
+		NotAfter:       time.Now().Add(30 * (24 * time.Hour)),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, certTemplate, s.caCert, req.PublicKey, s.caKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return string(pemBytes), nil
+}
+
+// CreateCertificate implements the certificate signing process.
+func (s *Server) CreateCertificate(ctx context.Context, csr *pb.IstioCertificateRequest) (*pb.IstioCertificateResponse, error) {
+	s.log.Debug("received CSR request")
+
+	if len(csr.Csr) == 0 {
+		return nil, fmt.Errorf("received empty CSR")
+	}
+
+	buf := bytes.NewBufferString(csr.Csr)
+
+	block, _ := pem.Decode(buf.Bytes())
+	if block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("not a certificate signing request")
+	}
+
+	req, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CSR: %w", err)
+	}
+
+	if err = req.CheckSignature(); err != nil {
+		return nil, fmt.Errorf("CSR signature check failed: %w", err)
+	}
+
+	if len(req.URIs) != 1 {
+		return nil, fmt.Errorf("CSR must contain exactly one URI SAN")
+	}
+
+	uri := req.URIs[0]
+
+	if uri.Scheme != "spiffe" {
+		return nil, fmt.Errorf("CSR URI scheme must be 'spiffe', got %q", uri.Scheme)
+	}
+
+	fields := strings.Split(uri.Path, "/")
+	// 5 fields since uri has leading '/', strings.Split will never omit empty
+	// fields.
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("CSR URI path must be in the format /ns/<namespace>/sa/<service-account>, got %q %q", uri.Path, fields)
+	}
+	k8sNamespace := fields[2]
+	k8sSA := fields[4]
+
+	// we must confirm at least one endpoint with the k8s namespace and
+	// service account in the CSR exists on the node.
+	//
+	// this is a security measure ensuring we do not issue certificates for
+	// pods that are not available on the host.
+	eps := s.epManager.GetEndpointsByServiceAccount(k8sNamespace, k8sSA)
+	if len(eps) == 0 {
+		return nil, fmt.Errorf("no endpoints found for service account %s in namespace %s", k8sSA, k8sNamespace)
+	}
+
+	pemCert, err := s.createCertificate(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	s.log.Debug("created certificate for service account",
+		logfields.K8sNamespace, k8sNamespace,
+		logfields.K8sServiceAccount, k8sSA,
+	)
+	resp := &pb.IstioCertificateResponse{
+		CertChain: []string{
+			pemCert,
+			s.caCertPEM,
+		},
+	}
+	return resp, nil
+}

--- a/pkg/ztunnel/ca/ca_server_test.go
+++ b/pkg/ztunnel/ca/ca_server_test.go
@@ -1,12 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package xds
+package ca
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
 	"net/netip"
+	"net/url"
 	"sync"
+	"testing"
+	"time"
 
 	"github.com/cilium/hive/cell"
 
@@ -18,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/ztunnel/pb"
 )
 
 // MockEndpointManager is a mock implementation of endpointmanager.EndpointManager
@@ -169,4 +182,168 @@ func (m *MockEndpointManager) InitHostEndpointLabels(ctx context.Context) {
 
 func (m *MockEndpointManager) UpdatePolicy(idsToRegen *set.Set[identity.NumericIdentity], fromRev, toRev uint64) {
 	panic("MockEndpointManager.UpdatePolicy not implemented")
+}
+
+//	Serial Number:
+//	    65:09:76:9c:41:d2:d8:ba:5c:f4:2f:df:98:e5:d5:b8
+//	Signature Algorithm: sha256WithRSAEncryption
+//	Issuer: O=cluster.local
+//	Validity
+//	    Not Before: Jun 25 13:49:10 2025 GMT
+//	    Not After : Jun 23 13:49:10 2035 GMT
+//	Subject: O=cluster.local
+//	Subject Public Key Info:
+//	    Public Key Algorithm: rsaEncryption
+//	        Public-Key: (2048 bit)
+//	        Modulus:
+//	        Exponent: 65537 (0x10001)
+//	X509v3 extensions:
+//	    X509v3 Key Usage: critical
+//	        Certificate Sign
+//	    X509v3 Basic Constraints: critical
+//	        CA:TRUE
+//	    X509v3 Subject Key Identifier:
+//	        CA:74:4D:0E:F1:80:03:8A:9A:0D:14:7A:5F:F2:8A:1F:0C:48:D9:62
+//
+// Signature Algorithm: sha256WithRSAEncryption
+// Signature Value:
+func TestCreateCertificate(t *testing.T) {
+	// create an RSA private caKey
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	// create certificate for signing other certs, we need to do a round-trip
+	// through DER encoding to sign the certificate.
+	caSerialNumber := big.NewInt(0xDEADBEEF)
+	caCert := &x509.Certificate{
+		SerialNumber: caSerialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"cluster.local"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	caCert, err = x509.ParseCertificate(caCertDER)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	caCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCertDER,
+	})
+
+	s := Server{
+		caCert:    caCert,
+		caKey:     caKey,
+		caCertPEM: string(caCertPEM),
+		epManager: &MockEndpointManager{
+			_GetEndpointsByServiceAccount: func(namespace string, serviceAccount string) []*endpoint.Endpoint {
+				return []*endpoint.Endpoint{{}}
+			},
+		},
+		log: slog.Default(),
+	}
+
+	// we'll generate a CSR using the simple CSR we see in a default ztunnel
+	// deployment:
+	//         Version: 0 (0x0)
+	//     Subject:
+	//     Subject Public Key Info:
+	//         Public Key Algorithm: id-ecPublicKey
+	//             Public-Key: (256 bit)
+	//             pub:
+	//             ASN1 OID: prime256v1
+	//             NIST CURVE: P-256
+	//     Attributes:
+	//     Requested Extensions:
+	//         X509v3 Subject Alternative Name: critical
+	//             URI:spiffe:///ns/kube-system/sa/default
+	// Signature Algorithm: ecdsa-with-SHA256
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate private key: %v", err)
+	}
+
+	uriSAN, err := url.Parse("spiffe:///ns/kube-system/sa/default")
+	if err != nil {
+		t.Fatalf("failed to parse URI: %v", err)
+	}
+
+	csr := x509.CertificateRequest{
+		Subject:            pkix.Name{},
+		URIs:               []*url.URL{uriSAN},
+		PublicKey:          clientKey.PublicKey,
+		PublicKeyAlgorithm: x509.ECDSA,
+	}
+
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &csr, clientKey)
+	if err != nil {
+		t.Fatalf("failed to create CSR: %v", err)
+	}
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+	istioCSR := &pb.IstioCertificateRequest{
+		Csr: string(csrPEM),
+	}
+
+	istioCertResp, err := s.CreateCertificate(t.Context(), istioCSR)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	if len(istioCertResp.CertChain) != 2 {
+		t.Fatalf("expected 2 certificates in the chain, got %d", len(istioCertResp.CertChain))
+	}
+
+	// client certificate must be first per ztunnel's parsing rules
+	clientCertPEM := istioCertResp.CertChain[0]
+	clientCertBlock, _ := pem.Decode([]byte(clientCertPEM))
+	if clientCertBlock == nil || clientCertBlock.Type != "CERTIFICATE" {
+		t.Fatalf("failed to decode client certificate PEM")
+	}
+	clientCert, err := x509.ParseCertificate(clientCertBlock.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse client certificate: %v", err)
+	}
+
+	// trust anchor must be last per ztunnel's parsing rules.
+	rootCertPEM := istioCertResp.CertChain[1]
+	rootCertBlock, _ := pem.Decode([]byte(rootCertPEM))
+	if rootCertBlock == nil || rootCertBlock.Type != "CERTIFICATE" {
+		t.Fatalf("failed to decode root certificate PEM")
+	}
+	rootCert, err := x509.ParseCertificate(rootCertBlock.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse root certificate: %v", err)
+	}
+
+	// validate client certificate's signature
+	if err := clientCert.CheckSignatureFrom(rootCert); err != nil {
+		t.Fatalf("client certificate signature validation failed: %v", err)
+	}
+	// validate client cert's public key algo
+	if clientCert.PublicKeyAlgorithm != x509.ECDSA {
+		t.Fatalf("expected client certificate public key algorithm to be ECDSA, got %v", clientCert.PublicKeyAlgorithm)
+	}
+	// validate client's URI SAN
+	if len(clientCert.URIs) != 1 || clientCert.URIs[0].String() != uriSAN.String() {
+		t.Fatalf("expected client certificate to have URI SAN %s, got %s", uriSAN.String(), clientCert.URIs[0].String())
+	}
+
+	// we create the CA certificate, so lets just ensure we see the same
+	// certificate serial number, this is enough to know we served the cert
+	// we created above as the root
+	if rootCert.SerialNumber.Cmp(caSerialNumber) != 0 {
+		t.Fatalf("expected root certificate serial number to be %s, got %s", caSerialNumber, rootCert.SerialNumber)
+	}
 }

--- a/pkg/ztunnel/xds/xds_server.go
+++ b/pkg/ztunnel/xds/xds_server.go
@@ -4,27 +4,17 @@
 package xds
 
 import (
-	"bytes"
-	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"math"
-	"math/big"
 	"net"
-	"os"
-	"strings"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/cilium/statedb"
 
+	"github.com/cilium/cilium/pkg/ztunnel/ca"
 	"github.com/cilium/cilium/pkg/ztunnel/pb"
 	"github.com/cilium/cilium/pkg/ztunnel/table"
 
@@ -33,23 +23,10 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/safeio"
 	"github.com/cilium/cilium/pkg/time"
 )
 
 const (
-	// bootstrapKeyPath is the private key used to boostrap ZTunnel to CA
-	// TLS connection.
-	bootstrapKeyPath = "/etc/ztunnel/bootstrap-private.key"
-	// bootstrapCertPath is the certificate used to boostrap ZTunnel to CA
-	// TLS connection.
-	bootstrapCertPath = "/etc/ztunnel/bootstrap-root.crt"
-	// caKeyPath is the private key used to sign client certificates.
-	caKeyPath = "/etc/ztunnel/ca-private.key"
-	// caCertPath is the root certificate trust anchor for issued client
-	// certificates.
-	caCertPath = "/etc/ztunnel/ca-root.crt"
-
 	// xdsTypeURLAddress is the Aggregated Discovery Service (ADS) type URL
 	// signaling a subscription to workload and services.
 	xdsTypeURLAddress = "type.googleapis.com/istio.workload.Address"
@@ -58,33 +35,25 @@ const (
 	xdsTypeURLAuthorization = "type.googleapis.com/istio.security.Authorization"
 )
 
-var _ pb.IstioCertificateServiceServer = (*Server)(nil)
 var _ v3.AggregatedDiscoveryServiceServer = (*Server)(nil)
 
-// Server is a private implemenation of xDS for use with the stand-alone
-// zTunnel proxy.
+// Server is the xDS control plane for the stand-alone ztunnel proxy.
 //
-// This xDS server will implement a scoped-down xDS API consisting of a
-// certificate authority capable of signing CSR(s)s submitted by zTunnel and a
-// control plane capable of sending workload and service events to zTunnel.
+// It sends workload and service discovery events to ztunnel. The
+// certificate-signing handler lives in pkg/ztunnel/ca; Server registers it on
+// the same gRPC server alongside the ADS handler.
 type Server struct {
 	l                         net.Listener
 	g                         *grpc.Server
 	log                       *slog.Logger
 	epManager                 endpointmanager.EndpointManager
 	k8sCiliumEndpointsWatcher *watchers.K8sCiliumEndpointsWatcher
-	caCert                    *x509.Certificate
 	db                        *statedb.DB
 	enrolledNamespaceTable    statedb.RWTable[*table.EnrolledNamespace]
 	// endpointEventChan is shared across streams. Overlapping sends during
 	// ztunnel reconnect are safe since xDS upserts are idempotent.
 	endpointEventChan chan *EndpointEvent
 	metrics           *Metrics
-	// cache the PEM encoded certificate, we return this as the trust anchor
-	// on zTunnel certificate creation requests.
-	caCertPEM string
-	caKey     *rsa.PrivateKey
-	pb.UnimplementedIstioCertificateServiceServer
 	v3.UnimplementedAggregatedDiscoveryServiceServer
 }
 
@@ -108,100 +77,8 @@ func newServer(
 	}
 }
 
-// initCA performs the required action to initialize the certificate authority
-// server.
-func (x *Server) initCA() error {
-	// caCertPath will be a PEM encoded certificate, we need to decode this
-	// to DER to parse as an x509.Certificate and also cache the PEM string.
-	certFile, err := os.OpenFile(caCertPath, os.O_RDONLY, 0)
-	if err != nil {
-		return fmt.Errorf("failed to open CA certificate file %s: %w", caCertPath, err)
-	}
-	defer func() {
-		err := certFile.Close()
-		if err != nil {
-			x.log.Error("failed to close CA certificate file",
-				logfields.Path,
-				caCertPath,
-				logfields.Error,
-				err)
-		}
-	}()
-
-	buf, err := safeio.ReadAllLimit(certFile, safeio.MB)
-	if err != nil {
-		return fmt.Errorf("failed to read CA certificate file %s: %w", caCertPath, err)
-	}
-
-	x.caCertPEM = string(buf)
-
-	block, _ := pem.Decode(buf)
-	if block.Type != "CERTIFICATE" {
-		return fmt.Errorf("CA certificate file %s is not a valid PEM encoded certificate", caCertPath)
-	}
-
-	x.caCert, err = x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return fmt.Errorf("failed to parse CA certificate file %s: %w", caCertPath, err)
-	}
-
-	// caKeyPath will be a PEM encoded certificate. We can parse this into an
-	// rsa.PrivateKey.
-	keyFile, err := os.OpenFile(caKeyPath, os.O_RDONLY, 0)
-	if err != nil {
-		return fmt.Errorf("failed to open CA private key file %s: %w",
-			caKeyPath,
-			err)
-	}
-	defer func() {
-		err := keyFile.Close()
-		if err != nil {
-			x.log.Error("failed to close CA private key file",
-				logfields.Path,
-				caKeyPath,
-				logfields.Error,
-				err)
-		}
-	}()
-
-	buf, err = safeio.ReadAllLimit(keyFile, safeio.MB)
-	if err != nil {
-		return fmt.Errorf("failed to read CA private key file %s: %w", caKeyPath, err)
-	}
-
-	block, _ = pem.Decode(buf)
-	if block.Type != "PRIVATE KEY" {
-		return fmt.Errorf("CA private key file %s is not a valid PEM encoded RSA private key", caKeyPath)
-	}
-
-	switch block.Type {
-	case "PRIVATE KEY":
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
-		}
-
-		// only support RSA keys for now.
-		var ok bool
-		if x.caKey, ok = key.(*rsa.PrivateKey); !ok {
-			return fmt.Errorf("CA private key file %s is not a valid RSA private key", caKeyPath)
-		}
-	case "RSA PRIVATE KEY":
-		// this block type parses directly to an RSA private key.
-		x.caKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("failed to parse CA private key file %s: %w", caKeyPath, err)
-		}
-
-	default:
-		return fmt.Errorf("CA private key file %s is not a valid PEM encoded RSA private key, got %q", caKeyPath, block.Type)
-	}
-
-	return nil
-}
-
 // Serve will create the listening gRPC service and register the required xDS
-// endpoints.
+// and certificate-signing endpoints.
 //
 // If Serve returns without an error the gRPC server is launched within a new
 // go routine.
@@ -210,14 +87,15 @@ func (x *Server) initCA() error {
 func (x *Server) Serve() error {
 	var err error
 
-	// Note: this initialization code could technically be done during
-	// construction, but due to hive/cell needing construction to happen without
-	// side effects, do it right before serving.
-	if err = x.initCA(); err != nil {
+	// Note: this initialization could technically be done during
+	// construction, but due to hive/cell needing construction to happen
+	// without side effects, do it right before serving.
+	caSrv, err := ca.NewServer(x.log, x.epManager)
+	if err != nil {
 		return fmt.Errorf("failed to initialize CA: %w", err)
 	}
 
-	creds, err := credentials.NewServerTLSFromFile(bootstrapCertPath, bootstrapKeyPath)
+	creds, err := ca.LoadServerTLSCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC TLS credentials: %w", err)
 	}
@@ -240,7 +118,7 @@ func (x *Server) Serve() error {
 
 	x.g = grpc.NewServer(grpcOptions...)
 
-	pb.RegisterIstioCertificateServiceServer(x.g, x)
+	pb.RegisterIstioCertificateServiceServer(x.g, caSrv)
 	v3.RegisterAggregatedDiscoveryServiceServer(x.g, x)
 
 	x.l, err = net.Listen("tcp", "127.0.0.1:15012")
@@ -264,107 +142,6 @@ func (x *Server) Serve() error {
 // would occur when net.Listen() returns an error.
 func (x *Server) GracefulStop() {
 	x.g.GracefulStop()
-}
-
-// createCertificate will generate a certificate given a CSR and return the
-// PEM encoded string.
-func (x *Server) createCertificate(req *x509.CertificateRequest) (string, error) {
-	// generate the certificate serial
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serial, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate serial number: %w", err)
-	}
-
-	certTemplate := &x509.Certificate{
-		SerialNumber:   serial,
-		Subject:        req.Subject,
-		URIs:           req.URIs,
-		DNSNames:       req.DNSNames,
-		IPAddresses:    req.IPAddresses,
-		EmailAddresses: req.EmailAddresses,
-		NotBefore:      time.Now(),
-		NotAfter:       time.Now().Add(30 * (24 * time.Hour)),
-	}
-
-	der, err := x509.CreateCertificate(rand.Reader, certTemplate, x.caCert, req.PublicKey, x.caKey)
-	if err != nil {
-		return "", fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	pem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	return string(pem), nil
-}
-
-// CreateCertificate implements the certificate signing process.
-func (x *Server) CreateCertificate(ctx context.Context, csr *pb.IstioCertificateRequest) (*pb.IstioCertificateResponse, error) {
-	x.log.Debug("received CSR request")
-
-	if len(csr.Csr) == 0 {
-		return nil, fmt.Errorf("received empty CSR")
-	}
-
-	buf := bytes.NewBufferString(csr.Csr)
-
-	block, _ := pem.Decode(buf.Bytes())
-	if block.Type != "CERTIFICATE REQUEST" {
-		return nil, fmt.Errorf("not a certificate signing request")
-	}
-
-	req, err := x509.ParseCertificateRequest(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CSR: %w", err)
-	}
-
-	if err = req.CheckSignature(); err != nil {
-		return nil, fmt.Errorf("CSR signature check failed: %w", err)
-	}
-
-	if len(req.URIs) != 1 {
-		return nil, fmt.Errorf("CSR must contain exactly one URI SAN")
-	}
-
-	uri := req.URIs[0]
-
-	if uri.Scheme != "spiffe" {
-		return nil, fmt.Errorf("CSR URI scheme must be 'spiffe', got %q", uri.Scheme)
-	}
-
-	fields := strings.Split(uri.Path, "/")
-	// 5 fields since uri has leading '/', strings.Split will never omit empty
-	// fields.
-	if len(fields) != 5 {
-		return nil, fmt.Errorf("CSR URI path must be in the format /ns/<namespace>/sa/<service-account>, got %q %q", uri.Path, fields)
-	}
-	k8sNamespace := fields[2]
-	k8sSA := fields[4]
-
-	// we must confirm at least one endpoint with the k8s namespace and
-	// service account in the CSR exists on the node.
-	//
-	// this is a security measure ensuring we do not issue certificates for
-	// pods that are not available on the host.
-	eps := x.epManager.GetEndpointsByServiceAccount(k8sNamespace, k8sSA)
-	if len(eps) == 0 {
-		return nil, fmt.Errorf("no endpoints found for service account %s in namespace %s", k8sSA, k8sNamespace)
-	}
-
-	pem, err := x.createCertificate(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	x.log.Debug("created certificate for service account",
-		logfields.K8sNamespace, k8sNamespace,
-		logfields.K8sServiceAccount, k8sSA,
-	)
-	resp := &pb.IstioCertificateResponse{
-		CertChain: []string{
-			pem,
-			x.caCertPEM,
-		},
-	}
-	return resp, nil
 }
 
 func (x *Server) StreamAggregatedResources(stream v3.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {


### PR DESCRIPTION
Split the built-in certificate authority cert-handling code out of `pkg/ztunnel/xds` into a new `pkg/ztunnel/ca` package. The xDS server today combines two unrelated gRPC services on one TCP listener — `IstioCertificateService` (CA) and `AggregatedDiscoveryService` (ADS) — and the cert-loading and signing logic is mixed in with the xDS stream-processor and listener setup. Moving CA into its own package separates the concerns and lets a follow-up switch the xDS server to a Unix domain socket without dragging the CA's TLS-bootstrap plumbing along.

This is a code-organization refactor: the xDS server still owns the TCP listener on `127.0.0.1:15012` and the `*grpc.Server`. It now imports `ca`, constructs `ca.NewServer` (which loads the CA cert/key from disk), and registers it on the gRPC server alongside the ADS handler. The bootstrap TLS helper is exposed as `ca.LoadServerTLSCredentials`. No functional change for users, no Helm changes.

- **`pkg/ztunnel/ca`** (new): `Server` (cert handler), `NewServer`, `LoadServerTLSCredentials`, the `bootstrap{Key,Cert}Path` and `ca{Key,Cert}Path` constants, and `TestCreateCertificate` — all moved verbatim from `pkg/ztunnel/xds`.
- **`pkg/ztunnel/xds`**: stripped of all CA fields (`caCert`, `caCertPEM`, `caKey`) and the cert-handling methods. `Serve()` now calls `ca.LoadServerTLSCredentials` for TLS, `ca.NewServer` to construct the cert handler, and `pb.RegisterIstioCertificateServiceServer` to wire it up.

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
- [x] Thanks for contributing!
