### PR TITLE
Fix external traffic drops/inconsistencies on secondary ENIs with masquerade enabled

### DIFF
--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -98,32 +98,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 	}
 	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
 
-	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
-		// Lookup a VPC specific table for all traffic from an endpoint to the
-		// CIDR configured for the VPC on which the endpoint has the IP on.
-		// ReplaceRule doesn't handle an all-zero CIDR and can return "file exists",
-		// so omit To for unspecified CIDRs both here and in delete.
-		for _, cidr := range info.CIDRs {
-			rule := route.Rule{
-				Priority: egressPriority,
-				From:     &ipWithMask,
-				Table:    tableID,
-				Protocol: linux_defaults.RTProto,
-			}
-			if !cidr.IP.IsUnspecified() {
-				rule.To = &cidr
-			}
-			if err := replaceRule(rule); err != nil {
-				return fmt.Errorf("unable to install ip rule: %w", err)
-			}
-		}
-	}
-
-	// Always install an unconditional rule to ensure all traffic from the
-	// endpoint (including external/internet traffic) is routed through the
-	// correct ENI. Without this, external traffic may fall through to the
-	// default routing table and be routed via the wrong interface, resulting
-	// in drops. See https://github.com/cilium/cilium/issues/45137.
+	// Install an unconditional rule so all traffic from the endpoint
+	// (including external/internet traffic) is routed through the correct ENI.
+	// A previous implementation scoped rules to the VPC CIDRs, which let
+	// external traffic fall through to the default routing table and be routed
+	// via the wrong interface, resulting in drops.
+	// See https://github.com/cilium/cilium/issues/45137.
 	if err := replaceRule(route.Rule{
 		Priority: egressPriority,
 		From:     &ipWithMask,

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -98,24 +98,6 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 	}
 	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
 
-	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
-		// Lookup a VPC specific table for all traffic from an endpoint to the
-		// CIDR configured for the VPC on which the endpoint has the IP on.
-		// ReplaceRule function doesn't handle all zeros cidr and return `file exists` error,
-		// so we need to normalize the rule to cidr here and in Delete
-		for _, cidr := range info.CIDRs {
-			if err := replaceRule(route.Rule{
-				Priority: egressPriority,
-				From:     &ipWithMask,
-				To:       normalizeRuleToCIDR(&cidr),
-				Table:    tableID,
-				Protocol: linux_defaults.RTProto,
-			}); err != nil {
-				return fmt.Errorf("unable to install ip rule: %w", err)
-			}
-		}
-	}
-
 	// Always install an unconditional rule to ensure all traffic from the
 	// endpoint (including external/internet traffic) is routed through the
 	// correct ENI. Without this, external traffic may fall through to the

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -98,6 +98,27 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 	}
 	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
 
+	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
+		// Lookup a VPC specific table for all traffic from an endpoint to the
+		// CIDR configured for the VPC on which the endpoint has the IP on.
+		// ReplaceRule doesn't handle an all-zero CIDR and can return "file exists",
+		// so omit To for unspecified CIDRs both here and in delete.
+		for _, cidr := range info.CIDRs {
+			rule := route.Rule{
+				Priority: egressPriority,
+				From:     &ipWithMask,
+				Table:    tableID,
+				Protocol: linux_defaults.RTProto,
+			}
+			if !cidr.IP.IsUnspecified() {
+				rule.To = &cidr
+			}
+			if err := replaceRule(rule); err != nil {
+				return fmt.Errorf("unable to install ip rule: %w", err)
+			}
+		}
+	}
+
 	// Always install an unconditional rule to ensure all traffic from the
 	// endpoint (including external/internet traffic) is routed through the
 	// correct ENI. Without this, external traffic may fall through to the
@@ -412,12 +433,4 @@ func computeTableIDFromIfaceNumber(compat bool, num int) int {
 		return num
 	}
 	return linux_defaults.RouteTableInterfacesOffset + num
-}
-
-// normalizeRuleToCIDR returns nil when passed cidr is zeroes only cidr
-func normalizeRuleToCIDR(cidr *net.IPNet) *net.IPNet {
-	if cidr.IP.IsUnspecified() {
-		return nil
-	}
-	return cidr
 }

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -20,11 +20,9 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -100,7 +98,6 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 	}
 	tableID = computeTableIDFromIfaceNumber(info.useCompatEgressPriority(), ifaceNum)
 
-	// The condition here should mirror the condition in Delete.
 	if info.Masquerade && (info.IpamMode == ipamOption.IPAMENI || info.IpamMode == ipamOption.IPAMAzure) {
 		// Lookup a VPC specific table for all traffic from an endpoint to the
 		// CIDR configured for the VPC on which the endpoint has the IP on.
@@ -117,16 +114,20 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 				return fmt.Errorf("unable to install ip rule: %w", err)
 			}
 		}
