### PR TITLE
network-driver: Add VLAN to resource network config

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumresourcenetworkconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumresourcenetworkconfigs.yaml
@@ -168,6 +168,13 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                vlan:
+                  description: |-
+                    VLAN is the VLAN ID to configure on devices using this network config.
+                    A value of 0 means no VLAN is configured.
+                  maximum: 4094
+                  minimum: 0
+                  type: integer
               type: object
             minItems: 1
             type: array

--- a/pkg/k8s/apis/cilium.io/v2alpha1/network_driver_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/network_driver_types.go
@@ -292,6 +292,14 @@ type CiliumResourceNetworkConfigSpec struct {
 	// +kubebuilder:validation:Optional
 	IPPool string `json:"ipPool"`
 
+	// VLAN is the VLAN ID to configure on devices using this network config.
+	// A value of 0 means no VLAN is configured.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=4094
+	VLAN uint16 `json:"vlan,omitempty"`
+
 	// IPv4 specifies the network configuration for allocated IPv4 addresses
 	//
 	// +kubebuilder:validation:Optional

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1671,6 +1671,9 @@ func (in *CiliumResourceNetworkConfigSpec) DeepEqual(other *CiliumResourceNetwor
 	if in.IPPool != other.IPPool {
 		return false
 	}
+	if in.VLAN != other.VLAN {
+		return false
+	}
 	if (in.IPv4 == nil) != (other.IPv4 == nil) {
 		return false
 	} else if in.IPv4 != nil {

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -164,6 +164,7 @@ type netDevConfig struct {
 	ipv4   netip.Prefix
 	ipv6   netip.Prefix
 	routes []route
+	vlan   uint16
 }
 
 func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg types.DeviceConfig) (netDevConfig, error) {
@@ -171,6 +172,7 @@ func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg
 
 	devCfg.ipv4 = cfg.IPv4Addr
 	devCfg.ipv6 = cfg.IPv6Addr
+	devCfg.vlan = cfg.Vlan
 
 	if cfg.NetworkConfig == "" {
 		return devCfg, nil
@@ -196,6 +198,11 @@ func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg
 
 	devCfg.routes = make([]route, 0, len(targetCfg.IPv4Routes)+len(targetCfg.IPv6Routes))
 	devCfg.routes = append(targetCfg.IPv4Routes, targetCfg.IPv6Routes...)
+
+	// Overwrite VLAN only when it is not configured directly in the DeviceConfiga
+	if devCfg.vlan == 0 {
+		devCfg.vlan = targetCfg.Vlan
+	}
 
 	// just like the static IP addresses, if a pool is configured in the claim
 	// itself it takes precedence over the one in the CiliumResourceNetworkConfig
@@ -334,6 +341,7 @@ func (driver *Driver) prepareDeviceAllocation(ctx context.Context, claim string,
 	alloc.Config.IPv4Addr = devCfg.ipv4
 	alloc.Config.IPv6Addr = devCfg.ipv6
 	alloc.Config.IPPool = devCfg.ipPool
+	alloc.Config.Vlan = devCfg.vlan
 	alloc.Config.Routes = make([]types.Route, 0, len(devCfg.routes))
 	for _, r := range devCfg.routes {
 		alloc.Config.Routes = append(alloc.Config.Routes, types.Route{

--- a/pkg/networkdriver/dra_test.go
+++ b/pkg/networkdriver/dra_test.go
@@ -27,6 +27,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/networkdriver/dummy"
@@ -251,6 +252,7 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 		ipv6MaskSize = 64
 
 		networkConfigName = "test-network-config"
+		vlan              = uint16(1001)
 		v4NetMask         = 24
 		v4RouteDst        = "10.10.100.0/24"
 		v4RouteGw         = "10.10.100.254"
@@ -339,6 +341,7 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 					},
 				},
 				IPPool: ipPoolName,
+				VLAN:   vlan,
 				IPv4: &v2alpha1.IPv4NetworkConfigSpec{
 					NetMask: uint8(v4NetMask),
 					StaticRoutes: []v2alpha1.IPv4StaticRouteSpec{
@@ -527,6 +530,7 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 	var alloc allocation
 	assert.NoError(t, json.Unmarshal(claim.Status.Devices[0].Data.Raw, &alloc))
 	assert.Equal(t, ipPoolName, alloc.Config.IPPool)
+	assert.Equal(t, vlan, alloc.Config.Vlan)
 
 	assert.Equal(t, v4NetMask, alloc.Config.IPv4Addr.Bits())
 	assert.True(t, v4PoolCIDR.Contains(alloc.Config.IPv4Addr.Masked().Addr()))
@@ -573,4 +577,66 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 
 	assert.NoError(t, hive.Stop(tlog, t.Context()))
+}
+
+func TestNetConfigForDeviceVLANPrecedence(t *testing.T) {
+	db := statedb.New()
+	resourceNetCfgs, err := NewResourceNetworkConfigTable(db)
+	assert.NoError(t, err)
+
+	const networkConfigName = "test-network-config"
+	const networkConfigVLAN = uint16(1001)
+	const deviceConfigVLAN = uint16(1002)
+
+	wtxn := db.WriteTxn(resourceNetCfgs)
+	_, _, err = resourceNetCfgs.Insert(wtxn, resourceNetworkConfig{
+		Name: networkConfigName,
+		Specs: []spec{
+			{
+				NodeSelector: labels.Everything(),
+				Vlan:         networkConfigVLAN,
+			},
+		},
+		UpdatedAt: time.Now(),
+	})
+	assert.NoError(t, err)
+	wtxn.Commit()
+
+	driver := &Driver{
+		db:                     db,
+		resourceNetworkConfigs: resourceNetCfgs,
+		localNodeStore: node.NewTestLocalNodeStore(node.LocalNode{
+			Node: nodetypes.Node{},
+		}),
+	}
+
+	tests := []struct {
+		name string
+		cfg  types.DeviceConfig
+		want uint16
+	}{
+		{
+			name: "network config vlan is used when device config vlan is unset",
+			cfg: types.DeviceConfig{
+				NetworkConfig: networkConfigName,
+			},
+			want: networkConfigVLAN,
+		},
+		{
+			name: "device config vlan takes precedence when set",
+			cfg: types.DeviceConfig{
+				NetworkConfig: networkConfigName,
+				Vlan:          deviceConfigVLAN,
+			},
+			want: deviceConfigVLAN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			devCfg, err := driver.netConfigForDevice(t.Context(), "test-device", tt.cfg)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, devCfg.vlan)
+		})
+	}
 }

--- a/pkg/networkdriver/network_config.go
+++ b/pkg/networkdriver/network_config.go
@@ -37,6 +37,7 @@ type resourceNetworkConfig struct {
 type spec struct {
 	NodeSelector labels.Selector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty"`
 	IPPool       string          `json:"resourcePool" yaml:"resourcePool"`
+	Vlan         uint16          `json:"vlan,omitempty" yaml:"vlan,omitempty"`
 	IPv4NetMask  int             `json:"ipv4NetMask" yaml:"ipv4NetMask"`
 	IPv4Routes   []route         `json:"ipv4Routes" yaml:"ipv4Routes"`
 	IPv6NetMask  int             `json:"ipv6NetMask" yaml:"ipv6NetMask"`
@@ -82,6 +83,10 @@ func (c resourceNetworkConfig) TableRow() []string {
 		b.WriteString(s.NodeSelector.String())
 		b.WriteString(": ")
 		b.WriteString(s.IPPool)
+		if s.Vlan != 0 {
+			b.WriteString(", vlan ")
+			b.WriteString(strconv.Itoa(int(s.Vlan)))
+		}
 		b.WriteString(", /")
 		b.WriteString(strconv.Itoa(s.IPv4NetMask))
 		b.WriteString(", ")
@@ -183,6 +188,7 @@ func resourceNetworkConfigReflectorConfig(cs client.Clientset, crdSync promise.P
 				s := spec{
 					NodeSelector: nodeSel,
 					IPPool:       sp.IPPool,
+					Vlan:         sp.VLAN,
 				}
 
 				if sp.IPv4 != nil {


### PR DESCRIPTION
Allow setting a VLAN ID for a resource via the CiliumResourceNetworkConfig Custom Resource. The VLAN ID set directly in the device config, that is, in the ResourceClaim/ResourceClaimTemplate opaque configuration, takes precedence.

```release-note
network-driver: Allow setting a VLAN ID for a resource in the CiliumResourceNetworkConfig.
```
