### PR TITLE
bgp: add table-json format to hive shell commands

### DIFF
--- a/pkg/bgp/commands/peer.go
+++ b/pkg/bgp/commands/peer.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/cilium/hive/script"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -29,7 +28,7 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 			Summary: "List BGP peers on Cilium",
 			Flags: func(fs *pflag.FlagSet) {
 				addOutFileFlag(fs)
-				addFormatFlag(fs)
+				addFormatFlagPeers(fs)
 				fs.Bool("no-uptime", false, "Do not show Uptime for testing purpose")
 			},
 			Detail: []string{
@@ -66,6 +65,17 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					PrintPeerStatesTable(tw, res.Instances, noUptime)
 
 					tw.Flush()
+				case "table-json":
+					builder := strings.Builder{}
+					PrintPeerStatesTable(&builder, res.Instances, noUptime)
+					table := tableJSONfromString(builder.String())
+					out, err := json.MarshalIndent(table, "", "  ")
+					if err != nil {
+						return "", "", fmt.Errorf("json marshal failed: %w", err)
+					}
+					if _, err := w.Write(out); err != nil {
+						return "", "", err
+					}
 				case "json":
 					out, err := json.MarshalIndent(res.Instances, "", "  ")
 					if err != nil {
@@ -86,7 +96,7 @@ func BGPPeersCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 	)
 }
 
