### PR TITLE
lbipam: allow sharing IPs across services that select different pods

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -510,3 +510,58 @@ As long as the services do not have conflicting ports, they will be allocated th
 If a service has a sharing key and also requests a specific IP, the service will be allocated the requested IP and it will be added to the set of IPs belonging to that sharing key.
 
 By default, sharing IPs across namespaces is not allowed. To allow sharing across a namespace, set the ``lbipam.cilium.io/sharing-cross-namespace`` annotation to the namespaces the service can be shared with. The value must be a comma-separated list of namespaces. The annotation must be present on both services. You can allow all namespaces with ``*``.
+
+Sharing an IP across services that select different pods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When both services use ``externalTrafficPolicy: Local``, LB IPAM by default requires the services to select the same set of pods. This guarantees that any node receiving traffic for the shared IP has a backend for every service sharing it; otherwise traffic would be dropped on nodes without a backend.
+
+Some deployments steer traffic with mechanisms outside Cilium's view, for example an external L4-aware load balancer that uses the per-service ``healthCheckNodePort`` to direct each connection only to nodes with a backend. In that case the same-selector requirement is too strict.
+
+Setting the ``lbipam.cilium.io/sharing-permit-different-pods: "true"`` annotation on all services opts out of this check. With the opt-in present on all services with the same sharing key, LB IPAM allows them to share an IP even when their selectors differ. The annotation only relaxes the same-selector requirement; services without a selector (Endpoints-based) are still rejected because LB IPAM cannot read endpoints to determine where traffic should land.
+
+.. warning::
+
+   This annotation disables a safety check. The user is responsible for ensuring traffic only reaches nodes that have a backend for the destination service.
+
+   Cilium's built-in BGP and L2 announcements are **not** L4 aware and will advertise the shared IP from every node that hosts at least one of the sharing services. Combining this opt-in with those announcers can result in dropped traffic.
+
+   Safe ways to use it include an L4-aware external load balancer that respects each service's ``healthCheckNodePort``, or deploying every service in the sharing group as a DaemonSet with matching node coverage so all nodes host all backends.
+
+In the examples below, ``externalTrafficPolicy: Local`` makes Kubernetes auto-assign a per-service ``spec.healthCheckNodePort``. An external L4-aware load balancer must use that node port for its per-service health checks so that traffic for each service is sent only to nodes that have a backend for it.
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-blue
+    namespace: example
+    annotations:
+      "lbipam.cilium.io/sharing-key": "1234"
+      "lbipam.cilium.io/sharing-permit-different-pods": "true"
+  spec:
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    selector:
+      app: blue
+    ports:
+    - port: 1234
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-red
+    namespace: example
+    annotations:
+      "lbipam.cilium.io/sharing-key": "1234"
+      "lbipam.cilium.io/sharing-permit-different-pods": "true"
+  spec:
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    selector:
+      app: red
+    ports:
+    - port: 2345

--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -510,3 +510,56 @@ As long as the services do not have conflicting ports, they will be allocated th
 If a service has a sharing key and also requests a specific IP, the service will be allocated the requested IP and it will be added to the set of IPs belonging to that sharing key.
 
 By default, sharing IPs across namespaces is not allowed. To allow sharing across a namespace, set the ``lbipam.cilium.io/sharing-cross-namespace`` annotation to the namespaces the service can be shared with. The value must be a comma-separated list of namespaces. The annotation must be present on both services. You can allow all namespaces with ``*``.
