### PR TITLE
endpoint: describe RTInfo encoding

### DIFF
--- a/pkg/datapath/config/endpoint.go
+++ b/pkg/datapath/config/endpoint.go
@@ -62,7 +62,7 @@ func Endpoint(ep endpoint.Config, lnc *Config) any {
 	cfg.TunnelProtocol = lnc.TunnelProtocol
 	cfg.TunnelPort = lnc.TunnelPort
 
-	cfg.RtInfo = ep.GetRTInfo()
+	cfg.RtInfo, _ = ep.GetRTInfo()
 
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -109,8 +109,8 @@ func (t *templateCfg) GetPolicyVerdictLogFilter() uint32 {
 	return templatePolicyVerdictFilter
 }
 
-func (*templateCfg) GetRTInfo() uint32 {
-	return 0
+func (*templateCfg) GetRTInfo() (uint32, eptypes.RTInfoEncoding) {
+	return 0, eptypes.RTInfoNone
 }
 
 func (*templateCfg) GetPropertyValue(key string) any {

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -27,6 +27,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/ipam"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -261,7 +262,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 
 			if tid, ok := pod.Annotations[annotation.FIBTableID]; option.Config.EnableFibTableIDAnnotation && ok {
 				if tidInt, err := strconv.ParseUint(tid, 10, 32); err == nil {
-					ep.SetRTInfo(uint32(tidInt))
+					ep.SetRTInfo(uint32(tidInt), endpointtypes.RTInfoFIB)
 				} else {
 					m.logger.Warn("Unable to parse fib-table-id annotation as uint32, pod will use default routing table.",
 						logfields.K8sPodName, epTemplate.K8sPodName,

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"strconv"
 
+	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
@@ -101,8 +102,9 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 	}
 }
 
-func (ep *epInfoCache) GetRTInfo() uint32 {
-	return ep.rtInfo
+func (ep *epInfoCache) GetRTInfo() (uint32, endpoint.RTInfoEncoding) {
+	enc, _ := ep.properties[PropertyRTInfo].(string)
+	return ep.rtInfo, endpoint.RTInfoEncoding(enc)
 }
 
 func (ep *epInfoCache) GetIfIndex() int {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -104,6 +104,8 @@ const (
 	PropertySkipMasqueradeV4 = "property-skip-masquerade-v4"
 	// PropertySkipMasqueradeV6 will mark the endpoint to skip IPv6 masquerade.
 	PropertySkipMasqueradeV6 = "property-skip-masquerade-v6"
+	// Property RTInfo describes the endpoint's RTInfo encoding.
+	PropertyRTInfo = "property-rt-info"
 )
 
 var (
@@ -1919,10 +1921,14 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 	)
 	if tid, ok := pod.Annotations[annotation.FIBTableID]; option.Config.EnableFibTableIDAnnotation && ok {
 		if tidInt, err := strconv.ParseUint(tid, 10, 32); err == nil {
-			e.SetRTInfo(uint32(tidInt))
+			e.SetRTInfo(uint32(tidInt), endpoint.RTInfoFIB)
 		}
 	} else {
-		e.SetRTInfo(0)
+		// if either endpoint is no longer annotated, or EnableFibTableIDAnnotation was
+		// disabled, remove pod from FIB table if bound.
+		if _, enc := e.GetRTInfo(); enc == endpoint.RTInfoFIB {
+			e.ClearRTInfo()
+		}
 	}
 
 	// Handle DisableSourceIPVerification annotation.
@@ -2823,32 +2829,51 @@ func (e *Endpoint) GetCreatedAt() time.Time {
 	return e.createdAt
 }
 
-func (e *Endpoint) SetRTInfo(info uint32) {
+func (e *Endpoint) SetRTInfo(info uint32, t endpoint.RTInfoEncoding) {
 	e.mutex.RWMutex.Lock()
 	defer e.mutex.RWMutex.Unlock()
+
 	e.rtInfo = info
+	e.setPropertyValue(PropertyRTInfo, string(t))
+
 }
 
-func (e *Endpoint) GetRTInfo() uint32 {
+func (e *Endpoint) GetRTInfo() (uint32, endpoint.RTInfoEncoding) {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
-	return e.rtInfo
+	enc, _ := e.getPropertyValue(PropertyRTInfo).(string)
+	return e.rtInfo, endpoint.RTInfoEncoding(enc)
+}
+
+func (e *Endpoint) ClearRTInfo() {
+	e.mutex.RWMutex.Lock()
+	defer e.mutex.RWMutex.Unlock()
+	e.rtInfo = 0
+	delete(e.properties, PropertyRTInfo)
+}
+
+func (e *Endpoint) getPropertyValue(key string) any {
+	return e.properties[key]
 }
 
 // GetPropertyValue returns the endpoint property value for this key.
 func (e *Endpoint) GetPropertyValue(key string) any {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
-	return e.properties[key]
+	return e.getPropertyValue(key)
+}
+
+func (e *Endpoint) setPropertyValue(key string, value any) any {
+	old := e.properties[key]
+	e.properties[key] = value
+	return old
 }
 
 // SetPropertyValue sets the endpoint property value for this key.
 func (e *Endpoint) SetPropertyValue(key string, value any) any {
 	e.mutex.RWMutex.Lock()
 	defer e.mutex.RWMutex.Unlock()
-	old := e.properties[key]
-	e.properties[key] = value
-	return old
+	return e.setPropertyValue(key, value)
 }
 
 // IsProperty checks if the value of the properties map is set, it's a boolean

--- a/pkg/endpoint/types/config.go
+++ b/pkg/endpoint/types/config.go
@@ -11,6 +11,14 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
+// RTInfoEncoding describes a possible encoding of the RTInfo field of an endpoint.
+type RTInfoEncoding string
+
+const (
+	RTInfoNone RTInfoEncoding = ""
+	RTInfoFIB  RTInfoEncoding = "fib"
+)
+
 // Config provides datapath implementations a clean interface to access
 // endpoint-specific configuration when configuring the datapath.
 type Config interface {
@@ -48,8 +56,8 @@ type LoadTimeConfig interface {
 	// GetPropertyValue returns the endpoint property value for this key.
 	GetPropertyValue(key string) any
 
-	// GetRTInfo returns the routing domain info for the pod.
-	GetRTInfo() uint32
+	// GetRTInfo returns the routing domain info for the pod and its encoding.
+	GetRTInfo() (uint32, RTInfoEncoding)
 
 	// RequireARPPassthrough returns true if the datapath must implement
 	// ARP passthrough for this endpoint

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -33,6 +33,7 @@ import (
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -416,15 +417,15 @@ func (k *K8sPodWatcher) updateK8sPodV1(ctx context.Context, oldK8sPod, newK8sPod
 			if annoChangedFIBTableID {
 				if tid, ok := newK8sPod.Annotations[annotation.FIBTableID]; ok {
 					if tidInt, err := strconv.ParseUint(tid, 10, 32); err == nil {
-						podEP.SetRTInfo(uint32(tidInt))
+						podEP.SetRTInfo(uint32(tidInt), endpointtypes.RTInfoFIB)
 					} else {
 						scopedLog.Warn("Unable to parse fib-table-id annotation as uint32, pod will use default routing table.",
 							logfields.Annotation, annotation.FIBTableID,
 							logfields.Error, err,
 						)
 					}
-				} else {
-					podEP.SetRTInfo(0)
+				} else if _, enc := podEP.GetRTInfo(); enc == endpointtypes.RTInfoFIB {
+					podEP.ClearRTInfo()
 				}
 				regenMetadata := &regeneration.ExternalRegenerationMetadata{
 					Reason:            "fib-table-id annotation updated",

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	eptypes "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -119,7 +120,7 @@ type EndpointFrontend interface {
 	GetIfIndex() int
 	GetParentIfIndex() int
 	GetID() uint64
-	GetRTInfo() uint32
+	GetRTInfo() (uint32, eptypes.RTInfoEncoding)
 	IPv4Address() netip.Addr
 	IPv6Address() netip.Addr
 	GetIdentity() identity.NumericIdentity
@@ -161,6 +162,7 @@ func (m *lxcMap) getBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 		return nil, fmt.Errorf("invalid node MAC: %w", err)
 	}
 
+	rtInfo, _ := e.GetRTInfo()
 	// Both lxc and node mac can be nil for the case of L3/NOARP devices.
 	info := &EndpointInfo{
 		IfIndex:       uint32(e.GetIfIndex()),
@@ -169,7 +171,7 @@ func (m *lxcMap) getBPFValue(e EndpointFrontend) (*EndpointInfo, error) {
 		NodeMAC:       nodeMAC,
 		SecID:         e.GetIdentity().Uint32(), // Host byte-order
 		ParentIfIndex: uint32(e.GetParentIfIndex()),
-		RTInfo:        e.GetRTInfo(),
+		RTInfo:        rtInfo,
 	}
 
 	if e.IsAtHostNS() {

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 
+	eptypes "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -91,7 +92,7 @@ func (e *TestEndpoint) GetOptions() *option.IntOptions { return e.Opts }
 
 func (e *TestEndpoint) IsHost() bool { return e.isHost }
 
-func (e *TestEndpoint) GetRTInfo() uint32 { return 0 }
+func (e *TestEndpoint) GetRTInfo() (uint32, eptypes.RTInfoEncoding) { return 0, eptypes.RTInfoNone }
 
 func (e *TestEndpoint) GetPropertyValue(key string) any { return nil }
 


### PR DESCRIPTION
An endpoint can have an associated RTInfo field the datapath can use for
specialized routing procedures.

Currently, the only implemented feature is binding a Pod's egress next
hop resolution to a particular FIB table ID.

Add the RTInfo encoding type as a first class citizen so the control
plane can identify what the RTInfo field, if set, is expressing to the
datapath.

In the future this will also support multiple control planes handling
pods separately, and each not clobbering RTInfo, as long as each control
plane manages a particular RTInfo encoding type.


```release-note
endpoint: set and get the value of the RTInfo's encoding
```