### PR TITLE
endpoint: drain proxy redirects before removing network policy during teardown

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -317,13 +317,15 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 	return desiredRedirects, skipped, revertStack.Revert
 }
 
+// removeOldRedirects removes redirects that are no longer required by policy.
 // Must be called with endpoint.mutex locked for writing, as this calls back to
 // 'e.OnDNSPolicyUpdateLocked()'.
-func (e *Endpoint) removeOldRedirects(desiredRedirects, realizedRedirects map[string]uint16) {
+func (e *Endpoint) removeOldRedirects(desiredRedirects, realizedRedirects map[string]uint16, waitForDrain bool) {
 	if e.isProperty(endpointtypes.PropertyFakeEndpoint) || e.IsProxyDisabled() {
 		return
 	}
 
+	staleRedirects := make([]string, 0, len(realizedRedirects))
 	for id, redirectPort := range realizedRedirects {
 		// Remove only the redirects that are not required.
 		if desiredRedirects[id] != 0 {
@@ -331,7 +333,7 @@ func (e *Endpoint) removeOldRedirects(desiredRedirects, realizedRedirects map[st
 		}
 
 		if redirectPort != 0 {
-			e.proxy.RemoveRedirect(id)
+			staleRedirects = append(staleRedirects, id)
 		}
 
 		// Update the endpoint API model to report that no redirect is
@@ -350,6 +352,21 @@ func (e *Endpoint) removeOldRedirects(desiredRedirects, realizedRedirects map[st
 			)
 		}
 		e.proxyStatisticsMutex.Unlock()
+	}
+
+	if len(staleRedirects) == 0 {
+		return
+	}
+
+	if waitForDrain {
+		if err := e.proxy.DrainRedirects(staleRedirects); err != nil {
+			e.getLogger().Warn("Failed to fully drain proxy redirects during endpoint teardown", logfields.Error, err)
+		}
+		return
+	}
+
+	for _, id := range staleRedirects {
+		e.proxy.RemoveRedirect(id)
 	}
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1250,12 +1250,12 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	e.desiredPolicy.Ready()
 	e.desiredPolicy.Detach(e.getLogger())
 	// Passing a new map of nil will purge all redirects
-	e.removeOldRedirects(nil, e.desiredPolicy.Redirects)
+	e.removeOldRedirects(nil, e.desiredPolicy.Redirects, true)
 
 	if e.realizedPolicy != e.desiredPolicy {
 		e.realizedPolicy.Detach(e.getLogger())
 		// Passing a new map of nil will purge all redirects
-		e.removeOldRedirects(nil, e.realizedPolicy.Redirects)
+		e.removeOldRedirects(nil, e.realizedPolicy.Redirects, true)
 	}
 
 	// Remove restored rules of cleaned endpoint

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -274,7 +274,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 			// At the point of this call, traffic is no longer redirected to the proxy
 			// for now-obsolete redirects, since we synced the updated policy map above.
 			// It's now safe to remove the redirects from the proxy's configuration.
-			e.removeOldRedirects(desiredRedirects, previousRedirects)
+			e.removeOldRedirects(desiredRedirects, previousRedirects, false)
 		})
 	}
 	e.runlock()

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -18,6 +18,7 @@ import (
 type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
+	DrainRedirects(ids []string) error
 	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
 	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
@@ -46,6 +47,11 @@ func (f *FakeEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 polic
 
 // RemoveRedirect does nothing.
 func (f *FakeEndpointProxy) RemoveRedirect(id string) {
+}
+
+// DrainRedirects does nothing.
+func (f *FakeEndpointProxy) DrainRedirects(ids []string) error {
+	return nil
 }
 
 // UpdateNetworkPolicy does nothing.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -17,6 +17,7 @@ import (
 	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
 	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
 	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
+	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -98,6 +99,7 @@ func setupRedirectSuite(tb testing.TB) *RedirectSuite {
 type RedirectSuiteProxy struct {
 	parserProxyPortMap map[string]uint16
 	redirects          map[string]uint16
+	callOrder          []string
 }
 
 // CreateOrUpdateRedirect returns the proxy port for the given L7Parser from the
@@ -110,7 +112,17 @@ func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 poli
 
 // RemoveRedirect removes a redirect from the map
 func (r *RedirectSuiteProxy) RemoveRedirect(id string) {
+	r.callOrder = append(r.callOrder, "remove-redirect")
 	delete(r.redirects, id)
+}
+
+// DrainRedirects removes redirects from the map and records the drain call.
+func (r *RedirectSuiteProxy) DrainRedirects(ids []string) error {
+	r.callOrder = append(r.callOrder, "drain-redirects")
+	for _, id := range ids {
+		delete(r.redirects, id)
+	}
+	return nil
 }
 
 // UpdateNetworkPolicy does nothing.
@@ -119,7 +131,9 @@ func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, po
 }
 
 // RemoveNetworkPolicy does nothing.
-func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {}
+func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
+	r.callOrder = append(r.callOrder, "remove-network-policy")
+}
 
 // UpdateSDP does nothing.
 func (r *RedirectSuiteProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
@@ -140,6 +154,12 @@ type DummyOwner struct {
 	repo  policy.PolicyRepository
 	idmgr identitymanager.IDManager
 }
+
+type fakeDNSRulesAPI struct{}
+
+func (fakeDNSRulesAPI) GetDNSRules(epID uint16) restore.DNSRules { return nil }
+
+func (fakeDNSRulesAPI) RemoveRestoredDNSRules(epID uint16) {}
 
 // GetNodeSuffix does nothing.
 func (d *DummyOwner) GetNodeSuffix() string {
@@ -185,7 +205,7 @@ func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
 	p := s.createTestEndpointParams(t)
 	p.KVStoreSynchronizer = kvstoreSync
-	ep, err := NewEndpointFromChangeModel(p, nil, s.rsp, model, nil)
+	ep, err := NewEndpointFromChangeModel(p, fakeDNSRulesAPI{}, s.rsp, model, nil)
 	require.NoError(t, err)
 
 	ep.Start(uint16(model.ID))
@@ -209,6 +229,24 @@ func (s *RedirectSuite) TearDownTest(t *testing.T) {
 	s.do.idmgr.RemoveAll()
 	s.mgr.Close()
 	policy.SetPolicyEnabled(s.oldPolicyEnable)
+}
+
+func TestLeaveLockedDrainsRedirectsBeforeRemovingNetworkPolicy(t *testing.T) {
+	s := setupRedirectSuite(t)
+	ep := s.NewTestEndpoint(t)
+
+	redirectID := policy.ProxyID(ep.ID, false, "TCP", 80, "")
+	ep.desiredPolicy.Redirects = map[string]uint16{redirectID: httpPort}
+	s.rsp.redirects[redirectID] = httpPort
+
+	ep.unconditionalLock()
+	ep.buildMutex.Lock()
+	errs := ep.leaveLocked(DeleteConfig{})
+	ep.buildMutex.Unlock()
+	ep.unlock()
+
+	require.Empty(t, errs)
+	require.Equal(t, []string{"drain-redirects", "remove-network-policy"}, s.rsp.callOrder)
 }
 
 var (

--- a/pkg/envoy/envoyadminclient.go
+++ b/pkg/envoy/envoyadminclient.go
@@ -11,11 +11,17 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/time"
 )
+
+const listenerDrainPollInterval = 100 * time.Millisecond
 
 type EnvoyAdminClient struct {
 	logger          *slog.Logger
@@ -36,8 +42,7 @@ func NewEnvoyAdminClientForSocket(logger *slog.Logger, envoySocketDir string, de
 	}
 }
 
-// Post sends a POST request with the given query to the Envoy Admin API.
-func (a *EnvoyAdminClient) Post(query string) (string, error) {
+func (a *EnvoyAdminClient) do(method, query string) (string, error) {
 	// Use a custom dialer to use a Unix domain socket for an HTTP connection.
 	var conn net.Conn
 	var err error
@@ -50,7 +55,12 @@ func (a *EnvoyAdminClient) Post(query string) (string, error) {
 		},
 	}
 
-	resp, err := client.Post(a.adminURL+query, "", nil)
+	req, err := http.NewRequestWithContext(context.Background(), method, a.adminURL+query, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +80,17 @@ func (a *EnvoyAdminClient) Post(query string) (string, error) {
 	return string(body), nil
 }
 
-// ChangeLogLevel changes Envoy log level to correspond to the specified 'level'.
+// Get sends a GET request with the given query to the Envoy Admin API.
+func (a *EnvoyAdminClient) Get(query string) (string, error) {
+	return a.do(http.MethodGet, query)
+}
+
+// Post sends a POST request with the given query to the Envoy Admin API.
+func (a *EnvoyAdminClient) Post(query string) (string, error) {
+	return a.do(http.MethodPost, query)
+}
+
+// ChangeLogLevel changes Envoy log level to correspond to the logrus log level 'level'.
 func (a *EnvoyAdminClient) ChangeLogLevel(agentLogLevel slog.Level) error {
 	envoyLevel := mapLogLevel(agentLogLevel, a.defaultLogLevel)
 
@@ -136,4 +156,94 @@ func (a *EnvoyAdminClient) GetEnvoyVersion() (string, error) {
 	}
 
 	return fmt.Sprintf("%s", version), nil
+}
+
+// WaitForListenerDrain waits until the named listener disappears from Envoy's listener list,
+// which indicates that the listener has fully drained and been removed.
+func (a *EnvoyAdminClient) WaitForListenerDrain(listenerName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		body, err := a.Get("listeners?format=json")
+		if err != nil {
+			return fmt.Errorf("failed to query listener state for %q: %w", listenerName, err)
+		}
+
+		active, err := listenerPresent(body, listenerName)
+		if err != nil {
+			return fmt.Errorf("failed to parse listener state for %q: %w", listenerName, err)
+		}
+		if !active {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			activeDownstream, err := a.getListenerDownstreamCxActive(listenerName)
+			if err != nil {
+				return fmt.Errorf("timed out waiting for listener %q to drain", listenerName)
+			}
+			return fmt.Errorf("timed out waiting for listener %q to drain: %d downstream connections still active", listenerName, activeDownstream)
+		}
+
+		time.Sleep(listenerDrainPollInterval)
+	}
+}
+
+// listenerPresent reports whether the named listener exists in Envoy's JSON
+// listener response.
+func listenerPresent(body string, listenerName string) (bool, error) {
+	var payload any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return false, err
+	}
+	return containsListenerName(payload, listenerName), nil
+}
+
+// containsListenerName recursively searches a decoded Envoy admin payload for a
+// matching listener name.
+func containsListenerName(v any, listenerName string) bool {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, child := range x {
+			if k == "name" {
+				if name, ok := child.(string); ok && name == listenerName {
+					return true
+				}
+			}
+			if containsListenerName(child, listenerName) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range x {
+			if containsListenerName(child, listenerName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (a *EnvoyAdminClient) getListenerDownstreamCxActive(listenerName string) (int, error) {
+	filter := "^listener\\." + regexp.QuoteMeta(listenerName) + "\\.downstream_cx_active$"
+	body, err := a.Get("stats?usedonly&filter=" + url.QueryEscape(filter))
+	if err != nil {
+		return 0, err
+	}
+
+	total := 0
+	for line := range strings.SplitSeq(body, "\n") {
+		line = strings.TrimSpace(line)
+		_, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse downstream connection count %q: %w", line, err)
+		}
+		total += n
+	}
+
+	return total, nil
 }

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/proxy/types"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // envoyRedirect implements the RedirectImplementation interface for an l7 proxy.
@@ -83,4 +84,12 @@ func (k *envoyRedirect) UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, 
 // Close the redirect.
 func (r *envoyRedirect) Close() {
 	r.xdsServer.RemoveListener(r.listenerName, nil)
+}
+
+// WaitForDrain waits for the Envoy listener backing this redirect to drain.
+func (r *envoyRedirect) WaitForDrain(timeout time.Duration) error {
+	if r.adminClient == nil {
+		return nil
+	}
+	return r.adminClient.WaitForListenerDrain(r.listenerName, timeout)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -33,7 +34,8 @@ const (
 	fieldProxyRedirectID = "id"
 
 	// redirectCreationAttempts is the number of attempts to create a redirect
-	redirectCreationAttempts = 5
+	redirectCreationAttempts  = 5
+	proxyRedirectDrainTimeout = 10 * time.Second
 )
 
 // Proxy maintains state about redirects
@@ -301,6 +303,41 @@ func (p *Proxy) RemoveRedirect(id string) {
 		p.mutex.Unlock()
 	}()
 	p.removeRedirect(id)
+}
+
+// DrainRedirects removes existing redirects and waits for Envoy listeners to drain
+// before returning. Missing redirects are ignored.
+func (p *Proxy) DrainRedirects(ids []string) error {
+	p.mutex.Lock()
+	impls := make([]RedirectImplementation, 0, len(ids))
+	for _, id := range ids {
+		impl, ok := p.redirects[id]
+		if !ok {
+			continue
+		}
+		delete(p.redirects, id)
+		impls = append(impls, impl)
+	}
+	p.updateRedirectMetrics()
+	p.mutex.Unlock()
+
+	var errs []error
+	for _, impl := range impls {
+		r := impl.GetRedirect()
+		impl.Close()
+
+		if drainer, ok := impl.(drainableRedirect); ok {
+			if err := drainer.WaitForDrain(proxyRedirectDrainTimeout); err != nil {
+				errs = append(errs, fmt.Errorf("draining proxy redirect %s failed: %w", r.name, err))
+			}
+		}
+
+		if err := p.proxyPorts.ReleaseProxyPort(r.name); err != nil {
+			errs = append(errs, fmt.Errorf("releasing proxy port for redirect %s failed: %w", r.name, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 // removeRedirect removes an existing redirect. p.mutex must be held

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
+	"github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -211,3 +213,53 @@ func (*fakeXdsServer) SetPolicySecretSyncNamespace(string) {
 }
 
 var _ envoy.XDSServer = &fakeXdsServer{}
+
+type fakeDrainableRedirect struct {
+	Redirect
+	closed  bool
+	drained bool
+}
+
+func (r *fakeDrainableRedirect) GetRedirect() *Redirect {
+	return &r.Redirect
+}
+
+func (r *fakeDrainableRedirect) UpdateRules(rules policy.L7DataMap) (revert.RevertFunc, error) {
+	return nil, nil
+}
+
+func (r *fakeDrainableRedirect) Close() {
+	r.closed = true
+}
+
+// WaitForDrain marks the redirect as drained for test assertions.
+func (r *fakeDrainableRedirect) WaitForDrain(timeout time.Duration) error {
+	r.drained = true
+	return nil
+}
+
+func TestDrainRedirectsWaitsForDrainableRedirects(t *testing.T) {
+	p := proxyForTest(t, nil)
+
+	const redirectName = "test-listener"
+
+	err := p.proxyPorts.SetProxyPort(redirectName, types.ProxyTypeCRD, 12345, false)
+	require.NoError(t, err)
+	name, pp := p.proxyPorts.FindByTypeWithReference(types.ProxyTypeCRD, redirectName, false)
+	require.Equal(t, redirectName, name)
+	require.NotNil(t, pp)
+
+	impl := &fakeDrainableRedirect{
+		Redirect: Redirect{
+			name:      redirectName,
+			proxyPort: pp,
+		},
+	}
+	p.redirects[redirectName] = impl
+
+	err = p.DrainRedirects([]string{redirectName})
+	require.NoError(t, err)
+	require.True(t, impl.closed)
+	require.True(t, impl.drained)
+	require.Empty(t, p.redirects)
+}

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -28,6 +29,12 @@ type RedirectImplementation interface {
 	// update is asynchronous and the update should not return until it is
 	// complete.
 	Close()
+}
+
+// drainableRedirect is an optional redirect capability for implementations
+// that can wait for in-flight proxy traffic to fully drain after Close.
+type drainableRedirect interface {
+	WaitForDrain(timeout time.Duration) error
 }
 
 // Redirect is the common static config for each RedirectImplementation


### PR DESCRIPTION
This fixes a race during endpoint deletion for endpoints with L7 proxy redirects.

During teardown, Cilium could remove the endpoint's proxy-backed network policy while the Envoy listener for a stale redirect was still draining. Late traffic could still reach the proxy during that window, but the policy state needed to handle it may already have been removed, resulting in DROP_EP_NOT_READY.

During endpoint teardown, stale redirects are now drained prior to to the removal of network policy.

Fixes: #41970


```release-note
endpoint: drain proxy redirects before removing network policy during teardown
```