+
+Sharing an IP across services that select different pods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When multiple services with the same sharing key use ``externalTrafficPolicy: Local``, LB IPAM requires those services to select the same set of backend pods by default. This guarantees that any node receiving traffic for the shared IP has a backend for every service sharing it; otherwise traffic would be dropped on nodes without a backend.
+
+This requirement can be relaxed when an external traffic delivery mechanism ensures traffic is only delivered to nodes with available backends, for example a deployment that uses an external L4-aware load balancer that probes each service's ``healthCheckNodePort`` to determine which nodes are eligible to receive traffic.
+
+Set the ``lbipam.cilium.io/sharing-permit-different-pods: "true"`` annotation on all services with the same sharing key to relax this requirement. LB IPAM will then allow the services to share an IP even when their selectors differ. Services without a selector (Endpoints-based) will still be rejected because LB IPAM cannot determine which nodes are eligible to receive traffic.
+
+.. warning::
+
+   This annotation disables a safety check. The user is responsible for ensuring traffic only reaches nodes that have a backend for the destination service.
+
+   Cilium's built-in BGP and L2 announcements are **not** L4 aware. BGP advertises the shared IP from every node that hosts a backend for at least one service using the sharing key, and L2 announcements elect one node per service, so services with different selectors can answer for the same IP from different nodes. Using the ``lbipam.cilium.io/sharing-permit-different-pods: "true"`` annotation with services that use either Cilium's BGP or L2 Announcements can result in dropped traffic. To mitigate this, consider backing every service with the same sharing key by a DaemonSet with matching node coverage, so all nodes host all backends.
+
+In the examples below, ``externalTrafficPolicy: Local`` makes Kubernetes auto-assign a per-service ``spec.healthCheckNodePort``. An external L4-aware load balancer must use that node port for its per-service health checks so that traffic for each service is sent only to nodes that have a backend for it.
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-blue
+    namespace: example
+    annotations:
+      "lbipam.cilium.io/sharing-key": "1234"
+      "lbipam.cilium.io/sharing-permit-different-pods": "true"
+  spec:
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    selector:
+      app: blue
+    ports:
+    - port: 1234
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-red
+    namespace: example
+    annotations:
+      "lbipam.cilium.io/sharing-key": "1234"
+      "lbipam.cilium.io/sharing-permit-different-pods": "true"
+  spec:
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    selector:
+      app: red
+    ports:
+    - port: 2345

--- a/Documentation/operations/upgrade-current.inc
+++ b/Documentation/operations/upgrade-current.inc
@@ -57,6 +57,13 @@ Informational Notes
   to flag early situations in which the CA certificates need to be manually
   regenerated, before they actually expire. This validation can be disabled
   setting ``certgen.enforceCAValidityThroughoutLeavesDuration=false``.
+* LB IPAM now supports an opt-in
+  ``lbipam.cilium.io/sharing-permit-different-pods`` annotation that,
+  when set to ``"true"`` on all services in a sharing group, allows
+  services with ``externalTrafficPolicy: Local`` to share an IP even
+  when they select different pods. The default same-selector
+  requirement is unchanged.
+  See :ref:`lb_ipam` for the safety trade-off.
 
 Changes to Features
 ~~~~~~~~~~~~~~~~~~~

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -531,6 +531,7 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 	sv.RequestedIPs = getSVCRequestedIPs(ipam.logger, svc)
 	sv.SharingKey = getSVCSharingKey(svc)
 	sv.SharingCrossNamespace = getSVCSharingCrossNamespace(svc)
+	sv.SharingPermitDifferentPods = getSVCSharingPermitDifferentPods(ipam.logger, svc)
 	sv.ExternalTrafficPolicy = svc.Spec.ExternalTrafficPolicy
 	sv.Ports = make([]slim_core_v1.ServicePort, len(svc.Spec.Ports))
 	copy(sv.Ports, svc.Spec.Ports)
@@ -784,6 +785,25 @@ func getSVCSharingCrossNamespace(svc *slim_core_v1.Service) []string {
 		return strings.Split(val, ",")
 	}
 	return []string{}
