### PR TITLE
[41867] Part 5: bpf: nat: skip SNAT for same subnet traffic in hybrid overlay mode

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -390,12 +390,10 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	/* Check if the source and destination IP has same subnet ID. */
 	bool same_subnet_id = false;
 
-	if (CONFIG(hybrid_routing_enabled)) {
-		__u32 src_subnet_id = lookup_ip6_subnet_id((union v6addr *)&ip6->saddr);
-		__u32 dst_subnet_id = lookup_ip6_subnet_id((union v6addr *)&ip6->daddr);
+	if (CONFIG(hybrid_routing_enabled))
+		same_subnet_id = is_subnet_same_id6((union v6addr *)&ip6->saddr,
+						    (union v6addr *)&ip6->daddr);
 
-		same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-	}
 	if ((info && info->flag_skip_tunnel) || same_subnet_id)
 		goto skip_tunnel;
 
@@ -859,12 +857,9 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	/* Check if the source and destination IP has same subnet ID. */
 	bool same_subnet_id = false;
 	/* Lookup the subnet IDs for the source and destination IPs in hybrid routing mode. */
-	if (CONFIG(hybrid_routing_enabled)) {
-		__u32 src_subnet_id = lookup_ip4_subnet_id(ip4->saddr);
-		__u32 dst_subnet_id = lookup_ip4_subnet_id(ip4->daddr);
+	if (CONFIG(hybrid_routing_enabled))
+		same_subnet_id = is_subnet_same_id4(ip4->saddr, ip4->daddr);
 
-		same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-	}
 	if ((info && info->flag_skip_tunnel) || same_subnet_id)
 		goto skip_tunnel;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -847,13 +847,9 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		const union v6addr *daddr = (union v6addr *)&ip6->daddr;
 		bool same_subnet_id = false;
 
-		if (CONFIG(hybrid_routing_enabled)) {
-			const union v6addr *saddr = (union v6addr *)&ip6->saddr;
-			__u32 src_subnet_id = lookup_ip6_subnet_id(saddr);
-			__u32 dst_subnet_id = lookup_ip6_subnet_id(daddr);
-
-			same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-		}
+		if (CONFIG(hybrid_routing_enabled))
+			same_subnet_id = is_subnet_same_id6((union v6addr *)&ip6->saddr,
+							    (union v6addr *)&ip6->daddr);
 
 		info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info) {
@@ -1424,12 +1420,8 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 
 	bool same_subnet_id = false;
 
-	if (CONFIG(hybrid_routing_enabled)) {
-		__u32 src_subnet_id = lookup_ip4_subnet_id(ip4->saddr);
-		__u32 dst_subnet_id = lookup_ip4_subnet_id(ip4->daddr);
-
-		same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-	}
+	if (CONFIG(hybrid_routing_enabled))
+		same_subnet_id = is_subnet_same_id4(ip4->saddr, ip4->daddr);
 
 	/* Determine the destination category for policy fallback. */
 	info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -24,6 +24,7 @@
 #include "stubs.h"
 #include "trace.h"
 #include "aux.h"
+#include "subnet.h"
 
 /* Nodeport NAT minimum port value */
 #define NODEPORT_PORT_MIN_NAT CONFIG(nodeport_port_max) + 1
@@ -776,6 +777,18 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 		 * by the remote node if its native dev's
 		 * rp_filter=1.
 		 */
+
+		/* In hybrid routing mode, skip SNAT for traffic within the same
+		 * subnet group. These packets are natively routed and don't need
+		 * masquerading.
+		 */
+		if (CONFIG(hybrid_routing_enabled)) {
+			__u32 src_subnet_id = lookup_ip4_subnet_id(tuple->saddr);
+			__u32 dst_subnet_id = lookup_ip4_subnet_id(tuple->daddr);
+
+			if ((src_subnet_id == dst_subnet_id) && (src_subnet_id != 0))
+				return NAT_PUNT_TO_STACK;
+		}
 
 		if (remote_ep->flag_skip_tunnel)
 			return NAT_PUNT_TO_STACK;
@@ -1768,6 +1781,18 @@ __snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 		}
 		if (!is_defined(TUNNEL_MODE))
 			return NAT_PUNT_TO_STACK;
+
+		/* In hybrid routing mode, skip SNAT for traffic within the same
+		 * subnet group. These packets are natively routed and don't need
+		 * masquerading.
+		 */
+		if (CONFIG(hybrid_routing_enabled)) {
+			__u32 src_subnet_id = lookup_ip6_subnet_id((union v6addr *)&tuple->saddr);
+			__u32 dst_subnet_id = lookup_ip6_subnet_id(&tuple->daddr);
+
+			if ((src_subnet_id == dst_subnet_id) && (src_subnet_id != 0))
+				return NAT_PUNT_TO_STACK;
+		}
 
 		if (remote_ep->flag_skip_tunnel)
 			return NAT_PUNT_TO_STACK;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -25,6 +25,7 @@
 #include "icmp6.h"
 #include "nat_46x64.h"
 #include "signal.h"
+#include "subnet.h"
 #include "trace.h"
 
 /* Nodeport NAT minimum port value */
