### PR TITLE
Revert Gateway-API/Ingress endpointslice removal (incl. restore of dummy ingress endpoint)

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -66,6 +66,9 @@ metadata:
     {{- toYaml .Values.ingressController.service.annotations | nindent 4 }}
   {{- end }}
 addressType: IPv4
-endpoints: []
-ports: []
+endpoints:
+- addresses:
+  - "192.192.192.192"
+ports:
+- port: 9999
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -48,4 +48,24 @@ spec:
   {{- if and .Values.ingressController.service.externalTrafficPolicy (not .Values.ingressController.hostNetwork.enabled) }}
   externalTrafficPolicy: {{ .Values.ingressController.service.externalTrafficPolicy }}
   {{- end }}
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: {{ .Values.ingressController.service.name }}
+  namespace: {{ include "cilium.namespace" . }}
+  labels:
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingressController.service.labels }}
+    {{- toYaml .Values.ingressController.service.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.ingressController.service.annotations }}
+  annotations:
+    {{- toYaml .Values.ingressController.service.annotations | nindent 4 }}
+  {{- end }}
+addressType: IPv4
+endpoints: []
+ports: []
 {{- end }}

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -136,7 +137,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	setGammaServiceAccepted(svc, true, "Gamma Service has routes attached", CiliumGammaReasonAccepted)
 
-	cec, _, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
+	cec, _, cep, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
@@ -144,6 +145,11 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if err = r.ensureEnvoyConfig(ctx, cec); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to ensure CiliumEnvoyConfig", logfields.Error, err)
+		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+	}
+
+	if err = r.ensureEndpointSlice(ctx, cep); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
 	}
 
@@ -339,6 +345,18 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 	}
 
 	return nil
+}
+
+func (r *gammaReconciler) ensureEndpointSlice(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
+	ep := desired.DeepCopy()
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, ep, func() error {
+		ep.Endpoints = desired.Endpoints
+		ep.Ports = desired.Ports
+		ep.OwnerReferences = desired.OwnerReferences
+		setMergedLabelsAndAnnotations(ep, desired)
+		return nil
+	})
+	return err
 }
 
 func (r *gammaReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -27,10 +26,8 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
-	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/shortener"
 )
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -52,13 +49,6 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			return controllerruntime.Success()
 		}
 		scopedLog.ErrorContext(ctx, "Unable to get Service for GAMMA checks", logfields.Error, err)
-		return controllerruntime.Fail(err)
-	}
-
-	// Ensure that any existing EndpointSlice from a previous version gets deleted (dummy ingress endpoints are no longer required)
-	// This can be removed in v1.21
-	if err := r.ensureEndpointSliceDeleted(ctx, types.NamespacedName{Namespace: originalSvc.Namespace, Name: shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + originalSvc.Name)}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure EndpointSlice deleted", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
 
@@ -347,27 +337,6 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 			return fmt.Errorf("failed to update GRPCRoute status: %w", err)
 		}
 	}