+}
+
+func getSVCSharingPermitDifferentPods(log *slog.Logger, svc *slim_core_v1.Service) bool {
+	val, _ := annotation.Get(svc, annotation.LBIPAMSharingPermitDifferentPods, annotation.LBIPAMSharingPermitDifferentPodsAlias)
+	if val == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		log.Warn(
+			"Invalid value for sharing-permit-different-pods annotation, defaulting to disabled",
+			logfields.ServiceName, svc.Name,
+			logfields.ServiceNamespace, svc.Namespace,
+			logfields.Value, val,
+			logfields.Error, err,
+		)
+		return false
+	}
+	return enabled
 }
 
 func (ipam *LBIPAM) handleDeletedService(svc *slim_core_v1.Service) {

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -531,6 +531,7 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 	sv.RequestedIPs = getSVCRequestedIPs(ipam.logger, svc)
 	sv.SharingKey = getSVCSharingKey(svc)
 	sv.SharingCrossNamespace = getSVCSharingCrossNamespace(svc)
+	sv.SharingPermitDifferentPods = getSVCSharingPermitDifferentPods(ipam.logger, svc)
 	sv.ExternalTrafficPolicy = svc.Spec.ExternalTrafficPolicy
 	sv.Ports = make([]slim_core_v1.ServicePort, len(svc.Spec.Ports))
 	copy(sv.Ports, svc.Spec.Ports)
@@ -784,6 +785,25 @@ func getSVCSharingCrossNamespace(svc *slim_core_v1.Service) []string {
 		return strings.Split(val, ",")
 	}
 	return []string{}
+}
+
+func getSVCSharingPermitDifferentPods(log *slog.Logger, svc *slim_core_v1.Service) bool {
+	val, _ := annotation.Get(svc, annotation.LBIPAMSharingPermitDifferentPods)
+	if val == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		log.Warn(
+			"Invalid value for sharing-permit-different-pods annotation, defaulting to disabled",
+			logfields.ServiceName, svc.Name,
+			logfields.ServiceNamespace, svc.Namespace,
+			logfields.Value, val,
+			logfields.Error, err,
+		)
+		return false
+	}
+	return enabled
 }
 
 func (ipam *LBIPAM) handleDeletedService(svc *slim_core_v1.Service) {

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -4,6 +4,8 @@
 package lbipam
 
 import (
+	"bytes"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strconv"
@@ -818,6 +820,306 @@ func TestSharingCrossNamespace(t *testing.T) {
 	fixture.DeleteSvc(t, svcA)
 	fixture.DeleteSvc(t, svcB)
 	fixture.DeleteSvc(t, svcC)
+}
+
+// TestSharingPermitDifferentPods tests the sharing-permit-different-pods opt-in. With
+// externalTrafficPolicy=Local, the default same-selector check rejects services that select
+// different pods. The opt-in must be present on both services for them to share an IP. The
+// opt-in only relaxes the same-selector requirement; it does not allow sharing for services
+// that lack a selector (Endpoints-based), since LB IPAM cannot reason about endpoints.
+func TestSharingPermitDifferentPods(t *testing.T) {
+	mkSvc := func(name string, uid types.UID, selector map[string]string, annotations map[string]string) *slim_core_v1.Service {
+		etp := slim_core_v1.ServiceExternalTrafficPolicyLocal
+		return &slim_core_v1.Service{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Name:        name,
+				Namespace:   "default",
+				UID:         uid,
+				Annotations: annotations,
+			},
+			Spec: slim_core_v1.ServiceSpec{
+				Type:                  slim_core_v1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy: etp,
+				Selector:              selector,
+				IPFamilies:            []slim_core_v1.IPFamily{slim_core_v1.IPv4Protocol},
+			},
+		}
+	}
+
+	t.Run("rejects different selectors without opt-in", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "without opt-in, services with different selectors must not share an IP")
+	})
+
+	t.Run("rejects when only one service opts in (A then B)", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "opt-in must be symmetric; one-sided opt-in must not share an IP")
+	})
+
+	t.Run("rejects when only one service opts in (B then A)", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		ipB := svcB.Status.LoadBalancer.Ingress[0].IP
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipB, svcA.Status.LoadBalancer.Ingress[0].IP, "opt-in symmetry must hold regardless of upsert order")
+	})
+
+	t.Run("allows different selectors when both services opt in", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "with both opt-ins, services must share an IP")
+	})
+
+	t.Run("alias annotation enables opt-in", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKeyAlias:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPodsAlias: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKeyAlias:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPodsAlias: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "alias annotation must enable the opt-in")
+	})
+
+	t.Run("rejects empty selectors even with opt-in (Endpoints-based services)", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, nil, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, nil, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "opt-in must not enable sharing for services without a selector; LB IPAM cannot reason about endpoints")
+	})
+
+	// Each value is fed to strconv.ParseBool. Values it accepts as truthy enable the opt-in;
+	// everything else (including empty, "yes", "no", "on", "off", garbage) leaves it disabled.
+	parseBoolCases := []struct {
+		name      string
+		value     string
+		shouldOpt bool
+	}{
+		{"true lower", "true", true},
+		{"True mixed", "True", true},
+		{"TRUE upper", "TRUE", true},
+		{"1", "1", true},
+		{"t", "t", true},
+		{"false lower", "false", false},
+		{"FALSE upper", "FALSE", false},
+		{"0", "0", false},
+		{"empty", "", false},
+		{"yes (not parsed)", "yes", false},
+		{"garbage", "definitely-not-a-bool", false},
+	}
+	for _, tc := range parseBoolCases {
+		t.Run("ParseBool/"+tc.name, func(t *testing.T) {
+			fixture := mkTestFixture(t, true, true)
+			fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+			svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+				annotation.LBIPAMSharingKey:                 "key-a",
+				annotation.LBIPAMSharingPermitDifferentPods: tc.value,
+			})
+			fixture.UpsertSvc(t, svcA)
+			svcA = fixture.GetSvc("default", "service-a")
+			require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+			ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+			svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+				annotation.LBIPAMSharingKey:                 "key-a",
+				annotation.LBIPAMSharingPermitDifferentPods: tc.value,
+			})
+			fixture.UpsertSvc(t, svcB)
+			svcB = fixture.GetSvc("default", "service-b")
+			require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+
+			if tc.shouldOpt {
+				assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "value %q must enable the opt-in", tc.value)
+			} else {
+				assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "value %q must not enable the opt-in", tc.value)
+			}
+		})
+	}
+
+	t.Run("invalid value logs a warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		svc := &slim_core_v1.Service{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Annotations: map[string]string{
+					annotation.LBIPAMSharingPermitDifferentPods: "yes",
+				},
+			},
+		}
+		assert.False(t, getSVCSharingPermitDifferentPods(logger, svc), "unparseable value must default to disabled")
+		assert.Contains(t, buf.String(), "sharing-permit-different-pods", "an invalid value must surface in the log so users can debug typos")
+	})
+
+	t.Run("opt-in is a no-op when externalTrafficPolicy is Cluster", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		// Both services have ETP=Cluster and different selectors. The opt-in is irrelevant
+		// because the same-selector check only applies to ETP=Local; both services must share
+		// the IP regardless.
+		mkClusterSvc := func(name string, uid types.UID, selector map[string]string) *slim_core_v1.Service {
+			return &slim_core_v1.Service{
+				ObjectMeta: slim_meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					UID:       uid,
+					Annotations: map[string]string{
+						annotation.LBIPAMSharingKey: "key-a",
+					},
+				},
+				Spec: slim_core_v1.ServiceSpec{
+					Type:                  slim_core_v1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy: slim_core_v1.ServiceExternalTrafficPolicyCluster,
+					Selector:              selector,
+					IPFamilies:            []slim_core_v1.IPFamily{slim_core_v1.IPv4Protocol},
+				},
+			}
+		}
+
+		svcA := mkClusterSvc("service-a", serviceAUID, map[string]string{"app": "a"})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkClusterSvc("service-b", serviceBUID, map[string]string{"app": "b"})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "ETP=Cluster services with the same sharing key must share an IP regardless of selector or opt-in")
+	})
+
+	t.Run("removing opt-in releases the shared IP", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		require.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "precondition: services share an IP")
+
+		// Remove the opt-in from service-b. The same-selector check now rejects sharing,
+		// so service-b must be re-allocated a different IP and the shared IP must be released
+		// from service-b's allocation.
+		svcB.Annotations = map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		}
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "removing the opt-in must release the shared IP from service-b")
+
+		// service-a keeps its IP (it is still satisfied; only the no-longer-compatible peer is moved).
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcA.Status.LoadBalancer.Ingress[0].IP, "service-a must keep its IP")
+	})
 }
 
 // TestServiceDelete tests the service deletion logic. It makes sure that the IP that was assigned to the service is

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -4,6 +4,8 @@
 package lbipam
 
 import (
+	"bytes"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strconv"
@@ -819,6 +821,283 @@ func TestSharingCrossNamespace(t *testing.T) {
 	fixture.DeleteSvc(t, svcA)
 	fixture.DeleteSvc(t, svcB)
 	fixture.DeleteSvc(t, svcC)
+}
+
+// TestSharingPermitDifferentPods tests the sharing-permit-different-pods opt-in. With
+// externalTrafficPolicy=Local, the default same-selector check rejects services that select
+// different pods. The opt-in must be present on both services for them to share an IP. The
+// opt-in only relaxes the same-selector requirement; it does not allow sharing for services
+// that lack a selector (Endpoints-based), since LB IPAM cannot reason about endpoints.
+func TestSharingPermitDifferentPods(t *testing.T) {
+	mkSvc := func(name string, uid types.UID, selector map[string]string, annotations map[string]string) *slim_core_v1.Service {
+		etp := slim_core_v1.ServiceExternalTrafficPolicyLocal
+		return &slim_core_v1.Service{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Name:        name,
+				Namespace:   "default",
+				UID:         uid,
+				Annotations: annotations,
+			},
+			Spec: slim_core_v1.ServiceSpec{
+				Type:                  slim_core_v1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy: etp,
+				Selector:              selector,
+				IPFamilies:            []slim_core_v1.IPFamily{slim_core_v1.IPv4Protocol},
+			},
+		}
+	}
+
+	t.Run("rejects different selectors without opt-in", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "without opt-in, services with different selectors must not share an IP")
+	})
+
+	t.Run("rejects when only one service opts in (A then B)", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "opt-in must be symmetric; one-sided opt-in must not share an IP")
+	})
+
+	t.Run("rejects when only one service opts in (B then A)", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		ipB := svcB.Status.LoadBalancer.Ingress[0].IP
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipB, svcA.Status.LoadBalancer.Ingress[0].IP, "opt-in symmetry must hold regardless of upsert order")
+	})
+
+	t.Run("allows different selectors when both services opt in", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "with both opt-ins, services must share an IP")
+	})
+
+	t.Run("rejects empty selectors even with opt-in (Endpoints-based services)", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, nil, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, nil, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "opt-in must not enable sharing for services without a selector; LB IPAM cannot reason about endpoints")
+	})
+
+	// Each value is fed to strconv.ParseBool. Values it accepts as truthy enable the opt-in;
+	// everything else (including empty, "yes", "no", "on", "off", garbage) leaves it disabled.
+	parseBoolCases := []struct {
+		name      string
+		value     string
+		shouldOpt bool
+	}{
+		{"true lower", "true", true},
+		{"True mixed", "True", true},
+		{"TRUE upper", "TRUE", true},
+		{"1", "1", true},
+		{"t", "t", true},
+		{"false lower", "false", false},
+		{"FALSE upper", "FALSE", false},
+		{"0", "0", false},
+		{"empty", "", false},
+		{"yes (not parsed)", "yes", false},
+		{"garbage", "definitely-not-a-bool", false},
+	}
+	for _, tc := range parseBoolCases {
+		t.Run("ParseBool/"+tc.name, func(t *testing.T) {
+			fixture := mkTestFixture(t, true, true)
+			fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+			svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+				annotation.LBIPAMSharingKey:                 "key-a",
+				annotation.LBIPAMSharingPermitDifferentPods: tc.value,
+			})
+			fixture.UpsertSvc(t, svcA)
+			svcA = fixture.GetSvc("default", "service-a")
+			require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+			ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+			svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+				annotation.LBIPAMSharingKey:                 "key-a",
+				annotation.LBIPAMSharingPermitDifferentPods: tc.value,
+			})
+			fixture.UpsertSvc(t, svcB)
+			svcB = fixture.GetSvc("default", "service-b")
+			require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+
+			if tc.shouldOpt {
+				assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "value %q must enable the opt-in", tc.value)
+			} else {
+				assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "value %q must not enable the opt-in", tc.value)
+			}
+		})
+	}
+
+	t.Run("invalid value logs a warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		svc := &slim_core_v1.Service{
+			ObjectMeta: slim_meta_v1.ObjectMeta{
+				Annotations: map[string]string{
+					annotation.LBIPAMSharingPermitDifferentPods: "yes",
+				},
+			},
+		}
+		assert.False(t, getSVCSharingPermitDifferentPods(logger, svc), "unparseable value must default to disabled")
+		assert.Contains(t, buf.String(), "sharing-permit-different-pods", "an invalid value must surface in the log so users can debug typos")
+	})
+
+	t.Run("opt-in is a no-op when externalTrafficPolicy is Cluster", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		// Both services have ETP=Cluster and different selectors. The opt-in is irrelevant
+		// because the same-selector check only applies to ETP=Local; both services must share
+		// the IP regardless.
+		mkClusterSvc := func(name string, uid types.UID, selector map[string]string) *slim_core_v1.Service {
+			return &slim_core_v1.Service{
+				ObjectMeta: slim_meta_v1.ObjectMeta{
+					Name:      name,
+					Namespace: "default",
+					UID:       uid,
+					Annotations: map[string]string{
+						annotation.LBIPAMSharingKey: "key-a",
+					},
+				},
+				Spec: slim_core_v1.ServiceSpec{
+					Type:                  slim_core_v1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy: slim_core_v1.ServiceExternalTrafficPolicyCluster,
+					Selector:              selector,
+					IPFamilies:            []slim_core_v1.IPFamily{slim_core_v1.IPv4Protocol},
+				},
+			}
+		}
+
+		svcA := mkClusterSvc("service-a", serviceAUID, map[string]string{"app": "a"})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkClusterSvc("service-b", serviceBUID, map[string]string{"app": "b"})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "ETP=Cluster services with the same sharing key must share an IP regardless of selector or opt-in")
+	})
+
+	t.Run("removing opt-in releases the shared IP", func(t *testing.T) {
+		fixture := mkTestFixture(t, true, true)
+		fixture.UpsertPool(t, mkPool(poolAUID, "pool-a", []string{"10.0.10.0/24"}))
+
+		svcA := mkSvc("service-a", serviceAUID, map[string]string{"app": "a"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcA)
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		ipA := svcA.Status.LoadBalancer.Ingress[0].IP
+
+		svcB := mkSvc("service-b", serviceBUID, map[string]string{"app": "b"}, map[string]string{
+			annotation.LBIPAMSharingKey:                 "key-a",
+			annotation.LBIPAMSharingPermitDifferentPods: "true",
+		})
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		require.Equal(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "precondition: services share an IP")
+
+		// Remove the opt-in from service-b. The same-selector check now rejects sharing,
+		// so service-b must be re-allocated a different IP and the shared IP must be released
+		// from service-b's allocation.
+		svcB.Annotations = map[string]string{
+			annotation.LBIPAMSharingKey: "key-a",
+		}
+		fixture.UpsertSvc(t, svcB)
+		svcB = fixture.GetSvc("default", "service-b")
+		require.Len(t, svcB.Status.LoadBalancer.Ingress, 1)
+		assert.NotEqual(t, ipA, svcB.Status.LoadBalancer.Ingress[0].IP, "removing the opt-in must release the shared IP from service-b")
+
+		// service-a keeps its IP (it is still satisfied; only the no-longer-compatible peer is moved).
+		svcA = fixture.GetSvc("default", "service-a")
+		require.Len(t, svcA.Status.LoadBalancer.Ingress, 1)
+		assert.Equal(t, ipA, svcA.Status.LoadBalancer.Ingress[0].IP, "service-a must keep its IP")
+	})
 }
 
 // TestServiceDelete tests the service deletion logic. It makes sure that the IP that was assigned to the service is

