### PR TITLE
[v1.19] install: Restore RBAC for ciliumbgppeeringpolicies

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -94,6 +94,7 @@ rules:
   - cilium.io
   resources:
   - ciliumloadbalancerippools
+  - ciliumbgppeeringpolicies
   - ciliumbgpnodeconfigs
   - ciliumbgpadvertisements
   - ciliumbgppeerconfigs

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -281,6 +281,7 @@ rules:
   resources:
   - ciliumloadbalancerippools
   - ciliumpodippools
+  - ciliumbgppeeringpolicies
   - ciliumbgpclusterconfigs
   - ciliumbgpnodeconfigoverrides
   - ciliumbgppeerconfigs

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -94,6 +94,7 @@ rules:
   - cilium.io
   resources:
   - ciliumloadbalancerippools
+  - ciliumbgppeeringpolicies
   - ciliumbgpnodeconfigs
   - ciliumbgpadvertisements
   - ciliumbgppeerconfigs


### PR DESCRIPTION
To allow for gradual upgrade of Cilium pods from `v1.18` to `v1.19`, restore RBAC access for agent and operator to `ciliumbgppeeringpolicies` that was removed in `v1.19` (https://github.com/cilium/cilium/pull/42278), so that pods running with `1.18` version can still access it during upgrade.

We need to do this only for v1.19 to allow hitless `v1.18` -> `v1.19` upgrade.

Fixes: #45802

```release-note
install: Restore RBAC for ciliumbgppeeringpolicies to allow for gradual upgrade of Cilium pods from `v1.18` to `v1.19`.
```
