### PR TITLE
pkg/policy: Support multiple endpoint selectors in (C)CNPs

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -73,6 +73,10 @@ spec:
               required:
               - endpointSelector
             - properties:
+                endpointSelectors: {}
+              required:
+              - endpointSelectors
+            - properties:
                 nodeSelector: {}
               required:
               - nodeSelector
@@ -1719,7 +1723,7 @@ spec:
               endpointSelector:
                 description: |-
                   EndpointSelector selects all endpoints which should be subject to
-                  this rule. EndpointSelector and NodeSelector cannot be both empty and
+                  this rule. EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and
                   are mutually exclusive.
                 properties:
                   matchExpressions:
@@ -1774,6 +1778,67 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              endpointSelectors:
+                description: |-
+                  EndpointSelectors is a list of endpoint selectors.
+                  An endpoint is subject to this rule if it matches at least one of the endpoint selectors in the list.
+                  EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually exclusive.
+                items:
+                  description: EndpointSelector is a wrapper for k8s LabelSelector.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        description: MatchLabelsValue represents the value from the
+                          MatchLabels {key,value} pair.
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               ingress:
                 description: |-
                   Ingress is a list of IngressRule which are enforced at ingress.
@@ -3182,7 +3247,7 @@ spec:
               nodeSelector:
                 description: |-
                   NodeSelector selects all nodes which should be subject to this rule.
-                  EndpointSelector and NodeSelector cannot be both empty and are mutually
+                  EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually
                   exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
                 properties:
                   matchExpressions:
@@ -3275,6 +3340,10 @@ spec:
                   endpointSelector: {}
                 required:
                 - endpointSelector
+              - properties:
+                  endpointSelectors: {}
+                required:
+                - endpointSelectors
               - properties:
                   nodeSelector: {}
                 required:
@@ -4924,7 +4993,7 @@ spec:
                 endpointSelector:
                   description: |-
                     EndpointSelector selects all endpoints which should be subject to
-                    this rule. EndpointSelector and NodeSelector cannot be both empty and
+                    this rule. EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and
                     are mutually exclusive.
                   properties:
                     matchExpressions:
@@ -4979,6 +5048,67 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                endpointSelectors:
+                  description: |-
+                    EndpointSelectors is a list of endpoint selectors.
+                    An endpoint is subject to this rule if it matches at least one of the endpoint selectors in the list.
+                    EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually exclusive.
+                  items:
+                    description: EndpointSelector is a wrapper for k8s LabelSelector.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          description: MatchLabelsValue represents the value from
+                            the MatchLabels {key,value} pair.
+                          maxLength: 63
+                          pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
                 ingress:
                   description: |-
                     Ingress is a list of IngressRule which are enforced at ingress.
@@ -6391,7 +6521,7 @@ spec:
                 nodeSelector:
                   description: |-
                     NodeSelector selects all nodes which should be subject to this rule.
-                    EndpointSelector and NodeSelector cannot be both empty and are mutually
+                    EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually
                     exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
                   properties:
                     matchExpressions:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -76,6 +76,10 @@ spec:
               required:
               - endpointSelector
             - properties:
+                endpointSelectors: {}
+              required:
+              - endpointSelectors
+            - properties:
                 nodeSelector: {}
               required:
               - nodeSelector
@@ -1722,7 +1726,7 @@ spec:
               endpointSelector:
                 description: |-
                   EndpointSelector selects all endpoints which should be subject to
-                  this rule. EndpointSelector and NodeSelector cannot be both empty and
+                  this rule. EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and
                   are mutually exclusive.
                 properties:
                   matchExpressions:
@@ -1777,6 +1781,67 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              endpointSelectors:
+                description: |-
+                  EndpointSelectors is a list of endpoint selectors.
+                  An endpoint is subject to this rule if it matches at least one of the endpoint selectors in the list.
+                  EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually exclusive.
+                items:
+                  description: EndpointSelector is a wrapper for k8s LabelSelector.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            enum:
+                            - In
+                            - NotIn
+                            - Exists
+                            - DoesNotExist
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        description: MatchLabelsValue represents the value from the
+                          MatchLabels {key,value} pair.
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               ingress:
                 description: |-
                   Ingress is a list of IngressRule which are enforced at ingress.
