### PR TITLE
k8s/node: Remove NodeIdentity field from CiliumNode

### DIFF
--- a/clustermesh-apiserver/clustermesh/testdata/ciliumnodes.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumnodes.txtar
@@ -136,7 +136,6 @@ spec:
   "Annotations": {
     "network.cilium.io/wg-pub-key": "VRksOB6ZNds4oXWIGfSVpvc0gBhcOWFmzvTDcyvULlI="
   },
-  "NodeIdentity": 0,
   "WireguardPubKey": "VRksOB6ZNds4oXWIGfSVpvc0gBhcOWFmzvTDcyvULlI=",
   "BootID": "570d3fd1-93db-4862-ba99-6a3c2c10c38f"
 }
@@ -184,7 +183,6 @@ spec:
     "kubernetes.io/hostname": "test-node-2"
   },
   "Annotations": null,
-  "NodeIdentity": 0,
   "WireguardPubKey": "",
   "BootID": "c1d2cda2-aca0-4033-abca-3843298860b9"
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -424,11 +424,6 @@ spec:
                       filter Elastic IP Addresses.
                     type: object
                 type: object
-              nodeidentity:
-                description: NodeIdentity is the Cilium numeric identity allocated
-                  for the node, if any.
-                format: int64
-                type: integer
             type: object
           status:
             description: |-

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.3"
+	CustomResourceDefinitionSchemaVersion = "1.33.4"
 )

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -458,11 +458,6 @@ type NodeSpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	IPAM ipamTypes.IPAMSpec `json:"ipam,omitempty"`
-
-	// NodeIdentity is the Cilium numeric identity allocated for the node, if any.
-	//
-	// +kubebuilder:validation:Optional
-	NodeIdentity uint64 `json:"nodeidentity,omitempty"`
 }
 
 // HealthAddressingSpec is the addressing information required to do

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -2326,10 +2326,6 @@ func (in *NodeSpec) DeepEqual(other *NodeSpec) bool {
 		return false
 	}
 
-	if in.NodeIdentity != other.NodeIdentity {
-		return false
-	}
-
 	return true
 }
 

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -21,13 +21,13 @@ import (
 type testSynchronizer struct{ identity chan uint32 }
 
 func (testSynchronizer) InitLocalNode(ctx context.Context, n *LocalNode) error {
-	n.NodeIdentity = 1
+	n.ClusterID = 1
 	return nil
 }
 
 func (ts testSynchronizer) SyncLocalNode(ctx context.Context, lns *LocalNodeStore) {
 	id := <-ts.identity
-	lns.Update(func(n *LocalNode) { n.NodeIdentity = id })
+	lns.Update(func(n *LocalNode) { n.ClusterID = id })
 	<-ctx.Done()
 }
 
@@ -49,9 +49,9 @@ func TestLocalNodeStore(t *testing.T) {
 	observe := func(store *LocalNodeStore) {
 		store.Observe(context.TODO(),
 			func(n LocalNode) {
-				observed = append(observed, n.NodeIdentity)
+				observed = append(observed, n.ClusterID)
 
-				if n.NodeIdentity == expected[len(expected)-1] {
+				if n.ClusterID == expected[len(expected)-1] {
 					waitObserve.Done()
 				}
 			},
@@ -72,7 +72,7 @@ func TestLocalNodeStore(t *testing.T) {
 					}
 
 					store.Update(func(n *LocalNode) {
-						n.NodeIdentity = i
+						n.ClusterID = i
 					})
 				}
 				return nil

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -81,9 +80,7 @@ type nodeEntry struct {
 type IPCache interface {
 	GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source
 	UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
-	OverrideIdentity(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID)
 	RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata)
-	RemoveIdentityOverride(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, resource ipcacheTypes.ResourceID)
 	UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64)
 	RemoveMetadataBatch(updates ...ipcache.MU) (revision uint64)
 }
@@ -620,8 +617,8 @@ func (m *manager) endpointEncryptionKey(n *nodeTypes.Node) ipcacheTypes.EncryptK
 	return ipcacheTypes.EncryptKey(n.EncryptionKey)
 }
 
-func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels, hasOverride bool) {
-	nodeLabels = labels.NewFrom(labels.LabelRemoteNode)
+func (m *manager) nodeIdentityLabels(n nodeTypes.Node) labels.Labels {
+	nodeLabels := labels.NewFrom(labels.LabelRemoteNode)
 	if n.IsLocal() {
 		nodeLabels = labels.NewFrom(labels.LabelHost)
 		if m.conf.PolicyCIDRMatchesNodes() {
@@ -640,10 +637,6 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 				}
 			}
 		}
-	} else if !identity.NumericIdentity(n.NodeIdentity).IsReservedIdentity() {
-		// This needs to match clustermesh-apiserver's VMManager.AllocateNodeIdentity
-		nodeLabels = labels.Map2Labels(n.Labels, labels.LabelSourceK8s)
-		hasOverride = true
 	}
 
 	if option.Config.PerNodeLabelsEnabled() {
@@ -654,7 +647,7 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 		nodeLabels.MergeLabels(filteredLbls)
 	}
 
-	return nodeLabels, hasOverride
+	return nodeLabels
 }
 
 // worldLabelForPrefix returns the labels which will resolve to
