### PR TITLE
[network-driver] Add support for direct routes in CiliumResourceNetworkConfig

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumresourcenetworkconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumresourcenetworkconfigs.yaml
@@ -72,7 +72,6 @@ spec:
                             type: string
                         required:
                         - destination
-                        - gateway
                         type: object
                       type: array
                   required:
@@ -104,7 +103,6 @@ spec:
                             type: string
                         required:
                         - destination
-                        - gateway
                         type: object
                       type: array
                   required:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/network_driver_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/network_driver_types.go
@@ -362,7 +362,7 @@ type IPv4StaticRouteSpec struct {
 
 	// Gateway specifies the route gateway address
 	//
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Format=ipv4
 	Gateway string `json:"gateway"`
 }
@@ -376,7 +376,7 @@ type IPv6StaticRouteSpec struct {
 
 	// Gateway specifies the route gateway address
 	//
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Format=ipv6
 	Gateway string `json:"gateway"`
 }

--- a/pkg/networkdriver/dra_test.go
+++ b/pkg/networkdriver/dra_test.go
@@ -252,11 +252,13 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 
 		networkConfigName = "test-network-config"
 		v4NetMask         = 24
-		v4RouteDst        = "10.10.100.0/24"
-		v4RouteGw         = "10.10.100.254"
+		v4Route1Dst       = "10.10.100.0/24"
+		v4Route1Gw        = "10.10.100.254"
+		v4Route2Dst       = "10.10.200.0/24"
 		v6NetMask         = 96
-		v6RouteDst        = "fd00:200:1::/96"
-		v6RouteGw         = "fd00:200:1::1"
+		v6Route1Dst       = "fd00:200:1::/96"
+		v6Route1Gw        = "fd00:200:1::1"
+		v6Route2Dst       = "fd00:200:2::/96"
 	)
 
 	rawParam, err := json.Marshal(map[string]string{"networkConfig": networkConfigName})
@@ -343,8 +345,11 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 					NetMask: uint8(v4NetMask),
 					StaticRoutes: []v2alpha1.IPv4StaticRouteSpec{
 						{
-							Destination: v4RouteDst,
-							Gateway:     v4RouteGw,
+							Destination: v4Route1Dst,
+							Gateway:     v4Route1Gw,
+						},
+						{
+							Destination: v4Route2Dst,
 						},
 					},
 				},
@@ -352,8 +357,11 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 					NetMask: uint8(v6NetMask),
 					StaticRoutes: []v2alpha1.IPv6StaticRouteSpec{
 						{
-							Destination: v6RouteDst,
-							Gateway:     v6RouteGw,
+							Destination: v6Route1Dst,
+							Gateway:     v6Route1Gw,
+						},
+						{
+							Destination: v6Route2Dst,
 						},
 					},
 				},
@@ -536,11 +544,12 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 	assert.True(t, v6PoolCIDR.Contains(alloc.Config.IPv6Addr.Masked().Addr()))
 	assert.True(t, v6NodeCIDR.Contains(alloc.Config.IPv6Addr.Masked().Addr()))
 
-	assert.Len(t, alloc.Config.Routes, 2)
 	assert.ElementsMatch(t,
 		[]types.Route{
-			{Destination: netip.MustParsePrefix(v4RouteDst), Gateway: netip.MustParseAddr(v4RouteGw)},
-			{Destination: netip.MustParsePrefix(v6RouteDst), Gateway: netip.MustParseAddr(v6RouteGw)},
+			{Destination: netip.MustParsePrefix(v4Route1Dst), Gateway: netip.MustParseAddr(v4Route1Gw)},
+			{Destination: netip.MustParsePrefix(v4Route2Dst)},
+			{Destination: netip.MustParsePrefix(v6Route1Dst), Gateway: netip.MustParseAddr(v6Route1Gw)},
+			{Destination: netip.MustParsePrefix(v6Route2Dst)},
 		},
 		alloc.Config.Routes,
 	)

