### PR TITLE
docs: add small CiliumCIDRGroup scalability callout

### DIFF
--- a/Documentation/network/kubernetes/ciliumcidrgroup.rst
+++ b/Documentation/network/kubernetes/ciliumcidrgroup.rst
@@ -6,9 +6,9 @@
 
 .. _CiliumCIDRGroup:
 
-***************************
+***************
 CiliumCIDRGroup
-***************************
+***************
 
 CiliumCIDRGroup (CCG) is a feature that allows administrators to reference a group of
 CIDR blocks in a :ref:`CiliumNetworkPolicy`. Unlike :ref:`CiliumEndpoint` resources,
@@ -63,3 +63,12 @@ by names or labels.
 In this example, the ``fromCIDRSet`` directive in the CNP references the
 ``vpn-example-1`` group defined in the ``CiliumCIDRGroup``. This allows the CNP to
 apply ingress rules based on the CIDRs grouped under the ``vpn-example-1`` name.
+
+
+Scalability impacts
+-------------------
+
+CiliumCIDRGroups generally result in the creation of a single
+:ref:`security identity <arch_id_security>` per group. For large groups,
+this can be a significant savings. Use CiliumCIDRGroup
+when large numbers of CIDRs must be selected.

--- a/Documentation/security/policy/layer3.rst
+++ b/Documentation/security/policy/layer3.rst
@@ -445,6 +445,14 @@ but not CIDR prefix ``10.96.0.0/12``
 .. literalinclude:: ../../../examples/policies/l3/cidr/cidr.yaml
   :language: yaml
 
+
+Scalability
+~~~~~~~~~~~
+
+Policies that select large numbers of distinct CIDRs can cause agents to allocate
+large numbers of :ref:`security identities <arch_id_security>`. In this scenario,
+use a :ref:`CiliumCIDRGroup` to reduce identity usage.
+
 .. _cidr_select_nodes:
 
 Selecting nodes with CIDR / ipBlock


### PR DESCRIPTION
We worked hard to make CCGs more efficient. Expose that to users so they can better design their policies.