### PR TITLE
hubble: refactor local node watcher as a cell

### DIFF
--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -28,7 +28,6 @@ import (
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
-	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 )
 
@@ -86,7 +85,6 @@ type hubbleParams struct {
 	IPCache           *ipcache.IPCache
 	CGroupManager     manager.CGroupManager
 	NodeManager       nodeManager.NodeManager
-	NodeLocalStore    *node.LocalNodeStore
 	MonitorAgent      monitorAgent.Agent
 
 	TLSConfigPromise tlsConfigPromise
@@ -120,7 +118,6 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 		params.IPCache,
 		params.CGroupManager,
 		params.NodeManager,
-		params.NodeLocalStore,
 		params.MonitorAgent,
 		params.TLSConfigPromise,
 		params.ObserverOptions,

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
-	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -63,7 +62,6 @@ type hubbleIntegration struct {
 	ipcache           *ipcache.IPCache
 	cgroupManager     manager.CGroupManager
 	nodeManager       nodeManager.NodeManager
-	nodeLocalStore    *node.LocalNodeStore
 	monitorAgent      monitorAgent.Agent
 	tlsConfigPromise  tlsConfigPromise
 	exporters         []exporter.FlowLogExporter
@@ -92,7 +90,6 @@ func createHubbleIntegration(
 	ipcache *ipcache.IPCache,
 	cgroupManager manager.CGroupManager,
 	nodeManager nodeManager.NodeManager,
-	nodeLocalStore *node.LocalNodeStore,
 	monitorAgent monitorAgent.Agent,
 	tlsConfigPromise tlsConfigPromise,
 	observerOptions []observeroption.Option,
@@ -123,7 +120,6 @@ func createHubbleIntegration(
 		ipcache:              ipcache,
 		cgroupManager:        cgroupManager,
 		nodeManager:          nodeManager,
-		nodeLocalStore:       nodeLocalStore,
 		monitorAgent:         monitorAgent,
 		tlsConfigPromise:     tlsConfigPromise,
 		observerOptions:      observerOptions,
@@ -232,14 +228,6 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 			}),
 		)
 	}
-
-	// fill in the local node information after the dropEventEmitter logique,
-	// but before anything else (e.g. metrics).
-	localNodeWatcher, err := observer.NewLocalNodeWatcher(ctx, h.nodeLocalStore)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve local node information: %w", err)
-	}
-	observerOpts = append(observerOpts, observeroption.WithOnDecodedFlow(localNodeWatcher))
 
 	maxFlows, err := container.NewCapacity(h.config.EventBufferCapacity)
 	if err != nil {

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -46,6 +46,7 @@ func noopParser(tb testing.TB) *parser.Parser {
 		&testutils.NoopServiceGetter,
 		&testutils.NoopLinkGetter,
 		&testutils.NoopPodMetadataGetter,
+		nil, // localNodeWatcher
 	)
 	require.NoError(tb, err)
 	return pp
@@ -653,8 +654,8 @@ func TestLocalObserverServer_OnGetFlows(t *testing.T) {
 	assert.Positive(t, flowsReceived)
 }
 
-// TestLocalObserverServer_NodeLabels test the LocalNodeWatcher integration
-// with the observer.
+// TestLocalObserverServer_NodeLabels tests that node labels are populated
+// on flows when the parser has a LocalNodeWatcher.
 func TestLocalObserverServer_NodeLabels(t *testing.T) {
 	ctx := t.Context()
 
@@ -671,22 +672,51 @@ func TestLocalObserverServer_NodeLabels(t *testing.T) {
 			},
 		},
 	}