@@ -759,6 +760,14 @@ __snat_v4_needs_masquerade(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 		 * by the remote node if its native dev's
 		 * rp_filter=1.
 		 */
+
+		/* In hybrid routing mode, skip SNAT for traffic within the same
+		 * subnet group. These packets are natively routed and don't need
+		 * masquerading.
+		 */
+		if (CONFIG(hybrid_routing_enabled) &&
+		    is_subnet_same_id4(tuple->saddr, tuple->daddr))
+			return NAT_PUNT_TO_STACK;
 
 		if (remote_ep->flag_skip_tunnel)
 			return NAT_PUNT_TO_STACK;
@@ -1764,6 +1773,14 @@ __snat_v6_needs_masquerade(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 			return NAT_NEEDED;
 		}
 		if (!is_defined(TUNNEL_MODE))
+			return NAT_PUNT_TO_STACK;
+
+		/* In hybrid routing mode, skip SNAT for traffic within the same
+		 * subnet group. These packets are natively routed and don't need
+		 * masquerading.
+		 */
+		if (CONFIG(hybrid_routing_enabled) &&
+		    is_subnet_same_id6(&tuple->saddr, &tuple->daddr))
 			return NAT_PUNT_TO_STACK;
 
 		if (remote_ep->flag_skip_tunnel)

--- a/bpf/lib/subnet.h
+++ b/bpf/lib/subnet.h
@@ -100,3 +100,33 @@ subnet_lookup4(const void *map, __be32 addr)
 	subnet_lookup6(&cilium_subnet_map, addr)
 #define lookup_ip4_subnet_id(addr) \
 	subnet_lookup4(&cilium_subnet_map, addr)
+
+/* is_subnet_same_id4 returns true if both addresses have the same ID and it's
+ * different than zero.
+ */
+static __always_inline __maybe_unused bool
+is_subnet_same_id4(__be32 saddr, __be32 daddr)
+{
+	__u32 sid, did;
+
+	sid = lookup_ip4_subnet_id(saddr);
+	if (sid == 0)
+		return false;
+	did = lookup_ip4_subnet_id(daddr);
+	return sid == did;
+}
+
+/* is_subnet_same_id6 returns true if both addresses have the same ID and it's
+ * different than zero.
+ */
+static __always_inline __maybe_unused bool
+is_subnet_same_id6(const union v6addr *saddr, const union v6addr *daddr)
+{
+	__u32 sid, did;
+
+	sid = lookup_ip6_subnet_id(saddr);
+	if (sid == 0)
+		return false;
+	did = lookup_ip6_subnet_id(daddr);
+	return sid == did;
+}

--- a/bpf/tests/hybrid_snat_skip_v4.c
+++ b/bpf/tests/hybrid_snat_skip_v4.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/*
+ * Test Matrix for hybrid SNAT skip logic (IPv4):
+ *
+ * Uses PKTGEN/SETUP/CHECK pattern to create real packets and verify
+ * the hybrid skip logic when same subnet traffic is detected.
+ *
+ * | Test Case              | src_subnet_id | dst_subnet_id | hybrid_enabled | remote_masq | Expected        | Test File        |
+ * |------------------------|---------------|---------------|----------------|-------------|-----------------|------------------|
+ * | same_subnet_skip       | 100           | 100           | true           | false       | NAT_PUNT_TO_STACK| this file        |
+ * | different_subnet       | 100           | 200           | true           | false       | NAT_NEEDED*     | remote_masq file |
+ * | zero_subnet            | 0             | 0             | true           | false       | NAT_NEEDED*     | remote_masq file |
+ * | same_subnet_override   | 100           | 100           | true           | true        | NAT_NEEDED      | remote_masq file |
+ * | different_subnet_override| 100         | 200           | true           | true        | NAT_NEEDED      | remote_masq file |
+ * | zero_subnet_override   | 0             | 0             | true           | true        | NAT_NEEDED      | remote_masq file |
+ *
+ * *Note: different_subnet and zero_subnet with remote_masq=false return NAT_NEEDED
+ * when local_ep exists. This is verified indirectly via the remote_masq tests
+ * which confirm the logic flow when hybrid skip conditions are NOT met.
+ *
+ * Test Coverage Summary:
+ * - hybrid skip triggers when src_subnet == dst_subnet && src_subnet != 0 ✓
+ * - enable_remote_node_masquerade=true overrides hybrid skip ✓
+ * - zero subnet_id excluded from hybrid skip ✓
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_SCTP
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENCAP_IFINDEX 1
+#define TUNNEL_MODE
+#include <bpf/config/global.h>
+#include <bpf/config/node.h>
+
+#define ENABLE_BPF_MASQUERADE 1
+#define ENABLE_MASQUERADE_IPV4 1
+#define IS_BPF_HOST 1
+
+#define IPV4_MASQUERADE bpf_htonl(0x0A000001) /* 10.0.0.1 */
+#define IPV4_SRC        bpf_htonl(0xC0A80101) /* 192.168.1.1 */
+#define IPV4_DST        bpf_htonl(0xC0A80201) /* 192.168.2.1 */
+#define SRC_PORT        bpf_htons(12345)
+#define DST_PORT        bpf_htons(443)
+
+static volatile const __u8 *src_mac = mac_one;
+static volatile const __u8 *dst_mac = mac_two;
+
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(union v4addr, nat_ipv4_masquerade, { .be32 = IPV4_MASQUERADE })
+ASSIGN_CONFIG(bool, enable_remote_node_masquerade, false)
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, true)
+ASSIGN_CONFIG(__u32, trace_payload_len, 128UL)
+ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/subnet.h"
+
+/*
+ * Test 1: Same subnet should skip SNAT
+ * Packet from IPV4_SRC (subnet 100) to IPV4_DST (subnet 100).
+ * Hybrid skip triggers, return NAT_PUNT_TO_STACK (packet passes unmodified).
+ */
+PKTGEN("tc", "hybrid_snat_v4_same_subnet_skip")
+int hybrid_snat_v4_same_subnet_skip_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *tcp;
+
+	pktgen__init(&builder, ctx);
+	tcp = pktgen__push_ipv4_tcp_packet(&builder,
+					   (__u8 *)src_mac, (__u8 *)dst_mac,
+					   IPV4_SRC, IPV4_DST,
+					   SRC_PORT, DST_PORT);
+	if (!tcp)
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hybrid_snat_v4_same_subnet_skip")
+int hybrid_snat_v4_same_subnet_skip_setup(struct __ctx_buff *ctx)
+{
+	subnet_v4_add_entry(IPV4_SRC, 100);
+	subnet_v4_add_entry(IPV4_DST, 100);
+	ipcache_v4_add_entry(IPV4_DST, 0, REMOTE_NODE_ID, 0, 0);
+	endpoint_v4_add_entry(IPV4_SRC, 0, 0, 0, 0, 0, NULL, NULL);
+
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "hybrid_snat_v4_same_subnet_skip")
+int hybrid_snat_v4_same_subnet_skip_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *ip4;
+
+	test_init();
+	endpoint_v4_del_entry(IPV4_SRC);
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+
+	/* Expect CTX_ACT_OK - packet passed through without SNAT */
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Verify source IP is NOT masqueraded (stays original) */
+	data += sizeof(__u32);
+	if (data + sizeof(struct ethhdr) > data_end)
+		test_fatal("ctx doesn't fit ethhdr");
+	data += sizeof(struct ethhdr);
+	if (data + sizeof(struct iphdr) > data_end)
+		test_fatal("ctx doesn't fit iphdr");
+	ip4 = data;
+	assert(ip4->saddr == IPV4_SRC);
+
+	test_finish();
+}

