### PR TITLE
conformance-eks: fix bpf-masq-v4 check

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -353,7 +353,8 @@ jobs:
             CILIUM_INSTALL_DEFAULTS+=" --helm-set eni.awsEnablePrefixDelegation=true"
           fi
 
-          if [[ "${{ matrix.bpf-masq-v4 }}" == "true" ]]; then
+          BPFMASQV4=$(echo "${EXTRA_ARGS}" | jq -r '.["bpf-masq-v4"] // false')
+          if [[ "${BPFMASQV4}" == "true" ]]; then
             CILIUM_INSTALL_DEFAULTS+=" --helm-set bpf.masquerade=true \
               --helm-set enableIPv4Masquerade=true"
           fi


### PR DESCRIPTION
Commit 434d0eff1f ("conformance-{aks,eks,gke,kpr}: split out bpf masquerade") split out bpf.masquerade into its own matrix variable ("bpf-masq-v4") and each of the EKS, AKS and GKE workflows were updated to use this new key.

Unfortunately the EKS, AKS and GKE workflows are all slightly different and the commit accidentally modified the EKS workflow to check for the new key in the matrix, when in fact the EKS workflow just queries the workflow input variable directly for the value.

This commit aligns the bpf.masquerade check with logic in the EKS workflow so that we properly enable bpf.masquerade when called for.

Fixes: 434d0eff1f ("conformance-{aks,eks,gke,kpr}: split out bpf masquerade")