--- a/operator/pkg/lbipam/service_store.go
+++ b/operator/pkg/lbipam/service_store.go
@@ -67,6 +67,8 @@ type ServiceView struct {
 
 	SharingKey            sharingKey
 	SharingCrossNamespace []string
+	// SharingPermitDifferentPods relaxes the same-selector requirement for sharing an IP; see the lbipam.cilium.io/sharing-permit-different-pods annotation.
+	SharingPermitDifferentPods bool
 	// These required to determine if a service conflicts with another for sharing an ip
 	ExternalTrafficPolicy slim_core_v1.ServiceExternalTrafficPolicy
 	Ports                 []slim_core_v1.ServicePort
@@ -126,12 +128,21 @@ func (sv *ServiceView) isCompatible(osv *ServiceView) (bool, string) {
 	if sv.ExternalTrafficPolicy == slim_core_v1.ServiceExternalTrafficPolicyLocal {
 		// If any of the two service doesn't select any pods with the selector, it likely uses an endpoints object to
 		// link the service to pods. LB-IPAM isn't smart enough to handle this case (yet), so we don't allow it.
+		// This applies even when both services opt in via sharing-permit-different-pods, because the opt-in only
+		// relaxes the same-selector requirement and does not give LB-IPAM a way to reason about endpoints.
 		if len(sv.Selector) == 0 || len(osv.Selector) == 0 {
 			return false, "compatible ExternalTrafficPolicy local but selecting different set of pods"
 		}
 
 		// If both use selectors, and they are not the same, then the services are not compatible.
-		if !maps.Equal(sv.Selector, osv.Selector) {
+		//
+		// Both services may opt out of this same-selector check by setting the
+		// sharing-permit-different-pods annotation. The user is then responsible for steering traffic
+		// to a node that has a backend, e.g. via an L4-aware external load balancer or by deploying
+		// both services as DaemonSets with matching node coverage. Cilium's built-in BGP and L2
+		// announcements are not L4 aware, so combining them with this opt-in can drop traffic.
+		if !maps.Equal(sv.Selector, osv.Selector) &&
+			!(sv.SharingPermitDifferentPods && osv.SharingPermitDifferentPods) {
 			return false, "compatible ExternalTrafficPolicy local but selecting different set of pods"
 		}
 	}

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -274,10 +274,12 @@ const (
 	LBIPAMIPsKey     = LBIPAMPrefix + "/ips"
 	LBIPAMIPKeyAlias = Prefix + "/lb-ipam-ips"
 
-	LBIPAMSharingKey                  = LBIPAMPrefix + "/sharing-key"
-	LBIPAMSharingKeyAlias             = Prefix + "/lb-ipam-sharing-key"
-	LBIPAMSharingAcrossNamespace      = LBIPAMPrefix + "/sharing-cross-namespace"
-	LBIPAMSharingAcrossNamespaceAlias = Prefix + "/lb-ipam-sharing-cross-namespace"
+	LBIPAMSharingKey                      = LBIPAMPrefix + "/sharing-key"
+	LBIPAMSharingKeyAlias                 = Prefix + "/lb-ipam-sharing-key"
+	LBIPAMSharingAcrossNamespace          = LBIPAMPrefix + "/sharing-cross-namespace"
+	LBIPAMSharingAcrossNamespaceAlias     = Prefix + "/lb-ipam-sharing-cross-namespace"
+	LBIPAMSharingPermitDifferentPods      = LBIPAMPrefix + "/sharing-permit-different-pods"
+	LBIPAMSharingPermitDifferentPodsAlias = Prefix + "/lb-ipam-sharing-permit-different-pods"
 
 	CECInjectCiliumFilters      = CECPrefix + "/inject-cilium-filters"
 	CECIsL7LB                   = CECPrefix + "/is-l7lb"

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -278,6 +278,7 @@ const (
 	LBIPAMSharingKeyAlias             = Prefix + "/lb-ipam-sharing-key"
 	LBIPAMSharingAcrossNamespace      = LBIPAMPrefix + "/sharing-cross-namespace"
 	LBIPAMSharingAcrossNamespaceAlias = Prefix + "/lb-ipam-sharing-cross-namespace"
+	LBIPAMSharingPermitDifferentPods  = LBIPAMPrefix + "/sharing-permit-different-pods"
 
 	CECInjectCiliumFilters      = CECPrefix + "/inject-cilium-filters"
 	CECIsL7LB                   = CECPrefix + "/is-l7lb"


### PR DESCRIPTION
## Description of change

LB IPAM rejected services with `externalTrafficPolicy: Local` from sharing an IP unless they selected the same set of pods. This default is correct for users relying on Cilium's built-in BGP or L2 announcers, which are not L4 aware: announcing the shared IP from a node that lacks a backend for one of the services would drop traffic for that service.

Some deployments steer traffic with mechanisms outside Cilium's view — most notably an external L4-aware load balancer that uses each service's `healthCheckNodePort` to route only to nodes with a backend, or DaemonSets with matching node coverage so every node hosts every backend. For these the same-selector check is too strict.

This PR adds an opt-in annotation `lbipam.cilium.io/sharing-permit-different-pods`. When set to `true` on **all** services in a sharing group, LB IPAM relaxes the same-selector requirement. The opt-in is symmetric (every service in the group must opt in), and it only relaxes the same-selector branch — services without a selector (Endpoints-based) are still rejected because LB IPAM cannot read endpoints to determine which nodes host backends.

The annotation value is parsed via `strconv.ParseBool`. Unparseable values default to disabled and emit a warning so users can debug typos.

The need for this opt-in was discussed in the linked CFP, where the maintainer initially preferred a smarter compatibility check but acknowledged that for use cases involving an external L4-aware load balancer there is no reliable way to validate the setup automatically, leaving an explicit opt-in as the practical path.

## AI disclosure

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.

Fixes: #38766

```release-note
LB IPAM: introduce the lbipam.cilium.io/sharing-permit-different-pods annotation to allow sharing an IP between services with externalTrafficPolicy=Local that select different pods. The annotation must be set to "true" on all services in the sharing group and is intended for deployments that steer traffic outside Cilium's built-in announcers.
```
