### PR TITLE
Relax DisableCiliumEndpointCRD to work with CES and operator slim mode

### DIFF
--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -48,9 +48,9 @@ func agentCRDResourceNames() []string {
 
 	if !option.Config.DisableCiliumEndpointCRD {
 		result = append(result, CRDResourceName(v2.CEPName))
-		if option.Config.EnableCiliumEndpointSlice {
-			result = append(result, CRDResourceName(v2alpha1.CESName))
-		}
+	}
+	if option.Config.EnableCiliumEndpointSlice {
+		result = append(result, CRDResourceName(v2alpha1.CESName))
 	}
 
 	if option.Config.EnableCiliumNodeCRD {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -287,7 +287,9 @@ func (k *K8sWatcher) enableK8sWatchers(ctx context.Context, resourceNames []stri
 				k.k8sCiliumEndpointsWatcher.initCiliumEndpointOrSlices(ctx)
 			}
 		case k8sAPIGroupCiliumEndpointSliceV2Alpha1:
-			// no-op; handled in k8sAPIGroupCiliumEndpointV2
+			if !k.kcfg.IsEnabled() && option.Config.DisableCiliumEndpointCRD {
+				k.k8sCiliumEndpointsWatcher.initCiliumEndpointOrSlices(ctx)
+			}
 		default:
 			logging.Fatal(k.logger,
 				"Not listening for Kubernetes resource updates for unhandled type",

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -574,7 +574,8 @@ const (
 	LogSystemLoadConfigName = "log-system-load"
 
 	// DisableCiliumEndpointCRDName is the name of the option to disable
-	// use of the CEP CRD
+	// use of the CEP CRD. Can be used along with operator's 'ces-controller-mode=slim'
+	// mode to distribute endpoints without creating them.
 	DisableCiliumEndpointCRDName = "disable-endpoint-crd"
 
 	// MaxCtrlIntervalName and MaxCtrlIntervalNameEnv allow configuration
@@ -2771,12 +2772,10 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 		logging.Fatal(logger, "Unable to parse excluded local addresses", logfields.Error, err)
 	}
 
-	// Ensure CiliumEndpointSlice is enabled only if CiliumEndpointCRD is enabled too.
+	// Relaxed: In operator-driven slim mode configurations, both CiliumEndpointSlices
+	// and DisableCiliumEndpointCRD can be true concurrently. The synchronization
+	// components skip standalone CEP creation in agent while leveraging CEPs.
 	c.EnableCiliumEndpointSlice = vp.GetBool(EnableCiliumEndpointSlice)
-	if c.EnableCiliumEndpointSlice && c.DisableCiliumEndpointCRD {
-		logging.Fatal(logger, fmt.Sprintf("Running Cilium with %s=%t requires %s set to false to enable CiliumEndpoint CRDs.",
-			EnableCiliumEndpointSlice, c.EnableCiliumEndpointSlice, DisableCiliumEndpointCRDName))
-	}
 
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)
@@ -2805,7 +2804,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 			logger.Warn(fmt.Sprintf("Running Cilium with %q=%q requires identity allocation via CRDs. Changing %s to %q", KVStore, theKVStore, IdentityAllocationMode, IdentityAllocationModeCRD))
 			c.IdentityAllocationMode = IdentityAllocationModeCRD
 		}
-		if c.DisableCiliumEndpointCRD && NetworkPolicyEnabled(c) {
+		if c.DisableCiliumEndpointCRD && NetworkPolicyEnabled(c) && !c.EnableCiliumEndpointSlice {
 			logger.Warn(fmt.Sprintf("Running Cilium with %q=%q requires endpoint CRDs when network policy enforcement system is enabled. Changing %s to %t", KVStore, theKVStore, DisableCiliumEndpointCRDName, false))
 			c.DisableCiliumEndpointCRD = false
 		}

--- a/pkg/option/features.go
+++ b/pkg/option/features.go
@@ -14,7 +14,7 @@ func NetworkPolicyEnabled(cfg *DaemonConfig) bool {
 		cfg.EnableK8sClusterNetworkPolicy,
 		cfg.EnableCiliumNetworkPolicy,
 		cfg.EnableCiliumClusterwideNetworkPolicy,
-		!cfg.DisableCiliumEndpointCRD,
+		(!cfg.DisableCiliumEndpointCRD || cfg.EnableCiliumEndpointSlice),
 		cfg.IdentityAllocationMode != IdentityAllocationModeCRD,
 	)
 }

--- a/pkg/option/features_test.go
+++ b/pkg/option/features_test.go
@@ -17,6 +17,7 @@ func TestNetworkPolicyEnabled(t *testing.T) {
 		enableCNP       bool
 		enableCCNP      bool
 		disableCEP      bool
+		enableCES       bool
 		idAllocMode     string
 	}
 
@@ -84,6 +85,22 @@ func TestNetworkPolicyEnabled(t *testing.T) {
 			idAllocMode: "test",
 			disableCEP:  false,
 		},
+		{
+			description:  "enabled_slim_mode",
+			want:         true,
+			enablePolicy: NeverEnforce,
+			disableCEP:   true,
+			enableCES:    true,
+			idAllocMode:  IdentityAllocationModeCRD,
+		},
+		{
+			description:  "enabled_traditional_slicing",
+			want:         true,
+			enablePolicy: NeverEnforce,
+			disableCEP:   false,
+			enableCES:    true,
+			idAllocMode:  IdentityAllocationModeCRD,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -93,6 +110,7 @@ func TestNetworkPolicyEnabled(t *testing.T) {
 			EnableCiliumNetworkPolicy:            tc.enableCNP,
 			EnableCiliumClusterwideNetworkPolicy: tc.enableCCNP,
 			DisableCiliumEndpointCRD:             tc.disableCEP,
+			EnableCiliumEndpointSlice:            tc.enableCES,
 			IdentityAllocationMode:               tc.idAllocMode,
 		}
 


### PR DESCRIPTION
This PR follows up on https://github.com/cilium/cilium/pull/38388, allowing cilium setup no to create CEP.

To further reduce pressure put on kube-apiserver, this PR allows disabling CEP CRD, so that it can be paired with cilium-operator's `ces-controller-mode=slim` mode, making CES only source of endpoint information in the cluster. While existing validation checks were relaxed to support this setup, the most critical part is that `EndpointSynchronizer.RunK8sCiliumEndpointSync` is not being run when `DisableCiliumEndpointCRD` flag is true, this ultimately removes usage of CEP in the cluster, which improves scalability by removing CiliumEndpoints GET and PATCH requests.