### PR TITLE
bpf: parse inner IPv4 header for IPIP external LB traffic

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1024,6 +1024,7 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 	__u8 __maybe_unused next_proto = 0;
 	__s8 __maybe_unused ext_err = 0;
 	int ret;
+	int __maybe_unused l3_off;
 
 	switch (proto) {
 #ifdef ENABLE_IPV6
@@ -1088,7 +1089,8 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 		 * Make sure that we don't legitimately drop the packet if the skb
 		 * arrived with the header not being not in the linear data.
 		 */
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4)) {
+		if (!revalidate_data_ipv4_l3_pull(ctx, &data, &data_end, &ip4,
+					      &l3_off)) {
 			ret = DROP_INVALID;
 			goto drop_err_ingress;
 		}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -527,6 +527,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	__s8 ext_err = 0;							\
 	__u32 zero = 0;								\
 	void *map;								\
+	int l3_off;								\
 										\
 	ct_buffer = map_lookup_elem(&cilium_tail_call_buffer4, &zero);		\
 	if (!ct_buffer)								\
@@ -536,13 +537,14 @@ int NAME(struct __ctx_buff *ctx)						\
 	ct_state = (struct ct_state *)&ct_buffer->ct_state;			\
 	tuple = (struct ipv4_ct_tuple *)&ct_buffer->tuple;			\
 										\
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))			\
+	if (!revalidate_data_ipv4_l3_pull(ctx, &data, &data_end, &ip4,		\
+					  &l3_off))				\
 		return drop_for_direction(ctx, DIR, DROP_INVALID, ext_err);	\
 										\
 	tuple->nexthdr = ip4->protocol;						\
 	tuple->daddr = ip4->daddr;						\
 	tuple->saddr = ip4->saddr;						\
-	ct_buffer->l4_off = ETH_HLEN + ipv4_hdrlen(ip4);			\
+	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);			\
 										\
 	map = select_ct_map4(ctx, DIR, tuple);					\
 	if (!map)								\
@@ -2403,8 +2405,9 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	__u16 proxy_port = 0;
 	__s8 ext_err = 0;
 	int ret;
+	int l3_off;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+	if (!revalidate_data_ipv4_l3(ctx, &data, &data_end, &ip4, &l3_off)) {
 		ret = DROP_INVALID;
 		goto out;
 	}

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -50,3 +50,46 @@ static __always_inline int ipv4_l3(struct __ctx_buff *ctx, int l3_off,
 
 	return CTX_ACT_OK;
 }
+
+/* IPIP-aware IPv4 revalidation helpers.
+ *
+ * When an external load balancer forwards traffic using IPIP
+ * encapsulation, the outer IPv4 header has protocol=IPPROTO_IPIP. These
+ * helpers detect that case and advance past the outer header to the inner
+ * IPv4 header, so the BPF programs process the actual TCP/UDP payload.
+ *
+ * *l3_off is set to the L3 offset of the (possibly inner) IPv4 header.
+ */
+static __always_inline __maybe_unused bool
+__revalidate_data_ipv4_l3(struct __ctx_buff *ctx, void **data, void **data_end,
+			  struct iphdr **ip4, int *l3_off, bool pull)
+{
+	bool result;
+
+	*l3_off = ETH_HLEN;
+	result = __revalidate_data_pull(ctx, data, data_end, (void **)ip4,
+					ETH_HLEN, sizeof(**ip4), pull);
+	if (result && (*ip4)->protocol == IPPROTO_IPIP) {
+		*l3_off = ETH_HLEN + ipv4_hdrlen(*ip4);
+		result = __revalidate_data_pull(ctx, data, data_end,
+						(void **)ip4, *l3_off,
+						sizeof(**ip4), pull);
+	}
+	return result;
+}
+
+static __always_inline __maybe_unused bool
+revalidate_data_ipv4_l3(struct __ctx_buff *ctx, void **data, void **data_end,
+			struct iphdr **ip4, int *l3_off)
+{
+	return __revalidate_data_ipv4_l3(ctx, data, data_end, ip4, l3_off,
+					 false);
+}
+
+static __always_inline __maybe_unused bool
+revalidate_data_ipv4_l3_pull(struct __ctx_buff *ctx, void **data,
+			     void **data_end, struct iphdr **ip4, int *l3_off)
+{
+	return __revalidate_data_ipv4_l3(ctx, data, data_end, ip4, l3_off,
+					 true);
+}


### PR DESCRIPTION
When an external load balancer forwards traffic to pods using IPIP
encapsulation, Cilium's BPF datapath sees the outer IP header with
protocol=IPPROTO_IPIP. The conntrack lookup then fails with
DROP_CT_UNKNOWN_PROTO ("CT: Unknown L4 protocol") because IPIP is not a
recognized L4 protocol for CT purposes.

This PR introduces IPIP-aware IPv4 revalidation helpers that detect an
outer IPIP header and automatically advance past it to the inner IPv4
header, allowing the BPF programs to process the actual TCP/UDP payload
correctly.

The new helpers use ipv4_hdrlen() on the outer header to correctly
handle IP options, and propagate the pull flag to both outer and inner
header revalidations to avoid false drops on non-linear skbs.

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
- [x] Thanks for contributing!

This PR was prepared with AIL:1. Human-created, minor AI assistance.

Fixes: #32473

   ```release-note
   bpf: Fix IPIP packet drops from external load balancers by parsing the inner IPv4 header for conntrack and policy lookups.
   ```