### PR TITLE
Fix: verifier_diff.py Out-of-bounds exception when no difference at all

### DIFF
--- a/contrib/scripts/verifier_diff.py
+++ b/contrib/scripts/verifier_diff.py
@@ -206,7 +206,7 @@ def _store_stats_group(df: pd.DataFrame, output_file: str, fmt: str, key: str, g
     if groupby:
         output_file = os.path.join(output_file, f"groupby_{'_'.join(groupby)}.{fmt}")
         df = df.groupby(groupby)['diff'].describe(percentiles=[])
-        df_nonzero = df[(df[y] != 0).any(axis=1)]
+        df_nonzero = df[(df[y] >= 0).any(axis=1)]
         df_nonzero.plot(kind='barh', y=y, figsize=(10, 0.15*len(df)), xlabel=key,
                 title=f"Difference in {key} grouped by {tuple(groupby)}")
     else:


### PR DESCRIPTION
Changed df_nonzero to include 0
I looked at the values with the key pairs and file 2 values were greater than file 1 and line 204 in verifier_diff.py shows df['diff'] = df['file2'] - df['file1'] which means that all values should be positive values
Tested with the provided 49c0eafb91-bpf-next.json, 49c0eafb91-cnums.json and after modification the index 0 is out of bounds for axis 0 with size 0 did not occur nor any other errors were outputted.

Signed-off-by: phantomight <280124361+phantomight@users.noreply.github.com>