-
-	return nil
-}
-
-func (r *gatewayReconciler) ensureEndpointSliceDeleted(ctx context.Context, name types.NamespacedName) error {
-	eps := discoveryv1.EndpointSlice{}
-
-	if err := r.Client.Get(ctx, name, &eps); err != nil {
-		if k8serrors.IsNotFound(err) {
-			// no longer exists
-			return nil
-		}
-
-		return fmt.Errorf("failed to get existing EndpointSlice (%s): %w", name, err)
-	}
-
-	if err := r.Client.Delete(ctx, &eps); err != nil {
-		return fmt.Errorf("failed to delete existing EndpointSlice (%s): %w", name, err)
-	}
-
-	r.logger.DebugContext(ctx, "Successfully deleted EndpointSlice", logfields.Name, name)
 
 	return nil
 }

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -150,7 +151,8 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
-		Owns(&corev1.Service{})
+		Owns(&corev1.Service{}).
+		Owns(&discoveryv1.EndpointSlice{})
 
 	if tlsRouteEnabled {
 		// Watch TLSRoute linked to Gateway

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -217,7 +218,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 
 	// Step 3: Translate the listeners into Cilium model
-	cec, svc, err := r.translator.Translate(&model.Model{HTTP: httpListeners, TLSPassthrough: tlsPassthroughListeners})
+	cec, svc, ep, err := r.translator.Translate(&model.Model{HTTP: httpListeners, TLSPassthrough: tlsPassthroughListeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to translate resources", gatewayv1.GatewayReasonNoResources)
@@ -234,6 +235,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "Unable to create Service", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to create Service resource", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create Service resource", gatewayv1.GatewayReasonNoResources)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	}
+
+	if err = r.ensureEndpointSlice(ctx, ep); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
+		setGatewayAccepted(gw, false, "Unable to ensure Endpoints resource", gatewayv1.GatewayReasonNoResources)
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create Endpoints resource", gatewayv1.GatewayReasonNoResources)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
@@ -279,6 +287,18 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 
 		// Ignore the loadBalancerClass if it was set by a mutating webhook
 		svc.Spec.LoadBalancerClass = lbClass
+		return nil
+	})
+	return err
+}
+
+func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
+	eps := desired.DeepCopy()
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, eps, func() error {
+		eps.Endpoints = desired.Endpoints
+		eps.Ports = desired.Ports
+		eps.OwnerReferences = desired.OwnerReferences
+		setMergedLabelsAndAnnotations(eps, desired)
 		return nil
 	})
 	return err

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -32,7 +31,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
-	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -58,13 +57,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return controllerruntime.Success()
 		}
 		scopedLog.ErrorContext(ctx, "Unable to get Gateway", logfields.Error, err)
-		return controllerruntime.Fail(err)
-	}
-
-	// Ensure that any existing EndpointSlice from a previous version gets deleted (dummy ingress endpoints are no longer required)
-	// This can be removed in v1.21
-	if err := r.ensureEndpointSliceDeleted(ctx, types.NamespacedName{Namespace: original.Namespace, Name: shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + original.Name)}); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure EndpointSlice deleted", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
 
@@ -292,27 +284,6 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 	return err
 }
 
