### PR TITLE
hubble: Add Script tests for pkg/hubble/exporter

### DIFF
--- a/pkg/hubble/exporter/aggregator_test.go
+++ b/pkg/hubble/exporter/aggregator_test.go
@@ -325,6 +325,66 @@ func TestAggregateAdd(t *testing.T) {
 			assert.Equal(t, 0, value.EgressFlowCount)
 		}
 	})
+
+	t.Run("different keys create separate aggregates", func(t *testing.T) {
+		// Test that flows with DIFFERENT aggregation keys create SEPARATE aggregates,
+		// not grouped together. This is the inverse case of all the tests above.
+		fieldMask, err := fieldmaskpb.New(&flowpb.Flow{}, "verdict")
+		require.NoError(t, err)
+
+		fieldAgg, err := fieldaggregate.New(fieldMask)
+		require.NoError(t, err)
+
+		aggregator := NewAggregatorWithFields(fieldAgg, hivetest.Logger(t))
+
+		// Add flows with DIFFERENT verdicts - should create 3 separate aggregates.
+		aggregator.Add(&v1.Event{
+			Event: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_FORWARDED,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+			},
+		})
+		aggregator.Add(&v1.Event{
+			Event: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_DROPPED,
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+			},
+		})
+		aggregator.Add(&v1.Event{
+			Event: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_ERROR,
+				TrafficDirection: flowpb.TrafficDirection_INGRESS,
+			},
+		})
+
+		// Add another FORWARDED flow - should add to existing FORWARDED aggregate.
+		aggregator.Add(&v1.Event{
+			Event: &flowpb.Flow{
+				Verdict:          flowpb.Verdict_FORWARDED,
+				TrafficDirection: flowpb.TrafficDirection_EGRESS,
+			},
+		})
+
+		// Should have 3 separate aggregates (FORWARDED, DROPPED, ERROR).
+		assert.Len(t, aggregator.m, 3, "different verdicts should create separate aggregates")
+
+		// Verify each aggregate has correct counts.
+		forwardedKey := generateAggregationKey(&flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED})
+		forwardedValue, exists := aggregator.m[forwardedKey]
+		require.True(t, exists, "FORWARDED aggregate should exist")
+		assert.Equal(t, 1, forwardedValue.IngressFlowCount, "FORWARDED should have 1 ingress")
+		assert.Equal(t, 1, forwardedValue.EgressFlowCount, "FORWARDED should have 1 egress")
+
+		droppedKey := generateAggregationKey(&flowpb.Flow{Verdict: flowpb.Verdict_DROPPED})
+		droppedValue, exists := aggregator.m[droppedKey]
+		require.True(t, exists, "DROPPED aggregate should exist")
+		assert.Equal(t, 1, droppedValue.EgressFlowCount, "DROPPED should have 1 egress")
+
+		errorKey := generateAggregationKey(&flowpb.Flow{Verdict: flowpb.Verdict_ERROR})
+		errorValue, exists := aggregator.m[errorKey]
+		require.True(t, exists, "ERROR aggregate should exist")
+		assert.Equal(t, 1, errorValue.IngressFlowCount, "ERROR should have 1 ingress")
+	})
 }
 
 func TestAggregateTimeEnrichment(t *testing.T) {

--- a/pkg/hubble/exporter/script_test.go
+++ b/pkg/hubble/exporter/script_test.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package exporter_test
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"go.yaml.in/yaml/v3"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/exporter"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+const defaultFileMode = 0o644
+
+type testState struct {
+	mu        lock.Mutex
+	exporters map[string]exporter.FlowLogExporter
+	logger    *slog.Logger
+}
+
+type exporterConfig struct {
+	Name               string                `yaml:"name"`
+	FilePath           string                `yaml:"filePath"`
+	FieldMask          []string              `yaml:"fieldMask"`
+	AggregationOptions *aggregationOptions   `yaml:"aggregationOptions"`
+	IncludeFilters     []map[string][]string `yaml:"includeFilters"`
+	ExcludeFilters     []map[string][]string `yaml:"excludeFilters"`
+}
+
+type aggregationOptions struct {
+	WindowInterval    string   `yaml:"windowInterval"`
+	AggregationFields []string `yaml:"aggregationFields"`
+}
+
+type multiExporterConfig struct {
+	Exporters []exporterConfig `yaml:"exporters"`
+}
+
+func TestScript(t *testing.T) {
+	var opts []hivetest.LogOption
+	if *debug {
+		opts = append(opts, hivetest.LogLevel(slog.LevelDebug))
+	}
+	log := hivetest.Logger(t, opts...)
+
+	setup := func(t testing.TB, args []string) *script.Engine {
+		state := &testState{
+			exporters: make(map[string]exporter.FlowLogExporter),
+			logger:    log,
+		}
+
+		cmds := map[string]script.Cmd{
+			"config/add":      configAddCmd(state),
+			"config/delete":   configDeleteCmd(state),
+			"event/send":      eventSendCmd(state),
+			"file/read":       fileReadCmd(),
+			"file/exists":     fileExistsCmd(),
+			"exporters/count": exportersCountCmd(state),
+			"sleep":           sleepCmd(),
+		}
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{
+			Cmds:             cmds,
+			RetryInterval:    20 * time.Millisecond,
+			MaxRetryInterval: time.Second,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{},
+		"testdata/scripts/*.txtar")
+}
+
+// parseConfigFile reads and parses a config file, returning either single or multiple exporter configs
+func parseConfigFile(configPath string) ([]exporterConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	// Try to parse as multi-exporter config first
+	var multiConfig multiExporterConfig
+	if err := yaml.Unmarshal(data, &multiConfig); err == nil && len(multiConfig.Exporters) > 0 {
+		return multiConfig.Exporters, nil
+	}
+
+	// Try single exporter config
+	var config exporterConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	return []exporterConfig{config}, nil
+}
+
+func configAddCmd(state *testState) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Add or update exporter configuration",
+			Args:    "file",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("usage: config/add <file>")
+			}
+
+			configs, err := parseConfigFile(s.Path(args[0]))
+			if err != nil {
+				return nil, err
+			}
+
+			for _, cfg := range configs {
+				if err := createExporter(s, state, cfg); err != nil {
+					return nil, err
+				}
+			}
+
+			return nil, nil
+		},
+	)
+}
+
+func createExporter(s *script.State, state *testState, config exporterConfig) error {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	// Expand environment variables in file path (e.g., $WORK)
+	filePath := s.ExpandEnv(config.FilePath, false)
+
+	// Build options
+	opts := []exporter.Option{
+		exporter.WithNewWriterFunc(exporter.FileWriter(exporter.FileWriterConfig{
+			Filename: filePath,
+		})),
+	}
+
+	// Add field mask if specified
+	if len(config.FieldMask) > 0 {
+		opts = append(opts, exporter.WithFieldMask(config.FieldMask))
+	}
+
+	// Add aggregation if specified
+	if config.AggregationOptions != nil {
+		if len(config.AggregationOptions.AggregationFields) > 0 {
+			opts = append(opts, exporter.WithFieldAggregate(config.AggregationOptions.AggregationFields))
+		}
+		if config.AggregationOptions.WindowInterval != "" {
+			duration, err := time.ParseDuration(config.AggregationOptions.WindowInterval)
+			if err != nil {
+				return fmt.Errorf("invalid window interval: %w", err)
+			}
+			opts = append(opts, exporter.WithAggregationInterval(duration))
+		}
+	}
+
+	// Add filters if specified
+	if len(config.IncludeFilters) > 0 {
+		filters, err := convertToFlowFilters(config.IncludeFilters)
+		if err != nil {
+			return fmt.Errorf("invalid include filters: %w", err)
+		}
+		opts = append(opts, exporter.WithAllowList(state.logger, filters))
+	}
+
+	if len(config.ExcludeFilters) > 0 {
+		filters, err := convertToFlowFilters(config.ExcludeFilters)
+		if err != nil {
+			return fmt.Errorf("invalid exclude filters: %w", err)
+		}
+		opts = append(opts, exporter.WithDenyList(state.logger, filters))
+	}
+
+	// Create exporter
+	exp, err := exporter.NewExporter(state.logger, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create exporter: %w", err)
+	}
+
+	state.exporters[config.Name] = exp
+	return nil
+}
+
+// convertToFlowFilters converts YAML filter maps to FlowFilter protobuf objects
+func convertToFlowFilters(filterMaps []map[string][]string) ([]*flowpb.FlowFilter, error) {
+	filters := make([]*flowpb.FlowFilter, 0, len(filterMaps))
+
+	for _, filterMap := range filterMaps {
+		filter := &flowpb.FlowFilter{}
+
+		for key, values := range filterMap {
+			switch key {
+			case "sourcePod":
+				filter.SourcePod = values
+			case "destinationPod":
+				filter.DestinationPod = values
+			default:
+				return nil, fmt.Errorf("Uncovered filter field: %s", key)
+			}
+		}
+
+		filters = append(filters, filter)
+	}
+
+	return filters, nil
+}
+
+func configDeleteCmd(state *testState) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Delete exporter configuration",
+			Args:    "file",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("usage: config/delete <file>")
+			}
+
+			configs, err := parseConfigFile(s.Path(args[0]))
+			if err != nil {
+				return nil, err
+			}
+
+			for _, cfg := range configs {
+				deleteExporter(state, cfg.Name)
+			}
+
+			return nil, nil
+		},
+	)
+}
+
+func deleteExporter(state *testState, name string) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if exp, ok := state.exporters[name]; ok {
+		exp.Stop()
+		delete(state.exporters, name)
+	}
+}
+
+func eventSendCmd(state *testState) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Send a flow event to all active exporters",
+			Args:    "file",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("usage: event/send <file>")
+			}
+
+			eventPath := s.Path(args[0])
+			data, err := os.ReadFile(eventPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read event: %w", err)
+			}
+
+			var flow flowpb.Flow
+			if err := json.Unmarshal(data, &flow); err != nil {
+				return nil, fmt.Errorf("failed to parse event: %w", err)
+			}
+
+			ev := &v1.Event{
+				Event: &flow,
+			}
+
+			state.mu.Lock()
+			defer state.mu.Unlock()
+
+			for _, exp := range state.exporters {
+				if err := exp.Export(context.Background(), ev); err != nil {
+					return nil, fmt.Errorf("failed to export event: %w", err)
+				}
+			}
+
+			return nil, nil
+		},
+	)
+}
+
+func fileReadCmd() script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Read file contents to output file",
+			Args:    "source dest",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 2 {
+				return nil, fmt.Errorf("usage: file/read <source> <dest>")
+			}
+
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file: %w", err)
+			}
+
+			destPath := s.Path(args[1])
+			if err := os.WriteFile(destPath, data, defaultFileMode); err != nil {
+				return nil, fmt.Errorf("failed to write output: %w", err)
+			}
+
+			return nil, nil
+		},
+	)
+}
+
+func fileExistsCmd() script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Check if file exists",
+			Args:    "path",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("usage: file/exists <path>")
+			}
+
+			if _, err := os.Stat(args[0]); err != nil {
+				if os.IsNotExist(err) {
+					return nil, fmt.Errorf("file does not exist: %s", args[0])
+				}
+				return nil, err
+			}
+
+			return nil, nil
+		},
+	)
+}
+
+func exportersCountCmd(state *testState) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Check number of active exporters",
+			Args:    "expected",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("usage: exporters/count <expected>")
+			}
+
+			expected := args[0]
+
+			state.mu.Lock()
+			actual := fmt.Sprintf("%d", len(state.exporters))
+			state.mu.Unlock()
+
+			if actual != expected {
+				return nil, fmt.Errorf("expected %s exporters, got %s", expected, actual)
+			}
+			return nil, nil
+		},
+	)
+}
+
+func sleepCmd() script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Sleep for a duration",
+			Args:    "duration",
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("usage: sleep <duration>")
+			}
+
+			duration, err := time.ParseDuration(args[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid duration: %w", err)
+			}
+
+			time.Sleep(duration)
+			return nil, nil
+		},
+	)
+}

