### PR TITLE
contrib/scripts: fix check-fmt.sh aborting with exit 123 on Go 1.26+

### DIFF
--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -5,6 +5,13 @@ set -o pipefail
 
 _goroot=$(${GO:-go} env GOROOT)
 
+# Go 1.26 changed `gofmt -d` to exit non-zero when a diff is found
+# (https://cs.opensource.google/go/go/+/d945600d060e7a0b7c5e72ac606a017d105a17f3),
+# which combined with `set -e -o pipefail` above kills this script before the
+# user-friendly "Unformatted Go source code" branch below can run. Capture the
+# output and exit code explicitly so we can dispatch on whether a diff was found
+# (exit 1 with helpful message) versus a real gofmt failure (propagate the code).
+set +e
 diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -regex '.*/vendor/.*' -prune \) \
         ! \( -path './_build' -prune \) \
@@ -12,11 +19,18 @@ diff="$(find . ! \( -path './contrib' -prune \) \
         ! \( -path '*.validate.go' -prune \) \
         -type f -name '*.go' | grep -Ev "(pkg/k8s/apis/cilium.io/v2/client/bindata.go)" | \
         xargs $_goroot/bin/gofmt -d -l -s )"
+gofmt_exit=$?
+set -e
 
 if [ -n "$diff" ]; then
 	echo "Unformatted Go source code:"
 	echo "$diff"
 	exit 1
+fi
+
+if [ "$gofmt_exit" -ne 0 ]; then
+	echo "gofmt exited with $gofmt_exit but produced no diff" >&2
+	exit "$gofmt_exit"
 fi
 
 exit 0


### PR DESCRIPTION
## Problem

After the recent bump of `go.mod` to require Go 1.26, running `make precheck` on a tree with an unformatted Go file aborts with a cryptic `Error 123` and no diff output. The contributor never sees the friendly `Unformatted Go source code:` block this script was designed to produce.

## Root cause

Go 1.26 changed `gofmt -d` to exit non-zero when it finds a diff:
https://cs.opensource.google/go/go/+/d945600d060e7a0b7c5e72ac606a017d105a17f3

`contrib/scripts/check-fmt.sh` runs `gofmt` via `xargs` inside a command substitution, with `set -e` and `set -o pipefail` at the top. The non-zero exit from `gofmt` propagates through `xargs` as exit 123, `pipefail` makes the pipeline return 123, and `set -e` kills the script **before** the `if [ -n "$diff" ]` branch can fire.

## Fix

Wrap the `gofmt` pipeline with `set +e` / `set -e`, capture the exit code, and dispatch on what we got:

- non-empty `$diff` → exit 1 with the existing helpful message
- empty `$diff` but non-zero exit → surface the real `gofmt` error on stderr and propagate
- clean → exit 0

A 14-line shell-only change.

## Verification

Manual repro on Go 1.26.2:

**Before the fix** (with a stray space in `package  features`):
```
$ ./contrib/scripts/check-fmt.sh
$ echo $?
123
```
No diff output, just the cryptic 123.

**After the fix**, same broken file:
```
$ ./contrib/scripts/check-fmt.sh
Unformatted Go source code:
./cilium-cli/utils/features/utils.go
diff ./cilium-cli/utils/features/utils.go.orig ./cilium-cli/utils/features/utils.go
--- ./cilium-cli/utils/features/utils.go.orig
+++ ./cilium-cli/utils/features/utils.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium

-package  features
+package features
...

$ echo $?
1
```

**Clean tree** (after reverting):
```
$ ./contrib/scripts/check-fmt.sh
$ echo $?
0
```

`make precheck` invokes this script (`Makefile:476`), so every contributor on Go 1.26+ hits this on the first formatting mistake until the fix lands.

Fixes: #45677

```release-note
contrib/scripts: fix check-fmt.sh aborting with exit 123 (instead of printing the diff) when run with Go 1.26 or newer.
```