### PR TITLE
fix: handle CE out-of-order deletion in clustermesh

### DIFF
--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -51,47 +51,57 @@ type CachedConverter[T runtime.Object] struct {
 	mapper func(T) iter.Seq[store.Key]
 	// cache remembers the kvstore keys associated with any Kubernetes resource.
 	cache map[resource.Key]sets.Set[string]
+	// refCount tracks the number of resources referencing each kvstore key.
+	refCount map[string]int
 }
 
 func NewCachedCoverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
 	return &CachedConverter[T]{
-		mapper: mapper,
-		cache:  make(map[resource.Key]sets.Set[string]),
+		mapper:   mapper,
+		cache:    make(map[resource.Key]sets.Set[string]),
+		refCount: make(map[string]int),
 	}
 }
 
 func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
-	if event.Kind == resource.Delete {
-		toDelete := maps.Keys(ec.cache[event.Key])
+	toDelete := ec.cache[event.Key]
+	if toDelete == nil {
+		toDelete = sets.New[string]()
+	}
+	var toAdd []store.Key
+
+	if event.Kind != resource.Delete {
+		var current = sets.New[string]()
+		for entry := range ec.mapper(event.Object) {
+			key := entry.GetKeyName()
+			toAdd = append(toAdd, entry)
+
+			if !current.Has(key) {
+				if !toDelete.Has(key) {
+					ec.refCount[key]++
+				}
+				current.Insert(key)
+			}
+			toDelete.Delete(key)
+		}
+		ec.cache[event.Key] = current
+	} else {
 		delete(ec.cache, event.Key)
-		return noneIter[store.Key], ec.deletesIter(toDelete)
 	}
 
-	var (
-		toAdd    []store.Key
-		toDelete = ec.cache[event.Key]
-		current  = sets.New[string]()
-	)
-
-	for entry := range ec.mapper(event.Object) {
-		key := entry.GetKeyName()
-		toAdd = append(toAdd, entry)
-		current.Insert(key)
-		toDelete.Delete(key)
-	}
-
-	ec.cache[event.Key] = current
-	return slices.Values(toAdd), ec.deletesIter(maps.Keys(toDelete))
-}
-
-func (ec *CachedConverter[T]) deletesIter(keys iter.Seq[string]) iter.Seq[store.NamedKey] {
-	return func(yield func(store.NamedKey) bool) {
-		for key := range keys {
-			if !yield(store.NewKVPair(key, "")) {
-				return
+	deleteIter := func(yield func(store.NamedKey) bool) {
+		for entry := range maps.Keys(toDelete) {
+			ec.refCount[entry]--
+			if ec.refCount[entry] == 0 {
+				delete(ec.refCount, entry)
+				if !yield(store.NewKVPair(entry, "")) {
+					return
+				}
 			}
 		}
 	}
+
+	return slices.Values(toAdd), deleteIter
 }
 
 // ----- CiliumNodes ----- //

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"path"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -40,6 +41,55 @@ func singleIter[T any](value T) iter.Seq[T] {
 	}
 }
 
+type resourceOwner struct {
+	owner resource.Key
+	entry store.Key
+}
+
+// entryGroup tracks all Kubernetes resources claiming a given kvstore key.
+// It is optimized for the common case where a key is owned by a single resource.
+type entryGroup struct {
+	primary resource.Key
+	pending []resourceOwner
+}
+
+func (e *entryGroup) upsert(owner resource.Key, entry store.Key) (primary bool) {
+	if e.primary == (resource.Key{}) || e.primary == owner {
+		e.primary = owner
+		return true
+	}
+
+	if i := slices.IndexFunc(e.pending, func(ro resourceOwner) bool { return ro.owner == owner }); i >= 0 {
+		e.pending[i].entry = entry
+		return false
+	}
+
+	e.pending = append(e.pending, resourceOwner{owner: owner, entry: entry})
+	return false
+}
+
+func (e *entryGroup) release(owner resource.Key) store.Key {
+	if e.primary == owner {
+		if len(e.pending) > 0 {
+			next := e.pending[0]
+			e.primary = next.owner
+			e.pending = e.pending[1:]
+			return next.entry
+		}
+		e.primary = resource.Key{}
+		return nil
+	}
+
+	e.pending = slices.DeleteFunc(e.pending, func(ro resourceOwner) bool {
+		return ro.owner == owner
+	})
+	return nil
+}
+
+func (e *entryGroup) empty() bool {
+	return e.primary == (resource.Key{})
+}
+
 // ----- Generic ----- //
 
 // CachedConverter implements the common logic of a converter that, given a single
@@ -49,83 +99,61 @@ type CachedConverter[T runtime.Object] struct {
 	mapper func(T) iter.Seq[store.Key]
 	// cache remembers the kvstore keys associated with any Kubernetes resource.
 	cache map[resource.Key]sets.Set[string]
-	// ownership tracks the entries proposed by each resource for each kvstore key.
-	ownership map[string]map[resource.Key]store.Key
+	// ownership tracks all Kubernetes resources claiming a given kvstore key.
+	ownership map[string]*entryGroup
 }
 
-func NewCachedCoverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
+func NewCachedConverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
 	return &CachedConverter[T]{
 		mapper:    mapper,
 		cache:     make(map[resource.Key]sets.Set[string]),
-		ownership: make(map[string]map[resource.Key]store.Key),
+		ownership: make(map[string]*entryGroup),
 	}
 }
 
 func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
-	toDelete := ec.cache[event.Key]
+	stale := ec.cache[event.Key]
 	var toAdd []store.Key
 
-	if event.Kind != resource.Delete {
+	if event.Kind == resource.Upsert {
 		current := sets.New[string]()
 		for entry := range ec.mapper(event.Object) {
 			key := entry.GetKeyName()
-			toAdd = append(toAdd, entry)
 			current.Insert(key)
 
-			ownerMap, ok := ec.ownership[key]
+			group, ok := ec.ownership[key]
 			if !ok {
-				ownerMap = make(map[resource.Key]store.Key)
-				ec.ownership[key] = ownerMap
+				group = &entryGroup{}
+				ec.ownership[key] = group
 			}
-			ownerMap[event.Key] = entry
-			toDelete.Delete(key)
+			if group.upsert(event.Key, entry) {
+				toAdd = append(toAdd, entry)
+			}
+			stale.Delete(key)
 		}
 		ec.cache[event.Key] = current
 	} else {
 		delete(ec.cache, event.Key)
 	}
 
+	var toDelete []store.NamedKey
 	// For each key scheduled for deletion, make sure the resource from the event
 	// is removed as an owner of that key.
-	for keyName := range toDelete {
-		delete(ec.ownership[keyName], event.Key)
-	}
-
-	upsertIter := func(yield func(store.Key) bool) {
-		// Fresh updates from this event
-		for _, entry := range toAdd {
-			if !yield(entry) {
-				return
-			}
+	for keyName := range stale {
+		group := ec.ownership[keyName]
+		if entry := group.release(event.Key); entry != nil {
+			// if the primary owner is removed, but other resources still own the key,
+			// we must re-upsert the entry of the new primary owner.
+			toAdd = append(toAdd, entry)
 		}
-		// if a key is marked for deletion but other resources still own the key,
-		// we must re-upsert one of the other owner's values to ensure kvstore is
-		// correct.
-		for keyName := range toDelete {
-			if ownerMap := ec.ownership[keyName]; len(ownerMap) > 0 {
-				for _, entry := range ownerMap {
-					if !yield(entry) {
-						return
-					}
-					break
-				}
-			}
+
+		if group.empty() {
+			delete(ec.ownership, keyName)
+			toDelete = append(toDelete, store.NewKVPair(keyName, ""))
 		}
 	}
 
-	// only delete the key from the kvstore if no resource owns the key.
-	deleteIter := func(yield func(store.NamedKey) bool) {
-		for keyName := range toDelete {
-			if len(ec.ownership[keyName]) == 0 {
-				delete(ec.ownership, keyName)
-				if !yield(store.NewKVPair(keyName, "")) {
-					return
-				}
-			}
-		}
-	}
-
-	return upsertIter, deleteIter
+	return slices.Values(toAdd), slices.Values(toDelete)
 }
 
 // ----- CiliumNodes ----- //
@@ -211,7 +239,7 @@ func newCiliumEndpointOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[*type
 }
 
 func newCiliumEndpointConverter(logger *slog.Logger, cinfo cmtypes.ClusterInfo) Converter[*types.CiliumEndpoint] {
-	return NewCachedCoverter(ciliumEndpointMapper)
+	return NewCachedConverter(ciliumEndpointMapper)
 }
 
 func ciliumEndpointMapper(endpoint *types.CiliumEndpoint) iter.Seq[store.Key] {
@@ -258,7 +286,7 @@ func newCiliumEndpointSliceOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[
 }
 
 func newCiliumEndpointSliceConverter(logger *slog.Logger, cinfo cmtypes.ClusterInfo) Converter[*cilium_api_v2a1.CiliumEndpointSlice] {
-	return NewCachedCoverter(ciliumEndpointSliceMapper)
+	return NewCachedConverter(ciliumEndpointSliceMapper)
 }
 
 func ciliumEndpointSliceMapper(endpointslice *cilium_api_v2a1.CiliumEndpointSlice) iter.Seq[store.Key] {

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -7,10 +7,8 @@ import (
 	"errors"
 	"iter"
 	"log/slog"
-	"maps"
 	"net"
 	"path"
-	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -51,37 +49,35 @@ type CachedConverter[T runtime.Object] struct {
 	mapper func(T) iter.Seq[store.Key]
 	// cache remembers the kvstore keys associated with any Kubernetes resource.
 	cache map[resource.Key]sets.Set[string]
-	// refCount tracks the number of resources referencing each kvstore key.
-	refCount map[string]int
+	// ownership tracks the entries proposed by each resource for each kvstore key.
+	ownership map[string]map[resource.Key]store.Key
 }
 
 func NewCachedCoverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
 	return &CachedConverter[T]{
-		mapper:   mapper,
-		cache:    make(map[resource.Key]sets.Set[string]),
-		refCount: make(map[string]int),
+		mapper:    mapper,
+		cache:     make(map[resource.Key]sets.Set[string]),
+		ownership: make(map[string]map[resource.Key]store.Key),
 	}
 }
 
 func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
 	toDelete := ec.cache[event.Key]
-	if toDelete == nil {
-		toDelete = sets.New[string]()
-	}
 	var toAdd []store.Key
 
 	if event.Kind != resource.Delete {
-		var current = sets.New[string]()
+		current := sets.New[string]()
 		for entry := range ec.mapper(event.Object) {
 			key := entry.GetKeyName()
 			toAdd = append(toAdd, entry)
+			current.Insert(key)
 
-			if !current.Has(key) {
-				if !toDelete.Has(key) {
-					ec.refCount[key]++
-				}
-				current.Insert(key)
+			ownerMap, ok := ec.ownership[key]
+			if !ok {
+				ownerMap = make(map[resource.Key]store.Key)
+				ec.ownership[key] = ownerMap
 			}
+			ownerMap[event.Key] = entry
 			toDelete.Delete(key)
 		}
 		ec.cache[event.Key] = current
@@ -89,19 +85,47 @@ func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq
 		delete(ec.cache, event.Key)
 	}
 
+	// For each key scheduled for deletion, make sure the resource from the event
+	// is removed as an owner of that key.
+	for keyName := range toDelete {
+		delete(ec.ownership[keyName], event.Key)
+	}
+
+	upsertIter := func(yield func(store.Key) bool) {
+		// Fresh updates from this event
+		for _, entry := range toAdd {
+			if !yield(entry) {
+				return
+			}
+		}
+		// if a key is marked for deletion but other resources still own the key,
+		// we must re-upsert one of the other owner's values to ensure kvstore is
+		// correct.
+		for keyName := range toDelete {
+			if ownerMap := ec.ownership[keyName]; len(ownerMap) > 0 {
+				for _, entry := range ownerMap {
+					if !yield(entry) {
+						return
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// only delete the key from the kvstore if no resource owns the key.
 	deleteIter := func(yield func(store.NamedKey) bool) {
-		for entry := range maps.Keys(toDelete) {
-			ec.refCount[entry]--
-			if ec.refCount[entry] == 0 {
-				delete(ec.refCount, entry)
-				if !yield(store.NewKVPair(entry, "")) {
+		for keyName := range toDelete {
+			if len(ec.ownership[keyName]) == 0 {
+				delete(ec.ownership, keyName)
+				if !yield(store.NewKVPair(keyName, "")) {
 					return
 				}
 			}
 		}
 	}
 
-	return slices.Values(toAdd), deleteIter
+	return upsertIter, deleteIter
 }
 
 // ----- CiliumNodes ----- //

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -44,53 +44,54 @@ kvstore/list -o json cilium/state/ip ips-1+3.actual
 # Add one more CiliumEndpoint; the IPv4 address overlaps with that of endpoint-3
 k8s/add endpoint-4.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
-# to that of endpoint-4
-kvstore/list -o json cilium/state/ip ips-1+3+4.actual
-* cmp ips-1+3+4.actual ips-1+3+4.expected
+# Wait for synchronization. The entry for the IP of endpoint-3 should be preserved
+# as the primary entry.
+kvstore/list -o json cilium/state/ip ips-1+4+3.actual
+* cmp ips-1+4+3.actual ips-1+4+3.expected
 
 # Delete endpoint-4.
 k8s/delete endpoint-4.yaml
 
-# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+# Wait for synchronization. The entry for endpoint-3 remains the primary entry.
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 
 # Add endpoint-4 again
 k8s/add endpoint-4.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
-# to that of endpoint-4
-kvstore/list -o json cilium/state/ip ips-1+3+4.actual
-* cmp ips-1+3+4.actual ips-1+3+4.expected
+# Wait for synchronization. The entry for the IP of endpoint-3 should be preserved
+# as the primary entry.
+kvstore/list -o json cilium/state/ip ips-1+4+3.actual
+* cmp ips-1+4+3.actual ips-1+4+3.expected
 
 # Delete endpoint-3.
 k8s/delete endpoint-3.yaml
 
-# Wait for synchronization. The entry for endpoint-4 should be preserved after endpoint-3 is deleted.
+# Wait for synchronization. The entry for endpoint-4 should become the primary entry
+# after endpoint-3 is deleted.
 kvstore/list -o json cilium/state/ip ips-1+4.actual
 * cmp ips-1+4.actual ips-1+4.expected
 
 # Add endpoint-3 again
 k8s/add endpoint-3.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-4 should be updated
-# to that of endpoint-3.
+# Wait for synchronization. The entry for the IP of endpoint-4 should be preserved
+# as the primary entry
 kvstore/list -o json cilium/state/ip ips-1+3+4.actual
-* cmp ips-1+3+4.actual ips-1+4+3.expected
+* cmp ips-1+3+4.actual ips-1+3+4.expected
 
 # Trigger an update for endpoint-4
 k8s/update endpoint-4.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
-# to that of endpoint-4.
+# Wait for synchronization. The entry for the IP of endpoint-4 should be updated.
 kvstore/list -o json cilium/state/ip ips-1+3+4.actual
 * cmp ips-1+3+4.actual ips-1+3+4.expected
 
 # Delete endpoint-4.
 k8s/delete endpoint-4.yaml
 
-# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+# Wait for synchronization. The entry for endpoint-3 should become the primary entry
+# after endpoint-4 is deleted.
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -41,6 +41,27 @@ k8s/delete endpoint-2.yaml
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 
+# Add one more CiliumEndpoint; the IPv4 address overlaps with that of endpoint-3
+k8s/add endpoint-4.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+3+4.expected
+
+# Delete endpoint-3. The entry for endpoint-4 should be preserved
+k8s/delete endpoint-3.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+4.actual
+* cmp ips-1+4.actual ips-1+4.expected
+
+# Delete endpoint-4. No entry for the ip should exist anymore
+k8s/delete endpoint-4.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1.actual
+* cmp ips-1.actual ips-1.expected
+
 # Annotate namespace-1 as non-global
 k8s/update namespace-1-annotated.yaml
 
@@ -129,6 +150,26 @@ status:
     - ipv4: 10.244.2.91
       ipv6: fd00:10:244:2::e4b4
     node: 172.18.0.2
+  service-account: default
+  state: ready
+
+-- endpoint-4.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-004
+  namespace: foo
+status:
+  id: 1484
+  identity:
+    id: 199479
+    labels:
+    - k8s:app=foo
+  networking:
+    addressing:
+    - ipv4: 10.244.2.91
+      ipv6: fd00:10:244:2::e4b5
+    node: 172.18.0.3
   service-account: default
   state: ready
 
@@ -314,5 +355,153 @@ status:
   "Metadata": "",
   "K8sNamespace": "foo",
   "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+3+4.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b5
+{
+  "IP": "fd00:10:244:2::e4b5",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+3+4-bis.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b5
+{
+  "IP": "fd00:10:244:2::e4b5",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+4.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b5
+{
+  "IP": "fd00:10:244:2::e4b5",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+-- ips-1.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
   "K8sServiceAccount": "default"
 }

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -44,21 +44,60 @@ kvstore/list -o json cilium/state/ip ips-1+3.actual
 # Add one more CiliumEndpoint; the IPv4 address overlaps with that of endpoint-3
 k8s/add endpoint-4.yaml
 
-# Wait for synchronization
+# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
+# to that of endpoint-4
 kvstore/list -o json cilium/state/ip ips-1+3+4.actual
 * cmp ips-1+3+4.actual ips-1+3+4.expected
 
-# Delete endpoint-3. The entry for endpoint-4 should be preserved
+# Delete endpoint-4.
+k8s/delete endpoint-4.yaml
+
+# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# Add endpoint-4 again
+k8s/add endpoint-4.yaml
+
+# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
+# to that of endpoint-4
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+3+4.expected
+
+# Delete endpoint-3.
 k8s/delete endpoint-3.yaml
 
-# Wait for synchronization
+# Wait for synchronization. The entry for endpoint-4 should be preserved after endpoint-3 is deleted.
 kvstore/list -o json cilium/state/ip ips-1+4.actual
 * cmp ips-1+4.actual ips-1+4.expected
 
-# Delete endpoint-4. No entry for the ip should exist anymore
+# Add endpoint-3 again
+k8s/add endpoint-3.yaml
+
+# Wait for synchronization. The entry for the IP of endpoint-4 should be updated
+# to that of endpoint-3.
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+4+3.expected
+
+# Trigger an update for endpoint-4
+k8s/update endpoint-4.yaml
+
+# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
+# to that of endpoint-4.
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+3+4.expected
+
+# Delete endpoint-4.
 k8s/delete endpoint-4.yaml
 
-# Wait for synchronization
+# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# Delete endpoint-3.
+k8s/delete endpoint-3.yaml
+
+# Wait for synchronization. No entry for the IP of endpoint-3 should exist anymore.
 kvstore/list -o json cilium/state/ip ips-1.actual
 * cmp ips-1.actual ips-1.expected
 
@@ -406,7 +445,7 @@ status:
   "K8sPodName": "cep-004",
   "K8sServiceAccount": "default"
 }
--- ips-1+3+4-bis.expected --
+-- ips-1+4+3.expected --
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",


### PR DESCRIPTION
In the clustermesh package, modify the CachedConverter struct to add a concept of IP ownership, where the key is IP and value is the ciliumEndpoints that are using it.

On a CE delete event, only delete the kvstore entry for an IP if no CiliumEndpoints are using it. 
On an update event, make sure to not delete a stale kvstore entry if the IP is being used by another ciliumendpoint. 

Tested with increased coverage in script test:
```
go test -v ./clustermesh-apiserver/clustermesh/ -run TestScript/ciliumendpoints.txtar
```
and with manual check with kind:
```
make kind-clustermesh
make kind-clustermesh-images
make kind-install-cilium-clustermesh
```
Then, run a script that adds a pod `pod-a`, adds a finalizer on the corresponding CiliumEndpoint, then deletes `pod-a`. Then, create a `pod-b` again and again until it has the same IP as `pod-a`. Finally, remove the finalizer so that the CiliumEndpoint for `pod-a` is deleted. This effectively reproduces the ADD ADD DELETE sequence of events for CiliumEndpoints that reference the same IP.

Before the change, the clustermesh-apiserver etcd did not have an entry for the IP. After, it does:
```
cilium/state/ip/v1/default/10.1.0.19
{"IP":"10.1.0.19","Mask":null,"HostIP":"192.168.10.3","ID":78446,"Key":0,"Metadata":"","K8sNamespace":"default","K8sPodName":"pod-b","K8sServiceAccount":"default"}
```

Fixes: #44020

```release-note
Fix a rare bug in clustermesh-apiserver that triggers incorrect deletion of a valid endpoint entry from the etcd under high pod churn
```