### PR TITLE
bgp: Deprecate BGP REST APIs

### DIFF
--- a/Documentation/cmdref/cilium-dbg.md
+++ b/Documentation/cmdref/cilium-dbg.md
@@ -21,7 +21,7 @@ CLI for interacting with the local Cilium Agent
 
 ### SEE ALSO
 
-* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane
+* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane (deprecated)
 * [cilium-dbg bpf](cilium-dbg_bpf.md)	 - Direct access to local BPF maps
 * [cilium-dbg build-config](cilium-dbg_build-config.md)	 - Resolve all of the configuration sources that apply to this node
 * [cilium-dbg cgroups](cilium-dbg_cgroups.md)	 - Cgroup metadata

--- a/Documentation/cmdref/cilium-dbg_bgp.md
+++ b/Documentation/cmdref/cilium-dbg_bgp.md
@@ -2,7 +2,7 @@
 
 ## cilium-dbg bgp
 
-Access to BGP control plane
+Access to BGP control plane (deprecated)
 
 ### Options
 
@@ -23,7 +23,7 @@ Access to BGP control plane
 ### SEE ALSO
 
 * [cilium-dbg](cilium-dbg.md)	 - CLI
-* [cilium-dbg bgp peers](cilium-dbg_bgp_peers.md)	 - List current state of all peers
-* [cilium-dbg bgp route-policies](cilium-dbg_bgp_route-policies.md)	 - List configured route policies
-* [cilium-dbg bgp routes](cilium-dbg_bgp_routes.md)	 - List routes in the BGP Control Plane's RIBs
+* [cilium-dbg bgp peers](cilium-dbg_bgp_peers.md)	 - List current state of all peers (deprecated)
+* [cilium-dbg bgp route-policies](cilium-dbg_bgp_route-policies.md)	 - List configured route policies (deprecated)
+* [cilium-dbg bgp routes](cilium-dbg_bgp_routes.md)	 - List routes in the BGP Control Plane's RIBs (deprecated)
 

--- a/Documentation/cmdref/cilium-dbg_bgp_peers.md
+++ b/Documentation/cmdref/cilium-dbg_bgp_peers.md
@@ -2,11 +2,11 @@
 
 ## cilium-dbg bgp peers
 
-List current state of all peers
+List current state of all peers (deprecated)
 
 ### Synopsis
 
-List state of all peers defined in Cilium BGP configuration
+List state of all peers defined in Cilium BGP configuration (deprecated)
 
 ```
 cilium-dbg bgp peers [flags]
@@ -32,5 +32,5 @@ cilium-dbg bgp peers [flags]
 
 ### SEE ALSO
 
-* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane
+* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane (deprecated)
 

--- a/Documentation/cmdref/cilium-dbg_bgp_route-policies.md
+++ b/Documentation/cmdref/cilium-dbg_bgp_route-policies.md
@@ -2,11 +2,11 @@
 
 ## cilium-dbg bgp route-policies
 
-List configured route policies
+List configured route policies (deprecated)
 
 ### Synopsis
 
-List route policies configured in the underlying routing daemon
+List route policies configured in the underlying routing daemon (deprecated)
 
 ```
 cilium-dbg bgp route-policies [vrouter <asn>] [flags]
@@ -31,5 +31,5 @@ cilium-dbg bgp route-policies [vrouter <asn>] [flags]
 
 ### SEE ALSO
 
-* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane
+* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane (deprecated)
 

--- a/Documentation/cmdref/cilium-dbg_bgp_routes.md
+++ b/Documentation/cmdref/cilium-dbg_bgp_routes.md
@@ -2,11 +2,11 @@
 
 ## cilium-dbg bgp routes
 
-List routes in the BGP Control Plane's RIBs
+List routes in the BGP Control Plane's RIBs (deprecated)
 
 ### Synopsis
 
