### PR TITLE
endpoint: use temporary directory for log file in TestPolicyLog

### DIFF
--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -19,11 +19,12 @@ import (
 )
 
 func TestPolicyLog(t *testing.T) {
-	logger := hivetest.Logger(t)
-	logPath := filepath.Join(option.Config.StateDir, "endpoint-policy.log")
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "endpoint-policy.log")
 	f, err := os.Create(logPath)
 	require.NoError(t, err)
 
+	logger := hivetest.Logger(t)
 	do := &DummyOwner{repo: policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())}
 
 	model := newTestEndpointModel(12345, StateReady)
@@ -45,11 +46,6 @@ func TestPolicyLog(t *testing.T) {
 	ep.UpdateLogger(nil)
 	policyLogger = ep.getPolicyLogger()
 	require.NotNil(t, policyLogger)
-	defer func() {
-		// remote created log file when we are done.
-		err := os.Remove(logPath)
-		require.NoError(t, err)
-	}()
 
 	// Test logging, policyLogger must not be nil
 	policyLogger.Info("testing policy logging")


### PR DESCRIPTION
This way running the test doesn't clutter the checked out repository. The directory and thus the log file will be automatically removed on test end in all cases. Currently, the file wouldn't be deleted in some cases if the test failed.