### PR TITLE
helm: add extension for cilium-envoy container lifecycle hooks

### DIFF
--- a/install/kubernetes/cilium/templates/_extensions.tpl
+++ b/install/kubernetes/cilium/templates/_extensions.tpl
@@ -104,6 +104,12 @@ Allow packagers to add extra arguments to the clustermesh-apiserver kvstoremesh 
 {{- end }}
 
 {{/*
+Allow packagers to add lifecycle hooks to the cilium-envoy container.
+*/}}
+{{- define "envoy.lifecycle" -}}
+{{- end }}
+
+{{/*
 Allow packagers to add init containers to the cilium-envoy pods.
 */}}
 {{- define "envoy.initContainers" -}}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -187,6 +187,13 @@ spec:
           failureThreshold: {{ .Values.envoy.readinessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.envoy.readinessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.envoy.readinessProbe.timeoutSeconds }}
+
+        {{- $lifecycleHooks := include "envoy.lifecycle" . | trim }}
+        {{- if $lifecycleHooks }}
+        lifecycle:
+        {{- $lifecycleHooks | nindent 10 }}
+        {{- end }}
+
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
Allows packagers to add lifecycle hooks to the cilium-envoy container.

```release-note
Add extension points for cilium-envoy container lifecycle hooks 
```