--- a/pkg/hubble/exporter/testdata/scripts/aggregation.txtar
+++ b/pkg/hubble/exporter/testdata/scripts/aggregation.txtar
@@ -1,0 +1,85 @@
+# Configure exporter with aggregation
+config/add aggregated-exporter.yaml
+
+# Send multiple similar events quickly
+event/send agg-flow-1.json
+event/send agg-flow-2.json
+event/send agg-flow-3.json
+
+# Wait for aggregation window to complete
+sleep 150ms
+
+# Verify file was created
+* file/exists $WORK/aggregated.log
+
+# Verify we got aggregated output with proper structure
+* file/read $WORK/aggregated.log aggregated.actual
+
+# Check that aggregation actually happened - should have aggregate field with count
+* grep -q '"aggregate"' aggregated.actual
+* grep -q '"unknown_direction_flow_count":3' aggregated.actual
+
+# Verify source and destination fields are present (from aggregationFields)
+* grep -q '"source".*"pod_name":"web-pod"' aggregated.actual
+* grep -q '"destination".*"pod_name":"db-pod"' aggregated.actual
+
+
+# Clean up
+config/delete aggregated-exporter.yaml
+
+# ---
+
+-- aggregated-exporter.yaml --
+name: aggregator-1
+filePath: $WORK/aggregated.log
+fieldMask:
+  - source
+  - destination
+  - verdict
+aggregationOptions:
+  windowInterval: 100ms
+  aggregationFields:
+    - source
+    - destination
+
+-- agg-flow-1.json --
+{
+  "time": "2024-01-01T10:00:00Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "default",
+    "pod_name": "web-pod"
+  },
+  "destination": {
+    "namespace": "default",
+    "pod_name": "db-pod"
+  }
+}
+
+-- agg-flow-2.json --
+{
+  "time": "2024-01-01T10:00:01Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "default",
+    "pod_name": "web-pod"
+  },
+  "destination": {
+    "namespace": "default",
+    "pod_name": "db-pod"
+  }
+}
+
+-- agg-flow-3.json --
+{
+  "time": "2024-01-01T10:00:02Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "default",
+    "pod_name": "web-pod"
+  },
+  "destination": {
+    "namespace": "default",
+    "pod_name": "db-pod"
+  }
+}

