### PR TITLE
policy fall back to LPM lookup for port-range correlation

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1326,7 +1326,10 @@ func (e *Endpoint) UpdateBandwidthPolicy(bandwidthEgress, bandwidthIngress, prio
 }
 
 // GetPolicyCorrelationInfoForKey returns the list of policy rule labels which match a given flow
-// key (in host byte-order) and associated correlation information.
+// key (in host byte-order) and associated correlation information. The lookup mirrors the bpf
+// datapath's L3-vs-L4 precedence (via EndpointPolicy.Lookup), so port-range entries and the
+// various matchType-equivalent stored shapes (L3L4, L4Only, L3Proto, ProtoOnly, L3Only, All)
+// resolve through a single LPM walk without per-matchType key adjustments on the caller side.
 func (e *Endpoint) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
 	info policyTypes.PolicyCorrelationInfo,
 	ok bool,
@@ -1334,14 +1337,14 @@ func (e *Endpoint) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
-	ruleMeta, err := e.realizedPolicy.GetRuleMeta(key)
-	if err != nil {
+	_, ruleMeta, found := e.realizedPolicy.Lookup(key)
+	if !found {
 		return info, false
 	}
 	info.RuleLabels = ruleMeta.LabelArrayListString()
 	info.Log = ruleMeta.Log()
 	info.Revision = e.policyRevision
-	return info, err == nil
+	return info, true
 }
 
 // setDNSRulesLocked is called when the Endpoint's DNS policy has been updated.

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -463,9 +463,32 @@ func (e *FakeEndpointInfo) GetPolicyCorrelationInfoForKey(key policyTypes.Key) (
 	info policyTypes.PolicyCorrelationInfo,
 	ok bool,
 ) {
-	info.RuleLabels, ok = e.PolicyMap[key]
 	info.Revision = e.PolicyRevision
-	return info, ok
+	if rl, hit := e.PolicyMap[key]; hit {
+		info.RuleLabels = rl
+		return info, true
+	}
+
+	var bestKey policyTypes.Key
+	var bestRules labels.LabelArrayListString
+	found := false
+	for storedKey, rl := range e.PolicyMap {
+		if !storedKey.Covers(key) {
+			continue
+		}
+		if !found ||
+			storedKey.PrefixLength() > bestKey.PrefixLength() ||
+			(storedKey.PrefixLength() == bestKey.PrefixLength() && storedKey.Identity != 0 && bestKey.Identity == 0) {
+			bestKey = storedKey
+			bestRules = rl
+			found = true
+		}
+	}
+	if !found {
+		return info, false
+	}
+	info.RuleLabels = bestRules
+	return info, true
 }
 
 // FakePodMetadataGetter is used for unit tests that need a PodMetadataGetter.

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -61,9 +61,9 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 		return
 	}
 
