### PR TITLE
gh: introduce netkit testing in kpr-eks workflow

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -223,6 +223,16 @@ jobs:
             mv /tmp/result.json.tmp /tmp/result.json
           fi
 
+          # Check if we have a BPF Datapath mode via extra-args
+          # Note we leave the input as a free-form string but validate it to mitigate
+          # any command-line injection issues when this lands in --helm-set
+          BPF_DATAPATH=$(echo "${EXTRA_ARGS}" | jq -r 'select(.["bpf-datapath"] | type == "string") | .["bpf-datapath"]')
+          if [ "${BPF_DATAPATH}" == "netkit" ] || [ "${BPF_DATAPATH}" == "netkit-l2" ]; then
+              echo "::notice::BPFDatapath specified -- setting bpf-datapath=${BPF_DATAPATH} for all matrix entries"
+              jq '.include |= map(. + {"bpf-datapath": "'${BPF_DATAPATH}'"})' /tmp/result.json > /tmp/result.json.tmp
+              mv /tmp/result.json.tmp /tmp/result.json
+          fi
+
           jq -c '.include[]' /tmp/matrix.json | while read i; do
             VERSION=$(echo $i | jq -r '.version')
             aws eks describe-cluster-versions | jq -r '.clusterVersions[].clusterVersion' > /tmp/output
@@ -323,6 +333,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           VERSION_SANITIZED: ${{ matrix.version }}
           EXTRA_ARGS: ${{ inputs.extra-args }}
+          BPF_DATAPATH: ${{ matrix.bpf-datapath }}
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             OWNER="${PR_NUMBER}"
@@ -368,6 +379,12 @@ jobs:
           WG=$(echo "${EXTRA_ARGS}" | jq -r '.["wireguard"] // false')
           if [[ "$WG" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set encryption.enabled=true --helm-set encryption.type=wireguard"
+          fi
+
+          # Pass any bpf-datapath values verbatim. Note this is validated as our matrix
+          # is being computed, so we assume this contains a valid datapath mode.
+          if [ "${BPF_DATAPATH}" != "" ]; then
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.datapathMode=${BPF_DATAPATH}"
           fi
 
           CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"

--- a/.github/workflows/conformance-kpr-eks.yaml
+++ b/.github/workflows/conformance-kpr-eks.yaml
@@ -135,13 +135,41 @@ jobs:
       extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "wireguard": true}'
       test-concurrency: 2
 
+  conformance-eks-kpr-netkit:
+    name: Conformance EKS with KPR + Netkit
+    if: ${{ github.event_name == 'schedule' }}
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-eks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 4
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "bpf-datapath": "netkit", "bpf-masq-v4": true }'
+      test-concurrency: 2
+
+  conformance-eks-kpr-netkit-l2:
+    name: Conformance EKS with KPR + Netkit-L2
+    if: ${{ github.event_name == 'schedule' }}
+    needs: wait-for-images
+    uses: ./.github/workflows/conformance-eks.yaml
+    secrets: inherit
+    with:
+      PR-number: ${{ inputs.PR-number || github.ref_name }}
+      UID: 5
+      context-ref: ${{ inputs.context-ref || github.sha }}
+      SHA: ${{ inputs.SHA || github.sha }}
+      extra-args: '{"kpr": true, "bpf-datapath": "netkit-l2", "bpf-masq-v4": true }'
+      test-concurrency: 2
+
   merge-upload-and-status:
     name: Merge Upload and Status
     if: ${{ always() }}
-    needs: [conformance-eks-kpr, conformance-eks-kpr-ipsec, conformance-eks-kpr-wireguard]
+    needs: [conformance-eks-kpr, conformance-eks-kpr-ipsec, conformance-eks-kpr-wireguard, conformance-eks-kpr-netkit, conformance-eks-kpr-netkit-l2]
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-eks-kpr.result == 'success' && needs.conformance-eks-kpr-ipsec.result == 'success' && needs.conformance-eks-kpr-wireguard.result == 'success') }}
+      success: ${{ (needs.conformance-eks-kpr.result == 'success' && needs.conformance-eks-kpr-ipsec.result == 'success' && needs.conformance-eks-kpr-wireguard.result == 'success' && needs.conformance-eks-kpr-netkit.result == 'success' && needs.conformance-eks-kpr-netkit-l2.result == 'success') }}


### PR DESCRIPTION
This commit introduces two additional jobs in the kpr-eks workflow that cover testing of netkit and netkit-l2. These are limited to scheduled runs only in order to observe outcome before being expanded further.

```release-note
Introduce scheduled conformance testing on EKS with netkit and netkit-l2.
```
