### PR TITLE
gateway-api: fix allowedRoute namespace and kind restrictions on multi-listener

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -200,6 +200,10 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-backend-protocol-websocket", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-cross-namespace", gateway: []gwDetails{gatewayBackendNamespace}},
 		{
+			name:    "httproute-allowed-kind-by-section-name",
+			gateway: []gwDetails{{FullName: types.NamespacedName{Name: "kind-restricted-multi-listener", Namespace: "gateway-conformance-infra"}}},
+		},
+		{
 			name:    "httproute-disallowed-kind",
 			gateway: []gwDetails{{FullName: types.NamespacedName{Name: "tlsroutes-only", Namespace: "gateway-conformance-infra"}}},
 		},

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -59,22 +59,11 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 				return false, fmt.Errorf("unable to list namespaces: %w", err)
 			}
 
-			allowed := false
 			for _, ns := range nsList.Items {
 				if ns.Name == input.GetNamespace() {
-					allowed = true
+					return true, nil
 				}
 			}
-			if !allowed {
-				input.SetParentCondition(parentRef, metav1.Condition{
-					Type:    "Accepted",
-					Status:  metav1.ConditionFalse,
-					Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
-					Message: input.GetGVK().Kind + " is not allowed to attach to this Gateway due to namespace selector restrictions",
-				})
-				return false, nil
-			}
-			return true, nil
 		}
 	}
 	if hasNamespaceRestriction {

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -101,37 +101,38 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 		return false, nil
 	}
 
+	routeGVK := input.GetGVK()
+	hasKindRestriction := false
 	for _, listener := range gw.Spec.Listeners {
+		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
+			continue
+		}
+		if parentRef.Port != nil && listener.Port != *parentRef.Port {
+			continue
+		}
+
 		if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
 			continue
 		}
 
-		allowed := false
-		routeGVK := input.GetGVK()
+		hasKindRestriction = true
 		for _, kind := range listener.AllowedRoutes.Kinds {
 			if (kind.Group == nil || (kind.Group != nil && *kind.Group == gatewayv1.Group(routeGVK.Group))) &&
 				kind.Kind == gatewayv1.Kind(routeGVK.Kind) {
-				allowed = true
-				break
+				// At least one matching listener allows this route kind.
+				return true, nil
 			}
 		}
+	}
 
-		if !allowed {
-			input.SetParentCondition(parentRef, metav1.Condition{
-				Type:    string(gatewayv1.RouteConditionAccepted),
-				Status:  metav1.ConditionFalse,
-				Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
-				Message: routeGVK.Kind + " is not allowed to attach to this Gateway due to route kind restrictions",
-			})
-		} else {
-			input.SetParentCondition(parentRef, metav1.Condition{
-				Type:    string(gatewayv1.RouteConditionAccepted),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(gatewayv1.RouteReasonAccepted),
-				Message: "Accepted " + routeGVK.Kind,
-			})
-			// return true, nil
-		}
+	if hasKindRestriction {
+		input.SetParentCondition(parentRef, metav1.Condition{
+			Type:    string(gatewayv1.RouteConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
+			Message: routeGVK.Kind + " is not allowed to attach to this Gateway due to route kind restrictions",
+		})
+		return false, nil
 	}
 
 	return true, nil

--- a/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
@@ -60,6 +60,48 @@ var kindRestrictedGateway = &gatewayv1.Gateway{
 	},
 }
 
+// Gateway fixture with restrictive Selector listener first, permissive All
+// listener second. Used to test that CheckGatewayAllowedForNamespace does not
+// early-return on a Selector failure before checking remaining listeners.
+var mixedNamespaceGateway = &gatewayv1.Gateway{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mixed-ns-gateway",
+		Namespace: "default",
+	},
+	Spec: gatewayv1.GatewaySpec{
+		GatewayClassName: "cilium",
+		Listeners: []gatewayv1.Listener{
+			{
+				Name:     "http-selector",
+				Port:     8082,
+				Protocol: gatewayv1.HTTPProtocolType,
+				Hostname: ptr.To[gatewayv1.Hostname]("*.http-selector.io"),
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Namespaces: &gatewayv1.RouteNamespaces{
+						From: ptr.To(gatewayv1.NamespacesFromSelector),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "default",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:     "http-all",
+				Port:     8081,
+				Protocol: gatewayv1.HTTPProtocolType,
+				Hostname: ptr.To[gatewayv1.Hostname]("*.http-all.io"),
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Namespaces: &gatewayv1.RouteNamespaces{
+						From: ptr.To(gatewayv1.NamespacesFromAll),
+					},
+				},
+			},
+		},
+	},
+}
+
 // Gateway fixture with no kind restrictions on any listener.
 var noKindRestrictedGateway = &gatewayv1.Gateway{
 	ObjectMeta: metav1.ObjectMeta{
@@ -228,7 +270,13 @@ func TestCheckGatewayAllowedForNamespace(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(gatewayFixtures...).
+		WithObjects(mixedNamespaceGateway).
 		WithObjects(namespaceFixture...).
+		WithObjects(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cross-ns",
+			},
+		}).
 		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
 		Build()
 
@@ -600,6 +648,48 @@ func TestCheckGatewayAllowedForNamespace(t *testing.T) {
 				},
 			},
 			want: false,