--- a/bpf/tests/hybrid_snat_skip_v4.c
+++ b/bpf/tests/hybrid_snat_skip_v4.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_REMOTE_NODE_MASQUERADE 0
+#define ENABLE_HYBRID_ROUTING 1
+#include "hybrid_snat_skip_v4.h"
+
+PKTGEN("tc", "hybrid_snat_v4_same_subnet")
+int hybrid_snat_v4_same_subnet_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_same_subnet")
+int hybrid_snat_v4_same_subnet_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 100, 100);
+}
+
+CHECK("tc", "hybrid_snat_v4_same_subnet")
+int hybrid_snat_v4_same_subnet_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, false);
+}
+
+PKTGEN("tc", "hybrid_snat_v4_different_subnet")
+int hybrid_snat_v4_different_subnet_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_different_subnet")
+int hybrid_snat_v4_different_subnet_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 100, 200);
+}
+
+CHECK("tc", "hybrid_snat_v4_different_subnet")
+int hybrid_snat_v4_different_subnet_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, true);
+}
+
+PKTGEN("tc", "hybrid_snat_v4_zero_subnet")
+int hybrid_snat_v4_zero_subnet_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_zero_subnet")
+int hybrid_snat_v4_zero_subnet_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 0, 0);
+}
+
+CHECK("tc", "hybrid_snat_v4_zero_subnet")
+int hybrid_snat_v4_zero_subnet_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, true);
+}
+
+PKTGEN("tc", "hybrid_snat_v4_source_subnet_missing")
+int hybrid_snat_v4_source_subnet_missing_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_source_subnet_missing")
+int hybrid_snat_v4_source_subnet_missing_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 0, 100);
+}
+
+CHECK("tc", "hybrid_snat_v4_source_subnet_missing")
+int hybrid_snat_v4_source_subnet_missing_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, true);
+}
+
+PKTGEN("tc", "hybrid_snat_v4_destination_subnet_missing")
+int hybrid_snat_v4_destination_subnet_missing_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_destination_subnet_missing")
+int hybrid_snat_v4_destination_subnet_missing_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 100, 0);
+}
+
+CHECK("tc", "hybrid_snat_v4_destination_subnet_missing")
+int hybrid_snat_v4_destination_subnet_missing_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, true);
+}

--- a/bpf/tests/hybrid_snat_skip_v4.h
+++ b/bpf/tests/hybrid_snat_skip_v4.h
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4 1
+#define ENABLE_NODEPORT 1
+#define ENCAP_IFINDEX 1
+#define TUNNEL_MODE 1
+#define ENABLE_BPF_MASQUERADE 1
+#define ENABLE_MASQUERADE_IPV4 1
+
+#include "nodeport_defaults.h"
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(union v4addr, nat_ipv4_masquerade, { .be32 = v4_node_one })
+ASSIGN_CONFIG(bool, enable_remote_node_masquerade, ENABLE_REMOTE_NODE_MASQUERADE)
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, ENABLE_HYBRID_ROUTING)
+
+#include "lib/clear.h"
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/subnet.h"
+
+static __always_inline int
+hybrid_snat_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  v4_pod_one, v4_node_two,
+					  tcp_src_one, tcp_svc_two))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return 0;
+}
+
+static __always_inline int
+hybrid_snat_v4_setup(struct __ctx_buff *ctx, __u32 src_subnet_id, __u32 dst_subnet_id)
+{
+	struct subnet_key key = {
+		.lpm_key = { .prefixlen = SUBNET_PREFIX_LEN(V4_SUBNET_KEY_LEN) },
+		.family = ENDPOINT_KEY_IPV4,
+	};
+
+	/* Each case uses the same flow. Reset CT/NAT state so a preceding case
+	 * cannot determine whether this packet is masqueraded.
+	 */
+	clear_map(&cilium_ct4_global);
+	clear_map(&cilium_ct_any4_global);
+	clear_map(get_cluster_snat_map_v4(0));
+
+	/* Remove both LPM entries explicitly: a zero ID models a lookup miss,
+	 * including when a previous case installed a non-zero ID.
+	 */
+	key.ip4.be32 = v4_pod_one;
+	map_delete_elem(&cilium_subnet_map, &key);
+	key.ip4.be32 = v4_node_two;
+	map_delete_elem(&cilium_subnet_map, &key);
+	if (src_subnet_id)
+		subnet_v4_add_entry(v4_pod_one, src_subnet_id);
+	if (dst_subnet_id)
+		subnet_v4_add_entry(v4_node_two, dst_subnet_id);
+
+	ipcache_v4_add_entry(v4_node_two, 0, REMOTE_NODE_ID, 0, 0);
+	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
+
+	return netdev_send_packet(ctx);
+}
+
+static __always_inline int
+hybrid_snat_v4_check(const struct __ctx_buff *ctx, bool snat)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	__u32 *status_code = data;
+	struct ethhdr *eth;
+	struct iphdr *ip;
+	struct tcphdr *tcp;
+	__u32 csum, pseudo;
+	__u8 *payload;
+
+	test_init();
+
+	if ((void *)(status_code + 1) > data_end)
+		test_fatal("status code out of bounds");
+	assert(*status_code == CTX_ACT_OK);
+
+	eth = (void *)(status_code + 1);
+	if ((void *)(eth + 1) > data_end)
+		test_fatal("Ethernet header out of bounds");
+	assert(eth->h_proto == bpf_htons(ETH_P_IP));
+	assert(memcmp(eth->h_source, (__u8 *)mac_one, ETH_ALEN) == 0);
+	assert(memcmp(eth->h_dest, (__u8 *)mac_two, ETH_ALEN) == 0);
+
+	ip = (void *)(eth + 1);
+	if ((void *)(ip + 1) > data_end)
+		test_fatal("IP header out of bounds");
+	assert(ip->saddr == (snat ? CONFIG(nat_ipv4_masquerade).be32 : v4_pod_one));
+	assert(ip->daddr == v4_node_two);
+	assert(ip->protocol == IPPROTO_TCP);
+	assert(csum_fold(csum_diff(NULL, 0, ip, sizeof(*ip), 0)) == 0);
+
+	tcp = (void *)(ip + 1);
+	if ((void *)(tcp + 1) > data_end)
+		test_fatal("TCP header out of bounds");
+	if (snat) {
+		assert(bpf_ntohs(tcp->source) >= NODEPORT_PORT_MIN_NAT);
+		assert(bpf_ntohs(tcp->source) <= NODEPORT_PORT_MAX_NAT);
+	} else {
+		assert(tcp->source == tcp_src_one);
+	}
+	assert(tcp->dest == tcp_svc_two);
+
+	payload = (void *)(tcp + 1);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("payload out of bounds");
+	assert(memcmp(payload, default_data, sizeof(default_data)) == 0);
+
+	/* Validate the TCP checksum against the resulting IP pseudo-header,
+	 * including when SNAT changed the address and source port.
+	 */
+	csum = csum_diff(NULL, 0, &ip->saddr, sizeof(ip->saddr), 0);
+	csum = csum_diff(NULL, 0, &ip->daddr, sizeof(ip->daddr), csum);
+	pseudo = bpf_htonl(IPPROTO_TCP);
+	csum = csum_diff(NULL, 0, &pseudo, sizeof(pseudo), csum);
+	pseudo = bpf_htonl(sizeof(*tcp) + sizeof(default_data));
+	csum = csum_diff(NULL, 0, &pseudo, sizeof(pseudo), csum);
+	csum = csum_diff(NULL, 0, tcp, sizeof(*tcp) + sizeof(default_data), csum);
+	assert(csum_fold(csum) == 0);
+
+	test_finish();
+}

