### PR TITLE
node: filter tentative/dadfailed addresses in firstGlobalAddr

### DIFF
--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -49,6 +49,7 @@ retryScope:
 	ipsPublic := []netlink.Addr{}
 	ipsPrivate := []netlink.Addr{}
 	hasPreferred := false
+	hadFilteredCandidate := false
 
 	for _, a := range addr {
 		if a.Scope > linkScopeMax {
@@ -63,6 +64,16 @@ retryScope:
 		isPreferredIP := a.IP.Equal(preferredIP)
 		if a.Flags&unix.IFA_F_SECONDARY > 0 && !isPreferredIP {
 			// Skip secondary addresses if they're not the preferredIP
+			continue
+		}
+		// Skip tentative (DAD in progress) and DAD-failed addresses. The
+		// kernel won't send/receive on these — they're either still being
+		// validated or in a permanent DAD-conflict state. Picking one
+		// silently produces an unusable node IP. Track that we saw a
+		// candidate so the cross-interface fallback below can refuse to
+		// substitute an unrelated interface's address.
+		if a.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_DADFAILED) != 0 {
+			hadFilteredCandidate = true
 			continue
 		}
 
@@ -114,6 +125,18 @@ retryScope:
 		goto retryScope
 	}
 
+	// If the named interface had global candidates that were all filtered
+	// out as tentative/dadfailed, refuse to fall back to scanning every
+	// interface on the host — that path can pick up unrelated addresses
+	// (Cilium-managed lxc, sibling-node mirrors via L2 announce responder)
+	// and silently use them as the node identity. Surface the network-state
+	// problem as a clear startup error instead.
+	if link != nil && hadFilteredCandidate {
+		return nil, fmt.Errorf(
+			"all global %s addresses on %q are tentative or dadfailed; refusing all-interfaces fallback",
+			familyName(family), intf)
+	}
+
 	// Fall back with retry for all interfaces with full scope again
 	// (which then goes back to lower scope again for all interfaces
 	// before we give up completely).
@@ -124,6 +147,13 @@ retryScope:
 	}
 
 	return nil, fmt.Errorf("No address found")
+}
+
+func familyName(family int) string {
+	if family == netlink.FAMILY_V4 {
+		return "IPv4"
+	}
+	return "IPv6"
 }
 
 // firstGlobalV4Addr returns the first IPv4 global IP of an interface,


### PR DESCRIPTION
Fixes #45840.

## Summary

`firstGlobalAddr` (called via `FirstGlobalV4Addr` / `FirstGlobalV6Addr` to populate `CiliumNode.spec.addresses`, among other things) accepted every address returned by `netlink.AddrList` on the named interface — including ones with `IFA_F_TENTATIVE` (DAD in progress) and `IFA_F_DADFAILED` (DAD detected a duplicate). Those addresses cannot send or receive packets; picking one silently produces an unusable node IP.

Worse, when every global candidate on the named interface was filtered out (e.g., all IPv6 addresses were `dadfailed` because a sibling node briefly held the same `/128` during a controller-managed lease handover), the function silently fell back to scanning every interface on the host. That path could surface addresses from Cilium-managed `lxc*` devices or from a sibling-node L2 announce responder, leading to two `CiliumNode` CRDs claiming the same IPv6 in `spec.addresses` and downstream `Stale or unroutable IP` drops at `bpf_host.c:961`.

## Change

1. Filters `IFA_F_TENTATIVE` and `IFA_F_DADFAILED` in the per-address loop, alongside the existing `IFA_F_SECONDARY` filter.
2. Tracks whether any candidate was filtered (`hadFilteredCandidate`), and refuses the cross-interface fallback when an interface was named and every candidate was filtered. Returns a clear error surfacing the network-state problem instead of silently substituting another interface's address.

The flag values are already exposed by `golang.org/x/sys/unix`, and the existing `IFA_F_SECONDARY` filter establishes the precedent.

## Issue

See #45840 for the full incident write-up: cilium-agent on a worker started up with `eth0` showing 5 dadfailed IPv6 addresses (caused by a transient duplicate-address conflict on the LAN). Address autodetect's all-interfaces fallback then surfaced an IPv6 belonging to a sibling node. Two `CiliumNode` CRDs reported the same IPv6 in `spec.addresses[ip]`, and inter-node pod traffic from the affected worker started failing with `Stale or unroutable IP`.

There was no log line indicating the chosen address came from a different interface than `--ipv6-node` and no warning that all named-interface candidates were `dadfailed` — diagnosis took an incident.

With this change, the agent fails loudly at startup with a clear error pointing at the network-state bug:

```
all global IPv6 addresses on \"eth0\" are tentative or dadfailed; refusing all-interfaces fallback
```

## Tests

Existing `TestPrivilegedFirstGlobalV4Addr` continues to pass. A unit test that exercises the new dadfailed filter would either need:
- kernel-cooperative DAD induction in the privileged test setup (hard to make deterministic), or
- a refactor of `firstGlobalAddr` to accept a pre-built `[]netlink.Addr` so the filter logic is pure-function-testable.

Happy to follow up on either direction in review.

## Release note

```release-note
node: filter tentative/dadfailed addresses in firstGlobalAddr; fail-loud instead of silent cross-interface fallback when the named interface has only-filtered candidates.
```