-func (r *gammaReconciler) ensureEndpointSliceDeleted(ctx context.Context, name types.NamespacedName) error {
-	eps := discoveryv1.EndpointSlice{}
-
-	if err := r.Client.Get(ctx, name, &eps); err != nil {
-		if k8serrors.IsNotFound(err) {
-			// no longer exists
-			return nil
-		}
-
-		return fmt.Errorf("failed to get existing EndpointSlice (%s): %w", name, err)
-	}
-
-	if err := r.Client.Delete(ctx, &eps); err != nil {
-		return fmt.Errorf("failed to delete existing EndpointSlice (%s): %w", name, err)
-	}
-
-	r.logger.DebugContext(ctx, "Successfully deleted EndpointSlice", logfields.Name, name)
-
-	return nil
-}
-
 func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {
 	cec := desired.DeepCopy()
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
@@ -337,7 +308,7 @@ func (r *gatewayReconciler) ensureOwnedServiceDeleted(ctx context.Context, gw *g
 	svc := &corev1.Service{}
 	key := types.NamespacedName{
 		Namespace: gw.Namespace,
-		Name:      shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + gw.Name),
+		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
 	}
 
 	if err := r.Client.Get(ctx, key, svc); err != nil {
@@ -354,7 +325,7 @@ func (r *gatewayReconciler) ensureOwnedEnvoyConfigDeleted(ctx context.Context, g
 	cec := &ciliumv2.CiliumEnvoyConfig{}
 	key := types.NamespacedName{
 		Namespace: gw.Namespace,
-		Name:      shortener.ShortenK8sResourceName(gwModel.CiliumGatewayPrefix + gw.Name),
+		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
 	}
 
 	if err := r.Client.Get(ctx, key, cec); err != nil {

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -105,6 +106,8 @@ func (r *ingressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&networkingv1.Ingress{}, r.forCiliumManagedIngress()).
 		// (LoadBalancer) Service resource with OwnerReference to the Ingress with dedicated loadbalancing mode
 		Owns(&corev1.Service{}).
+		// EndpointSlice resource with OwnerReference to the Ingress with dedicated loadbalancing mode
+		Owns(&discoveryv1.EndpointSlice{}).
 		// CiliumEnvoyConfig resource with OwnerReference to the Ingress with dedicated loadbalancing mode
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		// Watching shared loadbalancer Service and reconcile all shared Cilium Ingresses.

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -64,12 +64,6 @@ func (r *ingressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Success()
 	}
 
-	// Ensure that any existing EndpointSlice from a previous version gets deleted (dummy ingress endpoints are no longer required)
-	// This can be removed in v1.21
-	if err := r.ensureEndpointSliceDeleted(ctx, types.NamespacedName{Namespace: ingress.Namespace, Name: fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingress.Name)}); err != nil {
-		return controllerruntime.Fail(err)
-	}
-
 	// Ingress is no longer managed by Cilium.
 	// Trying to cleanup resources.
 	if !isCiliumManagedIngress(ctx, r.client, r.logger, *ingress) {
@@ -177,6 +171,7 @@ func (r *ingressReconciler) createOrUpdateSharedResources(ctx context.Context) e
 func (r *ingressReconciler) tryCleanupDedicatedResources(ctx context.Context, ingressNamespacedName types.NamespacedName) error {
 	resources := map[client.Object]types.NamespacedName{
 		&corev1.Service{}:             {Namespace: ingressNamespacedName.Namespace, Name: fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingressNamespacedName.Name)},
+		&discoveryv1.EndpointSlice{}:  {Namespace: ingressNamespacedName.Namespace, Name: fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingressNamespacedName.Name)},
 		&ciliumv2.CiliumEnvoyConfig{}: {Namespace: ingressNamespacedName.Namespace, Name: fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, ingressNamespacedName.Namespace, ingressNamespacedName.Name)},
 	}
 
@@ -366,27 +361,6 @@ func (r *ingressReconciler) createOrUpdateService(ctx context.Context, desiredSe
 	}
 
 	r.logger.DebugContext(ctx, fmt.Sprintf("Service %s has been %s", client.ObjectKeyFromObject(svc), result))
-
-	return nil
-}
-
-func (r *ingressReconciler) ensureEndpointSliceDeleted(ctx context.Context, name types.NamespacedName) error {
-	eps := discoveryv1.EndpointSlice{}
-
-	if err := r.client.Get(ctx, name, &eps); err != nil {
-		if k8serrors.IsNotFound(err) {
-			// no longer exists
-			return nil
-		}
-
-		return fmt.Errorf("failed to get existing EndpointSlice (%s): %w", name, err)
-	}
-
-	if err := r.client.Delete(ctx, &eps); err != nil {
-		return fmt.Errorf("failed to delete existing EndpointSlice (%s): %w", name, err)
-	}
-
-	r.logger.DebugContext(ctx, "Successfully deleted EndpointSlice", logfields.Name, name)
 
 	return nil
 }

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -126,7 +126,7 @@ func (r *ingressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *ingressReconciler) createOrUpdateDedicatedResources(ctx context.Context, ingress *networkingv1.Ingress, scopedLog *slog.Logger) error {
-	desiredCiliumEnvoyConfig, desiredService, err := r.buildDedicatedResources(ctx, ingress, scopedLog)
+	desiredCiliumEnvoyConfig, desiredService, desiredEndpoints, err := r.buildDedicatedResources(ctx, ingress, scopedLog)
 	if err != nil {
 		return fmt.Errorf("failed to build dedicated resources: %w", err)
 	}
@@ -136,6 +136,10 @@ func (r *ingressReconciler) createOrUpdateDedicatedResources(ctx context.Context
 	}
 
 	if err := r.createOrUpdateCiliumEnvoyConfig(ctx, desiredCiliumEnvoyConfig); err != nil {
+		return err
+	}
+
+	if err := r.createOrUpdateEndpoints(ctx, desiredEndpoints); err != nil {
 		return err
 	}
 
@@ -155,7 +159,7 @@ func (r *ingressReconciler) propagateIngressAnnotationsAndLabels(ingress *networ
 
 func (r *ingressReconciler) createOrUpdateSharedResources(ctx context.Context) error {
 	// In shared loadbalancing mode, only the CiliumEnvoyConfig is managed by the Operator.
-	// The K8s Loadbalancer Service is created by the Helm Chart.
+	// Service and Endpoints are created by the Helm Chart.
 	desiredCiliumEnvoyConfig, err := r.buildSharedResources(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to build shared resources: %w", err)
@@ -186,7 +190,7 @@ func (r *ingressReconciler) tryCleanupDedicatedResources(ctx context.Context, in
 
 func (r *ingressReconciler) tryCleanupSharedResources(ctx context.Context) error {
 	// In shared loadbalancing mode, only the CiliumEnvoyConfig is managed by the Operator.
-	// The K8s Loadbalancer Service is created by the Helm Chart.
+	// Service and Endpoints are created by the Helm Chart.
 	desiredCiliumEnvoyConfig, err := r.buildSharedResources(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to build shared resources: %w", err)
@@ -248,7 +252,7 @@ func (r *ingressReconciler) effectiveHostNetworkPort(port uint32) uint32 {
 	return defaultHostNetworkListenerPort
 }
 
-func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress *networkingv1.Ingress, scopedLog *slog.Logger) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress *networkingv1.Ingress, scopedLog *slog.Logger) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	passthroughPort, insecureHTTPPort, secureHTTPPort := r.getDedicatedListenerPorts(ingress)
 
 	m := &model.Model{}
@@ -259,9 +263,9 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 		m.HTTP = append(m.HTTP, ingestion.Ingress(nil, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
-	cec, svc, err := r.dedicatedTranslator.Translate(m)
+	cec, svc, ep, err := r.dedicatedTranslator.Translate(m)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to translate model into resources: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to translate model into resources: %w", err)
 	}
 
 	r.propagateIngressAnnotationsAndLabels(ingress, &svc.ObjectMeta)
@@ -283,10 +287,10 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 
 	// Explicitly set the controlling OwnerReference on the CiliumEnvoyConfig
 	if err := controllerutil.SetControllerReference(ingress, cec, r.client.Scheme()); err != nil {
-		return nil, nil, fmt.Errorf("failed to set controller reference on CiliumEnvoyConfig: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to set controller reference on CiliumEnvoyConfig: %w", err)
 	}
 
-	return cec, svc, err
+	return cec, svc, ep, err
 }
 
 func (r *ingressReconciler) getDedicatedListenerPorts(ingress *networkingv1.Ingress) (uint32, uint32, uint32) {
@@ -361,6 +365,27 @@ func (r *ingressReconciler) createOrUpdateService(ctx context.Context, desiredSe
 	}
 
 	r.logger.DebugContext(ctx, fmt.Sprintf("Service %s has been %s", client.ObjectKeyFromObject(svc), result))
+
+	return nil
+}
+
+func (r *ingressReconciler) createOrUpdateEndpoints(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
+	eps := desired.DeepCopy()
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.client, eps, func() error {
+		eps.Endpoints = desired.Endpoints
+		eps.Ports = desired.Ports
+		eps.OwnerReferences = desired.OwnerReferences
+		eps.Annotations = mergeMap(eps.Annotations, desired.Annotations)
+		eps.Labels = mergeMap(eps.Labels, desired.Labels)
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or update Endpoints: %w", err)
+	}
+
+	r.logger.DebugContext(ctx, fmt.Sprintf("Endpoints %s has been %s", client.ObjectKeyFromObject(eps), result))
 
 	return nil
 }

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1171,11 +1171,12 @@ type fakeDedicatedIngressTranslator struct {
 	model *model.Model
 }
 
-func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	r.model = model
 
 	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		&discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		nil
 }
 

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -92,6 +92,10 @@ func TestReconcile(t *testing.T) {
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
 
+		eps := discoveryv1.EndpointSlice{}
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
+		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
+
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
 		require.NoError(t, err, "Dedicated CiliumEnvoyConfig should exist")
@@ -143,6 +147,10 @@ func TestReconcile(t *testing.T) {
 		svc := corev1.Service{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &svc)
 		require.NoError(t, err, "Dedicated loadbalancer service should exist")
+
+		eps := discoveryv1.EndpointSlice{}
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
+		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -196,7 +204,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &discoveryv1.EndpointSlice{})
-		require.True(t, k8sApiErrors.IsNotFound(err), "EndpointSlice should not be created")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
@@ -317,7 +325,7 @@ func TestReconcile(t *testing.T) {
 
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer EndpointSlice should not exist for shared Ingress")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should not exist for shared Ingress")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -379,7 +387,7 @@ func TestReconcile(t *testing.T) {
 
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer EndpointSlice should not exist at all")
+		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -515,7 +523,7 @@ func TestReconcile(t *testing.T) {
 
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
-		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer EndpointSlice should be cleaned up")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer endpoints should be cleaned up")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -848,6 +856,18 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 				},
+				&discoveryv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "cilium-ingress-test",
+						Annotations: map[string]string{
+							"additional.annotation/test-annotation": "test",
+						},
+						Labels: map[string]string{
+							"additional.label/test-label": "test",
+						},
+					},
+				},
 				&ciliumv2.CiliumEnvoyConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test",
@@ -886,6 +906,13 @@ func TestReconcile(t *testing.T) {
 
 		require.Contains(t, svc.Labels, "additional.label/test-label", "Existing labels should not be deleted")
 		require.Contains(t, svc.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")
+
+		eps := discoveryv1.EndpointSlice{}
+		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
+		require.NoError(t, err)
+
+		require.Contains(t, eps.Labels, "additional.label/test-label", "Existing labels should not be deleted")
+		require.Contains(t, eps.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -981,7 +1008,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &discoveryv1.EndpointSlice{})
-		require.True(t, k8sApiErrors.IsNotFound(err), "EndpointSlice should not be created")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")
@@ -1039,7 +1066,7 @@ func TestReconcile(t *testing.T) {
 		require.True(t, k8sApiErrors.IsNotFound(err), "Service should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &discoveryv1.EndpointSlice{})
-		require.True(t, k8sApiErrors.IsNotFound(err), "EndpointSlice should not be created")
+		require.True(t, k8sApiErrors.IsNotFound(err), "Endpoints should not be created")
 
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &ciliumv2.CiliumEnvoyConfig{})
 		require.True(t, k8sApiErrors.IsNotFound(err), "CiliumEnvoyConfig should not be created")

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -42,10 +43,10 @@ func NewTranslator(cecTranslator translation.CECTranslator, cfg translation.Conf
 	}
 }
 
-func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	listeners := m.GetListeners()
 	if len(listeners) == 0 || len(listeners[0].GetSources()) == 0 {
-		return nil, nil, fmt.Errorf("model source can't be empty, %d listeners", len(listeners))
+		return nil, nil, nil, fmt.Errorf("model source can't be empty, %d listeners", len(listeners))
 	}
 
 	// source is the main object that is the source of the model.Model
@@ -71,7 +72,7 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	}
 
 	if source == nil || source.Name == "" {
-		return nil, nil, fmt.Errorf("model source name can't be empty")
+		return nil, nil, nil, fmt.Errorf("model source name can't be empty")
 	}
 
 	// generatedName is the name of the generated objects.
@@ -85,7 +86,7 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	}
 	cec, err := t.cecTranslator.Translate(source.Namespace, shortener.ShortenK8sResourceName(generatedName), m)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var allLabels, allAnnotations map[string]string
@@ -97,12 +98,13 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	}
 
 	if err = decorateCEC(cec, owner, allLabels, allAnnotations); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
+	eps := t.desiredEndpointSlice(source, allLabels, allAnnotations)
 	lbSvc := t.desiredService(listeners[0].GetService(), source, ports, allLabels, allAnnotations)
 
-	return cec, lbSvc, err
+	return cec, lbSvc, eps, err
 }
 
 func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *model.FullyQualifiedResource,
@@ -297,6 +299,37 @@ func (t *gatewayAPITranslator) toTrafficDistribution(params *model.Service) *str
 		return nil
 	}
 	return params.TrafficDistribution
+}
+
+func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedResource, labels, annotations map[string]string) *discoveryv1.EndpointSlice {
+	if owner == nil {
+		return nil
+	}
+	shortedName := shortener.ShortenK8sResourceName(owner.Name)
+
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
+			Namespace: owner.Namespace,
+			Labels: mergeMap(map[string]string{
+				owningGatewayLabel: shortedName,
+				gatewayNameLabel:   shortedName,
+			}, labels),
+			Annotations: annotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: gatewayv1beta1.GroupVersion.String(),
+					Kind:       owner.Kind,
+					Name:       owner.Name,
+					UID:        types.UID(owner.UID),
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   nil,
+		Ports:       nil,
+	}
 }
 
 func (t *gatewayAPITranslator) toServiceAnnotations(annotations map[string]string, params *model.Service) map[string]string {

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -327,8 +327,19 @@ func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedR
 			},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints:   nil,
