### PR TITLE
bpf: sockLB: allow translation for L2-announced ExternalIPs

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -27,7 +27,10 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -36,10 +39,12 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	ciliumlabels "github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/shortener"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -49,6 +54,7 @@ var Cell = cell.Module(
 
 	cell.Provide(NewL2Announcer),
 	cell.Provide(l2AnnouncementPolicyResource),
+	cell.Provide(func(ipc *ipcache.IPCache) ipCacheUpdater { return ipc }),
 	cell.Invoke(func(*L2Announcer) {}), // register and start L2 announcer
 )
 
@@ -61,6 +67,14 @@ func l2AnnouncementPolicyResource(lc cell.Lifecycle, cs k8sClient.Clientset,
 		cs.CiliumV2alpha1().CiliumL2AnnouncementPolicies(),
 	)
 	return resource.New[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy](lc, lw, mp, resource.WithMetric("CiliumL2AnnouncementPolicy")), nil
+}
+
+// ipCacheUpdater is the subset of *ipcache.IPCache that the l2announcer uses
+// to publish HOST_ID metadata for VIPs this node is currently L2-announcing.
+// Pulled out so tests can supply a recorder fake.
+type ipCacheUpdater interface {
+	UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcachetypes.ResourceID, aux ...ipcache.IPMetadata)
+	RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcachetypes.ResourceID, aux ...ipcache.IPMetadata)
 }
 
 type l2AnnouncerParams struct {
@@ -78,6 +92,7 @@ type l2AnnouncerParams struct {
 	Devices              statedb.Table[*tables.Device]
 	StateDB              *statedb.DB
 	JobGroup             job.Group
+	IPCache              ipCacheUpdater
 }
 
 // L2Announcer takes all L2 announcement policies and filters down to those that match the labels of the local node. It
@@ -114,7 +129,6 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 		leaderChannel:     make(chan leaderElectionEvent, leaderElectionBufferSize),
 		devicesUpdatedSig: make(chan struct{}, 1),
 	}
-
 	// Can't operate or GC if client set is disabled
 	if !params.Clientset.IsEnabled() {
 		return announcer
@@ -952,10 +966,16 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 
 	entriesIter := tbl.List(txn, tables.L2AnnounceOriginIndex.Query(svcKey))
 
+	// IPs announced for this service before any changes, collected while
+	// walking the existing entries below, so we can reconcile ipcache
+	// after the transaction commits.
+	prevIPs := make(map[netip.Addr]bool)
+
 	// If we are not the leader, we should not have any proxy entries for the service.
 	if !ss.currentlyLeader {
 		// Remove origin from entries, and delete if no origins left
 		for e := range entriesIter {
+			prevIPs[e.IP] = true
 			// Copy, since modifying objects directly is not allowed.
 			e = e.DeepCopy()
 
@@ -977,6 +997,7 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 			}
 		}
 		txn.Commit()
+		l2a.syncAnnouncedIPsInIPCache(ss, prevIPs)
 		return nil
 	}
 
@@ -988,6 +1009,7 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 
 	// Loop over existing entries, delete undesired entries
 	for e := range entriesIter {
+		prevIPs[e.IP] = true
 		key := fmt.Sprintf("%s/%s", e.IP, e.NetworkInterface)
 
 		_, desired := desiredEntries[key]
@@ -1054,7 +1076,44 @@ func (l2a *L2Announcer) recalculateL2EntriesTableEntries(ss *selectedService) er
 	}
 	txn.Commit()
 
+	l2a.syncAnnouncedIPsInIPCache(ss, prevIPs)
 	return nil
