### PR TITLE
datapath: apply vlan-bpf-bypass even without VLAN subinterface

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -608,12 +608,35 @@ func vlanFilterMacros(nativeDevices []*tables.Device) (string, error) {
 		return "", fmt.Errorf("listing network interfaces: %w", err)
 	}
 
+	vlanIndexes := make(map[int]bool)
 	for _, l := range links {
 		vlan, ok := l.(*netlink.Vlan)
-		// if it's vlan device and we're controlling vlan main device
-		// and either all vlans are allowed, or we're controlling vlan device or vlan is explicitly allowed
-		if ok && devices[vlan.ParentIndex] && (devices[vlan.Index] || allowedVlans[vlan.VlanId]) {
+		if !ok {
+			continue
+		}
+		vlanIndexes[vlan.Index] = true
+		// Include this VLAN if its parent is a native device and either the
+		// VLAN subinterface is itself a native device, or the VLAN ID is in
+		// the explicit bypass list.
+		if devices[vlan.ParentIndex] && (devices[vlan.Index] || allowedVlans[vlan.VlanId]) {
 			vlansByIfIndex[vlan.ParentIndex] = append(vlansByIfIndex[vlan.ParentIndex], vlan.VlanId)
+		}
+	}
+
+	// Explicitly allowed VLANs must be included for all native parent devices
+	// even when the corresponding VLAN subinterface does not exist yet (e.g. it
+	// is created after the agent starts). Without this, the BPF VLAN filter
+	// drops tagged frames on a bypass VLAN until the agent is restarted.
+	// VLAN subinterfaces are skipped: they are not parents and the BPF filter
+	// is keyed by parent device ifindex.
+	for ifIndex := range devices {
+		if vlanIndexes[ifIndex] {
+			continue
+		}
+		for vlanId := range allowedVlans {
+			if !slices.Contains(vlansByIfIndex[ifIndex], vlanId) {
+				vlansByIfIndex[ifIndex] = append(vlansByIfIndex[ifIndex], vlanId)
+			}
 		}
 	}
 

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -254,6 +254,9 @@ func TestPrivilegedVLANBypassConfig(t *testing.T) {
 		}()
 	}
 
+	// VLAN 4004 is explicitly in the bypass list. With the fix, it must appear
+	// on both parent devices (main1 and main2), not only on the device that
+	// already has a dummy1.4004 subinterface.
 	option.Config.VLANBPFBypass = []int{4004}
 	m, err := vlanFilterMacros(devs)
 	require.NoError(t, err)
@@ -262,6 +265,7 @@ case %d: \
 switch (vlan_id) { \
 case 4000: \
 case 4001: \
+case 4004: \
 return true; \
 } \
 break; \
@@ -283,6 +287,37 @@ return false;`, main1.Index, main2.Index), m)
 	m, err = vlanFilterMacros(devs)
 	require.NoError(t, err)
 	require.Equal(t, "return true", m)
+}
+
+// TestPrivilegedVLANBypassConfigNoSubinterface verifies that explicitly
+// configured bypass VLANs are included in the BPF filter even when the
+// corresponding VLAN subinterface does not exist at the time the agent
+// compiles its BPF programs (e.g. the subinterface is created after startup).
+func TestPrivilegedVLANBypassConfigNoSubinterface(t *testing.T) {
+	setupConfigSuite(t)
+
+	var devs []*tables.Device
+
+	main1 := createMainLink("dummy2", t)
+	devs = append(devs, &tables.Device{Name: main1.Name, Index: main1.Index})
+	defer func() {
+		netlink.LinkDel(main1)
+	}()
+
+	// No VLAN subinterfaces exist at all.
+	option.Config.VLANBPFBypass = []int{20, 40}
+	m, err := vlanFilterMacros(devs)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf(`switch (ifindex) { \
+case %d: \
+switch (vlan_id) { \
+case 20: \
+case 40: \
+return true; \
+} \
+break; \
+} \
+return false;`, main1.Index), m)
 }
 
 func TestPrivilegedWriteNodeConfigExtraDefines(t *testing.T) {


### PR DESCRIPTION
## Problem

`vlanFilterMacros` builds the BPF VLAN filter by scanning existing VLAN
subinterfaces via `safenetlink.LinkList`. If a subinterface (e.g.
`bond0.20`) does not exist when the agent starts, its VLAN ID is absent
from the generated filter. Tagged frames are then silently dropped until
the agent restarts, even though the ID is listed in `--vlan-bpf-bypass`.

Reported in #45719. The issue includes a concrete timing trace showing
the agent attaching BPF programs to `bond0` before `bond0.20` is created,
and confirming that a restart (with no config change) immediately fixes
the problem.

## Fix

Add a second pass over native parent devices in `vlanFilterMacros`. For
each non-VLAN native device, any VLAN ID that is in `allowedVlans` but
not yet present in `vlansByIfIndex` is appended. VLAN subinterfaces are
excluded from this pass because the BPF `VLAN_FILTER` macro is keyed by
parent device ifindex, not subinterface ifindex.

This corrects the semantics of `--vlan-bpf-bypass`: bypass VLANs now
apply to all native parent devices regardless of whether the corresponding
VLAN subinterface exists at BPF compilation time.

## Testing

- Updated `TestPrivilegedVLANBypassConfig` to reflect the corrected
  behavior (explicit bypass VLANs apply to all parent devices, not only
  to the one whose subinterface happens to exist).
- Added `TestPrivilegedVLANBypassConfigNoSubinterface` which directly
  covers the regression: bypass VLANs configured with no subinterface
  present at all.

---

This PR was prepared with AIL:3. I used an AI assistant to help locate
the root cause in `vlanFilterMacros` and draft the fix. I personally
reviewed each line of the diff prior to opening this PR.

Fixes: #45719

```release-note
Fix VLAN-tagged frames being dropped by the BPF VLAN filter when a
VLAN subinterface listed in --vlan-bpf-bypass is created after the
Cilium agent starts.
```