### PR TITLE
policy: Include priority in PerSelectorPolicy.Equal check

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -201,9 +201,11 @@ func (a *PerSelectorPolicy) EnvoyHTTPRules() *cilium.HttpNetworkPolicyRules {
 	return a.envoyHTTPRules
 }
 
-// Equal returns true if 'a' and 'b' represent the same L7 Rules
+// Equal returns true if 'a' and 'b' represent the same per-selector policy for
+// merge purposes.
 func (a *PerSelectorPolicy) Equal(b *PerSelectorPolicy) bool {
 	return a == nil && b == nil || a != nil && b != nil &&
+		a.Priority == b.Priority &&
 		a.L7Parser == b.L7Parser &&
 		a.TerminatingTLS.Equal(b.TerminatingTLS) &&
 		a.OriginatingTLS.Equal(b.OriginatingTLS) &&

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -215,6 +215,54 @@ func TestMergePortProtoRejectsDifferentTiers(t *testing.T) {
 	require.ErrorContains(t, err, "cannot merge filters with different tiers")
 }
 
+func TestMergePortProtoIdenticalPolicyDifferentPriority(t *testing.T) {
+	td := newTestData(t, hivetest.Logger(t))
+	cs := td.cachedSelectorA
+
+	existingOrigin := OriginForTest(map[CachedSelector]labels.LabelArrayList{
+		cs: {labels.LabelArray{labels.ParseLabel("existing")}},
+	})
+	newOrigin := OriginForTest(map[CachedSelector]labels.LabelArrayList{
+		cs: {labels.LabelArray{labels.ParseLabel("new")}},
+	})
+	expectedOrigin := newOrigin[cs]
+
+	existingFilter := &L4Filter{
+		Tier:     0,
+		Port:     80,
+		Protocol: api.ProtoTCP,
+		U8Proto:  u8proto.TCP,
+		Ingress:  true,
+		PerSelectorPolicies: L7DataMap{
+			cs: &PerSelectorPolicy{
+				Verdict:  types.Allow,
+				Priority: 50,
+			},
+		},
+		RuleOrigin: existingOrigin,
+	}
+	filterToMerge := &L4Filter{
+		Tier:     0,
+		Port:     80,
+		Protocol: api.ProtoTCP,
+		U8Proto:  u8proto.TCP,
+		Ingress:  true,
+		PerSelectorPolicies: L7DataMap{
+			cs: &PerSelectorPolicy{
+				Verdict:  types.Allow,
+				Priority: 10,
+			},
+		},
+		RuleOrigin: newOrigin,
+	}
+
+	err := existingFilter.mergePortProto(td.testPolicyContext, filterToMerge)
+	require.NoError(t, err)
+
+	require.Equal(t, types.Priority(10), existingFilter.PerSelectorPolicies[cs].GetPriority())
+	require.Equal(t, expectedOrigin, existingFilter.RuleOrigin[cs])
+}
+
 func TestMergeL4PolicyIngress(t *testing.T) {
 	td := newTestData(t, hivetest.Logger(t))
 


### PR DESCRIPTION
Compare all fields, including Priority, in PerSelectorPolicy.Equal.

Without this fix it was possible that an otherwise equal, but lower priority rule was selected when merging L4Filters on policy ingestion.

A new regression test is added that fails without this fix. This test was created by Codex.

Fixes: #42784
