### PR TITLE
operator/ingress: pass scopedLog into ingestion callers in buildDedicatedResources

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -259,9 +259,9 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	m := &model.Model{}
 
 	if annotations.GetAnnotationTLSPassthroughEnabled(ingress) {
-		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(nil, *ingress, passthroughPort)...)
+		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(scopedLog, *ingress, passthroughPort)...)
 	} else {
-		m.HTTP = append(m.HTTP, ingestion.Ingress(nil, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
+		m.HTTP = append(m.HTTP, ingestion.Ingress(scopedLog, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
 	cec, svc, err := r.dedicatedTranslator.Translate(m)


### PR DESCRIPTION
Fixes #45722.

`buildDedicatedResources` passed `nil` as the logger to `ingestion.IngressPassthrough` (and the sibling `ingestion.Ingress` non-passthrough branch). When the ingress contained a TLS-passthrough rule with a non-`/` path, `IngressPassthrough` reached `log.Warn(...)` and the operator panicked with `runtime error: invalid memory address or nil pointer dereference`. The peer call site at line 226 already passes `r.logger`. Forward the per-reconcile `scopedLog` instead so logs land in the right scope and the warn path does not crash.

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.

```release-note
operator/ingress: Avoid nil-pointer panic when a TLS-passthrough Ingress has a non-`/` path. The reconcile logger is now threaded through to ingestion.IngressPassthrough / ingestion.Ingress instead of nil.
```