### PR TITLE
docs: fix Markdown-style hyperlink in mutual-authentication.rst

### DIFF
--- a/Documentation/network/servicemesh/mutual-authentication/mutual-authentication.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/mutual-authentication.rst
@@ -128,7 +128,7 @@ Detailed Roadmap Status
 
 The following table shows the roadmap status of the mutual authentication feature.
 There are several work items outstanding before the feature is complete from a security model perspective.
-For details, see the [roadmap issue](https://github.com/cilium/cilium/issues/28986).
+For details, see :gh-issue:`28986`.
 
 
 +--------------------------------------------------+----------------------------------------------------------+


### PR DESCRIPTION
Fix a Markdown-style hyperlink in the "Detailed Roadmap Status" section of
`mutual-authentication.rst`. The link `[roadmap issue](url)` has been present
since the roadmap section was added in November 2023. Sphinx does not render
Markdown link syntax in RST files, so the link silently fails to become a
clickable hyperlink in the published documentation.

Replaced with the `:gh-issue:` role as preferred by the Cilium docs style guide.

Documentation-only change, no tests required.