-List routes in the BGP Control Plane's Routing Information Bases (RIBs)
+List routes in the BGP Control Plane's Routing Information Bases (RIBs) (deprecated)
 
 ```
 cilium-dbg bgp routes <available | advertised> <afi> <safi> [vrouter <asn>] [peer|neighbor <address>] [flags]
@@ -44,5 +44,5 @@ cilium-dbg bgp routes <available | advertised> <afi> <safi> [vrouter <asn>] [pee
 
 ### SEE ALSO
 
-* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane
+* [cilium-dbg bgp](cilium-dbg_bgp.md)	 - Access to BGP control plane (deprecated)
 

--- a/Documentation/configuration/api-restrictions-table.rst
+++ b/Documentation/configuration/api-restrictions-table.rst
@@ -27,10 +27,13 @@ DeleteIPAMIP              -
 DeletePrefilter           -
 GetBGPPeers               Retrieves current operational state of BGP peers created by
                           Cilium BGP virtual router. This includes session state,
-                          uptime, information per address family, etc.
-GetBGPRoutePolicies       Retrieves route policies from BGP Control Plane.
+                          uptime, information per address family, etc. Deprecated:
+                          This will be removed in the future.
+GetBGPRoutePolicies       Retrieves route policies from BGP Control Plane. Deprecated:
+                          This will be removed in the future.
 GetBGPRoutes              Retrieves routes from BGP Control Plane RIB filtered by
-                          parameters you specify
+                          parameters you specify. Deprecated: This will be removed in
+                          the future.
 GetCgroupDumpMetadata     -
 GetClusterNodes           -
 GetConfig                 Returns the configuration of the Cilium daemon.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -317,6 +317,8 @@ Informational Notes
   upgrade should be fully transparent. You are still encouraged to update
   your ``ServiceExport`` resources to ``v1beta1`` to benefit from future
   improvements and prepare for the eventual deprecation of ``v1alpha1``.
+* Listing BGP peers, routes and route-policies via the local REST API and ``cilium-dbg bgp`` commands is deprecated.
+  Use the BGP hive shell commands instead: ``cilium shell -- bgp/*``.
 
 Changes to Features
 ~~~~~~~~~~~~~~~~~~~

--- a/api/v1/client/bgp/bgp_client.go
+++ b/api/v1/client/bgp/bgp_client.go
@@ -72,6 +72,7 @@ type ClientService interface {
 
 Cilium BGP virtual router. This includes session state, uptime,
 information per address family, etc.
+Deprecated: This will be removed in the future.
 */
 func (a *Client) GetBgpPeers(params *GetBgpPeersParams, opts ...ClientOption) (*GetBgpPeersOK, error) {
 	// NOTE: parameters are not validated before sending
@@ -114,9 +115,11 @@ func (a *Client) GetBgpPeers(params *GetBgpPeersParams, opts ...ClientOption) (*
 }
 
 /*
-GetBgpRoutePolicies lists b g p route policies configured in b g p control plane
+	GetBgpRoutePolicies lists b g p route policies configured in b g p control plane
 
-Retrieves route policies from BGP Control Plane.
+	Retrieves route policies from BGP Control Plane.
+
+Deprecated: This will be removed in the future.
 */
 func (a *Client) GetBgpRoutePolicies(params *GetBgpRoutePoliciesParams, opts ...ClientOption) (*GetBgpRoutePoliciesOK, error) {
 	// NOTE: parameters are not validated before sending
@@ -159,9 +162,11 @@ func (a *Client) GetBgpRoutePolicies(params *GetBgpRoutePoliciesParams, opts ...
 }
 
 /*
-GetBgpRoutes lists b g p routes from b g p control plane r i b
+	GetBgpRoutes lists b g p routes from b g p control plane r i b
 
-Retrieves routes from BGP Control Plane RIB filtered by parameters you specify
+	Retrieves routes from BGP Control Plane RIB filtered by parameters you specify.
+
+Deprecated: This will be removed in the future.
 */
 func (a *Client) GetBgpRoutes(params *GetBgpRoutesParams, opts ...ClientOption) (*GetBgpRoutesOK, error) {
 	// NOTE: parameters are not validated before sending

--- a/api/v1/models/bgp_peer.go
+++ b/api/v1/models/bgp_peer.go
@@ -17,6 +17,7 @@ import (
 )
 
 // BgpPeer State of a BGP Peer
+// Deprecated: This will be removed in the future.
 //
 // +k8s:deepcopy-gen=true
 //

--- a/api/v1/models/bgp_route.go
+++ b/api/v1/models/bgp_route.go
@@ -16,6 +16,7 @@ import (
 )
 
 // BgpRoute Single BGP route retrieved from the RIB of underlying router
+// Deprecated: This will be removed in the future.
 //
 // swagger:model BgpRoute
 type BgpRoute struct {

--- a/api/v1/models/bgp_route_policy.go
+++ b/api/v1/models/bgp_route_policy.go
@@ -18,6 +18,7 @@ import (
 )
 
 // BgpRoutePolicy Single BGP route policy retrieved from the underlying router
+// Deprecated: This will be removed in the future.
 //
 // swagger:model BgpRoutePolicy
 type BgpRoutePolicy struct {

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -877,6 +877,8 @@ paths:
         Retrieves current operational state of BGP peers created by
         Cilium BGP virtual router. This includes session state, uptime,
         information per address family, etc.
+        Deprecated: This will be removed in the future.
+      deprecated: true
       tags:
         - bgp
       responses:
@@ -898,7 +900,10 @@ paths:
   "/bgp/routes":
     get:
       summary: Lists BGP routes from BGP Control Plane RIB.
-      description: Retrieves routes from BGP Control Plane RIB filtered by parameters you specify
+      description: |
+        Retrieves routes from BGP Control Plane RIB filtered by parameters you specify.
+        Deprecated: This will be removed in the future.
+      deprecated: true
       tags:
         - bgp
       parameters:
@@ -926,7 +931,10 @@ paths:
   "/bgp/route-policies":
     get:
       summary: Lists BGP route policies configured in BGP Control Plane.
-      description: Retrieves route policies from BGP Control Plane.
+      description: |
+        Retrieves route policies from BGP Control Plane.
+        Deprecated: This will be removed in the future.
+      deprecated: true
       tags:
         - bgp
       parameters:
@@ -3618,6 +3626,7 @@ definitions:
   BgpPeer:
     description: |-
       State of a BGP Peer
+      Deprecated: This will be removed in the future.
 
       +k8s:deepcopy-gen=true
     properties:
@@ -3730,7 +3739,9 @@ definitions:
           (RFC 4724 section 4.2)
         type: integer
   BgpRoute:
-    description: Single BGP route retrieved from the RIB of underlying router
+    description: |
+      Single BGP route retrieved from the RIB of underlying router
+      Deprecated: This will be removed in the future.
     properties:
       router-asn:
         description: Autonomous System Number (ASN) identifying a BGP virtual router instance
@@ -3791,7 +3802,9 @@ definitions:
         description: Base64-encoded BGP path attribute in the BGP UPDATE message format
         type: string
   BgpRoutePolicy:
-    description: Single BGP route policy retrieved from the underlying router
+    description: |
+      Single BGP route policy retrieved from the underlying router
+      Deprecated: This will be removed in the future.
     properties:
       router-asn:
         description: Autonomous System Number (ASN) identifying a BGP virtual router instance

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -34,11 +34,12 @@ func init() {
   "paths": {
     "/bgp/peers": {
       "get": {
-        "description": "Retrieves current operational state of BGP peers created by\nCilium BGP virtual router. This includes session state, uptime,\ninformation per address family, etc.\n",
+        "description": "Retrieves current operational state of BGP peers created by\nCilium BGP virtual router. This includes session state, uptime,\ninformation per address family, etc.\nDeprecated: This will be removed in the future.\n",
         "tags": [
           "bgp"
         ],
         "summary": "Lists operational state of BGP peers",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "Success",
@@ -67,11 +68,12 @@ func init() {
     },
     "/bgp/route-policies": {
       "get": {
-        "description": "Retrieves route policies from BGP Control Plane.",
+        "description": "Retrieves route policies from BGP Control Plane.\nDeprecated: This will be removed in the future.\n",
         "tags": [
           "bgp"
         ],
         "summary": "Lists BGP route policies configured in BGP Control Plane.",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/parameters/bgp-router-asn"
@@ -105,11 +107,12 @@ func init() {
     },
     "/bgp/routes": {
       "get": {
-        "description": "Retrieves routes from BGP Control Plane RIB filtered by parameters you specify",
+        "description": "Retrieves routes from BGP Control Plane RIB filtered by parameters you specify.\nDeprecated: This will be removed in the future.\n",
         "tags": [
           "bgp"
         ],
         "summary": "Lists BGP routes from BGP Control Plane RIB.",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/parameters/bgp-table-type"
@@ -1735,7 +1738,7 @@ func init() {
       }
     },
     "BgpPeer": {
-      "description": "State of a BGP Peer\n\n+k8s:deepcopy-gen=true",
+      "description": "State of a BGP Peer\nDeprecated: This will be removed in the future.\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "applied-hold-time-seconds": {
           "description": "Applied initial value for the BGP HoldTimer (RFC 4271, Section 4.2) in seconds.\nThe applied value holds the value that is in effect on the current BGP session.\n",
@@ -1848,7 +1851,7 @@ func init() {
       }
     },
     "BgpRoute": {
-      "description": "Single BGP route retrieved from the RIB of underlying router",
+      "description": "Single BGP route retrieved from the RIB of underlying router\nDeprecated: This will be removed in the future.\n",
       "properties": {
         "neighbor": {
           "description": "IP address specifying a BGP neighbor if the source table type is adj-rib-in or adj-rib-out",
@@ -1872,7 +1875,7 @@ func init() {
       }
     },
     "BgpRoutePolicy": {
-      "description": "Single BGP route policy retrieved from the underlying router",
+      "description": "Single BGP route policy retrieved from the underlying router\nDeprecated: This will be removed in the future.\n",
       "properties": {
         "name": {
           "description": "Name of the route policy",
@@ -5198,11 +5201,12 @@ func init() {
   "paths": {
     "/bgp/peers": {
       "get": {
-        "description": "Retrieves current operational state of BGP peers created by\nCilium BGP virtual router. This includes session state, uptime,\ninformation per address family, etc.\n",
+        "description": "Retrieves current operational state of BGP peers created by\nCilium BGP virtual router. This includes session state, uptime,\ninformation per address family, etc.\nDeprecated: This will be removed in the future.\n",
         "tags": [
           "bgp"
         ],
         "summary": "Lists operational state of BGP peers",
+        "deprecated": true,
         "responses": {
           "200": {
             "description": "Success",
@@ -5231,11 +5235,12 @@ func init() {
     },
     "/bgp/route-policies": {
       "get": {
-        "description": "Retrieves route policies from BGP Control Plane.",
+        "description": "Retrieves route policies from BGP Control Plane.\nDeprecated: This will be removed in the future.\n",
         "tags": [
           "bgp"
         ],
         "summary": "Lists BGP route policies configured in BGP Control Plane.",
+        "deprecated": true,
         "parameters": [
           {
             "type": "integer",
@@ -5272,11 +5277,12 @@ func init() {
     },
     "/bgp/routes": {
       "get": {
-        "description": "Retrieves routes from BGP Control Plane RIB filtered by parameters you specify",
+        "description": "Retrieves routes from BGP Control Plane RIB filtered by parameters you specify.\nDeprecated: This will be removed in the future.\n",
         "tags": [
           "bgp"
         ],
         "summary": "Lists BGP routes from BGP Control Plane RIB.",
+        "deprecated": true,
         "parameters": [
           {
             "enum": [
@@ -7076,7 +7082,7 @@ func init() {
       }
     },
     "BgpPeer": {
-      "description": "State of a BGP Peer\n\n+k8s:deepcopy-gen=true",
+      "description": "State of a BGP Peer\nDeprecated: This will be removed in the future.\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "applied-hold-time-seconds": {
           "description": "Applied initial value for the BGP HoldTimer (RFC 4271, Section 4.2) in seconds.\nThe applied value holds the value that is in effect on the current BGP session.\n",
@@ -7189,7 +7195,7 @@ func init() {
       }
     },
     "BgpRoute": {
-      "description": "Single BGP route retrieved from the RIB of underlying router",
+      "description": "Single BGP route retrieved from the RIB of underlying router\nDeprecated: This will be removed in the future.\n",
       "properties": {
         "neighbor": {
           "description": "IP address specifying a BGP neighbor if the source table type is adj-rib-in or adj-rib-out",
@@ -7213,7 +7219,7 @@ func init() {
       }
     },
     "BgpRoutePolicy": {
-      "description": "Single BGP route policy retrieved from the underlying router",
+      "description": "Single BGP route policy retrieved from the underlying router\nDeprecated: This will be removed in the future.\n",
       "properties": {
         "name": {
           "description": "Name of the route policy",

--- a/api/v1/server/restapi/bgp/get_bgp_peers.go
+++ b/api/v1/server/restapi/bgp/get_bgp_peers.go
@@ -37,6 +37,7 @@ func NewGetBgpPeers(ctx *middleware.Context, handler GetBgpPeersHandler) *GetBgp
 Retrieves current operational state of BGP peers created by
 Cilium BGP virtual router. This includes session state, uptime,
 information per address family, etc.
+Deprecated: This will be removed in the future.
 */
 type GetBgpPeers struct {
 	Context *middleware.Context

--- a/api/v1/server/restapi/bgp/get_bgp_route_policies.go
+++ b/api/v1/server/restapi/bgp/get_bgp_route_policies.go
@@ -35,6 +35,7 @@ func NewGetBgpRoutePolicies(ctx *middleware.Context, handler GetBgpRoutePolicies
 Lists BGP route policies configured in BGP Control Plane.
 
 Retrieves route policies from BGP Control Plane.
+Deprecated: This will be removed in the future.
 */
 type GetBgpRoutePolicies struct {
 	Context *middleware.Context

--- a/api/v1/server/restapi/bgp/get_bgp_routes.go
+++ b/api/v1/server/restapi/bgp/get_bgp_routes.go
@@ -34,7 +34,8 @@ func NewGetBgpRoutes(ctx *middleware.Context, handler GetBgpRoutesHandler) *GetB
 
 Lists BGP routes from BGP Control Plane RIB.
 
-Retrieves routes from BGP Control Plane RIB filtered by parameters you specify
+Retrieves routes from BGP Control Plane RIB filtered by parameters you specify.
+Deprecated: This will be removed in the future.
 */
 type GetBgpRoutes struct {
 	Context *middleware.Context

--- a/cilium-dbg/cmd/bgp.go
+++ b/cilium-dbg/cmd/bgp.go
@@ -8,7 +8,7 @@ import "github.com/spf13/cobra"
 // BgpCmd represents the bgp command
 var BgpCmd = &cobra.Command{
 	Use:   "bgp",
-	Short: "Access to BGP control plane",
+	Short: "Access to BGP control plane (deprecated)",
 }
 
 func init() {

--- a/cilium-dbg/cmd/bgp_peer_get.go
+++ b/cilium-dbg/cmd/bgp_peer_get.go
@@ -22,8 +22,8 @@ var (
 	BgpPeersCmd = &cobra.Command{
 		Use:     "peers",
 		Aliases: []string{"neighbors"},
-		Short:   "List current state of all peers",
-		Long:    "List state of all peers defined in Cilium BGP configuration",
+		Short:   "List current state of all peers (deprecated)",
+		Long:    "List state of all peers defined in Cilium BGP configuration (deprecated)",
 		Run: func(cmd *cobra.Command, args []string) {
 			res, err := client.Bgp.GetBgpPeers(nil)
 			if err != nil {

--- a/cilium-dbg/cmd/bgp_route_get.go
+++ b/cilium-dbg/cmd/bgp_route_get.go
@@ -34,8 +34,8 @@ const (
 
 var BgpRoutesCmd = &cobra.Command{
 	Use:   "routes <available | advertised> <afi> <safi> [vrouter <asn>] [peer|neighbor <address>]",
-	Short: "List routes in the BGP Control Plane's RIBs",
-	Long:  "List routes in the BGP Control Plane's Routing Information Bases (RIBs)",
+	Short: "List routes in the BGP Control Plane's RIBs (deprecated)",
+	Long:  "List routes in the BGP Control Plane's Routing Information Bases (RIBs) (deprecated)",
 	Example: `  Get all IPv4 unicast routes available:
     cilium-dbg bgp routes available ipv4 unicast
 

--- a/cilium-dbg/cmd/bgp_route_policy_get.go
+++ b/cilium-dbg/cmd/bgp_route_policy_get.go
@@ -18,8 +18,8 @@ import (
 var BgpRoutePoliciesCmd = &cobra.Command{
 	Use:     "route-policies [vrouter <asn>]",
 	Aliases: []string{"rps"},
-	Short:   "List configured route policies",
-	Long:    "List route policies configured in the underlying routing daemon",
+	Short:   "List configured route policies (deprecated)",
+	Long:    "List route policies configured in the underlying routing daemon (deprecated)",
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 		params := bgp.NewGetBgpRoutePoliciesParams()


### PR DESCRIPTION
With the transition to BGPv2, the legacy BGPv1 REST APIs are now deprecated. Users should migrate to the `cilium shell -- bgp/*` commands.

- Marked `/bgp/peers`, `/bgp/routes` and `/bgp/route-policies` as deprecated.
- Marked `bgp peers`, `bgp routes` and `bgp route-policies` commands as deprecated.

```release-note
The local REST BGP APIs are deprecated. It will be removed in the future.
```