--- a/bpf/tests/hybrid_snat_skip_v4_disabled.c
+++ b/bpf/tests/hybrid_snat_skip_v4_disabled.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_REMOTE_NODE_MASQUERADE 0
+#define ENABLE_HYBRID_ROUTING 0
+#include "hybrid_snat_skip_v4.h"
+
+PKTGEN("tc", "hybrid_snat_v4_same_subnet_hybrid_disabled")
+int hybrid_snat_v4_same_subnet_hybrid_disabled_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_same_subnet_hybrid_disabled")
+int hybrid_snat_v4_same_subnet_hybrid_disabled_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 100, 100);
+}
+
+CHECK("tc", "hybrid_snat_v4_same_subnet_hybrid_disabled")
+int hybrid_snat_v4_same_subnet_hybrid_disabled_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, true);
+}

--- a/bpf/tests/hybrid_snat_skip_v4_remote_masq.c
+++ b/bpf/tests/hybrid_snat_skip_v4_remote_masq.c
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/*
+ * Test Matrix for hybrid SNAT skip logic with enable_remote_node_masquerade=true:
+ *
+ * This file tests scenarios where NAT_NEEDED is expected by using
+ * enable_remote_node_masquerade=true to override the hybrid skip logic.
+ *
+ * | Test Case              | src_subnet_id | dst_subnet_id | hybrid_enabled | remote_masq | Expected   |
+ * |------------------------|---------------|---------------|----------------|-------------|------------|
+ * | same_subnet_override   | 100           | 100           | true           | true        | NAT_NEEDED |
+ * | different_subnet       | 100           | 200           | true           | true        | NAT_NEEDED |
+ * | zero_subnet            | 0             | 0             | true           | true        | NAT_NEEDED |
+ *
+ * Note: This is a separate compilation unit from hybrid_snat_skip_v4.c because
+ * ASSIGN_CONFIG can only be used once per config variable per compilation unit.
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_SCTP
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENCAP_IFINDEX 1
+#define TUNNEL_MODE
+#include <bpf/config/global.h>
+#include <bpf/config/node.h>
+
+#define DEBUG
+
+#define ENABLE_BPF_MASQUERADE 1
+#define ENABLE_MASQUERADE_IPV4 1
+#define IS_BPF_HOST 1
+
+#include <lib/dbg.h>
+#include <lib/time.h>
+#include "bpf_nat_tuples.h"
+
+#define IPV4_MASQUERADE bpf_htonl(0x0A000001) /* 10.0.0.1 */
+#define IPV4_SRC        bpf_htonl(0xC0A80101) /* 192.168.1.1 */
+#define IPV4_DST        bpf_htonl(0xC0A80201) /* 192.168.2.1 */
+
+#include <lib/conntrack.h>
+#include <lib/nat.h>
+
+#include "lib/ipcache.h"
+#include "lib/subnet.h"
+
+ASSIGN_CONFIG(union v4addr, nat_ipv4_masquerade, { .be32 = IPV4_MASQUERADE })
+ASSIGN_CONFIG(bool, enable_remote_node_masquerade, true)
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, true)
+ASSIGN_CONFIG(__u32, trace_payload_len, 128UL)
+ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
+
+/* Test 1: Same subnet with remote_masq=true should NOT skip SNAT */
+CHECK("tc", "hybrid_snat_v4_same_subnet_override")
+int test_hybrid_snat_v4_same_subnet_override(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv4_ct_tuple tuple = {};
+	struct iphdr ip4 = { .protocol = IPPROTO_TCP };
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	test_init();
+
+	subnet_v4_add_entry(IPV4_SRC, 100);
+	subnet_v4_add_entry(IPV4_DST, 100);
+	ipcache_v4_add_entry(IPV4_DST, 0, REMOTE_NODE_ID, 0, 0);
+
+	tuple.daddr = IPV4_DST;
+	tuple.saddr = IPV4_SRC;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.sport = bpf_htons(12345);
+	tuple.dport = bpf_htons(443);
+	tuple.flags = NAT_DIR_EGRESS;
+
+	struct ipv4_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+
+	ret = snat_v4_needs_masquerade(ctx, &tuple, &ip4, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=100 dst_subnet=100 remote_masq=true", ret);
+	assert(ret == NAT_NEEDED);
+	assert(target.addr == IPV4_MASQUERADE);
+
+	test_finish();
+	return 0;
+}
+
+/* Test 2: Different subnet with remote_masq=true should NOT skip SNAT */
+CHECK("tc", "hybrid_snat_v4_different_subnet_override")
+int test_hybrid_snat_v4_different_subnet_override(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv4_ct_tuple tuple = {};
+	struct iphdr ip4 = { .protocol = IPPROTO_TCP };
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	test_init();
+
+	subnet_v4_add_entry(IPV4_SRC, 100);
+	subnet_v4_add_entry(IPV4_DST, 200);
+	ipcache_v4_add_entry(IPV4_DST, 0, REMOTE_NODE_ID, 0, 0);
+
+	tuple.daddr = IPV4_DST;
+	tuple.saddr = IPV4_SRC;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.sport = bpf_htons(12345);
+	tuple.dport = bpf_htons(443);
+	tuple.flags = NAT_DIR_EGRESS;
+
+	struct ipv4_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+
+	ret = snat_v4_needs_masquerade(ctx, &tuple, &ip4, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=100 dst_subnet=200 remote_masq=true", ret);
+	assert(ret == NAT_NEEDED);
+	assert(target.addr == IPV4_MASQUERADE);
+
+	test_finish();
+	return 0;
+}
+
+/* Test 3: Zero subnet with remote_masq=true should NOT skip SNAT */
+CHECK("tc", "hybrid_snat_v4_zero_subnet_override")
+int test_hybrid_snat_v4_zero_subnet_override(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv4_ct_tuple tuple = {};
+	struct iphdr ip4 = { .protocol = IPPROTO_TCP };
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	test_init();
+
+	/* No subnet entries -> both return subnet_id=0 */
+	ipcache_v4_add_entry(IPV4_DST, 0, REMOTE_NODE_ID, 0, 0);
+
+	tuple.daddr = IPV4_DST;
+	tuple.saddr = IPV4_SRC;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.sport = bpf_htons(12345);
+	tuple.dport = bpf_htons(443);
+	tuple.flags = NAT_DIR_EGRESS;
+
+	struct ipv4_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+
+	ret = snat_v4_needs_masquerade(ctx, &tuple, &ip4, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=0 dst_subnet=0 remote_masq=true", ret);
+	assert(ret == NAT_NEEDED);
+	assert(target.addr == IPV4_MASQUERADE);
+
+	test_finish();
+	return 0;
+}

--- a/bpf/tests/hybrid_snat_skip_v4_remote_masq.c
+++ b/bpf/tests/hybrid_snat_skip_v4_remote_masq.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_REMOTE_NODE_MASQUERADE 1
+#define ENABLE_HYBRID_ROUTING 1
+#include "hybrid_snat_skip_v4.h"
+
+PKTGEN("tc", "hybrid_snat_v4_same_subnet_remote_masq")
+int hybrid_snat_v4_same_subnet_remote_masq_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v4_same_subnet_remote_masq")
+int hybrid_snat_v4_same_subnet_remote_masq_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_setup(ctx, 100, 100);
+}
+
+CHECK("tc", "hybrid_snat_v4_same_subnet_remote_masq")
+int hybrid_snat_v4_same_subnet_remote_masq_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v4_check(ctx, true);
+}

--- a/bpf/tests/hybrid_snat_skip_v6.c
+++ b/bpf/tests/hybrid_snat_skip_v6.c
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/*
+ * Test Matrix for hybrid SNAT skip logic (IPv6):
+ *
+ * | Test Case              | src_subnet_id | dst_subnet_id | hybrid_enabled | remote_masq | Expected        |
+ * |------------------------|---------------|---------------|----------------|-------------|-----------------|
+ * | same_subnet_skip       | 100           | 100           | true           | false       | NAT_PUNT_TO_STACK|
+ * | different_subnet       | 100           | 200           | true           | false       | NAT_NEEDED      | (tested via remote_masq file)
+ * | zero_subnet            | 0             | 0             | true           | false       | NAT_NEEDED      | (tested via remote_masq file)
+ * | remote_masq_override   | 100           | 100           | true           | true        | NAT_NEEDED      | (see hybrid_snat_skip_v6_remote_masq.c)
+ *
+ * Key behaviors:
+ * - SNAT skipped when (src_subnet_id == dst_subnet_id && src_subnet_id != 0)
+ * - enable_remote_node_masquerade=true overrides hybrid skip (user intent)
+ * - Zero subnet_id excluded from skip (fallback to normal behavior)
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENCAP_IFINDEX 1
+#define TUNNEL_MODE
+#include <bpf/config/global.h>
+#include <bpf/config/node.h>
+
+#define DEBUG
+
+#define ENABLE_BPF_MASQUERADE 1
+#define ENABLE_MASQUERADE_IPV6 1
+#define IS_BPF_HOST 1
+
+#include <lib/dbg.h>
+#include <lib/time.h>
+#include <lib/ipv6.h>
+
+#define IPV6_MASQUERADE_ADDR { .p1 = 0x0A000001, .p2 = 0, .p3 = 0, .p4 = 0 }
+#define IPV6_SRC_ADDR { .p1 = bpf_htonl(0x2001), .p2 = bpf_htonl(0x0DB8), .p3 = bpf_htonl(0x0001), .p4 = bpf_htonl(0x0001) }
+#define IPV6_DST_ADDR { .p1 = bpf_htonl(0x2001), .p2 = bpf_htonl(0x0DB8), .p3 = bpf_htonl(0x0002), .p4 = bpf_htonl(0x0001) }
+
+#include <lib/conntrack.h>
+#include <lib/nat.h>
+
+#include "lib/ipcache.h"
+#include "lib/subnet.h"
+
+ASSIGN_CONFIG(union v6addr, nat_ipv6_masquerade, IPV6_MASQUERADE_ADDR)
+ASSIGN_CONFIG(bool, enable_remote_node_masquerade, false)
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, true)
+ASSIGN_CONFIG(__u32, trace_payload_len, 128UL)
+ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
+
+static __always_inline void
+init_ipv6_tuple(struct ipv6_ct_tuple *tuple, const union v6addr *src,
+		const union v6addr *dst, __u8 nexthdr, __be16 sport, __be16 dport)
+{
+	ipv6_addr_copy(&tuple->saddr, src);
+	ipv6_addr_copy(&tuple->daddr, dst);
+	tuple->nexthdr = nexthdr;
+	tuple->sport = sport;
+	tuple->dport = dport;
+	tuple->flags = NAT_DIR_EGRESS;
+}
+
+/* Test 1: Same subnet should skip SNAT */
+CHECK("tc", "hybrid_snat_v6_same_subnet_skip")
+int test_hybrid_snat_v6_same_subnet_skip(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	union v6addr src_addr = IPV6_SRC_ADDR;
+	union v6addr dst_addr = IPV6_DST_ADDR;
+
+	test_init();
+
+	subnet_v6_add_entry(&src_addr, 100);
+	subnet_v6_add_entry(&dst_addr, 100);
+	ipcache_v6_add_entry(&dst_addr, 0, REMOTE_NODE_ID, 0, 0);
+
+	init_ipv6_tuple(&tuple, &src_addr, &dst_addr, IPPROTO_TCP,
+			bpf_htons(12345), bpf_htons(443));
+
+	struct ipv6_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+
+	ret = __snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=100 dst_subnet=100", ret);
+	assert(ret == NAT_PUNT_TO_STACK);
+
+	test_finish();
+	return 0;
+}

--- a/bpf/tests/hybrid_snat_skip_v6.c
+++ b/bpf/tests/hybrid_snat_skip_v6.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_REMOTE_NODE_MASQUERADE 0
+#define ENABLE_HYBRID_ROUTING 1
+#include "hybrid_snat_skip_v6.h"
+
+PKTGEN("tc", "hybrid_snat_v6_same_subnet")
+int hybrid_snat_v6_same_subnet_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_same_subnet")
+int hybrid_snat_v6_same_subnet_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 100, 100);
+}
+
+CHECK("tc", "hybrid_snat_v6_same_subnet")
+int hybrid_snat_v6_same_subnet_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, false);
+}
+
+PKTGEN("tc", "hybrid_snat_v6_different_subnet")
+int hybrid_snat_v6_different_subnet_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_different_subnet")
+int hybrid_snat_v6_different_subnet_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 100, 200);
+}
+
+CHECK("tc", "hybrid_snat_v6_different_subnet")
+int hybrid_snat_v6_different_subnet_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, true);
+}
+
+PKTGEN("tc", "hybrid_snat_v6_zero_subnet")
+int hybrid_snat_v6_zero_subnet_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_zero_subnet")
+int hybrid_snat_v6_zero_subnet_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 0, 0);
+}
+
+CHECK("tc", "hybrid_snat_v6_zero_subnet")
+int hybrid_snat_v6_zero_subnet_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, true);
+}
+
+PKTGEN("tc", "hybrid_snat_v6_source_subnet_missing")
+int hybrid_snat_v6_source_subnet_missing_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_source_subnet_missing")
+int hybrid_snat_v6_source_subnet_missing_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 0, 100);
+}
+
+CHECK("tc", "hybrid_snat_v6_source_subnet_missing")
+int hybrid_snat_v6_source_subnet_missing_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, true);
+}
+
+PKTGEN("tc", "hybrid_snat_v6_destination_subnet_missing")
+int hybrid_snat_v6_destination_subnet_missing_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_destination_subnet_missing")
+int hybrid_snat_v6_destination_subnet_missing_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 100, 0);
+}
+
+CHECK("tc", "hybrid_snat_v6_destination_subnet_missing")
+int hybrid_snat_v6_destination_subnet_missing_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, true);
+}

