### PR TITLE
bpf: don't silently drop packets with tcx hooks

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1241,7 +1241,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 #endif
 	ret = tcx_early_hook(ctx, proto);
 	if (ret != CTX_ACT_OK)
-		return ret;
+		goto drop_err;
 
 	return do_netdev(ctx, proto, UNKNOWN_ID, TRACE_FROM_NETWORK, false);
 drop_err:


### PR DESCRIPTION
In case of errors in tcx hooks we should notify the drop as suggested here https://github.com/cilium/cilium/pull/41821/changes#r2416424295