### PR TITLE
cilium-cli/connectivity: skip non-Running cilium agent pods on test init

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -20,7 +20,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/cilium-cli/connectivity/perf/common"
@@ -974,22 +976,36 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	return nil
 }
 
-// initCiliumPods fetches the Cilium agent pod information from all clients
+// initCiliumPods fetches Running Cilium agent pods from all clients. Each
+// cluster must contribute at least one Running, non-terminating pod.
 func (ct *ConnectivityTest) initCiliumPods(ctx context.Context) error {
+	runningPhase := fields.OneTermEqualSelector("status.phase", string(corev1.PodRunning)).String()
 	for _, client := range ct.clients.clients() {
-		ciliumPods, err := client.ListPods(ctx, ct.params.CiliumNamespace, metav1.ListOptions{LabelSelector: ct.params.AgentPodSelector})
+		ciliumPods, err := client.ListPods(ctx, ct.params.CiliumNamespace, metav1.ListOptions{
+			LabelSelector: ct.params.AgentPodSelector,
+			FieldSelector: runningPhase,
+		})
 		if err != nil {
 			return fmt.Errorf("unable to list Cilium pods: %w", err)
 		}
-		if len(ciliumPods.Items) == 0 {
-			return fmt.Errorf("no cilium agent pods found in -n %s -l %s", ct.params.CiliumNamespace, ct.params.AgentPodSelector)
-		}
+
+		clusterRunning := 0
 		for _, ciliumPod := range ciliumPods.Items {
+			// FieldSelector cannot match DeletionTimestamp, recheck locally.
+			if ciliumPod.DeletionTimestamp != nil {
+				ct.Warnf("Skipping Cilium pod %q: terminating", ciliumPod.Name)
+				continue
+			}
 			// TODO: Can Cilium pod names collide across clusters?
 			ct.ciliumPods[ciliumPod.Name] = Pod{
 				K8sClient: client,
 				Pod:       ciliumPod.DeepCopy(),
 			}
+			clusterRunning++
+		}
+		if clusterRunning == 0 {
+			return fmt.Errorf("no Running cilium agent pods available in cluster %q (namespace %s, selector %s)",
+				client.ClusterName(), ct.params.CiliumNamespace, ct.params.AgentPodSelector)
 		}
 	}
 
@@ -1035,11 +1051,26 @@ func (ct *ConnectivityTest) getCiliumNodes(ctx context.Context) error {
 }
 
 // DetectMinimumCiliumVersion returns the smallest Cilium version running in
-// the cluster(s)
+// the cluster(s). Pods are re-fetched before exec to skip ones that have
+// transitioned out of Running since initCiliumPods.
 func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*semver.Version, error) {
 	var minVersion *semver.Version
 	for name, ciliumPod := range ct.ciliumPods {
-		podVersion, err := ciliumPod.K8sClient.GetCiliumVersion(ctx, ciliumPod.Pod)
+		fresh, err := ciliumPod.K8sClient.GetPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				ct.Warnf("Skipping Cilium pod %q for version detection: pod no longer exists", name)
+				continue
+			}
+			return nil, fmt.Errorf("unable to refresh Cilium pod %q: %w", name, err)
+		}
+		if fresh.Status.Phase != corev1.PodRunning || fresh.DeletionTimestamp != nil {
+			ct.Warnf("Skipping Cilium pod %q for version detection: phase=%q terminating=%v",
+				name, fresh.Status.Phase, fresh.DeletionTimestamp != nil)
+			continue
+		}
+
+		podVersion, err := ciliumPod.K8sClient.GetCiliumVersion(ctx, fresh)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse Cilium version on pod %q: %w", name, err)
 		}

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -20,7 +20,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/cilium-cli/connectivity/perf/common"
@@ -970,22 +972,36 @@ func (ct *ConnectivityTest) initClients(ctx context.Context) error {
 	return nil
 }
 