-	localNodeWatcher, err := NewLocalNodeWatcher(ctx, node.NewTestLocalNodeStore(localNode))
+	expectedLabels := []string{
+		"kubernetes.io/arch=amd64",
+		"kubernetes.io/hostname=ip-1-2-3-4.us-west-2.compute.internal",
+		"kubernetes.io/os=linux",
+		"topology.kubernetes.io/region=us-west-2",
+		"topology.kubernetes.io/zone=us-west-2d",
+	}
+
+	// Start the LocalNodeWatcher via Run.
+	store := node.NewTestLocalNodeStore(localNode)
+	watcher := &parser.LocalNodeWatcher{}
+	watcherCtx, watcherCancel := context.WithCancel(ctx)
+	defer watcherCancel()
+	go watcher.Run(watcherCtx, store)
+
+	// Wait for the watcher to be initialized.
+	require.EventuallyWithT(
+		t,
+		func(c *assert.CollectT) {
+			assert.NotEmpty(c, watcher.NodeLabels())
+		},
+		10*time.Second,
+		10*time.Millisecond,
+	)
+
+	// Create a parser with the watcher.
+	pp, err := parser.New(
+		hivetest.Logger(t),
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter,
+		&testutils.NoopLinkGetter,
+		&testutils.NoopPodMetadataGetter,
+		watcher,
+	)
 	require.NoError(t, err)