--- a/pkg/hubble/exporter/testdata/scripts/basic-export.txtar
+++ b/pkg/hubble/exporter/testdata/scripts/basic-export.txtar
@@ -1,0 +1,41 @@
+# Start the exporter with initial config
+config/add exporter-1.yaml
+
+# Send a flow event
+event/send flow-1.json
+
+# Wait for file to be created and verify contents
+* file/exists $WORK/export.log
+* file/read $WORK/export.log output-1.actual
+
+# Verify the file contains a complete JSON entry
+* grep -q '"flow"' output-1.actual
+* grep -q '"time":"2024-01-01T10:00:00Z"' output-1.actual
+* grep -q '"verdict":"FORWARDED"' output-1.actual
+* grep -q '"source".*"namespace":"default"' output-1.actual
+* grep -q '"source".*"pod_name":"pod-1"' output-1.actual
+* grep -q '"destination".*"pod_name":"pod-target"' output-1.actual
+
+
+# Delete the exporter config
+config/delete exporter-1.yaml
+
+# ---
+
+-- exporter-1.yaml --
+name: exporter-1
+filePath: $WORK/export.log
+
+-- flow-1.json --
+{
+  "time": "2024-01-01T10:00:00Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "default",
+    "pod_name": "pod-1"
+  },
+  "destination": {
+    "namespace": "default",
+    "pod_name": "pod-target"
+  }
+}

