### PR TITLE
[network-driver] Add support for static IPs allocation from Pod annotation

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -285,6 +285,11 @@ const (
 
 	// FIBTableID is the annotation used to specify the FIB table ID for egress routing.
 	FIBTableID = NetworkPrefix + "/fib-table-id"
+
+	// NetworkDriverStaticAddresses is the pod annotation used to specify static IP
+	// addresses for network driver DRA requests. The value is a JSON object
+	// ResourceClaim's requests to objects containing v4 and v6 addresses.
+	NetworkDriverStaticAddresses = IPAMPrefix + "/network-driver-static-addresses"
 )
 
 // CiliumPrefixRegex is a regex matching Cilium specific annotations.

--- a/pkg/networkdriver/README.md
+++ b/pkg/networkdriver/README.md
@@ -277,6 +277,27 @@ spec:
     image: my-dpdk-app:latest
 ```
 
+### 6. IPAM — static IP address allocation
+
+Besides ResourceClaim or ResourceClaimTemplate Spec, static IP addresses can also
+be supplied on the pod with the `ipam.cilium.io/network-driver-static-addresses` annotation.
+The annotation value is a JSON object mapping ResourceClaim's and ResourceClaimTemplate's
+requests to objects containing `ipv4` and `ipv6` fields for IPv4 and IPv6 addresses, respectively:
+
+```
+metadata:
+  annotations:
+    ipam.cilium.io/network-driver-static-addresses: |
+      {
+        "sriov-claim-direct": {
+          "net": {
+            "ipv4": "192.168.1.10/24",
+            "ipv6": "2001:db8::10/64"
+          }
+        }
+      }
+```
+
 ### 6. IPAM — dynamic IP address allocation
 
 The operator can manage IP pools for network driver devices using

--- a/pkg/networkdriver/cell.go
+++ b/pkg/networkdriver/cell.go
@@ -101,7 +101,6 @@ func podResource(
 	lc cell.Lifecycle,
 	cs k8sClient.Clientset,
 	mp workqueue.MetricsProvider,
-	crdSync promise.Promise[synced.CRDSync],
 ) (resource.Resource[*corev1.Pod], error) {
 	if !cs.IsEnabled() {
 		return nil, nil
@@ -114,7 +113,6 @@ func podResource(
 	)
 	return resource.New[*corev1.Pod](lc, lw, mp,
 		resource.WithMetric("Pod"),
-		resource.WithCRDSync(crdSync),
 	), nil
 }
 

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -12,16 +12,21 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strings"
 
 	"go4.org/netipx"
+	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kube_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
@@ -157,6 +162,127 @@ func (driver *Driver) deviceClaimConfigs(ctx context.Context, claim *resourceapi
 		}
 	}
 	return devicesCfg, nil
+}
+
+func (driver *Driver) podForClaim(ctx context.Context, claim *resourceapi.ResourceClaim, podRef resourceapi.ResourceClaimConsumerReference) (*corev1.Pod, error) {
+	if podRef.Resource != "pods" {
+		return nil, fmt.Errorf("claim %s is reserved for unsupported resource %s", path.Join(claim.Namespace, claim.Name), podRef.Resource)
+	}
+
+	podStore, err := driver.pods.Store(ctx)
+	if err == nil {
+		pod, exists, err := podStore.GetByKey(resource.Key{Namespace: claim.Namespace, Name: podRef.Name})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get pod %s/%s from store: %w", claim.Namespace, podRef.Name, err)
+		}
+		if exists {
+			return pod, nil
+		}
+	}
+
+	driver.logger.DebugContext(ctx, "unable to get pod from store, falling back to kubernetes client",
+		logfields.K8sNamespace, claim.Namespace,
+		logfields.Name, claim.Name,
+		logfields.K8sPodName, podRef.Name,
+		logfields.Error, err,
+	)
+
+	pod, err := driver.kubeClient.CoreV1().Pods(claim.Namespace).Get(ctx, podRef.Name, metav1.GetOptions{})
+	if k8sErrors.IsNotFound(err) {
+		driver.logger.DebugContext(ctx, "pod for claim not found, skipping pod annotations",
+			logfields.K8sNamespace, claim.Namespace,
+			logfields.Name, claim.Name,
+			logfields.K8sPodName, podRef.Name,
+		)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pod %s/%s for claim %s: %w", claim.Namespace, podRef.Name, path.Join(claim.Namespace, claim.Name), err)
+	}
+
+	return pod, nil
+}
+
+func addressesForClaim(pod *corev1.Pod, claim string) (types.StaticAddrsMap, error) {
+	if pod == nil {
+		return nil, nil
+	}
+
+	raw, found := annotation.Get(pod, annotation.NetworkDriverStaticAddresses)
+	if !found || strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	// claim → request → addresses
+	var prefixes map[string]types.StaticAddrsMap
+	if err := json.Unmarshal([]byte(raw), &prefixes); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s annotation on pod %s/%s: %w", annotation.NetworkDriverStaticAddresses, pod.Namespace, pod.Name, err)
+	}
+
+	return prefixes[claim], nil
+}
+
+func (driver *Driver) applyAddressToConfig(
+	claim *resourceapi.ResourceClaim,
+	request string,
+	prefix netip.Prefix,
+	devicesCfg map[string]types.DeviceConfig,
+) error {
+	if !prefix.IsValid() {
+		if prefix == (netip.Prefix{}) {
+			// treat zero address as "no address specified" and skip without error
+			return nil
+		}
+		return fmt.Errorf("invalid prefix %s for request %s in claim %s", prefix, request, claim.Name)
+	}
+
+	family := "ipv6"
+	if prefix.Addr().Is4() {
+		family = "ipv4"
+	}
+
+	cfg, found := devicesCfg[request]
+	if !found {
+		return fmt.Errorf("unable to find request %s in claim %s, static prefixes will not be applied", request, claim.Name)
+	}
+	if family == "ipv4" {
+		cfg.IPv4Addr = prefix
+	} else {
+		cfg.IPv6Addr = prefix
+	}
+	devicesCfg[request] = cfg
+
+	return nil
+}
+
+func (driver *Driver) applyAddressesFromAnnotation(ctx context.Context, claim *resourceapi.ResourceClaim, podRef resourceapi.ResourceClaimConsumerReference, devicesCfg map[string]types.DeviceConfig) error {
+	pod, err := driver.podForClaim(ctx, claim, podRef)
+	if err != nil {
+		return err
+	}
+
+	// ResourceClaim generated from a ResourceClaimTemplate stores the original template name in an annotation
+	// (see https://kubernetes.io/docs/reference/labels-annotations-taints/#resource-kubernetes-io-pod-claim-name).
+	// For generated claims we need to use that name to look up the prefixes, because that's how users will specify
+	// them in the pod annotation.
+	claimName, found := annotation.Get(claim, "resource.kubernetes.io/pod-claim-name")
+	if !found {
+		claimName = claim.Name // annotation not found, it is a regular claim, use its own name to look up prefixes
+	}
+
+	prefixes, err := addressesForClaim(pod, claimName)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for request, prefix := range prefixes {
+		errs = append(errs,
+			driver.applyAddressToConfig(claim, request, prefix.IPv4, devicesCfg),
+			driver.applyAddressToConfig(claim, request, prefix.IPv6, devicesCfg),
+		)
+	}
+	return errors.Join(errs...)
 }
 
 type netDevConfig struct {
@@ -392,6 +518,23 @@ func (driver *Driver) prepareResourceClaim(ctx context.Context, claim *resourcea
 	deviceClaimConfigs, err := driver.deviceClaimConfigs(ctx, claim)
 	if err != nil {
 		return kubeletplugin.PrepareResult{Err: err}
+	}
+
+	// where available, apply static IP addresses from the pod annotation.
+	if err := driver.applyAddressesFromAnnotation(ctx, claim, pod, deviceClaimConfigs); err != nil {
+		driver.logger.ErrorContext(ctx, "failed to apply static IP addresses from pod annotation",
+			logfields.K8sNamespace, claim.Namespace,
+			logfields.Name, claim.Name,
+			logfields.K8sPodName, pod,
+			logfields.Error, err,
+		)
+		return kubeletplugin.PrepareResult{Err: err}
+	} else {
+		driver.logger.DebugContext(ctx, "applied static IP addresses from pod annotation",
+			logfields.K8sNamespace, claim.Namespace,
+			logfields.Name, claim.Name,
+			logfields.K8sPodName, pod,
+		)
 	}
 
 	// Validate podIfName in all configs before proceeding

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -140,7 +140,7 @@ func (driver *Driver) UnprepareResourceClaims(ctx context.Context, claims []kube
 func (driver *Driver) deviceClaimConfigs(ctx context.Context, claim *resourceapi.ResourceClaim) (map[string]types.DeviceConfig, error) {
 	devicesCfg := map[string]types.DeviceConfig{}
 	for _, cfg := range claim.Status.Allocation.Devices.Config {
-		if cfg.Opaque.Parameters.Raw != nil {
+		if cfg.Opaque != nil && cfg.Opaque.Parameters.Raw != nil {
 			c := types.DeviceConfig{}
 			if err := json.Unmarshal(cfg.Opaque.Parameters.Raw, &c); err != nil {
 				driver.logger.ErrorContext(

--- a/pkg/networkdriver/dra_test.go
+++ b/pkg/networkdriver/dra_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	v1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/synced"
@@ -124,16 +126,20 @@ func TestNetworkDriverIPAM(t *testing.T) {
 	}
 
 	var (
-		mgr *ipam.MultiPoolManager
-		cs  *k8sClient.FakeClientset
+		mgr  *ipam.MultiPoolManager
+		cs   *k8sClient.FakeClientset
+		pods resource.Resource[*corev1.Pod]
 	)
 
 	hive := hive.New(
 		k8sClient.FakeClientCell(),
 		k8s.ResourcesCell,
-		cell.Provide(func() *option.DaemonConfig {
-			return daemonCfg
-		}),
+		cell.Provide(
+			podResource,
+			func() *option.DaemonConfig {
+				return daemonCfg
+			},
+		),
 		resourceIPAM,
 
 		cell.Invoke(func(c *k8sClient.FakeClientset) {
@@ -143,9 +149,10 @@ func TestNetworkDriverIPAM(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		}),
-		cell.Invoke(func(m *ipam.MultiPoolManager, c *k8sClient.FakeClientset) {
+		cell.Invoke(func(m *ipam.MultiPoolManager, c *k8sClient.FakeClientset, p resource.Resource[*corev1.Pod]) {
 			mgr = m
 			cs = c
+			pods = p
 		}),
 	)
 
@@ -155,6 +162,7 @@ func TestNetworkDriverIPAM(t *testing.T) {
 	driver := &Driver{
 		logger:     tlog,
 		kubeClient: cs,
+		pods:       pods,
 		config: &v2alpha1.CiliumNetworkDriverNodeConfigSpec{
 			DriverName: driverName,
 		},
@@ -375,6 +383,7 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 	var (
 		mgr             *ipam.MultiPoolManager
 		cs              *k8sClient.FakeClientset
+		pods            resource.Resource[*corev1.Pod]
 		db              *statedb.DB
 		resourceNetCfgs statedb.Table[resourceNetworkConfig]
 	)
@@ -383,6 +392,7 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 		k8sClient.FakeClientCell(),
 		k8s.ResourcesCell,
 		cell.Provide(
+			podResource,
 			func() *option.DaemonConfig {
 				return daemonCfg
 			},
@@ -424,11 +434,13 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 		cell.Invoke(func(
 			m *ipam.MultiPoolManager,
 			c *k8sClient.FakeClientset,
+			p resource.Resource[*corev1.Pod],
 			d *statedb.DB,
 			netCfgs statedb.Table[resourceNetworkConfig],
 		) {
 			mgr = m
 			cs = c
+			pods = p
 			db = d
 			resourceNetCfgs = netCfgs
 		}),
@@ -450,6 +462,7 @@ func TestNetworkDriverIPAMPool(t *testing.T) {
 	driver := &Driver{
 		logger:     tlog,
 		kubeClient: cs,
+		pods:       pods,
 		config: &v2alpha1.CiliumNetworkDriverNodeConfigSpec{
 			DriverName: driverName,
 		},

--- a/pkg/networkdriver/prepare_test.go
+++ b/pkg/networkdriver/prepare_test.go
@@ -22,20 +22,27 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/netip"
+	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
 )
 
@@ -51,6 +58,7 @@ type trackedDevice struct {
 	freeErr    error
 	setupCalls atomic.Int32
 	freeCalls  atomic.Int32
+	setupCfgs  []types.DeviceConfig
 }
 
 func (d *trackedDevice) IfName() string       { return d.name }
@@ -60,8 +68,9 @@ func (d *trackedDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.Dev
 	return nil
 }
 
-func (d *trackedDevice) Setup(_ types.DeviceConfig) error {
+func (d *trackedDevice) Setup(cfg types.DeviceConfig) error {
 	d.setupCalls.Add(1)
+	d.setupCfgs = append(d.setupCfgs, cfg)
 	return d.setupErr
 }
 
@@ -96,6 +105,7 @@ const (
 	prepTestClaimNS    = "default"
 	prepTestClaimName  = "test-claim"
 	prepTestClaimUID   = kubetypes.UID("aaaaaaaa-0000-0000-0000-000000000001")
+	prepTestPodName    = "test-pod"
 	prepTestPodUID     = kubetypes.UID("bbbbbbbb-0000-0000-0000-000000000002")
 	prepTestDev0       = "dev-0"
 	prepTestDev1       = "dev-1"
@@ -150,10 +160,23 @@ func buildPrepClaim(devices ...string) *resourceapi.ResourceClaim {
 				},
 			},
 			ReservedFor: []resourceapi.ResourceClaimConsumerReference{
-				{Resource: "pods", Name: "test-pod", UID: prepTestPodUID},
+				{Resource: "pods", Name: prepTestPodName, UID: prepTestPodUID},
 			},
 		},
 	}
+}
+
+// buildGeneratedPrepClaim returns a ResourceClaim like buildPrepClaim does,
+// but generates the claim name using the pod, the claim name and a random suffix,
+// to mimic a ResourceClaim generated from a ResourceClaimTemplate.
+// This is needed to test the logic that looks up the original claim name in the annotation when the claim is generated.
+func buildGeneratedPrepClaim(devices ...string) *resourceapi.ResourceClaim {
+	claim := buildPrepClaim(devices...)
+	claim.Name = strings.Join([]string{prepTestPodName, prepTestClaimName, "4qttt"}, "-")
+	claim.Annotations = map[string]string{
+		"resource.kubernetes.io/pod-claim-name": prepTestClaimName,
+	}
+	return claim
 }
 
 // buildPrepDriver builds a *Driver with a fake kube client and the given
@@ -168,9 +191,25 @@ func buildPrepDriver(t *testing.T, cs *k8sClient.FakeClientset, devs ...*tracked
 		deviceList = append(deviceList, d)
 	}
 
+	// hive is used to provide the pods resource only
+	var pods resource.Resource[*corev1.Pod]
+	hive := hive.New(
+		k8sClient.FakeClientCell(),
+		cell.Provide(
+			podResource,
+		),
+		cell.Invoke(func(p resource.Resource[*corev1.Pod]) {
+			pods = p
+		}),
+	)
+	tlog := hivetest.Logger(t)
+	assert.NoError(t, hive.Start(tlog, t.Context()))
+	t.Cleanup(func() { hive.Stop(tlog, context.Background()) })
+
 	return &Driver{
 		logger:     hivetest.Logger(t),
 		kubeClient: cs,
+		pods:       pods,
 		config: &v2alpha1.CiliumNetworkDriverNodeConfigSpec{
 			DriverName: prepTestDriverName,
 		},
@@ -190,6 +229,20 @@ func createPrepClaim(t *testing.T, cs *k8sClient.FakeClientset, claim *resourcea
 		ResourceClaims(claim.Namespace).Create(context.Background(), claim, metav1.CreateOptions{})
 	require.NoError(t, err)
 	claim.ResourceVersion = updated.ResourceVersion
+}
+
+func createPod(t *testing.T, cs *k8sClient.FakeClientset, annotations map[string]string) {
+	t.Helper()
+	_, err := cs.KubernetesFakeClientset.CoreV1().
+		Pods(prepTestClaimNS).Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pod",
+			Namespace:   prepTestClaimNS,
+			UID:         prepTestPodUID,
+			Annotations: annotations,
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
 }
 
 // namedObject is a small helper to build a kubeletplugin.NamespacedObject.
@@ -259,6 +312,143 @@ func TestPrepare_TwoDevices_BothSucceed(t *testing.T) {
 		ResourceClaims(prepTestClaimNS).Get(t.Context(), prepTestClaimName, metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Len(t, updated.Status.Devices, 2)
+}
+
+func TestPrepare_PodStaticIPsAnnotation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotation  map[string]types.StaticAddrsMap
+		expectedIPs []string
+	}{
+		{
+			name: "IPv4 and IPv6",
+			annotation: map[string]types.StaticAddrsMap{
+
+				prepTestClaimName: {
+					prepTestRequest: {
+						IPv4: netip.MustParsePrefix("10.44.0.9/24"),
+						IPv6: netip.MustParsePrefix("fdaa::1/128"),
+					},
+				},
+			},
+			expectedIPs: []string{"10.44.0.9/24", "fdaa::1/128"}, // IPs from annotation must be used instead of defaults in claim config
+		},
+		{
+			name: "IPv4 only",
+			annotation: map[string]types.StaticAddrsMap{
+				prepTestClaimName: {
+					prepTestRequest: {
+						IPv4: netip.MustParsePrefix("10.44.0.9/24"),
+					},
+				},
+			},
+			expectedIPs: []string{"10.44.0.9/24", "fd00::1/128"}, // IPv4 from annotation, IPv6 from claim config (annotation must not override missing IP family)
+		},
+		{
+			name: "IPv6 only",
+			annotation: map[string]types.StaticAddrsMap{
+				prepTestClaimName: {
+					prepTestRequest: {
+						IPv6: netip.MustParsePrefix("fdaa::1/128"),
+					},
+				},
+			},
+			expectedIPs: []string{"10.1.0.1/32", "fdaa::1/128"}, // IPv4 from claim config (annotation must not override missing IP family), IPv6 from annotation
+		},
+	}
+
+	claimCases := []struct {
+		name          string
+		generateClaim func(devices ...string) *resourceapi.ResourceClaim
+	}{
+		{
+			name:          "From ResourceClaim",
+			generateClaim: buildPrepClaim,
+		},
+		{
+			name:          "From ResourceClaimTemplate",
+			generateClaim: buildGeneratedPrepClaim,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, cc := range claimCases {
+				t.Run(cc.name, func(t *testing.T) {
+					tlog := hivetest.Logger(t)
+					cs, _ := k8sClient.NewFakeClientset(tlog)
+
+					dev := &trackedDevice{name: prepTestDev0}
+					claim := cc.generateClaim(prepTestDev0)
+					createPrepClaim(t, cs, claim)
+
+					staticIPs, err := json.Marshal(tc.annotation)
+					require.NoError(t, err)
+
+					createPod(t, cs, map[string]string{
+						annotation.NetworkDriverStaticAddresses: string(staticIPs),
+					})
+
+					driver := buildPrepDriver(t, cs, dev)
+
+					result := driver.prepareResourceClaim(t.Context(), claim)
+					require.NoError(t, result.Err)
+
+					require.Len(t, dev.setupCfgs, 1)
+					assert.Equal(t, netip.MustParsePrefix(tc.expectedIPs[0]), dev.setupCfgs[0].IPv4Addr)
+					assert.Equal(t, netip.MustParsePrefix(tc.expectedIPs[1]), dev.setupCfgs[0].IPv6Addr)
+					updated, err := cs.KubernetesFakeClientset.ResourceV1().
+						ResourceClaims(prepTestClaimNS).Get(t.Context(), claim.Name, metav1.GetOptions{})
+					require.NoError(t, err)
+					require.Len(t, updated.Status.Devices, 1)
+					require.ElementsMatch(t, tc.expectedIPs, updated.Status.Devices[0].NetworkData.IPs)
+				})
+			}
+		})
+	}
+}
+
+func TestPrepare_PodStaticIPsAnnotation_Errors(t *testing.T) {
+	claimCases := []struct {
+		name          string
+		generateClaim func(devices ...string) *resourceapi.ResourceClaim
+	}{
+		{
+			name:          "From ResourceClaim",
+			generateClaim: buildPrepClaim,
+		},
+		{
+			name:          "From ResourceClaimTemplate",
+			generateClaim: buildGeneratedPrepClaim,
+		},
+	}
+
+	for _, cc := range claimCases {
+		t.Run(cc.name, func(t *testing.T) {
+			tlog := hivetest.Logger(t)
+			cs, _ := k8sClient.NewFakeClientset(tlog)
+
+			dev := &trackedDevice{name: prepTestDev0}
+			claim := buildPrepClaim(prepTestDev0)
+			createPrepClaim(t, cs, claim)
+
+			staticIPs, err := json.Marshal(map[string]types.StaticAddrsMap{
+				prepTestClaimName: {
+					"other-request": {IPv4: netip.MustParsePrefix("10.44.0.9/24")},
+				},
+			})
+			require.NoError(t, err)
+
+			createPod(t, cs, map[string]string{
+				annotation.NetworkDriverStaticAddresses: string(staticIPs),
+			})
+
+			driver := buildPrepDriver(t, cs, dev)
+
+			result := driver.prepareResourceClaim(t.Context(), claim)
+			require.Error(t, result.Err) // request name in annotation doesn't match any request in claim config → error expected
+		})
+	}
 }
 
 // TestPrepare_UpdateStatusFails_MapEmpty verifies that

--- a/pkg/networkdriver/types/types.go
+++ b/pkg/networkdriver/types/types.go
@@ -224,3 +224,11 @@ type SerializedDevice struct {
 	Dev     json.RawMessage
 	Config  DeviceConfig
 }
+
+type StaticAddrs struct {
+	IPv4 netip.Prefix `json:"ipv4,omitempty"`
+	IPv6 netip.Prefix `json:"ipv6,omitempty"`
+}
+
+// claim request → static addresses
+type StaticAddrsMap map[string]StaticAddrs


### PR DESCRIPTION
Add support for `ipam.cilium.io/network-driver-static-addresses` annotation in Pods. The annotation allows to specify static IP addresses to configure claimed resources. The configuration in the annotation takes precedence over the IP addresses specified in the ResourceClaim/ResourceClaimTemplate and CiliumResourceNetworkConfig.

The reason to do this is to have Pods that can customize IP addresses for specific scenarios while still applying the remaining part of the configuration (e.g: routes, VLAN ID and so on) from the ResourceClaimTemplate.

The annotation expected format is: ResourceClaim → Request → IP Addresses

ResourceClaimTemplate and Pod objs example:

```yaml
apiVersion: resource.k8s.io/v1
kind: ResourceClaimTemplate
metadata:
  name: dummy
spec:
  spec:
    devices:
      requests:
      - name: dummy-a
        exactly:
          deviceClassName: dummy.cilium.k8s.io
      - name: dummy-b
        exactly:
          deviceClassName: dummy.cilium.k8s.io
      config:
        - requests:
          - dummy-a
          opaque:
            driver: dummy.cilium.k8s.io
            parameters:
              podIfName: dummy-a
        - requests:
          - dummy-b
          opaque:
            driver: dummy.cilium.k8s.io
            parameters:
              podIfName: dummy-b
---
apiVersion: v1
kind: Pod
metadata:
  name: dummy-pod
  annotations:
    ipam.cilium.io/network-driver-static-addresses: |
      {
        "dummy": {
          "dummy-a": {
            "ipv4": "10.10.0.128/28",
            "ipv6": "fd00:100:1::2900/120"
          },
          "dummy-b": {
            "ipv4": "10.20.0.128/28",
            "ipv6": "fd00:200:1::2900/120"
          }
        }
      }
spec:
  securityContext:
    runAsUser: 0
  containers:
  - name: app
    image: busybox
    command: ["sleep", "inf"]
  resourceClaims:
  - name: dummy
    resourceClaimTemplateName: dummy
```