### PR TITLE
CODEOWNERS: Assign ztunnel workflows to ztunnel

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -267,6 +267,7 @@
 /.github/workflows/*ipsec*.yaml @cilium/ipsec @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*ingress*.yaml @cilium/sig-servicemesh @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*kpr*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure
+/.github/workflows/*ztunnel*.yaml @cilium/ztunnel @cilium/github-sec @cilium/ci-structure
 /.github/actions/cl2-modules/ @cilium/sig-scalability
 /.github/actions/cl2-modules/l7 @cilium/envoy @cilium/sig-scalability
 /.github/workflows/*scale*.yaml @cilium/sig-scalability @cilium/github-sec @cilium/ci-structure


### PR DESCRIPTION
@cilium/ztunnel is the team who owns quality for the ztunnel areas of the
codebase, so if this workflow fails then they should investigate.