-func PrintPeerStatesTable(tw *tabwriter.Writer, instances []agent.InstancePeerStates, noUptime bool) {
+func PrintPeerStatesTable(w io.Writer, instances []agent.InstancePeerStates, noUptime bool) {
 	type row struct {
 		Instance     string
 		Peer         string
@@ -184,7 +194,7 @@ func PrintPeerStatesTable(tw *tabwriter.Writer, instances []agent.InstancePeerSt
 			}
 		}
 
-		fmt.Fprintf(tw, "%s\n", strings.Join([]string{
+		fmt.Fprintf(w, "%s\n", strings.Join([]string{
 			row.Instance,
 			row.Peer,
 			row.SessionState,

--- a/pkg/bgp/commands/route_polices.go
+++ b/pkg/bgp/commands/route_polices.go
@@ -51,7 +51,7 @@ func BGPRoutePoliciesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 				}
 				tw := getCmdTabWriter(w)
 
-				PrintBGPRoutePoliciesTable(tw, res.Instances)
+				PrintRoutePoliciesTable(tw, res.Instances)
 				tw.Flush()
 
 				return buf.String(), "", err
@@ -60,8 +60,8 @@ func BGPRoutePoliciesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 	)
 }
 
-// PrintBGPRoutePoliciesTable prints table of provided BGP route policies in the provided tab writer.
-func PrintBGPRoutePoliciesTable(tw *tabwriter.Writer, instances []agent.InstanceRoutePolicies) {
+// PrintRoutePoliciesTable prints table of provided BGP route policies in the provided tab writer.
+func PrintRoutePoliciesTable(tw *tabwriter.Writer, instances []agent.InstanceRoutePolicies) {
 	type row struct {
 		Instance      string
 		PolicyName    string

--- a/pkg/bgp/commands/routes.go
+++ b/pkg/bgp/commands/routes.go
@@ -4,11 +4,12 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"slices"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/cilium/hive/script"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -27,6 +28,7 @@ func BGPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 			Args:    "<table type> <afi> <safi>",
 			Flags: func(fs *pflag.FlagSet) {
 				addOutFileFlag(fs)
+				addFormatFlag(fs)
 				fs.Bool("no-age", false, "Do not show Age column for testing purpose")
 				fs.BoolP("with-attrs", "a", false, "Show path attributes (excluding NEXT_HOP and MP_REACH_NLRI)")
 			},
@@ -68,6 +70,11 @@ func BGPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 					return "", "", err
 				}
 
+				format, err := s.Flags.GetString(formatFlag)
+				if err != nil {
+					return "", "", err
+				}
+
 				printAttr, err := s.Flags.GetBool("with-attrs")
 				if err != nil {
 					return "", "", err
@@ -88,8 +95,25 @@ func BGPRoutesCmd(bgpMgr agent.BGPRouterManager) script.Cmd {
 				}
 
 				printPeer := tableType == types.TableTypeAdjRIBIn || tableType == types.TableTypeAdjRIBOut
-				PrintRoutes(tw, res.Instances, printPeer, noAge, printAttr)
-				tw.Flush()
+
+				switch format {
+				case "table":
+					PrintRoutes(tw, res.Instances, printPeer, noAge, printAttr)
+					tw.Flush()
+				case "table-json":
+					builder := strings.Builder{}
+					PrintRoutes(&builder, res.Instances, printPeer, noAge, printAttr)
+					table := tableJSONfromString(builder.String())
+					out, err := json.MarshalIndent(table, "", "  ")
+					if err != nil {
+						return "", "", fmt.Errorf("json marshal failed: %w", err)
+					}
+					if _, err := w.Write(out); err != nil {
+						return "", "", err
+					}
+				default:
+					return "", "", fmt.Errorf("unsupported format: %s", format)
+				}
 
 				return buf.String(), stderr, nil
 			}, nil
@@ -126,7 +150,7 @@ func parseTableTypeArg(arg string) (types.TableType, error) {
 	}
 }
 
-func PrintRoutes(tw *tabwriter.Writer, instances []agent.InstanceRoutes, printPeer, noAge, printAttr bool) {
+func PrintRoutes(w io.Writer, instances []agent.InstanceRoutes, printPeer, noAge, printAttr bool) {
 	type row struct {
 		Instance string
 		Peer     string
@@ -197,15 +221,15 @@ func PrintRoutes(tw *tabwriter.Writer, instances []agent.InstanceRoutes, printPe
 		}
 
 		if printPeer {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s", row.Instance, row.Peer, row.Prefix, row.NextHop, row.Age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s", row.Instance, row.Peer, row.Prefix, row.NextHop, row.Age)
 		} else {
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s", row.Instance, row.Prefix, row.NextHop, row.Best, row.Age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s", row.Instance, row.Prefix, row.NextHop, row.Best, row.Age)
 		}
 
 		if printAttr {
-			fmt.Fprintf(tw, "\t%s\n", row.Attrs)
+			fmt.Fprintf(w, "\t%s\n", row.Attrs)
 		} else {
-			fmt.Fprintf(tw, "\n")
+			fmt.Fprintf(w, "\n")
 		}
 
 		if row.Instance != "" {

--- a/pkg/bgp/commands/utils.go
+++ b/pkg/bgp/commands/utils.go
@@ -27,12 +27,46 @@ const (
 	tabPaddingChar = ' '
 )
 
+type tableJSON struct {
+	Columns []string            `json:"columns"`
+	Rows    []map[string]string `json:"rows"`
+}
+
+func tableJSONfromString(output string) tableJSON {
+	lines := strings.FieldsFunc(output, func(c rune) bool {
+		return c == '\n'
+	})
+	table := tableJSON{
+		Rows: []map[string]string{},
+	}
+
+	for i, line := range lines {
+		rows := strings.Split(line, "\t")
+		for j, row := range rows {
+			if i == 0 {
+				table.Columns = append(table.Columns, row)
+			} else {
+				if j == 0 {
+					table.Rows = append(table.Rows, map[string]string{})
+				}
+				table.Rows[i-1][table.Columns[j]] = row
+			}
+		}
+	}
+
+	return table
+}
+
 func addOutFileFlag(fs *pflag.FlagSet) {
 	fs.StringP(outFileFlag, outFileFlagShort, "", "File to write to instead of stdout")
 }
 
 func addFormatFlag(fs *pflag.FlagSet) {
-	fs.StringP(formatFlag, formatFlagShort, "table", "Format to write in (table, json or detailed)")
+	fs.StringP(formatFlag, formatFlagShort, "table", "Format to write in (table or table-json)")
+}
+
+func addFormatFlagPeers(fs *pflag.FlagSet) {
+	fs.StringP(formatFlag, formatFlagShort, "table", "Format to write in (table, table-json, json or detailed)")
 }
 
 func getCmdWriter(s *script.State) (writer io.Writer, buf *strings.Builder, f *os.File, err error) {


### PR DESCRIPTION
The table-json format will be used in cilium-cli to make the serialization format simpler.
Added table-json format to `bgp/peers` and `bgp/routes`.

```release-note
cilium-dbg: add table-json format to bgp/peers and bgp/routes
```