-// initCiliumPods fetches the Cilium agent pod information from all clients
+// initCiliumPods fetches Running Cilium agent pods from all clients. Each
+// cluster must contribute at least one Running, non-terminating pod.
 func (ct *ConnectivityTest) initCiliumPods(ctx context.Context) error {
+	runningPhase := fields.OneTermEqualSelector("status.phase", string(corev1.PodRunning)).String()
 	for _, client := range ct.clients.clients() {
-		ciliumPods, err := client.ListPods(ctx, ct.params.CiliumNamespace, metav1.ListOptions{LabelSelector: ct.params.AgentPodSelector})
+		ciliumPods, err := client.ListPods(ctx, ct.params.CiliumNamespace, metav1.ListOptions{
+			LabelSelector: ct.params.AgentPodSelector,
+			FieldSelector: runningPhase,
+		})
 		if err != nil {
 			return fmt.Errorf("unable to list Cilium pods: %w", err)
 		}
-		if len(ciliumPods.Items) == 0 {
-			return fmt.Errorf("no cilium agent pods found in -n %s -l %s", ct.params.CiliumNamespace, ct.params.AgentPodSelector)
-		}
+
+		clusterRunning := 0
 		for _, ciliumPod := range ciliumPods.Items {
+			// FieldSelector cannot match DeletionTimestamp, recheck locally.
+			if ciliumPod.DeletionTimestamp != nil {
+				ct.Warnf("Skipping Cilium pod %q: terminating", ciliumPod.Name)
+				continue
+			}
 			// TODO: Can Cilium pod names collide across clusters?
 			ct.ciliumPods[ciliumPod.Name] = Pod{
 				K8sClient: client,
 				Pod:       ciliumPod.DeepCopy(),
 			}
+			clusterRunning++
+		}
+		if clusterRunning == 0 {
+			return fmt.Errorf("no Running cilium agent pods available in cluster %q (namespace %s, selector %s)",
+				client.ClusterName(), ct.params.CiliumNamespace, ct.params.AgentPodSelector)
 		}
 	}
 
@@ -1031,11 +1047,26 @@ func (ct *ConnectivityTest) getCiliumNodes(ctx context.Context) error {
 }
 
 // DetectMinimumCiliumVersion returns the smallest Cilium version running in
-// the cluster(s)
+// the cluster(s). Pods are re-fetched before exec to skip ones that have
+// transitioned out of Running since initCiliumPods.
 func (ct *ConnectivityTest) DetectMinimumCiliumVersion(ctx context.Context) (*semver.Version, error) {
 	var minVersion *semver.Version
 	for name, ciliumPod := range ct.ciliumPods {
-		podVersion, err := ciliumPod.K8sClient.GetCiliumVersion(ctx, ciliumPod.Pod)
+		fresh, err := ciliumPod.K8sClient.GetPod(ctx, ciliumPod.Pod.Namespace, ciliumPod.Pod.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				ct.Warnf("Skipping Cilium pod %q for version detection: pod no longer exists", name)
+				continue
+			}
+			return nil, fmt.Errorf("unable to refresh Cilium pod %q: %w", name, err)
+		}
+		if fresh.Status.Phase != corev1.PodRunning || fresh.DeletionTimestamp != nil {
+			ct.Warnf("Skipping Cilium pod %q for version detection: phase=%q terminating=%v",
+				name, fresh.Status.Phase, fresh.DeletionTimestamp != nil)
+			continue
+		}
+
+		podVersion, err := ciliumPod.K8sClient.GetCiliumVersion(ctx, fresh)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse Cilium version on pod %q: %w", name, err)
 		}

--- a/cilium-cli/connectivity/check/context_test.go
+++ b/cilium-cli/connectivity/check/context_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/k8s"
+)
+
+func newCiliumAgentPod(name string, phase corev1.PodPhase, terminating bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kube-system",
+			Labels:    map[string]string{"k8s-app": "cilium"},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+	if terminating {
+		now := metav1.Now()
+		pod.DeletionTimestamp = &now
+		pod.Finalizers = []string{"cilium.io/test"}
+	}
+	return pod
+}
+
+func TestInitCiliumPodsSkipsNonRunning(t *testing.T) {
+	objs := []runtime.Object{
+		newCiliumAgentPod("cilium-running", corev1.PodRunning, false),
+		newCiliumAgentPod("cilium-terminating", corev1.PodRunning, true),
+	}
+	ct, _ := newFakeConnectivityTest(t, objs...)
+	ct.params.CiliumNamespace = "kube-system"
+	ct.params.AgentPodSelector = defaults.AgentPodSelector
+	ct.ciliumPods = make(map[string]Pod)
+
+	require.NoError(t, ct.initCiliumPods(context.Background()))
+	assert.Len(t, ct.ciliumPods, 1, "only the Running, non-terminating pod should be included")
+	_, ok := ct.ciliumPods["cilium-running"]
+	assert.True(t, ok, "Running pod should be included")
+	_, ok = ct.ciliumPods["cilium-terminating"]
+	assert.False(t, ok, "Terminating pod should be skipped")
+}
+
+func TestInitCiliumPodsErrorWhenAllNonRunning(t *testing.T) {
+	objs := []runtime.Object{
+		newCiliumAgentPod("cilium-terminating-1", corev1.PodRunning, true),
+		newCiliumAgentPod("cilium-terminating-2", corev1.PodRunning, true),
+	}
+	ct, _ := newFakeConnectivityTest(t, objs...)
+	ct.params.CiliumNamespace = "kube-system"
+	ct.params.AgentPodSelector = defaults.AgentPodSelector
+	ct.ciliumPods = make(map[string]Pod)
+
+	err := ct.initCiliumPods(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Running cilium agent pods")
+}
+
+func TestInitCiliumPodsMultiClusterErrorWhenOneClusterEmpty(t *testing.T) {
+	srcClient := &k8s.Client{
+		Clientset: fake.NewSimpleClientset(newCiliumAgentPod("cilium-src-running", corev1.PodRunning, false)),
+	}
+	dstClient := &k8s.Client{
+		Clientset: fake.NewSimpleClientset(newCiliumAgentPod("cilium-dst-terminating", corev1.PodRunning, true)),
+	}
+
+	ct := &ConnectivityTest{
+		params: Parameters{
+			CiliumNamespace:  "kube-system",
+			AgentPodSelector: defaults.AgentPodSelector,
+			Writer:           &bytes.Buffer{},
+		},
+		clients:    &deploymentClients{src: srcClient, dst: dstClient},
+		ciliumPods: make(map[string]Pod),
+	}
+
+	err := ct.initCiliumPods(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Running cilium agent pods available in cluster")
+}


### PR DESCRIPTION
## Problem

`cilium connectivity test` fails to start when any cilium agent pod in the cluster is in a Pending, Initializing, or Terminating state — a common condition on clusters with node churn, partial rollouts, or routine DaemonSet restarts.

## Root cause

`initCiliumPods` accepts every pod returned by the API. The next step (`DetectMinimumCiliumVersion`) iterates that map and execs into each pod to read its version. On a non-Running pod the cilium binary isn't available, the exec fails, and the user sees:

```
Unable to detect Cilium version, assuming v1.X.Y for connectivity tests:
unable to parse Cilium version on pod "cilium-..."
```

Downstream feature detection then runs against the wrong assumed version.

## Fix

Filter at intake in `initCiliumPods`: skip any pod where `Phase != Running` or `DeletionTimestamp != nil`, with a per-pod warning. If no Running pods remain after filtering, return a clear error rather than silently falling through to the assumed-version path.

```go
if ciliumPod.Status.Phase != corev1.PodRunning || ciliumPod.DeletionTimestamp != nil {
    ct.Warnf("Skipping Cilium pod %q: phase=%q terminating=%v", …)
    continue
}
```

## Verification

Two new unit tests in `cilium-cli/connectivity/check/context_test.go`:

- `TestInitCiliumPodsSkipsNonRunning` — seeds Running, Pending, and Terminating cilium pods; asserts only the Running, non-terminating one is retained.
- `TestInitCiliumPodsErrorWhenAllNonRunning` — all pods are Pending; asserts the new error path with `"no Running cilium agent pods"`.

```
$ go test ./cilium-cli/connectivity/check/... -count=1 -race -run "TestInitCiliumPods" -v
=== RUN   TestInitCiliumPodsSkipsNonRunning
--- PASS: TestInitCiliumPodsSkipsNonRunning (0.00s)
=== RUN   TestInitCiliumPodsErrorWhenAllNonRunning
--- PASS: TestInitCiliumPodsErrorWhenAllNonRunning (0.00s)
PASS
ok  	github.com/cilium/cilium/cilium-cli/connectivity/check	1.126s
```

Full package tests, `golangci-lint`, and `go build ./...` all clean locally.

Fixes: #36404

```release-note
cilium-cli: connectivity test now skips non-Running and Terminating cilium agent pods on init instead of failing, making the test resilient to node churn and rolling restarts.
```