### PR TITLE
.github: Make release note instructions clearer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,5 @@ Please ensure your pull request adheres to the following guidelines:
 Fixes: #issue-number
 
 ```release-note
-<!-- Enter the release note text here if needed or remove this section! -->
+<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
 ```


### PR DESCRIPTION
Apparently some contributors struggled to understand the previous
instructions, so let's try to make it more explicit.