-		Ports:       nil,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				// This dummy endpoint is required as agent refuses to push service entry
+				// to the lb map when the service has no backends.
+				// Related github issue https://github.com/cilium/cilium/issues/19262
+				Addresses: []string{"192.192.192.192"}, // dummy
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Port: ptr.To[int32](9999), // dummy
+			},
+		},
 	}
 }
 

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -84,7 +84,7 @@ func Test_translator_Translate(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, err := trans.Translate(input)
+			cec, svc, _, err := trans.Translate(input)
 
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
@@ -198,7 +198,7 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					expectedService := &corev1.Service{}
 					readOutput(t, fmt.Sprintf("testdata/%s/%s/service-output.yaml", tt.name, translatorCase.name), expectedService)
 
-					cec, svc, err := trans.Translate(input)
+					cec, svc, ep, err := trans.Translate(input)
 					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 					require.Equal(t, expectedService, svc, "Service mismatch")
 
@@ -206,6 +206,7 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					if len(diffOutput) != 0 {
 						t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
 					}
+					require.NotNil(t, ep)
 				})
 			}
 		})
@@ -251,7 +252,7 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, err := trans.Translate(input)
+			cec, svc, ep, err := trans.Translate(input)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
 			diffOutput := cmp.Diff(output, cec, protocmp.Transform())
