### PR TITLE
docs: Update docs-builder for Makefile usage

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -31,10 +31,12 @@ DOCS_BASE_IMG ?= cilium/docs-base
 base-image: Dockerfile ## Build the docs-base image for updating the requirements.txt file.
 	$(call build_image,$<,docs-base,$(DOCS_BASE_IMG))
 
-DOCS_BUILDER_IMG ?= cilium/docs-builder
+DOCS_BUILDER_IMG ?= quay.io/cilium/docs-builder:299b1b0619ca41010e1a3d930848cfbba6166df5@sha256:30b84cea76127ba89cf3aec9dc6cc2a7d81825e49957a59b648f8b26c414800b
+DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's#:.*##')
+
 ifndef SKIP_BUILDER_IMAGE
 builder-image: Dockerfile $(REQUIREMENTS) ## Build the docs-builder image for rendering and checking the documentation.
-	$(call build_image,$<,docs-builder,$(DOCS_BUILDER_IMG))
+	$(call build_image,$<,docs-builder,$(DOCS_BUILDER_REPO))
 else
 builder-image:
 	@echo "SKIP_BUILDER_IMAGE set, assuming image is already present and up-to-date."

--- a/Documentation/update-docs-builder-image.sh
+++ b/Documentation/update-docs-builder-image.sh
@@ -11,10 +11,15 @@ image_full=${1}
 image="${image_full%%:*}"
 root_dir="$(git rev-parse --show-toplevel)"
 
+usage_globs=(
+    ".github/workflows/"
+    "Documentation/Makefile"
+)
+
 cd "${root_dir}"
 
 # shellcheck disable=SC2207
-used_by=($(git grep -l "${image}:" .github/workflows/))
+used_by=($(git grep -l "${image}:" -- "${usage_globs[@]}"))
 
 for i in "${used_by[@]}" ; do
   sed -E "s#${image}:.*#${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"


### PR DESCRIPTION
When building and pushing a new quay.io/cilium/docs-builder image, we
should also update the reference to this image within the Makefile so
that developers don't pull an out-of-date docs-builder image.

Keep the same variable name `$DOCS_BUILDER_IMG` but set it to a specific
sha by default, so that the `update-docs-builder-image.sh` script will
update this reference as well. Create a new variable for use when
building the builder image, as that is used for tagging, and hence
shouldn't pull a specific sha.