--- a/bpf/tests/hybrid_snat_skip_v6.h
+++ b/bpf/tests/hybrid_snat_skip_v6.h
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV6 1
+#define ENABLE_NODEPORT 1
+#define ENCAP_IFINDEX 1
+#define TUNNEL_MODE 1
+#define ENABLE_BPF_MASQUERADE 1
+#define ENABLE_MASQUERADE_IPV6 1
+
+#include "nodeport_defaults.h"
+#include "lib/bpf_host.h"
+
+ASSIGN_CONFIG(union v6addr, nat_ipv6_masquerade, { .addr = v6_node_one_addr })
+ASSIGN_CONFIG(bool, enable_remote_node_masquerade, ENABLE_REMOTE_NODE_MASQUERADE)
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, ENABLE_HYBRID_ROUTING)
+
+#include "lib/clear.h"
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/subnet.h"
+
+static __always_inline int
+hybrid_snat_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	if (!pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  (__u8 *)v6_pod_one, (__u8 *)v6_node_two,
+					  tcp_src_one, tcp_svc_two))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, default_data, sizeof(default_data)))
+		return TEST_ERROR;
+	pktgen__finish(&builder);
+	return 0;
+}
+
+static __always_inline int
+hybrid_snat_v6_setup(struct __ctx_buff *ctx, __u32 src_subnet_id, __u32 dst_subnet_id)
+{
+	union v6addr src = { .addr = v6_pod_one_addr };
+	union v6addr dst = { .addr = v6_node_two_addr };
+	struct subnet_key key = {
+		.lpm_key = { .prefixlen = SUBNET_PREFIX_LEN(V6_SUBNET_KEY_LEN) },
+		.family = ENDPOINT_KEY_IPV6,
+	};
+
+	/* Each case uses the same flow. Reset CT/NAT state so a preceding case
+	 * cannot determine whether this packet is masqueraded.
+	 */
+	clear_map(&cilium_ct6_global);
+	clear_map(&cilium_ct_any6_global);
+	clear_map(get_cluster_snat_map_v6(0));
+
+	/* Remove both LPM entries explicitly: a zero ID models a lookup miss,
+	 * including when a previous case installed a non-zero ID.
+	 */
+	key.ip6 = src;
+	map_delete_elem(&cilium_subnet_map, &key);
+	key.ip6 = dst;
+	map_delete_elem(&cilium_subnet_map, &key);
+	if (src_subnet_id)
+		subnet_v6_add_entry(&src, src_subnet_id);
+	if (dst_subnet_id)
+		subnet_v6_add_entry(&dst, dst_subnet_id);
+
+	ipcache_v6_add_entry(&dst, 0, REMOTE_NODE_ID, 0, 0);
+	endpoint_v6_add_entry(&src, 0, 0, 0, 0, NULL, NULL);
+
+	return netdev_send_packet(ctx);
+}
+
+static __always_inline int
+hybrid_snat_v6_check(const struct __ctx_buff *ctx, bool snat)
+{
+	union v6addr src = { .addr = v6_pod_one_addr };
+	union v6addr dst = { .addr = v6_node_two_addr };
+	union v6addr masq = CONFIG(nat_ipv6_masquerade);
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	__u32 *status_code = data;
+	struct ethhdr *eth;
+	struct ipv6hdr *ip;
+	struct tcphdr *tcp;
+	__u32 csum, pseudo;
+	__u8 *payload;
+
+	test_init();
+
+	if ((void *)(status_code + 1) > data_end)
+		test_fatal("status code out of bounds");
+	assert(*status_code == CTX_ACT_OK);
+
+	eth = (void *)(status_code + 1);
+	if ((void *)(eth + 1) > data_end)
+		test_fatal("Ethernet header out of bounds");
+	assert(eth->h_proto == bpf_htons(ETH_P_IPV6));
+	assert(memcmp(eth->h_source, (__u8 *)mac_one, ETH_ALEN) == 0);
+	assert(memcmp(eth->h_dest, (__u8 *)mac_two, ETH_ALEN) == 0);
+
+	ip = (void *)(eth + 1);
+	if ((void *)(ip + 1) > data_end)
+		test_fatal("IP header out of bounds");
+	assert(ipv6_addr_equals((union v6addr *)&ip->saddr, snat ? &masq : &src));
+	assert(ipv6_addr_equals((union v6addr *)&ip->daddr, &dst));
+	assert(ip->nexthdr == IPPROTO_TCP);
+
+	tcp = (void *)(ip + 1);
+	if ((void *)(tcp + 1) > data_end)
+		test_fatal("TCP header out of bounds");
+	if (snat) {
+		assert(bpf_ntohs(tcp->source) >= NODEPORT_PORT_MIN_NAT);
+		assert(bpf_ntohs(tcp->source) <= NODEPORT_PORT_MAX_NAT);
+	} else {
+		assert(tcp->source == tcp_src_one);
+	}
+	assert(tcp->dest == tcp_svc_two);
+
+	payload = (void *)(tcp + 1);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("payload out of bounds");
+	assert(memcmp(payload, default_data, sizeof(default_data)) == 0);
+
+	/* Validate the TCP checksum against the resulting IP pseudo-header,
+	 * including when SNAT changed the address and source port.
+	 */
+	csum = csum_diff(NULL, 0, &ip->saddr, sizeof(ip->saddr), 0);
+	csum = csum_diff(NULL, 0, &ip->daddr, sizeof(ip->daddr), csum);
+	pseudo = bpf_htonl(IPPROTO_TCP);
+	csum = csum_diff(NULL, 0, &pseudo, sizeof(pseudo), csum);
+	pseudo = bpf_htonl(sizeof(*tcp) + sizeof(default_data));
+	csum = csum_diff(NULL, 0, &pseudo, sizeof(pseudo), csum);
+	csum = csum_diff(NULL, 0, tcp, sizeof(*tcp) + sizeof(default_data), csum);
+	assert(csum_fold(csum) == 0);
+
+	test_finish();
+}