+		},
+		{
+			name: "selector-first then all-second without sectionName, cross-namespace (allowed by all listener)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "cross-ns",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:      "mixed-ns-gateway",
+					Namespace: ptr.To[gatewayv1.Namespace]("default"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "selector-first then all-second with sectionName targeting all listener (allowed)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "cross-ns",
+						},
+						Spec: gatewayv1.HTTPRouteSpec{
+							Hostnames: []gatewayv1.Hostname{
+								"*.http-all.io",
+							},
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "mixed-ns-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("http-all"),
+				},
+			},
+			want: true,
 		},
 	}
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
@@ -15,6 +15,69 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+// Gateway fixture with kind restrictions on each listener:
+//
+// - https: kinds [HTTPRoute]
+// - grpcs: kinds [GRPCRoute]
+//
+// Used to test that CheckGatewayRouteKindAllowed evaluates only the
+// listener targeted by parentRef.sectionName, not all listeners.
+var kindRestrictedGateway = &gatewayv1.Gateway{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "kind-restricted-gateway",
+		Namespace: "default",
+	},
+	Spec: gatewayv1.GatewaySpec{
+		GatewayClassName: "cilium",
+		Listeners: []gatewayv1.Listener{
+			{
+				Name:     "https",
+				Port:     443,
+				Protocol: gatewayv1.HTTPSProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Kinds: []gatewayv1.RouteGroupKind{
+						{
+							Group: ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							Kind:  "HTTPRoute",
+						},
+					},
+				},
+			},
+			{
+				Name:     "grpcs",
+				Port:     50051,
+				Protocol: gatewayv1.HTTPSProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Kinds: []gatewayv1.RouteGroupKind{
+						{
+							Group: ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							Kind:  "GRPCRoute",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// Gateway fixture with no kind restrictions on any listener.
+var noKindRestrictedGateway = &gatewayv1.Gateway{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "no-kind-restricted-gateway",
+		Namespace: "default",
+	},
+	Spec: gatewayv1.GatewaySpec{
+		GatewayClassName: "cilium",
+		Listeners: []gatewayv1.Listener{
+			{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayv1.HTTPProtocolType,
+			},
+		},
+	},
+}
+
 var gatewayFixtures = []client.Object{
 	// Gateway fixture with allow rules:
 	//
@@ -548,6 +611,134 @@ func TestCheckGatewayAllowedForNamespace(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("CheckGatewayAllowedForNamespace() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckGatewayRouteKindAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = gatewayv1.Install(scheme)
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kindRestrictedGateway, noKindRestrictedGateway).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		Build()
+
+	type args struct {
+		input     Input
+		parentRef gatewayv1.ParentReference
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "gateway not found",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:      "non-existing-gateway",
+					Namespace: ptr.To[gatewayv1.Namespace]("default"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no kind restrictions on listener (allowed)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "no-kind-restricted-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("http"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPRoute targeting https listener with kinds [HTTPRoute] (allowed)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "kind-restricted-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("https"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPRoute targeting grpcs listener with kinds [GRPCRoute] (rejected)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "kind-restricted-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("grpcs"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "HTTPRoute without sectionName on kind-restricted gateway (allowed by https listener)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:      "kind-restricted-gateway",
+					Namespace: ptr.To[gatewayv1.Namespace]("default"),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckGatewayRouteKindAllowed(tt.args.input, tt.args.parentRef)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckGatewayRouteKindAllowed() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CheckGatewayRouteKindAllowed() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-1.yaml
@@ -19,7 +19,7 @@ status:
   - conditions:
     - lastTransitionTime: "2025-07-01T06:20:17Z"
       message: HTTPRoute is not allowed to attach to this Gateway due to namespace
-        selector restrictions
+        restrictions
       reason: NotAllowedByListeners
       status: "False"
       type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-2.yaml
@@ -19,7 +19,7 @@ status:
   - conditions:
     - lastTransitionTime: "2025-07-01T06:20:17Z"
       message: HTTPRoute is not allowed to attach to this Gateway due to namespace
-        selector restrictions
+        restrictions
       reason: NotAllowedByListeners
       status: "False"
       type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-3.yaml
@@ -19,7 +19,7 @@ status:
   - conditions:
     - lastTransitionTime: "2025-07-01T06:20:17Z"
       message: HTTPRoute is not allowed to attach to this Gateway due to namespace
-        selector restrictions
+        restrictions
       reason: NotAllowedByListeners
       status: "False"
       type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-with-attached-routes/output/httproute-http-route-4.yaml
@@ -21,7 +21,7 @@ status:
         - lastTransitionTime: "2025-07-01T06:20:17Z"
           message:
             HTTPRoute is not allowed to attach to this Gateway due to namespace
-            selector restrictions
+            restrictions
           reason: NotAllowedByListeners
           status: "False"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/input/httproute-allowed-kind-by-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/input/httproute-allowed-kind-by-section-name.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kind-restricted-multi-listener
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: HTTPRoute
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
+    - name: grpcs
+      port: 50051
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: GRPCRoute
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-via-section-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: kind-restricted-multi-listener
+      namespace: gateway-conformance-infra
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /kind-allowed
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-via-section-name
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: kind-restricted-multi-listener
+      namespace: gateway-conformance-infra
+      sectionName: grpcs
+  rules:
+    - matches:
+        - method:
+            service: com.example.KindAllowed
+            method: Check
+      backendRefs:
+        - name: grpc-infra-backend-v1
+          port: 8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
@@ -1,0 +1,168 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: kind-restricted-multi-listener
+  name: cilium-gateway-kind-restricted-multi-listener
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: kind-restricted-multi-listener
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: grpc-infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-secure
+                statPrefix: listener-secure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: /gateway-conformance-infra-tls-checks-certificate
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-secure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - match:
+                path: /com.example.KindAllowed/Check
+              route:
+                cluster: gateway-conformance-infra:grpc-infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+            - match:
+                pathSeparatedPrefix: /kind-allowed
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/grpc-infra-backend-v1:8080
+      name: gateway-conformance-infra:grpc-infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          explicitHttpConfig:
+            http2ProtocolOptions: {}
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - name: cilium-gateway-kind-restricted-multi-listener
+      namespace: gateway-conformance-infra
+      ports:
+        - 443
+        - 50051

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/grpcroute-grpc-via-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/grpcroute-grpc-via-section-name.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  creationTimestamp: null
+  name: grpc-via-section-name
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+    - name: kind-restricted-multi-listener
+      namespace: gateway-conformance-infra
+      sectionName: grpcs
+  rules:
+    - matches:
+        - method:
+            service: com.example.KindAllowed
+            method: Check
+      backendRefs:
+        - name: grpc-infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Accepted GRPCRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: kind-restricted-multi-listener
+        namespace: gateway-conformance-infra
+        sectionName: grpcs

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/httproute-http-via-section-name.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/httproute-http-via-section-name.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: http-via-section-name
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+    - name: kind-restricted-multi-listener
+      namespace: gateway-conformance-infra
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /kind-allowed
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: kind-restricted-multi-listener
+        namespace: gateway-conformance-infra
+        sectionName: https

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/kind-restricted-multi-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/kind-restricted-multi-listener.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: kind-restricted-multi-listener
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+        namespaces:
+          from: Same
+      name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: tls-checks-certificate
+        mode: Terminate
+    - allowedRoutes:
+        kinds:
+          - kind: GRPCRoute
+        namespaces:
+          from: Same
+      name: grpcs
+      port: 50051
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: tls-checks-certificate
+        mode: Terminate
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:52:17Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T05:52:17Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:52:17Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T05:52:17Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: grpcs
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute


### PR DESCRIPTION
Fix two related bugs in the Gateway API route allowedRoute logic where multi-listener Gateways produce incorrect `Accepted` conditions on routes. This is a follow up of #44889.

This PR was prepared with AIL:3. I personally reviewed each line of the submission as well as run regression tests from https://github.com/eufriction/k8s-cilium-gapi#test-results-by-version.

See each commit for description of the changes.

Fixes: #42159
Fixes: #45559

```release-note
Fix allowedRoute namespace and kind restrictions on multi-listener Gateways.
```