@@ -261,6 +262,8 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 
 			require.NotNil(t, svc)
 			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+
+			require.NotNil(t, ep)
 		})
 	}
 }
@@ -406,10 +409,11 @@ func Test_translator_Translate_ShortensCECName(t *testing.T) {
 		},
 	}
 
-	cec, svc, err := trans.Translate(input)
+	cec, svc, ep, err := trans.Translate(input)
 	require.NoError(t, err)
 	require.NotNil(t, cec)
 	require.NotNil(t, svc)
+	require.NotNil(t, ep)
 	require.Equal(t, shortener.ShortenK8sResourceName(CiliumGatewayPrefix+longName), cec.Name)
 	require.Equal(t, svc.Name, cec.Name)
 	require.LessOrEqual(t, len(cec.Name), 63, "CiliumEnvoyConfig name is too long")

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -175,7 +175,18 @@ func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.Endpoi
 			},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints:   nil,
-		Ports:       nil,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				// This dummy endpoint is required as agent refuses to push service entry
+				// to the lb map when the service has no backends.
+				// Related github issue https://github.com/cilium/cilium/issues/19262
+				Addresses: []string{"192.192.192.192"}, // dummy
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Port: ptr.To[int32](9999), // dummy
+			},
+		},
 	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -40,9 +41,9 @@ func NewDedicatedIngressTranslator(log *slog.Logger, cecTranslator translation.C
 	}
 }
 