--- a/bpf/tests/hybrid_snat_skip_v6_disabled.c
+++ b/bpf/tests/hybrid_snat_skip_v6_disabled.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_REMOTE_NODE_MASQUERADE 0
+#define ENABLE_HYBRID_ROUTING 0
+#include "hybrid_snat_skip_v6.h"
+
+PKTGEN("tc", "hybrid_snat_v6_same_subnet_hybrid_disabled")
+int hybrid_snat_v6_same_subnet_hybrid_disabled_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_same_subnet_hybrid_disabled")
+int hybrid_snat_v6_same_subnet_hybrid_disabled_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 100, 100);
+}
+
+CHECK("tc", "hybrid_snat_v6_same_subnet_hybrid_disabled")
+int hybrid_snat_v6_same_subnet_hybrid_disabled_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, true);
+}

--- a/bpf/tests/hybrid_snat_skip_v6_remote_masq.c
+++ b/bpf/tests/hybrid_snat_skip_v6_remote_masq.c
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/*
+ * Test Matrix for hybrid SNAT skip logic with enable_remote_node_masquerade=true (IPv6):
+ *
+ * This file tests scenarios where NAT_NEEDED is expected by using
+ * enable_remote_node_masquerade=true to override the hybrid skip logic.
+ *
+ * | Test Case              | src_subnet_id | dst_subnet_id | hybrid_enabled | remote_masq | Expected   |
+ * |------------------------|---------------|---------------|----------------|-------------|------------|
+ * | same_subnet_override   | 100           | 100           | true           | true        | NAT_NEEDED |
+ * | different_subnet       | 100           | 200           | true           | true        | NAT_NEEDED |
+ * | zero_subnet            | 0             | 0             | true           | true        | NAT_NEEDED |
+ *
+ * Note: This is a separate compilation unit from hybrid_snat_skip_v6.c because
+ * ASSIGN_CONFIG can only be used once per config variable per compilation unit.
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENCAP_IFINDEX 1
+#define TUNNEL_MODE
+#include <bpf/config/global.h>
+#include <bpf/config/node.h>
+
+#define DEBUG
+
+#define ENABLE_BPF_MASQUERADE 1
+#define ENABLE_MASQUERADE_IPV6 1
+#define IS_BPF_HOST 1
+
+#include <lib/dbg.h>
+#include <lib/time.h>
+#include <lib/ipv6.h>
+
+#define IPV6_MASQUERADE_ADDR { .p1 = 0x0A000001, .p2 = 0, .p3 = 0, .p4 = 0 }
+#define IPV6_SRC_ADDR { .p1 = bpf_htonl(0x2001), .p2 = bpf_htonl(0x0DB8), .p3 = bpf_htonl(0x0001), .p4 = bpf_htonl(0x0001) }
+#define IPV6_DST_ADDR { .p1 = bpf_htonl(0x2001), .p2 = bpf_htonl(0x0DB8), .p3 = bpf_htonl(0x0002), .p4 = bpf_htonl(0x0001) }
+
+#include <lib/conntrack.h>
+#include <lib/nat.h>
+
+#include "lib/ipcache.h"
+#include "lib/subnet.h"
+
+ASSIGN_CONFIG(union v6addr, nat_ipv6_masquerade, IPV6_MASQUERADE_ADDR)
+ASSIGN_CONFIG(bool, enable_remote_node_masquerade, true)
+ASSIGN_CONFIG(bool, hybrid_routing_enabled, true)
+ASSIGN_CONFIG(__u32, trace_payload_len, 128UL)
+ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
+
+static __always_inline void
+init_ipv6_tuple(struct ipv6_ct_tuple *tuple, const union v6addr *src,
+		const union v6addr *dst, __u8 nexthdr, __be16 sport, __be16 dport)
+{
+	ipv6_addr_copy(&tuple->saddr, src);
+	ipv6_addr_copy(&tuple->daddr, dst);
+	tuple->nexthdr = nexthdr;
+	tuple->sport = sport;
+	tuple->dport = dport;
+	tuple->flags = NAT_DIR_EGRESS;
+}
+
+/* Test 1: Same subnet with remote_masq=true should NOT skip SNAT */
+CHECK("tc", "hybrid_snat_v6_same_subnet_override")
+int test_hybrid_snat_v6_same_subnet_override(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	union v6addr src_addr = IPV6_SRC_ADDR;
+	union v6addr dst_addr = IPV6_DST_ADDR;
+	union v6addr masq_addr = IPV6_MASQUERADE_ADDR;
+
+	test_init();
+
+	subnet_v6_add_entry(&src_addr, 100);
+	subnet_v6_add_entry(&dst_addr, 100);
+	ipcache_v6_add_entry(&dst_addr, 0, REMOTE_NODE_ID, 0, 0);
+
+	init_ipv6_tuple(&tuple, &src_addr, &dst_addr, IPPROTO_TCP,
+			bpf_htons(12345), bpf_htons(443));
+
+	struct ipv6_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+	ipv6_addr_copy(&target.addr, &masq_addr);
+
+	ret = __snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=100 dst_subnet=100 remote_masq=true", ret);
+	assert(ret == NAT_NEEDED);
+
+	test_finish();
+	return 0;
+}
+
+/* Test 2: Different subnet with remote_masq=true should NOT skip SNAT */
+CHECK("tc", "hybrid_snat_v6_different_subnet_override")
+int test_hybrid_snat_v6_different_subnet_override(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	union v6addr src_addr = IPV6_SRC_ADDR;
+	union v6addr dst_addr = IPV6_DST_ADDR;
+	union v6addr masq_addr = IPV6_MASQUERADE_ADDR;
+
+	test_init();
+
+	subnet_v6_add_entry(&src_addr, 100);
+	subnet_v6_add_entry(&dst_addr, 200);
+	ipcache_v6_add_entry(&dst_addr, 0, REMOTE_NODE_ID, 0, 0);
+
+	init_ipv6_tuple(&tuple, &src_addr, &dst_addr, IPPROTO_TCP,
+			bpf_htons(12345), bpf_htons(443));
+
+	struct ipv6_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+	ipv6_addr_copy(&target.addr, &masq_addr);
+
+	ret = __snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=100 dst_subnet=200 remote_masq=true", ret);
+	assert(ret == NAT_NEEDED);
+
+	test_finish();
+	return 0;
+}
+
+/* Test 3: Zero subnet with remote_masq=true should NOT skip SNAT */
+CHECK("tc", "hybrid_snat_v6_zero_subnet_override")
+int test_hybrid_snat_v6_zero_subnet_override(__maybe_unused struct __ctx_buff *ctx)
+{
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	fraginfo_t fraginfo = 0;
+	int l4_off = 0, ret;
+
+	union v6addr src_addr = IPV6_SRC_ADDR;
+	union v6addr dst_addr = IPV6_DST_ADDR;
+	union v6addr masq_addr = IPV6_MASQUERADE_ADDR;
+
+	test_init();
+
+	/* No subnet entries -> both return subnet_id=0 */
+	ipcache_v6_add_entry(&dst_addr, 0, REMOTE_NODE_ID, 0, 0);
+
+	init_ipv6_tuple(&tuple, &src_addr, &dst_addr, IPPROTO_TCP,
+			bpf_htons(12345), bpf_htons(443));
+
+	struct ipv6_nat_target target = {
+		.min_port = NODEPORT_PORT_MIN_NAT,
+		.max_port = NODEPORT_PORT_MAX_NAT,
+	};
+	ipv6_addr_copy(&target.addr, &masq_addr);
+
+	ret = __snat_v6_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	test_log("ret=%d src_subnet=0 dst_subnet=0 remote_masq=true", ret);
+	assert(ret == NAT_NEEDED);
+
+	test_finish();
+	return 0;
+}

