### PR TITLE
fix(hubble): correctly render socket flow type using hubble observe with default mask

### DIFF
--- a/hubble/pkg/printer/printer.go
+++ b/hubble/pkg/printer/printer.go
@@ -201,7 +201,7 @@ func GetFlowType(f *flowpb.Flow) string {
 	case api.MessageTypeCapture:
 		return f.GetDebugCapturePoint().String()
 	case api.MessageTypeTraceSock:
-		switch f.GetSockXlatePoint() {
+		switch flowpb.SocketTranslationPoint(f.GetEventType().GetSubType()) {
 		case flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_POST_DIRECTION_FWD:
 			return "post-xlate-fwd"
 		case flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_POST_DIRECTION_REV:
@@ -211,7 +211,7 @@ func GetFlowType(f *flowpb.Flow) string {
 		case flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_PRE_DIRECTION_REV:
 			return "pre-xlate-rev"
 		}
-		return f.GetSockXlatePoint().String()
+		return flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_UNKNOWN.String()
 	}
 
 	return "UNKNOWN"

--- a/hubble/pkg/printer/printer_test.go
+++ b/hubble/pkg/printer/printer_test.go
@@ -849,9 +849,9 @@ func Test_getFlowType(t *testing.T) {
 				f: &flowpb.Flow{
 					Verdict: flowpb.Verdict_TRACED,
 					EventType: &flowpb.CiliumEventType{
-						Type: monitorAPI.MessageTypeTraceSock,
+						Type:    monitorAPI.MessageTypeTraceSock,
+						SubType: int32(flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_PRE_DIRECTION_FWD),
 					},
-					SockXlatePoint: flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_PRE_DIRECTION_FWD,
 				},
 			},
 			want: "pre-xlate-fwd",
@@ -862,9 +862,9 @@ func Test_getFlowType(t *testing.T) {
 				f: &flowpb.Flow{
 					Verdict: flowpb.Verdict_TRANSLATED,
 					EventType: &flowpb.CiliumEventType{
-						Type: monitorAPI.MessageTypeTraceSock,
+						Type:    monitorAPI.MessageTypeTraceSock,
+						SubType: int32(flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_POST_DIRECTION_FWD),
 					},
-					SockXlatePoint: flowpb.SocketTranslationPoint_SOCK_XLATE_POINT_POST_DIRECTION_FWD,
 				},
 			},
 			want: "post-xlate-fwd",


### PR DESCRIPTION
Today, using this command `hubble observe --pod <pod-name> --protocol TCP --follow` when the socket LB is enabled generates the following output.

```txt
Apr 26 10:52:57.233: default/http-client-654df84b77-9xtk9 (ID:18837) <> default/http-service:80 (world-ipv4) SOCK_XLATE_POINT_UNKNOWN TRACED (TCP)
Apr 26 10:52:57.233: default/http-client-654df84b77-9xtk9 (ID:18837) <> default/http-server-8457bf88b9-xmbfs:80 (ID:4502) SOCK_XLATE_POINT_UNKNOWN TRANSLATED (TCP)
```

As you can see, `SOCK_XLATE_POINT_UNKNOWN` is printed instead of the right type. 

This is because [`GetFlowType()`](https://github.com/cilium/cilium/blob/f966f5359d2f407e44542b26232bab6d30200cca/hubble/pkg/printer/printer.go#L176) method relies on the `sock_xlate_point` field to obtain the type. `sock_xlate_point` is not enabled in the default [`FieldMask`](https://github.com/cilium/cilium/blob/f966f5359d2f407e44542b26232bab6d30200cca/hubble/pkg/defaults/defaults.go#L48), so it is zeroed out unless a specific mask is provided. That's why we see `SOCK_XLATE_POINT_UNKNOWN`.
On the other side `event_type.sub_type` field is always populated and contains the same information, so it seems the best field to use here.

This PR was prepared with AIL:0

### Repro

Change the Kind makefile inside the repo to enable the sockLB. In my case, I was using this config

```diff
diff --git a/Makefile.kind b/Makefile.kind
index 0814837bae..22e1eaf8a4 100644
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -239,6 +239,9 @@ kind-install-cilium-fast: check_deps kind-ready kind-load-base-images ## "Fast"
                sleep 5; \
                $(CILIUM_CLI) install --context=kind-$$cluster_name \
                        --chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
+                       --set hostFirewall.enabled=true \
+                       --set kubeProxyReplacement=true \
+                       --set ipam.mode=kubernetes \
                        $(KIND_VALUES_FAST_FILES) \
                        --version= >/dev/null ; \
        done
```

Deploy the cluster with cilium

```bash
make kind
make kind-image-fast
make kind-install-cilium-fast
````

Deploy a simple application in the cluster

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: http-client
spec:
  replicas: 1
  selector:
    matchLabels:
      app: http-client
  template:
    metadata:
      labels:
        app: http-client
    spec:
      nodeSelector:
        node-role.kubernetes.io/control-plane: ""
      tolerations:
        - key: node-role.kubernetes.io/control-plane
          operator: Exists
          effect: NoSchedule
      containers:
        - image: curlimages/curl:8.1.1
          name: curl-client
          command: ["sleep", "10d"]
---
apiVersion: v1
kind: Service
metadata:
  name: http-service
spec:
  selector:
    app: http-server
  ports:
    - protocol: TCP
      port: 80
      targetPort: 80
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: http-server
spec:
  replicas: 1
  selector:
    matchLabels:
      app: http-server
  template:
    metadata:
      labels:
        app: http-server
    spec:
      nodeSelector:
        kubernetes.io/hostname: kind-worker
      containers:
      - name: http-server
        image: nginx:alpine
        ports:
        - containerPort: 80
```

Follow the client pod flows

```
kubectl -n kube-system exec cilium-426w7 -- hubble observe --pod default/http-client-654df84b77-qx6cp --protocol TCP --follow
```

Call `curl` in the client

```bash
kubectl exec -n default deployment/http-client -- curl http://http-service:80
```

You should see some logs like these

```txt
Apr 26 10:52:57.233: default/http-client-654df84b77-9xtk9 (ID:18837) <> default/http-service:80 (world-ipv4) SOCK_XLATE_POINT_UNKNOWN TRACED (TCP)
Apr 26 10:52:57.233: default/http-client-654df84b77-9xtk9 (ID:18837) <> default/http-server-8457bf88b9-xmbfs:80 (ID:4502) SOCK_XLATE_POINT_UNKNOWN TRANSLATED (TCP)
```

After this patch you should see

```txt
Apr 29 06:12:18.829: default/http-client-654df84b77-qx6cp (ID:1716) <> default/http-service:80 (world-ipv4) pre-xlate-fwd TRACED (TCP)
Apr 29 06:12:18.829: default/http-client-654df84b77-qx6cp (ID:1716) <> default/http-server-8457bf88b9-r4h5w:80 (ID:40605) post-xlate-fwd TRANSLATED (TCP)
```


```release-note
fix(hubble): derive socket flow type from event subtype
```