+}
+
+// syncAnnouncedIPsInIPCache reconciles ipcache HOST_ID metadata for the IPs
+// this node announces on L2 for the given service. When the node holds the L2
+// leader lease, the announced ExternalIPs must resolve to HOST_ID in ipcache
+// so that sock{4,6}_skip_xlate() allows socket-LB translation for connections
+// targeting those VIPs from the host network namespace. prevIPs is the set of
+// IPs that were in the L2AnnounceTable for this service before the most recent
+// recalculation.
+func (l2a *L2Announcer) syncAnnouncedIPsInIPCache(ss *selectedService, prevIPs map[netip.Addr]bool) {
+	resourceID := ipcachetypes.NewResourceID(
+		ipcachetypes.ResourceKindDaemon,
+		ss.svc.Name.Namespace(),
+		"l2-announcer/"+ss.svc.Name.Name(),
+	)
+
+	nextIPs := make(map[netip.Addr]bool)
+	if ss.currentlyLeader {
+		for _, entry := range l2a.desiredEntries(ss) {
+			nextIPs[entry.IP] = true
+		}
+	}
+
+	for ip := range nextIPs {
+		if !prevIPs[ip] {
+			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(ip, ip.BitLen()))
+			l2a.params.IPCache.UpsertMetadata(p, source.Local, resourceID, ciliumlabels.LabelHost)
+		}
+	}
+
+	for ip := range prevIPs {
+		if !nextIPs[ip] {
+			p := cmtypes.NewLocalPrefixCluster(netip.PrefixFrom(ip, ip.BitLen()))
+			l2a.params.IPCache.RemoveMetadata(p, resourceID, ciliumlabels.LabelHost)
+		}
+	}
 }
 
 func (l2a *L2Announcer) desiredEntries(ss *selectedService) map[string]*tables.L2AnnounceEntry {

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -25,9 +25,12 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
@@ -36,11 +39,13 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
 type fixture struct {
 	announcer          *L2Announcer
+	ipc                *recordingIPCache
 	proxyNeighborTable statedb.Table[*tables.L2AnnounceEntry]
 	stateDB            *statedb.DB
 	svcs               statedb.RWTable[*loadbalancer.Service]
@@ -85,8 +90,10 @@ func newFixture(t testing.TB) *fixture {
 
 	fakePolicyStore := &fakeStore[*v2alpha1.CiliumL2AnnouncementPolicy]{}
 
+	rec := &recordingIPCache{}
 	params := l2AnnouncerParams{
-		Logger: logger,
+		Logger:  logger,
+		IPCache: rec,
 		DaemonConfig: &option.DaemonConfig{
 			K8sNamespace:             "kube_system",
 			EnableL2Announcements:    true,
@@ -112,6 +119,7 @@ func newFixture(t testing.TB) *fixture {
 
 	return &fixture{
 		announcer:          announcer,
+		ipc:                rec,
 		proxyNeighborTable: tbl,
 		stateDB:            db,
 		svcs:               svcs,
@@ -1120,6 +1128,12 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 				EnableL2Announcements: true,
 			}
 		}),
+		cell.Provide(func() *ipcache.IPCache {
+			return ipcache.NewIPCache(&ipcache.Configuration{
+				Context: startCtx,
+				Logger:  hivetest.Logger(t),
+			})
+		}),
 		cell.Config(envoyCfg.SecretSyncConfig{}),
 		k8sClient.FakeClientCell(),
 		k8s.ResourcesCell,
@@ -1137,4 +1151,189 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 		err = h.Stop(tlog, stopCtx)
 		assert.NoError(t, err)
 	}
+}
+
+// recordingIPCache is a recorder fake for the ipCacheUpdater interface used by
+// the l2announcer's HOST_ID metadata sync. It just appends each call to a
+// slice so tests can assert ordering/contents.
+type recordingIPCache struct {
+	upserts []ipcEvent
+	removes []ipcEvent
+}
+
+type ipcEvent struct {
+	prefix   cmtypes.PrefixCluster
+	src      source.Source
+	resource ipcachetypes.ResourceID
+	aux      []ipcache.IPMetadata
+}
+
+func (r *recordingIPCache) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, res ipcachetypes.ResourceID, aux ...ipcache.IPMetadata) {
+	r.upserts = append(r.upserts, ipcEvent{prefix: prefix, src: src, resource: res, aux: append([]ipcache.IPMetadata(nil), aux...)})
+}
+
+func (r *recordingIPCache) RemoveMetadata(prefix cmtypes.PrefixCluster, res ipcachetypes.ResourceID, aux ...ipcache.IPMetadata) {
+	r.removes = append(r.removes, ipcEvent{prefix: prefix, resource: res, aux: append([]ipcache.IPMetadata(nil), aux...)})
+}
+
+// upsertedPrefixes returns the prefix strings recorded as upserts in order.
+func (r *recordingIPCache) upsertedPrefixes() []string {
+	out := make([]string, 0, len(r.upserts))
+	for _, e := range r.upserts {
+		out = append(out, e.prefix.AsPrefix().String())
+	}
+	return out
+}
+
+// removedPrefixes returns the prefix strings recorded as removes in order.
+func (r *recordingIPCache) removedPrefixes() []string {
+	out := make([]string, 0, len(r.removes))
+	for _, e := range r.removes {
+		out = append(out, e.prefix.AsPrefix().String())
+	}
+	return out
+}
+
+// driveToSelectedService runs the standard happy-path setup (devices, local
+// node, blue policy, blue service) and returns the resulting selectedService
+// from the announcer for use in leader-event tests.
+func driveToSelectedService(t *testing.T, fix *fixture) *selectedService {
+	t.Helper()
+	fix.announcer.devices = []string{"eno01"}
+	require.NoError(t, fix.announcer.processDevicesChanged(context.Background()))
+
+	require.NoError(t, fix.announcer.upsertLocalNode(context.Background(), blueNode()))
+
+	policy := bluePolicy()
+	fix.fakePolicyStore.slice = append(fix.fakePolicyStore.slice, policy)
+	require.NoError(t, fix.announcer.processPolicyEvent(context.Background(), resource.Event[*v2alpha1.CiliumL2AnnouncementPolicy]{
+		Kind:   resource.Upsert,
+		Key:    resource.NewKey(policy),
+		Object: policy,
+		Done:   func(err error) {},
+	}))
+
+	svc, fe := blueService()
+	fix.insertService(svc, fe)
+	require.NoError(t, fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+		Deleted: false,
+		Object:  svc,
+	}))
+
+	ss, ok := fix.announcer.selectedServices[serviceKey(svc)]
+	require.True(t, ok, "blue-service should have been selected by the announcer")
+	return ss
+}
+
+// TestSyncIPCache_LeaderUpsertsHostID verifies that when the announcer wins
+// the L2 lease for a service, the announced ExternalIP is upserted into the
+// (fake) ipcache as HOST_ID with a per-service resource ID.
+func TestSyncIPCache_LeaderUpsertsHostID(t *testing.T) {
+	fix := newFixture(t)
+	rec := fix.ipc
+
+	ss := driveToSelectedService(t, fix)
+
+	require.NoError(t, fix.announcer.processLeaderEvent(leaderElectionEvent{
+		typ:             leaderElectionLeading,
+		selectedService: ss,
+	}))
+
+	require.Len(t, rec.upserts, 1, "leader acquire should upsert exactly one VIP")
+	assert.Empty(t, rec.removes)
+
+	upsert := rec.upserts[0]
+	assert.Equal(t, "192.168.2.1/32", upsert.prefix.AsPrefix().String())
+	assert.Equal(t, source.Local, upsert.src)
+	assert.Contains(t, string(upsert.resource), "l2-announcer/blue-service",
+		"resource ID should encode the service name so per-service tracking works")
+	assert.Contains(t, string(upsert.resource), "default",
+		"resource ID should encode the service namespace")
+	require.Len(t, upsert.aux, 1)
+	assert.Equal(t, labels.LabelHost, upsert.aux[0])
+}
+
+// TestSyncIPCache_LossOfLeadershipRemovesHostID verifies that losing the L2
+// lease removes the HOST_ID metadata that was upserted on acquire.
+func TestSyncIPCache_LossOfLeadershipRemovesHostID(t *testing.T) {
+	fix := newFixture(t)
+	rec := fix.ipc
+
+	ss := driveToSelectedService(t, fix)
+
+	require.NoError(t, fix.announcer.processLeaderEvent(leaderElectionEvent{
+		typ:             leaderElectionLeading,
+		selectedService: ss,
+	}))
+	require.Len(t, rec.upserts, 1)
+
+	require.NoError(t, fix.announcer.processLeaderEvent(leaderElectionEvent{
+		typ:             leaderElectionStoppedLeading,
+		selectedService: ss,
+	}))
+
+	require.Len(t, rec.removes, 1, "leader loss should remove exactly one VIP")
+	remove := rec.removes[0]
+	assert.Equal(t, "192.168.2.1/32", remove.prefix.AsPrefix().String())
+	assert.Contains(t, string(remove.resource), "l2-announcer/blue-service")
+}
+
+// TestSyncIPCache_NotLeaderNoUpserts verifies that when leadership is never
+// won (only a stoppedLeading transition with no prior entries), the announcer
+// neither upserts nor tries to remove anything.
+func TestSyncIPCache_NotLeaderNoUpserts(t *testing.T) {
+	fix := newFixture(t)
+	rec := fix.ipc
+
+	ss := driveToSelectedService(t, fix)
+
+	require.NoError(t, fix.announcer.processLeaderEvent(leaderElectionEvent{
+		typ:             leaderElectionStoppedLeading,
+		selectedService: ss,
+	}))
+
+	assert.Empty(t, rec.upserts)
+	assert.Empty(t, rec.removes)
+}
+
+// TestSyncIPCache_ResourceIDPerService verifies that two services with the
+// same announced IP get distinct ipcache resource IDs, so removal of one
+// does not race with the other's metadata.
+func TestSyncIPCache_ResourceIDPerService(t *testing.T) {
+	fix := newFixture(t)
+	rec := fix.ipc
+
+	// First service via the standard fixture.
+	ssBlue := driveToSelectedService(t, fix)
+	require.NoError(t, fix.announcer.processLeaderEvent(leaderElectionEvent{
+		typ:             leaderElectionLeading,
+		selectedService: ssBlue,
+	}))
+
+	require.Len(t, rec.upserts, 1)
+	blueResource := rec.upserts[0].resource
+
+	// Synthesise a second selected service in the same namespace announcing
+	// the same IP — different name. We can't easily use the policy machinery
+	// to add another service without conflicting, so call the sync helper
+	// directly with a hand-built selectedService.
+	rec.upserts = nil
+	otherSvc := &loadbalancer.Service{
+		Name: loadbalancer.NewServiceName("default", "green-service"),
+	}
+	otherSS := &selectedService{
+		svc:               otherSvc,
+		externalAddresses: []netip.Addr{netip.MustParseAddr("192.168.2.1")},
+		byPolicies:        ssBlue.byPolicies, // reuse the blue policy
+		currentlyLeader:   true,
+	}
+	fix.announcer.syncAnnouncedIPsInIPCache(otherSS, map[netip.Addr]bool{})
+
+	require.Len(t, rec.upserts, 1)
+	greenResource := rec.upserts[0].resource
+
+	assert.NotEqual(t, blueResource, greenResource,
+		"two services announcing the same VIP must use distinct ipcache resource IDs")
+	assert.Contains(t, string(greenResource), "green-service")
+	assert.Contains(t, string(blueResource), "blue-service")
 }