-	} else {
-		// Lookup a VPC specific table for all traffic from an endpoint.
-		if err := replaceRule(route.Rule{
-			Priority: egressPriority,
-			From:     &ipWithMask,
-			Table:    tableID,
-			Protocol: linux_defaults.RTProto,
-		}); err != nil {
-			return fmt.Errorf("unable to install ip rule: %w", err)
-		}
+	}
+
+	// Always install an unconditional rule to ensure all traffic from the
+	// endpoint (including external/internet traffic) is routed through the
+	// correct ENI. Without this, external traffic may fall through to the
+	// default routing table and be routed via the wrong interface, resulting
+	// in drops. See https://github.com/cilium/cilium/issues/45137.
+	if err := replaceRule(route.Rule{
+		Priority: egressPriority,
+		From:     &ipWithMask,
+		Table:    tableID,
+		Protocol: linux_defaults.RTProto,
+	}); err != nil {
+		return fmt.Errorf("unable to install ip rule: %w", err)
 	}
 
 	return info.installRoutes(ifindex, tableID)
@@ -313,60 +314,21 @@ func Delete(logger *slog.Logger, ip netip.Addr) error {
 		msg: "rule does not refer to a per-ENI routing table ID",
 	}
 
-	// The condition here should mirror the conditions in Configure.
-	info := node.GetRouterInfo()
-	if info != nil && option.Config.EnableIPv4Masquerade && (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
-		ipCIDRs := info.GetCIDRs()
-		cidrs := make([]*net.IPNet, 0, len(ipCIDRs))
-		for i := range ipCIDRs {
-			cidrs = append(cidrs, &ipCIDRs[i])
-		}
-		// Coalesce CIDRs into minimum set needed for route rules
-		// This code here mirrors interfaceAdd() in cilium-cni/interface.go
-		// and must be kept in sync when modified
-		ipv4RoutingCIDRs, ipv6RoutingCIDRs := iputil.CoalesceCIDRs(cidrs)
-		for _, cidr := range ipv4RoutingCIDRs {
-			egress := route.Rule{
-				Priority: priority,
-				From:     ipWithMask,
-				To:       normalizeRuleToCIDR(cidr),
-			}
-			if err := deleteRulesFiltered(logger, egress, netlink.FAMILY_V4, withENIRouteTableID); err != nil {
-				return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
-			}
-			logger.Debug("Deleted egress rule",
-				logfields.Rule, egress,
-				logfields.IPAddr, ipWithMask,
-			)
-		}
-		for _, cidr := range ipv6RoutingCIDRs {
-			egress := route.Rule{
-				Priority: priority,
-				From:     ipWithMask,
-				To:       normalizeRuleToCIDR(cidr),
-			}
-			if err := deleteRulesFiltered(logger, egress, netlink.FAMILY_V6, withENIRouteTableID); err != nil {
-				return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
-			}
-			logger.Debug("Deleted egress rule",
-				logfields.Rule, egress,
-				logfields.IPAddr, ipWithMask,
-			)
-		}
-	} else {
-		egress := route.Rule{
-			Priority: priority,
-			From:     ipWithMask,
-		}
-		if err := deleteRulesFiltered(
-			logger, egress, family, withENIRouteTableID); err != nil {
-			return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
-		}
-		logger.Debug("Deleted egress rule",
-			logfields.Rule, egress,
-			logfields.IPAddr, ipWithMask,
-		)
+	// Delete all egress rules matching the priority and source IP.
+	// This covers the unconditional rule (from <IP> lookup <table>) and
+	// any CIDR-specific rules (from <IP> to <CIDR> lookup <table>).
+	egress := route.Rule{
+		Priority: priority,
+		From:     ipWithMask,
 	}
+	if err := deleteRulesFiltered(
+		logger, egress, family, withENIRouteTableID); err != nil {
+		return fmt.Errorf("unable to delete egress rule with ip %s: %w", ipWithMask.String(), err)
+	}
+	logger.Debug("Deleted egress rule",
+		logfields.Rule, egress,
+		logfields.IPAddr, ipWithMask,
+	)
 
 	if option.Config.EnableUnreachableRoutes {
 		// Replace route to old IP with an unreachable route. This will

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -214,8 +214,10 @@ func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
 }
 
 // verifyMasqueradeRules checks that rules are consistent with the masquerading configuration:
-// - If masquerading is enabled, rules need to have the 'to' field (example: 'from 10.194.0.56 to 10.0.0.0/8 lookup 3')
-// - If masquerading is disabled or if ri.CIDRs has 0.0.0.0/0, the 'to' field should not be there
+//   - If masquerading is enabled, rules should include both CIDR-specific rules (with 'to' field)
+//     and an unconditional rule (without 'to' field) for correct external traffic routing.
+//   - If masquerading is disabled, only the unconditional rule (no 'to' field) should be present.
+//   - If ri.CIDRs has 0.0.0.0/0, only the unconditional rule should be present (zero CIDR normalizes to nil).
 func verifyMasqueradeRules(t *testing.T, rules []netlink.Rule, ri RoutingInfo, ip netip.Addr) {
 	t.Helper()
 
@@ -227,16 +229,31 @@ func verifyMasqueradeRules(t *testing.T, rules []netlink.Rule, ri RoutingInfo, i
 		}
 	}
 
+	var hasUnconditionalRule bool
+	var hasCIDRRule bool
 	for _, rule := range rules {
 		if rule.Src != nil && rule.Src.IP.Equal(ip.AsSlice()) {
-			if ri.Masquerade && !hasZeroCidr && rule.Dst == nil {
-				require.Fail(t, "rule is missing the 'to' field with masquerading enabled")
-			} else if ri.Masquerade && hasZeroCidr && rule.Dst != nil {
-				require.Fail(t, "rule has the 'to' field with a 0.0.0.0/0 CIDR")
-			} else if !ri.Masquerade && rule.Dst != nil {
+			if rule.Dst == nil {
+				hasUnconditionalRule = true
+			} else {
+				hasCIDRRule = true
+			}
+
+			if !ri.Masquerade && rule.Dst != nil {
 				require.Fail(t, "rule has the 'to' field despite masquerading being disabled")
 			}
+			if ri.Masquerade && hasZeroCidr && rule.Dst != nil {
+				require.Fail(t, "rule has the 'to' field with a 0.0.0.0/0 CIDR")
+			}
 		}
+	}
+
+	// The unconditional rule must always be present for correct ENI routing.
+	require.True(t, hasUnconditionalRule, "unconditional egress rule (from <IP> lookup <table>) must be present")
+
+	// When masquerade is enabled with non-zero CIDRs, CIDR-specific rules should also be present.
+	if ri.Masquerade && !hasZeroCidr && len(ri.CIDRs) > 0 {
+		require.True(t, hasCIDRRule, "CIDR-specific egress rules must be present when masquerade is enabled")
 	}
 }
 

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -214,47 +214,26 @@ func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
 }
 
 // verifyMasqueradeRules checks that rules are consistent with the masquerading configuration:
-//   - If masquerading is enabled, rules should include both CIDR-specific rules (with 'to' field)
-//     and an unconditional rule (without 'to' field) for correct external traffic routing.
-//   - If masquerading is disabled, only the unconditional rule (no 'to' field) should be present.
-//   - If ri.CIDRs has 0.0.0.0/0, only the unconditional rule should be present (zero CIDR normalizes to nil).
+//   - An unconditional rule (from <IP> lookup <table>) must always be present for correct ENI routing.
+//   - No CIDR-specific rules (with 'to' field) should be present.
 func verifyMasqueradeRules(t *testing.T, rules []netlink.Rule, ri RoutingInfo, ip netip.Addr) {
 	t.Helper()
 
-	hasZeroCidr := false
-	for _, cidr := range ri.CIDRs {
-		if cidr.IP.IsUnspecified() {
-			hasZeroCidr = true
-			break
-		}
-	}
-
 	var hasUnconditionalRule bool
-	var hasCIDRRule bool
 	for _, rule := range rules {
 		if rule.Src != nil && rule.Src.IP.Equal(ip.AsSlice()) {
+			// Should not have CIDR-specific rules
+			if rule.Dst != nil {
+				require.Fail(t, "unexpected CIDR-specific rule found; only unconditional rule should be present")
+			}
 			if rule.Dst == nil {
 				hasUnconditionalRule = true
-			} else {
-				hasCIDRRule = true
-			}
-
-			if !ri.Masquerade && rule.Dst != nil {
-				require.Fail(t, "rule has the 'to' field despite masquerading being disabled")
-			}
-			if ri.Masquerade && hasZeroCidr && rule.Dst != nil {
-				require.Fail(t, "rule has the 'to' field with a 0.0.0.0/0 CIDR")
 			}
 		}
 	}
 
 	// The unconditional rule must always be present for correct ENI routing.
 	require.True(t, hasUnconditionalRule, "unconditional egress rule (from <IP> lookup <table>) must be present")
-
-	// When masquerade is enabled with non-zero CIDRs, CIDR-specific rules should also be present.
-	if ri.Masquerade && !hasZeroCidr && len(ri.CIDRs) > 0 {
-		require.True(t, hasCIDRRule, "CIDR-specific egress rules must be present when masquerade is enabled")
-	}
 }
 
 func runDelete(t *testing.T, ip netip.Addr) {


### PR DESCRIPTION
I noticed an inconsistency in EKS with multiple ENIs and masquerade enabled, I have seen similar issue while benchmarking cilium with and without prefixDelegation. 
external traffic from pods on secondary ENIs was dropped. Only from <IP> to <VPC_CIDR> rules were installed, internet traffic didn't match and fell to the default routing table (wrong interface), I had to set the masqueradeinterfaceindex to 1 for it to work.

the fix updates the Configure() function to always install rules ensuring all traffic goes through the correct eni?  

Fixes: #45137