@@ -698,7 +691,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	}
 
 	resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-	nodeLabels, nodeIdentityOverride := m.nodeIdentityLabels(n)
+	nodeLabels := m.nodeIdentityLabels(n)
 
 	var ipsetEntries []netip.Prefix
 	var nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix
@@ -764,9 +757,6 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 			ipcacheTypes.TunnelPeer{Addr: tunnelIP},
 			ipcacheTypes.EncryptKey(key),
 			endpointFlags)
-		if nodeIdentityOverride {
-			m.ipcache.OverrideIdentity(prefixCluster, nodeLabels, n.Source, resource)
-		}
 		nodeIPsAdded = append(nodeIPsAdded, prefixCluster.AsPrefix())
 	}
 
@@ -969,7 +959,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		// See comment in NodeUpdated().
 		oldNodeIP, _ = netipx.FromStdIP(nIP)
 	}
-	oldNodeLabels, oldNodeIdentityOverride := m.nodeIdentityLabels(oldNode)
+	oldNodeLabels := m.nodeIdentityLabels(oldNode)
 
 	// Delete the old node IP addresses if they have changed in this node.
 	var v4Addrs, v6Addrs []netip.Addr
@@ -1022,9 +1012,6 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 			ipcacheTypes.TunnelPeer{Addr: oldTunnelIP},
 			ipcacheTypes.EncryptKey(oldKey),
 			oldEndpointFlags)
-		if oldNodeIdentityOverride {
-			m.ipcache.RemoveIdentityOverride(oldPrefixCluster, oldNodeLabels, resource)
-		}
 	}
 
 	m.ipsetMgr.RemoveFromIPSet(ipset.CiliumNodeIPSetV4, v4Addrs...)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -106,16 +106,8 @@ func (i *ipcacheMock) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.So
 	i.Upsert(prefix.String(), nil, 0, nil, ipcache.Identity{}, aux...)
 }
 
-func (i *ipcacheMock) OverrideIdentity(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, src source.Source, resource ipcacheTypes.ResourceID) {
-	i.UpsertMetadata(prefix, src, resource)
-}
-
 func (i *ipcacheMock) RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
 	i.Delete(prefix.String(), source.CustomResource, aux...)
-}
-
-func (i *ipcacheMock) RemoveIdentityOverride(prefix cmtypes.PrefixCluster, identityLabels labels.Labels, resource ipcacheTypes.ResourceID) {
-	i.Delete(prefix.String(), source.CustomResource)
 }
 
 func (i *ipcacheMock) UpsertMetadataBatch(updates ...ipcache.MU) (revision uint64) {
@@ -414,7 +406,7 @@ func TestNodeLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			option.Config.EnableNodeSelectorLabels = tt.nodeSelectorLabels
 			option.Config.ClusterName = "default"
-			got, _ := mngr.nodeIdentityLabels(tt.node)
+			got := mngr.nodeIdentityLabels(tt.node)
 			want := tt.setupWanted()
 			assert.True(t, want.Equals(got), "Mismatched labels: want=%v got=%v", want, got)
 		})

