### PR TITLE
azure: Merge subnets in resyncInstance instead of replacing

### DIFF
--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -141,7 +141,10 @@ func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.instances.UpdateInstance(instanceID, instance)
-	m.subnets = subnets
+	if m.subnets == nil {
+		m.subnets = ipamTypes.SubnetMap{}
+	}
+	maps.Copy(m.subnets, subnets)
 
 	return resyncStart, nil
 }

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -184,6 +184,71 @@ func TestSubnetDiscovery(t *testing.T) {
 	require.NotNil(t, mngr.subnets["subnet-3"])
 }
 
+// TestResyncInstancePreservesOtherNodesSubnets ensures that a per-instance
+// resync does not evict subnets that are owned by other instances from the
+// cluster-wide subnet cache. The targeted-subnet optimization in
+// resyncInstance only fetches the subnets referenced by a single instance's
+// interfaces; if that narrow set wholesale-replaces the global map, every
+// other node's subnets disappear and PrepareIPAllocation falls through to
+// the wrong subnet, which Azure rejects with
+// VMScaleSetIpConfigurationsOnSameNicCannotUseDifferentSubnets.
+func TestResyncInstancePreservesOtherNodesSubnets(t *testing.T) {
+	api := apimock.NewAPI(subnets2, vnets)
+	require.NotNil(t, api)
+
+	mngr := NewInstancesManager(hivetest.Logger(t), api)
+	require.NotNil(t, mngr)
+
+	// Two instances using DIFFERENT subnets:
+	//   vm-1 → subnet-1
+	//   vm-2 → subnet-3
+	instances := ipamTypes.NewInstanceMap()
+
+	iface1 := &types.AzureInterface{
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.1.1",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	iface1.SetID("intf-vm-1")
+	instances.Update("vm-1", iface1.DeepCopy())
+
+	iface2 := &types.AzureInterface{
+		SecurityGroup: "sg2",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "3.3.3.3",
+				Subnet: "subnet-3",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	iface2.SetID("intf-vm-2")
+	instances.Update("vm-2", iface2.DeepCopy())
+
+	api.UpdateInstances(instances)
+
+	// Initial full resync populates m.subnets with both subnets.
+	_, err := mngr.Resync(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, mngr.subnets["subnet-1"])
+	require.NotNil(t, mngr.subnets["subnet-3"])
+
+	// Per-instance resync for vm-1 only references subnet-1. It must not
+	// evict subnet-3 (owned by vm-2) from the cluster-wide map.
+	_, err = mngr.InstanceSync(t.Context(), "vm-1")
+	require.NoError(t, err)
+
+	require.NotNil(t, mngr.subnets["subnet-1"], "vm-1's subnet should still be present after its own per-instance resync")
+	require.NotNil(t, mngr.subnets["subnet-3"], "vm-2's subnet must not be evicted by a per-instance resync of vm-1")
+}
+
 func TestExtractSubnetIDs(t *testing.T) {
 	api := apimock.NewAPI(subnets, vnets)
 	require.NotNil(t, api)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->

While working in Azure on another feature (PR coming soon!), I believe I've caught a bug in the implementation from https://github.com/cilium/cilium/pull/41555 . We were occasionally seeing errors from Azure like the following:

```
  Unable to assign additional IPs to interface, will create new interface
  | error.message: unable to update virtualMachineScaleSetVMs:
    PUT https://management.azure.com/subscriptions/<SUB>/resourceGroups/<RG>/providers/Microsoft.Compute/virtualMachineScaleSets/<VMSS>/virtualMachines/1147
  --------------------------------------------------------------------------------
  RESPONSE 400: 400 Bad Request
  ERROR CODE: VMScaleSetIpConfigurationsOnSameNicCannotUseDifferentSubnets
  --------------------------------------------------------------------------------
  {
    "error": {
      "details": [],
      "code": "VMScaleSetIpConfigurationsOnSameNicCannotUseDifferentSubnets",
      "message": "Network Interface Configuration pods on VM Scale Set <VMSS> has IpConfigurations with different subnets. All IpConfigurations within a Network Interface Configuration must be on the same subnet. Subnets referred:
         /subscriptions/<SUB>/resourceGroups/<NET_RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/pod-subnet-3,
         /subscriptions/<SUB>/resourceGroups/<NET_RG>/providers/Microsoft.Network/virtualNetworks/<VNET>/subnets/host-subnet-2"
    }
  }
  --------------------------------------------------------------------------------
```

This change merges the resync'ed subnets into the overall map instead of the replacement. This function is used at the per-instance scope so it's only seeing that instances subnets. By merging them instead, this avoids `PrepareIPAllocation` from failing with the above later on. 

The test attempts to highlight the bug, I've also built and deployed with this patch to a testing Azure environment and it looks good there too. 


Fixes: N/A 

```release-note
Azure: Merge subnets during resyncInstance instead of replacing them
```
