### PR TITLE
gateway-api: Fix silent drops of routes on multi listener gateways

### DIFF
--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -58,7 +58,10 @@ func isAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, rout
 
 		// all routes in the same namespace are allowed for this listener
 		if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
-			return route.GetNamespace() == gw.GetNamespace()
+			if route.GetNamespace() == gw.GetNamespace() {
+				return true
+			}
+			continue
 		}
 
 		// check if route is kind-allowed
@@ -79,7 +82,7 @@ func isAllowed(ctx context.Context, c client.Client, gw *gatewayv1.Gateway, rout
 			selector, _ := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
 			if err := c.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
 				logger.ErrorContext(ctx, "Unable to list namespaces", logfields.Error, err)
-				return false
+				continue
 			}
 
 			for _, ns := range nsList.Items {

--- a/operator/pkg/gateway-api/helpers_test.go
+++ b/operator/pkg/gateway-api/helpers_test.go
@@ -4,10 +4,18 @@
 package gateway_api
 
 import (
+	"context"
+	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -56,5 +64,162 @@ func Test_isKindAllowed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, isKindAllowed(listener, tt.route))
 		})
+	}
+}
+
+func Test_isAllowed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, gatewayv1.Install(scheme))
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	logger := slog.New(slog.DiscardHandler)
+
+	tests := []struct {
+		name  string
+		gw    *gatewayv1.Gateway
+		route metav1.Object
+		c     client.Client
+		want  bool
+	}{
+		{
+			name: "nil AllowedRoutes listener rejects cross-namespace route, later All listener allows",
+			gw: gatewayWithListeners(
+				listener("same-namespace", nil),
+				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
+			),
+			route: testHTTPRoute("cross-ns"),
+			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+			want:  true,
+		},
+		{
+			name: "nil AllowedRoutes Namespaces listener rejects cross-namespace route, later All listener allows",
+			gw: gatewayWithListeners(
+				listener("same-namespace", &gatewayv1.AllowedRoutes{}),
+				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
+			),
+			route: testHTTPRoute("cross-ns"),
+			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+			want:  true,
+		},
+		{
+			name: "selector listener does not match route namespace, later All listener allows",
+			gw: gatewayWithListeners(
+				listener("selector", selectorAllowedRoutes("allowed", "true")),
+				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
+			),
+			route: testHTTPRoute("cross-ns"),
+			c: fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(namespace("other-ns", map[string]string{"allowed": "true"})).
+				Build(),
+			want: true,
+		},
+		{
+			name: "selector listener list error, later All listener allows",
+			gw: gatewayWithListeners(
+				listener("selector", selectorAllowedRoutes("allowed", "true")),
+				listener("all", allowedRoutes(gatewayv1.NamespacesFromAll)),
+			),
+			route: testHTTPRoute("cross-ns"),
+			c: namespaceListErrorClient{
+				Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			},
+			want: true,
+		},
+		{
+			name: "same-namespace default listener allows same-namespace route",
+			gw: gatewayWithListeners(
+				listener("same-namespace", nil),
+			),
+			route: testHTTPRoute("default"),
+			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+			want:  true,
+		},
+		{
+			name: "only same-namespace default listener rejects cross-namespace route",
+			gw: gatewayWithListeners(
+				listener("same-namespace", nil),
+			),
+			route: testHTTPRoute("cross-ns"),
+			c:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAllowed(context.Background(), tt.c, tt.gw, tt.route, logger))
+		})
+	}
+}
+
+type namespaceListErrorClient struct {
+	client.Client
+}
+
+func (c namespaceListErrorClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, ok := list.(*corev1.NamespaceList); ok {
+		return errors.New("unable to list namespaces")
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func gatewayWithListeners(listeners ...gatewayv1.Listener) *gatewayv1.Gateway {
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners:        listeners,
+		},
+	}
+}
+
+func listener(name gatewayv1.SectionName, allowedRoutes *gatewayv1.AllowedRoutes) gatewayv1.Listener {
+	return gatewayv1.Listener{
+		Name:          name,
+		Protocol:      gatewayv1.HTTPProtocolType,
+		Port:          80,
+		AllowedRoutes: allowedRoutes,
+	}
+}
+
+func allowedRoutes(from gatewayv1.FromNamespaces) *gatewayv1.AllowedRoutes {
+	return &gatewayv1.AllowedRoutes{
+		Namespaces: &gatewayv1.RouteNamespaces{
+			From: ptr.To(from),
+		},
+	}
+}
+
+func selectorAllowedRoutes(key, value string) *gatewayv1.AllowedRoutes {
+	return &gatewayv1.AllowedRoutes{
+		Namespaces: &gatewayv1.RouteNamespaces{
+			From: ptr.To(gatewayv1.NamespacesFromSelector),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					key: value,
+				},
+			},
+		},
+	}
+}
+
+func testHTTPRoute(namespace string) *gatewayv1.HTTPRoute {
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+		},
+	}
+}
+
+func namespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
 	}
 }


### PR DESCRIPTION
Gateway API silently drops routes on multi listener gateways despite accepted status 


##  Nil AllowedRoutes causes premature false return                                                                                                 

Trigger: 
Multi-listener gateway where the first listener has no AllowedRoutes configured (defaulting to same-namespace only), and a later listener has  From: All. A route from a different namespace attempts to attach.
                                                                                                                                                           
The route is silently excluded from Envoy configuration generation — traffic is dropped. However, the route's Accepted status shows Accepted: True, creating a contradiction between status and actual behavior.
                                                                                                                                                           
Expected: 
Per Gateway API spec, the gateway must consider all listeners. If any listener allows the route, it should be accepted. The function should  continue checking remaining listeners when one rejects.
                                                                                                                                                           
Root cause: 
return route.GetNamespace() == gw.GetNamespace() exits the listener loop immediately when the first listener lacks           
  AllowedRoutes, without evaluating subsequent listeners.
                                                                                                                                                           
 Fix: 
Check same-namespace → return true on match, continue on mismatch.                                                                                  
   

## Namespace selector list failure causes premature false return                                                                                   
                                                                                                                                                           
Trigger: 
Multi-listener gateway where one listener uses NamespacesFromSelector, the Kubernetes API call to list namespaces fails, and a subsequent  listener has a more permissive rule (e.g., From: All).                                                                                                   
                                                                                                                                                         
 route is silently dropped while status shows Accepted: True.                                                                    
                                                                                                                                                         
Expected: 
A transient API error on one listener's namespace selector should not block evaluation of other listeners. The function should log the error  and continue checking remaining listeners.                                                                                                             
                                                                                                                                                           
               