--- a/pkg/hubble/exporter/testdata/scripts/dynamic-reload.txtar
+++ b/pkg/hubble/exporter/testdata/scripts/dynamic-reload.txtar
@@ -1,0 +1,96 @@
+# Start with initial configuration with two exporters
+config/add multi-exporter-1.yaml
+
+# Verify exporters are created
+* exporters/count 2
+
+# Send events to both exporters
+event/send flow-web.json
+event/send flow-api.json
+
+# Verify both files exist
+* file/exists $WORK/web.log
+* file/exists $WORK/api.log
+
+# Check web exporter got events
+* file/read $WORK/web.log web-1.actual
+* grep -q '"flow"' web-1.actual
+* grep -q '"source".*"pod_name":"web-frontend"' web-1.actual
+* grep -q '"destination".*"pod_name":"api-backend"' web-1.actual
+
+# Check api exporter got events
+* file/read $WORK/api.log api-1.actual
+* grep -q '"flow"' api-1.actual
+* grep -q '"source".*"pod_name":"api-backend"' api-1.actual
+* grep -q '"destination".*"pod_name":"db-postgres"' api-1.actual
+
+# Update config - remove web exporter, keep api exporter
+config/delete multi-exporter-1.yaml
+config/add multi-exporter-2.yaml
+
+# Verify only 1 exporter remains
+* exporters/count 1
+
+# Send more events - only api should receive them
+event/send flow-web.json
+event/send flow-api.json
+
+# Wait a bit for events to be written
+sleep 50ms
+
+# Clean up
+config/delete multi-exporter-2.yaml
+
+# ---
+
+-- multi-exporter-1.yaml --
+exporters:
+  - name: web-exporter
+    filePath: $WORK/web.log
+    fieldMask:
+      - source
+      - destination
+  
+  - name: api-exporter
+    filePath: $WORK/api.log
+    fieldMask:
+      - source
+      - destination
+
+-- multi-exporter-2.yaml --
+exporters:
+  - name: api-exporter
+    filePath: $WORK/api.log
+    fieldMask:
+      - source
+      - destination
+
+-- flow-web.json --
+{
+  "time": "2024-01-01T10:00:00Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "default",
+    "pod_name": "web-frontend",
+    "labels": ["app=web", "tier=frontend"]
+  },
+  "destination": {
+    "namespace": "default",
+    "pod_name": "api-backend"
+  }
+}
+
+-- flow-api.json --
+{
+  "time": "2024-01-01T10:00:01Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "default",
+    "pod_name": "api-backend",
+    "labels": ["app=api", "tier=backend"]
+  },
+  "destination": {
+    "namespace": "default",
+    "pod_name": "db-postgres"
+  }
+}