-func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error) {
+func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	if m == nil || (len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0) {
-		return nil, nil, fmt.Errorf("model source can't be empty")
+		return nil, nil, nil, fmt.Errorf("model source can't be empty")
 	}
 
 	var name string
@@ -71,7 +72,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	// (i.e. the HTTP listeners are just belonged to one Ingress resource).
 	cec, err := d.cecTranslator.Translate(namespace, name, m)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Set the name to avoid any breaking change during upgrade.
@@ -79,7 +80,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 
 	dedicatedService := d.getService(sourceResource, modelService, tlsOnly)
 
-	return cec, dedicatedService, err
+	return cec, dedicatedService, getEndpointSlice(sourceResource), err
 }
 
 func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedResource, service *model.Service, tlsOnly bool) *corev1.Service {
@@ -154,5 +155,27 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 			Ports:          ports,
 			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 		},
+	}
+}
+
+func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
+			Namespace: resource.Namespace,
+			Labels:    map[string]string{ciliumIngressLabelKey: "true"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: slim_networkingv1.SchemeGroupVersion.String(),
+					Kind:       "Ingress",
+					Name:       resource.Name,
+					UID:        types.UID(resource.UID),
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   nil,
+		Ports:       nil,
 	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	k8syaml "sigs.k8s.io/yaml"
@@ -188,6 +189,36 @@ func Test_getService(t *testing.T) {
 	})
 }
 