--- a/bpf/tests/hybrid_snat_skip_v6_remote_masq.c
+++ b/bpf/tests/hybrid_snat_skip_v6_remote_masq.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_REMOTE_NODE_MASQUERADE 1
+#define ENABLE_HYBRID_ROUTING 1
+#include "hybrid_snat_skip_v6.h"
+
+PKTGEN("tc", "hybrid_snat_v6_same_subnet_remote_masq")
+int hybrid_snat_v6_same_subnet_remote_masq_pktgen(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_pktgen(ctx);
+}
+
+SETUP("tc", "hybrid_snat_v6_same_subnet_remote_masq")
+int hybrid_snat_v6_same_subnet_remote_masq_setup(struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_setup(ctx, 100, 100);
+}
+
+CHECK("tc", "hybrid_snat_v6_same_subnet_remote_masq")
+int hybrid_snat_v6_same_subnet_remote_masq_check(const struct __ctx_buff *ctx)
+{
+	return hybrid_snat_v6_check(ctx, true);
+}

--- a/pkg/datapath/config/overlay_config.go
+++ b/pkg/datapath/config/overlay_config.go
@@ -28,6 +28,8 @@ type BPFOverlay struct {
 	EnableRemoteNodeMasquerade bool `config:"enable_remote_node_masquerade"`
 	// Ephemeral port range minimum.
 	EphemeralMin uint16 `config:"ephemeral_min"`
+	// Enable hybrid mode routing based on subnet IDs.
+	HybridRoutingEnabled bool `config:"hybrid_routing_enabled"`
 	// Ifindex of the interface the bpf program is attached to.
 	InterfaceIfIndex uint32 `config:"interface_ifindex"`
 	// MAC address of the interface the bpf program is attached to.
@@ -49,7 +51,7 @@ type BPFOverlay struct {
 }
 
 func NewBPFOverlay(node Node) *BPFOverlay {
-	return &BPFOverlay{0x0, false, false, false, false, false, false, 0x0, 0x0,
+	return &BPFOverlay{0x0, false, false, false, false, false, false, 0x0, false, 0x0,
 		cast[types.MACAddr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
 		cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
 		cast[types.V6Addr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),

--- a/pkg/datapath/config/wireguard_config.go
+++ b/pkg/datapath/config/wireguard_config.go
@@ -28,6 +28,8 @@ type BPFWireguard struct {
 	EnableRemoteNodeMasquerade bool `config:"enable_remote_node_masquerade"`
 	// Ephemeral port range minimum.
 	EphemeralMin uint16 `config:"ephemeral_min"`
+	// Enable hybrid mode routing based on subnet IDs.
+	HybridRoutingEnabled bool `config:"hybrid_routing_enabled"`
 	// Ifindex of the interface the bpf program is attached to.
 	InterfaceIfIndex uint32 `config:"interface_ifindex"`
 	// MAC address of the interface the bpf program is attached to.
@@ -47,7 +49,7 @@ type BPFWireguard struct {
 }
 
 func NewBPFWireguard(node Node) *BPFWireguard {
-	return &BPFWireguard{0x0, false, false, false, false, false, false, 0x0, 0x0,
+	return &BPFWireguard{0x0, false, false, false, false, false, false, 0x0, false, 0x0,
 		cast[types.MACAddr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
 		cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
 		cast[types.V6Addr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),

--- a/pkg/datapath/config/xdp_config.go
+++ b/pkg/datapath/config/xdp_config.go
@@ -28,6 +28,8 @@ type BPFXDP struct {
 	EnableXDPPrefilter bool `config:"enable_xdp_prefilter"`
 	// Ephemeral port range minimum.
 	EphemeralMin uint16 `config:"ephemeral_min"`
+	// Enable hybrid mode routing based on subnet IDs.
+	HybridRoutingEnabled bool `config:"hybrid_routing_enabled"`
 	// IPv4 source prefix used for DSR IPIP RSS.
 	IPv4RSSPrefix types.V4Addr `config:"ipv4_rss_prefix"`
 	// Prefix length of the IPv4 DSR IPIP RSS source prefix.
@@ -55,7 +57,7 @@ type BPFXDP struct {
 }
 
 func NewBPFXDP(node Node) *BPFXDP {
-	return &BPFXDP{0x0, false, false, false, false, false, false, 0x0, cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
+	return &BPFXDP{0x0, false, false, false, false, false, false, 0x0, false, cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
 		0x20,
 		cast[types.V6Addr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
 		0x80, 0x0,


### PR DESCRIPTION
In hybrid overlay routing, pod-to-remote-node traffic within the same non-zero
subnet topology group now skips BPF SNAT, preserving the Pod source address.
Explicit remote-node masquerading keeps precedence. IPv4 and IPv6 use shared
subnet-comparison helpers, also reused by host and endpoint tunnel decisions.

The tests send real TCP packets through `cil_to_netdev`, with CT/NAT state and
subnet entries reset for every case. For both IP families they cover matching
IDs, different IDs, both entries missing, either entry missing, the remote-node
masquerade override, and hybrid routing disabled. They verify addresses, ports,
payload preservation, and checksums.

Validation: all six hybrid test objects compile with standard `-Werror` flags;
all 14 hybrid cases and 36 related skip-tunnel regression cases pass the BPF
verifier/test runner. Strict checkpatch passes for all eight test source files.
As a negative control, removing both new SNAT exclusions in a temporary source
copy causes exactly the IPv4 and IPv6 same-subnet source-address assertions to
fail; the other 12 cases continue to pass.

---

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description and are signed off.
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)

Fixes: #41867

```release-note
In hybrid routing mode, skip SNAT for pod-to-remote-node traffic when source
and destination belong to the same subnet topology group, preserving the
original Pod source IP for same-subnet communication.
```