--- a/pkg/networkdriver/network_config.go
+++ b/pkg/networkdriver/network_config.go
@@ -66,8 +66,10 @@ func (c resourceNetworkConfig) TableRow() []string {
 			route := routes[i]
 			b.WriteRune('[')
 			b.WriteString(route.Destination.String())
-			b.WriteString(" via ")
-			b.WriteString(route.Gateway.String())
+			if route.Gateway.IsValid() {
+				b.WriteString(" via ")
+				b.WriteString(route.Gateway.String())
+			}
 			b.WriteRune(']')
 			if i != len(routes)-1 {
 				b.WriteString(", ")
@@ -189,15 +191,11 @@ func resourceNetworkConfigReflectorConfig(cs client.Clientset, crdSync promise.P
 					s.IPv4NetMask = int(sp.IPv4.NetMask)
 					s.IPv4Routes = make([]route, 0, len(sp.IPv4.StaticRoutes))
 					for _, r := range sp.IPv4.StaticRoutes {
-						dst, err := netip.ParsePrefix(r.Destination)
+						r, err := parseRoute(r.Destination, r.Gateway)
 						if err != nil {
 							return resourceNetworkConfig{}, false
 						}
-						gw, err := netip.ParseAddr(r.Gateway)
-						if err != nil {
-							return resourceNetworkConfig{}, false
-						}
-						s.IPv4Routes = append(s.IPv4Routes, route{Destination: dst, Gateway: gw})
+						s.IPv4Routes = append(s.IPv4Routes, r)
 					}
 				}
 
@@ -205,15 +203,11 @@ func resourceNetworkConfigReflectorConfig(cs client.Clientset, crdSync promise.P
 					s.IPv6NetMask = int(sp.IPv6.NetMask)
 					s.IPv6Routes = make([]route, 0, len(sp.IPv6.StaticRoutes))
 					for _, r := range sp.IPv6.StaticRoutes {
-						dst, err := netip.ParsePrefix(r.Destination)
+						r, err := parseRoute(r.Destination, r.Gateway)
 						if err != nil {
 							return resourceNetworkConfig{}, false
 						}
-						gw, err := netip.ParseAddr(r.Gateway)
-						if err != nil {
-							return resourceNetworkConfig{}, false
-						}
-						s.IPv6Routes = append(s.IPv6Routes, route{Destination: dst, Gateway: gw})
+						s.IPv4Routes = append(s.IPv4Routes, r)
 					}
 				}
 
@@ -228,4 +222,21 @@ func resourceNetworkConfigReflectorConfig(cs client.Clientset, crdSync promise.P
 		},
 		CRDSync: crdSync,
 	}
+}
+
+func parseRoute(destination, gateway string) (route, error) {
+	dst, err := netip.ParsePrefix(destination)
+	if err != nil {
+		return route{}, err
+	}
+
+	var gw netip.Addr
+	if gateway != "" {
+		gw, err = netip.ParseAddr(gateway)
+		if err != nil {
+			return route{}, err
+		}
+	}
+
+	return route{Destination: dst, Gateway: gw}, nil
 }

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/netip"
 	"path"
+	"syscall"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -290,11 +291,12 @@ func (driver *Driver) configureRoutes(logger *slog.Logger, l netlink.Link, act a
 				errs = append(errs, fmt.Errorf("failed to add static route [%s via %s dev %s]: %w", r.Destination, r.Gateway, l.Attrs().Name, err))
 			}
 		case del:
-			if err := linuxRoute.Delete(route); err != nil {
+			if err := linuxRoute.Delete(route); err != nil && !errors.Is(err, syscall.ESRCH) {
 				errs = append(errs, fmt.Errorf("failed to delete static route [%s via %s dev %s]: %w", r.Destination, r.Gateway, l.Attrs().Name, err))
 			}
 		}
 	}
