### PR TITLE
labeler: fix invalid changed-files config for feature/k8s-gateway-api

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,8 +29,9 @@ sig/policy:
     - pkg/proxy/dns.go
     - test/**/net_policies.go
 feature/k8s-gateway-api:
-  - changed-files:
-      - Documentation/network/servicemesh/gateway-api/**
-      - operator/pkg/gateway-api/**
-      - operator/pkg/model/**
-      - vendor/sigs.k8s.io/gateway-api/**
+- changed-files:
+  - any-glob-to-any-file:
+    - Documentation/network/servicemesh/gateway-api/**
+    - operator/pkg/gateway-api/**
+    - operator/pkg/model/**
+    - vendor/sigs.k8s.io/gateway-api/**


### PR DESCRIPTION
The feature/k8s-gateway-api entry was missing the 'any-glob-to-any-file' matcher key and used incorrect indentation, causing the labeler action to fail with:
  The "changed-files" section must have a valid config structure.
Align it with the structure used by the other entries in this file.

Fixes: 01933ca1aa26 (".github: Auto-label PRs related to Gateway API")