### PR TITLE
imges: Remove broken operator `CMD` with unexpanded arg

### DIFF
--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -87,7 +87,6 @@ WORKDIR /
 # issues depending on the UID configured to run the entrypoint.
 COPY --chmod=777 --from=scratch / /home/gops
 ENV GOPS_CONFIG_DIR=/home/gops
-CMD ["/usr/bin/cilium-${OPERATOR_VARIANT}"]
 
 FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} AS debug-tools
 


### PR DESCRIPTION
The operator image Dockerfile currently has a [`CMD`](https://docs.docker.com/reference/dockerfile/#cmd):
```dockerfile
CMD ["/usr/bin/cilium-${OPERATOR_VARIANT}"]
```

But docker never performs any variable interpolation/expansion for `CMD` instructions, so this ends up as is in the final image:
```sh
$ docker inspect quay.io/cilium/operator-aws:v1.19.3 | jq '.[].Config.Cmd[]'
"/usr/bin/cilium-${OPERATOR_VARIANT}"
```

```sh
$ docker run quay.io/cilium/operator-aws:v1.19.3
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/usr/bin/cilium-${OPERATOR_VARIANT}": stat /usr/bin/cilium-${OPERATOR_VARIANT}: no such file or directory

Run 'docker run --help' for more information
```

In practice this is fine as no one ever runs the operator image without overriding the pod `command` (see official cilim chart [here](https://github.com/cilium/cilium/blob/8418a20754e4cd0a74f92293bf4b2fb79e0ea96a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml#L82-L83)).

This PR removes this unused and broken CMD instruction.