### PR TITLE
Miscellaneous improvements to the fake client 

### DIFF
--- a/clustermesh-apiserver/mcsapi-coredns-cfg/testdata/configure.txtar
+++ b/clustermesh-apiserver/mcsapi-coredns-cfg/testdata/configure.txtar
@@ -30,8 +30,6 @@ metadata:
     k8s-app: kube-dns
   name: coredns
   namespace: kube-system
-  resourceVersion: "408"
-  uid: af12a0f4-1bc0-4e5e-a03d-3cdf981433d2
 spec:
   progressDeadlineSeconds: 600
   replicas: 2
@@ -175,8 +173,6 @@ metadata:
   creationTimestamp: "2025-07-19T20:31:47Z"
   name: coredns
   namespace: kube-system
-  resourceVersion: "491"
-  uid: ce89078b-0a1a-4bce-a61f-1c65d374c1d5
 
 -- configmap-expected.yaml --
 apiVersion: v1
@@ -237,5 +233,3 @@ metadata:
   creationTimestamp: "2025-07-19T20:31:47Z"
   name: coredns
   namespace: kube-system
-  resourceVersion: "3"
-  uid: ce89078b-0a1a-4bce-a61f-1c65d374c1d5

--- a/pkg/ipam/podippool/testdata/podippool.txtar
+++ b/pkg/ipam/podippool/testdata/podippool.txtar
@@ -42,6 +42,7 @@ pool1
   "apiVersion": "cilium.io/v2alpha1",
   "metadata": {
     "name": "pool1",
+    "uid": "7945af14-84a1-4822-9986-a009ce90f178",
     "resourceVersion": "1",
     "annotations": {
       "ipam.cilium.io/skip-masquerade": "true"
@@ -73,7 +74,7 @@ ciliumpodippool:
         generatename: ""
         namespace: ""
         selflink: ""
-        uid: ""
+        uid: 7945af14-84a1-4822-9986-a009ce90f178
         resourceversion: "1"
         generation: 0
         creationtimestamp: "0001-01-01T00:00:00Z"
@@ -104,6 +105,7 @@ metadata:
   name: pool1
   annotations:
     ipam.cilium.io/skip-masquerade: "true"
+  uid: "7945af14-84a1-4822-9986-a009ce90f178"
 spec:
   ipv4:
     cidrs:

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -225,11 +225,75 @@ type prepender interface {
 }
 
 func prependReactors(cs prepender, ot k8sTesting.ObjectTracker) {
-	cs.PrependReactor("*", "*", k8sTesting.ObjectReaction(ot))
+	cs.PrependReactor("*", "*", reactorFunc(ot))
 	cs.PrependWatchReactor("*", watchReactorFunc(ot))
 
 	// Switch out the tracker to our version.
 	overrideTracker(cs, ot)
+}
+
+func reactorFunc(ot k8sTesting.ObjectTracker) k8sTesting.ReactionFunc {
+	var reactor = k8sTesting.ObjectReaction(ot)
+
+	return func(act k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch action := act.(type) {
+		case k8sTesting.UpdateActionImpl:
+			if action.Subresource != "" {
+				act, err = subresourceMutator(action, ot)
+				if err != nil {
+					return true, nil, err
+				}
+			}
+		}
+
+		return reactor(act)
+	}
+}
+
+func subresourceMutator(action k8sTesting.UpdateActionImpl, ot k8sTesting.ObjectTracker) (k8sTesting.Action, error) {
+	var copy = func(dst, src runtime.Object, field string) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("setting %s: %v", strings.ToLower(field), r)
+			}
+		}()
+
+		reflect.ValueOf(dst).Elem().FieldByName(field).Set(
+			reflect.ValueOf(src).Elem().FieldByName(field))
+
+		return nil
+	}
+
+	ns, gvr := action.GetNamespace(), action.GetResource()
+	objMeta, err := meta.Accessor(action.GetObject())
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := ot.Get(gvr, ns, objMeta.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	switch action.GetSubresource() {
+	case "status":
+		err = errors.Join(
+			copy(obj, action.GetObject(), "Status"),
+			// Preserve the resource version, to handle optimistic concurrency.
+			copy(obj, action.GetObject(), "ResourceVersion"),
+		)
+	default:
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sTesting.UpdateActionImpl{
+		ActionImpl:    action.ActionImpl.DeepCopy().(k8sTesting.ActionImpl),
+		Object:        obj,
+		UpdateOptions: action.UpdateOptions,
+	}, nil
 }
 
 func watchReactorFunc(ot k8sTesting.ObjectTracker) k8sTesting.WatchReactionFunc {

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -448,6 +448,7 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 				Args: "resource name",
 				Flags: func(fs *pflag.FlagSet) {
 					fs.StringP("out", "o", "", "File to write to instead of stdout")
+					fs.StringSlice("show-redacted", nil, "Redacted fields to show (supported: resource-version, uid)")
 				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
@@ -479,6 +480,10 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					for _, tc := range fc.trackers {
 						obj, err := tc.tracker.Get(gvr, ns, name)
 						if err == nil {
+							if err := redact(obj, s.Flags); err != nil {
+								return "", "", fmt.Errorf("redacting fields: %w", err)
+							}
+
 							bs, err := k8sYaml.Marshal(obj)
 							if file != "" {
 								return "", "", os.WriteFile(s.Path(file), bs, 0644)
@@ -502,6 +507,7 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 				Args: "resource namespace",
 				Flags: func(fs *pflag.FlagSet) {
 					fs.StringP("out", "o", "", "File to write to instead of stdout")
+					fs.StringSlice("show-redacted", nil, "Redacted fields to show (supported: resource-version, uid)")
 				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
@@ -527,6 +533,10 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					for _, tc := range fc.trackers {
 						obj, err := tc.tracker.List(gvr, gvk, args[1])
 						if err == nil {
+							if err := redact(obj, s.Flags); err != nil {
+								return "", "", fmt.Errorf("redacting fields: %w", err)
+							}
+
 							bs, err := k8sYaml.Marshal(obj)
 							if file != "" {
 								return "", "", os.WriteFile(s.Path(file), bs, 0644)
@@ -639,6 +649,42 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 			},
 		),
 	}
+}
+
+// redact redacts the UID and resource version fields, to make the output more deterministic.
+func redact(obj runtime.Object, flags *pflag.FlagSet) error {
+	show, err := flags.GetStringSlice("show-redacted")
+	if err != nil {
+		return err
+	}
+
+	redactObj := func(obj runtime.Object) error {
+		meta, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+
+		if !slices.Contains(show, "resource-version") {
+			meta.SetResourceVersion("")
+		}
+
+		if !slices.Contains(show, "uid") {
+			meta.SetUID("")
+		}
+
+		return nil
+	}
+
+	list, err := meta.ListAccessor(obj)
+	if err != nil {
+		return redactObj(obj)
+	}
+
+	if !slices.Contains(show, "resource-version") {
+		list.SetResourceVersion("")
+	}
+
+	return meta.EachListItem(obj, redactObj)
 }
 
 // overrideTracker changes the internal 'tracker' field in the generated

--- a/pkg/k8s/client/testutils/object_tracker.go
+++ b/pkg/k8s/client/testutils/object_tracker.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
+	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -357,6 +358,9 @@ func (s *statedbObjectTracker) Add(obj runtime.Object) error {
 
 	version := s.tbl.Revision(wtxn) + 1
 	objMeta.SetResourceVersion(strconv.FormatUint(version, 10))
+	if objMeta.GetUID() == "" {
+		objMeta.SetUID(types.UID(uuid.NewString()))
+	}
 
 	gvks, _, err := s.scheme.ObjectKinds(obj)
 	if err != nil {
@@ -485,6 +489,10 @@ func (s *statedbObjectTracker) Create(gvr schema.GroupVersionResource, obj runti
 	wtxn := s.db.WriteTxn(s.tbl)
 	version := s.tbl.Revision(wtxn) + 1
 	newMeta.SetResourceVersion(strconv.FormatUint(version, 10))
+	if newMeta.GetUID() == "" {
+		newMeta.SetUID(types.UID(uuid.NewString()))
+	}
+
 	old, found, _ := s.tbl.Insert(wtxn, object{
 		objectId: newObjectId(s.domain, gvr, ns, newMeta.GetName()),
 		o:        obj,
@@ -670,18 +678,13 @@ func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersio
 	defer wtxn.Abort()
 
 	version := s.tbl.Revision(wtxn) + 1
-
-	newRV := newMeta.GetResourceVersion()
-	newMeta.SetResourceVersion(strconv.FormatUint(version, 10))
-
 	log := s.log.With(
 		logfieldClientset, s.domain,
 		logfields.Object, obj,
 		logfieldResourceVersion, version)
 
-	oldObj, found, _ := s.tbl.Insert(wtxn,
-		object{objectId: newObjectId(s.domain, gvr, ns, newMeta.GetName()), o: obj, kind: gvk.Kind},
-	)
+	var oid = newObjectId(s.domain, gvr, ns, newMeta.GetName())
+	oldObj, _, found := s.tbl.Get(wtxn, objectIndex.Query(oid))
 	if !found || oldObj.deleted {
 		gr := gvr.GroupResource()
 		err := apierrors.NewNotFound(gr, newMeta.GetName())
@@ -696,6 +699,7 @@ func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersio
 	}
 
 	oldRV := oldMeta.GetResourceVersion()
+	newRV := newMeta.GetResourceVersion()
 	if checkConflict && oldRV != newRV {
 		err = apierrors.NewConflict(gvr.GroupResource(), newMeta.GetName(),
 			fmt.Errorf("the object has been modified; resource version mismatch, current %q, got %q", oldRV, newRV),
@@ -703,6 +707,10 @@ func (s *statedbObjectTracker) updateOrPatch(what string, gvr schema.GroupVersio
 		s.log.Debug(what, logfields.Error, err)
 		return err
 	}
+
+	newMeta.SetResourceVersion(strconv.FormatUint(version, 10))
+	newMeta.SetUID(oldMeta.GetUID())
+	s.tbl.Insert(wtxn, object{objectId: oid, o: obj, kind: gvk.Kind})
 
 	wtxn.Commit()
 	log.Debug(what)

--- a/pkg/k8s/client/testutils/script_test.go
+++ b/pkg/k8s/client/testutils/script_test.go
@@ -5,10 +5,12 @@ package testutils
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"maps"
 	"testing"
 
+	uhive "github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/hive/script"
@@ -20,6 +22,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -47,6 +51,34 @@ func TestScript(t *testing.T) {
 						metav1.CreateOptions{},
 					)
 					return err
+				}),
+
+				cell.Provide(func(cs *FakeClientset) uhive.ScriptCmdOut {
+					return uhive.NewScriptCmd("k8s/svc/update-status", script.Command(
+						script.CmdUsage{
+							Summary: "Invoke [Services.UpdateStatus]",
+							Args:    "file",
+						},
+						func(s *script.State, args ...string) (script.WaitFunc, error) {
+							if len(args) != 1 {
+								return nil, script.ErrUsage
+							}
+
+							obj, err := testutils.DecodeFile(s.Path(args[0]))
+							if err != nil {
+								return nil, fmt.Errorf("reading %s: %w", args[0], err)
+							}
+
+							svc, ok := obj.(*slimcorev1.Service)
+							if !ok {
+								return nil, fmt.Errorf("reading %s: not a slim service (%T)", args[0], svc)
+							}
+
+							_, err = cs.SlimFakeClientset.CoreV1().Services(svc.Namespace).
+								UpdateStatus(s.Context(), svc, metav1.UpdateOptions{})
+							return nil, err
+						},
+					))
 				}),
 			)
 			flags := pflag.NewFlagSet("", pflag.ContinueOnError)

--- a/pkg/k8s/client/testutils/testdata/conflicts.txtar
+++ b/pkg/k8s/client/testutils/testdata/conflicts.txtar
@@ -13,7 +13,7 @@ k8s/update service.v2.yaml
 ! k8s/update --strict service.v2.yaml
 
 # Updates in strict mode shall succeed if the resource version does match.
-k8s/get v1.services test/echo -o service.v3.yaml
+k8s/get v1.services test/echo --show-redacted=resource-version -o service.v3.yaml
 replace 10.96.1.2 10.96.1.3 service.v3.yaml
 k8s/update --strict service.v3.yaml
 

--- a/pkg/k8s/client/testutils/testdata/redact.txtar
+++ b/pkg/k8s/client/testutils/testdata/redact.txtar
@@ -1,0 +1,157 @@
+#!
+
+hive/start
+
+# Add object
+k8s/add service.v1.yaml
+
+# By default, both get and list should redact the UID and resource version fields.
+k8s/get v1.services test/echo -o actual.yaml
+cmp service-get-redacted.yaml actual.yaml
+
+k8s/list v1.services test -o actual.yaml
+cmp service-list-redacted.yaml actual.yaml
+
+# The non-redacted version can be retrieved using the dedicated flag.
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=resource-version,uid
+cmp service-get.yaml actual.yaml
+
+k8s/list v1.services test -o actual.yaml --show-redacted=resource-version,uid
+cmp service-list.yaml actual.yaml
+
+# Check the redaction of individual fields
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=resource-version
+cmp service-get-redacted-uid.yaml actual.yaml
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=uid
+cmp service-get-redacted-resource-version.yaml actual.yaml
+
+k8s/list v1.services test -o actual.yaml --show-redacted=resource-version
+cmp service-list-redacted-uid.yaml actual.yaml
+k8s/list v1.services test -o actual.yaml --show-redacted=uid
+cmp service-list-redacted-resource-version.yaml actual.yaml
+
+###
+
+-- service.v1.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+spec:
+  clusterIP: 10.96.1.1
+
+-- service-get-redacted.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.1.1
+status:
+  loadBalancer: {}
+-- EOF --
+
+-- service-get.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "2"
+  uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+spec:
+  clusterIP: 10.96.1.1
+status:
+  loadBalancer: {}
+-- EOF --
+
+-- service-get-redacted-uid.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "2"
+spec:
+  clusterIP: 10.96.1.1
+status:
+  loadBalancer: {}
+-- EOF --
+
+-- service-get-redacted-resource-version.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+spec:
+  clusterIP: 10.96.1.1
+status:
+  loadBalancer: {}
+-- EOF --
+
+-- service-list-redacted.yaml --
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: echo
+    namespace: test
+  spec:
+    clusterIP: 10.96.1.1
+  status:
+    loadBalancer: {}
+metadata: {}
+-- EOF --
+
+-- service-list.yaml --
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: echo
+    namespace: test
+    resourceVersion: "2"
+    uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+  spec:
+    clusterIP: 10.96.1.1
+  status:
+    loadBalancer: {}
+metadata:
+  resourceVersion: "3"
+-- EOF --
+
+-- service-list-redacted-uid.yaml --
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: echo
+    namespace: test
+    resourceVersion: "2"
+  spec:
+    clusterIP: 10.96.1.1
+  status:
+    loadBalancer: {}
+metadata:
+  resourceVersion: "3"
+-- EOF --
+
+-- service-list-redacted-resource-version.yaml --
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: echo
+    namespace: test
+    uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+  spec:
+    clusterIP: 10.96.1.1
+  status:
+    loadBalancer: {}
+metadata: {}
+-- EOF --

--- a/pkg/k8s/client/testutils/testdata/status.txtar
+++ b/pkg/k8s/client/testutils/testdata/status.txtar
@@ -1,0 +1,93 @@
+#!
+
+hive/start
+
+# Add object.
+k8s/add service.v1.yaml
+
+# Update the status, it should not mutate the other fields
+k8s/svc/update-status service.v2.yaml
+k8s/get v1.services test/echo -o actual.yaml
+cmp service-expected.v2.yaml actual.yaml
+
+# Perform a normal update, it will mutate all fields (including the status)
+k8s/update service.v3.yaml
+k8s/get v1.services test/echo -o actual.yaml
+cmp service-expected.v3.yaml actual.yaml
+
+###
+
+-- service.v1.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+  labels:
+    foo: bar
+spec:
+  clusterIP: 10.96.1.1
+  type: LoadBalancer
+
+-- service.v2.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  resourceVersion: "2"
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.2.3.4
+
+-- service-expected.v2.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    foo: bar
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.1.1
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 1.2.3.4
+-- EOF --
+
+-- service.v3.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  labels:
+    bar: baz
+spec:
+  clusterIP: 10.96.1.1
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 5.6.7.8
+
+-- service-expected.v3.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    bar: baz
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.1.1
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 5.6.7.8
+-- EOF --

--- a/pkg/k8s/client/testutils/testdata/uid.txtar
+++ b/pkg/k8s/client/testutils/testdata/uid.txtar
@@ -1,0 +1,60 @@
+#!
+
+hive/start
+
+# Add object, the provided UID should be preserved.
+k8s/add service.v1.yaml
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=uid
+grep -q 'uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5' actual.yaml
+
+# Update the object, the existing UID cannot be mutated.
+k8s/update service.v2.yaml
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=uid
+grep -q 'uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5' actual.yaml
+
+# Delete the object and re-create it, the UID should have changed.
+k8s/delete service.v2.yaml
+k8s/add service.v2.yaml
+
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=uid
+grep -q 'uid: 19df579f-6133-49bc-a63f-495ce9951fb2' actual.yaml
+
+# Create an object without a UID, a random one should be generated.
+k8s/delete service.v2.yaml
+k8s/add service.v3.yaml
+
+k8s/get v1.services test/echo -o actual.yaml --show-redacted=uid
+grep -q 'uid: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' actual.yaml
+! grep -q 'uid: 19df579f-6133-49bc-a63f-495ce9951fb2' actual.yaml
+! grep -q 'uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5' actual.yaml
+
+###
+
+-- service.v1.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: 3e5a3605-a4ff-4fc2-b244-d5baee6180a5
+spec:
+  clusterIP: 10.96.1.1
+
+-- service.v2.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  uid: 19df579f-6133-49bc-a63f-495ce9951fb2
+spec:
+  clusterIP: 10.96.1.1
+
+-- service.v3.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.1.1

--- a/test/controlplane/node/localnode.go
+++ b/test/controlplane/node/localnode.go
@@ -33,6 +33,7 @@ var (
 			Annotations: map[string]string{
 				"cilium.io/baz": "quux",
 			},
+			UID: "c76e1794-d298-4570-a995-fd5ac6f01ec9",
 		},
 		Spec: corev1.NodeSpec{
 			PodCIDR:  podCIDR.String(),


### PR DESCRIPTION
At a high level:
* Automatically redact the UID and resource-version fields in script commands output, as non-deterministic
* Ensure that every resource is associated a UID, and that it cannot be mutated after creation
* Prevent `UpdateStatus` from mutating unrelated fields

Please review commit by commit, and refer to the individual commit messages for additional details