### PR TITLE
feat(chart): add `helm.sh/chart` label

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -26,6 +26,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-agent
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -78,6 +79,7 @@ spec:
         k8s-app: cilium
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/dashboards-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" $ }}
     {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/role.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -41,6 +42,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
 rules:
 - apiGroups:
   - ""
@@ -65,6 +67,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
 rules:
 - apiGroups:
   - ""
@@ -89,6 +92,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
 rules:
 - apiGroups:
   - ""
@@ -109,6 +113,7 @@ metadata:
   namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
 rules:
 - apiGroups:
   - ""
@@ -133,6 +138,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
 rules:
 - apiGroups:
   - ""

--- a/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/rolebinding.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -39,6 +40,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -65,6 +67,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -91,6 +94,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -113,6 +117,7 @@ metadata:
   namespace: {{ .Values.bgpControlPlane.secretsNamespace.name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -135,6 +140,7 @@ metadata:
   namespace: {{ .Values.tls.secretsNamespace.name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/service.yaml
@@ -14,6 +14,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -46,6 +47,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-agent
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-agent
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
     name: cilium-envoy
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -46,6 +47,7 @@ spec:
         name: cilium-envoy
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/node-locality-clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/node-locality-clusterrole.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/node-locality-clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/node-locality-clusterrolebinding.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -19,6 +19,7 @@ metadata:
     k8s-app: cilium-envoy
     app.kubernetes.io/name: cilium-envoy
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     io.cilium/app: proxy
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-envoy
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     cilium.io/ingress: "true"
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- if .Values.ingressController.service.labels }}
     {{- toYaml .Values.ingressController.service.labels | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -13,6 +13,7 @@ metadata:
     app: cilium-node-init
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-node-init
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -42,6 +43,7 @@ spec:
         app: cilium-node-init
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-node-init
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/name: cilium-operator
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" $ }}
     {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -14,6 +14,7 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -60,6 +61,7 @@ spec:
         name: cilium-operator
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-operator
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/poddisruptionbudget.yaml
@@ -14,6 +14,7 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/name: cilium-operator
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/role.yaml
@@ -13,6 +13,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -41,6 +42,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -69,6 +71,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -97,6 +100,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -35,6 +36,7 @@ metadata:
   namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -61,6 +63,7 @@ metadata:
   namespace: {{ .Values.tls.secretsNamespace.name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -87,6 +90,7 @@ metadata:
   namespace: {{ include "cilium.namespace" . }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/service.yaml
@@ -13,6 +13,7 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         app.kubernetes.io/part-of: cilium
         k8s-app: cilium-pre-flight-check
         app.kubernetes.io/name: cilium-pre-flight-check
+        helm.sh/chart: {{ include "cilium.chart" . }}
         kubernetes.io/cluster-service: "true"
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-pre-flight-check
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -30,6 +31,7 @@ spec:
         k8s-app: cilium-pre-flight-check-deployment
         kubernetes.io/cluster-service: "true"
         app.kubernetes.io/name: cilium-pre-flight-check
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/poddisruptionbudget.yaml
@@ -13,6 +13,7 @@ metadata:
     k8s-app: cilium-pre-flight-check-deployment
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-pre-flight-check
+    helm.sh/chart: {{ include "cilium.chart" . }}
     kubernetes.io/cluster-service: "true"
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
+++ b/install/kubernetes/cilium/templates/cilium-resource-quota.yaml
@@ -24,6 +24,7 @@ metadata:
   namespace: {{ include "cilium.namespace" . }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -17,6 +17,7 @@ metadata:
   name: {{ $name | quote }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" $ }}
     {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -5,6 +5,7 @@ metadata:
   name: clustermesh-apiserver
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   name: clustermesh-apiserver
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -15,6 +15,7 @@ metadata:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -45,6 +46,7 @@ spec:
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: clustermesh-apiserver
         k8s-app: clustermesh-apiserver
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
     app.kubernetes.io/component: metrics
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/poddisruptionbudget.yaml
@@ -13,6 +13,7 @@ metadata:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -8,6 +8,7 @@ metadata:
     k8s-app: clustermesh-apiserver
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: clustermesh-apiserver
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/cronjob.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     k8s-app: clustermesh-apiserver-generate-certs
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/job.yaml
@@ -20,6 +20,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
   {{- if or .Values.certgen.annotations.job .Values.clustermesh.annotations }}
   annotations:
     {{- with .Values.certgen.annotations.job }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/role.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/rolebinding.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/users-configmap.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-coredns-mcsapi/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-coredns-mcsapi/clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
   name: coredns-mcsapi
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-coredns-mcsapi/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-coredns-mcsapi/clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   name: coredns-mcsapi
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-coredns-mcsapi/job.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-coredns-mcsapi/job.yaml
@@ -11,6 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     {{- with .Values.clustermesh.annotations }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -43,6 +44,7 @@ spec:
         k8s-app: hubble-relay
         app.kubernetes.io/name: hubble-relay
         app.kubernetes.io/part-of: cilium
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/poddisruptionbudget.yaml
@@ -13,6 +13,7 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/service.yaml
@@ -16,6 +16,7 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: hubble-relay
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -42,6 +43,7 @@ spec:
         k8s-app: hubble-ui
         app.kubernetes.io/name: hubble-ui
         app.kubernetes.io/part-of: cilium
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/poddisruptionbudget.yaml
@@ -13,6 +13,7 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -18,6 +18,7 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/hubble/dashboards-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: hubble
     app.kubernetes.io/name: hubble
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" $ }}
 
     {{- with $.Values.commonLabels }}
     {{- toYaml . | nindent 4 }}

--- a/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/metrics-service.yaml
@@ -8,6 +8,7 @@ metadata:
     k8s-app: hubble
     app.kubernetes.io/name: hubble
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/peer-service.yaml
+++ b/install/kubernetes/cilium/templates/hubble/peer-service.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: cilium
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: hubble-peer
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/hubble/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: hubble
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/cronjob.yaml
@@ -8,6 +8,7 @@ metadata:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/job.yaml
@@ -18,6 +18,7 @@ metadata:
     k8s-app: hubble-generate-certs
     app.kubernetes.io/name: hubble-generate-certs
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/role.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/rolebinding.yaml
@@ -10,6 +10,7 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/install/kubernetes/cilium/templates/standalone-dns-proxy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/standalone-dns-proxy/daemonset.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: standalone-dns-proxy
     name: standalone-dns-proxy
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -39,6 +40,7 @@ spec:
         name: standalone-dns-proxy
         app.kubernetes.io/name: standalone-dns-proxy
         app.kubernetes.io/part-of: cilium
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/ztunnel/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/ztunnel/daemonset.yaml
@@ -13,6 +13,7 @@ metadata:
     app: ztunnel-cilium
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: ztunnel-cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -36,6 +37,7 @@ spec:
         app: ztunnel-cilium
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: ztunnel-cilium
+        helm.sh/chart: {{ include "cilium.chart" . }}
         {{- with .Values.commonLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/install/kubernetes/cilium/templates/ztunnel/secret.yaml
+++ b/install/kubernetes/cilium/templates/ztunnel/secret.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: ztunnel-cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
`helm.sh/chart` is a standard label recommended by Helm best practices: https://helm.sh/docs/chart_best_practices/labels/#standard-labels.

Label value is set to the result of `cilium.chart` template that, according to the comment, was added specifically for this purpose, but was never actually used.
https://github.com/cilium/cilium/blob/cf36bed7d0410a2fc7256886d9076a69bc54ceef/install/kubernetes/cilium/templates/_helpers.tpl#L2

Label is added only to resources where another standard label `app.kubernetes.io/part-of` is already present. Resources with the following label definition were skipped:
```gotmpl
  {{- with .Values.commonLabels }}
  labels:
    {{- toYaml . | nindent 4 }}
  {{- end }}
```

Generative AI in any form was not used to prepare this PR.

```release-note
Add `helm.sh/chart` standard label
```