### PR TITLE
fix: nil pointer dereference panic due to uninitialized logger

### DIFF
--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -55,6 +55,7 @@ func RegisterReflector[Obj any](jobGroup job.Group, db *statedb.DB, cfg Reflecto
 		db:              db,
 		table:           targetTable,
 		source:          source,
+		log:             slog.Default(),
 	}
 	wtxn := db.WriteTxn(targetTable)
 	r.initDone = targetTable.RegisterInitializer(wtxn, r.ReflectorConfig.Name)


### PR DESCRIPTION
## scenario: 
As described in issue #45758 , rapidly creating and deleting Gateway API resources (Gateway, xRoutes, Services, Pods) across multiple test scenarios . When commitBuffer encounters an error during table operations (Insert/Modify/Delete), it calls r.log.Error() to log the BUG-level error.                                               
                                                                                                                                                                           
panic: runtime error: invalid memory address or nil pointer dereference , crashing the cilium-agent.                      
                                                                                                                                                                        
                                                                                                                                                                        
## Root cause: 
RegisterReflector  creates a k8sReflector struct without initializing the log *slog.Logger field . Since the field is   
  never set, it remains nil. When commitBuffer tries to call r.log.Error(...), it dereferences a nil pointer and panics.                                                
                                                                                                                                                                          