+func Test_getEndpointForIngress(t *testing.T) {
+	res := getEndpointSlice(model.FullyQualifiedResource{
+		Name:      "dummy-ingress",
+		Namespace: "dummy-namespace",
+		Version:   "v1",
+		Kind:      "Ingress",
+		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+	})
+
+	require.Equal(t, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cilium-ingress-dummy-ingress",
+			Namespace: "dummy-namespace",
+			Labels:    map[string]string{"cilium.io/ingress": "true"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "Ingress",
+					Name:       "dummy-ingress",
+					UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints:   nil,
+		Ports:       nil,
+	}, res)
+}
+
 func Test_translator_Translate(t *testing.T) {
 	type args struct {
 		useProxyProtocol             bool
@@ -296,7 +327,7 @@ func Test_translator_Translate(t *testing.T) {
 			input := &model.Model{}
 			readInput(t, fmt.Sprintf("testdata/%s/input.yaml", tt.name), input)
 
-			cec, svc, err := trans.Translate(input)
+			cec, svc, ep, err := trans.Translate(input)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 
 			output := &ciliumv2.CiliumEnvoyConfig{}
@@ -308,6 +339,8 @@ func Test_translator_Translate(t *testing.T) {
 			}
 			require.NotNil(t, svc)
 			assert.Equal(t, tt.wantLBSvcType, svc.Spec.Type)
+
+			require.NotNil(t, ep)
 		})
 	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -214,8 +214,15 @@ func Test_getEndpointForIngress(t *testing.T) {
 			},
 		},
 		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints:   nil,
-		Ports:       nil,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				// This dummy endpoint is required as agent refuses to push service entry
+				// to the lb map when the service has no backends.
+				// Related github issue https://github.com/cilium/cilium/issues/19262
+				Addresses: []string{"192.192.192.192"}, // dummy
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port
 	}, res)
 }
 

--- a/operator/pkg/model/translation/types.go
+++ b/operator/pkg/model/translation/types.go
@@ -5,17 +5,18 @@ package translation
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
-// Translator is the interface to take the model and generate required CiliumEnvoyConfig
-// and LoadBalancer Service.
+// Translator is the interface to take the model and generate required CiliumEnvoyConfig,
+// LoadBalancer Service, Endpoint, etc.
 //
 // Different use cases (e.g. Ingress, Gateway API) can provide its own generation logic.
 type Translator interface {
-	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, error)
+	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error)
 }
 
 // CECTranslator is the interface to take the model and generate required CiliumEnvoyConfig.

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -8,7 +8,7 @@
 hive/start
 
 # Add the objects
-k8s/add svc-ingress.yaml cec.yaml
+k8s/add svc-ingress.yaml eps-ingress.yaml cec.yaml
 k8s/add svc-details.yaml eps-details.yaml
 k8s/add svc-productpage.yaml eps-productpage.yaml
 
@@ -108,6 +108,39 @@ spec:
   type: LoadBalancer
 status:
   loadBalancer: {}
