### PR TITLE
bpf: mark cilium_devices as read-only, document why other maps can't

### DIFF
--- a/bpf/lib/act.h
+++ b/bpf/lib/act.h
@@ -18,6 +18,7 @@ struct lb_act_value {
 	__u32 closed;
 };
 
+/* The map cannot be marked read-only because values are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct lb_act_key);

--- a/bpf/lib/conntrack_map.h
+++ b/bpf/lib/conntrack_map.h
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "clustermesh.h"
 
+/* The map cannot be marked read-only because CT entries are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv6_ct_tuple);
@@ -16,6 +17,7 @@ struct {
 	__uint(map_flags, LRU_MEM_FLAVOR);
 } cilium_ct6_global __section_maps_btf;
 
+/* The map cannot be marked read-only because CT entries are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv6_ct_tuple);
@@ -43,6 +45,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 256);
+	/* The inner map cannot be marked read-only because CT entries are written from BPF. */
 	__array(values, struct {
 		__uint(type, BPF_MAP_TYPE_LRU_HASH);
 		__type(key, struct ipv6_ct_tuple);
@@ -58,6 +61,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 256);
+	/* The inner map cannot be marked read-only because CT entries are written from BPF. */
 	__array(values, struct {
 		__uint(type, BPF_MAP_TYPE_LRU_HASH);
 		__type(key, struct ipv6_ct_tuple);

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -29,6 +29,7 @@ struct edt_info {
 	__u64		pad[3];
 };
 
+/* The map cannot be marked read-only because values are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct edt_id);

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -26,6 +26,7 @@ struct ipv4_frag_l4ports {
 	__be16	dport;
 } __packed;
 
+/* The map cannot be marked read-only because ports are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv4_frag_id);

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -53,6 +53,7 @@ struct ipv6_frag_l4ports {
 	__be16 dport;
 } __packed;
 
+/* The map cannot be marked read-only because ports are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv6_frag_id);

--- a/bpf/lib/l2_responder.h
+++ b/bpf/lib/l2_responder.h
@@ -16,6 +16,7 @@ struct l2_responder_stats {
 	__u64 responses_sent;
 };
 
+/* The map cannot be marked read-only because stats are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct l2_responder_v4_key);
@@ -31,6 +32,7 @@ struct l2_responder_v6_key {
 	__u32 pad;
 };
 
+/* The map cannot be marked read-only because stats are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct l2_responder_v6_key);

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -214,6 +214,7 @@ struct {
 	__uint(map_flags, CONDITIONAL_PREALLOC);
 } cilium_lb6_backends_v3 __section_maps_btf;
 
+/* The map cannot be marked read-only because LB affinity is written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct lb6_affinity_key);
@@ -232,6 +233,7 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb6_source_range __section_maps_btf;
 
+/* The map cannot be marked read-only because LB health is written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, __sock_cookie);
@@ -294,6 +296,7 @@ struct {
 	__uint(map_flags, CONDITIONAL_PREALLOC);
 } cilium_lb4_backends_v3 __section_maps_btf;
 
+/* The map cannot be marked read-only because LB affinity is written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct lb4_affinity_key);
@@ -312,6 +315,7 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_lb4_source_range __section_maps_btf;
 
+/* The map cannot be marked read-only because LB health is written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, __sock_cookie);

--- a/bpf/lib/mcast.h
+++ b/bpf/lib/mcast.h
@@ -51,6 +51,8 @@ struct mcast_subscriber_v4 {
  * The outer map is keyed by a 'mcast_group_v4' multicast group address.
  * The inner value is an hash map of 'mcast_subscriber_v4' structures keyed
  * by a their IPv4 source address in big endian format.
+ * These cannot be marked read-only because multicast groups and subscribers are
+ * written from BPF.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);

--- a/bpf/lib/metrics.h
+++ b/bpf/lib/metrics.h
@@ -25,6 +25,7 @@ struct metrics_value {
 	__u64	bytes;
 };
 
+/* The map cannot be marked read-only because metrics are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 	__type(key, struct metrics_key);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -132,6 +132,7 @@ struct ipv4_nat_target {
 	__u32 tbid;
 };
 
+/* The map cannot be marked read-only because NAT entries are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv4_ct_tuple);
@@ -149,6 +150,7 @@ struct {
 	__uint(max_entries, SNAT_COLLISION_RETRIES + 1);
 } cilium_snat_v4_alloc_retries __section_maps_btf;
 
+/* The map cannot be marked read-only because NAT entries are written from BPF. */
 struct per_cluster_snat_mapping_ipv4_inner_map {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv4_ct_tuple);
@@ -1274,6 +1276,7 @@ struct ipv6_nat_target {
 	__u32 tbid;
 };
 
+/* The map cannot be marked read-only because NAT entries are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv6_ct_tuple);
@@ -1296,6 +1299,7 @@ struct {
 	__type(value, __u32);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 256);
+	/* The inner map cannot be marked read-only because NAT entries are written from BPF. */
 	__array(values, struct {
 		__uint(type, BPF_MAP_TYPE_LRU_HASH);
 		__type(key, struct ipv6_ct_tuple);

--- a/bpf/lib/neigh.h
+++ b/bpf/lib/neigh.h
@@ -9,6 +9,7 @@
 #include "common.h"
 #include "eth.h"
 
+/* The map cannot be marked read-only because neighbors are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, union v6addr);	/* ipv6 addr */
@@ -54,6 +55,7 @@ neigh_lookup_ip6(const union v6addr *addr __maybe_unused)
 }
 #endif /* ENABLE_NODEPORT && ENABLE_IPV6 */
 
+/* The map cannot be marked read-only because neighbors are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, __be32);		/* ipv4 addr */

--- a/bpf/lib/network_device.h
+++ b/bpf/lib/network_device.h
@@ -29,7 +29,7 @@ struct {
 	__type(value, struct device_state);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, 512);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_devices __section_maps_btf;
 
 static __always_inline const struct device_state *

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -107,6 +107,7 @@ struct policy_stats_value {
 };
 
 /* Global policy stats map */
+/* The map cannot be marked read-only because stats are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_PERCPU_HASH);
 	__type(key, struct policy_stats_key);

--- a/bpf/lib/ratelimit.h
+++ b/bpf/lib/ratelimit.h
@@ -24,6 +24,7 @@ struct ratelimit_value {
 	__u64 tokens;
 };
 
+/* The map cannot be marked read-only because ratelimit values are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ratelimit_key);
@@ -41,6 +42,7 @@ struct ratelimit_metrics_value {
 	__u64 dropped;
 };
 
+/* The map cannot be marked read-only because metrics are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, struct ratelimit_metrics_key);

--- a/bpf/lib/sock.h
+++ b/bpf/lib/sock.h
@@ -32,6 +32,7 @@ struct ipv4_revnat_entry {
 	__u16 rev_nat_index;
 };
 
+/* The map cannot be marked read-only because revNAT entries are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv4_revnat_tuple);
@@ -54,6 +55,7 @@ struct ipv6_revnat_entry {
 	__u16 rev_nat_index;
 };
 
+/* The map cannot be marked read-only because revNAT entries are written from BPF. */
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ipv6_revnat_tuple);

--- a/pkg/datapath/maps/maps_generated.go
+++ b/pkg/datapath/maps/maps_generated.go
@@ -285,7 +285,7 @@ func newCiliumDevicesSpec(btf *btf.Spec) *ebpf.MapSpec {
 		ValueSize:  16,
 		Value:      anyTypeByName(btf, "device_state"),
 		MaxEntries: 512,
-		Flags:      unix.BPF_F_NO_PREALLOC,
+		Flags:      unix.BPF_F_NO_PREALLOC | unix.BPF_F_RDONLY_PROG,
 		Pinning:    ebpf.PinByName,
 	}
 }


### PR DESCRIPTION
Mark the `cilium_devices` map as read-only from BPF. It is only read by programs using `map_lookup_elem` and values are accessed using `const` pointers since commit ba6826e563eb ("bpf: constify device map access"). Thus, mark it as `BPF_F_RDONLY_PROG` (conditionally disabled during BPF unit tests by means of `BPF_F_RDONLY_PROG_COND`), only allowing writes from user-space. This prevents accidental writes from the datapath, following the pattern used in other maps.

All other remaining maps are all updated from the datapath side. Add comments to the respective map definitions on why they cannot be marked read-only.

Fixes #42473