### PR DESCRIPTION
Fixes #44348

## Description

`sock4_skip_xlate()` / `sock6_skip_xlate()` reject ExternalIPs whose ipcache identity is not `HOST_ID`. That check is the MITM mitigation against arbitrary remote endpoints claiming a service ExternalIP.

L2-announced ExternalIPs (`CiliumL2AnnouncementPolicy`) are added to the selected leader node's primary interface so the kernel can answer ARP/NDP for the VIP. The address really is locally hosted, but in ipcache it resolves to world identity (or a CIDR identity), not `HOST_ID`. As a result, socket-LB translation is skipped for connections originating in the host network namespace (for example `hostNetwork` pods) that target an L2-announced ExternalIP, even though this node is the elected leader and genuinely owns the VIP.

This matches @selfuryon's diagnosis in #44348 (and his follow-up comment from 2026-02-26 confirming the issue is specific to `bpf-lb-sock` translation being short-circuited). Without translation, the connection leaves the host with the VIP as the destination, the kernel routes it back via `lo`, and the service is never selected. UDP source-port rewriting / conntrack reply confusion follows from the same control-flow path.

## Fix

Before returning `true` from the skip-xlate path, look up the destination address in the per-interface L2 responder BPF map (`cilium_l2_responder_v4` / `cilium_l2_responder_v6`) keyed by `(addr, interface_ifindex)`. A hit means this node is the elected L2 leader for the VIP, the address is legitimately local, and the MITM concern does not apply — so socket-LB translation can proceed.

