### PR TITLE
Fix dedicated Ingress reconciliation panic on invalid TLS passthrough rules

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -259,9 +259,9 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	m := &model.Model{}
 
 	if annotations.GetAnnotationTLSPassthroughEnabled(ingress) {
-		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(nil, *ingress, passthroughPort)...)
+		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(scopedLog, *ingress, passthroughPort)...)
 	} else {
-		m.HTTP = append(m.HTTP, ingestion.Ingress(nil, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
+		m.HTTP = append(m.HTTP, ingestion.Ingress(scopedLog, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
 	cec, svc, err := r.dedicatedTranslator.Translate(m)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1121,6 +1121,69 @@ func TestReconcile(t *testing.T) {
 		assert.Len(t, dedicatedIngressTranslator.model.HTTP, 1)
 		assert.Equal(t, uint32(55555), dedicatedIngressTranslator.model.HTTP[0].Port)
 	})
+
+	t.Run("Reconcile of dedicated TLS passthrough Ingress with a non-root path skips invalid rules without panicking", func(t *testing.T) {
+		pathType := networkingv1.PathTypePrefix
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithObjects(
+				&networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+						Annotations: map[string]string{
+							"ingress.cilium.io/loadbalancer-mode": "dedicated",
+							"ingress.cilium.io/tls-passthrough":   "true",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: ptr.To("cilium"),
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Path:     "/api/webhook",
+												PathType: &pathType,
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "test",
+														Port: networkingv1.ServiceBackendPort{
+															Number: 8080,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			).
+			Build()
+
+		cecTranslator := &fakeCECTranslator{}
+		dedicatedIngressTranslator := &fakeDedicatedIngressTranslator{}
+
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
+
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "test",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Empty(t, dedicatedIngressTranslator.model.TLSPassthrough)
+		assert.Empty(t, dedicatedIngressTranslator.model.HTTP)
+	})
 }
 
 var _ translation.CECTranslator = &fakeCECTranslator{}


### PR DESCRIPTION

symptom: 
When creating a dedicated Ingress with ingress.cilium.io/tls-passthrough:
"true" and a path other than / such as /api/webhook, the Cilium Operator crashes during
reconciliation with runtime error: invalid memory address or nil pointer dereference.

Expected behavior: 
For invalid TLS passthrough paths, the operator should log a warning,
skip the invalid rule, and continue reconciliation without panicking.

Root cause: 
In operator/pkg/ingress/ingress_reconcile.go, buildDedicatedResources() passed
nil into both ingestion.IngressPassthrough() and ingestion.Ingress(). In
operator/pkg/model/ingestion/ingress.go, these code paths call log.Warn(...) when they
encounter invalid input. If the logger is nil, that warning path dereferences a nil pointer
and panics. The confirmed trigger is dedicated mode + TLS passthrough + non-root path.

Fix: 
Keep the change minimal by replacing the two nil logger arguments in the dedicated
reconciliation path with the existing scopedLog, matching the shared reconciliation path. A
focused regression test was also added for dedicated TLS passthrough with a non-root path
to ensure invalid rules are skipped without a panic.


Fixes:  https://github.com/cilium/cilium/issues/45722


