### PR TITLE
docs: fix typo cillium -> cilium in encryption-ztunnel.rst

### DIFF
--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -144,7 +144,7 @@ Validate the Setup
    processed by the enrollment reconciler.
 
 #. Run a ``bash`` shell in one of the Cilium pods hosting a mtls-enrolled pod with
-   ``kubectl -n kube-system exec -ti pod/<cillium-pod-hosting-mtls-pod> -- bash`` 
+   ``kubectl -n kube-system exec -ti pod/<cilium-pod-hosting-mtls-pod> -- bash``
    and execute the following commands:
 
    Install tcpdump


### PR DESCRIPTION
Fix a typo in the mTLS/ztunnel encryption validation docs where the example pod placeholder used `cillium` instead of `cilium`.

This is a documentation-only change.

Signed-off-by: Chikkala Kiran babu <chikkalakiranbabu1@gmail.com>