### PR TITLE
policy: Add error logging when parsing invalid CIDRs in `GetAsEndpointSelectors`

### DIFF
--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -91,7 +91,6 @@ func (s CIDRSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 		if err == nil {
 			slice = append(slice, NewESFromLabels(lbl))
 		}
-		// TODO: Log the error?
 	}
 
 	return slice


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->
This PR addresses a `TODO` in `pkg/policy/api/cidr.go` regarding invalid CIDR parsing. 
Previously, invalid CIDRs were silently dropped when converting to `EndpointSelector`.
To provide better visibility without polluting the dependency tree of the `api` package, this PR introduces warning logs using the Go standard library `log/slog`. 
Since `pkg/policy/api` is widely imported by external consumers (e.g., custom operators or third-party tools), using standard `log/slog` avoids forcing downstream users to pull in internal Cilium dependencies (like `pkg/logging`).

### Changes:
* Added standard `log/slog` to emit warnings on CIDR parsing failures.
* Avoided internal `pkg/logging` dependencies to maintain a zero-dependency API package.

**Testing Performed:**
Successfully ran unit tests for the modified package:

```text
$ go test -v ./pkg/policy/api/...
...
=== RUN   TestParseQualifiedName
--- PASS: TestParseQualifiedName (0.00s)
PASS
ok  	github.com/cilium/cilium/pkg/policy/api	0.374s
```

This PR was prepared with AIL:3. Also, I personally reviewed each line of the submission prior to opening this PR.