--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -15,7 +15,6 @@ import (
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -61,7 +60,6 @@ type localNodeSynchronizer struct {
 
 func (ini *localNodeSynchronizer) InitLocalNode(ctx context.Context, n *node.LocalNode) error {
 	n.Source = source.Local
-	n.NodeIdentity = uint32(identity.ReservedIdentityHost)
 
 	if err := ini.initFromConfig(n); err != nil {
 		return err

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -69,7 +69,6 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node Node) {
 		Source:          source.CustomResource,
 		Labels:          n.ObjectMeta.Labels,
 		Annotations:     n.ObjectMeta.Annotations,
-		NodeIdentity:    uint32(n.Spec.NodeIdentity),
 		WireguardPubKey: wireguardPubKey,
 		BootID:          n.Spec.BootID,
 	}
@@ -168,8 +167,7 @@ func (n *Node) ToCiliumNode() *ciliumv2.CiliumNode {
 			IPAM: ipamTypes.IPAMSpec{
 				PodCIDRs: podCIDRs,
 			},
-			NodeIdentity: uint64(n.NodeIdentity),
-			BootID:       n.BootID,
+			BootID: n.BootID,
 		},
 	}
 }
@@ -233,9 +231,6 @@ type Node struct {
 
 	// Node annotations
 	Annotations map[string]string
-
-	// NodeIdentity is the numeric identity allocated for the node
-	NodeIdentity uint32
 
 	// WireguardPubKey is the WireGuard public key of this node
 	WireguardPubKey string

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -140,7 +140,6 @@ func TestParseCiliumNode(t *testing.T) {
 				IPV4: "1.1.1.2",
 				IPV6: "c0de::2",
 			},
-			NodeIdentity: uint64(12345),
 		},
 	}
 
@@ -163,7 +162,6 @@ func TestParseCiliumNode(t *testing.T) {
 		IPv6HealthIP:            net.ParseIP("c0de::1"),
 		IPv4IngressIP:           net.ParseIP("1.1.1.2"),
 		IPv6IngressIP:           net.ParseIP("c0de::2"),
-		NodeIdentity:            uint32(12345),
 	}, n)
 }
 
@@ -186,7 +184,6 @@ func TestNode_ToCiliumNode(t *testing.T) {
 		IPv6HealthIP:            net.ParseIP("c0de::1"),
 		IPv4IngressIP:           net.ParseIP("1.1.1.2"),
 		IPv6IngressIP:           net.ParseIP("c0de::2"),
-		NodeIdentity:            uint32(12345),
 		WireguardPubKey:         "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
 		Annotations: map[string]string{
 			annotation.BGPVRouterAnnoPrefix + "64512": "router-id=172.0.0.3",
@@ -228,7 +225,6 @@ func TestNode_ToCiliumNode(t *testing.T) {
 				IPV4: "1.1.1.2",
 				IPV6: "c0de::2",
 			},
-			NodeIdentity: uint64(12345),
 		},
 	}, n)
 }

--- a/pkg/node/types/zz_generated.deepequal.go
+++ b/pkg/node/types/zz_generated.deepequal.go
@@ -207,9 +207,6 @@ func (in *Node) DeepEqual(other *Node) bool {
 		}
 	}
 
-	if in.NodeIdentity != other.NodeIdentity {
-		return false
-	}
 	if in.WireguardPubKey != other.WireguardPubKey {
 		return false
 	}


### PR DESCRIPTION
This removes the `NodeIdentity` field (and related infrastructure) from the CiliumNode CRD. The field used to be part of the external workloads feature which got removed over a year ago in https://github.com/cilium/cilium/pull/37418.

Review per commit.