@@ -3185,7 +3250,7 @@ spec:
               nodeSelector:
                 description: |-
                   NodeSelector selects all nodes which should be subject to this rule.
-                  EndpointSelector and NodeSelector cannot be both empty and are mutually
+                  EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually
                   exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
                 properties:
                   matchExpressions:
@@ -3278,6 +3343,10 @@ spec:
                   endpointSelector: {}
                 required:
                 - endpointSelector
+              - properties:
+                  endpointSelectors: {}
+                required:
+                - endpointSelectors
               - properties:
                   nodeSelector: {}
                 required:
@@ -4927,7 +4996,7 @@ spec:
                 endpointSelector:
                   description: |-
                     EndpointSelector selects all endpoints which should be subject to
-                    this rule. EndpointSelector and NodeSelector cannot be both empty and
+                    this rule. EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and
                     are mutually exclusive.
                   properties:
                     matchExpressions:
@@ -4982,6 +5051,67 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                endpointSelectors:
+                  description: |-
+                    EndpointSelectors is a list of endpoint selectors.
+                    An endpoint is subject to this rule if it matches at least one of the endpoint selectors in the list.
+                    EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually exclusive.
+                  items:
+                    description: EndpointSelector is a wrapper for k8s LabelSelector.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          description: MatchLabelsValue represents the value from
+                            the MatchLabels {key,value} pair.
+                          maxLength: 63
+                          pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
                 ingress:
                   description: |-
                     Ingress is a list of IngressRule which are enforced at ingress.
@@ -6394,7 +6524,7 @@ spec:
                 nodeSelector:
                   description: |-
                     NodeSelector selects all nodes which should be subject to this rule.
-                    EndpointSelector and NodeSelector cannot be both empty and are mutually
+                    EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually
                     exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
                   properties:
                     matchExpressions:

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.4"
+	CustomResourceDefinitionSchemaVersion = "1.33.5"
 )

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -376,16 +376,15 @@ func ParseToCiliumRule(logger *slog.Logger, clusterName, namespace, name string,
 		// so it wouldn't make sense to inject a namespace match for
 		// those policies.
 		if namespace != "" {
-			userNamespace, present := r.EndpointSelector.GetMatch(podPrefixLbl)
-			if present && !namespacesAreValid(namespace, userNamespace) {
-				logger.Warn("CiliumNetworkPolicy contains illegal namespace match in EndpointSelector."+
-					" EndpointSelector always applies in namespace of the policy resource, removing illegal namespace match'.",
-					logfields.K8sNamespace, namespace,
-					logfields.CiliumNetworkPolicyName, name,
-					logfields.K8sNamespaceIllegal, userNamespace,
-				)
+			overrideNamespaceLabel(logger, namespace, name, &retRule.EndpointSelector)
+		}
+	} else if r.EndpointSelectors != nil {
+		retRule.EndpointSelectors = make([]api.EndpointSelector, len(r.EndpointSelectors))
+		for i, es := range r.EndpointSelectors {
+			retRule.EndpointSelectors[i] = api.NewESFromK8sLabelSelector("", es.LabelSelector)
+			if namespace != "" {
+				overrideNamespaceLabel(logger, namespace, name, &retRule.EndpointSelectors[i])
 			}
-			retRule.EndpointSelector.AddMatch(podPrefixLbl, namespace)
 		}
 	} else if r.NodeSelector.LabelSelector != nil {
 		retRule.NodeSelector = api.NewESFromK8sLabelSelector("", r.NodeSelector.LabelSelector)
@@ -428,4 +427,22 @@ func ParseToCiliumLabels(namespace, name string, uid types.UID, ruleLbs labels.L
 	}
 
 	return append(policyLbls, userLbls...).Sort()
+}
+
+// overrideNamespaceLabel overrides the namespace label in the EndpointSelector if it is present and invalid.
+func overrideNamespaceLabel(logger *slog.Logger, namespace, name string, es *api.EndpointSelector) {
+	if es.LabelSelector == nil {
+		return
+	}
+
+	userNamespace, present := es.GetMatch(podPrefixLbl)
+	if present && !namespacesAreValid(namespace, userNamespace) {
+		logger.Warn("CiliumNetworkPolicy contains illegal namespace match in EndpointSelector."+
+			" EndpointSelector always applies in namespace of the policy resource, overriding illegal namespace match'.",
+			logfields.K8sNamespace, namespace,
+			logfields.CiliumNetworkPolicyName, name,
+			logfields.K8sNamespaceIllegal, userNamespace,
+		)
+	}
+	es.AddMatch(podPrefixLbl, namespace)
 }

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -681,6 +681,121 @@ func Test_ParseToCiliumRule(t *testing.T) {
 				},
 			),
 		},
