### PR TITLE
Fix error where policymap overflow errors were swallowed

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -953,13 +953,11 @@ type policyMapPressureUpdater interface {
 	Remove(uint16)
 }
 
-func (e *Endpoint) updatePolicyMapPressureMetric(add float64) {
-	// We want to use desiredPolicy, but it can be nil.
-	policyLen := add
-	if e.desiredPolicy != nil {
-		policyLen += float64(e.desiredPolicy.Len())
+func (e *Endpoint) updatePolicyMapPressureMetric(len int) {
+	if e.policyMap == nil {
+		return
 	}
-	value := policyLen / float64(e.policyMap.MaxEntries())
+	value := float64(len) / float64(e.policyMap.MaxEntries())
 	e.PolicyMapPressureUpdater.Update(PolicyMapPressureEvent{
 		Value:      value,
 		EndpointID: e.ID,
@@ -998,8 +996,6 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key) bool {
 		)
 		return false
 	}
-
-	e.updatePolicyMapPressureMetric(0)
 
 	e.PolicyDebug(
 		"deletePolicyKey",
@@ -1044,8 +1040,6 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry)
 		)
 		return false
 	}
-
-	e.updatePolicyMapPressureMetric(0)
 
 	e.PolicyDebug(
 		"addPolicyKey",
@@ -1107,9 +1101,10 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	closer, changes := e.desiredPolicy.ConsumeMapChanges()
 	defer closer()
 
-	changeSize := changes.Size()
-	if e.shouldLockdownLocked(changeSize) {
-		return e.startLockdownLocked(changeSize)
+	e.updatePolicyMapPressureMetric(e.desiredPolicy.Len())
+
+	if e.shouldLockdownLocked() {
+		return e.startLockdownLocked()
 	}
 	if e.stopLockdownLocked() {
 		return ErrComingOutOfLockdown
@@ -1209,19 +1204,19 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 
 // shouldLockdownLockdown returns true if the desiredPolicy, after changes,
 // will be larger than policymap.MaxEntries. The Endpoint must be locked.
-func (e *Endpoint) shouldLockdownLocked(changeSize int) bool {
+func (e *Endpoint) shouldLockdownLocked() bool {
 	if !option.Config.EnableEndpointLockdownOnPolicyOverflow {
 		return false
 	}
 	// The desiredPolicy will be larger than the BPF maximum after
 	// the changes.
 	return e.desiredPolicy != nil && e.policyMap != nil &&
-		e.desiredPolicy.Len()+changeSize > int(e.policyMap.MaxEntries())
+		e.desiredPolicy.Len() > int(e.policyMap.MaxEntries())
 }
 
 // startLockdownLocked initiates an endpoint lockdown, and returns an
 // error if it fails. The Endpoint must be locked.
-func (e *Endpoint) startLockdownLocked(changeSize int) error {
+func (e *Endpoint) startLockdownLocked() error {
 	// We only need to go through the mechanics of
 	// lockdown once.
 	if !e.lockdown {
@@ -1244,7 +1239,6 @@ func (e *Endpoint) startLockdownLocked(changeSize int) error {
 			return err
 		}
 		e.lockdown = true
-		e.updatePolicyMapPressureMetric(float64(changeSize))
 	}
 	return ErrPolicyEntryMaxExceeded
 }
@@ -1326,8 +1320,10 @@ func (e *Endpoint) endpointPolicyLockdown() error {
 func (e *Endpoint) syncPolicyMap() error {
 	addErrors, deleteErrors := 0, 0
 
-	if e.shouldLockdownLocked(0) {
-		return e.startLockdownLocked(0)
+	e.updatePolicyMapPressureMetric(e.desiredPolicy.Len())
+
+	if e.shouldLockdownLocked() {
+		return e.startLockdownLocked()
 	}
 	if e.stopLockdownLocked() {
 		return ErrComingOutOfLockdown
@@ -1371,8 +1367,10 @@ func (e *Endpoint) syncPolicyMap() error {
 func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
 	addErrors, deleteErrors := 0, 0
 
-	if e.shouldLockdownLocked(0) {
-		err = e.startLockdownLocked(0)
+	e.updatePolicyMapPressureMetric(e.desiredPolicy.Len())
+
+	if e.shouldLockdownLocked() {
+		err = e.startLockdownLocked()
 		return
 	}
 	if e.stopLockdownLocked() {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -531,7 +531,7 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	if !datapathRegenCtxt.policyMapSyncDone {
 		err = e.policyMapSync(datapathRegenCtxt.policyMapDump, stats)
 		if err != nil {
-			return 0, newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policy map synchronization failed: %w", err)
+			return 0, newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap synchronization failed: %w", err)
 		}
 		datapathRegenCtxt.policyMapSyncDone = true
 	}
@@ -766,7 +766,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 		}
 		e.policyMap, err = e.policyMapFactory.OpenEndpoint(e.ID)
 		if err != nil {
-			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "failed to open endpoint BPF policy map: %w", err)
+			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "failed to open endpoint BPF policymap: %w", err)
 		}
 	}
 
@@ -1210,6 +1210,9 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 // shouldLockdownLockdown returns true if the desiredPolicy, after changes,
 // will be larger than policymap.MaxEntries. The Endpoint must be locked.
 func (e *Endpoint) shouldLockdownLocked(changeSize int) bool {
+	if !option.Config.EnableEndpointLockdownOnPolicyOverflow {
+		return false
+	}
 	// The desiredPolicy will be larger than the BPF maximum after
 	// the changes.
 	return e.desiredPolicy != nil && e.policyMap != nil &&

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -359,6 +359,7 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 		datapathRegenCtxt.revertStack.Push(func() error {
 			// Do nothing if e.policyMap was not initialized already
 			if e.policyMap != nil && e.desiredPolicy != e.realizedPolicy {
+				desiredPolicyMapLen := e.desiredPolicy.Len()
 				// Revert nextPolicyRevision; otherwise,
 				// res.endpointPolicy will not be recalculated
 				// on the next regeneration attempt, and we
@@ -377,6 +378,10 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 				if err != nil {
 					e.getLogger().Error("failed to sync PolicyMap when reverting to last known good policy", logfields.Error, err)
 				}
+
+				// The pressure was set when we performed the sync above;
+				// override it to the "real" value.
+				e.updatePolicyMapPressureMetric(desiredPolicyMapLen)
 			}
 			return nil
 		})

--- a/pkg/endpointmanager/policymap_pressure.go
+++ b/pkg/endpointmanager/policymap_pressure.go
@@ -21,10 +21,24 @@ import (
 func (p *policyMapPressure) Update(ev endpoint.PolicyMapPressureEvent) {
 	val := ev.Value
 	p.Lock()
+	prev := p.current[ev.EndpointID]
 	p.current[ev.EndpointID] = val
 	p.Unlock()
 
-	p.logger.Debug("EndpointManager policymap received event", logfields.Value, val)
+	// Log if nearing or over threshold
+	if prev < 0.9 && val >= 0.9 && val <= 1.0 {
+		p.logger.Warn("Endpoint nearing policymap overflow!",
+			logfields.EndpointID, ev.EndpointID,
+			logfields.Value, val)
+	} else if prev <= 1.0 && val > 1.0 {
+		p.logger.Error("Endpoint policymap has overflowed!",
+			logfields.EndpointID, ev.EndpointID,
+			logfields.Value, val)
+	} else if prev != val {
+		p.logger.Debug("Endpoint policymap pressure set",
+			logfields.EndpointID, ev.EndpointID,
+			logfields.Value, val)
+	}
 
 	p.trigger.Trigger()
 }


### PR DESCRIPTION
This fixes two issues that caused policymap overflow to be silently ignored on first regeneration.

The first bug  is the lockdown logic partially kicking in, even when lockdown is disabled.

The second bug is the revert-on-failure (added in https://github.com/cilium/cilium/pull/35372) which had the inadvertent effect of setting the pressure to 0.

Fixes: #45788

```release-note
Fixes a bug where policymap pressure was incorrectly being reported as 0.
```
