### PR TITLE
[v1.19] bpf: egressgw: respect egress ifindex during FIB lookup

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -82,7 +82,6 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 				      __u32 egress_ifindex, __s8 *ext_err)
 {
 	struct bpf_fib_lookup_padded fib_params = {};
-	__u32 oif;
 	int ret;
 
 	/* Immediate redirect to egress_ifindex requires L2 resolution.
@@ -102,13 +101,15 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 		return DROP_NO_FIB;
 	}
 
-	oif = fib_params.l.ifindex;
+	if (!egress_ifindex)
+		egress_ifindex = fib_params.l.ifindex;
 
 	/* Skip redirect in to-netdev if we stay on the same iface: */
-	if (is_defined(IS_BPF_HOST) && oif == ctx_get_ifindex(ctx))
+	if (is_defined(IS_BPF_HOST) && egress_ifindex == ctx_get_ifindex(ctx))
 		return CTX_ACT_OK;
 
-	return fib_do_redirect(ctx, true, &fib_params, false, ret, oif, ext_err);
+	return fib_do_redirect(ctx, true, &fib_params, false, ret,
+			       egress_ifindex, ext_err);
 }
 
 # ifdef ENABLE_EGRESS_GATEWAY
@@ -399,7 +400,6 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 {
 	struct bpf_fib_lookup_padded *fib_params;
 	int ret, zero = 0;
-	__u32 oif;
 
 	if (egress_ifindex && neigh_resolver_without_nh_available())
 		return redirect_neigh(egress_ifindex, NULL, 0, 0);
@@ -421,12 +421,14 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 		return DROP_NO_FIB;
 	}
 
-	oif = fib_params->l.ifindex;
+	if (!egress_ifindex)
+		egress_ifindex = fib_params->l.ifindex;
 
-	if (is_defined(IS_BPF_HOST) && oif == ctx_get_ifindex(ctx))
+	if (is_defined(IS_BPF_HOST) && egress_ifindex == ctx_get_ifindex(ctx))
 		return CTX_ACT_OK;
 
-	return fib_do_redirect(ctx, true, fib_params, false, ret, oif, ext_err);
+	return fib_do_redirect(ctx, true, fib_params, false, ret,
+			       egress_ifindex, ext_err);
 }
 
 static __always_inline


### PR DESCRIPTION
Manual backport of
* [ ] #45661

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45661
```