### PR TITLE
pkg/{aws,azure}: Use k8s `sets.Set` type for string sets

### DIFF
--- a/pkg/aws/ec2/ec2.go
+++ b/pkg/aws/ec2/ec2.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
@@ -380,7 +381,7 @@ func (c *Client) describeNetworkInterfacesByInstance(ctx context.Context, instan
 
 // describeNetworkInterfacesFromInstances lists all ENIs matching filtered EC2 instances
 func (c *Client) describeNetworkInterfacesFromInstances(ctx context.Context) ([]ec2_types.NetworkInterface, error) {
-	enisFromInstances := make(map[string]struct{})
+	enisFromInstances := sets.New[string]()
 
 	instanceAttrs := &ec2.DescribeInstancesInput{}
 	if len(c.instancesFilters) > 0 {
@@ -401,16 +402,13 @@ func (c *Client) describeNetworkInterfacesFromInstances(ctx context.Context) ([]
 		for _, r := range output.Reservations {
 			for _, i := range r.Instances {
 				for _, ifs := range i.NetworkInterfaces {
-					enisFromInstances[aws.ToString(ifs.NetworkInterfaceId)] = struct{}{}
+					enisFromInstances.Insert(aws.ToString(ifs.NetworkInterfaceId))
 				}
 			}
 		}
 	}
 
-	enisListFromInstances := make([]string, 0, len(enisFromInstances))
-	for k := range enisFromInstances {
-		enisListFromInstances = append(enisListFromInstances, k)
-	}
+	enisListFromInstances := enisFromInstances.UnsortedList()
 
 retry:
 	for {

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
 	"github.com/cilium/cilium/pkg/azure/types"
@@ -205,13 +206,10 @@ func (a *API) GetSubnetsByIDs(ctx context.Context, nodeSubnetIDs []string) (ipam
 	subnets := ipamTypes.SubnetMap{}
 
 	// Only return subnets that match the requested subnet IDs
-	subnetIDSet := make(map[string]struct{})
-	for _, id := range nodeSubnetIDs {
-		subnetIDSet[id] = struct{}{}
-	}
+	subnetIDSet := sets.New[string](nodeSubnetIDs...)
 
 	for _, s := range a.subnets {
-		if _, exists := subnetIDSet[s.subnet.ID]; exists {
+		if subnetIDSet.Has(s.subnet.ID) {
 			sd := s.subnet.DeepCopy()
 			sd.AvailableAddresses = s.allocator.Free()
 			subnets[sd.ID] = sd

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"slices"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
 	// Register the Azure resource-ID parser. This is the canonical place
@@ -155,17 +155,16 @@ func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string
 
 // extractSubnetIDs extracts unique subnet IDs from node network interfaces
 func (m *InstancesManager) extractSubnetIDs(instances *ipamTypes.InstanceMap) []string {
-	// Use map[string]struct{} as a set for efficient deduplication (O(1) insertion, zero memory overhead)
-	subnetIDs := make(map[string]struct{})
+	subnetIDs := sets.New[string]()
 
 	instances.ForeachAddress("", func(instanceID, interfaceID, ip, poolID string, address ipamTypes.Address) error {
 		if poolID != "" {
-			subnetIDs[poolID] = struct{}{}
+			subnetIDs.Insert(poolID)
 		}
 		return nil
 	})
 
-	return slices.Collect(maps.Keys(subnetIDs))
+	return subnetIDs.UnsortedList()
 }
 
 // resyncInstances performs a full sync of all instances using three-phase strategy


### PR DESCRIPTION
We currently have a couple `map[string]struct{}` under `pkg/aws` and `pkg/azure` that are used as sets. the `k8s.io/apimachinery/pkg/util/sets` package provides a set abstraction with methods for common operations (`Has()`, `Insert()`, `Delete()`, ...). In terms of implementation/performance, there is no change, but this makes the code more readable for humans as it's immediately clear that `sets.New[string]()` is "a set of strings" where as for someone not familiar with the pattern, the `make(map[string]struct{})` "map of string to empty struct" can be confusing.

Note: `k8s.io/apimachinery/pkg/util/sets` is already widely used throughout the codebase so this PR does not bring in a new dependency.