To make the L2 responder map usable from `bpf_sock.c`, the patch factors the key/value structs and map definitions out of `lib/l2_responder.h` into a new `lib/l2_responder_maps.h`. The full header (`l2_responder.h`) pulls in the ARP/NDP handler, which depends on helpers (`config_get`, `arp_validate`, `arp_respond`, the `icmp6_*` helpers, ...) that are not available in the sock program context. `bpf_sock.c` includes only the maps-only header; `l2_responder.h` includes the maps header and adds the handler on top, so existing callers (`bpf_host.c`) are unchanged.

## Production exposure

This fix has been running in production at Blockcast on Cilium 1.19.x rebased onto v1.19.3 across a 4-node on-prem Talos cluster for several weeks with no regressions observed: hostNetwork pods on the elected L2 leader can now reach L2-announced ExternalIP services correctly.

## Reviewers

cc @julianwiedmann (engaged on the original issue thread, datapath maintainer of record).

## AI disclosure

This PR was prepared with AIL:3 — an AI assistant helped with editing and the writeup; a human authored, reviewed, and validated each line of the change in production prior to opening this PR.

```release-note
sockLB: allow translation for L2-announced ExternalIPs on the elected leader node, fixing hostNetwork connectivity to ExternalIP services with CiliumL2AnnouncementPolicy.
```