### PR TITLE
Fix: Prevent external-group hash collisions that can merge distinct policies

### DIFF
--- a/pkg/policy/api/groups.go
+++ b/pkg/policy/api/groups.go
@@ -58,8 +58,8 @@ func (g *Groups) Hash() string {
 		// unreachable; we already loaded this from JSON via the apiserver...
 		return ""
 	}
-	sum := sha256.New224().Sum(b)
-	return base64.RawURLEncoding.EncodeToString(sum)[0:63]
+	sum := sha256.Sum224(b)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
 // LabelKey returns a unique label key for this group, in the format of


### PR DESCRIPTION
 

scenario: 
When a policy toGroups/fromGroups value has a long JSON prefix and differs only later in the object, the current Groups.Hash() implementation can produce the same ID for different groups.
Different external groups may be treated as the same ExternalGroup / CiliumCIDRGroup, so one policy can reuse another policy’s resolved CIDRs.


 Root cause: 
the function name Hash(), the old implementation was not behaving as expected. Hash() implies it should return a digest of the group content, but sha256.New224().Sum(b) did not actually hash b. It appended the SHA-224 digest of  empty input to b, so the result was effectively a base64-encoded JSON prefix, not a real hash of the full group

Fix: 
Replace it with sha256.Sum224(b) and encode the full digest directly. 

