### PR TITLE
loadbalancer: use structured logging in config

### DIFF
--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/lbipamconfig"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -364,7 +365,10 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, dcfg *option.DaemonConfi
 	if cfg.LBSockRevNatEntries == 0 {
 		getEntries := dcfg.GetDynamicSizeCalculator(log)
 		cfg.LBSockRevNatEntries = getEntries(option.SockRevNATMapEntriesDefault, option.LimitTableAutoSockRevNatMin, option.LimitTableMax)
-		log.Info(fmt.Sprintf("option %s set by dynamic sizing to %v", LBSockRevNatEntriesName, cfg.LBSockRevNatEntries)) // FIXME
+		log.Info("Option set by dynamic sizing",
+			logfields.Option, LBSockRevNatEntriesName,
+			logfields.Value, cfg.LBSockRevNatEntries,
+		)
 	}
 
 	cfg.LBSockRevNatEntries = dcfg.AlignMapSizeForLRU(log, LBSockRevNatEntriesName, cfg.LBSockRevNatEntries)


### PR DESCRIPTION
I migrated legacy `fmt.Sprintf` in slog to structured logging.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->

This PR migrates legacy logging patterns (`fmt.Sprintf`) in the loadbalancer configuration to use structured `slog` logging. This addresses a specific `FIXME` left in the dynamic sizing logic for the `LBSockRevNatEntriesName` option.

*Note: This PR originally aimed to address both this logging `FIXME` and the commented-out DSR validation logic `FIXME` in the same file. However, since [PR #45545](https://github.com/cilium/cilium/pull/45545) was recently opened and already covers the DSR validation comprehensively (including unit tests), I have scoped this PR down to focus exclusively on the `slog` migration to avoid duplicate work and conflicts.*

**AI Usage**
This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.
