### PR TITLE
ipam: Migrate `AllocationResult.{CIDRs,GatewayIP}` to netip types

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/resiliency"
+	cslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -142,22 +144,20 @@ func (r *infraIPAllocator) allocateRouterIPv6(ctx context.Context, family node.A
 }
 
 // Coalesce CIDRS when allocating the DatapathIPs and healthIPs. GH #18868
-func (r *infraIPAllocator) coalesceCIDRs(rCIDRs []string) (result []string, err error) {
+func (r *infraIPAllocator) coalesceCIDRs(rCIDRs []netip.Prefix) []netip.Prefix {
 	cidrs := make([]*net.IPNet, 0, len(rCIDRs))
-	for _, k := range rCIDRs {
-		ip, mask, err := net.ParseCIDR(k)
-		if err != nil {
-			return nil, err
-		}
-		cidrs = append(cidrs, &net.IPNet{IP: ip, Mask: mask.Mask})
+	for _, p := range rCIDRs {
+		cidrs = append(cidrs, netipx.PrefixIPNet(p))
 	}
 	ipv4cidr, ipv6cidr := iputil.CoalesceCIDRs(cidrs)
 	combinedcidrs := append(ipv4cidr, ipv6cidr...)
-	result = make([]string, len(combinedcidrs))
-	for i, k := range combinedcidrs {
-		result[i] = k.String()
+	result := make([]netip.Prefix, 0, len(combinedcidrs))
+	for _, k := range combinedcidrs {
+		if p, ok := netipx.FromStdIPNet(k); ok {
+			result = append(result, p)
+		}
 	}
-	return result, err
+	return result
 }
 
 // reallocateOldRouterIPs attempts to reallocate the old router IP from IPAM.
@@ -278,17 +278,14 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 		(r.daemonConfig.IPAM == ipamOption.IPAMENI || r.daemonConfig.IPAM == ipamOption.IPAMAzure) &&
 		result != nil &&
 		len(result.CIDRs) > 0 {
-		result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)
-		if err != nil {
-			return nil, fmt.Errorf("failed to coalesce CIDRs: %w", err)
-		}
+		result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 	}
 
 	if (r.daemonConfig.IPAM == ipamOption.IPAMENI ||
 		r.daemonConfig.IPAM == ipamOption.IPAMAlibabaCloud ||
 		r.daemonConfig.IPAM == ipamOption.IPAMAzure) && result != nil {
 		var routingInfo *linuxrouting.RoutingInfo
-		routingInfo, err = linuxrouting.NewRoutingInfo(r.logger, result.GatewayIP, result.CIDRs,
+		routingInfo, err = linuxrouting.NewRoutingInfo(r.logger, result.GatewayIP.String(), prefixesToStrings(result.CIDRs),
 			result.PrimaryMAC, result.InterfaceNumber, r.daemonConfig.IPAM,
 			masq)
 		if err != nil {
@@ -382,10 +379,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 			(r.daemonConfig.IPAM == ipamOption.IPAMENI || r.daemonConfig.IPAM == ipamOption.IPAMAzure) &&
 			result != nil &&
 			len(result.CIDRs) > 0 {
-			result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)
-			if err != nil {
-				return fmt.Errorf("failed to coalesce CIDRs: %w", err)
-			}
+			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
 		r.logger.Debug("Allocated IPv4 health endpoint address", logfields.IPAddr, result.IP)
@@ -467,10 +461,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			(r.daemonConfig.IPAM == ipamOption.IPAMENI || r.daemonConfig.IPAM == ipamOption.IPAMAzure) &&
 			result != nil &&
 			len(result.CIDRs) > 0 {
-			result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)
-			if err != nil {
-				return fmt.Errorf("failed to coalesce CIDRs: %w", err)
-			}
+			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
 		ingressIPv4 = net.IP(result.IP.AsSlice()).To16()
@@ -531,10 +522,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			r.daemonConfig.IPAM == ipamOption.IPAMENI &&
 			result != nil &&
 			len(result.CIDRs) > 0 {
-			result.CIDRs, err = r.coalesceCIDRs(result.CIDRs)
-			if err != nil {
-				return fmt.Errorf("failed to coalesce CIDRs: %w", err)
-			}
+			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
 		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = net.IP(result.IP.AsSlice()).To16() })
@@ -674,8 +662,8 @@ func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*lin
 	if result.IP.Is4() {
 		return linuxrouting.NewRoutingInfo(
 			r.logger,
-			result.GatewayIP,
-			result.CIDRs,
+			result.GatewayIP.String(),
+			prefixesToStrings(result.CIDRs),
 			result.PrimaryMAC,
 			result.InterfaceNumber,
 			r.daemonConfig.IPAM,
@@ -684,14 +672,18 @@ func (r *infraIPAllocator) parseRoutingInfo(result *ipam.AllocationResult) (*lin
 	} else {
 		return linuxrouting.NewRoutingInfo(
 			r.logger,
-			result.GatewayIP,
-			result.CIDRs,
+			result.GatewayIP.String(),
+			prefixesToStrings(result.CIDRs),
 			result.PrimaryMAC,
 			result.InterfaceNumber,
 			r.daemonConfig.IPAM,
 			r.daemonConfig.EnableIPv6Masquerade,
 		)
 	}
+}
+
+func prefixesToStrings(prefixes []netip.Prefix) []string {
+	return cslices.Map(prefixes, func(p netip.Prefix) string { return p.String() })
 }
 
 // removeOldCiliumHostIPs calls removeOldRouterState() for both IPv4 and IPv6

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -30,60 +30,72 @@ func TestCoalesceCIDRs(t *testing.T) {
 		logger: hivetest.Logger(t),
 	}
 
-	CIDR := []string{"10.0.0.0/8"}
-	expectedCIDR := []string{"10.0.0.0/8"}
-	newCIDR, err := infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
+	cases := []struct {
+		in   []netip.Prefix
+		want []netip.Prefix
+	}{
+		{
+			in:   []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+			want: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+		},
+		{
+			in:   []netip.Prefix{netip.MustParsePrefix("10.105.0.0/16"), netip.MustParsePrefix("10.0.0.0/8")},
+			want: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+		},
+		{
+			in: []netip.Prefix{
+				netip.MustParsePrefix("10.105.0.0/16"),
+				netip.MustParsePrefix("10.104.0.0/19"),
+				netip.MustParsePrefix("10.0.0.0/8"),
+			},
+			want: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+		},
+		{
+			in:   []netip.Prefix{netip.MustParsePrefix("10.105.0.0/16"), netip.MustParsePrefix("192.168.1.0/24")},
+			want: []netip.Prefix{netip.MustParsePrefix("10.105.0.0/16"), netip.MustParsePrefix("192.168.1.0/24")},
+		},
+		{
+			in: []netip.Prefix{
+				netip.MustParsePrefix("10.105.0.0/16"),
+				netip.MustParsePrefix("192.168.1.0/24"),
+				netip.MustParsePrefix("10.0.0.0/8"),
+			},
+			want: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8"), netip.MustParsePrefix("192.168.1.0/24")},
+		},
+		{
+			in: []netip.Prefix{
+				netip.MustParsePrefix("10.105.0.0/16"),
+				netip.MustParsePrefix("192.168.1.0/24"),
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("f00d::a0f:0:0:0/96"),
+			},
+			want: []netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("192.168.1.0/24"),
+				netip.MustParsePrefix("f00d::a0f:0:0:0/96"),
+			},
+		},
+		{
+			in: []netip.Prefix{
+				netip.MustParsePrefix("f00d::a0f:0:0:0/96"),
+				netip.MustParsePrefix("10.105.0.0/16"),
+				netip.MustParsePrefix("192.168.1.0/24"),
+				netip.MustParsePrefix("10.0.0.0/8"),
+			},
+			want: []netip.Prefix{
+				netip.MustParsePrefix("10.0.0.0/8"),
+				netip.MustParsePrefix("192.168.1.0/24"),
+				netip.MustParsePrefix("f00d::a0f:0:0:0/96"),
+			},
+		},
+		{
+			in:   []netip.Prefix{netip.MustParsePrefix("f00d::a0f:0:0:0/96")},
+			want: []netip.Prefix{netip.MustParsePrefix("f00d::a0f:0:0:0/96")},
+		},
 	}
 
-	CIDR = []string{"10.105.0.0/16", "10.0.0.0/8"}
-	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
-	}
-
-	CIDR = []string{"10.105.0.0/16", "10.104.0.0/19", "10.0.0.0/8"}
-	expectedCIDR = []string{"10.0.0.0/8"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
-	}
-
-	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
-	expectedCIDR = []string{"10.105.0.0/16", "192.168.1.0/24"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
-	}
-
-	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
-	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
-	}
-
-	CIDR = []string{"10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8", "f00d::a0f:0:0:0/96"}
-	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
-	}
-
-	CIDR = []string{"f00d::a0f:0:0:0/96", "10.105.0.0/16", "192.168.1.0/24", "10.0.0.0/8"}
-	expectedCIDR = []string{"10.0.0.0/8", "192.168.1.0/24", "f00d::a0f:0:0:0/96"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] || newCIDR[1] != expectedCIDR[1] || newCIDR[2] != expectedCIDR[2] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
-	}
-
-	CIDR = []string{"f00d::a0f:0:0:0/96"}
-	expectedCIDR = []string{"f00d::a0f:0:0:0/96"}
-	newCIDR, err = infraIPAllocator.coalesceCIDRs(CIDR)
-	if err != nil || len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
-		t.Errorf("got %v, want %v, err: %v\n", newCIDR, expectedCIDR, err)
+	for _, tc := range cases {
+		require.Equal(t, tc.want, infraIPAllocator.coalesceCIDRs(tc.in))
 	}
 }
 

