### PR TITLE
workflows/verifier: Wait for `complexity-diff` to set workflow status

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -278,11 +278,11 @@ jobs:
   commit-status-final:
     if: ${{ always() }}
     name: Commit Status Final
-    needs: setup-and-test
+    needs: merge-and-diff
     runs-on: ubuntu-24.04
     steps:
       - name: Set final commit status
         uses: cilium/cilium/.github/actions/set-commit-status@354584b6acb8b1d0203ab1001815fc50916979be # main
         with:
           sha: ${{ inputs.SHA || github.sha }}
-          status: ${{ needs.setup-and-test.result }}
+          status: ${{ needs.merge-and-diff.result }}


### PR DESCRIPTION
The `commit-status-final` job, which sets the workflow status in GitHub, only has the `setup-and-test` job as dependency. As a result, it can run before the `merge-and-diff` job, which runs `complexity-diff`, is done.

In commit 3aa7e07ce35b ("complexity-diff: Fail the workflow if near verifier limits") we updated `complexity-diff` to not just compute complexity diffs but also check and fail when we're close to the verifier limits. Since `commit-status-final` doesn't wait for `complexity-diff` to run, we'll actually skip any error it might throw.

This pull request fixes it by making `merge-and-diff` (with `complexity-diff`) a dependency of `commit-status-final`.

Fixes: https://github.com/cilium/cilium/pull/45659.