### PR TITLE
docs: fix malformed code-block directive in routing.rst

### DIFF
--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -245,7 +245,7 @@ Configuration
 
 The AWS ENI datapath is enabled by setting the following option:
 
-.. code-block: yaml
+.. code-block:: yaml
 
         ipam: eni
         enable-endpoint-routes: "true"


### PR DESCRIPTION
Fix a broken Sphinx directive in the AWS ENI configuration section of `routing.rst`.
The directive `.. code-block: yaml` (single colon) has been present since the file
was first created in 2020 and causes the YAML configuration snippet to render as a
plain indented paragraph instead of a syntax-highlighted code block in the published
documentation.

Documentation-only change, no tests required.
