### PR TITLE
datapath: add altname to mark cilium owned interfaces & do not change MTU for interfaces not managed by cilium

### DIFF
--- a/pkg/datapath/connector/add.go
+++ b/pkg/datapath/connector/add.go
@@ -6,7 +6,9 @@ package connector
 import (
 	"crypto/sha256"
 	"fmt"
+	"slices"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
@@ -17,7 +19,22 @@ const (
 	HostInterfacePrefix = "lxc"
 	// temporaryInterfacePrefix is the temporary interface prefix while setting up libNetwork interface.
 	temporaryInterfacePrefix = "tmp"
+	// ciliumCNIAltName is the alternative interface name set on the peer (pod-side)
+	// end of every veth/netkit pair created by Cilium. Used to identify
+	// Cilium-owned interfaces.
+	ciliumCNIAltName = "cilium_cni"
 )
+
+// IsCiliumManagedLink returns true if the link was created by Cilium, identified
+// by the presence of the CniAltName(ifname) altname attribute.
+func IsCiliumManagedLink(link netlink.Link) bool {
+	return slices.Contains(link.Attrs().AltNames, CniAltName(link.Attrs().Name))
+}
+
+// CniAltName returns the altname for this `ifName`
+func CniAltName(ifName string) string {
+	return fmt.Sprintf("%s:%s", ciliumCNIAltName, ifName)
+}
 
 // Endpoint2IfName returns the host interface name for the given endpointID.
 func Endpoint2IfName(endpointID string) string {

--- a/pkg/datapath/connector/link.go
+++ b/pkg/datapath/connector/link.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/netns"
@@ -134,22 +135,9 @@ func NewLinkPair(
 	}
 
 	// Rename the peer link, if we generated a temporary name earlier
-	if finalPeerIfName != "" && finalPeerIfName != cfg.PeerIfName {
-		rename := func() error {
-			if err := link.Rename(cfg.PeerIfName, finalPeerIfName); err != nil {
-				return fmt.Errorf("failed to rename link from %s to %s: %w", cfg.PeerIfName, finalPeerIfName, err)
-			}
-			return nil
-		}
-
-		if cfg.PeerNamespace != nil {
-			err = cfg.PeerNamespace.Do(func() error { return rename() })
-		} else {
-			err = rename()
-		}
-		if err != nil {
-			return nil, err
-		}
+	finalPeerIfName, err = renameIfNeeded(finalPeerIfName, cfg.PeerIfName, cfg.PeerNamespace)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := markOwned(cfg.PeerNamespace, finalPeerIfName); err != nil {
@@ -157,6 +145,21 @@ func NewLinkPair(
 			logfields.Error, err,
 			logfields.Name, finalPeerIfName,
 		)
+	}
+
+	// re-generate the peer Link as the previous one is likely stale
+	if cfg.PeerNamespace != nil {
+		if err := cfg.PeerNamespace.Do(func() error {
+			peerLink, err = safenetlink.LinkByName(finalPeerIfName)
+			return err
+		}); err != nil {
+			return nil, err
+		}
+	} else {
+		peerLink, err = safenetlink.LinkByName(finalPeerIfName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	pair := &linkPair{
@@ -270,6 +273,39 @@ func (lp *linkPair) Delete() error {
 		*lp = linkPair{}
 	}
 	return nil
+}
+
+// renameIfNeeded renames the link, if needed. also returns the desired interface name.
+func renameIfNeeded(finalName, currentName string, ns *netns.NetNS) (string, error) {
+	// nsDo runs `f` within namespace context if necessary
+	nsDo := func(f func() error) error {
+		if ns != nil {
+			return ns.Do(f)
+		}
+
+		return f()
+	}
+
+	// if finalName is empty OR it matches currentName, just try returning
+	// the existing link.
+	if finalName == "" || finalName == currentName {
+		return currentName, nil
+	}
+
+	rename := func() error {
+		err := link.Rename(currentName, finalName)
+		if err != nil {
+			return fmt.Errorf("failed to rename link from %s to %s: %w", currentName, finalName, err)
+		}
+
+		return nil
+	}
+
+	if err := nsDo(rename); err != nil {
+		return "", err
+	}
+
+	return finalName, nil
 }
 
 // markOwned marks interface at `ifName` inside `ns` context

--- a/pkg/datapath/connector/link.go
+++ b/pkg/datapath/connector/link.go
@@ -152,6 +152,13 @@ func NewLinkPair(
 		}
 	}
 
+	if err := markOwned(cfg.PeerNamespace, finalPeerIfName); err != nil {
+		log.Warn("unable to mark peer link cilium ownership",
+			logfields.Error, err,
+			logfields.Name, finalPeerIfName,
+		)
+	}
+
 	pair := &linkPair{
 		hostLink: hostLink,
 		peerLink: peerLink,
@@ -263,4 +270,18 @@ func (lp *linkPair) Delete() error {
 		*lp = linkPair{}
 	}
 	return nil
+}
+
+// markOwned marks interface at `ifName` inside `ns` context
+// as cilium owned by writing to the link altname.
+func markOwned(ns *netns.NetNS, ifName string) error {
+	markFunc := func() error {
+		return link.AddAltName(ifName, CniAltName(ifName))
+	}
+
+	if ns != nil {
+		return ns.Do(markFunc)
+	}
+
+	return markFunc()
 }

--- a/pkg/datapath/connector/link_test.go
+++ b/pkg/datapath/connector/link_test.go
@@ -248,6 +248,10 @@ func TestPrivilegedNewLinkPair(t *testing.T) {
 				assert.NotNil(t, linkPair.hostLink)
 				assert.NotNil(t, linkPair.peerLink)
 				assert.Equal(t, linkPair.mode, tt.mode)
+				// for now we are getting a stale link back
+				// in peerLink! it doesnt contain the modifications
+				// we did like changing the link name.
+				require.False(t, IsCiliumManagedLink(linkPair.peerLink))
 			}
 		})
 	}
@@ -352,6 +356,10 @@ func TestPrivilegedLinkPairDelete(t *testing.T) {
 			require.NotNil(t, linkPair)
 			assert.NotNil(t, linkPair.hostLink)
 			assert.NotNil(t, linkPair.peerLink)
+			// for now we are getting a stale link back
+			// in peerLink! it doesnt contain the modifications
+			// we did like changing the link name.
+			require.False(t, IsCiliumManagedLink(linkPair.peerLink))
 
 			require.NoError(t, ns.Do(func() error {
 				return linkPair.Delete()

--- a/pkg/datapath/connector/link_test.go
+++ b/pkg/datapath/connector/link_test.go
@@ -248,10 +248,7 @@ func TestPrivilegedNewLinkPair(t *testing.T) {
 				assert.NotNil(t, linkPair.hostLink)
 				assert.NotNil(t, linkPair.peerLink)
 				assert.Equal(t, linkPair.mode, tt.mode)
-				// for now we are getting a stale link back
-				// in peerLink! it doesnt contain the modifications
-				// we did like changing the link name.
-				require.False(t, IsCiliumManagedLink(linkPair.peerLink))
+				require.True(t, IsCiliumManagedLink(linkPair.peerLink))
 			}
 		})
 	}
@@ -356,10 +353,7 @@ func TestPrivilegedLinkPairDelete(t *testing.T) {
 			require.NotNil(t, linkPair)
 			assert.NotNil(t, linkPair.hostLink)
 			assert.NotNil(t, linkPair.peerLink)
-			// for now we are getting a stale link back
-			// in peerLink! it doesnt contain the modifications
-			// we did like changing the link name.
-			require.False(t, IsCiliumManagedLink(linkPair.peerLink))
+			require.True(t, IsCiliumManagedLink(linkPair.peerLink))
 
 			require.NoError(t, ns.Do(func() error {
 				return linkPair.Delete()

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -49,6 +49,16 @@ func Rename(curName, newName string) error {
 	return netlink.LinkSetName(link, newName)
 }
 
+// SetAltNames sets the altnames for a link
+func AddAltName(linkName, altName string) error {
+	link, err := safenetlink.LinkByName(linkName)
+	if err != nil {
+		return err
+	}
+
+	return netlink.LinkAddAltName(link, altName)
+}
+
 func GetHardwareAddr(ifName string) (mac.MAC, error) {
 	iface, err := safenetlink.LinkByName(ifName)
 	if err != nil {

--- a/pkg/mtu/endpoint_updater.go
+++ b/pkg/mtu/endpoint_updater.go
@@ -298,6 +298,10 @@ func defaultRouteHook(routeMTUs []RouteMTU) error {
 			continue
 		}
 
+		if !connector.IsCiliumManagedLink(link) {
+			continue
+		}
+
 		netlink.LinkSetMTU(link, defaultRouteMTU.DeviceMTU)
 
 		routes, err := safenetlink.RouteList(link, netlink.FAMILY_ALL)

--- a/pkg/mtu/endpoint_updater_test.go
+++ b/pkg/mtu/endpoint_updater_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mtu
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/connector"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/testutils"
+	"github.com/cilium/cilium/pkg/testutils/netns"
+)
+
+// TestPrivilegedDefaultRouteHookOnlyUpdatesCiliumLinks verifies that
+// defaultRouteHook only updates the MTU of links with the CiliumCNIAltName
+// altname, leaving other veth links untouched.
+func TestPrivilegedDefaultRouteHookOnlyUpdatesCiliumLinks(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	const (
+		newMTU  = 1400
+		initMTU = 1500
+	)
+
+	routeMTUs := []RouteMTU{
+		{
+			Prefix:    DefaultPrefixV4,
+			DeviceMTU: newMTU,
+			RouteMTU:  newMTU,
+		},
+	}
+
+	ns := netns.NewNetNS(t)
+	require.NoError(t, ns.Do(func() error {
+		// Create the Cilium-managed veth pair (with altname).
+		ciliumVeth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: "cilium0",
+				MTU:  initMTU,
+			},
+			PeerName: "cilium0peer",
+		}
+		require.NoError(t, netlink.LinkAdd(ciliumVeth))
+
+		ciliumPeer, err := safenetlink.LinkByName("cilium0peer")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkAddAltName(ciliumPeer, connector.CniAltName("cilium0peer")))
+
+		// Create a non-Cilium veth pair (without altname) — simulates Multus.
+		otherVeth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: "other0",
+				MTU:  initMTU,
+			},
+			PeerName: "other0peer",
+		}
+		require.NoError(t, netlink.LinkAdd(otherVeth))
+
+		// Add a default IPv4 route on the Cilium-managed peer so the hook
+		// has a route to update.
+		require.NoError(t, netlink.LinkSetUp(ciliumPeer))
+		require.NoError(t, netlink.RouteAdd(&netlink.Route{
+			LinkIndex: ciliumPeer.Attrs().Index,
+			Dst:       &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+			Family:    netlink.FAMILY_V4,
+		}))
+
+		// Run the hook.
+		require.NoError(t, defaultRouteHook(routeMTUs))
+
+		// Re-query MTUs.
+		updatedCiliumPeer, err := safenetlink.LinkByName("cilium0peer")
+		require.NoError(t, err)
+		updatedOtherPeer, err := safenetlink.LinkByName("other0peer")
+		require.NoError(t, err)
+
+		require.Equal(t, newMTU, updatedCiliumPeer.Attrs().MTU,
+			"cilium0peer MTU should have been updated by defaultRouteHook")
+		require.Equal(t, initMTU, updatedOtherPeer.Attrs().MTU,
+			"other0peer MTU should not have been changed by defaultRouteHook")
+
+		return nil
+	}))
+}


### PR DESCRIPTION
right now there is no way to know if a device on a pod was added by cilium. this makes it tricky when the cni decides to change the MTU on a device as they could have been added (therefore, managed) by a different CNI.

this PR adds an altname attribute to cilium added links so we have an unambiguous way of knowing that
cilium is the owner of a link.

```
/ # ip link show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
20: eth0@if21: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 62:3a:4b:c0:32:69 brd ff:ff:ff:ff:ff:ff
/ # ip link show dev cilium_cni <<<<<
20: eth0@if21: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 62:3a:4b:c0:32:69 brd ff:ff:ff:ff:ff:ff
/ #
```

3rd commit includes a small refactoring which puts the interface renaming logic inside its own function, for better readability. and it also re-queries the peerLink so the caller gets back the updated link after modifications (not the link we got during creation time)

Fixes: #37824

```release-note
datapath/mtu: add altname to mark cilium owned interfaces and do skip changing MTU on interfaces not managed by cilium
```
