### PR TITLE
Gateway-API: Added useRemoteAddress support.

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -65,6 +65,7 @@ cilium-operator-alibabacloud [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-alibabacloud
@@ -88,6 +89,7 @@ cilium-operator-alibabacloud [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "alibabacloud")
       --k8s-api-server-urls strings                                Kubernetes API server URLs

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -56,6 +56,7 @@ cilium-operator-alibabacloud hive [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
@@ -78,6 +79,7 @@ cilium-operator-alibabacloud hive [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -62,6 +62,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
@@ -83,6 +84,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -72,6 +72,7 @@ cilium-operator-aws [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-aws
@@ -95,6 +96,7 @@ cilium-operator-aws [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "eni")
       --k8s-api-server-urls strings                                Kubernetes API server URLs

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -63,6 +63,7 @@ cilium-operator-aws hive [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
@@ -85,6 +86,7 @@ cilium-operator-aws hive [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -69,6 +69,7 @@ cilium-operator-aws hive dot-graph [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
@@ -90,6 +91,7 @@ cilium-operator-aws hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -67,6 +67,7 @@ cilium-operator-azure [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-azure
@@ -90,6 +91,7 @@ cilium-operator-azure [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "azure")
       --k8s-api-server-urls strings                                Kubernetes API server URLs

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -58,6 +58,7 @@ cilium-operator-azure hive [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
@@ -80,6 +81,7 @@ cilium-operator-azure hive [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -64,6 +64,7 @@ cilium-operator-azure hive dot-graph [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
@@ -85,6 +86,7 @@ cilium-operator-azure hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -68,6 +68,7 @@ cilium-operator-generic [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-generic
@@ -91,6 +92,7 @@ cilium-operator-generic [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server-urls strings                                Kubernetes API server URLs

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -59,6 +59,7 @@ cilium-operator-generic hive [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
@@ -81,6 +82,7 @@ cilium-operator-generic hive [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -65,6 +65,7 @@ cilium-operator-generic hive dot-graph [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
@@ -86,6 +87,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -83,6 +83,7 @@ cilium-operator [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator
@@ -106,6 +107,7 @@ cilium-operator [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server-urls strings                                Kubernetes API server URLs

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -74,6 +74,7 @@ cilium-operator hive [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
@@ -96,6 +97,7 @@ cilium-operator hive [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -80,6 +80,7 @@ cilium-operator hive dot-graph [flags]
       --gateway-api-hostnetwork-nodelabelselector string           Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'
       --gateway-api-secrets-namespace string                       Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gateway-api-service-externaltrafficpolicy string           Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances. (default "Cluster")
+      --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
@@ -101,6 +102,7 @@ cilium-operator hive dot-graph [flags]
       --ingress-lb-annotation-prefixes strings                     Annotations and labels which are needed to propagate from Ingress to the Load Balancer. (default [lbipam.cilium.io,service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
+      --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2052,6 +2052,10 @@
      - Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally.
      - bool
      - ``true``
+   * - :spelling:ignore:`gatewayAPI.useRemoteAddress`
+     - Configure whether to use the remote address of the client when determining the source IP. When enabled, the source IP is determined from the remote address instead of the proxy protocol header.
+     - bool
+     - ``true``
    * - :spelling:ignore:`gatewayAPI.xffNumTrustedHops`
      - The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
      - int
@@ -2912,6 +2916,14 @@
      - Service type for the shared LB service
      - string
      - ``"LoadBalancer"``
+   * - :spelling:ignore:`ingressController.useRemoteAddress`
+     - Configure whether to use the remote address of the client when determining the source IP. When enabled, the source IP is determined from the remote address instead of the proxy protocol header.
+     - bool
+     - ``true``
+   * - :spelling:ignore:`ingressController.xffNumTrustedHops`
+     - The number of additional Ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+     - int
+     - ``0``
    * - :spelling:ignore:`initResources`
      - resources & limits for the agent init containers
      - object

--- a/Documentation/network/servicemesh/ingress-reference.rst
+++ b/Documentation/network/servicemesh/ingress-reference.rst
@@ -79,6 +79,15 @@ have Envoy use the ``n`` th value from the list, counting from the right.
 Envoy will also set the ``X-Envoy-External-Address`` header to the trusted client
 address, whatever that turns out to be, based on ``X-Forwarded-For``.
 
+By default, Cilium uses the source IP of the client of a connection to apply policies for Layer 7 functionality including Ingress. 
+If you trust the source of the traffic to inject an ``X-Forwarded-For`` header (such as when using a cloud load balancer), 
+you can force Envoy to treat the traffic as coming from the client IP encoded in the ``X-Forwarded-For`` header by setting 
+``useRemoteAddress`` to ``false`` in ``gatewayAPI`` or ``ingressController`` sections of values files.
+
+For more information, see the `Envoy X-Forwarded-For`_ headers documentation.
+
+.. _Envoy X-Forwarded-For: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html#x-forwarded-for
+
 .. Note::
     
     Backends using Cilium ingress (whether via Ingress or Gateway API) should

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -563,6 +563,7 @@ contributors across the globe, there is almost always someone available to help.
 | gatewayAPI.secretsNamespace.create | bool | `true` | Create secrets namespace for Gateway API. |
 | gatewayAPI.secretsNamespace.name | string | `"cilium-secrets"` | Name of Gateway API secret namespace. |
 | gatewayAPI.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
+| gatewayAPI.useRemoteAddress | bool | `true` | Configure whether to use the remote address of the client when determining the source IP. When enabled, the source IP is determined from the remote address instead of the proxy protocol header. |
 | gatewayAPI.xffNumTrustedHops | int | `0` | The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthCheckICMPFailureThreshold | int | `3` | Number of ICMP requests sent for each health check before marking a node or endpoint unreachable. |
@@ -778,6 +779,8 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.service.name | string | `"cilium-ingress"` | Service name |
 | ingressController.service.secureNodePort | string | `nil` | Configure a specific nodePort for secure HTTPS traffic on the shared LB service |
 | ingressController.service.type | string | `"LoadBalancer"` | Service type for the shared LB service |
+| ingressController.useRemoteAddress | bool | `true` | Configure whether to use the remote address of the client when determining the source IP. When enabled, the source IP is determined from the remote address instead of the proxy protocol header. |
+| ingressController.xffNumTrustedHops | int | `0` | The number of additional Ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address. |
 | initResources | object | `{}` | resources & limits for the agent init containers |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -285,6 +285,8 @@ data:
   ingress-lb-annotation-prefixes: {{ .Values.ingressController.ingressLBAnnotationPrefixes | join " " | quote }}
   ingress-default-lb-mode: {{ .Values.ingressController.loadbalancerMode }}
   ingress-shared-lb-service-name: {{ .Values.ingressController.service.name }}
+  ingress-default-xff-num-trusted-hops: {{ .Values.ingressController.xffNumTrustedHops | quote }}
+  ingress-use-remote-address: {{ .Values.ingressController.useRemoteAddress | quote }}
   {{- if and .Values.ingressController.defaultSecretNamespace .Values.ingressController.defaultSecretName }}
   ingress-default-secret-namespace: {{ .Values.ingressController.defaultSecretNamespace | quote }}
   ingress-default-secret-name: {{ .Values.ingressController.defaultSecretName | quote }}
@@ -304,6 +306,7 @@ data:
   enable-gateway-api-app-protocol: {{ or .Values.gatewayAPI.enableAppProtocol .Values.gatewayAPI.enableAlpn | quote }}
   enable-gateway-api-alpn: {{ .Values.gatewayAPI.enableAlpn | quote }}
   gateway-api-xff-num-trusted-hops: {{ .Values.gatewayAPI.xffNumTrustedHops | quote }}
+  gateway-api-use-remote-address: {{ .Values.gatewayAPI.useRemoteAddress | quote }}
   gateway-api-service-externaltrafficpolicy: {{ .Values.gatewayAPI.externalTrafficPolicy | quote }}
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
   gateway-api-hostnetwork-enabled: {{ .Values.gatewayAPI.hostNetwork.enabled | quote }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -3015,6 +3015,12 @@
           },
           "type": "object"
         },
+        "useRemoteAddress": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "xffNumTrustedHops": {
           "type": "integer"
         }
@@ -4451,6 +4457,15 @@
             }
           },
           "type": "object"
+        },
+        "useRemoteAddress": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "xffNumTrustedHops": {
+          "type": "integer"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -998,6 +998,14 @@ ingressController:
   enforceHttps: true
   # -- Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
+  # @schema
+  # type: [null, boolean]
+  # @schema
+  # -- Configure whether to use the remote address of the client when determining the source IP.
+  # When enabled, the source IP is determined from the remote address instead of the proxy protocol header.
+  useRemoteAddress: true
+  # -- The number of additional Ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+  xffNumTrustedHops: 0
   # -- IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service
   ingressLBAnnotationPrefixes: ['lbipam.cilium.io', 'nodeipam.cilium.io', 'service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
   # @schema
@@ -1089,6 +1097,12 @@ gatewayAPI:
   enabled: false
   # -- Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
+  # @schema
+  # type: [null, boolean]
+  # @schema
+  # -- Configure whether to use the remote address of the client when determining the source IP.
+  # When enabled, the source IP is determined from the remote address instead of the proxy protocol header.
+  useRemoteAddress: true
   # -- Enable Backend Protocol selection support (GEP-1911) for Gateway API via appProtocol.
   enableAppProtocol: false
   # -- Enable ALPN for all listeners configured with Gateway API. ALPN will attempt HTTP/2, then HTTP 1.1.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1007,6 +1007,14 @@ ingressController:
   enforceHttps: true
   # -- Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
+  # @schema
+  # type: [null, boolean]
+  # @schema
+  # -- Configure whether to use the remote address of the client when determining the source IP.
+  # When enabled, the source IP is determined from the remote address instead of the proxy protocol header.
+  useRemoteAddress: true
+  # -- The number of additional Ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
+  xffNumTrustedHops: 0
   # -- IngressLBAnnotations are the annotation and label prefixes, which are used to filter annotations and/or labels to propagate from Ingress to the Load Balancer service
   ingressLBAnnotationPrefixes: ['lbipam.cilium.io', 'nodeipam.cilium.io', 'service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
   # @schema
@@ -1098,6 +1106,12 @@ gatewayAPI:
   enabled: false
   # -- Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
+  # @schema
+  # type: [null, boolean]
+  # @schema
+  # -- Configure whether to use the remote address of the client when determining the source IP.
+  # When enabled, the source IP is determined from the remote address instead of the proxy protocol header.
+  useRemoteAddress: true
   # -- Enable Backend Protocol selection support (GEP-1911) for Gateway API via appProtocol.
   enableAppProtocol: false
   # -- Enable ALPN for all listeners configured with Gateway API. ALPN will attempt HTTP/2, then HTTP 1.1.

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -54,6 +54,7 @@ var Cell = cell.Module(
 
 		GatewayAPIHostnetworkEnabled:           false,
 		GatewayAPIHostnetworkNodelabelselector: "",
+		GatewayAPIUseRemoteAddress:             true,
 	}),
 
 	// Private provider for preconditions - consumed by both initGatewayAPIController
@@ -192,6 +193,7 @@ type gatewayApiConfig struct {
 
 	GatewayAPIHostnetworkEnabled           bool
 	GatewayAPIHostnetworkNodelabelselector string
+	GatewayAPIUseRemoteAddress             bool
 }
 
 func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
@@ -203,6 +205,7 @@ func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("gateway-api-service-externaltrafficpolicy", r.GatewayAPIServiceExternalTrafficPolicy, "Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances.")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "Namespace having tls secrets used by CEC for Gateway API")
 	flags.Bool("gateway-api-hostnetwork-enabled", r.GatewayAPIHostnetworkEnabled, "Exposes Gateway listeners on the host network.")
+	flags.Bool("gateway-api-use-remote-address", r.GatewayAPIUseRemoteAddress, "Use the immediate client's IP address as the origin client's IP address")
 	flags.String("gateway-api-hostnetwork-nodelabelselector", r.GatewayAPIHostnetworkNodelabelselector, "Label selector that matches the nodes where the gateway listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
 }
 
@@ -271,6 +274,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		},
 		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
 			XFFNumTrustedHops: params.GatewayApiConfig.GatewayAPIXffNumTrustedHops,
+			UseRemoteAddress:  params.GatewayApiConfig.GatewayAPIUseRemoteAddress,
 		},
 	}
 	cecTranslator := translation.NewCECTranslator(cfg)

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -55,10 +55,16 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 		ClusterConfig: translation.ClusterConfig{
 			IdleTimeoutSeconds: 60,
 		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
 	})
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
 		ServiceConfig: translation.ServiceConfig{
 			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
 		},
 	})
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -67,10 +67,16 @@ func Test_Conformance(t *testing.T) {
 		ClusterConfig: translation.ClusterConfig{
 			IdleTimeoutSeconds: 60,
 		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
 	})
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
 		ServiceConfig: translation.ServiceConfig{
 			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
 		},
 	})
 

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -46,6 +46,7 @@ var Cell = cell.Module(
 		IngressHostnetworkHTTPSListenerPort:          0,
 		IngressHostnetworkTLSPassthroughListenerPort: 0,
 		IngressHostnetworkNodelabelselector:          "",
+		IngressUseRemoteAddress:                      true,
 	}),
 	cell.Invoke(registerReconciler),
 	cell.Provide(registerSecretSync),
@@ -70,6 +71,7 @@ type IngressConfig struct {
 	IngressHostnetworkTLSPassthroughListenerPort uint32
 	IngressHostnetworkNodelabelselector          string
 	IngressDefaultXffNumTrustedHops              uint32
+	IngressUseRemoteAddress                      bool
 }
 
 func (r IngressConfig) Flags(flags *pflag.FlagSet) {
@@ -91,6 +93,7 @@ func (r IngressConfig) Flags(flags *pflag.FlagSet) {
 	flags.Uint32("ingress-hostnetwork-tls-passthrough-listener-port", r.IngressHostnetworkTLSPassthroughListenerPort, "Port on the host network that gets used for the shared TLS passthrough listener")
 	flags.String("ingress-hostnetwork-nodelabelselector", r.IngressHostnetworkNodelabelselector, "Label selector that matches the nodes where the ingress listeners should be exposed. It's a list of comma-separated key-value label pairs. e.g. 'kubernetes.io/os=linux,kubernetes.io/hostname=kind-worker'")
 	flags.Uint32("ingress-default-xff-num-trusted-hops", r.IngressDefaultXffNumTrustedHops, "The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
+	flags.Bool("ingress-use-remote-address", r.IngressUseRemoteAddress, "Use the immediate client's IP address as the origin client's IP address")
 }
 
 // IsEnabled returns true if the Ingress Controller is enabled.
@@ -143,6 +146,7 @@ func registerReconciler(params ingressParams) error {
 		},
 		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
 			XFFNumTrustedHops: params.IngressConfig.IngressDefaultXffNumTrustedHops,
+			UseRemoteAddress:  params.IngressConfig.IngressUseRemoteAddress,
 		},
 	})
 

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -82,6 +83,34 @@ func withAlpn() ListenerMutator {
 
 			transportSocket.ConfigType = &envoy_config_core_v3.TransportSocket_TypedConfig{
 				TypedConfig: toAny(downstreamContext),
+			}
+		}
+		return listener
+	}
+}
+
+func withUseRemoteAddress(useRemoteAddress bool) ListenerMutator {
+	return func(listener *envoy_config_listener.Listener) *envoy_config_listener.Listener {
+		for _, filterChain := range listener.FilterChains {
+			for _, filter := range filterChain.Filters {
+				if filter.Name == httpConnectionManagerType {
+					tc := filter.GetTypedConfig()
+					switch tc.GetTypeUrl() {
+					case envoy.HttpConnectionManagerTypeURL:
+						hcm, err := tc.UnmarshalNew()
+						if err != nil {
+							continue
+						}
+						hcmConfig, ok := hcm.(*httpConnectionManagerv3.HttpConnectionManager)
+						if !ok {
+							continue
+						}
+						hcmConfig.UseRemoteAddress = wrapperspb.Bool(useRemoteAddress)
+						filter.ConfigType = &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(hcmConfig),
+						}
+					}
+				}
 			}
 		}
 		return listener
@@ -289,6 +318,8 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 	if i.Config.ListenerConfig.StreamIdleTimeoutSeconds > 0 {
 		res = append(res, WithStreamIdleTimeout(i.Config.ListenerConfig.StreamIdleTimeoutSeconds))
 	}
+
+	res = append(res, withUseRemoteAddress(i.Config.OriginalIPDetectionConfig.UseRemoteAddress))
 
 	if i.Config.OriginalIPDetectionConfig.XFFNumTrustedHops > 0 {
 		res = append(res, withXffNumTrustedHops(i.Config.OriginalIPDetectionConfig.XFFNumTrustedHops))

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -8,6 +8,7 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_extensions_filters_network_hcm_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_filters_network_tcp_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -507,6 +508,215 @@ func getTCPProxy(t *testing.T, filterChain *envoy_config_listener.FilterChain) *
 	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{}
 	require.NoError(t, filterChain.GetFilters()[0].GetTypedConfig().UnmarshalTo(tcpProxy))
 	return tcpProxy
+}
+
+func Test_withUseRemoteAddress(t *testing.T) {
+	tests := []struct {
+		name               string
+		useRemoteAddress   bool
+		wantUseRemoteValue bool
+	}{
+		{
+			name:               "use_remote_address_true",
+			useRemoteAddress:   true,
+			wantUseRemoteValue: true,
+		},
+		{
+			name:               "use_remote_address_false",
+			useRemoteAddress:   false,
+			wantUseRemoteValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hcmAny := toAny(&envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{})
+			listener := &envoy_config_listener.Listener{
+				Name: "listener",
+				FilterChains: []*envoy_config_listener.FilterChain{
+					{
+						Filters: []*envoy_config_listener.Filter{
+							{
+								Name: httpConnectionManagerType,
+								ConfigType: &envoy_config_listener.Filter_TypedConfig{
+									TypedConfig: hcmAny,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			mutator := withUseRemoteAddress(tt.useRemoteAddress)
+			listener = mutator(listener)
+
+			require.Len(t, listener.FilterChains, 1)
+			require.Len(t, listener.FilterChains[0].Filters, 1)
+
+			filter := listener.FilterChains[0].Filters[0]
+			typedConfig := filter.GetTypedConfig()
+			hcm, err := typedConfig.UnmarshalNew()
+			require.NoError(t, err)
+			hcmConfig, ok := hcm.(*envoy_extensions_filters_network_hcm_v3.HttpConnectionManager)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantUseRemoteValue, hcmConfig.UseRemoteAddress.GetValue())
+		})
+	}
+}
+
+func Test_desiredEnvoyListener_UseRemoteAddressFalse(t *testing.T) {
+	translator := &cecTranslator{
+		Config: Config{
+			OriginalIPDetectionConfig: OriginalIPDetectionConfig{
+				UseRemoteAddress: false,
+			},
+		},
+	}
+
+	resources, err := translator.desiredEnvoyListener(&model.Model{
+		HTTP: []model.HTTPListener{{
+			Name:     "listener",
+			Port:     80,
+			Hostname: "*",
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	require.NotNil(t, resources[0].Any)
+
+	msg, err := resources[0].Any.UnmarshalNew()
+	require.NoError(t, err)
+
+	listener, ok := msg.(*envoy_config_listener.Listener)
+	require.True(t, ok)
+	require.NotEmpty(t, listener.FilterChains)
+	require.NotEmpty(t, listener.FilterChains[0].Filters)
+
+	hcmAny := listener.FilterChains[0].Filters[0].GetTypedConfig()
+	hcmMsg, err := hcmAny.UnmarshalNew()
+	require.NoError(t, err)
+
+	hcm, ok := hcmMsg.(*envoy_extensions_filters_network_hcm_v3.HttpConnectionManager)
+	require.True(t, ok)
+	require.NotNil(t, hcm.UseRemoteAddress)
+	assert.False(t, hcm.UseRemoteAddress.GetValue(), "generated listener should honor UseRemoteAddress=false from config")
+}
+
+func Test_withUseRemoteAddress_NoHCMFilter(t *testing.T) {
+	listener := &envoy_config_listener.Listener{
+		Name: "listener",
+		FilterChains: []*envoy_config_listener.FilterChain{
+			{
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: "envoy.filters.network.tcp_proxy",
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{}),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mutator := withUseRemoteAddress(true)
+	modifiedListener := mutator(listener)
+
+	require.Len(t, modifiedListener.FilterChains, 1)
+	require.Len(t, modifiedListener.FilterChains[0].Filters, 1)
+	assert.Equal(t, "envoy.filters.network.tcp_proxy", modifiedListener.FilterChains[0].Filters[0].Name)
+}
+
+func Test_withUseRemoteAddress_NoFilterChains(t *testing.T) {
+	listener := &envoy_config_listener.Listener{
+		Name: "listener",
+	}
+
+	mutator := withUseRemoteAddress(true)
+	modifiedListener := mutator(listener)
+
+	require.NotNil(t, modifiedListener)
+}
+
+func Test_withUseRemoteAddress_MultipleFilterChains(t *testing.T) {
+	hcmAny := toAny(&envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{})
+	tcpProxyAny := toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{})
+
+	listener := &envoy_config_listener.Listener{
+		Name: "listener",
+		FilterChains: []*envoy_config_listener.FilterChain{
+			{
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: httpConnectionManagerType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: hcmAny,
+						},
+					},
+				},
+			},
+			{
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: "envoy.filters.network.tcp_proxy",
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: tcpProxyAny,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mutator := withUseRemoteAddress(true)
+	modifiedListener := mutator(listener)
+
+	require.Len(t, modifiedListener.FilterChains, 2)
+
+	// First filter chain should have HCM with default useRemoteAddress value (false).
+	firstFilterChain := modifiedListener.FilterChains[0]
+	require.Len(t, firstFilterChain.Filters, 1)
+	filter := firstFilterChain.Filters[0]
+	typedConfig := filter.GetTypedConfig()
+	hcm, err := typedConfig.UnmarshalNew()
+	require.NoError(t, err)
+	hcmConfig, ok := hcm.(*envoy_extensions_filters_network_hcm_v3.HttpConnectionManager)
+	require.True(t, ok)
+	assert.True(t, hcmConfig.UseRemoteAddress.Value, "First filter chain HCM should have useRemoteAddress=true")
+
+	// Second filter chain should be unchanged (no HCM)
+	secondFilterChain := modifiedListener.FilterChains[1]
+	require.Len(t, secondFilterChain.Filters, 1)
+	assert.Equal(t, "envoy.filters.network.tcp_proxy", secondFilterChain.Filters[0].Name)
+}
+
+func Test_withUseRemoteAddress_Idempotent(t *testing.T) {
+	hcmAny := toAny(&envoy_extensions_filters_network_hcm_v3.HttpConnectionManager{})
+
+	listener := &envoy_config_listener.Listener{
+		Name: "listener",
+		FilterChains: []*envoy_config_listener.FilterChain{
+			{
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: httpConnectionManagerType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: hcmAny,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Apply the mutator twice
+	mutator := withUseRemoteAddress(true)
+	firstModified := mutator(listener)
+	secondModified := mutator(firstModified)
+
+	// Both should be identical
+	diffOutput := cmp.Diff(firstModified, secondModified, protocmp.Transform())
+	require.Empty(t, diffOutput, "Applying the mutator twice should produce identical results")
 }
 
 func Test_withHostNetworkPortSorted(t *testing.T) {

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_external_traffic_policy/config-input.yaml
@@ -5,7 +5,9 @@ ip_config:
   ipv4_enabled: true
   ipv6_enabled: true
 listener_config: {}
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_load_balancer/config-input.yaml
@@ -5,7 +5,9 @@ ip_config:
   ipv4_enabled: true
   ipv6_enabled: true
 listener_config: {}
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_nodeport/config-input.yaml
@@ -5,7 +5,9 @@ ip_config:
   ipv4_enabled: true
   ipv6_enabled: true
 listener_config: {}
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_without_grpc_web_translation/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_without_grpc_web_translation/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_tls_sni_listener/config-input.yaml
@@ -4,7 +4,9 @@ host_network_config: {}
 ip_config: {}
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_frontend/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_frontend/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_ports/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_ports/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_splits/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/gamma/mesh_splits/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httpexact_path_matching/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_protocol_h_2_c_app_protocol/config-input.yaml
@@ -7,7 +7,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_request_header_modifier/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_backend_refs_response_header_modifier/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_cross_namespace/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_header_matching/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_hostname_intersection/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_listener_hostname_matching/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_matching_across_routes/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_method_matching/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_query_param_matching/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_header_modifier/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_mirror/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_request_redirect_with_multi_httplisteners/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_response_header_modifier/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_host/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_rewrite_path/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/httproute_simple_same_namespace/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_grpc/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_grpc/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_grpc_with_tls/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_grpc_with_tls/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_http/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_http/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config: 
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_http_with_tls/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_http_with_tls/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config: 
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_mixed/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_mixed/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_shared_and_no_auth/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_external_auth_shared_and_no_auth/config-input.yaml
@@ -6,7 +6,9 @@ ip_config:
   ipv6_enabled: true
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config: 
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/config-input.yaml
@@ -4,7 +4,9 @@ host_network_config: {}
 ip_config: {}
 listener_config:
   stream_idle_timeout_seconds: 300
-original_ip_detection_config: {}
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
 route_config:
   host_name_suffix_match: true
 secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -165,6 +165,10 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 						IPv4Enabled: tt.ipv4Enabled,
 						IPv6Enabled: tt.ipv6Enabled,
 					},
+					OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+						UseRemoteAddress:  true,
+						XFFNumTrustedHops: 0,
+					},
 				},
 			},
 			{
@@ -190,6 +194,10 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					IPConfig: translation.IPConfig{
 						IPv4Enabled: tt.ipv4Enabled,
 						IPv6Enabled: tt.ipv6Enabled,
+					},
+					OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+						UseRemoteAddress:  true,
+						XFFNumTrustedHops: 0,
 					},
 				},
 			},
@@ -239,6 +247,7 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 					Enabled: true,
 				},
 				OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+					UseRemoteAddress:  true,
 					XFFNumTrustedHops: 2,
 				},
 				ListenerConfig: translation.ListenerConfig{

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -334,6 +334,10 @@ func Test_translator_Translate(t *testing.T) {
 					RouteConfig: translation.RouteConfig{
 						HostNameSuffixMatch: false,
 					},
+					OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+						UseRemoteAddress:  true,
+						XFFNumTrustedHops: 0,
+					},
 				}),
 				hostNetworkEnabled: tt.args.hostNetworkEnabled,
 			}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->


This option allows users to set useRemoteAddress option on envoy proxy to ignore client's provided X-Forwarded-For header.

This PR was prepared with AIL:1. All the code was written by human, validated by AI.

Fixes: #43521