-	info, ok := lookupPolicyForKey(epInfo,
+	info, ok := epInfo.GetPolicyCorrelationInfoForKey(
 		policy.KeyForDirection(direction).WithIdentity(remoteIdentity).WithPortProto(proto, dport),
-		f.GetPolicyMatchType())
+	)
 	if !ok {
 		logger.Debug(
 			"unable to find policy for policy verdict notification",
@@ -140,86 +140,6 @@ func extractFlowKey(f *flowpb.Flow) (
 	}
 
 	return
-}
-
-func lookupPolicyForKey(ep getters.EndpointInfo, key policy.Key, matchType uint32) (policyTypes.PolicyCorrelationInfo, bool) {
-	switch matchType {
-	case monitorAPI.PolicyMatchL3L4:
-		// Check for L4 policy rules.
-		//
-		// Consider the network policy:
-		//
-		// spec:
-		//  podSelector: {}
-		//  ingress:
-		//  - podSelector:
-		//      matchLabels:
-		//        app: client
-		//    ports:
-		//    - port: 80
-		//      protocol: TCP
-	case monitorAPI.PolicyMatchL3Proto:
-		// Check for L3 policy rules with protocol (but no port).
-		//
-		// Consider the network policy:
-		//
-		// spec:
-		//  podSelector: {}
-		//  ingress:
-		//  - podSelector:
-		//      matchLabels:
-		//        app: client
-		//    ports:
-		//    - protocol: TCP
-		key = policy.KeyForDirection(key.TrafficDirection()).WithIdentity(key.Identity).WithProto(key.Nexthdr)
-	case monitorAPI.PolicyMatchL4Only:
-		// Check for port-specific rules.
-		// This covers the case where one or more identities are allowed by network policy.
-		//
-		// Consider the network policy:
-		//
-		// spec:
-		//  podSelector: {}
-		//  ingress:
-		//  - ports:
-		//    - port: 80
-		//      protocol: TCP // protocol is optional for this match.
-		key = policy.KeyForDirection(key.TrafficDirection()).WithPortProto(key.Nexthdr, key.DestPort)
-	case monitorAPI.PolicyMatchProtoOnly:
-		// Check for protocol-only policies.
-		//
-		// Consider the network policy:
-		//
-		// spec:
-		//  podSelector: {}
-		//  ingress:
-		//  - ports:
-		//    - protocol: TCP
-		key = policy.KeyForDirection(key.TrafficDirection()).WithProto(key.Nexthdr)
-	case monitorAPI.PolicyMatchL3Only:
-		// Check for L3 policy rules.
-		//
-		// Consider the network policy:
-		//
-		// spec:
-		//  podSelector: {}
-		//  ingress:
-		//  - podSelector:
-		//      matchLabels:
-		//        app: client
-		key = policy.KeyForDirection(key.TrafficDirection()).WithIdentity(key.Identity)
-	case monitorAPI.PolicyMatchAll:
-		// Check for allow-all policy rules.
-		//
-		// Consider the network policy:
-		//
-		// spec:
-		//  podSelector: {}
-		//  ingress:
-		//  - {}
-		key = policy.KeyForDirection(key.TrafficDirection())
-	}
-	return ep.GetPolicyCorrelationInfoForKey(key)
 }
 
 func toProto(info policyTypes.PolicyCorrelationInfo) (policies []*flowpb.Policy) {

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -838,3 +838,77 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 }
+
+func TestCorrelatePolicy_PortRange(t *testing.T) {
+	localIP := "1.2.3.4"
+	localIdentity := uint32(1234)
+	localID := uint32(12)
+	remoteIP := "5.6.7.8"
+	remoteIdentity := uint32(5678)
+	remoteID := uint32(56)
+	dstPort := uint32(80) // inside [64, 127]
+
+	flow := &flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		Verdict:          flowpb.Verdict_FORWARDED,
+		TrafficDirection: flowpb.TrafficDirection_EGRESS,
+		IP:               &flowpb.IP{Source: localIP, Destination: remoteIP},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: dstPort}},
+		},
+		Source:          &flowpb.Endpoint{ID: localID, Identity: localIdentity},
+		Destination:     &flowpb.Endpoint{ID: remoteID, Identity: remoteIdentity},
+		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+	}
+
+	policyLabel := utils.GetPolicyLabels("foo-namespace", "port-range-policy", "abcd-ef01", utils.ResourceTypeCiliumNetworkPolicy)
+	rangeKey := policy.EgressKey().
+		WithIdentity(identity.NumericIdentity(remoteIdentity)).
+		WithTCPPortPrefix(64, 10)
+
+	ep := &testutils.FakeEndpointInfo{
+		ID:           uint64(localID),
+		Identity:     identity.NumericIdentity(localIdentity),
+		IPv4:         net.ParseIP(localIP),
+		PodName:      "client",
+		PodNamespace: "default",
+		PolicyMap: map[policy.Key]labels.LabelArrayListString{
+			rangeKey: labels.LabelArrayList{policyLabel}.ArrayListString(),
+		},
+		PolicyRevision: 1,
+	}
+
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfoByID: func(id uint16) (getters.EndpointInfo, bool) {
+			if uint64(id) == ep.ID {
+				return ep, true
+			}
+			t.Fatalf("did not expect endpoint retrieval for non-local endpoint: %d", id)
+			return nil, false
+		},
+	}
+
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+
+	expected := []*flowpb.Policy{
+		{
+			Name:      "port-range-policy",
+			Namespace: "foo-namespace",
+			Kind:      utils.ResourceTypeCiliumNetworkPolicy,
+			Labels: []string{
+				"k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
+				"k8s:io.cilium.k8s.policy.name=port-range-policy",
+				"k8s:io.cilium.k8s.policy.namespace=foo-namespace",
+				"k8s:io.cilium.k8s.policy.uid=abcd-ef01",
+			},
+			Revision: 1,
+		},
+	}
+
+	require.Nil(t, flow.IngressAllowedBy)
+	require.Nil(t, flow.EgressDeniedBy)
+	require.Nil(t, flow.IngressDeniedBy)
+	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+		t.Fatalf("not equal (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -402,10 +402,12 @@ func (ms *mapState) LPMAncestors(key Key) iter.Seq2[Key, mapStateEntry] {
 // between L3 and L4-only policies as the bpf datapath  when both match the given 'key'.
 // To be used in testing in place of the bpf datapath when full integration testing is not desired.
 // Returns the closest matching covering policy entry and 'true' if found.
-// 'key' must not have a wildcard identity or port.
+// 'key' must have a non-zero protocol and a non-wildcard port. Identity may be
+// zero, in which case only entries with zero identity are considered, mirroring
+// the L4-only side of the L3-vs-L4 precedence logic below.
 func (ms *mapState) lookup(key Key) (mapStateEntry, bool) {
-	// Validate that the search key has no wildcards
-	if key.Identity == 0 || key.Nexthdr == 0 || key.DestPort == 0 || key.EndPort() != key.DestPort {
+	// Validate that the search key has no wildcards in protocol or port.
+	if key.Nexthdr == 0 || key.DestPort == 0 || key.EndPort() != key.DestPort {
 		ms.logger.Error(
 			"invalid key for Lookup",
 			logfields.Stacktrace, hclog.Stacktrace(),

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -1193,3 +1193,54 @@ func TestEndpointPolicy_GetRuleMeta(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, NilRuleOrigin.Value(), rm)
 }
+
+func TestEndpointPolicy_Lookup_PortRange(t *testing.T) {
+	log := hivetest.Logger(t)
+
+	rangeEntry := ingressKey(192, 6, 64, 10)
+	flowKey := ingressKey(192, 6, 80, 16)
+
+	lbls := labels.ParseLabelArray("k8s:io.cilium.k8s.policy.name=allow-egress-port-range")
+	lblss := labels.LabelArrayList{lbls}
+
+	p := &EndpointPolicy{
+		policyMapState: emptyMapState(log).withState(mapStateMap{
+			rangeEntry: newMapStateEntry(0, types.HighestPriority, types.LowestPriority, makeSingleRuleOrigin(lbls, "log"), 0, 0, types.Allow, NoAuthRequirement),
+		}),
+	}
+
+	_, rm, found := p.Lookup(flowKey)
+	require.True(t, found, "Lookup for a port inside a stored range should succeed")
+	require.Equal(t, lblss, rm.LabelArray(),
+		"rule meta should come from the covering port-range entry")
+
+	outOfRangeKey := ingressKey(192, 6, 200, 16)
+	_, _, found = p.Lookup(outOfRangeKey)
+	require.False(t, found, "Lookup for a port outside the stored range should miss")
+}
+
+// TestEndpointPolicy_Lookup_PortRange_L4Only covers the L4-only side of the
+// L3-vs-L4 precedence in mapState.lookup: when the stored entry has identity
+// zero and a port range, a flow keyed by a specific port inside that range
+// must still resolve to it.
+func TestEndpointPolicy_Lookup_PortRange_L4Only(t *testing.T) {
+	log := hivetest.Logger(t)
+
+	// L4-only range entry: identity == 0, port 64-127, TCP.
+	rangeEntry := ingressKey(0, 6, 64, 10)
+	flowKey := ingressKey(0, 6, 80, 16)
+
+	lbls := labels.ParseLabelArray("k8s:io.cilium.k8s.policy.name=allow-l4only-port-range")
+	lblss := labels.LabelArrayList{lbls}
+
+	p := &EndpointPolicy{
+		policyMapState: emptyMapState(log).withState(mapStateMap{
+			rangeEntry: newMapStateEntry(0, types.HighestPriority, types.LowestPriority, makeSingleRuleOrigin(lbls, "log"), 0, 0, types.Allow, NoAuthRequirement),
+		}),
+	}
+
+	_, rm, found := p.Lookup(flowKey)
+	require.True(t, found, "L4Only Lookup for a port inside a stored range should succeed")
+	require.Equal(t, lblss, rm.LabelArray(),
+		"rule meta should come from the covering port-range entry")
+}


### PR DESCRIPTION
When a CiliumNetworkPolicy uses endPort to allow a port range, Hubble fails to populate egress_allowed_by and ingress_allowed_by on the matching policy verdict flow. The cause is that GetRuleMeta does an exact hash-map lookup, but port-range entries live in the policy map under a key with a port prefix shorter than 16, so a flow keyed by the actual destination port never finds the covering entry. This change falls back to LPM ancestor iteration after the exact miss, which yields the most specific covering entry first and matches how the bpf datapath resolves the same flow.

Fixes #45761