### PR TITLE
ci: Bump operator leader-election timing to reduce conflict noise

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -116,11 +116,9 @@ runs:
             --set-string=hubble.relay.extraEnv[1].name=CILIUM_INVALID_METRIC_VALUE_DETECTOR \
             --set-string=hubble.relay.extraEnv[1].value=true \
             --set-string=hubble.relay.extraEnv[2].name=CILIUM_SLOG_DUP_ATTR_DETECTOR \
-            --set-string=hubble.relay.extraEnv[2].value=true"
-
-          if [ -f "${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml" ]; then
-            DEFAULTS+=" --values=${{ inputs.chart-dir }}/../../../.github/actions/helm-default/ci-required-values.yaml"
-          fi
+            --set-string=hubble.relay.extraEnv[2].value=true \
+            --helm-set-string=operator.extraArgs[0]=--leader-election-lease-duration=30s \
+            --helm-set-string=operator.extraArgs[1]=--leader-election-renew-deadline=20s"
 
           IMAGE=""
           if [ "${{ inputs.image-tag }}" != "" ]; then


### PR DESCRIPTION
Conformance L7-only frequently fails check-log-errors on this operator
log:

    "Failed to update lease" err="Operation cannot be fulfilled on
    leases.coordination.k8s.io \"cilium-operator-resource-lock\": the
    object has been modified..." subsys=klog

The attached sysdump in GH-45426 shows a single operator replica with a single
managedFields entry on the Lease, so this is not a replica race.  The fast-path
Update has a client timeout of 5s by default. It's possible that the GitHub
runner that L7-only test runs on is resource-constrained enough to timeout at
5s.

My best interpretation of what's happening is that client gives up, the
request stays in flight and eventually commits, and the slow-path Get/Update
then races that delayed commit and returns 409. The next iteration succeeds.

Rather than filter this in logging, let's raise the timeouts in CI. Bumping
RenewDeadline to 20s doubles the derived HTTP timeout to 10s, which is enough
room for this resource-constrained runner. Hopefully this is acceptable for a
CI environment.

Fixes: #45426