+
 	return errors.Join(errs...)
 }
 

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -272,13 +272,16 @@ func (driver *Driver) configureIPs(l netlink.Link, act action, ipv4, ipv6 netip.
 func (driver *Driver) configureRoutes(logger *slog.Logger, l netlink.Link, act action, routes []types.Route) error {
 	var errs []error
 	for _, r := range routes {
-		nextHop := net.IP(r.Gateway.AsSlice())
 		route := linuxRoute.Route{
-			Prefix:  *netipx.PrefixIPNet(r.Destination),
-			Nexthop: &nextHop,
-			Device:  l.Attrs().Name,
-			Table:   unix.RT_TABLE_MAIN,
-			Proto:   unix.RTPROT_STATIC,
+			Prefix: *netipx.PrefixIPNet(r.Destination),
+			Device: l.Attrs().Name,
+			Table:  unix.RT_TABLE_MAIN,
+			Proto:  unix.RTPROT_STATIC,
+		}
+
+		if r.Gateway.IsValid() {
+			nextHop := net.IP(r.Gateway.AsSlice())
+			route.Nexthop = &nextHop
 		}
 
 		switch act {

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -31,6 +31,12 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
+var (
+	// Overridden by privileged tests to keep namespace moves isolated.
+	podNetNSPath  = defaults.NetNsPath
+	rootNetNSPath = "/proc/1/ns/net"
+)
+
 func getNetworkNamespace(pod *api.PodSandbox) string {
 	// get the pod network namespace
 	for _, namespace := range pod.Linux.GetNamespaces() {
@@ -70,7 +76,7 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 			return nil
 		}
 
-		nsPath := path.Join(defaults.NetNsPath, path.Base(networkNamespace))
+		nsPath := path.Join(podNetNSPath, path.Base(networkNamespace))
 
 		podNs, err := netns.OpenPinned(nsPath)
 		if err != nil {
@@ -162,7 +168,7 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 			return nil
 		}
 
-		nsPath := path.Join(defaults.NetNsPath, path.Base(networkNamespace))
+		nsPath := path.Join(podNetNSPath, path.Base(networkNamespace))
 
 		podNs, err := netns.OpenPinned(nsPath)
 		if err != nil {
@@ -172,7 +178,7 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 		defer podNs.Close()
 
 		// Get the root network namespace to move interfaces back to it
-		rootNs, err := netns.OpenPinned("/proc/1/ns/net")
+		rootNs, err := netns.OpenPinned(rootNetNSPath)
 		if err != nil {
 			return fmt.Errorf("failed to open root netns: %w", err)
 		}

--- a/pkg/networkdriver/nri_test.go
+++ b/pkg/networkdriver/nri_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package networkdriver
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/containerd/nri/pkg/api"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
+	"golang.org/x/sys/unix"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/networkdriver/dummy"
+	"github.com/cilium/cilium/pkg/networkdriver/types"
+	"github.com/cilium/cilium/pkg/testutils"
+	testnetns "github.com/cilium/cilium/pkg/testutils/netns"
+)
+
+func TestPrivilegedRunStopPodSandbox(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	const (
+		rootNSName = "nri-root"
+		podNSName  = "nri-pod"
+		deviceName = "dummy0"
+		podIfName  = "net1"
+	)
+
+	var (
+		podUID   = kubetypes.UID("bbbbbbbb-0000-0000-0000-000000000002")
+		claimUID = kubetypes.UID("aaaaaaaa-0000-0000-0000-000000000001")
+		ipv4Addr = netip.MustParsePrefix("10.10.0.1/24")
+		routes   = []types.Route{
+			{
+				Destination: netip.MustParsePrefix("10.10.0.128/28"),
+				Gateway:     netip.MustParseAddr("10.10.0.128"),
+			},
+			{
+				Destination: netip.MustParsePrefix("10.10.0.144/28"),
+			},
+		}
+	)
+
+	rootNS := testnetns.NewNetNS(t)
+	podNS := testnetns.NewNetNS(t)
+
+	pinDir := t.TempDir()
+	rootNSPath := filepath.Join(pinDir, rootNSName)
+	podNSPath := filepath.Join(pinDir, podNSName)
+	pinNetNS(t, rootNS, rootNSPath)
+	pinNetNS(t, podNS, podNSPath)
+
+	origPodNetNSPath := podNetNSPath
+	origRootNetNSPath := rootNetNSPath
+	t.Cleanup(func() {
+		podNetNSPath = origPodNetNSPath
+		rootNetNSPath = origRootNetNSPath
+	})
+	podNetNSPath = pinDir
+	rootNetNSPath = rootNSPath
+
+	require.NoError(t, rootNS.Do(func() error {
+		return netlink.LinkAdd(&netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{Name: deviceName},
+		})
+	}))
+
+	driver := &Driver{
+		logger: hivetest.Logger(t),
+		allocations: map[kubetypes.UID]map[kubetypes.UID][]allocation{
+			podUID: {
+				claimUID: {
+					{
+						Device: &dummy.DummyDevice{Name: deviceName},
+						Config: types.DeviceConfig{
+							IPv4Addr:  ipv4Addr,
+							PodIfName: podIfName,
+							Routes:    routes,
+						},
+						Manager: types.DeviceManagerTypeDummy,
+					},
+				},
+			},
+		},
+		ipv4Enabled: true,
+	}
+	podSandbox := &api.PodSandbox{
+		Name:      "test-pod",
+		Uid:       string(podUID),
+		Namespace: "default",
+		Linux: &api.LinuxPodSandbox{
+			Namespaces: []*api.LinuxNamespace{
+				{
+					Type: "network",
+					Path: podNSPath,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, rootNS.Do(func() error {
+		return driver.RunPodSandbox(t.Context(), podSandbox)
+	}))
+
+	require.NoError(t, rootNS.Do(func() error {
+		if _, err := safenetlink.LinkByName(deviceName); err == nil {
+			return fmt.Errorf("expected %q to be moved out of root netns", deviceName)
+		}
+		return nil
+	}))
+
+	require.NoError(t, podNS.Do(func() error {
+		if _, err := safenetlink.LinkByName(deviceName); err == nil {
+			return fmt.Errorf("expected %q to be renamed in pod netns", deviceName)
+		}
+
+		link, err := safenetlink.LinkByName(podIfName)
+		if err != nil {
+			return fmt.Errorf("expected %q to be moved into pod netns", podIfName)
+		}
+
+		if link.Attrs().Flags&net.FlagUp == 0 {
+			return fmt.Errorf("expected %q to be up", podIfName)
+		}
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("failed to list %q addresses", podIfName)
+		}
+		if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
+			prefix, ok := netipx.FromStdIPNet(addr.IPNet)
+			if !ok {
+				return false
+			}
+			return ipv4Addr.Compare(prefix) == 0
+		}); !found {
+			return fmt.Errorf("expected address %q to be assigned to %q interface", ipv4Addr, podIfName)
+		}
+
+		nlRoutes, err := safenetlink.RouteListFiltered(
+			netlink.FAMILY_V4,
+			&netlink.Route{
+				LinkIndex: link.Attrs().Index,
+				Dst:       netipx.PrefixIPNet(routes[0].Destination),
+				Gw:        routes[0].Gateway.AsSlice(),
+			},
+			netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST|netlink.RT_FILTER_GW,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to list routes for %q", podIfName)
+		}
+		if len(nlRoutes) != 1 {
+			return fmt.Errorf("no route \"%s via %s dev %s\" found", routes[0].Destination, routes[0].Gateway, podIfName)
+		}
+
+		nlRoutes, err = safenetlink.RouteListFiltered(
+			netlink.FAMILY_V4,
+			&netlink.Route{
+				LinkIndex: link.Attrs().Index,
+				Dst:       netipx.PrefixIPNet(routes[1].Destination),
+			},
+			netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to list routes for %q", podIfName)
+		}
+		if len(nlRoutes) != 1 {
+			return fmt.Errorf("no route \"%s dev %s\" found", routes[1].Destination, podIfName)
+		}
+
+		return nil
+	}))
+
+	require.NoError(t, rootNS.Do(func() error {
+		return driver.StopPodSandbox(t.Context(), podSandbox)
+	}))
+
+	require.NoError(t, podNS.Do(func() error {
+		if _, err := safenetlink.LinkByName(podIfName); err == nil {
+			return fmt.Errorf("expected %q to be moved out of pod netns", podIfName)
+		}
+		return nil
+	}))
+
+	require.NoError(t, rootNS.Do(func() error {
+		if _, err := safenetlink.LinkByName(podIfName); err == nil {
+			return fmt.Errorf("expected %q to be restored to %q in root netns", podIfName, deviceName)
+		}
+
+		link, err := safenetlink.LinkByName(deviceName)
+		if err != nil {
+			return err
+		}
+
+		if link.Attrs().Flags&net.FlagUp != 0 {
+			return fmt.Errorf("expected %q to be down", deviceName)
+		}
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("failed to list %q addresses", deviceName)
+		}
+		if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
+			prefix, ok := netipx.FromStdIPNet(addr.IPNet)
+			if !ok {
+				return false
+			}
+			return ipv4Addr.Compare(prefix) == 0
+		}); found {
+			return fmt.Errorf("expected %q to have %s removed", deviceName, ipv4Addr)
+		}
+
+		nlRoutes, err := safenetlink.RouteListFiltered(
+			netlink.FAMILY_V4,
+			&netlink.Route{
+				Dst: netipx.PrefixIPNet(routes[0].Destination),
+				Gw:  routes[0].Gateway.AsSlice(),
+			},
+			netlink.RT_FILTER_DST|netlink.RT_FILTER_GW,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to list routes for destination %q", routes[0].Destination)
+		}
+		if len(nlRoutes) > 0 {
+			return fmt.Errorf("expected no routes for destination %q", routes[0].Destination)
+		}
+
+		nlRoutes, err = safenetlink.RouteListFiltered(
+			netlink.FAMILY_V4,
+			&netlink.Route{
+				Dst: netipx.PrefixIPNet(routes[1].Destination),
+			},
+			netlink.RT_FILTER_DST,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to list routes for destination %q", routes[1].Destination)
+		}
+		if len(nlRoutes) > 0 {
+			return fmt.Errorf("expected no routes for destination %q", routes[1].Destination)
+		}
+
+		return nil
+	}))
+}
+
+func pinNetNS(t *testing.T, ns *testnetns.NetNS, target string) {
+	t.Helper()
+
+	f, err := os.Create(target)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	nsFDPath := fmt.Sprintf("/proc/self/fd/%d", ns.FD())
+	require.NoError(t, unix.Mount(nsFDPath, target, "none", unix.MS_BIND, ""))
+	t.Cleanup(func() {
+		require.NoError(t, unix.Unmount(target, unix.MNT_DETACH))
+		require.NoError(t, os.Remove(target))
+	})
+}


### PR DESCRIPTION
Add support for direct routes in CiliumResourceNetworkConfig. Also, add a privileged tests to validate setup and teardown of the allocated resources in NRI hooks.