### PR TITLE
hubble/metrics: fix labelsContext parsing to always use comma separator

### DIFF
--- a/pkg/hubble/metrics/api/api.go
+++ b/pkg/hubble/metrics/api/api.go
@@ -179,7 +179,11 @@ func parseOptionConfigs(s string) (options []*ContextOptionConfig) {
 			Name: kv[0],
 		}
 		if len(kv) == 2 {
-			ctxOption.Values = parseOptionValues(kv[1])
+			if strings.ToLower(kv[0]) == "labelscontext" {
+				ctxOption.Values = parseLabelsOptionValues(kv[1])
+			} else {
+				ctxOption.Values = parseOptionValues(kv[1])
+			}
 		} else {
 			ctxOption.Values = []string{""}
 		}
@@ -192,21 +196,23 @@ func parseOptionConfigs(s string) (options []*ContextOptionConfig) {
 func parseOptionValues(s string) (values ContextValues) {
 	values = ContextValues{}
 
-	if strings.Contains(s, "|") {
-		for option := range strings.SplitSeq(s, "|") {
-			if option == "" {
-				continue
-			}
-			values = append(values, option)
+	for option := range strings.SplitSeq(s, "|") {
+		if option == "" {
+			continue
 		}
-	} else {
-		// temporarily handling comma separated values for labels context
-		for option := range strings.SplitSeq(s, ",") {
-			if option == "" {
-				continue
-			}
-			values = append(values, option)
+		values = append(values, option)
+	}
+	return
+}
+
+func parseLabelsOptionValues(s string) (values ContextValues) {
+	values = ContextValues{}
+
+	for option := range strings.SplitSeq(s, ",") {
+		if option == "" {
+			continue
 		}
+		values = append(values, option)
 	}
 	return
 }

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -194,9 +194,6 @@ func parseContextValues(s ContextValues) (cs ContextIdentifierList, err error) {
 }
 
 func parseLabels(s ContextValues) (labelsSet, error) {
-	// TODO this labels parsing is different from options | parsing
-	// be care ful and support this
-	//labels := strings.Split(s, ",")
 	for _, label := range s {
 		if !allowedContextLabels.HasLabel(label) {
 			return labelsSet{}, fmt.Errorf("invalid labelsContext value: %s", label)


### PR DESCRIPTION
parseOptionValues used a heuristic to handle labelsContext — if no '|'
was found it fell back to splitting by ','. This was fragile and would
break if a user wrote labelsContext=source_ip,destination_ip|traffic_direction
since the presence of '|' causes the whole string to split by '|', producing
'source_ip,destination_ip' as a single invalid token.

Add parseLabelsOptionValues that always splits by ',' and route labelscontext
to it explicitly in parseOptionConfigs. parseOptionValues now only splits
by '|' as intended.

Fixes the TODO in parseLabels in context.go.

This PR was prepared with AIL:3. I personally reviewed each line of the
submission prior to opening this PR.

```release-note  
Fix Hubble metrics `labelsContext` parsing: values must now be comma-separated  
(e.g. `labelsContext=source_ip,destination_ip`). Previously, mixing `,` and `|`  
in the value would silently produce invalid tokens.  
```