-	require.NotNil(t, localNodeWatcher)
 
 	// fake hubble server setup.
 	flowsReceived := 0
 	req := &observerpb.GetFlowsRequest{Number: uint64(1)}
 	fakeServer := &testutils.FakeGetFlowsServer{
 		OnSend: func(response *observerpb.GetFlowsResponse) error {
-			// NOTE: a bit hacky to directly access the localNodeWatcher cache,
-			// but we don't have any use yet for an accessor method beyond this
-			// package local test.
-			localNodeWatcher.mu.Lock()
-			expected := localNodeWatcher.cache.labels
-			localNodeWatcher.mu.Unlock()
-			assert.Equal(t, expected, response.GetFlow().GetNodeLabels())
+			assert.Equal(t, expectedLabels, response.GetFlow().GetNodeLabels())
 			flowsReceived++
 			return nil
 		},
@@ -698,10 +728,8 @@ func TestLocalObserverServer_NodeLabels(t *testing.T) {
 	}
 
 	// local hubble observer setup.
-	pp, nm := noopParser(t), testutils.NoopNamespaceManager
-	s, err := NewLocalServer(pp, nm, hivetest.Logger(t),
-		observeroption.WithOnDecodedFlow(localNodeWatcher),
-	)
+	nm := testutils.NoopNamespaceManager
+	s, err := NewLocalServer(pp, nm, hivetest.Logger(t))
 	require.NoError(t, err)
 	go s.Start()
 

--- a/pkg/hubble/observer/types/types.go
+++ b/pkg/hubble/observer/types/types.go
@@ -31,7 +31,10 @@ type MonitorEvent struct {
 	UUID uuid.UUID
 	// Timestamp when the event was received by the consumer
 	Timestamp time.Time
-	// NodeName where the event occurred
+	// NodeName where the event occurred.
+	//
+	// Deprecated: Hubble now derives the node name from the LocalNodeStore
+	// via the parser's LocalNodeWatcher.
 	NodeName string
 	// Payload is one of: AgentEvent, PerfEvent or LostEvent
 	Payload any

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -31,6 +31,8 @@ var Cell = cell.Module(
 	"payload-parser",
 	"Provides a payload parser for Hubble",
 
+	parser.LocalNodeWatcherCell,
+
 	cell.Provide(newPayloadParser),
 	cell.Config(defaultConfig),
 )
@@ -74,7 +76,7 @@ func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
 		parserOpts,
 		params.ParserOptions...,
 	)
-	return parser.New(params.Log, g, g, g, params.Ipcache, g, params.LinkCache, params.CGroupManager, parserOpts...)
+	return parser.New(params.Log, g, g, g, params.Ipcache, g, params.LinkCache, params.CGroupManager, params.LocalNodeWatcher, parserOpts...)
 }
 
 type payloadParserParams struct {
@@ -89,6 +91,7 @@ type payloadParserParams struct {
 	Ipcache           *ipcache.IPCache
 	CGroupManager     manager.CGroupManager
 	LinkCache         *link.LinkCache
+	LocalNodeWatcher  *parser.LocalNodeWatcher
 
 	Config config
 	// NOTE: ordering is not guaranteed, do not rely on it.

--- a/pkg/hubble/parser/fuzz_test.go
+++ b/pkg/hubble/parser/fuzz_test.go
@@ -21,7 +21,7 @@ var (
 
 func FuzzParserDecode(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		p, err := New(slog.New(slog.DiscardHandler), nil, nil, nil, nil, nil, nil, nil)
+		p, err := New(slog.New(slog.DiscardHandler), nil, nil, nil, nil, nil, nil, nil, nil)
 		if err != nil {
 			return
 		}

--- a/pkg/hubble/parser/local_node_watcher.go
+++ b/pkg/hubble/parser/local_node_watcher.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Hubble
 
-package observer
+package parser
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 )
 
-// LocalNodeWatcher populate Hubble flows local node related fields (currently
+// LocalNodeWatcher populates Hubble flows local node related fields (currently
 // only labels).
 type LocalNodeWatcher struct {
 	mu    lock.Mutex
@@ -23,26 +23,28 @@ type LocalNodeWatcher struct {
 	}
 }
 
-// NewLocalNodeWatcher return a new LocalNodeWatcher. The given context control
-// whether the LocalNodeWatcher gets updated by the localNodeStore. It is safe
-// to use the returned LocalNodeWatcher once the context is cancelled, but its
-// information might be out-of-date.
-func NewLocalNodeWatcher(ctx context.Context, localNodeStore *node.LocalNodeStore) (*LocalNodeWatcher, error) {
-	watcher := LocalNodeWatcher{}
-	// fetch the initial local node
+// Run initializes the LocalNodeWatcher and subscribes to local node changes.
+// It blocks until the context is cancelled.
+func (w *LocalNodeWatcher) Run(ctx context.Context, localNodeStore *node.LocalNodeStore) error {
 	n, err := localNodeStore.Get(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	watcher.update(n)
-	// subscribe to local node changes.
-	localNodeStore.Observe(ctx, watcher.update, watcher.complete)
+	w.update(n)
+	localNodeStore.Observe(ctx, w.update, w.complete)
+	<-ctx.Done()
+	return nil
+}
 
-	return &watcher, nil
+// NodeLabels returns the current node labels as a sorted key=val slice.
+func (w *LocalNodeWatcher) NodeLabels() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.cache.labels
 }
 
 // OnDecodedFlow implements OnDecodedFlow for LocalNodeWatcher. The
-// LocalNodeWatcher populate the flow's node_labels field.
+// LocalNodeWatcher populates the flow's node_labels field.
 func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *flowpb.Flow) (bool, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -50,7 +52,7 @@ func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *flowpb.Flow) (
 	return false, nil
 }
 
-// update synchronize the LocalNodeWatcher cache with the given LocalNode info.
+// update synchronizes the LocalNodeWatcher cache with the given LocalNode info.
 func (w *LocalNodeWatcher) update(n node.LocalNode) {
 	labels := sortedLabelSlice(n.Labels)
 	w.mu.Lock()
@@ -65,7 +67,7 @@ func (w *LocalNodeWatcher) complete(error) {
 	w.cache.labels = nil
 }
 
-// sortedLabelSlice convert a given map of key/val labels, and return a sorted
+// sortedLabelSlice converts a given map of key/val labels, and returns a sorted
 // key=val slice.
 func sortedLabelSlice(src map[string]string) []string {
 	labels := make([]string, 0, len(src))

--- a/pkg/hubble/parser/local_node_watcher.go
+++ b/pkg/hubble/parser/local_node_watcher.go
@@ -7,16 +7,17 @@ import (
 	"context"
 	"slices"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 )
 
-// LocalNodeWatcher populates Hubble flows local node related fields (currently
-// only labels).
+// LocalNodeWatcher populates Hubble flows local node related fields such as
+// the node name and labels.
 type LocalNodeWatcher struct {
 	mu    lock.Mutex
 	cache struct {
+		// nodeName is the absolute node name (cluster/node or just node).
+		nodeName string
 		// labels are represented as a Go map in node.LocalNode, but we need a
 		// key=val slice for Hubble flows.
 		labels []string
@@ -36,27 +37,32 @@ func (w *LocalNodeWatcher) Run(ctx context.Context, localNodeStore *node.LocalNo
 	return nil
 }
 
-// NodeLabels returns the current node labels as a sorted key=val slice.
-func (w *LocalNodeWatcher) NodeLabels() []string {
+// NodeInfo returns the current node name and labels under a single lock.
+func (w *LocalNodeWatcher) NodeInfo() (string, []string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.cache.labels
+	return w.cache.nodeName, w.cache.labels
 }
 
-// OnDecodedFlow implements OnDecodedFlow for LocalNodeWatcher. The
-// LocalNodeWatcher populates the flow's node_labels field.
-func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *flowpb.Flow) (bool, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	flow.NodeLabels = w.cache.labels
-	return false, nil
+// NodeName returns the current absolute node name.
+func (w *LocalNodeWatcher) NodeName() string {
+	name, _ := w.NodeInfo()
+	return name
+}
+
+// NodeLabels returns the current node labels as a sorted key=val slice.
+func (w *LocalNodeWatcher) NodeLabels() []string {
+	_, labels := w.NodeInfo()
+	return labels
 }
 
 // update synchronizes the LocalNodeWatcher cache with the given LocalNode info.
 func (w *LocalNodeWatcher) update(n node.LocalNode) {
+	nodeName := n.Fullname()
 	labels := sortedLabelSlice(n.Labels)
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	w.cache.nodeName = nodeName
 	w.cache.labels = labels
 }
 
@@ -64,6 +70,7 @@ func (w *LocalNodeWatcher) update(n node.LocalNode) {
 func (w *LocalNodeWatcher) complete(error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	w.cache.nodeName = ""
 	w.cache.labels = nil
 }
 

--- a/pkg/hubble/parser/local_node_watcher_cell.go
+++ b/pkg/hubble/parser/local_node_watcher_cell.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package parser
+
+import (
+	"context"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/node"
+)
+
+// LocalNodeWatcherCell provides the LocalNodeWatcher. It manages the
+// LocalNodeStore subscription via a job.OneShot and provides the watcher
+// to the PayloadParser for populating the flow's node_labels field.
+var LocalNodeWatcherCell = cell.Provide(newLocalNodeWatcher)
+
+type localNodeWatcherParams struct {
+	cell.In
+
+	JobGroup       job.Group
+	NodeLocalStore *node.LocalNodeStore
+}
+
+func newLocalNodeWatcher(params localNodeWatcherParams) *LocalNodeWatcher {
+	watcher := &LocalNodeWatcher{}
+
+	params.JobGroup.Add(job.OneShot(
+		"hubble-local-node-watcher",
+		func(ctx context.Context, _ cell.Health) error {
+			return watcher.Run(ctx, params.NodeLocalStore)
+		},
+	))
+
+	return watcher
+}

--- a/pkg/hubble/parser/local_node_watcher_test.go
+++ b/pkg/hubble/parser/local_node_watcher_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/time"
@@ -71,18 +70,11 @@ func Test_LocalNodeWatcher(t *testing.T) {
 			t,
 			func(c *assert.CollectT) {
 				assert.Equal(c, localNodeLabelSlice, watcher.NodeLabels())
+				assert.Equal(c, localNode.Fullname(), watcher.NodeName())
 			},
 			10*time.Second,
 			10*time.Millisecond,
 		)
-	})
-
-	t.Run("OnDecodedFlow", func(t *testing.T) {
-		var flow flowpb.Flow
-		stop, err := watcher.OnDecodedFlow(ctx, &flow)
-		require.False(t, stop)
-		require.NoError(t, err)
-		require.Equal(t, localNodeLabelSlice, flow.GetNodeLabels())
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -93,6 +85,7 @@ func Test_LocalNodeWatcher(t *testing.T) {
 			t,
 			func(c *assert.CollectT) {
 				assert.Equal(c, updatedNodeLabelSlice, watcher.NodeLabels(), "node labels mismatch")
+				assert.Equal(c, updatedNode.Fullname(), watcher.NodeName(), "node name mismatch")
 			},
 			10*time.Second,
 			10*time.Millisecond,
@@ -103,11 +96,12 @@ func Test_LocalNodeWatcher(t *testing.T) {
 		cancel()
 		err := <-runDone
 		require.NoError(t, err)
-		// After cancellation, labels should be cleared by complete().
+		// After cancellation, cache should be cleared by complete().
 		require.EventuallyWithT(
 			t,
 			func(c *assert.CollectT) {
 				assert.Empty(c, watcher.NodeLabels())
+				assert.Empty(c, watcher.NodeName())
 			},
 			10*time.Second,
 			10*time.Millisecond,

--- a/pkg/hubble/parser/local_node_watcher_test.go
+++ b/pkg/hubble/parser/local_node_watcher_test.go
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Hubble
 
-package observer
+package parser
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,8 +17,6 @@ import (
 )
 
 func Test_LocalNodeWatcher(t *testing.T) {
-	ctx := t.Context()
-
 	localNode := node.LocalNode{
 		Node: types.Node{
 			Name: "ip-1-2-3-4.us-west-2.compute.internal",
@@ -55,14 +54,27 @@ func Test_LocalNodeWatcher(t *testing.T) {
 		"kubernetes.io/os=linux",
 	}
 
-	var watcher *LocalNodeWatcher
 	store := node.NewTestLocalNodeStore(localNode)
 
-	t.Run("NewLocalNodeWatcher", func(t *testing.T) {
-		var err error
-		watcher, err = NewLocalNodeWatcher(ctx, store)
-		require.NoError(t, err)
-		require.NotNil(t, watcher)
+	// Start the watcher with a cancellable context.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	watcher := &LocalNodeWatcher{}
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- watcher.Run(ctx, store)
+	}()
+
+	t.Run("NodeLabels", func(t *testing.T) {
+		require.EventuallyWithT(
+			t,
+			func(c *assert.CollectT) {
+				assert.Equal(c, localNodeLabelSlice, watcher.NodeLabels())
+			},
+			10*time.Second,
+			10*time.Millisecond,
+		)
 	})
 
 	t.Run("OnDecodedFlow", func(t *testing.T) {
@@ -80,25 +92,26 @@ func Test_LocalNodeWatcher(t *testing.T) {
 		require.EventuallyWithT(
 			t,
 			func(c *assert.CollectT) {
-				var flow flowpb.Flow
-				stop, err := watcher.OnDecodedFlow(ctx, &flow)
-				if assert.False(c, stop) {
-					assert.NoError(c, err)
-					assert.Equal(c, updatedNodeLabelSlice, flow.GetNodeLabels(), "node labels mismatch")
-				}
+				assert.Equal(c, updatedNodeLabelSlice, watcher.NodeLabels(), "node labels mismatch")
 			},
 			10*time.Second,
 			10*time.Millisecond,
 		)
 	})
 
-	t.Run("complete", func(t *testing.T) {
-		watcher.complete(nil)
-		var flow flowpb.Flow
-		stop, err := watcher.OnDecodedFlow(ctx, &flow)
-		require.False(t, stop)
+	t.Run("context_cancellation", func(t *testing.T) {
+		cancel()
+		err := <-runDone
 		require.NoError(t, err)
-		require.Empty(t, flow.GetNodeLabels())
+		// After cancellation, labels should be cleared by complete().
+		require.EventuallyWithT(
+			t,
+			func(c *assert.CollectT) {
+				assert.Empty(c, watcher.NodeLabels())
+			},
+			10*time.Second,
+			10*time.Millisecond,
+		)
 	})
 }
 

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -35,10 +35,11 @@ type Decoder interface {
 
 // Parser for all flows
 type Parser struct {
-	l34  *threefour.Parser
-	l7   *seven.Parser
-	dbg  *debug.Parser
-	sock *sock.Parser
+	l34              *threefour.Parser
+	l7               *seven.Parser
+	dbg              *debug.Parser
+	sock             *sock.Parser
+	localNodeWatcher *LocalNodeWatcher
 }
 
 // New creates a new parser
@@ -51,6 +52,7 @@ func New(
 	serviceGetter getters.ServiceGetter,
 	linkGetter getters.LinkGetter,
 	cgroupGetter getters.PodMetadataGetter,
+	localNodeWatcher *LocalNodeWatcher,
 	opts ...options.Option,
 ) (*Parser, error) {
 
@@ -75,10 +77,11 @@ func New(
 	}
 
 	return &Parser{
-		l34:  l34,
-		l7:   l7,
-		dbg:  dbg,
-		sock: sock,
+		l34:              l34,
+		l7:               l7,
+		dbg:              dbg,
+		sock:             sock,
+		localNodeWatcher: localNodeWatcher,
 	}, nil
 }
 
@@ -145,6 +148,9 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 		// populate these fields for compatibility with old clients.
 		flow.Time = ts
 		flow.NodeName = monitorEvent.NodeName
+		if p.localNodeWatcher != nil {
+			flow.NodeLabels = p.localNodeWatcher.NodeLabels()
+		}
 		ev.Event = flow
 		return ev, nil
 	case *observerTypes.AgentEvent:
@@ -168,6 +174,9 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 			// populate these fields for compatibility with old clients.
 			flow.Time = ts
 			flow.NodeName = monitorEvent.NodeName
+			if p.localNodeWatcher != nil {
+				flow.NodeLabels = p.localNodeWatcher.NodeLabels()
+			}
 			ev.Event = flow
 			return ev, nil
 		case monitorAPI.MessageTypeAgent:

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -149,7 +149,7 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 		flow.Time = ts
 		flow.NodeName = monitorEvent.NodeName
 		if p.localNodeWatcher != nil {
-			flow.NodeLabels = p.localNodeWatcher.NodeLabels()
+			flow.NodeName, flow.NodeLabels = p.localNodeWatcher.NodeInfo()
 		}
 		ev.Event = flow
 		return ev, nil
@@ -175,7 +175,7 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 			flow.Time = ts
 			flow.NodeName = monitorEvent.NodeName
 			if p.localNodeWatcher != nil {
-				flow.NodeLabels = p.localNodeWatcher.NodeLabels()
+				flow.NodeName, flow.NodeLabels = p.localNodeWatcher.NodeInfo()
 			}
 			ev.Event = flow
 			return ev, nil

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_InvalidPayloads(t *testing.T) {
-	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil)
+	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	_, err = p.Decode(nil)
@@ -49,7 +49,7 @@ func Test_InvalidPayloads(t *testing.T) {
 }
 
 func Test_ParserDispatch(t *testing.T) {
-	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil)
+	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	// Test L3/L4 record
@@ -91,7 +91,7 @@ func Test_ParserDispatch(t *testing.T) {
 }
 
 func Test_EventType_RecordLost(t *testing.T) {
-	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil)
+	p, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, nil, nil)
 	assert.NoError(t, err)
 
 	ts := time.Now()

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -64,6 +64,7 @@ func noopParser(t testing.TB) *parser.Parser {
 		&testutils.NoopServiceGetter,
 		&testutils.NoopLinkGetter,
 		&testutils.NoopPodMetadataGetter,
+		nil,
 	)
 	require.NoError(t, err)
 	return pp


### PR DESCRIPTION


<!-- Description of change -->

Move the `LocalNodeWatcher` from `pkg/hubble/observer` into `pkg/hubble/parser` and inject it into the `PayloadParser` to populate `node_labels` and `NodeName` during flow parsing, rather than via observer hooks

- Add a `Run` method for lifecycle management via `job.OneShot`
- Set `node_labels` and `NodeName` at the two flow paths in `Decode()`
- Derive `NodeName` from `LocalNode` using `Node.Fullname()` instead of `MonitorEvent.NodeName`
- Remove the inline watcher creation from `hubbleintegration.go`



Fixes: #40062


```release-note
hubble: Refactor the local node watcher as a hive cell
```
