### PR TITLE
ci: use extra power github runner if available for kubespray workflow

### DIFF
--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -103,7 +103,7 @@ jobs:
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     needs: wait-for-images
     timeout-minutes: 60
     env:


### PR DESCRIPTION
It's a rather demanding workflow. This change is similar to the change we recently did on multi-pool: https://github.com/cilium/cilium/pull/45555