+
+-- eps-ingress.yaml --
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 192.192.192.192
+  conditions:
+    ready: true
+kind: EndpointSlice
+metadata:
+  creationTimestamp: "2025-03-25T10:13:20Z"
+  generateName: cilium-ingress-basic-ingress-
+  generation: 1
+  labels:
+    cilium.io/ingress: "true"
+    endpointslice.kubernetes.io/managed-by: endpointslicemirroring-controller.k8s.io
+    kubernetes.io/service-name: cilium-ingress-basic-ingress
+  name: cilium-ingress-basic-ingress-gjh2c
+  namespace: default
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Endpoints
+    name: cilium-ingress-basic-ingress
+    uid: 9465c03a-ea0e-42bf-bd8d-56aabc86fcc2
+  resourceVersion: "126851"
+  uid: d93afa57-70a6-4b66-8906-16e53df84b3f
+ports:
+- name: ""
+  port: 9999
+  protocol: TCP
 
 -- cec.yaml --
 apiVersion: cilium.io/v2

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -33,7 +33,19 @@ import (
 var (
 	zeroV4 = cmtypes.MustParseAddrCluster("0.0.0.0")
 	zeroV6 = cmtypes.MustParseAddrCluster("::")
+
+	ingressDummyAddress = cmtypes.MustParseAddrCluster("192.192.192.192")
+	ingressDummyPort    = uint16(9999)
 )
+
+func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
+	// The ingress and gateway-api controllers (operator/pkg/model/translation/{gateway-api,ingress}) create
+	// a dummy endpoint to force Cilium to reconcile the service. This is no longer required with this new
+	// control-plane, but due to rolling upgrades we cannot remove it immediately. Hence we have the
+	// special handling here to just ignore this endpoint to avoid populating the tables with unnecessary
+	// data.
+	return l3n4Addr.AddrCluster() == ingressDummyAddress && l3n4Addr.Port() == ingressDummyPort
+}
 
 func getAnnotationServiceForwardingMode(cfg loadbalancer.Config, svc *slim_corev1.Service) (loadbalancer.SVCForwardingMode, error) {
 	if value, ok := annotation.Get(svc, annotation.ServiceForwardingMode); ok {
@@ -403,6 +415,9 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					l4Addr.Port,
 					loadbalancer.ScopeExternal,
 				)
+				if isIngressDummyEndpoint(l3n4Addr) {
+					continue
+				}
 
 				// Filter out the unnamed port, if present
 				if idx := slices.Index(portNames, ""); idx != -1 {

--- a/pkg/loadbalancer/tests/testdata/ingress.txtar
+++ b/pkg/loadbalancer/tests/testdata/ingress.txtar
@@ -1,5 +1,7 @@
 #! --lb-test-fault-probability=0.0
 # Test the handling for the ingress service created by the operator.
+# The control-plane should ignore the dummy ingress endpoint (192.192.192.192:9999), but
+# still process the service.
 # An extended version of this test that include CiliumEnvoyConfig processing can be found
 # from pkg/ciliumenvoyconfig/testdata/ingress.yaml.
 # Based on https://docs.cilium.io/en/stable/network/servicemesh/http/
@@ -76,7 +78,11 @@ status:
 -- eps-ingress.yaml --
 addressType: IPv4
 apiVersion: discovery.k8s.io/v1
-endpoints: []
+endpoints:
+- addresses:
+  - 192.192.192.192
+  conditions:
+    ready: true
 kind: EndpointSlice
 metadata:
   creationTimestamp: "2025-03-25T10:13:20Z"
@@ -97,4 +103,9 @@ metadata:
     uid: 9465c03a-ea0e-42bf-bd8d-56aabc86fcc2
   resourceVersion: "126851"
   uid: d93afa57-70a6-4b66-8906-16e53df84b3f
-ports: []
+ports:
+- name: ""
+  port: 9999
+  protocol: TCP
+
+

--- a/pkg/loadbalancer/tests/testdata/ingress.txtar
+++ b/pkg/loadbalancer/tests/testdata/ingress.txtar
@@ -7,7 +7,7 @@
 hive/start
 
 # Add the service and endpoints
-k8s/add svc-ingress.yaml
+k8s/add svc-ingress.yaml eps-ingress.yaml
 
 # Validate
 db/cmp services services.table
@@ -72,3 +72,29 @@ spec:
   type: LoadBalancer
 status:
   loadBalancer: {}
+
+-- eps-ingress.yaml --
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints: []
+kind: EndpointSlice
+metadata:
+  creationTimestamp: "2025-03-25T10:13:20Z"
+  generateName: cilium-ingress-basic-ingress-
+  generation: 1
+  labels:
+    cilium.io/ingress: "true"
+    endpointslice.kubernetes.io/managed-by: endpointslicemirroring-controller.k8s.io
+    kubernetes.io/service-name: cilium-ingress-basic-ingress
+  name: cilium-ingress-basic-ingress-gjh2c
+  namespace: default
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Endpoints
+    name: cilium-ingress-basic-ingress
+    uid: 9465c03a-ea0e-42bf-bd8d-56aabc86fcc2
+  resourceVersion: "126851"
+  uid: d93afa57-70a6-4b66-8906-16e53df84b3f
+ports: []


### PR DESCRIPTION
This PR reverts the following PRs:

* https://github.com/cilium/cilium/pull/43558
* https://github.com/cilium/cilium/pull/44318

Having a frontend loadbalancer service without an `EndpointSlice` (incl. one healthy endpoint (our dummy ingress endpoint)) is not compatible with MetalLB.  See https://github.com/cilium/cilium/issues/45209

Fixes https://github.com/cilium/cilium/issues/45209