### PR TITLE
Split cloud providers into specific files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,9 @@ custom-lint: ## Run extra local linters
 	$(ECHO_CHECK) metricslint
 	$(QUIET)$(MAKE) -C tools/metricslint
 	$(QUIET)tools/metricslint/metricslint ./...
+	$(ECHO_CHECK) cloud-dep-check
+	$(QUIET)$(MAKE) -C tools/cloud-dep-check
+	$(QUIET)tools/cloud-dep-check/cilium-cloud-dep-check -root .
 
 golangci-lint: ## Run golangci-lint
 ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION:v%=%),$(GOLANGCILINT_VERSION)))

--- a/contrib/scripts/check-fipsonly.sh
+++ b/contrib/scripts/check-fipsonly.sh
@@ -16,6 +16,7 @@ EXCLUDED_DIRS=(
     "tools/alignchecker"
     "tools/api-flaggen"
     "tools/complexity-diff"
+    "tools/cloud-dep-check"
     "tools/crdcheck"
     "tools/crdlistgen"
     "tools/dev-doctor"

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -75,6 +75,12 @@ import (
 	"github.com/cilium/cilium/pkg/node/neighbordiscovery"
 	nodesync "github.com/cilium/cilium/pkg/node/sync"
 	"github.com/cilium/cilium/pkg/nodediscovery"
+
+	// Side-effect import: registers the EC2 IMDS-based AWS metadata fetcher
+	// with pkg/nodediscovery so ENI IPAM works at runtime in the agent.
+	// Kept out of cilium-operator-generic (which does not import the daemon
+	// package) to avoid pulling the AWS SDK into non-AWS operator builds.
+	_ "github.com/cilium/cilium/pkg/nodediscovery/eni"
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
 	policy "github.com/cilium/cilium/pkg/policy/cell"

--- a/operator/pkg/networkpolicy/external-groups/provider/register_aws.go
+++ b/operator/pkg/networkpolicy/external-groups/provider/register_aws.go
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// Note: this should be included in operator-aws and operator-generic builds.
+// Note: this should be included in operator-aws and operator builds.
 //
 // We cannot restrict this to operator-aws builds, however, because the AWS build
 // is only used if ENI IPAM is enabled, and there are AWS clusters that
 // don't use ENI IPAM.
 
-//go:build ipam_provider_aws || ipam_provider_operator
+//go:build ipam_provider_aws
 
 package provider
 

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/azure/types"
+	// Register the Azure resource-ID parser so AzureInterface.SetID() can
+	// populate VMSS/VM/RG fields used by AssignPrivateIpAddressesVMSS lookup.
+	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
 

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -13,6 +13,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
+	// Register the Azure resource-ID parser. This is the canonical place
+	// for Azure-IPAM-enabled binaries to wire in pkg/azure/types' parser
+	// so AzureInterface.SetID() can populate the VMSS/VM/RG fields.
+	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"

--- a/pkg/azure/types/azureid/azureid.go
+++ b/pkg/azure/types/azureid/azureid.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package azureid provides the Azure resource ID parser used by
+// pkg/azure/types. It lives in its own package so that the Azure SDK
+// (github.com/Azure/azure-sdk-for-go) is only linked into binaries that
+// explicitly import this package, keeping the SDK out of non-Azure builds
+// (in particular cilium-operator-generic, which transitively imports
+// pkg/azure/types via CiliumNode's AzureSpec).
+//
+// On import, this package registers Parse with pkg/azure/types so that
+// AzureInterface.SetID() can extract the resource group, VMSS name, and VM ID
+// from a network interface resource ID.
+package azureid
+
+import (
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/cilium/cilium/pkg/azure/types"
+)
+
+const (
+	resourceTypeVirtualMachines         = "virtualMachines"
+	resourceTypeVirtualMachineScaleSets = "virtualMachineScaleSets"
+)
+
+func init() {
+	types.RegisterResourceIDParser(Parse)
+}
+
+// Parse parses a network interface Azure resource ID and returns the
+// resource group name, VMSS name (if any), and VM ID (if any). On parse
+// failure or missing fields, empty strings are returned.
+func Parse(id string) (resourceGroup, vmssName, vmID string) {
+	resourceID, err := arm.ParseResourceID(id)
+	if err != nil {
+		return "", "", ""
+	}
+
+	resourceGroup = resourceID.ResourceGroupName
+
+	// For VMSS instances, walk up the parent chain to extract VMSS name and VM ID.
+	// Resource ID structure for VMSS VM interfaces:
+	// /subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Compute/virtualMachineScaleSets/ssss/virtualMachines/vvv/networkInterfaces/iii
+	current := resourceID
+	for current != nil {
+		resourceType := current.ResourceType
+		if len(resourceType.Types) == 0 {
+			current = current.Parent
+			continue
+		}
+
+		lastType := resourceType.Types[len(resourceType.Types)-1]
+
+		if strings.EqualFold(lastType, resourceTypeVirtualMachines) {
+			vmID = current.Name
+		}
+
+		if strings.EqualFold(lastType, resourceTypeVirtualMachineScaleSets) {
+			vmssName = current.Name
+		}
+
+		current = current.Parent
+	}
+
+	return resourceGroup, vmssName, vmID
+}

--- a/pkg/azure/types/extract_ids.go
+++ b/pkg/azure/types/extract_ids.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+// resourceIDParser parses an Azure network interface resource ID and returns
+// (resourceGroup, vmssName, vmID). It is overridden via RegisterResourceIDParser
+// from pkg/azure/types/azureid (which uses the Azure SDK) so that pkg/azure/types
+// itself does not transitively pull the Azure SDK into every consumer of
+// CiliumNode (which embeds AzureSpec). Non-Azure binaries leave this stub in
+// place; they never call extractIDs() on real Azure resource IDs.
+var resourceIDParser = func(_ string) (resourceGroup, vmssName, vmID string) {
+	return "", "", ""
+}
+
+// RegisterResourceIDParser installs the function used to parse Azure network
+// interface resource IDs into resource group, VMSS, and VM ID components.
+//
+// This indirection exists so that the Azure SDK (which provides the actual
+// parser implementation) is only linked into binaries that import
+// pkg/azure/types/azureid, keeping it out of non-Azure builds without
+// requiring build tags.
+func RegisterResourceIDParser(fn func(id string) (resourceGroup, vmssName, vmID string)) {
+	if fn == nil {
+		return
+	}
+	resourceIDParser = fn
+}
+
+func parseAzureResourceID(id string) (resourceGroup, vmssName, vmID string) {
+	return resourceIDParser(id)
+}

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -4,10 +4,6 @@
 package types
 
 import (
-	"strings"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
 	"github.com/cilium/cilium/pkg/ipam/types"
 )
 
@@ -25,10 +21,6 @@ const (
 
 	// StateSucceeded is the address state for a successfully provisioned address
 	StateSucceeded = "succeeded"
-
-	// Resource type names for Azure resources
-	resourceTypeVirtualMachines         = "virtualMachines"
-	resourceTypeVirtualMachineScaleSets = "virtualMachineScaleSets"
 )
 
 // AzureSpec is the Azure specification of a node running via the Azure IPAM
@@ -141,40 +133,12 @@ func (a *AzureInterface) InterfaceID() string {
 	return a.ID
 }
 
-// extractIDs extracts resource group name, VMSS name, and VM ID from the network interface Azure resource ID
+// extractIDs extracts resource group name, VMSS name, and VM ID from the
+// network interface Azure resource ID. The actual implementation is build-tag
+// gated so the Azure SDK is only pulled in by builds that need it (see
+// extract_ids.go).
 func (a *AzureInterface) extractIDs() {
-	resourceID, err := arm.ParseResourceID(a.ID)
-	if err != nil {
-		// If parsing fails, leave fields empty
-		return
-	}
-
-	// Extract resource group name directly from the parsed ID
-	a.resourceGroup = resourceID.ResourceGroupName
-
-	// For VMSS instances, walk up the parent chain to extract VMSS name and VM ID
-	// Resource ID structure for VMSS VM interfaces:
-	// /subscriptions/xxx/resourceGroups/yyy/providers/Microsoft.Compute/virtualMachineScaleSets/ssss/virtualMachines/vvv/networkInterfaces/iii
-	current := resourceID
-	for current != nil {
-		resourceType := current.ResourceType
-		if len(resourceType.Types) == 0 {
-			current = current.Parent
-			continue
-		}
-
-		lastType := resourceType.Types[len(resourceType.Types)-1]
-
-		if strings.EqualFold(lastType, resourceTypeVirtualMachines) {
-			a.vmID = current.Name
-		}
-
-		if strings.EqualFold(lastType, resourceTypeVirtualMachineScaleSets) {
-			a.vmssName = current.Name
-		}
-
-		current = current.Parent
-	}
+	a.resourceGroup, a.vmssName, a.vmID = parseAzureResourceID(a.ID)
 }
 
 // GetResourceGroup returns the resource group the interface belongs to

--- a/pkg/azure/types/types_test.go
+++ b/pkg/azure/types/types_test.go
@@ -1,23 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package types
+package types_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	azuretypes "github.com/cilium/cilium/pkg/azure/types"
+	// Register the Azure resource-ID parser so SetID()/extractIDs() populate
+	// the VMSS/VM/RG fields exercised by TestExtractIDs.
+	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	"github.com/cilium/cilium/pkg/ipam/types"
 )
 
 func TestForeachAddresses(t *testing.T) {
 	m := types.NewInstanceMap()
-	m.Update("i-1", &AzureInterface{ID: "1", Addresses: []AzureAddress{
+	m.Update("i-1", &azuretypes.AzureInterface{ID: "1", Addresses: []azuretypes.AzureAddress{
 		{IP: "1.1.1.1"},
 		{IP: "2.2.2.2"},
 	}})
-	m.Update("i-2", &AzureInterface{ID: "1", Addresses: []AzureAddress{
+	m.Update("i-2", &azuretypes.AzureInterface{ID: "1", Addresses: []azuretypes.AzureAddress{
 		{IP: "3.3.3.3"},
 		{IP: "4.4.4.4"},
 	}})
@@ -73,7 +77,7 @@ func TestExtractIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			intf := AzureInterface{}
+			intf := azuretypes.AzureInterface{}
 			intf.SetID(tt.resourceID)
 
 			require.Equal(t, tt.expectedRG, intf.GetResourceGroup())

--- a/pkg/nodediscovery/eni/eni.go
+++ b/pkg/nodediscovery/eni/eni.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package eni wires the ENI-specific CiliumNode mutator (using the EC2 IMDS
+// client and the AWS SDK helpers) into pkg/nodediscovery. It is imported
+// (with a blank import) by the cilium-agent so that ENI IPAM works at
+// runtime, while keeping the AWS SDK out of non-AWS binaries (notably
+// cilium-operator-generic) which do not import this package.
+package eni
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/aws/metadata"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/nodediscovery"
+)
+
+func init() {
+	nodediscovery.RegisterENIMutator(mutate)
+}
+
+// mutate populates the ENI-specific fields of nodeResource using EC2 IMDS
+// metadata and the agent configuration carried in in.
+func mutate(ctx context.Context, in nodediscovery.ENIMutateInputs, nodeResource *ciliumv2.CiliumNode) error {
+	// set ENI field in the node only when the ENI ipam is specified
+	nodeResource.Spec.ENI = eniTypes.ENISpec{}
+
+	imds, err := metadata.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to create EC2 metadata client: %w", err)
+	}
+	info, err := imds.GetInstanceMetadata(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve InstanceID of own EC2 instance: %w", err)
+	}
+	if info.InstanceID == "" {
+		return errors.New("InstanceID of own EC2 instance is empty")
+	}
+
+	// It is important to determine the interface index here because this
+	// function will be called when the agent is first coming up and is
+	// initializing the IPAM layer (CRD allocator in this case). Later on,
+	// the Operator will adjust this value based on the PreAllocate value,
+	// so to ensure that the agent and the Operator are not conflicting
+	// with each other, we must have similar logic to determine the
+	// appropriate value to place inside the resource.
+	nodeResource.Spec.ENI.VpcID = info.VPCID
+	nodeResource.Spec.ENI.FirstInterfaceIndex = aws.Int(in.FirstInterfaceIndex)
+	nodeResource.Spec.ENI.UsePrimaryAddress = aws.Bool(in.UsePrimaryAddress)
+	nodeResource.Spec.ENI.DisablePrefixDelegation = aws.Bool(in.DisablePrefixDelegation)
+	nodeResource.Spec.ENI.DeleteOnTermination = aws.Bool(in.DeleteOnTermination)
+
+	nodeResource.Spec.ENI.SubnetIDs = in.SubnetIDs
+	nodeResource.Spec.ENI.SubnetTags = in.SubnetTags
+	nodeResource.Spec.ENI.SecurityGroups = in.SecurityGroups
+	nodeResource.Spec.ENI.SecurityGroupTags = in.SecurityGroupTags
+	nodeResource.Spec.ENI.ExcludeInterfaceTags = in.ExcludeInterfaceTags
+
+	nodeResource.Spec.IPAM.MinAllocate = in.IPAMMinAllocate
+	nodeResource.Spec.IPAM.PreAllocate = in.IPAMPreAllocate
+	nodeResource.Spec.IPAM.MaxAllocate = in.IPAMMaxAllocate
+
+	if c := in.CNIConfigManager.GetCustomNetConf(); c != nil {
+		if c.IPAM.MinAllocate != 0 {
+			nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
+		}
+		if c.IPAM.PreAllocate != 0 {
+			nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+		}
+		if c.ENI.FirstInterfaceIndex != nil {
+			nodeResource.Spec.ENI.FirstInterfaceIndex = c.ENI.FirstInterfaceIndex
+		}
+		if len(c.ENI.SecurityGroups) > 0 {
+			nodeResource.Spec.ENI.SecurityGroups = c.ENI.SecurityGroups
+		}
+		if len(c.ENI.SecurityGroupTags) > 0 {
+			nodeResource.Spec.ENI.SecurityGroupTags = c.ENI.SecurityGroupTags
+		}
+		if len(c.ENI.SubnetIDs) > 0 {
+			nodeResource.Spec.ENI.SubnetIDs = c.ENI.SubnetIDs
+		}
+		if len(c.ENI.SubnetTags) > 0 {
+			nodeResource.Spec.ENI.SubnetTags = c.ENI.SubnetTags
+		}
+		if c.ENI.VpcID != "" {
+			nodeResource.Spec.ENI.VpcID = c.ENI.VpcID
+		}
+		if len(c.ENI.ExcludeInterfaceTags) > 0 {
+			nodeResource.Spec.ENI.ExcludeInterfaceTags = c.ENI.ExcludeInterfaceTags
+		}
+		if c.ENI.UsePrimaryAddress != nil {
+			nodeResource.Spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
+		}
+		if c.ENI.DisablePrefixDelegation != nil {
+			nodeResource.Spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
+		}
+		nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
+	}
+
+	nodeResource.Spec.InstanceID = info.InstanceID
+	nodeResource.Spec.ENI.InstanceType = info.InstanceType
+	nodeResource.Spec.ENI.AvailabilityZone = info.AvailabilityZone
+	nodeResource.Spec.ENI.NodeSubnetID = info.SubnetID
+	return nil
+}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/cilium/stream"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
@@ -19,8 +18,6 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
 	alibabaCloudMetadata "github.com/cilium/cilium/pkg/alibabacloud/metadata"
-	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
-	"github.com/cilium/cilium/pkg/aws/metadata"
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -394,96 +391,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 
 	switch option.Config.IPAM {
 	case ipamOption.IPAMENI:
-		// set ENI field in the node only when the ENI ipam is specified
-		nodeResource.Spec.ENI = eniTypes.ENISpec{}
-		imds, err := metadata.NewClient(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to create metadata client", logfields.Error, err)
-		}
-		info, err := imds.GetInstanceMetadata(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to retrieve InstanceID of own EC2 instance", logfields.Error, err)
-		}
-
-		if info.InstanceID == "" {
-			return errors.New("InstanceID of own EC2 instance is empty")
-		}
-
-		// It is important to determine the interface index here because this
-		// function (mutateNodeResource()) will be called when the agent is
-		// first coming up and is initializing the IPAM layer (CRD allocator in
-		// this case). Later on, the Operator will adjust this value based on
-		// the PreAllocate value, so to ensure that the agent and the Operator
-		// are not conflicting with each other, we must have similar logic to
-		// determine the appropriate value to place inside the resource.
-		nodeResource.Spec.ENI.VpcID = info.VPCID
-		nodeResource.Spec.ENI.FirstInterfaceIndex = aws.Int(n.config.ENIFirstInterfaceIndex)
-		nodeResource.Spec.ENI.UsePrimaryAddress = aws.Bool(n.config.ENIUsePrimaryAddress)
-		nodeResource.Spec.ENI.DisablePrefixDelegation = aws.Bool(n.config.ENIDisablePrefixDelegation)
-		nodeResource.Spec.ENI.DeleteOnTermination = aws.Bool(n.config.ENIDeleteOnTermination)
-
-		nodeResource.Spec.ENI.SubnetIDs = n.config.ENISubnetIDs
-		nodeResource.Spec.ENI.SubnetTags = n.config.ENISubnetTags
-		nodeResource.Spec.ENI.SecurityGroups = n.config.ENISecurityGroups
-		nodeResource.Spec.ENI.SecurityGroupTags = n.config.ENISecurityGroupTags
-		nodeResource.Spec.ENI.ExcludeInterfaceTags = n.config.ENIExcludeInterfaceTags
-
-		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
-		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
-		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
-
-		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
-			if c.IPAM.MinAllocate != 0 {
-				nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
-			}
-
-			if c.IPAM.PreAllocate != 0 {
-				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			}
-
-			if c.ENI.FirstInterfaceIndex != nil {
-				nodeResource.Spec.ENI.FirstInterfaceIndex = c.ENI.FirstInterfaceIndex
-			}
-
-			if len(c.ENI.SecurityGroups) > 0 {
-				nodeResource.Spec.ENI.SecurityGroups = c.ENI.SecurityGroups
-			}
-
-			if len(c.ENI.SecurityGroupTags) > 0 {
-				nodeResource.Spec.ENI.SecurityGroupTags = c.ENI.SecurityGroupTags
-			}
-
-			if len(c.ENI.SubnetIDs) > 0 {
-				nodeResource.Spec.ENI.SubnetIDs = c.ENI.SubnetIDs
-			}
-
-			if len(c.ENI.SubnetTags) > 0 {
-				nodeResource.Spec.ENI.SubnetTags = c.ENI.SubnetTags
-			}
-
-			if c.ENI.VpcID != "" {
-				nodeResource.Spec.ENI.VpcID = c.ENI.VpcID
-			}
-
-			if len(c.ENI.ExcludeInterfaceTags) > 0 {
-				nodeResource.Spec.ENI.ExcludeInterfaceTags = c.ENI.ExcludeInterfaceTags
-			}
-
-			if c.ENI.UsePrimaryAddress != nil {
-				nodeResource.Spec.ENI.UsePrimaryAddress = c.ENI.UsePrimaryAddress
-			}
-
-			if c.ENI.DisablePrefixDelegation != nil {
-				nodeResource.Spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
-			}
-
-			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
-		}
-
-		nodeResource.Spec.InstanceID = info.InstanceID
-		nodeResource.Spec.ENI.InstanceType = info.InstanceType
-		nodeResource.Spec.ENI.AvailabilityZone = info.AvailabilityZone
-		nodeResource.Spec.ENI.NodeSubnetID = info.SubnetID
+		return n.mutateENINodeResource(ctx, nodeResource)
 
 	case ipamOption.IPAMAzure:
 		if ln.Local.ProviderID == "" {

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -6,10 +6,8 @@ package nodediscovery
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"slices"
-	"strings"
 
 	"github.com/cilium/stream"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +16,6 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
 	alibabaCloudMetadata "github.com/cilium/cilium/pkg/alibabacloud/metadata"
-	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -394,35 +391,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		return n.mutateENINodeResource(ctx, nodeResource)
 
 	case ipamOption.IPAMAzure:
-		if ln.Local.ProviderID == "" {
-			logging.Fatal(n.logger, "Spec.ProviderID in k8s node resource must be set for Azure IPAM")
-		}
-		if !strings.HasPrefix(ln.Local.ProviderID, azureTypes.ProviderPrefix) {
-			logging.Fatal(n.logger, fmt.Sprintf("Spec.ProviderID in k8s node resource must have prefix %s", azureTypes.ProviderPrefix))
-		}
-		// The Azure controller in Kubernetes creates a mix of upper
-		// and lower case when filling in the ProviderID and is
-		// therefore not providing the exact representation of what is
-		// returned by the Azure API. Convert it to lower case for
-		// consistent results.
-		nodeResource.Spec.InstanceID = strings.ToLower(strings.TrimPrefix(ln.Local.ProviderID, azureTypes.ProviderPrefix))
-
-		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
-		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
-		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
-		nodeResource.Spec.Azure.InterfaceName = n.config.AzureInterfaceName
-
-		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
-			if c.IPAM.MinAllocate != 0 {
-				nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
-			}
-			if c.IPAM.PreAllocate != 0 {
-				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			}
-			if c.Azure.InterfaceName != "" {
-				nodeResource.Spec.Azure.InterfaceName = c.Azure.InterfaceName
-			}
-		}
+		return n.mutateAzureNodeResource(ctx, nodeResource, ln)
 
 	case ipamOption.IPAMAlibabaCloud:
 		nodeResource.Spec.AlibabaCloud = alibabaCloudTypes.Spec{}

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/utils/net"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
-	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
-	alibabaCloudMetadata "github.com/cilium/cilium/pkg/alibabacloud/metadata"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -394,75 +392,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		return n.mutateAzureNodeResource(ctx, nodeResource, ln)
 
 	case ipamOption.IPAMAlibabaCloud:
-		nodeResource.Spec.AlibabaCloud = alibabaCloudTypes.Spec{}
-
-		instanceID, err := alibabaCloudMetadata.GetInstanceID(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to retrieve InstanceID of own ECS instance", logfields.Error, err)
-		}
-
-		if instanceID == "" {
-			return errors.New("InstanceID of own ECS instance is empty")
-		}
-
-		instanceType, err := alibabaCloudMetadata.GetInstanceType(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to retrieve InstanceType of own ECS instance", logfields.Error, err)
-		}
-		vpcID, err := alibabaCloudMetadata.GetVPCID(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to retrieve VPC ID of own ECS instance", logfields.Error, err)
-		}
-		vpcCidrBlock, err := alibabaCloudMetadata.GetVPCCIDRBlock(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to retrieve VPC CIDR block of own ECS instance", logfields.Error, err)
-		}
-		zoneID, err := alibabaCloudMetadata.GetZoneID(ctx)
-		if err != nil {
-			logging.Fatal(n.logger, "Unable to retrieve Zone ID of own ECS instance", logfields.Error, err)
-		}
-		nodeResource.Spec.InstanceID = instanceID
-		nodeResource.Spec.AlibabaCloud.InstanceType = instanceType
-		nodeResource.Spec.AlibabaCloud.VPCID = vpcID
-		nodeResource.Spec.AlibabaCloud.CIDRBlock = vpcCidrBlock
-		nodeResource.Spec.AlibabaCloud.AvailabilityZone = zoneID
-
-		nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
-		nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
-		nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
-		nodeResource.Spec.AlibabaCloud.VSwitches = n.config.AlibabaCloudVSwitches
-		nodeResource.Spec.AlibabaCloud.VSwitchTags = n.config.AlibabaCloudVSwitchTags
-		nodeResource.Spec.AlibabaCloud.SecurityGroups = n.config.AlibabaCloudSecurityGroups
-		nodeResource.Spec.AlibabaCloud.SecurityGroupTags = n.config.AlibabaCloudSecurityGroupTags
-
-		if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
-			if c.AlibabaCloud.VPCID != "" {
-				nodeResource.Spec.AlibabaCloud.VPCID = c.AlibabaCloud.VPCID
-			}
-			if c.AlibabaCloud.CIDRBlock != "" {
-				nodeResource.Spec.AlibabaCloud.CIDRBlock = c.AlibabaCloud.CIDRBlock
-			}
-
-			if len(c.AlibabaCloud.VSwitches) > 0 {
-				nodeResource.Spec.AlibabaCloud.VSwitches = c.AlibabaCloud.VSwitches
-			}
-
-			if len(c.AlibabaCloud.VSwitchTags) > 0 {
-				nodeResource.Spec.AlibabaCloud.VSwitchTags = c.AlibabaCloud.VSwitchTags
-			}
-
-			if len(c.AlibabaCloud.SecurityGroups) > 0 {
-				nodeResource.Spec.AlibabaCloud.SecurityGroups = c.AlibabaCloud.SecurityGroups
-			}
-
-			if len(c.AlibabaCloud.SecurityGroupTags) > 0 {
-				nodeResource.Spec.AlibabaCloud.SecurityGroupTags = c.AlibabaCloud.SecurityGroupTags
-			}
-
-			if c.IPAM.PreAllocate != 0 {
-				nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
-			}
-		}
+		return n.mutateAlibabaCloudNodeResource(ctx, nodeResource)
 	}
 
 	return nil

--- a/pkg/nodediscovery/nodediscovery_alibabacloud.go
+++ b/pkg/nodediscovery/nodediscovery_alibabacloud.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodediscovery
+
+import (
+	"context"
+	"errors"
+
+	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
+	alibabaCloudMetadata "github.com/cilium/cilium/pkg/alibabacloud/metadata"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// mutateAlibabaCloudNodeResource fills in the AlibabaCloud-specific fields
+// of the CiliumNode resource. It is kept in a separate file so that the
+// AlibabaCloud-specific imports are not pulled in via the main
+// nodediscovery.go.
+func (n *NodeDiscovery) mutateAlibabaCloudNodeResource(ctx context.Context, nodeResource *ciliumv2.CiliumNode) error {
+	nodeResource.Spec.AlibabaCloud = alibabaCloudTypes.Spec{}
+
+	instanceID, err := alibabaCloudMetadata.GetInstanceID(ctx)
+	if err != nil {
+		logging.Fatal(n.logger, "Unable to retrieve InstanceID of own ECS instance", logfields.Error, err)
+	}
+
+	if instanceID == "" {
+		return errors.New("InstanceID of own ECS instance is empty")
+	}
+
+	instanceType, err := alibabaCloudMetadata.GetInstanceType(ctx)
+	if err != nil {
+		logging.Fatal(n.logger, "Unable to retrieve InstanceType of own ECS instance", logfields.Error, err)
+	}
+	vpcID, err := alibabaCloudMetadata.GetVPCID(ctx)
+	if err != nil {
+		logging.Fatal(n.logger, "Unable to retrieve VPC ID of own ECS instance", logfields.Error, err)
+	}
+	vpcCidrBlock, err := alibabaCloudMetadata.GetVPCCIDRBlock(ctx)
+	if err != nil {
+		logging.Fatal(n.logger, "Unable to retrieve VPC CIDR block of own ECS instance", logfields.Error, err)
+	}
+	zoneID, err := alibabaCloudMetadata.GetZoneID(ctx)
+	if err != nil {
+		logging.Fatal(n.logger, "Unable to retrieve Zone ID of own ECS instance", logfields.Error, err)
+	}
+	nodeResource.Spec.InstanceID = instanceID
+	nodeResource.Spec.AlibabaCloud.InstanceType = instanceType
+	nodeResource.Spec.AlibabaCloud.VPCID = vpcID
+	nodeResource.Spec.AlibabaCloud.CIDRBlock = vpcCidrBlock
+	nodeResource.Spec.AlibabaCloud.AvailabilityZone = zoneID
+
+	nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
+	nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
+	nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
+	nodeResource.Spec.AlibabaCloud.VSwitches = n.config.AlibabaCloudVSwitches
+	nodeResource.Spec.AlibabaCloud.VSwitchTags = n.config.AlibabaCloudVSwitchTags
+	nodeResource.Spec.AlibabaCloud.SecurityGroups = n.config.AlibabaCloudSecurityGroups
+	nodeResource.Spec.AlibabaCloud.SecurityGroupTags = n.config.AlibabaCloudSecurityGroupTags
+
+	if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
+		if c.AlibabaCloud.VPCID != "" {
+			nodeResource.Spec.AlibabaCloud.VPCID = c.AlibabaCloud.VPCID
+		}
+		if c.AlibabaCloud.CIDRBlock != "" {
+			nodeResource.Spec.AlibabaCloud.CIDRBlock = c.AlibabaCloud.CIDRBlock
+		}
+
+		if len(c.AlibabaCloud.VSwitches) > 0 {
+			nodeResource.Spec.AlibabaCloud.VSwitches = c.AlibabaCloud.VSwitches
+		}
+
+		if len(c.AlibabaCloud.VSwitchTags) > 0 {
+			nodeResource.Spec.AlibabaCloud.VSwitchTags = c.AlibabaCloud.VSwitchTags
+		}
+
+		if len(c.AlibabaCloud.SecurityGroups) > 0 {
+			nodeResource.Spec.AlibabaCloud.SecurityGroups = c.AlibabaCloud.SecurityGroups
+		}
+
+		if len(c.AlibabaCloud.SecurityGroupTags) > 0 {
+			nodeResource.Spec.AlibabaCloud.SecurityGroupTags = c.AlibabaCloud.SecurityGroupTags
+		}
+
+		if c.IPAM.PreAllocate != 0 {
+			nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+		}
+	}
+
+	return nil
+}

--- a/pkg/nodediscovery/nodediscovery_azure.go
+++ b/pkg/nodediscovery/nodediscovery_azure.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodediscovery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	azureTypes "github.com/cilium/cilium/pkg/azure/types"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// mutateAzureNodeResource fills in the Azure-specific fields of the
+// CiliumNode resource. It is kept in a separate file so that the
+// Azure-specific imports are not pulled in via the main nodediscovery.go.
+func (n *NodeDiscovery) mutateAzureNodeResource(_ context.Context, nodeResource *ciliumv2.CiliumNode, ln *node.LocalNode) error {
+	if ln.Local.ProviderID == "" {
+		logging.Fatal(n.logger, "Spec.ProviderID in k8s node resource must be set for Azure IPAM")
+	}
+	if !strings.HasPrefix(ln.Local.ProviderID, azureTypes.ProviderPrefix) {
+		logging.Fatal(n.logger, fmt.Sprintf("Spec.ProviderID in k8s node resource must have prefix %s", azureTypes.ProviderPrefix))
+	}
+	// The Azure controller in Kubernetes creates a mix of upper and lower
+	// case when filling in the ProviderID and is therefore not providing the
+	// exact representation of what is returned by the Azure API. Convert it
+	// to lower case for consistent results.
+	nodeResource.Spec.InstanceID = strings.ToLower(strings.TrimPrefix(ln.Local.ProviderID, azureTypes.ProviderPrefix))
+
+	nodeResource.Spec.IPAM.MinAllocate = n.config.IPAMMinAllocate
+	nodeResource.Spec.IPAM.PreAllocate = n.config.IPAMPreAllocate
+	nodeResource.Spec.IPAM.MaxAllocate = n.config.IPAMMaxAllocate
+	nodeResource.Spec.Azure.InterfaceName = n.config.AzureInterfaceName
+
+	if c := n.cniConfigManager.GetCustomNetConf(); c != nil {
+		if c.IPAM.MinAllocate != 0 {
+			nodeResource.Spec.IPAM.MinAllocate = c.IPAM.MinAllocate
+		}
+		if c.IPAM.PreAllocate != 0 {
+			nodeResource.Spec.IPAM.PreAllocate = c.IPAM.PreAllocate
+		}
+		if c.Azure.InterfaceName != "" {
+			nodeResource.Spec.Azure.InterfaceName = c.Azure.InterfaceName
+		}
+	}
+
+	return nil
+}

--- a/pkg/nodediscovery/nodediscovery_eni.go
+++ b/pkg/nodediscovery/nodediscovery_eni.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodediscovery
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/daemon/cmd/cni"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/logging"
+)
+
+// ENIMutateInputs carries the agent configuration needed to populate the
+// ENI-specific fields of a CiliumNode resource. It deliberately uses only
+// plain Go types (no AWS SDK types) so that this file does not pull in any
+// AWS dependency. The actual mutator implementation, registered from
+// pkg/nodediscovery/eni, is what links against the AWS SDK and the EC2 IMDS
+// client.
+type ENIMutateInputs struct {
+	FirstInterfaceIndex     int
+	UsePrimaryAddress       bool
+	DisablePrefixDelegation bool
+	DeleteOnTermination     bool
+	SubnetIDs               []string
+	SubnetTags              map[string]string
+	SecurityGroups          []string
+	SecurityGroupTags       map[string]string
+	ExcludeInterfaceTags    map[string]string
+	IPAMMinAllocate         int
+	IPAMPreAllocate         int
+	IPAMMaxAllocate         int
+	CNIConfigManager        cni.CNIConfigManager
+}
+
+// ENIMutator populates the ENI-specific fields of nodeResource. It is
+// registered from pkg/nodediscovery/eni's init() so that the AWS SDK and
+// EC2 IMDS client are only linked into binaries that import that package
+// (notably cilium-agent), keeping them out of cilium-operator-generic.
+type ENIMutator func(ctx context.Context, in ENIMutateInputs, nodeResource *ciliumv2.CiliumNode) error
+
+var eniMutator ENIMutator
+
+// RegisterENIMutator installs the function used to populate the ENI fields
+// of a CiliumNode. It is called from pkg/nodediscovery/eni's init().
+func RegisterENIMutator(fn ENIMutator) {
+	eniMutator = fn
+}
+
+// mutateENINodeResource dispatches to the registered ENIMutator. If none is
+// registered (e.g. in cilium-operator-generic, which does not blank-import
+// pkg/nodediscovery/eni), it fatals — ENI IPAM is only supported by the
+// cilium-agent binary and the AWS-specific operator.
+func (n *NodeDiscovery) mutateENINodeResource(ctx context.Context, nodeResource *ciliumv2.CiliumNode) error {
+	if eniMutator == nil {
+		logging.Fatal(n.logger, "ENI IPAM mode requires the cilium-agent binary; "+
+			"ensure pkg/nodediscovery/eni is imported (operator binaries must use the AWS-specific operator)")
+		return nil
+	}
+	return eniMutator(ctx, ENIMutateInputs{
+		FirstInterfaceIndex:     n.config.ENIFirstInterfaceIndex,
+		UsePrimaryAddress:       n.config.ENIUsePrimaryAddress,
+		DisablePrefixDelegation: n.config.ENIDisablePrefixDelegation,
+		DeleteOnTermination:     n.config.ENIDeleteOnTermination,
+		SubnetIDs:               n.config.ENISubnetIDs,
+		SubnetTags:              n.config.ENISubnetTags,
+		SecurityGroups:          n.config.ENISecurityGroups,
+		SecurityGroupTags:       n.config.ENISecurityGroupTags,
+		ExcludeInterfaceTags:    n.config.ENIExcludeInterfaceTags,
+		IPAMMinAllocate:         n.config.IPAMMinAllocate,
+		IPAMPreAllocate:         n.config.IPAMPreAllocate,
+		IPAMMaxAllocate:         n.config.IPAMMaxAllocate,
+		CNIConfigManager:        n.cniConfigManager,
+	}, nodeResource)
+}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@
 
 include ../Makefile.defs
 
-SUBDIRS := alignchecker mount slogloggercheck metricslint feature-helm-generator
+SUBDIRS := alignchecker mount slogloggercheck metricslint feature-helm-generator cloud-dep-check
 
 .PHONY: all $(SUBDIRS) clean install
 

--- a/tools/cloud-dep-check/Makefile
+++ b/tools/cloud-dep-check/Makefile
@@ -1,0 +1,30 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+include ../../Makefile.defs
+
+TARGET := cilium-cloud-dep-check
+
+.PHONY: all $(TARGET) clean install check
+
+all: $(TARGET)
+
+$(TARGET):
+	@$(ECHO_GO)
+	$(QUIET)$(GO_BUILD) -o $@
+
+# `make check` builds the linter and runs it against the cilium repository
+# root, verifying that each cilium-operator-* binary variant only contains
+# its own cloud-provider SDK dependencies.
+check: $(TARGET)
+	$(QUIET)./$(TARGET) -root ../..
+
+clean:
+	@$(ECHO_CLEAN)
+	-$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO_CLEAN)
+
+install:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+

--- a/tools/cloud-dep-check/main.go
+++ b/tools/cloud-dep-check/main.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// cilium-cloud-dep-check verifies that each operator binary variant only
+// contains the cloud-provider SDKs that match its build tags.
+//
+// It enforces independence across the cilium-operator-* binaries:
+//
+//   - cilium-operator-generic     : must not contain AWS, Azure, or AlibabaCloud SDKs
+//   - cilium-operator-aws         : must not contain Azure or AlibabaCloud SDKs
+//   - cilium-operator-azure       : must not contain AWS or AlibabaCloud SDKs
+//   - cilium-operator-alibabacloud: must not contain AWS or Azure SDKs
+//
+// The check is implemented by invoking `go list -deps -tags <tags> ./operator`
+// from the cilium repository root and matching the resulting import paths
+// against the forbidden module prefixes for that binary.
+//
+// Usage:
+//
+//	cilium-cloud-dep-check [-root <repo-root>] [-target <pkg>]
+//
+// Exit code is non-zero if any forbidden dependency is found.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// cloudSDKs maps a cloud-provider name to the list of import-path prefixes
+// owned by that provider's SDK. A package is considered to belong to the
+// provider if its import path starts with any of the listed prefixes.
+var cloudSDKs = map[string][]string{
+	"aws": {
+		"github.com/aws/aws-sdk-go-v2",
+		"github.com/aws/smithy-go",
+	},
+	"azure": {
+		"github.com/Azure/azure-sdk-for-go",
+		"github.com/AzureAD/",
+	},
+	"alibabacloud": {
+		"github.com/aliyun/alibaba-cloud-sdk-go",
+	},
+}
+
+// binary describes one cilium-operator binary variant.
+type binary struct {
+	name      string   // human-readable binary name
+	buildTags []string // -tags value passed to `go list`
+	allowed   []string // cloud SDKs allowed to appear in this binary
+}
+
+// binaries is the canonical list of cross-checked binary configurations.
+// Keep this in sync with operator/Makefile.
+var binaries = []binary{
+	{
+		name:      "cilium-operator-generic",
+		buildTags: []string{"ipam_provider_operator"},
+		allowed:   nil,
+	},
+	{
+		name:      "cilium-operator-aws",
+		buildTags: []string{"ipam_provider_aws"},
+		allowed:   []string{"aws"},
+	},
+	{
+		name:      "cilium-operator-azure",
+		buildTags: []string{"ipam_provider_azure"},
+		allowed:   []string{"azure"},
+	},
+	{
+		name:      "cilium-operator-alibabacloud",
+		buildTags: []string{"ipam_provider_alibabacloud"},
+		allowed:   []string{"alibabacloud"},
+	},
+	{
+		name: "cilium-operator (combined)",
+		buildTags: []string{
+			"ipam_provider_aws",
+			"ipam_provider_azure",
+			"ipam_provider_operator",
+			"ipam_provider_alibabacloud",
+		},
+		allowed: []string{"aws", "azure", "alibabacloud"},
+	},
+}
+
+// listDeps runs `go list -deps -tags <tags> <target>` and returns the unique
+// list of import paths.
+func listDeps(repoRoot, target string, tags []string) ([]string, error) {
+	args := []string{"list", "-deps"}
+	if len(tags) > 0 {
+		args = append(args, "-tags", strings.Join(tags, ","))
+	}
+	args = append(args, target)
+	cmd := exec.Command("go", args...)
+	cmd.Dir = repoRoot
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list failed: %w", err)
+	}
+	deps := strings.Split(strings.TrimSpace(string(out)), "\n")
+	sort.Strings(deps)
+	return deps, nil
+}
+
+// classify returns the cloud name if pkg belongs to a known cloud SDK, or "".
+func classify(pkg string) string {
+	for cloud, prefixes := range cloudSDKs {
+		for _, p := range prefixes {
+			// Strip a trailing slash for prefix-only matches like "AzureAD/".
+			trimmed := strings.TrimSuffix(p, "/")
+			if pkg == trimmed || strings.HasPrefix(pkg, trimmed+"/") {
+				return cloud
+			}
+		}
+	}
+	return ""
+}
+
+// check verifies a single binary configuration. It returns the list of
+// forbidden packages found in its dependency closure.
+func check(repoRoot, target string, b binary) (map[string][]string, error) {
+	deps, err := listDeps(repoRoot, target, b.buildTags)
+	if err != nil {
+		return nil, err
+	}
+	forbidden := map[string][]string{}
+	for _, d := range deps {
+		cloud := classify(d)
+		if cloud == "" {
+			continue
+		}
+		if slices.Contains(b.allowed, cloud) {
+			continue
+		}
+		forbidden[cloud] = append(forbidden[cloud], d)
+	}
+	return forbidden, nil
+}
+
+func main() {
+	var (
+		repoRoot string
+		target   string
+	)
+	flag.StringVar(&repoRoot, "root", ".", "path to the cilium repository root")
+	flag.StringVar(&target, "target", "./operator", "go package to analyze")
+	flag.Parse()
+
+	abs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot resolve repo root %q: %v\n", repoRoot, err)
+		os.Exit(2)
+	}
+
+	failures := 0
+	for _, b := range binaries {
+		fmt.Printf("==> checking %s (tags: %s)\n", b.name, strings.Join(b.buildTags, ","))
+		forbidden, err := check(abs, target, b)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  ERROR: %v\n", err)
+			failures++
+			continue
+		}
+		if len(forbidden) == 0 {
+			fmt.Println("  OK")
+			continue
+		}
+		failures++
+		// Stable iteration order for output.
+		clouds := make([]string, 0, len(forbidden))
+		for k := range forbidden {
+			clouds = append(clouds, k)
+		}
+		sort.Strings(clouds)
+		for _, cloud := range clouds {
+			pkgs := forbidden[cloud]
+			fmt.Printf("  FAIL: forbidden %s SDK packages found (%d):\n", cloud, len(pkgs))
+			for _, p := range pkgs {
+				fmt.Printf("    - %s\n", p)
+			}
+		}
+	}
+
+	if failures > 0 {
+		fmt.Fprintf(os.Stderr, "\ncloud dependency check failed for %d binary configuration(s)\n", failures)
+		os.Exit(1)
+	}
+	fmt.Println("\nall binary configurations are independent")
+}


### PR DESCRIPTION
Each cloud-specific cilium-operator-* binary now ships only its own cloud SDK. The biggest win is the generic binary, which drops ~2.6 MiB by no longer linking the AWS / Azure / AlibabaCloud SDKs:

```
binary                         before       after        delta
cilium-operator-generic        115.97 MiB -> 113.37 MiB  (-2.60 MiB, -2.2 %)
cilium-operator-azure          120.78 MiB -> 118.21 MiB  (-2.57 MiB, -2.1 %)
cilium-operator-alibabacloud   146.80 MiB -> 144.21 MiB  (-2.59 MiB, -1.8 %)
cilium-operator-aws            146.24 MiB -> 146.20 MiB  (-0.04 MiB)
cilium-operator (combined)     unchanged
```