### PR TITLE
fix lbipam: initializes sharing cluster IP for requested allocations

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -931,7 +931,10 @@ func (ipam *LBIPAM) satisfySpecificIPRequests(sv *ServiceView) (statusModified b
 			cluster.Services = append(cluster.Services, sv)
 		} else {
 			ipam.logger.Debug(fmt.Sprintf("Allocate '%s' for '%s'", reqIP, sv.Key))
-			sharingCluster := &sharingCluster{Services: []*ServiceView{sv}}
+			sharingCluster := &sharingCluster{
+				SVIP:     ServiceViewIP{IP: reqIP, Origin: lbRange},
+				Services: []*ServiceView{sv},
+			}
 			err = lbRange.alloc.Alloc(reqIP, sharingCluster)
 			if err != nil {
 				if errors.Is(err, ipalloc.ErrInUse) {
@@ -942,7 +945,9 @@ func (ipam *LBIPAM) satisfySpecificIPRequests(sv *ServiceView) (statusModified b
 				continue
 			}
 
-			ipam.sharingIndex.Add(sv.SharingKey, sharingCluster)
+			if sv.SharingKey != "" {
+				ipam.sharingIndex.Add(sv.SharingKey, sharingCluster)
+			}
 		}
 
 		sv.AllocatedIPs = append(sv.AllocatedIPs, ServiceViewIP{

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -1661,6 +1661,57 @@ func TestSharedServicesUpdateSharingKeyAndRequestedIP(t *testing.T) {
 	}
 }
 
+func TestSharedSpecificIPThenGenericService(t *testing.T) {
+	poolA := mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"})
+	fixture := mkTestFixture(t, true, false)
+	fixture.UpsertPool(t, poolA)
+
+	svcA := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-a",
+			Namespace: "default",
+			UID:       serviceAUID,
+			Annotations: map[string]string{
+				annotation.LBIPAMIPsKey:     "10.0.10.22",
+				annotation.LBIPAMSharingKey: "key-1",
+			},
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type: slim_core_v1.ServiceTypeLoadBalancer,
+			IPFamilies: []slim_core_v1.IPFamily{
+				slim_core_v1.IPv4Protocol,
+			},
+		},
+	}
+	fixture.UpsertSvc(t, svcA)
+
+	svcB := &slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name:      "service-b",
+			Namespace: "default",
+			UID:       serviceBUID,
+			Annotations: map[string]string{
+				annotation.LBIPAMSharingKey: "key-1",
+			},
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type: slim_core_v1.ServiceTypeLoadBalancer,
+			IPFamilies: []slim_core_v1.IPFamily{
+				slim_core_v1.IPv4Protocol,
+			},
+		},
+	}
+	fixture.UpsertSvc(t, svcB)
+
+	svcA = fixture.GetSvc("default", "service-a")
+	svcB = fixture.GetSvc("default", "service-b")
+
+	require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+	require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+	require.Equal(t, "10.0.10.22", svcA.Status.LoadBalancer.Ingress[0].IP)
+	require.Equal(t, svcA.Status.LoadBalancer.Ingress[0].IP, svcB.Status.LoadBalancer.Ingress[0].IP)
+}
+
 // TestSharingClusters tests that when there are 4 services with the same sharing key (A, B, C and D) where A and B
 // are compatible and C and D are compatible but not with A and B, we end up with 2 IPs assigned.
 func TestSharingClusters(t *testing.T) {


### PR DESCRIPTION

## Root Cause
  the new introduced sharingCluster.SVIP as the canonical IP record used when
  another service reuses an existing sharing cluster. However, the specific-IP
  allocation path created a sharingCluster without initializing SVIP.

## Trigger Scenario
  1. Service A requests a specific LB-IP, for example 10.0.10.22.
  2. Service A also sets a sharing key.
  3. Service B uses the same sharing key but does not request a specific IP.
  4. Service B tries to reuse Service A’s sharing cluster through sharingIndex.

  Consequence
  Service B reuses a cluster whose SVIP is the zero value instead of 10.0.10.22.
  This can pollute ServiceView.AllocatedIPs with an invalid empty IP/origin and may
  later lead to incorrect ingress assignment or a panic when code dereferences the
  missing origin.

## Fix
  Initialize sharingCluster.SVIP when allocating a requested IP:


