### PR TITLE
lbipam: Apply fixes for bugs in LBIPAM refactor

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -553,6 +553,9 @@ func (ipam *LBIPAM) stripInvalidAllocations(sv *ServiceView) error {
 			ipam.logger.Debug(fmt.Sprintf("removing allocation '%s' from '%s'", alloc.IP, sv.Key))
 			if empty := cluster.Remove(sv); empty {
 				alloc.Origin.alloc.Free(alloc.IP)
+				if sv.SharingKey != "" {
+					ipam.sharingIndex.Remove(sv.SharingKey, cluster)
+				}
 			}
 			sv.AllocatedIPs = slices.Delete(sv.AllocatedIPs, allocIdx, allocIdx+1)
 		}
@@ -1679,7 +1682,10 @@ func (ipam *LBIPAM) handlePoolDeleted(ctx context.Context, k8sPool *cilium_api_v
 	ipam.metrics.AvailableIPs.DeleteLabelValues(k8sPool.GetName())
 	ipam.metrics.UsedIPs.DeleteLabelValues(k8sPool.GetName())
 
-	pool := ipam.pools[k8sPool.GetName()]
+	pool, found := ipam.pools[k8sPool.GetName()]
+	if !found {
+		return nil
+	}
 
 	var svsModified []*ServiceView
 	for _, poolRange := range pool.ranges {


### PR DESCRIPTION
Fix two bugs that were introduced during the refactor in #45602.

First, in the deletion path we were assuming that when we receive a pool deletion event, the pool will always be present in the IPAM's internal state. When this assumption is not true, the code panics with a nil pointer dereference. Added a nil check to prevent this.

Second, when the last service of a sharing cluster with a shared key is removed, we were not removing the sharing cluster from the index even though we had freed the IP from the allocator. This could lead to IP reuse where it was not permitted.
