### PR TITLE
connectivity: add host-firewall-l7-ingress regression test

### DIFF
--- a/cilium-cli/connectivity/builder/builder.go
+++ b/cilium-cli/connectivity/builder/builder.go
@@ -344,6 +344,7 @@ func sequentialTests(ct *check.ConnectivityTest) error {
 	tests := []testBuilder{
 		hostFirewallIngress{},
 		hostFirewallEgress{},
+		hostFirewallL7Ingress{},
 		clientEgressL7TlsDenyWithoutHeaders{},
 		clientEgressL7TlsHeaders{},
 		egresstoSpecificNamespace{},

--- a/cilium-cli/connectivity/builder/host_firewall_l7_ingress.go
+++ b/cilium-cli/connectivity/builder/host_firewall_l7_ingress.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package builder
+
+import (
+	_ "embed"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
+	"github.com/cilium/cilium/cilium-cli/utils/features"
+)
+
+//go:embed manifests/host-firewall-l7-ingress.yaml
+var hostFirewallL7IngressPolicyYAML string
+
+type hostFirewallL7Ingress struct{}
+
+// build verifies that an L7-proxied connection to a pod on a remote node
+// completes successfully when the host firewall is enabled and host
+// ingress is default-deny. The forward leg is redirected to envoy on the
+// destination node; the upstream socket envoy opens to the local pod is
+// sourced from the cilium_host IP. Without per-flow CT installed for that
+// upstream connection, the reply SYN,ACK from the backend hits the host's
+// default-deny ingress and is dropped, causing the curl to fail.
+//
+// Regression test for https://github.com/cilium/cilium/issues/45565.
+func (t hostFirewallL7Ingress) build(ct *check.ConnectivityTest, _ map[string]string) {
+	newTest("host-firewall-l7-ingress", ct).
+		WithUnsafeTests().
+		WithFeatureRequirements(
+			features.RequireEnabled(features.HostFirewall),
+			features.RequireEnabled(features.L7Proxy),
+		).
+		WithCiliumClusterwidePolicy(hostFirewallL7IngressPolicyYAML).
+		WithCiliumPolicy(echoIngressL7HTTPPolicyYAML).
+		WithScenarios(
+			tests.PodToPod(
+				tests.WithSourceLabelsOption(client2Label),
+				tests.WithDestinationLabelsOption(map[string]string{"name": "echo-other-node"}),
+			),
+		).
+		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
+			egress = check.ResultOK
+			egress.HTTP = check.HTTP{Method: "GET"}
+			return egress, check.ResultNone
+		})
+}

--- a/cilium-cli/connectivity/builder/manifests/host-firewall-l7-ingress.yaml
+++ b/cilium-cli/connectivity/builder/manifests/host-firewall-l7-ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "host-firewall-l7-ingress"
+spec:
+  nodeSelector: {}
+  ingress:
+  - fromEntities:
+    - health
+    - kube-apiserver
+    - remote-node
+    - world


### PR DESCRIPTION
Cover the cross-node + L7-ingress + host-firewall combination from cilium/cilium#45565: cilium-envoy on the destination node opens its upstream socket from the cilium_host IP with MARK_MAGIC_PROXY_INGRESS carrying the original pod identity. Without the bpf_host fix from the preceding commit, the SYN,ACK reply from the backend hits host-ingress default-deny and the L7 request times out (envoy returns 503).

Verified the test fails against stock 1.19.3 on a 2-node Talos cluster (client2@worker -> echo-other-node@control-plane returns 503).

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```