--- a/pkg/ipam/api/ipam_api_handler.go
+++ b/pkg/ipam/api/ipam_api_handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -22,8 +23,20 @@ import (
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	cslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 )
+
+func prefixesToStrings(prefixes []netip.Prefix) []string {
+	return cslices.Map(prefixes, func(p netip.Prefix) string { return p.String() })
+}
+
+func gatewayString(addr netip.Addr) string {
+	if !addr.IsValid() {
+		return ""
+	}
+	return addr.String()
+}
 
 type IpamDeleteIpamIPHandler struct {
 	IPAM            *ipam.IPAM
@@ -68,10 +81,10 @@ func (r *IpamPostIpamHandler) Handle(params ipamapi.PostIpamParams) middleware.R
 		resp.Address.IPv4 = ipv4Result.IP.String()
 		resp.Address.IPv4PoolName = ipv4Result.IPPoolName.String()
 		resp.IPv4 = &models.IPAMAddressResponse{
-			Cidrs:           ipv4Result.CIDRs,
+			Cidrs:           prefixesToStrings(ipv4Result.CIDRs),
 			IP:              ipv4Result.IP.String(),
 			MasterMac:       ipv4Result.PrimaryMAC,
-			Gateway:         ipv4Result.GatewayIP,
+			Gateway:         gatewayString(ipv4Result.GatewayIP),
 			ExpirationUUID:  ipv4Result.ExpirationUUID,
 			InterfaceNumber: ipv4Result.InterfaceNumber,
 			SkipMasquerade:  ipv4Result.SkipMasquerade,
@@ -82,10 +95,10 @@ func (r *IpamPostIpamHandler) Handle(params ipamapi.PostIpamParams) middleware.R
 		resp.Address.IPv6 = ipv6Result.IP.String()
 		resp.Address.IPv6PoolName = ipv6Result.IPPoolName.String()
 		resp.IPv6 = &models.IPAMAddressResponse{
-			Cidrs:           ipv6Result.CIDRs,
+			Cidrs:           prefixesToStrings(ipv6Result.CIDRs),
 			IP:              ipv6Result.IP.String(),
 			MasterMac:       ipv6Result.PrimaryMAC,
-			Gateway:         ipv6Result.GatewayIP,
+			Gateway:         gatewayString(ipv6Result.GatewayIP),
 			ExpirationUUID:  ipv6Result.ExpirationUUID,
 			InterfaceNumber: ipv6Result.InterfaceNumber,
 			SkipMasquerade:  ipv6Result.SkipMasquerade,

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -698,24 +699,6 @@ func newCRDAllocator(logger *slog.Logger, family Family, c *option.DaemonConfig,
 	return allocator
 }
 
-// deriveGatewayIP accept the CIDR and the index of the IP in this CIDR.
-func deriveGatewayIP(logger *slog.Logger, cidr string, index int) string {
-	_, ipNet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		logger.Warn(
-			"Unable to parse subnet CIDR",
-			logfields.Error, err,
-			logfields.CIDR, cidr,
-		)
-		return ""
-	}
-	gw := ip.GetIPAtIndex(*ipNet, int64(index))
-	if gw == nil {
-		return ""
-	}
-	return gw.String()
-}
-
 func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.AllocationIP) (result *AllocationResult, err error) {
 	result = &AllocationResult{IP: addr}
 
@@ -737,11 +720,17 @@ func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.
 		for _, iface := range a.store.ownNode.Status.Azure.Interfaces {
 			if iface.ID == ipInfo.Resource {
 				result.PrimaryMAC = iface.MAC
-				result.GatewayIP = iface.Gateway
-				result.CIDRs = append(result.CIDRs, iface.CIDR)
+				if gatewayIP, err := netip.ParseAddr(iface.Gateway); err == nil {
+					result.GatewayIP = gatewayIP
+				}
+				if p, err := netip.ParsePrefix(iface.CIDR); err == nil {
+					result.CIDRs = append(result.CIDRs, p)
+				}
 				// Add manually configured Native Routing CIDR
 				if a.conf.IPv4NativeRoutingCIDR != nil {
-					result.CIDRs = append(result.CIDRs, a.conf.IPv4NativeRoutingCIDR.String())
+					if p, ok := netipx.FromStdIPNet(a.conf.IPv4NativeRoutingCIDR.IPNet); ok {
+						result.CIDRs = append(result.CIDRs, p)
+					}
 				}
 				// If the ip-masq-agent is enabled, get the CIDRs that are not masqueraded.
 				// Note that the resulting ip rules will not be dynamically regenerated if the
@@ -750,9 +739,9 @@ func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.
 					nonMasqCidrs := a.ipMasqAgent.NonMasqCIDRsFromConfig()
 					for _, prefix := range nonMasqCidrs {
 						if addr.Is4() && prefix.Addr().Is4() {
-							result.CIDRs = append(result.CIDRs, prefix.String())
+							result.CIDRs = append(result.CIDRs, prefix)
 						} else if !addr.Is4() && prefix.Addr().Is6() {
-							result.CIDRs = append(result.CIDRs, prefix.String())
+							result.CIDRs = append(result.CIDRs, prefix)
 						}
 					}
 				}
@@ -781,10 +770,13 @@ func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.
 				continue
 			}
 			result.PrimaryMAC = eni.MACAddress
-			result.CIDRs = []string{eni.VSwitch.CIDRBlock}
+			if p, err := netip.ParsePrefix(eni.VSwitch.CIDRBlock); err == nil {
+				result.CIDRs = []netip.Prefix{p}
 
-			// Ref: https://www.alibabacloud.com/help/doc-detail/65398.html
-			result.GatewayIP = deriveGatewayIP(a.logger, eni.VSwitch.CIDRBlock, -3)
+				// AlibabaCloud reserves the third-to-last IP of the subnet for the gateway.
+				// Ref: https://www.alibabacloud.com/help/doc-detail/65398.html
+				result.GatewayIP = netipx.PrefixLastIP(p).Prev().Prev()
+			}
 			result.InterfaceNumber = strconv.Itoa(alibabaCloud.GetENIIndexFromTags(a.logger, eni.Tags))
 			return
 		}

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -214,23 +214,23 @@ func TestIPMasq(t *testing.T) {
 	// The resulting CIDRs should contain the VPC CIDRs and the default ip-masq-agent CIDRs from pkg/ipmasq/ipmasq.go
 	require.ElementsMatch(
 		t,
-		[]string{
+		[]netip.Prefix{
 			// VPC CIDRs
-			"10.1.0.0/16",
-			"10.2.0.0/16",
+			netip.MustParsePrefix("10.1.0.0/16"),
+			netip.MustParsePrefix("10.2.0.0/16"),
 			// Default ip-masq-agent CIDRs
-			"10.0.0.0/8",
-			"172.16.0.0/12",
-			"192.168.0.0/16",
-			"100.64.0.0/10",
-			"192.0.0.0/24",
-			"192.0.2.0/24",
-			"192.88.99.0/24",
-			"198.18.0.0/15",
-			"198.51.100.0/24",
-			"203.0.113.0/24",
-			"240.0.0.0/4",
-			"169.254.0.0/16",
+			netip.MustParsePrefix("10.0.0.0/8"),
+			netip.MustParsePrefix("172.16.0.0/12"),
+			netip.MustParsePrefix("192.168.0.0/16"),
+			netip.MustParsePrefix("100.64.0.0/10"),
+			netip.MustParsePrefix("192.0.0.0/24"),
+			netip.MustParsePrefix("192.0.2.0/24"),
+			netip.MustParsePrefix("192.88.99.0/24"),
+			netip.MustParsePrefix("198.18.0.0/15"),
+			netip.MustParsePrefix("198.51.100.0/24"),
+			netip.MustParsePrefix("203.0.113.0/24"),
+			netip.MustParsePrefix("240.0.0.0/4"),
+			netip.MustParsePrefix("169.254.0.0/16"),
 		},
 		result.CIDRs,
 	)
@@ -287,22 +287,22 @@ func TestAzureIPMasq(t *testing.T) {
 	// The resulting CIDRs should contain the Azure interface CIDR and the default ip-masq-agent CIDRs
 	require.ElementsMatch(
 		t,
-		[]string{
+		[]netip.Prefix{
 			// Azure interface CIDR
-			"10.10.1.0/24",
+			netip.MustParsePrefix("10.10.1.0/24"),
 			// Default ip-masq-agent CIDRs
-			"10.0.0.0/8",
-			"172.16.0.0/12",
-			"192.168.0.0/16",
-			"100.64.0.0/10",
-			"192.0.0.0/24",
-			"192.0.2.0/24",
-			"192.88.99.0/24",
-			"198.18.0.0/15",
-			"198.51.100.0/24",
-			"203.0.113.0/24",
-			"240.0.0.0/4",
-			"169.254.0.0/16",
+			netip.MustParsePrefix("10.0.0.0/8"),
+			netip.MustParsePrefix("172.16.0.0/12"),
+			netip.MustParsePrefix("192.168.0.0/16"),
+			netip.MustParsePrefix("100.64.0.0/10"),
+			netip.MustParsePrefix("192.0.0.0/24"),
+			netip.MustParsePrefix("192.0.2.0/24"),
+			netip.MustParsePrefix("192.88.99.0/24"),
+			netip.MustParsePrefix("198.18.0.0/15"),
+			netip.MustParsePrefix("198.51.100.0/24"),
+			netip.MustParsePrefix("203.0.113.0/24"),
+			netip.MustParsePrefix("240.0.0.0/4"),
+			netip.MustParsePrefix("169.254.0.0/16"),
 		},
 		result.CIDRs,
 	)

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/hive/job"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
@@ -350,13 +351,21 @@ func buildENIAllocationResult(
 		result := &AllocationResult{
 			IP:         allocatedAddr,
 			PrimaryMAC: eni.MAC,
-			CIDRs:      []string{eni.VPC.PrimaryCIDR},
 		}
-		result.CIDRs = append(result.CIDRs, eni.VPC.CIDRs...)
+		if primaryCIDR, err := netip.ParsePrefix(eni.VPC.PrimaryCIDR); err == nil {
+			result.CIDRs = append(result.CIDRs, primaryCIDR)
+		}
+		for _, c := range eni.VPC.CIDRs {
+			if p, err := netip.ParsePrefix(c); err == nil {
+				result.CIDRs = append(result.CIDRs, p)
+			}
+		}
 
 		// Add manually configured Native Routing CIDR
 		if conf.IPv4NativeRoutingCIDR != nil {
-			result.CIDRs = append(result.CIDRs, conf.IPv4NativeRoutingCIDR.String())
+			if p, ok := netipx.FromStdIPNet(conf.IPv4NativeRoutingCIDR.IPNet); ok {
+				result.CIDRs = append(result.CIDRs, p)
+			}
 		}
 
 		// If the ip-masq-agent is enabled, get the CIDRs that are not masqueraded.
@@ -365,17 +374,17 @@ func buildENIAllocationResult(
 		if conf.EnableIPMasqAgent {
 			for _, prefix := range ipMasqAgent.NonMasqCIDRsFromConfig() {
 				if allocatedAddr.Is4() && prefix.Addr().Is4() {
-					result.CIDRs = append(result.CIDRs, prefix.String())
+					result.CIDRs = append(result.CIDRs, prefix)
 				} else if !allocatedAddr.Is4() && prefix.Addr().Is6() {
-					result.CIDRs = append(result.CIDRs, prefix.String())
+					result.CIDRs = append(result.CIDRs, prefix)
 				}
 			}
 		}
 
-		if eni.Subnet.CIDR != "" {
-			// The gateway for a subnet and VPC is always x.x.x.1
+		if prefix, err := netip.ParsePrefix(eni.Subnet.CIDR); err == nil {
+			// AWS reserves the first subnet IP for the gateway.
 			// Ref: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
-			result.GatewayIP = deriveGatewayIP(logger, eni.Subnet.CIDR, 1)
+			result.GatewayIP = prefix.Addr().Next()
 		}
 		result.InterfaceNumber = strconv.Itoa(eni.Number)
 

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -270,9 +270,9 @@ func TestBuildENIAllocationResult(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
 		require.Equal(t, "1", result.InterfaceNumber)
-		require.Equal(t, "10.1.1.1", result.GatewayIP)
-		require.Contains(t, result.CIDRs, "10.1.0.0/16")
-		require.Contains(t, result.CIDRs, "10.2.0.0/16")
+		require.Equal(t, netip.MustParseAddr("10.1.1.1"), result.GatewayIP)
+		require.Contains(t, result.CIDRs, netip.MustParsePrefix("10.1.0.0/16"))
+		require.Contains(t, result.CIDRs, netip.MustParsePrefix("10.2.0.0/16"))
 	})
 
 	t.Run("secondary IP on eni-2", func(t *testing.T) {
@@ -280,7 +280,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "aa:bb:cc:dd:ee:02", result.PrimaryMAC)
 		require.Equal(t, "2", result.InterfaceNumber)
-		require.Equal(t, "10.3.1.1", result.GatewayIP)
+		require.Equal(t, netip.MustParseAddr("10.3.1.1"), result.GatewayIP)
 	})
 
 	t.Run("unknown IP returns error", func(t *testing.T) {
@@ -295,7 +295,7 @@ func TestBuildENIAllocationResult(t *testing.T) {
 		}
 		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), node, confWithNative, nil)
 		require.NoError(t, err)
-		require.Contains(t, result.CIDRs, "10.0.0.0/8")
+		require.Contains(t, result.CIDRs, netip.MustParsePrefix("10.0.0.0/8"))
 	})
 }
 

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -36,7 +36,7 @@ type AllocationResult struct {
 	// This is primarily useful if the IP has been allocated out of a VPC
 	// subnet range and the VPC provides routing to a set of CIDRs in which
 	// the IP is routable.
-	CIDRs []string
+	CIDRs []netip.Prefix
 
 	// PrimaryMAC is the MAC address of the primary interface. This is useful
 	// when the IP is a secondary address of an interface which is
@@ -47,7 +47,7 @@ type AllocationResult struct {
 	// GatewayIP is the IP of the gateway which must be used for this IP.
 	// If the allocated IP is derived from a VPC, then the gateway
 	// represented the gateway of the VPC or VPC subnet.
-	GatewayIP string
+	GatewayIP netip.Addr
 
 	// ExpirationUUID is the UUID of the expiration timer. This field is
 	// only set if AllocateNextWithExpiration is used.


### PR DESCRIPTION
Relates to #24246

Followup to:
* #45647
* #45508 
* #45495 
* #45395 
* #45260

This PR continues the netip migration by converting `AllocationResult`'s `CIDRs` and `GatewayIP` fields from `[]string` and `string` to `[]netip.Prefix` and `netip.Addr`.

As with previous PRs, there are now conversions at boundary (to/from `string` or `net` types). Those will eventually dissapear once everything is `netip`.