+		{
+			// EndpointSelectors should each have the policy namespace
+			// injected into their match labels.
+			name: "parse-endpoint-selectors-in-namespace",
+			args: args{
+				namespace: slim_metav1.NamespaceDefault,
+				uid:       uuid,
+				rule: &api.Rule{
+					EndpointSelectors: []api.EndpointSelector{
+						api.NewESFromMatchRequirements(
+							map[string]string{role: "backend"},
+							nil,
+						),
+						api.NewESFromMatchRequirements(
+							map[string]string{role: "frontend"},
+							nil,
+						),
+					},
+				},
+			},
+			want: &api.Rule{
+				EndpointSelectors: []api.EndpointSelector{
+					api.NewESFromMatchRequirements(
+						map[string]string{
+							role:      "backend",
+							namespace: "default",
+						},
+						nil,
+					),
+					api.NewESFromMatchRequirements(
+						map[string]string{
+							role:      "frontend",
+							namespace: "default",
+						},
+						nil,
+					),
+				},
+				Labels: labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-endpoint-selectors-in-namespace",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			},
+		},
+		{
+			// An invalid namespace match in an EndpointSelectors entry
+			// is overridden with the policy's namespace, mirroring the
+			// behaviour for EndpointSelector.
+			name: "parse-endpoint-selectors-with-invalid-namespace",
+			args: args{
+				namespace: slim_metav1.NamespaceDefault,
+				uid:       uuid,
+				rule: &api.Rule{
+					EndpointSelectors: []api.EndpointSelector{
+						api.NewESFromMatchRequirements(
+							map[string]string{
+								role:      "backend",
+								namespace: "foo",
+							},
+							nil,
+						),
+					},
+				},
+			},
+			want: &api.Rule{
+				EndpointSelectors: []api.EndpointSelector{
+					api.NewESFromMatchRequirements(
+						map[string]string{
+							role:      "backend",
+							namespace: "default",
+						},
+						nil,
+					),
+				},
+				Labels: labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-endpoint-selectors-with-invalid-namespace",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -67,14 +67,21 @@ type LogConfig struct {
 // +deepequal-gen:private-method=true
 type Rule struct {
 	// EndpointSelector selects all endpoints which should be subject to
-	// this rule. EndpointSelector and NodeSelector cannot be both empty and
+	// this rule. EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and
 	// are mutually exclusive.
 	//
 	// +kubebuilder:validation:OneOf
 	EndpointSelector EndpointSelector `json:"endpointSelector,omitzero"`
 
+	// EndpointSelectors is a list of endpoint selectors.
+	// An endpoint is subject to this rule if it matches at least one of the endpoint selectors in the list.
+	// EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually exclusive.
+	//
+	// +kubebuilder:validation:OneOf
+	EndpointSelectors []EndpointSelector `json:"endpointSelectors,omitempty"`
+
 	// NodeSelector selects all nodes which should be subject to this rule.
-	// EndpointSelector and NodeSelector cannot be both empty and are mutually
+	// EndpointSelector, EndpointSelectors and NodeSelector cannot be all empty and are mutually
 	// exclusive. Can only be used in CiliumClusterwideNetworkPolicies.
 	//
 	// +kubebuilder:validation:OneOf

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -63,15 +63,31 @@ func (r *Rule) Sanitize() error {
 		r.EnableDefaultDeny.Ingress = &enableDefaultDenyDefault
 	}
 
-	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil {
-		return errors.New("rule must have one of EndpointSelector or NodeSelector")
+	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil && len(r.EndpointSelectors) == 0 {
+		return errors.New("rule must have one of EndpointSelector or NodeSelector or EndpointSelectors")
 	}
-	if r.EndpointSelector.LabelSelector != nil && r.NodeSelector.LabelSelector != nil {
-		return errors.New("rule cannot have both EndpointSelector and NodeSelector")
+	count := 0
+	if r.EndpointSelector.LabelSelector != nil {
+		count++
+	}
+	if r.NodeSelector.LabelSelector != nil {
+		count++
+	}
+	if len(r.EndpointSelectors) > 0 {
+		count++
+	}
+	if count > 1 {
+		return errors.New("rule cannot have more than one of EndpointSelector, NodeSelector and EndpointSelectors")
 	}
 
 	if r.EndpointSelector.LabelSelector != nil {
 		if err := r.EndpointSelector.Sanitize(); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.EndpointSelectors {
+		if err := r.EndpointSelectors[i].Sanitize(); err != nil {
 			return err
 		}
 	}

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -942,13 +942,51 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 		Egress:           []EgressRule{{}},
 	}
 	err = invalidRuleBothSelectors.Sanitize()
-	require.Equal(t, "rule cannot have both EndpointSelector and NodeSelector", err.Error())
+	require.Equal(t, "rule cannot have more than one of EndpointSelector, NodeSelector and EndpointSelectors", err.Error())
+
+	invalidRuleEndpointSelectorAndEndpointSelectors := Rule{
+		EndpointSelector:  WildcardEndpointSelector,
+		EndpointSelectors: []EndpointSelector{WildcardEndpointSelector},
+		Egress:            []EgressRule{{}},
+	}
+	err = invalidRuleEndpointSelectorAndEndpointSelectors.Sanitize()
+	require.Equal(t, "rule cannot have more than one of EndpointSelector, NodeSelector and EndpointSelectors", err.Error())
+
+	invalidRuleNodeSelectorAndEndpointSelectors := Rule{
+		NodeSelector:      WildcardEndpointSelector,
+		EndpointSelectors: []EndpointSelector{WildcardEndpointSelector},
+		Egress:            []EgressRule{{}},
+	}
+	err = invalidRuleNodeSelectorAndEndpointSelectors.Sanitize()
+	require.Equal(t, "rule cannot have more than one of EndpointSelector, NodeSelector and EndpointSelectors", err.Error())
 
 	invalidRuleNoSelector := Rule{
 		Egress: []EgressRule{{}},
 	}
 	err = invalidRuleNoSelector.Sanitize()
-	require.Equal(t, "rule must have one of EndpointSelector or NodeSelector", err.Error())
+	require.Equal(t, "rule must have one of EndpointSelector or NodeSelector or EndpointSelectors", err.Error())
+
+	validRuleEndpointSelectors := Rule{
+		EndpointSelectors: []EndpointSelector{WildcardEndpointSelector},
+		Egress:            []EgressRule{{}},
+	}
+	require.NoError(t, validRuleEndpointSelectors.Sanitize())
+
+	invalidEndpointSelectors := &slim_metav1.LabelSelector{
+		MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+			{
+				Key:      "any.foo",
+				Operator: "asdfasdfasdf",
+				Values:   []string{"default"},
+			},
+		},
+	}
+	invalidRuleEndpointSelectors := Rule{
+		EndpointSelectors: []EndpointSelector{NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, invalidEndpointSelectors)},
+		Egress:            []EgressRule{{}},
+	}
+	err = invalidRuleEndpointSelectors.Sanitize()
+	require.EqualError(t, err, "invalid label selector: matchExpressions[0].operator: Invalid value: \"asdfasdfasdf\": not a valid selector operator")
 }
 
 func TestTooManyPortsRule(t *testing.T) {

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -958,6 +958,13 @@ func (in PortRulesHTTP) DeepCopy() PortRulesHTTP {
 func (in *Rule) DeepCopyInto(out *Rule) {
 	*out = *in
 	in.EndpointSelector.DeepCopyInto(&out.EndpointSelector)
+	if in.EndpointSelectors != nil {
+		in, out := &in.EndpointSelectors, &out.EndpointSelectors
+		*out = make([]EndpointSelector, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.NodeSelector.DeepCopyInto(&out.NodeSelector)
 	if in.Ingress != nil {
 		in, out := &in.Ingress, &out.Ingress

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -1170,6 +1170,23 @@ func (in *Rule) deepEqual(other *Rule) bool {
 		return false
 	}
 
+	if ((in.EndpointSelectors != nil) && (other.EndpointSelectors != nil)) || ((in.EndpointSelectors == nil) != (other.EndpointSelectors == nil)) {
+		in, other := &in.EndpointSelectors, &other.EndpointSelectors
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
+		}
+	}
+
 	if !in.NodeSelector.DeepEqual(&other.NodeSelector) {
 		return false
 	}

--- a/pkg/policy/utils/parserules.go
+++ b/pkg/policy/utils/parserules.go
@@ -12,134 +12,136 @@ import (
 func RulesToPolicyEntries(rules api.Rules) types.PolicyEntries {
 	entries := types.PolicyEntries{}
 	for _, rule := range rules {
-		ls, node := getSelector(rule)
+		lss, node := getSelectors(rule)
 
-		subjectSelector := types.NewLabelSelector(ls)
+		for _, ls := range lss {
+			subjectSelector := types.NewLabelSelector(ls)
 
-		for _, iRule := range rule.Ingress {
-			defaultDeny := rule.EnableDefaultDeny.Ingress == nil || *rule.EnableDefaultDeny.Ingress
+			for _, iRule := range rule.Ingress {
+				defaultDeny := rule.EnableDefaultDeny.Ingress == nil || *rule.EnableDefaultDeny.Ingress
 
-			l3 := mergeEndpointSelectors(
-				iRule.FromEndpoints,
-				iRule.FromNodes,
-				iRule.FromEntities,
-				iRule.FromCIDR,
-				iRule.FromCIDRSet,
-				nil,
-				iRule.FromGroups)
+				l3 := mergeEndpointSelectors(
+					iRule.FromEndpoints,
+					iRule.FromNodes,
+					iRule.FromEntities,
+					iRule.FromCIDR,
+					iRule.FromCIDRSet,
+					nil,
+					iRule.FromGroups)
 
-			l4 := make(api.PortRules, 0, len(iRule.ToPorts)+len(iRule.ICMPs))
-			l4 = append(l4, iRule.ToPorts...)
-			l4 = append(l4, icmpRules(iRule.ICMPs)...)
+				l4 := make(api.PortRules, 0, len(iRule.ToPorts)+len(iRule.ICMPs))
+				l4 = append(l4, iRule.ToPorts...)
+				l4 = append(l4, icmpRules(iRule.ICMPs)...)
 
-			entry := &types.PolicyEntry{
-				Tier:           types.Normal,
-				Subject:        subjectSelector,
-				Node:           node,
-				Labels:         rule.Labels,
-				DefaultDeny:    defaultDeny,
-				Verdict:        types.Allow,
-				Ingress:        true,
-				L3:             l3,
-				L4:             l4,
-				Authentication: iRule.Authentication,
-				Log:            rule.Log,
+				entry := &types.PolicyEntry{
+					Tier:           types.Normal,
+					Subject:        subjectSelector,
+					Node:           node,
+					Labels:         rule.Labels,
+					DefaultDeny:    defaultDeny,
+					Verdict:        types.Allow,
+					Ingress:        true,
+					L3:             l3,
+					L4:             l4,
+					Authentication: iRule.Authentication,
+					Log:            rule.Log,
+				}
+				entries = append(entries, entry)
 			}
-			entries = append(entries, entry)
-		}
 
-		for _, iRule := range rule.IngressDeny {
-			defaultDeny := rule.EnableDefaultDeny.Ingress == nil || *rule.EnableDefaultDeny.Ingress
+			for _, iRule := range rule.IngressDeny {
+				defaultDeny := rule.EnableDefaultDeny.Ingress == nil || *rule.EnableDefaultDeny.Ingress
 
-			l3 := mergeEndpointSelectors(
-				iRule.FromEndpoints,
-				iRule.FromNodes,
-				iRule.FromEntities,
-				iRule.FromCIDR,
-				iRule.FromCIDRSet,
-				nil,
-				iRule.FromGroups)
+				l3 := mergeEndpointSelectors(
+					iRule.FromEndpoints,
+					iRule.FromNodes,
+					iRule.FromEntities,
+					iRule.FromCIDR,
+					iRule.FromCIDRSet,
+					nil,
+					iRule.FromGroups)
 
-			l4 := make(api.PortRules, 0, len(iRule.ToPorts)+len(iRule.ICMPs))
-			l4 = append(l4, portDenyRulesToPortRules(iRule.ToPorts)...)
-			l4 = append(l4, icmpRules(iRule.ICMPs)...)
+				l4 := make(api.PortRules, 0, len(iRule.ToPorts)+len(iRule.ICMPs))
+				l4 = append(l4, portDenyRulesToPortRules(iRule.ToPorts)...)
+				l4 = append(l4, icmpRules(iRule.ICMPs)...)
 
-			entry := &types.PolicyEntry{
-				Tier:        types.Normal,
-				Subject:     subjectSelector,
-				Node:        node,
-				Labels:      rule.Labels,
-				DefaultDeny: defaultDeny,
-				Verdict:     types.Deny,
-				Ingress:     true,
-				L3:          l3,
-				L4:          l4,
-				Log:         rule.Log,
+				entry := &types.PolicyEntry{
+					Tier:        types.Normal,
+					Subject:     subjectSelector,
+					Node:        node,
+					Labels:      rule.Labels,
+					DefaultDeny: defaultDeny,
+					Verdict:     types.Deny,
+					Ingress:     true,
+					L3:          l3,
+					L4:          l4,
+					Log:         rule.Log,
+				}
+				entries = append(entries, entry)
 			}
-			entries = append(entries, entry)
-		}
 
-		for _, eRule := range rule.Egress {
-			defaultDeny := rule.EnableDefaultDeny.Egress == nil || *rule.EnableDefaultDeny.Egress
+			for _, eRule := range rule.Egress {
+				defaultDeny := rule.EnableDefaultDeny.Egress == nil || *rule.EnableDefaultDeny.Egress
 
-			l3 := mergeEndpointSelectors(
-				eRule.ToEndpoints,
-				eRule.ToNodes,
-				eRule.ToEntities,
-				eRule.ToCIDR,
-				eRule.ToCIDRSet,
-				eRule.ToFQDNs,
-				eRule.ToGroups)
+				l3 := mergeEndpointSelectors(
+					eRule.ToEndpoints,
+					eRule.ToNodes,
+					eRule.ToEntities,
+					eRule.ToCIDR,
+					eRule.ToCIDRSet,
+					eRule.ToFQDNs,
+					eRule.ToGroups)
 
-			l4 := make(api.PortRules, 0, len(eRule.ToPorts)+len(eRule.ICMPs))
-			l4 = append(l4, eRule.ToPorts...)
-			l4 = append(l4, icmpRules(eRule.ICMPs)...)
+				l4 := make(api.PortRules, 0, len(eRule.ToPorts)+len(eRule.ICMPs))
+				l4 = append(l4, eRule.ToPorts...)
+				l4 = append(l4, icmpRules(eRule.ICMPs)...)
 
-			entry := &types.PolicyEntry{
-				Tier:           types.Normal,
-				Subject:        subjectSelector,
-				Node:           node,
-				Labels:         rule.Labels,
-				DefaultDeny:    defaultDeny,
-				Verdict:        types.Allow,
-				Ingress:        false,
-				L3:             l3,
-				L4:             l4,
-				Authentication: eRule.Authentication,
-				Log:            rule.Log,
+				entry := &types.PolicyEntry{
+					Tier:           types.Normal,
+					Subject:        subjectSelector,
+					Node:           node,
+					Labels:         rule.Labels,
+					DefaultDeny:    defaultDeny,
+					Verdict:        types.Allow,
+					Ingress:        false,
+					L3:             l3,
+					L4:             l4,
+					Authentication: eRule.Authentication,
+					Log:            rule.Log,
+				}
+				entries = append(entries, entry)
 			}
-			entries = append(entries, entry)
-		}
 
-		for _, eRule := range rule.EgressDeny {
-			defaultDeny := rule.EnableDefaultDeny.Egress == nil || *rule.EnableDefaultDeny.Egress
+			for _, eRule := range rule.EgressDeny {
+				defaultDeny := rule.EnableDefaultDeny.Egress == nil || *rule.EnableDefaultDeny.Egress
 
-			l3 := mergeEndpointSelectors(
-				eRule.ToEndpoints,
-				eRule.ToNodes,
-				eRule.ToEntities,
-				eRule.ToCIDR,
-				eRule.ToCIDRSet,
-				nil,
-				eRule.ToGroups)
+				l3 := mergeEndpointSelectors(
+					eRule.ToEndpoints,
+					eRule.ToNodes,
+					eRule.ToEntities,
+					eRule.ToCIDR,
+					eRule.ToCIDRSet,
+					nil,
+					eRule.ToGroups)
 
-			l4 := make(api.PortRules, 0, len(eRule.ToPorts)+len(eRule.ICMPs))
-			l4 = append(l4, portDenyRulesToPortRules(eRule.ToPorts)...)
-			l4 = append(l4, icmpRules(eRule.ICMPs)...)
+				l4 := make(api.PortRules, 0, len(eRule.ToPorts)+len(eRule.ICMPs))
+				l4 = append(l4, portDenyRulesToPortRules(eRule.ToPorts)...)
+				l4 = append(l4, icmpRules(eRule.ICMPs)...)
 
-			entry := &types.PolicyEntry{
-				Tier:        types.Normal,
-				Subject:     subjectSelector,
-				Node:        node,
-				Labels:      rule.Labels,
-				DefaultDeny: defaultDeny,
-				Verdict:     types.Deny,
-				Ingress:     false,
-				L3:          l3,
-				L4:          l4,
-				Log:         rule.Log,
+				entry := &types.PolicyEntry{
+					Tier:        types.Normal,
+					Subject:     subjectSelector,
+					Node:        node,
+					Labels:      rule.Labels,
+					DefaultDeny: defaultDeny,
+					Verdict:     types.Deny,
+					Ingress:     false,
+					L3:          l3,
+					L4:          l4,
+					Log:         rule.Log,
+				}
+				entries = append(entries, entry)
 			}
-			entries = append(entries, entry)
 		}
 	}
 	return entries
@@ -186,10 +188,14 @@ func icmpRules(icmpRules api.ICMPRules) api.PortRules {
 	return out
 }
 
-// getSelector returns either the endpoint selector, which is the target of a policy rule and true if the endpoint represents a node.
-func getSelector(rule *api.Rule) (api.EndpointSelector, bool) {
+// getSelectors returns the endpoint selectors that are the targets of a policy rule,
+// and true if the selectors represent nodes.
+func getSelectors(rule *api.Rule) ([]api.EndpointSelector, bool) {
 	if es := rule.NodeSelector; es.LabelSelector != nil {
-		return es, true
+		return []api.EndpointSelector{es}, true
 	}
-	return rule.EndpointSelector, false
+	if ess := rule.EndpointSelectors; len(ess) > 0 {
+		return ess, false
+	}
+	return []api.EndpointSelector{rule.EndpointSelector}, false
 }

--- a/pkg/policy/utils/parserules_test.go
+++ b/pkg/policy/utils/parserules_test.go
@@ -254,6 +254,51 @@ func TestRulesToPolicyEntries(t *testing.T) {
 			},
 		},
 		{
+			name: "endpoint selectors expand into one entry per selector",
+			rules: api.Rules{
+				{
+					EndpointSelectors: []api.EndpointSelector{
+						api.NewESFromLabels(labels.ParseSelectLabel("app=foo")),
+						api.NewESFromLabels(labels.ParseSelectLabel("app=bar")),
+					},
+					Labels: lbls,
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromEndpoints: []api.EndpointSelector{api.NewESFromLabels(labels.ParseSelectLabel("from=endpoint"))},
+							},
+						},
+					},
+				},
+			},
+			want: types.PolicyEntries{
+				{
+					Tier:        types.Normal,
+					Subject:     types.NewLabelSelector(api.NewESFromLabels(labels.ParseSelectLabel("app=foo"))),
+					Labels:      lbls,
+					DefaultDeny: true,
+					Verdict:     types.Allow,
+					Ingress:     true,
+					L3: types.ToSelectors(
+						api.NewESFromLabels(labels.ParseSelectLabel("from=endpoint")),
+					),
+					L4: api.PortRules{},
+				},
+				{
+					Tier:        types.Normal,
+					Subject:     types.NewLabelSelector(api.NewESFromLabels(labels.ParseSelectLabel("app=bar"))),
+					Labels:      lbls,
+					DefaultDeny: true,
+					Verdict:     types.Allow,
+					Ingress:     true,
+					L3: types.ToSelectors(
+						api.NewESFromLabels(labels.ParseSelectLabel("from=endpoint")),
+					),
+					L4: api.PortRules{},
+				},
+			},
+		},
+		{
 			name: "default deny disabled",
 			rules: api.Rules{
 				{
@@ -537,11 +582,12 @@ func TestIcmpRules(t *testing.T) {
 func TestGetSelector(t *testing.T) {
 	endpointSelector := api.NewESFromLabels(labels.ParseSelectLabel("app=test"))
 	nodeSelector := api.NewESFromLabels(labels.ParseSelectLabel("node=test"))
+	endpointSelector2 := api.NewESFromLabels(labels.ParseSelectLabel("app=other"))
 
 	tests := []struct {
 		name     string
 		rule     *api.Rule
-		wantEs   api.EndpointSelector
+		wantEs   []api.EndpointSelector
 		wantNode bool
 	}{
 		{
@@ -549,7 +595,7 @@ func TestGetSelector(t *testing.T) {
 			rule: &api.Rule{
 				EndpointSelector: endpointSelector,
 			},
-			wantEs:   endpointSelector,
+			wantEs:   []api.EndpointSelector{endpointSelector},
 			wantNode: false,
 		},
 		{
@@ -557,7 +603,7 @@ func TestGetSelector(t *testing.T) {
 			rule: &api.Rule{
 				NodeSelector: nodeSelector,
 			},
-			wantEs:   nodeSelector,
+			wantEs:   []api.EndpointSelector{nodeSelector},
 			wantNode: true,
 		},
 		{
@@ -566,20 +612,37 @@ func TestGetSelector(t *testing.T) {
 				EndpointSelector: endpointSelector,
 				NodeSelector:     nodeSelector,
 			},
-			wantEs:   nodeSelector,
+			wantEs:   []api.EndpointSelector{nodeSelector},
+			wantNode: true,
+		},
+		{
+			name: "endpoint selectors",
+			rule: &api.Rule{
+				EndpointSelectors: []api.EndpointSelector{endpointSelector, endpointSelector2},
+			},
+			wantEs:   []api.EndpointSelector{endpointSelector, endpointSelector2},
+			wantNode: false,
+		},
+		{
+			name: "node selector takes precedence over endpoint selectors",
+			rule: &api.Rule{
+				NodeSelector:      nodeSelector,
+				EndpointSelectors: []api.EndpointSelector{endpointSelector, endpointSelector2},
+			},
+			wantEs:   []api.EndpointSelector{nodeSelector},
 			wantNode: true,
 		},
 		{
 			name:     "no selector",
 			rule:     &api.Rule{},
-			wantEs:   api.EndpointSelector{},
+			wantEs:   []api.EndpointSelector{{}},
 			wantNode: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotEs, gotNode := getSelector(tt.rule)
+			gotEs, gotNode := getSelectors(tt.rule)
 			assert.Equal(t, tt.wantEs, gotEs)
 			assert.Equal(t, tt.wantNode, gotNode)
 		})


### PR DESCRIPTION
# What is this

A detailed explanation of this feature is included in CFP #45682. What this PR does is add an `EndpointSelectors` field to the `Rule` type and subsequently the CRDs for Cilium Network Policies and Clusterwide Cilium Network Policies.

This also adds the logic to validate, sanitize, and parse this field. The way this is parsed is by creating one policy entry per `EndpointSelector` in the `EndpointSelectors` array. This ensures that beyond this translation layer, Cilium sees Rules created using this field the same way it would a rule using a single `EndpointSelector`.

One case this does not handle is detecting the use of the `reserved:init` label key, which then gates the following logic. I couldn't figure out how best to handle this when using `EndpointSelectors`.
```go
if !matchesInit {
  es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
}
```

Fixes: #45682

# Disclosure regarding the use of generative AI

Generative AI was not used to write the logic added in this PR. It was, however, used to add unit tests. Those unit tests were then reviewed by a human to make sure they are coherent and useful.

```release-note
pkg/policy: Add support for specifying multiple endpoint selectors in CNPs and CCNPs
```