--- a/pkg/hubble/exporter/testdata/scripts/filters.txtar
+++ b/pkg/hubble/exporter/testdata/scripts/filters.txtar
@@ -1,0 +1,224 @@
+# Test include filters with various patterns
+
+# Configure exporter with include filter for specific namespace
+config/add filter-namespace.yaml
+
+# Send events - some match, some don't
+event/send flow-match-namespace.json
+event/send flow-no-match-namespace.json
+event/send flow-match-namespace-2.json
+
+# Verify file was created
+* file/exists $WORK/filtered-namespace.log
+
+# Read and verify only matching events were exported
+* file/read $WORK/filtered-namespace.log filtered-output.actual
+
+# Should contain events from "production" namespace
+* grep -q '"namespace":"production"' filtered-output.actual
+
+# Should NOT contain events from "staging" namespace  
+! grep -q '"namespace":"staging"' filtered-output.actual
+
+# Verify we have the two matching events (both with production namespace)
+* grep -q 'app-server-1' filtered-output.actual
+* grep -q 'app-server-2' filtered-output.actual
+
+# Clean up
+config/delete filter-namespace.yaml
+
+
+# Test with multiple filter criteria (pod name pattern)
+config/add filter-pod.yaml
+
+event/send flow-web-frontend.json
+event/send flow-api-backend.json  
+event/send flow-db-postgres.json
+
+* file/exists $WORK/filtered-pod.log
+* file/read $WORK/filtered-pod.log filtered-pod-output.actual
+
+# Should contain web-frontend (matches "frontend/" pattern)
+* grep -q '"pod_name":"web-frontend"' filtered-pod-output.actual
+
+# Should NOT contain api-backend or db-postgres (different namespace prefix)
+! grep -q '"pod_name":"api-backend"' filtered-pod-output.actual
+! grep -q '"pod_name":"db-postgres"' filtered-pod-output.actual
+
+config/delete filter-pod.yaml
+
+
+# Test with multiple filters (OR logic - any filter matches)
+config/add filter-multiple.yaml
+
+event/send flow-prod-web.json
+event/send flow-staging-api.json
+event/send flow-dev-db.json
+
+* file/exists $WORK/filtered-multiple.log
+* file/read $WORK/filtered-multiple.log filtered-multi-output.actual
+
+# Should match flow-prod-web (matches namespace filter)
+* grep -q '"namespace":"production"' filtered-multi-output.actual
+* grep -q '"pod_name":"web-app"' filtered-multi-output.actual
+
+# Should match flow-staging-api (matches destinationPod filter for gateway)
+* grep -q '"namespace":"staging"' filtered-multi-output.actual
+* grep -q '"pod_name":"api-gateway"' filtered-multi-output.actual
+
+# Should NOT match flow-dev-db (doesn't match any filter)
+! grep -q '"namespace":"development"' filtered-multi-output.actual
+! grep -q '"pod_name":"dev-database"' filtered-multi-output.actual
+
+config/delete filter-multiple.yaml
+
+# ---
+
+-- filter-namespace.yaml --
+name: filter-namespace
+filePath: $WORK/filtered-namespace.log
+includeFilters:
+  - sourcePod:
+      - production/
+
+-- filter-pod.yaml --
+name: filter-pod
+filePath: $WORK/filtered-pod.log
+includeFilters:
+  - sourcePod:
+      - frontend/
+
+-- filter-multiple.yaml --
+name: filter-multiple
+filePath: $WORK/filtered-multiple.log
+includeFilters:
+  - sourcePod:
+      - production/
+  - destinationPod:
+      - staging/api-
+
+-- flow-match-namespace.json --
+{
+  "time": "2024-01-01T10:00:00Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "production",
+    "pod_name": "app-server-1"
+  },
+  "destination": {
+    "namespace": "production",
+    "pod_name": "db-primary"
+  }
+}
+
+-- flow-no-match-namespace.json --
+{
+  "time": "2024-01-01T10:00:01Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "staging",
+    "pod_name": "test-server"
+  },
+  "destination": {
+    "namespace": "staging",
+    "pod_name": "test-db"
+  }
+}
+
+-- flow-match-namespace-2.json --
+{
+  "time": "2024-01-01T10:00:02Z",
+  "verdict": "DROPPED",
+  "source": {
+    "namespace": "production",
+    "pod_name": "app-server-2"
+  },
+  "destination": {
+    "namespace": "external",
+    "pod_name": "internet"
+  }
+}
+
+-- flow-web-frontend.json --
+{
+  "time": "2024-01-01T10:00:00Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "frontend",
+    "pod_name": "web-frontend"
+  },
+  "destination": {
+    "namespace": "backend",
+    "pod_name": "api"
+  }
+}
+
+-- flow-api-backend.json --
+{
+  "time": "2024-01-01T10:00:01Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "backend",
+    "pod_name": "api-backend"
+  },
+  "destination": {
+    "namespace": "data",
+    "pod_name": "database"
+  }
+}
+
+-- flow-db-postgres.json --
+{
+  "time": "2024-01-01T10:00:02Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "data",
+    "pod_name": "db-postgres"
+  },
+  "destination": {
+    "namespace": "storage",
+    "pod_name": "s3-gateway"
+  }
+}
+
+-- flow-prod-web.json --
+{
+  "time": "2024-01-01T10:00:00Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "production",
+    "pod_name": "web-app"
+  },
+  "destination": {
+    "namespace": "production",
+    "pod_name": "backend-app"
+  }
+}
+
+-- flow-staging-api.json --
+{
+  "time": "2024-01-01T10:00:01Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "staging",
+    "pod_name": "test-app"
+  },
+  "destination": {
+    "namespace": "staging",
+    "pod_name": "api-gateway"
+  }
+}
+
+-- flow-dev-db.json --
+{
+  "time": "2024-01-01T10:00:02Z",
+  "verdict": "FORWARDED",
+  "source": {
+    "namespace": "development",
+    "pod_name": "dev-app"
+  },
+  "destination": {
+    "namespace": "development",
+    "pod_name": "dev-database"
+  }
+}


