### PR TITLE
workflows/verifier: Fix always-passing workflow status

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -278,11 +278,11 @@ jobs:
   commit-status-final:
     if: ${{ always() }}
     name: Commit Status Final
-    needs: merge-and-diff
+    needs: [merge-and-diff, setup-and-test]
     runs-on: ubuntu-24.04
     steps:
       - name: Set final commit status
         uses: cilium/cilium/.github/actions/set-commit-status@98995b41cfa4549131dadab2498f598c2a0c8d16 # main
         with:
           sha: ${{ inputs.SHA || github.sha }}
-          status: ${{ needs.merge-and-diff.result }}
+          status: ${{ needs.merge-and-diff.result && needs.setup-and-test.result }}


### PR DESCRIPTION
Commit 8418a20754e4 ("workflows/verifier: Wait for complexity-diff to set workflow status") was meant to have our verifier workflow report a failure if the merge-and-diff job failed. It however broke the status reporting, causing failures in the setup-and-test job, the job that actually runs the verifier, to be ignored.

This pull request fixes it.

Fixes: https://github.com/cilium/cilium/pull/45681.