### PR TITLE
ci/ztunnel: skip pod-to-world tests

### DIFF
--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -218,6 +218,7 @@ jobs:
           mkdir -p cilium-junits
 
           cilium connectivity test ${{ steps.e2e_config.outputs.test_flags }} \
+            --test='!pod-to-world.*' \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
             --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.name }}).xml" \
             --junit-property github_job_step="Run tests (${{ matrix.name }})"


### PR DESCRIPTION
Skipping `pod-to-world` tests as these are causing flakes and do not traverse ztunnel.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #45775