### PR DESCRIPTION
## Add txtar-style script integration tests for Hubble exporter

Adds script-based integration tests for the Hubble exporter package, complementing existing unit tests with end-to-end validation of real file I/O, configuration management, and temporal behavior.
Updates `aggregator_test.go` scenario for correctly splitting flows.
Script tests will run with all other tests under `pkg/hubble/exporter`.

### Test Scenarios
Four new integration test scenarios:
1. **basic-export.txtar** - Tests core export pipeline: config loading → event ingestion → JSON serialization → file output
2. **aggregation.txtar** - Tests time-window aggregation (100ms windows, event grouping, aggregate counts)
3. **dynamic-reload.txtar** - Tests multi-exporter orchestration and dynamic configuration changes
4. **filters.txtar** - Tests include filters with namespace/pod prefix patterns and OR logic
Each test validates end-to-end behavior that unit tests cannot easily cover (real file I/O, temporal windows, multi-component orchestration).

### Test Infrastructure
Implements 7 custom script commands for testing:
- `config/add/delete` - Manage exporter configurations
- `event/send` - Send flow events to exporters
- `file/read/exists` - Validate file output
- `exporters/count` - Assert exporter state
- `sleep` - Wait for time-based operations
Uses `github.com/cilium/hive/script` framework (same as clustermesh-apiserver tests used for ref).

### Why Script Tests?
Complement 30+ existing unit tests by validating:
- Real filesystem I/O and file creation
- Time-based aggregation windows (requires actual delays)
- End-to-end integration across components
- Multi-exporter orchestration and dynamic reload
Unit tests already cover: aggregation algorithms, filter matching logic, config validation, metrics, error handling, field masking.

### Test Results
```bash
$ go test ./pkg/hubble/exporter -run TestScript
ok      github.com/cilium/cilium/pkg/hubble/exporter    0.171s
...
--- PASS: TestScript (0.00s)
    --- PASS: TestScript/basic-export.txtar (0.00s)
    --- PASS: TestScript/filters.txtar (0.01s)
    --- PASS: TestScript/dynamic-reload.txtar (0.06s)
    --- PASS: TestScript/aggregation.txtar (0.16s)
```

Full test suite (all 30+ unit tests + 4 script tests):
```bash
$ go test ./pkg/hubble/exporter
ok      github.com/cilium/cilium/pkg/hubble/exporter    0.422s
```