### PR TITLE
cilium-cli/connectivity: require static routes only on kind

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -811,16 +811,6 @@ func (ct *ConnectivityTest) detectNodesWithoutCiliumIPs() error {
 	return nil
 }
 
-func (ct *ConnectivityTest) requiresStaticRoutes() bool {
-	if f, ok := ct.Feature(features.Flavor); ok && f.Enabled {
-		switch f.Mode {
-		case "gke", "aks", "eks":
-			return false
-		}
-	}
-	return true
-}
-
 type ipRouteVerb string
 
 const (
@@ -829,11 +819,6 @@ const (
 )
 
 func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.Context, verb ipRouteVerb) error {
-	if !ct.requiresStaticRoutes() {
-		ct.Debugf("Skipping modifying static route on nodes without Cilium, cloud platform has pod connectivity")
-		return nil
-	}
-
 	for _, e := range ct.params.PodCIDRs {
 		for withoutCilium := range ct.nodesWithoutCilium {
 			pod := ct.hostNetNSPodsByNode[withoutCilium]
@@ -861,6 +846,17 @@ func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.
 // NeedsStaticRoutes checks whether any test requires static ip routes
 // installed.
 func (ct *ConnectivityTest) NeedsStaticRoutes() bool {
+	// Static routes are only needed when running unsafe tests.
+	if !ct.params.IncludeUnsafeTests {
+		return false
+	}
+
+	// Static routes are only needed on kind. Cloud platforms have pod IP -> node IP
+	// connectivity.
+	if f, ok := ct.Feature(features.Flavor); ok && f.Enabled && f.Mode != "kind" {
+		return false
+	}
+
 	return slices.ContainsFunc(ct.tests, func(t *Test) bool {
 		return t.installIPRoutesFromOutsideToPodCIDRs
 	})


### PR DESCRIPTION
Installing the static routes on the nodes without Cilium installed is only required on Kind, see the original commit 6aa92f688bfa ("connectivity: Install podCIDR => nodeIP on non-Cilium nodes") adding this explicitly for the kind workflow. Also, the static routes should only be installed if unsafe tests (i.e. modifying the state of the cluster) are enabled.

Change the condition in the check and also move it into `(*ConnectivityTest).NeedsStaticRoutes` (which is called before `(*ConnectivityTest).modifyStaticRoutesForNodesWithoutCilium`) so all related checks are in the same place.

Fixes: ec2a0f3a87d2 ("cilium-cli: Skip adding static routes to pods on cloud providers")
Reported-by: @fgiloux