### PR TITLE
secretsync recreate synced secret when source secret type changes

### DIFF
--- a/operator/pkg/secretsync/secretsync_reconcile.go
+++ b/operator/pkg/secretsync/secretsync_reconcile.go
@@ -167,6 +167,13 @@ func (r *secretSyncer) ensureSyncedSecret(ctx context.Context, desired *corev1.S
 		return err
 	}
 
+	if existing.Type != desired.Type {
+		if err := r.client.Delete(ctx, existing); err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		return r.client.Create(ctx, desired)
+	}
+
 	temp := existing.DeepCopy()
 	temp.SetAnnotations(desired.GetAnnotations())
 	temp.SetLabels(desired.GetLabels())

--- a/operator/pkg/secretsync/secretsync_reconcile_test.go
+++ b/operator/pkg/secretsync/secretsync_reconcile_test.go
@@ -352,6 +352,107 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 	})
 }
 
+var secretFixtureTypeChange = []client.Object{
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "cert-tls",
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretsNamespace,
+			Name:      "test-cert-tls",
+			UID:       "stale-opaque-uid",
+			Labels: map[string]string{
+				secretsync.OwningSecretNamespace: "test",
+				secretsync.OwningSecretName:      "cert-tls",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	},
+	&gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "io.cilium/gateway-controller",
+		},
+	},
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "tls-gateway",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.cilium.io"),
+					Protocol: "HTTPS",
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "cert-tls"},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func Test_SecretSync_Reconcile_TypeChange(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(secretFixtureTypeChange...).
+		Build()
+
+	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
+		{
+			RefObject:            &gatewayv1.Gateway{},
+			RefObjectEnqueueFunc: gateway_api.EnqueueTLSSecrets(c, logger),
+			RefObjectCheckFunc:   gateway_api.IsReferencedByCiliumGateway,
+			SecretsNamespace:     secretsNamespace,
+		},
+	},
+		time.Minute,
+		0.1,
+	)
+
+	t.Run("synced secret type is updated when source secret type changes", func(t *testing.T) {
+		synced := &corev1.Secret{}
+		err := c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-cert-tls"}, synced)
+		require.NoError(t, err)
+		require.Equal(t, corev1.SecretTypeOpaque, synced.Type)
+
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "cert-tls",
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, resultHasResync(result))
+		synced = &corev1.Secret{}
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-cert-tls"}, synced)
+		require.NoError(t, err)
+		require.Equal(t, corev1.SecretTypeTLS, synced.Type, "synced secret should adopt the source secret's type")
+		require.Equal(t, []byte("cert"), synced.Data["tls.crt"])
+		require.Equal(t, []byte("key"), synced.Data["tls.key"])
+		require.NotEqual(t, types.UID("stale-opaque-uid"), synced.UID,
+			"synced secret must be recreated (new UID) since Secret.Type is immutable")
+	})
+}
+
 var secretFixtureDefaultSecret = []client.Object{
 	&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
When using Cilium Gateway API together with cert-manager, the synced secret in cilium-secrets gets stuck as Opaque even after cert-manager has issued a kubernetes.io/tls cert in the source namespace. The reconciler tries to patch the type field, but Kubernetes silently rejects that since Secret.Type is immutable, so the synced secret never picks up the new type. This change makes the reconciler delete and recreate the synced secret when the source type differs from the existing one, so the cert-manager workflow no longer needs a manual reconcile to recover. Fixes #45705.