### PR TITLE
metrics: Increase available api_duration_seconds metric buckets

### DIFF
--- a/pkg/api/metrics/metrics.go
+++ b/pkg/api/metrics/metrics.go
@@ -25,7 +25,7 @@ func New(subsystem string) *Metrics {
 			Name:      "api_duration_seconds",
 			Help:      "Duration of interactions with API",
 			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
-				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60, 90, 120, 300, 600},
 		}, []string{"operation", "response_code"}),
 
 		RateLimit: metric.NewHistogramVec(metric.HistogramOpts{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->

This is a small PR to increase the number of overall buckets for the api_duration_seconds metrics. While debugging for https://github.com/cilium/cilium/pull/45715, I'm seeing `cilium.cilium_operator_azure_api_duration_seconds` for `operator:virtualmachinescalesetvms.update` exceed the 60s bucket frequently. I'd like to get a better sense of how long this API call is taking relative to the rest so, I've added buckets for 90, 120, 300, and 600 seconds

Fixes: N/A

```release-note
metrics: Increase available api_duration_seconds metric buckets
```
