### PR TITLE
bpf: nodeport: make l3_off in nodeport_lb4() static

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -621,7 +621,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 		if (!ctx_skip_nodeport(ctx)) {
 			bool is_dsr = false;
 
-			int ret = nodeport_lb4(ctx, ip4, ETH_HLEN, secctx, punt_to_stack,
+			int ret = nodeport_lb4(ctx, ip4, secctx, punt_to_stack,
 					       ext_err, &is_dsr);
 
 			/* nodeport_lb4() returns with TC_ACT_REDIRECT for

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -288,7 +288,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	if (!ctx_skip_nodeport(ctx)) {
 		bool punt_to_stack = false;
 
-		ret = nodeport_lb4(ctx, ip4, ETH_HLEN, *identity, &punt_to_stack,
+		ret = nodeport_lb4(ctx, ip4, *identity, &punt_to_stack,
 				   ext_err, &is_dsr);
 		/* nodeport_lb4() returns with TC_ACT_REDIRECT for
 		 * traffic to L7 LB. Policy enforcement needs to take

--- a/bpf/bpf_wireguard.c
+++ b/bpf/bpf_wireguard.c
@@ -148,7 +148,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 identity __maybe_unused, __s8 *ext_err
 		bool punt_to_stack = false;
 		bool is_dsr = false;
 
-		ret = nodeport_lb4(ctx, ip4, ETH_HLEN, identity, &punt_to_stack,
+		ret = nodeport_lb4(ctx, ip4, identity, &punt_to_stack,
 				   ext_err, &is_dsr);
 		/* nodeport_lb4() returns with TC_ACT_REDIRECT for
 		 * traffic to L7 LB. Policy enforcement needs to take

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -111,7 +111,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 			goto out;
 		}
 
-		ret = nodeport_lb4(ctx, ip4, ETH_HLEN, UNKNOWN_ID, &punt_to_stack,
+		ret = nodeport_lb4(ctx, ip4, UNKNOWN_ID, &punt_to_stack,
 				   &ext_err, &is_dsr);
 	}
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2884,7 +2884,6 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
  */
 static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 					struct iphdr *ip4,
-					int l3_off,
 					__u32 src_sec_identity,
 					bool *punt_to_stack,
 					__s8 *ext_err,
@@ -2895,10 +2894,11 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 	bool is_svc_proto = true;
 	const struct lb4_service *svc;
 	struct lb4_key key = {};
+	int l3_off = ETH_HLEN;
 	int ret, l4_off;
 
 	fraginfo = ipfrag_encode_ipv4(ip4);
-	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+	l4_off = l3_off + ipv4_hdrlen(ip4);
 
 	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
 	if (IS_ERR(ret)) {


### PR DESCRIPTION
With ca782cd27439 ("bpf: nodeport: remove XDP-accel support for LB of tunnel traffic") all callers again pass ETH_HLEN as the l3 offset. So let's align nodeport_lb4() with its IPv6 variant.